### PR TITLE
fix(app-core): correct auth-token test import path

### DIFF
--- a/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
+++ b/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
@@ -3,7 +3,7 @@ import {
   extractHeaderValue,
   getProvidedApiToken,
   tokenMatches,
-} from "./tokens.ts";
+} from "../tokens.ts";
 
 describe("tokenMatches", () => {
   it("matches equal tokens", () => {


### PR DESCRIPTION
# Relates to

Closes #25549

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the focused app-core checks were run after sync; the
      full `bun run verify` gate was not run for reasons recorded under
      **Known gaps / failures** below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`6dbe78af21`); zero conflicts.
- [x] Focused app-core typecheck/test/lint pass post-sync. `bun run verify` not
      run in full — see **Known gaps / failures**.

# Risks

Low. The change touches a single import specifier in one test file. It is
strictly test-only and behavior-neutral: no runtime/implementation code is
modified, no test cases are added or removed, and no unrelated lines are
reformatted.

# Background

## What does this PR do?

Fixes a broken import path in the app-core auth-tokens test. The test file lives
at `packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts` but imported
its implementation from `"./tokens.ts"`. Because the test sits inside the
`__tests__/` subdirectory, `./tokens.ts` resolved to a non-existent
`__tests__/tokens.ts`, while the real implementation is one directory up at
`packages/app-core/src/api/auth/tokens.ts`.

This broke `@elizaos/app-core` typechecking with:

```
src/api/auth/__tests__/auth-tokens.test.ts(6,8): error TS2307: Cannot find module './tokens.ts' or its corresponding type declarations.
```

The one-line fix points the import at the real sibling implementation via
`"../tokens.ts"`. The implementation exports `extractHeaderValue`,
`getProvidedApiToken`, and `tokenMatches` — exactly the three symbols the test
imports.

## What kind of change is this?

Bug fix (non-breaking change which fixes a broken test-file import that failed
typecheck).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts` line 6 — the only
changed line, `from "./tokens.ts"` → `from "../tokens.ts"`.

## Detailed testing steps

From the repo root:

```bash
cd packages/app-core
# BEFORE the fix: this printed the TS2307 error below.
bun run typecheck 2>&1 | grep auth-tokens.test.ts
# AFTER the fix: no output (error resolved).

# Focused test — all 6 cases pass.
node ../scripts/run-vitest.mjs run --config vitest.config.ts \
  src/api/auth/__tests__/auth-tokens.test.ts

# Lint — clean.
bunx @biomejs/biome check src/api/auth/__tests__/auth-tokens.test.ts
```

**Before (failing typecheck):**

```
src/api/auth/__tests__/auth-tokens.test.ts(6,8): error TS2307: Cannot find module './tokens.ts' or its corresponding type declarations.
```

**After (typecheck for the file is clean, test passes):**

```
=== TYPECHECK for auth-tokens ===
(no output = TS2307 resolved)

=== FOCUSED TEST ===
 RUN  v4.1.10 /.../packages/app-core

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  362ms

=== LINT ===
Checked 1 file in 63ms. No fixes applied.
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:0e9327b5945ad4052540750d35f155689df32c5e -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only import-path fix; no UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only import-path fix; no UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only import-path fix; no user-facing flow.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - test/tooling-only import fix; no server runtime code path fires. Focused typecheck, vitest (6/6), and Biome lint output are pasted inline under Testing and Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path is exercised by this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, scheduled tasks, or generated files involved.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes.`

## Backend + frontend logs

Backend: focused test/typecheck/lint output showing the corrected import resolves
and the suite passes.

<details>
<summary>Before — failing typecheck (TS2307)</summary>

```
$ bun run typecheck 2>&1 | grep auth-tokens.test.ts
src/api/auth/__tests__/auth-tokens.test.ts(6,8): error TS2307: Cannot find module './tokens.ts' or its corresponding type declarations.
```
</details>

<details>
<summary>After — typecheck clean for the file, 6/6 tests pass, lint clean</summary>

```
$ bun run typecheck 2>&1 | grep auth-tokens.test.ts
(no output — TS2307 resolved)

$ node ../scripts/run-vitest.mjs run --config vitest.config.ts src/api/auth/__tests__/auth-tokens.test.ts
 RUN  v4.1.10 /.../packages/app-core

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  10:18:38
   Duration  362ms (transform 97ms, setup 0ms, import 124ms, tests 7ms, environment 0ms)

$ bunx @biomejs/biome check src/api/auth/__tests__/auth-tokens.test.ts
Checked 1 file in 63ms. No fixes applied.
```
</details>

Frontend: `N/A - no frontend code path is exercised by this change.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - test-only import-path fix; no rendered UI.`

### After

`N/A - test-only import-path fix; no rendered UI.`

### Walkthrough video

`N/A - test-only import-path fix; no user-facing flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT changes.`

## Known gaps / failures

- The full repository `bun run verify` gate was not run end-to-end. `bun install`
  in this environment requires overriding a machine-level `minimumReleaseAge`
  policy (`--minimum-release-age=0`), and a from-scratch workspace typecheck
  surfaces many pre-existing TS2307 errors for unbuilt sibling workspace
  packages (e.g. `@elizaos/plugin-*`) that are unrelated to this one-line change.
  Those errors exist on `develop` independently of this PR. The targeted proof —
  the app-core auth-tokens TS2307 error before/after, the focused vitest run, and
  Biome lint — is captured above and is fully sufficient to verify this change.
  The change is strictly test-only and cannot alter runtime behavior.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@beeaa92f7f50759ffec1dc2a6014c3d7ec1f28e3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@beeaa92f7f50759ffec1dc2a6014c3d7ec1f28e3:packages/skills/skills/contribute-to-eliza"} -->
