### PR TITLE
test(core): cover edge native feature policy

### DIFF
--- a/packages/core/src/plugins/__tests__/native-features-edge.test.ts
+++ b/packages/core/src/plugins/__tests__/native-features-edge.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	getNativeRuntimeFeaturePlugin,
+	nativeRuntimeFeatureDefaults,
+	nativeRuntimeFeaturePluginNames,
+	resolveNativeRuntimeFeatureFromPluginName,
+	resolveNativeRuntimeFeatureFromServiceType,
+} from "./native-features.edge.ts";
+
+describe("native-features.edge", () => {
+	it("defaults every native feature to disabled", () => {
+		expect(nativeRuntimeFeatureDefaults).toEqual({
+			documents: false,
+			relationships: false,
+			trajectories: false,
+			advancedPlanning: false,
+			advancedMemory: false,
+		});
+	});
+
+	it("maps feature names for plugin matching", () => {
+		expect(nativeRuntimeFeaturePluginNames.advancedMemory).toBe(
+			"advanced-memory",
+		);
+		expect(nativeRuntimeFeaturePluginNames.documents).toBe("documents");
+	});
+
+	it("resolves a feature from its plugin name", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName("advanced-planning")).toBe(
+			"advancedPlanning",
+		);
+		expect(resolveNativeRuntimeFeatureFromPluginName("documents")).toBe(
+			"documents",
+		);
+		expect(resolveNativeRuntimeFeatureFromPluginName("unknown")).toBeNull();
+		expect(resolveNativeRuntimeFeatureFromPluginName(null)).toBeNull();
+	});
+
+	it("rejects dedicated-host features explicitly", () => {
+		expect(() => getNativeRuntimeFeaturePlugin("documents")).toThrow(
+			"requires a dedicated runtime host",
+		);
+	});
+
+	it("resolves no feature from service types on the edge", () => {
+		expect(resolveNativeRuntimeFeatureFromServiceType("anything")).toBeNull();
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 5 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
