### PR TITLE
test(app-core): cover devtools layout refresh

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/devtools-layout.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/devtools-layout.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEVTOOLS_LAYOUT_REFRESH_DELAYS_MS,
+  scheduleDevtoolsLayoutRefresh,
+} from "./devtools-layout.ts";
+
+function collectWindow(initial: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}) {
+  const calls: number[][] = [];
+  let frame = { ...initial };
+  return {
+    window: {
+      getFrame: () => frame,
+      setFrame: (x: number, y: number, width: number, height: number) => {
+        frame = { x, y, width, height };
+        calls.push([x, y, width, height]);
+      },
+    },
+    calls,
+  };
+}
+
+describe("scheduleDevtoolsLayoutRefresh", () => {
+  it("schedules one refresh per delay", () => {
+    const { window, calls } = collectWindow({
+      x: 1,
+      y: 2,
+      width: 300,
+      height: 400,
+    });
+    const scheduled: (() => void)[] = [];
+    scheduleDevtoolsLayoutRefresh(window, (cb) => {
+      scheduled.push(cb);
+      return 0;
+    });
+    expect(scheduled).toHaveLength(DEVTOOLS_LAYOUT_REFRESH_DELAYS_MS.length);
+    scheduled.forEach((cb) => cb());
+    // 32ms 步会 nudge 高度 -1，其余恢复原帧
+    expect(calls).toHaveLength(DEVTOOLS_LAYOUT_REFRESH_DELAYS_MS.length);
+    const nudge = calls[DEVTOOLS_LAYOUT_REFRESH_DELAYS_MS.indexOf(32)];
+    expect(nudge[3]).toBe(399);
+    expect(calls[0][3]).toBe(400);
+  });
+
+  it("returns early when the window lacks setFrame", () => {
+    const cb = vi.fn();
+    scheduleDevtoolsLayoutRefresh(
+      { getFrame: () => ({ x: 0, y: 0, width: 1, height: 1 }) },
+      cb,
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("returns early for null windows", () => {
+    const cb = vi.fn();
+    scheduleDevtoolsLayoutRefresh(null, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("tolerates getFrame throwing", () => {
+    const cb = vi.fn();
+    scheduleDevtoolsLayoutRefresh(
+      {
+        getFrame: () => {
+          throw new Error("boom");
+        },
+        setFrame: () => {},
+      },
+      cb,
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
