### PR TITLE
test(agent): cover session-utils

### DIFF
--- a/packages/agent/src/providers/session-utils.test.ts
+++ b/packages/agent/src/providers/session-utils.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit coverage for session-utils — default session-store path resolution
+ * under the resolved state dir, and the identity re-export of core's
+ * session provider collection. Drives the real module; resolveStateDir is
+ * the live core helper so path composition is asserted against the same
+ * directory the production plugin uses.
+ */
+import path from "node:path";
+import {
+  getSessionProviders as coreGetSessionProviders,
+  resolveStateDir,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  getSessionProviders,
+  resolveDefaultSessionStorePath,
+} from "./session-utils.ts";
+
+function storePath(agentId: string): string {
+  return path.join(
+    resolveStateDir(),
+    "agents",
+    agentId,
+    "sessions",
+    "sessions.json",
+  );
+}
+
+describe("resolveDefaultSessionStorePath", () => {
+  it("places sessions.json under the agent's sessions directory", () => {
+    expect(resolveDefaultSessionStorePath("agent-1")).toBe(
+      storePath("agent-1"),
+    );
+  });
+
+  it("defaults to the main agent when agentId is omitted", () => {
+    expect(resolveDefaultSessionStorePath()).toBe(storePath("main"));
+  });
+
+  it("defaults to the main agent when agentId is undefined", () => {
+    expect(resolveDefaultSessionStorePath(undefined)).toBe(storePath("main"));
+  });
+
+  it("does not coalesce an empty agentId to main", () => {
+    // ?? only treats null/undefined as missing; "" is a provided id.
+    // path.join drops empty segments, so this is not agents/main/...
+    expect(resolveDefaultSessionStorePath("")).toBe(
+      path.join(resolveStateDir(), "agents", "sessions", "sessions.json"),
+    );
+    expect(resolveDefaultSessionStorePath("")).not.toBe(storePath("main"));
+  });
+
+  it("preserves an agentId that contains path separators", () => {
+    expect(resolveDefaultSessionStorePath("team/alpha")).toBe(
+      storePath("team/alpha"),
+    );
+  });
+
+  it("keeps the leaf filename sessions.json", () => {
+    expect(path.basename(resolveDefaultSessionStorePath("x"))).toBe(
+      "sessions.json",
+    );
+  });
+});
+
+describe("getSessionProviders", () => {
+  it("re-exports the canonical collection by identity", () => {
+    expect(getSessionProviders).toBe(coreGetSessionProviders);
+  });
+
+  it("returns the three default session providers", () => {
+    const providers = getSessionProviders();
+    expect(providers.map((provider) => provider.name)).toEqual([
+      "session",
+      "sessionSkills",
+      "sendPolicy",
+    ]);
+  });
+
+  it("forwards storePath without changing provider names", () => {
+    const providers = getSessionProviders({
+      storePath: resolveDefaultSessionStorePath("agent-1"),
+    });
+    expect(providers).toHaveLength(3);
+    expect(providers.map((provider) => provider.name)).toEqual([
+      "session",
+      "sessionSkills",
+      "sendPolicy",
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds colocated unit coverage for `packages/agent/src/providers/session-utils.ts`, which previously had no sibling `session-utils.test.ts`. The module resolves the default session-store path under the agent's state directory and re-exports core's session provider collection.

The suite drives the real module (live `resolveStateDir` and live `getSessionProviders`), not a mock that returns X and then asserts X.

Covered behaviour:

- `resolveDefaultSessionStorePath("agent-1")` joins `<stateDir>/agents/agent-1/sessions/sessions.json`
- omitted and `undefined` agentId both default to `"main"`
- empty-string agentId is **not** coalesced to `"main"` (`??` only treats nullish); `path.join` drops the empty segment
- agentIds containing path separators are preserved as path segments
- leaf filename is always `sessions.json`
- `getSessionProviders` is the canonical core function by identity
- calling it returns the three default providers (`session`, `sessionSkills`, `sendPolicy`) and forwards `storePath` without renaming them

Diff is the new test file only. No production behaviour change.

An older mock-based file at `packages/agent/src/providers/__tests__/session-utils.test.ts` is unchanged.

## Evidence

1. `bunx vitest run packages/agent/src/providers/session-utils.test.ts`

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

2. `bunx biome check --write packages/agent/src/providers/session-utils.test.ts`

```
Checked 1 file in 53ms. Fixed 1 file.
```

Config proven present: `biome.json` and `tsconfig.json` exist in the checkout; `git sparse-checkout list` reports this worktree is not sparse.

3. `cd packages/agent && bunx tsc --noEmit` — the new colocated `src/providers/session-utils.test.ts` does not appear in the output. Pre-existing `TS2556` diagnostics in `src/providers/__tests__/session-utils.test.ts` are from the untouched mock file and are not introduced by this PR.

4. `git diff --stat origin/develop...HEAD` is only `packages/agent/src/providers/session-utils.test.ts` (91 insertions).

Hosted CI does not run on this fork contributor PR; the counts above are local.

## Test plan

- [x] Vitest: 1 file, 9 tests passed
- [x] Biome clean on the new file after `--write`
- [x] `tsc --noEmit` does not report the new test file
- [ ] Maintainer review (fork PRs do not get hosted CI)

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:80c42c43c48d2af7b9ed49b3d6db50287d8fdaa3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
