### PR TITLE
test(agent): cover conversation-proximity

### DIFF
--- a/packages/agent/src/providers/conversation-proximity.test.ts
+++ b/packages/agent/src/providers/conversation-proximity.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Deterministic coverage for conversationProximityProvider. The provider is
+ * real; getMemories is an in-memory fixture so aggregation, exclusion, sorting,
+ * empty-window, and text formatting can be asserted without a database.
+ */
+
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { conversationProximityProvider } from "./conversation-proximity.ts";
+
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+
+const ROOM_ID = "00000000-0000-4000-8000-0000000000aa" as UUID;
+const SENDER_ID = "00000000-0000-4000-8000-0000000000bb" as UUID;
+const AGENT_ID = "00000000-0000-4000-8000-0000000000cc" as UUID;
+const ALICE_ID = "00000000-0000-4000-8000-0000000000a1" as UUID;
+const BOB_ID = "00000000-0000-4000-8000-0000000000b1" as UUID;
+const CAROL_ID = "00000000-0000-4000-8000-0000000000c1" as UUID;
+
+function message(overrides: {
+  id?: UUID;
+  entityId?: UUID;
+  roomId?: UUID;
+  createdAt?: number;
+}): Memory {
+  return {
+    id: overrides.id ?? ("00000000-0000-4000-8000-000000000001" as UUID),
+    entityId: overrides.entityId ?? SENDER_ID,
+    roomId: overrides.roomId ?? ROOM_ID,
+    content: { text: "hello" },
+    createdAt: overrides.createdAt,
+  } as Memory;
+}
+
+function runtimeWithMemories(
+  memories: Memory[],
+  captured: { query?: unknown } = {},
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getMemories: async (query: unknown) => {
+      captured.query = query;
+      return memories;
+    },
+  } as unknown as IAgentRuntime;
+}
+
+describe("conversationProximityProvider", () => {
+  it("declares turn-scoped metadata used by provider routing", () => {
+    expect(conversationProximityProvider.name).toBe("CONVERSATION_PROXIMITY");
+    expect(conversationProximityProvider.description).toBe(
+      "Recent co-participants in the current room with message counts and last-seen timestamps.",
+    );
+    expect(conversationProximityProvider.dynamic).toBe(true);
+    expect(conversationProximityProvider.position).toBe(40);
+    expect(conversationProximityProvider.cacheStable).toBe(false);
+    expect(conversationProximityProvider.cacheScope).toBe("turn");
+  });
+
+  it("returns empty context when the sender entity is missing", async () => {
+    const captured: { query?: unknown } = {};
+    const runtime = runtimeWithMemories(
+      [message({ entityId: ALICE_ID, createdAt: 10 })],
+      captured,
+    );
+    const inbound = {
+      id: "00000000-0000-4000-8000-000000000002" as UUID,
+      roomId: ROOM_ID,
+      content: { text: "hi" },
+    } as Memory;
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      inbound,
+      EMPTY_STATE,
+    );
+
+    expect(captured.query).toBeUndefined();
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+  });
+
+  it("returns empty context when the room is missing", async () => {
+    const captured: { query?: unknown } = {};
+    const runtime = runtimeWithMemories(
+      [message({ entityId: ALICE_ID, createdAt: 10 })],
+      captured,
+    );
+    const inbound = {
+      id: "00000000-0000-4000-8000-000000000003" as UUID,
+      entityId: SENDER_ID,
+      content: { text: "hi" },
+    } as Memory;
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      inbound,
+      EMPTY_STATE,
+    );
+
+    expect(captured.query).toBeUndefined();
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+  });
+
+  it("returns empty text for an empty recent-message window", async () => {
+    const captured: { query?: unknown } = {};
+    const runtime = runtimeWithMemories([], captured);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID, roomId: ROOM_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(captured.query).toEqual({
+      roomId: ROOM_ID,
+      tableName: "messages",
+      limit: 20,
+      unique: false,
+    });
+    expect(result.text).toBe("");
+    expect(result.values).toEqual({ conversationProximityParticipants: [] });
+    expect(result.data).toEqual({ coParticipants: [] });
+  });
+
+  it("skips memories without an entity, the sender, and the agent itself", async () => {
+    const runtime = runtimeWithMemories([
+      {
+        id: "00000000-0000-4000-8000-000000000010" as UUID,
+        roomId: ROOM_ID,
+        content: { text: "hello" },
+        createdAt: 30,
+      } as Memory,
+      message({
+        id: "00000000-0000-4000-8000-000000000011" as UUID,
+        entityId: SENDER_ID,
+        createdAt: 40,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000012" as UUID,
+        entityId: AGENT_ID,
+        createdAt: 50,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000013" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 20,
+      }),
+    ]);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(result.values?.conversationProximityParticipants).toEqual([
+      { entityId: ALICE_ID, lastSeen: 20, messageCount: 1 },
+    ]);
+    expect(result.data?.coParticipants).toEqual(
+      result.values?.conversationProximityParticipants,
+    );
+    expect(result.text).toBe(
+      `Conversation proximity:\n- ${ALICE_ID}: 1 recent messages, last seen 20`,
+    );
+  });
+
+  it("aggregates a single co-participant across repeats and missing createdAt", async () => {
+    const runtime = runtimeWithMemories([
+      message({
+        id: "00000000-0000-4000-8000-000000000020" as UUID,
+        entityId: ALICE_ID,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000021" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 7,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000022" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 3,
+      }),
+    ]);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(result.values?.conversationProximityParticipants).toEqual([
+      { entityId: ALICE_ID, lastSeen: 7, messageCount: 3 },
+    ]);
+  });
+
+  it("orders co-participants most-recent first", async () => {
+    const runtime = runtimeWithMemories([
+      message({
+        id: "00000000-0000-4000-8000-000000000030" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 10,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000031" as UUID,
+        entityId: BOB_ID,
+        createdAt: 30,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000032" as UUID,
+        entityId: CAROL_ID,
+        createdAt: 20,
+      }),
+    ]);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(result.data?.coParticipants).toEqual([
+      { entityId: BOB_ID, lastSeen: 30, messageCount: 1 },
+      { entityId: CAROL_ID, lastSeen: 20, messageCount: 1 },
+      { entityId: ALICE_ID, lastSeen: 10, messageCount: 1 },
+    ]);
+  });
+
+  it("breaks lastSeen ties by message count descending", async () => {
+    const runtime = runtimeWithMemories([
+      message({
+        id: "00000000-0000-4000-8000-000000000040" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 100,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000041" as UUID,
+        entityId: BOB_ID,
+        createdAt: 100,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000042" as UUID,
+        entityId: BOB_ID,
+        createdAt: 50,
+      }),
+    ]);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(result.values?.conversationProximityParticipants).toEqual([
+      { entityId: BOB_ID, lastSeen: 100, messageCount: 2 },
+      { entityId: ALICE_ID, lastSeen: 100, messageCount: 1 },
+    ]);
+  });
+
+  it("breaks lastSeen and count ties with entityId localeCompare", async () => {
+    const runtime = runtimeWithMemories([
+      message({
+        id: "00000000-0000-4000-8000-000000000050" as UUID,
+        entityId: BOB_ID,
+        createdAt: 5,
+      }),
+      message({
+        id: "00000000-0000-4000-8000-000000000051" as UUID,
+        entityId: ALICE_ID,
+        createdAt: 5,
+      }),
+    ]);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(result.data?.coParticipants).toEqual([
+      { entityId: ALICE_ID, lastSeen: 5, messageCount: 1 },
+      { entityId: BOB_ID, lastSeen: 5, messageCount: 1 },
+    ]);
+    expect(ALICE_ID.localeCompare(BOB_ID)).toBeLessThan(0);
+  });
+
+  it("processes every memory the query returns rather than applying a second cap", async () => {
+    const overflow = Array.from({ length: 21 }, (_, index) =>
+      message({
+        id: `00000000-0000-4000-8000-${String(index + 100).padStart(12, "0")}` as UUID,
+        entityId: ALICE_ID,
+        createdAt: index + 1,
+      }),
+    );
+    const captured: { query?: unknown } = {};
+    const runtime = runtimeWithMemories(overflow, captured);
+
+    const result = await conversationProximityProvider.get(
+      runtime,
+      message({ entityId: SENDER_ID }),
+      EMPTY_STATE,
+    );
+
+    expect(captured.query).toEqual({
+      roomId: ROOM_ID,
+      tableName: "messages",
+      limit: 20,
+      unique: false,
+    });
+    expect(result.values?.conversationProximityParticipants).toEqual([
+      { entityId: ALICE_ID, lastSeen: 21, messageCount: 21 },
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named unit suite for `packages/agent/src/providers/conversation-proximity.ts`, which previously had no dedicated test file. The production provider is unchanged.

`conversationProximityProvider.get` is driven for real. `getMemories` is an in-memory fixture so the suite can assert aggregation and ordering without a database. It does not stub the provider itself.

Covered behavior:

- Provider routing metadata (`name`, `dynamic`, `position`, `cacheStable`, `cacheScope`)
- Missing `entityId` or `roomId` on the inbound message returns empty context and does not query memories
- Empty recent-message window returns empty text plus empty `conversationProximityParticipants` / `coParticipants`
- Memories without an entity, from the sender, or from the agent are skipped
- A single co-participant is aggregated across repeats; missing `createdAt` is treated as `0` and `lastSeen` is the max
- Sort: `lastSeen` descending, then `messageCount` descending, then `entityId` via `localeCompare`
- Query window is `limit: 20`, `unique: false`, `tableName: "messages"`; the provider does not apply a second cap on whatever the query returns

## Evidence

1. `bunx vitest run packages/agent/src/providers/conversation-proximity.test.ts` — **Test Files 1 passed (1), Tests 10 passed (10)** (vitest v4.1.10, duration 285ms).
2. `bunx biome check --write packages/agent/src/providers/conversation-proximity.test.ts` — **Checked 1 file in 255ms. No fixes applied.** Config proof: checkout `biome.json` and `tsconfig.json` exist; `git sparse-checkout list` reports this worktree is not sparse.
3. `cd packages/agent && bunx tsc --noEmit` — grep for `conversation-proximity.test.ts` is empty (`GREP_EXIT:1`). Pre-existing package errors remain; this file introduced none.
4. Diff touches **only** `packages/agent/src/providers/conversation-proximity.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are local.

## Test plan

- [x] Focused vitest file passes (10/10)
- [x] Biome clean on the new file
- [x] `tsc --noEmit` does not mention the new file
- [ ] Maintainer review

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:88f223907414a5eb3d485e0f2505c77312fd7d5e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
