### PR TITLE
fix(ui): safe NaN handling in account priority, lastUsed, and reset time sort comparators

### DIFF
--- a/packages/ui/src/components/accounts/AccountCommandTable.tsx
+++ b/packages/ui/src/components/accounts/AccountCommandTable.tsx
@@ -253,7 +253,12 @@ export function AccountCommandTable({
   // up/down always targets the correct neighbour even when the user has
   // sorted the table by health or usage.
   const priorityOrder = useMemo(
-    () => [...accounts].sort((a, b) => a.priority - b.priority),
+    () =>
+      [...accounts].sort(
+        (a, b) =>
+          (Number.isFinite(a.priority) ? a.priority : 0) -
+          (Number.isFinite(b.priority) ? b.priority : 0),
+      ),
     [accounts],
   );
 

--- a/packages/ui/src/components/accounts/AccountList.tsx
+++ b/packages/ui/src/components/accounts/AccountList.tsx
@@ -56,7 +56,11 @@ export function AccountList({ providerId }: AccountListProps) {
   const sorted: AccountWithCredentialFlag[] = useMemo(
     () =>
       providerEntry
-        ? [...providerEntry.accounts].sort((a, b) => a.priority - b.priority)
+        ? [...providerEntry.accounts].sort(
+            (a, b) =>
+              (Number.isFinite(a.priority) ? a.priority : 0) -
+              (Number.isFinite(b.priority) ? b.priority : 0),
+          )
         : [],
     [providerEntry],
   );

--- a/packages/ui/src/components/accounts/ProviderAccountRow.tsx
+++ b/packages/ui/src/components/accounts/ProviderAccountRow.tsx
@@ -184,7 +184,12 @@ export function ProviderAccountRow({
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const accounts = provider?.accounts ?? [];
   const sorted = useMemo(
-    () => [...accounts].sort((a, b) => a.priority - b.priority),
+    () =>
+      [...accounts].sort(
+        (a, b) =>
+          (Number.isFinite(a.priority) ? a.priority : 0) -
+          (Number.isFinite(b.priority) ? b.priority : 0),
+      ),
     [accounts],
   );
   // A table earns its keep only for a genuinely multi-account pool; small

--- a/packages/ui/src/components/accounts/account-table-model.safe-sort.test.ts
+++ b/packages/ui/src/components/accounts/account-table-model.safe-sort.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Verifies safe sorting in account table model and reset-time helpers when timestamps, priority, or usage contains NaN.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sortAccounts, type AccountWithCredentialFlag } from "./account-table-model.js";
+import { bySoonestReset } from "./reset-time.js";
+
+function makeAccount(
+  id: string,
+  overrides: Partial<AccountWithCredentialFlag> = {},
+): AccountWithCredentialFlag {
+  return {
+    id,
+    providerId: "anthropic-api",
+    label: id,
+    source: "api-key",
+    enabled: true,
+    health: "ok",
+    priority: 1,
+    createdAt: 1000,
+    hasCredential: true,
+    ...overrides,
+  };
+}
+
+describe("account-table-model safe sort", () => {
+  it("safely sorts accounts by priority when priority is NaN or Infinity", () => {
+    const a1 = makeAccount("a1", { priority: 10 });
+    const aNan = makeAccount("aNan", { priority: NaN });
+    const aInf = makeAccount("aInf", { priority: Infinity });
+    const a2 = makeAccount("a2", { priority: 20 });
+
+    const sorted = sortAccounts([a2, aNan, a1, aInf], {
+      key: "priority",
+      direction: "asc",
+    });
+
+    expect(sorted).toHaveLength(4);
+    // Non-finite priority falls back to 0, so aNan/aInf come before 10 and 20
+    expect(sorted.map((a) => a.id)).toContain("a1");
+    expect(sorted.map((a) => a.id)).toContain("a2");
+    expect(sorted.map((a) => a.id)).toContain("aNan");
+    expect(sorted.map((a) => a.id)).toContain("aInf");
+  });
+
+  it("safely sorts accounts by lastUsed when lastUsedAt contains NaN", () => {
+    const a1 = makeAccount("a1", { lastUsedAt: 1000 });
+    const aNan = makeAccount("aNan", { lastUsedAt: NaN });
+    const a2 = makeAccount("a2", { lastUsedAt: 2000 });
+
+    const sortedAsc = sortAccounts([a2, aNan, a1], {
+      key: "lastUsed",
+      direction: "asc",
+    });
+    expect(sortedAsc).toHaveLength(3);
+    // NaN treated as 0 in ascending order
+    expect(sortedAsc[0].id).toBe("aNan");
+    expect(sortedAsc[1].id).toBe("a1");
+    expect(sortedAsc[2].id).toBe("a2");
+
+    const sortedDesc = sortAccounts([a2, aNan, a1], {
+      key: "lastUsed",
+      direction: "desc",
+    });
+    expect(sortedDesc).toHaveLength(3);
+    expect(sortedDesc[0].id).toBe("a2");
+    expect(sortedDesc[1].id).toBe("a1");
+    expect(sortedDesc[2].id).toBe("aNan");
+  });
+
+  it("safely resolves bySoonestReset when reset timestamps contain NaN", () => {
+    const acc1 = makeAccount("acc1", {
+      usage: {
+        sessionPct: 50,
+        weeklyPct: 50,
+        sessionResetAt: NaN,
+        weeklyResetAt: 1000,
+      } as unknown as AccountWithCredentialFlag["usage"],
+    });
+
+    const acc2 = makeAccount("acc2", {
+      usage: {
+        sessionPct: 50,
+        weeklyPct: 50,
+        sessionResetAt: 2000,
+        weeklyResetAt: 3000,
+      } as unknown as AccountWithCredentialFlag["usage"],
+    });
+
+    const result = bySoonestReset(acc1, acc2);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/accounts/account-table-model.ts
+++ b/packages/ui/src/components/accounts/account-table-model.ts
@@ -11,6 +11,17 @@
 import type { AccountWithCredentialFlag } from "../../api/client-agent";
 import { weeklyResetAt } from "./reset-time";
 
+export type { AccountWithCredentialFlag };
+
+/**
+ * Number.isFinite is not a type predicate, so it cannot narrow an optional
+ * numeric field. Coerce explicitly so comparators stay total under strict
+ * null checks.
+ */
+function finiteOrZero(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export type AccountHealthTone = "success" | "warning" | "danger" | "muted";
 
 export interface AccountHealthDescriptor {
@@ -168,9 +179,15 @@ function compareByKey(
       return (au - bu) * factor;
     }
     case "lastUsed":
-      return ((a.lastUsedAt ?? 0) - (b.lastUsedAt ?? 0)) * factor;
+      return (
+        (finiteOrZero(a.lastUsedAt) - finiteOrZero(b.lastUsedAt)) *
+        factor
+      );
     case "priority":
-      return (a.priority - b.priority) * factor;
+      return (
+        (finiteOrZero(a.priority) - finiteOrZero(b.priority)) *
+        factor
+      );
     default:
       return 0;
   }
@@ -187,7 +204,12 @@ export function sortAccounts(
   return [...accounts].sort((a, b) => {
     const primary = compareByKey(a, b, sort);
     if (primary !== 0) return primary;
-    if (a.priority !== b.priority) return a.priority - b.priority;
+    if (a.priority !== b.priority) {
+      return (
+        (Number.isFinite(a.priority) ? a.priority : 0) -
+        (Number.isFinite(b.priority) ? b.priority : 0)
+      );
+    }
     return a.id.localeCompare(b.id);
   });
 }

--- a/packages/ui/src/components/accounts/reset-time.ts
+++ b/packages/ui/src/components/accounts/reset-time.ts
@@ -63,6 +63,15 @@ export function weeklyResetAt(
  * instant come before those without; unknowns fall back to least-recently
  * used (proxy for least-recently-throttled) so the ordering is still stable.
  */
+/**
+ * Number.isFinite is not a type predicate, so it cannot narrow an optional
+ * numeric field. Coerce explicitly so the comparator stays total under strict
+ * null checks.
+ */
+function finiteOrZeroTimestamp(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export function bySoonestReset(
   a: AccountWithCredentialFlag,
   b: AccountWithCredentialFlag,
@@ -70,12 +79,18 @@ export function bySoonestReset(
   const ar = accountResetAt(a);
   const br = accountResetAt(b);
   if (ar != null && br != null) {
-    if (ar !== br) return ar - br;
+    if (ar !== br) {
+      return (
+        (Number.isFinite(ar) ? ar : 0) - (Number.isFinite(br) ? br : 0)
+      );
+    }
   } else if (ar != null) {
     return -1;
   } else if (br != null) {
     return 1;
   }
   // Both unknown: least-recently-used first (held-in-reserve heuristic).
-  return (a.lastUsedAt ?? 0) - (b.lastUsedAt ?? 0);
+  return (
+    finiteOrZeroTimestamp(a.lastUsedAt) - finiteOrZeroTimestamp(b.lastUsedAt)
+  );
 }

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -106,7 +106,11 @@ function replaceAccount(
         accounts: (existing
           ? p.accounts.map((a) => (a.id === next.id ? merged : a))
           : [...p.accounts, merged]
-        ).sort((a, b) => a.priority - b.priority),
+        ).sort(
+          (a, b) =>
+            (Number.isFinite(a.priority) ? a.priority : 0) -
+            (Number.isFinite(b.priority) ? b.priority : 0),
+        ),
       };
     }),
   };
@@ -208,7 +212,11 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
               const accounts = [
                 ...p.accounts,
                 { ...created, hasCredential: true },
-              ].sort((a, b) => a.priority - b.priority);
+              ].sort(
+                (a, b) =>
+                  (Number.isFinite(a.priority) ? a.priority : 0) -
+                  (Number.isFinite(b.priority) ? b.priority : 0),
+              );
               return { ...p, accounts };
             }),
           };
@@ -240,7 +248,11 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
               ...p,
               accounts: p.accounts
                 .map((a) => (a.id === accountId ? { ...a, ...body } : a))
-                .sort((x, y) => x.priority - y.priority),
+                .sort(
+                  (x, y) =>
+                    (Number.isFinite(x.priority) ? x.priority : 0) -
+                    (Number.isFinite(y.priority) ? y.priority : 0),
+                ),
             };
           }),
         };


### PR DESCRIPTION
## Summary
Guards numeric sort comparators against `NaN` and non-finite values across account management in `packages/ui`:

- **Account Table Model**: Guard `lastUsedAt` and `priority` subtractions in `compareByKey` and tiebreak sorting in `sortAccounts`.
- **Reset Time**: Guard `accountResetAt` and fallback `lastUsedAt` subtractions in `bySoonestReset` against `NaN`.
- **Account Views & Hooks**: Guard priority sorting in `AccountList`, `AccountCommandTable`, `ProviderAccountRow`, and `useAccounts`.

## Verification
- Added dedicated regression unit test:
  - `packages/ui/src/components/accounts/account-table-model.safe-sort.test.ts`
- Verified unit test suites pass with Vitest:
  ```
  ✓ packages/ui/src/components/accounts/reset-time.test.ts (11 tests)
  ✓ packages/ui/src/components/accounts/account-table-model.safe-sort.test.ts (3 tests)
  ✓ packages/ui/src/components/accounts/account-table-model.test.ts (17 tests)
  ```