### PR TITLE
test(agent): cover first-run-names pool

### DIFF
--- a/packages/agent/src/runtime/first-run-names.test.ts
+++ b/packages/agent/src/runtime/first-run-names.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Deterministic coverage for the first-run agent name pool: constant pool
+ * shape, default-name ordering, clamping, uniqueness, and pool-size bounds.
+ * The shuffle uses Math.random, so uniqueness and bounds are asserted
+ * statistically over many draws.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_NAME_POOL,
+  DEFAULT_AGENT_NAME,
+  pickRandomNames,
+} from "./first-run-names.ts";
+
+describe("first-run-names pool", () => {
+  it("exposes the default agent name first", () => {
+    expect(DEFAULT_AGENT_NAME).toBe("Eliza");
+    expect(AGENT_NAME_POOL[0]).toBe(DEFAULT_AGENT_NAME);
+  });
+
+  it("keeps the pool non-empty and unique", () => {
+    expect(AGENT_NAME_POOL.length).toBeGreaterThan(10);
+    expect(new Set(AGENT_NAME_POOL).size).toBe(AGENT_NAME_POOL.length);
+  });
+
+  it("returns an empty list for non-positive counts", () => {
+    expect(pickRandomNames(0)).toEqual([]);
+    expect(pickRandomNames(-3)).toEqual([]);
+  });
+
+  it("always keeps the default agent name first", () => {
+    for (let i = 0; i < 50; i += 1) {
+      const names = pickRandomNames(5);
+      expect(names[0]).toBe(DEFAULT_AGENT_NAME);
+      expect(names.length).toBe(5);
+    }
+  });
+
+  it("returns unique names for a draw", () => {
+    for (let i = 0; i < 50; i += 1) {
+      const names = pickRandomNames(10);
+      expect(new Set(names).size).toBe(names.length);
+    }
+  });
+
+  it("clamps counts above the pool size to the pool length", () => {
+    const names = pickRandomNames(AGENT_NAME_POOL.length + 10);
+    expect(names.length).toBe(AGENT_NAME_POOL.length);
+    expect(new Set(names).size).toBe(AGENT_NAME_POOL.length);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
