### PR TITLE
test(agent): cover first-run-names

### DIFF
--- a/packages/agent/src/runtime/first-run-names.test.ts
+++ b/packages/agent/src/runtime/first-run-names.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Behavioral coverage for the first-run agent name pool and pickRandomNames.
+ * Drives the real module: default-first ordering, uniqueness, empty and
+ * single-element selection, clamp/overflow, and Fisher-Yates shuffle edges.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AGENT_NAME_POOL,
+  DEFAULT_AGENT_NAME,
+  pickRandomNames,
+} from "./first-run-names.ts";
+
+const RANDOM_AGENT_NAMES = AGENT_NAME_POOL.slice(1);
+
+describe("first-run-names", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports Eliza as the default first-run agent name", () => {
+    expect(DEFAULT_AGENT_NAME).toBe("Eliza");
+  });
+
+  it("keeps the default name first in the published pool and lists each name once", () => {
+    expect(AGENT_NAME_POOL[0]).toBe(DEFAULT_AGENT_NAME);
+    expect(AGENT_NAME_POOL).toEqual([
+      "Eliza",
+      "Reimu",
+      "Sakuya",
+      "Yukari",
+      "Marisa",
+      "Youmu",
+      "Koakuma",
+      "Reisen",
+      "Yuyuko",
+      "Aya",
+      "Ran",
+      "Sanae",
+      "Suika",
+      "Koishi",
+      "Nue",
+      "Mokou",
+      "Satori",
+      "Remilia",
+      "Suwako",
+      "Momiji",
+      "Tenshi",
+      "Kaguya",
+      "Komachi",
+      "Nitori",
+      "Charlotte",
+      "Kasen",
+      "Mima",
+      "Yuuka",
+      "Kogasa",
+      "Rin",
+      "Tewi",
+      "Eirin",
+      "Hina",
+      "Kagerou",
+      "Sumireko",
+      "Kokoro",
+      "Mamizou",
+      "Rinnosuke",
+      "Yumemi",
+      "Akyuu",
+      "Kanako",
+      "Hatsune",
+      "Shinki",
+      "Shion",
+      "Daiyousei",
+      "Iku",
+      "Miya",
+      "Mai",
+      "Meira",
+      "Murasa",
+      "Usagi",
+      "Rei",
+      "Yumi",
+      "Miku",
+      "Kira",
+    ]);
+    expect(new Set(AGENT_NAME_POOL).size).toBe(AGENT_NAME_POOL.length);
+    expect(RANDOM_AGENT_NAMES).not.toContain(DEFAULT_AGENT_NAME);
+  });
+
+  it("returns an empty list when count is zero or negative", () => {
+    expect(pickRandomNames(0)).toEqual([]);
+    expect(pickRandomNames(-1)).toEqual([]);
+    expect(pickRandomNames(-100)).toEqual([]);
+    expect(pickRandomNames(Number.NEGATIVE_INFINITY)).toEqual([]);
+  });
+
+  it("returns only the default name for a single-element request", () => {
+    expect(pickRandomNames(1)).toEqual([DEFAULT_AGENT_NAME]);
+  });
+
+  it("keeps the default name first and fills the rest with unique pool members", () => {
+    const names = pickRandomNames(4);
+    expect(names).toHaveLength(4);
+    expect(names[0]).toBe(DEFAULT_AGENT_NAME);
+    expect(new Set(names).size).toBe(4);
+    expect(AGENT_NAME_POOL).toEqual(expect.arrayContaining(names));
+    expect(names.slice(1)).not.toContain(DEFAULT_AGENT_NAME);
+  });
+
+  it("clamps overflow to the full pool and still keeps the default name first", () => {
+    const overflow = pickRandomNames(AGENT_NAME_POOL.length + 25);
+    expect(overflow).toHaveLength(AGENT_NAME_POOL.length);
+    expect(overflow[0]).toBe(DEFAULT_AGENT_NAME);
+    expect(new Set(overflow)).toEqual(new Set(AGENT_NAME_POOL));
+  });
+
+  it("returns every pool name exactly once when count equals pool capacity", () => {
+    const names = pickRandomNames(AGENT_NAME_POOL.length);
+    expect(names).toHaveLength(AGENT_NAME_POOL.length);
+    expect(names[0]).toBe(DEFAULT_AGENT_NAME);
+    expect(new Set(names)).toEqual(new Set(AGENT_NAME_POOL));
+  });
+
+  it("does not mutate the published pool and returns a fresh array each call", () => {
+    const snapshot = [...AGENT_NAME_POOL];
+    const first = pickRandomNames(5);
+    const second = pickRandomNames(5);
+    first.push("not-a-pool-name");
+    expect(AGENT_NAME_POOL).toEqual(snapshot);
+    expect(second).not.toBe(first);
+    expect(second).not.toContain("not-a-pool-name");
+  });
+
+  it("skips shuffling when the clamped count is empty and shuffles otherwise", () => {
+    const spy = vi.spyOn(Math, "random");
+    expect(pickRandomNames(0)).toEqual([]);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockClear();
+    pickRandomNames(1);
+    expect(spy.mock.calls.length).toBe(RANDOM_AGENT_NAMES.length - 1);
+  });
+
+  it("rotates the random pool left by one when Math.random is always 0", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(pickRandomNames(4)).toEqual([
+      DEFAULT_AGENT_NAME,
+      RANDOM_AGENT_NAMES[1],
+      RANDOM_AGENT_NAMES[2],
+      RANDOM_AGENT_NAMES[3],
+    ]);
+  });
+
+  it("keeps random-pool order when Math.random always selects the current index", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.999999999999);
+    expect(pickRandomNames(4)).toEqual([
+      DEFAULT_AGENT_NAME,
+      RANDOM_AGENT_NAMES[0],
+      RANDOM_AGENT_NAMES[1],
+      RANDOM_AGENT_NAMES[2],
+    ]);
+  });
+
+  it("treats fractional counts below 2 as a single default-name result", () => {
+    expect(pickRandomNames(0.5)).toEqual([DEFAULT_AGENT_NAME]);
+    expect(pickRandomNames(1.9)).toEqual([DEFAULT_AGENT_NAME]);
+  });
+
+  it("treats NaN as a single default-name result and Infinity as the full pool", () => {
+    expect(pickRandomNames(Number.NaN)).toEqual([DEFAULT_AGENT_NAME]);
+    const infinite = pickRandomNames(Number.POSITIVE_INFINITY);
+    expect(infinite).toHaveLength(AGENT_NAME_POOL.length);
+    expect(infinite[0]).toBe(DEFAULT_AGENT_NAME);
+    expect(new Set(infinite)).toEqual(new Set(AGENT_NAME_POOL));
+  });
+
+  it("actually permutes the non-default names across independent draws", () => {
+    const seconds = new Set<string>();
+    for (let i = 0; i < 40; i++) {
+      const names = pickRandomNames(3);
+      expect(names[0]).toBe(DEFAULT_AGENT_NAME);
+      const second = names[1];
+      expect(typeof second).toBe("string");
+      if (second !== undefined) {
+        seconds.add(second);
+      }
+    }
+    expect(seconds.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/agent/src/runtime/first-run-names.ts`, which previously had no dedicated test file. Production code is unchanged.

The suite drives the real module and covers:

- `DEFAULT_AGENT_NAME` is `Eliza`
- `AGENT_NAME_POOL` composition: default first, 55 unique names, default not in the random tail
- `pickRandomNames(0)` / negative / `-Infinity` → empty list
- single-element request → `[Eliza]`
- default-first ordering, uniqueness, and subset of the published pool
- overflow clamp to pool capacity
- full-capacity draw returns every pool name once
- published pool is not mutated; each call returns a fresh array
- empty selection skips `Math.random`; non-empty selection shuffles
- Fisher-Yates edges with a fixed RNG (`0` rotates left; `~1` keeps order)
- fractional counts in `(0, 2)` and `NaN` → `[Eliza]`; `Infinity` → full pool
- independent draws actually permute the non-default names

## Evidence

1. `bunx vitest run src/runtime/first-run-names.test.ts` from `packages/agent`: **1 file, 14 tests passed** (249ms).
2. `bunx biome check --write packages/agent/src/runtime/first-run-names.test.ts`: **Checked 1 file, no fixes applied.** `biome.json` is present in the checkout.
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep first-run-names.test.ts ; echo EXIT:$?` → no matches, `EXIT:1` (this file introduced no TypeScript diagnostics). Pre-existing package errors, if any, are not from this file.
4. Diff vs `origin/develop` is **only** `packages/agent/src/runtime/first-run-names.test.ts`.

Hosted CI does not run on this fork contributor PR. The counts above are from local `bunx` on the shared checkout.

## Test plan

- [x] Vitest collects and passes the new file
- [x] Biome clean on the new file
- [x] Package `tsc --noEmit` does not name the new file
- [ ] Maintainer review / merge

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:317debe5f02ed8413e543270ebf14d2a77096755 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
