### PR TITLE
test(agent): cover version-resolver precedence

### DIFF
--- a/packages/agent/src/version-resolver.test.ts
+++ b/packages/agent/src/version-resolver.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Coverage for the Eliza version resolver: precedence order, module-not-found
+ * swallowing, env override, and the 0.0.0 fallback. createRequire is mocked so
+ * package/build-info lookups are deterministic.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createRequire: vi.fn(),
+}));
+
+vi.mock("node:module", () => ({
+  createRequire: mocks.createRequire,
+}));
+
+type VersionModule = {
+  resolveElizaVersion: (moduleUrl: string) => string;
+};
+
+async function loadResolver(): Promise<VersionModule> {
+  vi.resetModules();
+  return import("./version-resolver.ts");
+}
+
+function makeRequireFn(
+  overrides: {
+    packageJson?: unknown;
+    buildInfos?: Record<string, unknown>;
+  } = {},
+) {
+  const packageJson = overrides.packageJson;
+  const buildInfos = overrides.buildInfos ?? {};
+  return vi.fn((specifier: string) => {
+    if (specifier === "../../package.json") {
+      if (packageJson === undefined) {
+        const err = new Error("module not found") as NodeJS.ErrnoException;
+        err.code = "MODULE_NOT_FOUND";
+        throw err;
+      }
+      return packageJson;
+    }
+    if (specifier in buildInfos) {
+      return buildInfos[specifier];
+    }
+    const err = new Error("module not found") as NodeJS.ErrnoException;
+    err.code = "MODULE_NOT_FOUND";
+    throw err;
+  });
+}
+
+beforeEach(() => {
+  mocks.createRequire.mockReset();
+  delete process.env.ELIZA_BUNDLED_VERSION;
+});
+
+describe("resolveElizaVersion", () => {
+  it("prefers the build-injected __ELIZA_VERSION__ global", async () => {
+    const g = globalThis as Record<string, unknown>;
+    const previous = g.__ELIZA_VERSION__;
+    g.__ELIZA_VERSION__ = "9.9.9";
+    try {
+      mocks.createRequire.mockReturnValue(makeRequireFn());
+      const mod = await loadResolver();
+      expect(mod.resolveElizaVersion("/tmp/x")).toBe("9.9.9");
+    } finally {
+      if (previous === undefined) delete g.__ELIZA_VERSION__;
+      else g.__ELIZA_VERSION__ = previous;
+    }
+  });
+
+  it("falls back to the ELIZA_BUNDLED_VERSION env var", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "2.3.4";
+    mocks.createRequire.mockReturnValue(makeRequireFn());
+    const mod = await loadResolver();
+    expect(mod.resolveElizaVersion("/tmp/x")).toBe("2.3.4");
+  });
+
+  it("reads the version from package.json", async () => {
+    mocks.createRequire.mockReturnValue(
+      makeRequireFn({ packageJson: { version: "1.2.3" } }),
+    );
+    const mod = await loadResolver();
+    expect(mod.resolveElizaVersion("/tmp/x")).toBe("1.2.3");
+  });
+
+  it("reads the version from a build-info candidate", async () => {
+    mocks.createRequire.mockReturnValue(
+      makeRequireFn({
+        packageJson: undefined,
+        buildInfos: { "../../build-info.json": { version: "0.5.0" } },
+      }),
+    );
+    const mod = await loadResolver();
+    expect(mod.resolveElizaVersion("/tmp/x")).toBe("0.5.0");
+  });
+
+  it("tries later build-info candidates when the first is missing", async () => {
+    mocks.createRequire.mockReturnValue(
+      makeRequireFn({
+        buildInfos: { "../build-info.json": { version: "0.6.0" } },
+      }),
+    );
+    const mod = await loadResolver();
+    expect(mod.resolveElizaVersion("/tmp/x")).toBe("0.6.0");
+  });
+
+  it("falls back to 0.0.0 when every source is missing", async () => {
+    mocks.createRequire.mockReturnValue(makeRequireFn());
+    const mod = await loadResolver();
+    expect(mod.resolveElizaVersion("/tmp/x")).toBe("0.0.0");
+  });
+
+  it("propagates non-module-not-found require errors", async () => {
+    const requireFn = vi.fn(() => {
+      throw new Error("EACCES: permission denied");
+    });
+    mocks.createRequire.mockReturnValue(requireFn as never);
+    const mod = await loadResolver();
+    expect(() => mod.resolveElizaVersion("/tmp/x")).toThrow(/EACCES/);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  7 passed (7)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
