### PR TITLE
test(agent): cover local-execution-mode

### DIFF
--- a/packages/agent/src/runtime/local-execution-mode.test.ts
+++ b/packages/agent/src/runtime/local-execution-mode.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Behavioral coverage for the agent `local-execution-mode` re-export shim.
+ * Drives the real resolvers through this historical import path: setting-key
+ * order, env fallback, invalid/empty/non-string values, default mode, iOS
+ * local-yolo clamp, and the local-safe / sandbox / cloud helpers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isCloudExecutionMode,
+  type RuntimeExecutionModeSource,
+  resolveLocalExecutionMode,
+  resolveRuntimeExecutionMode,
+  shouldUseSandboxExecution,
+} from "./local-execution-mode.ts";
+
+const SETTING_KEYS = [
+  "ELIZA_RUNTIME_MODE",
+  "RUNTIME_MODE",
+  "LOCAL_RUNTIME_MODE",
+] as const;
+
+function sourceFrom(
+  values: Partial<Record<(typeof SETTING_KEYS)[number], unknown>>,
+): RuntimeExecutionModeSource {
+  return {
+    getSetting: (key: string) => values[key as (typeof SETTING_KEYS)[number]],
+  };
+}
+
+function recordingSource(
+  values: Partial<Record<(typeof SETTING_KEYS)[number], unknown>>,
+): { source: RuntimeExecutionModeSource; keys: string[] } {
+  const keys: string[] = [];
+  return {
+    keys,
+    source: {
+      getSetting: (key: string) => {
+        keys.push(key);
+        return values[key as (typeof SETTING_KEYS)[number]];
+      },
+    },
+  };
+}
+
+describe("local-execution-mode", () => {
+  beforeEach(() => {
+    vi.stubEnv("ELIZA_RUNTIME_MODE", undefined);
+    vi.stubEnv("RUNTIME_MODE", undefined);
+    vi.stubEnv("LOCAL_RUNTIME_MODE", undefined);
+    vi.stubEnv("ELIZA_PLATFORM", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("resolveRuntimeExecutionMode", () => {
+    it("defaults to local-yolo when the source and env queue are empty", () => {
+      expect(resolveRuntimeExecutionMode()).toBe("local-yolo");
+      expect(resolveRuntimeExecutionMode(null)).toBe("local-yolo");
+      expect(resolveRuntimeExecutionMode(undefined)).toBe("local-yolo");
+      expect(resolveRuntimeExecutionMode({})).toBe("local-yolo");
+    });
+
+    it("reads a single present setting and ignores later empty keys", () => {
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" }),
+        ),
+      ).toBe("cloud");
+    });
+
+    it("prefers earlier setting keys over later ones when several are set", () => {
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            ELIZA_RUNTIME_MODE: "local-safe",
+            RUNTIME_MODE: "cloud",
+            LOCAL_RUNTIME_MODE: "local-yolo",
+          }),
+        ),
+      ).toBe("local-safe");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            RUNTIME_MODE: "cloud",
+            LOCAL_RUNTIME_MODE: "local-yolo",
+          }),
+        ),
+      ).toBe("cloud");
+    });
+
+    it("treats a tied three-key setting as the first key's value", () => {
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            ELIZA_RUNTIME_MODE: "local-yolo",
+            RUNTIME_MODE: "local-yolo",
+            LOCAL_RUNTIME_MODE: "local-yolo",
+          }),
+        ),
+      ).toBe("local-yolo");
+    });
+
+    it("skips invalid, blank, and non-string settings and continues the queue", () => {
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            ELIZA_RUNTIME_MODE: "not-a-mode",
+            RUNTIME_MODE: "  ",
+            LOCAL_RUNTIME_MODE: "local-safe",
+          }),
+        ),
+      ).toBe("local-safe");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            ELIZA_RUNTIME_MODE: 42,
+            RUNTIME_MODE: null,
+            LOCAL_RUNTIME_MODE: "cloud",
+          }),
+        ),
+      ).toBe("cloud");
+    });
+
+    it("normalizes setting values by trimming and lowercasing", () => {
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "  CLOUD  " }),
+        ),
+      ).toBe("cloud");
+      expect(
+        resolveRuntimeExecutionMode(sourceFrom({ RUNTIME_MODE: "Local-Safe" })),
+      ).toBe("local-safe");
+    });
+
+    it("consults setting keys in documented order before reading env", () => {
+      const { source, keys } = recordingSource({
+        LOCAL_RUNTIME_MODE: "cloud",
+      });
+      vi.stubEnv("ELIZA_RUNTIME_MODE", "local-yolo");
+
+      expect(resolveRuntimeExecutionMode(source)).toBe("cloud");
+      expect(keys).toEqual([...SETTING_KEYS]);
+    });
+
+    it("does not fall through to env while a later setting is still valid", () => {
+      vi.stubEnv("ELIZA_RUNTIME_MODE", "cloud");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({
+            ELIZA_RUNTIME_MODE: "bogus",
+            RUNTIME_MODE: "local-safe",
+          }),
+        ),
+      ).toBe("local-safe");
+    });
+
+    it("falls back to env when the source has no getSetting", () => {
+      vi.stubEnv("ELIZA_RUNTIME_MODE", "cloud");
+      expect(resolveRuntimeExecutionMode(null)).toBe("cloud");
+      expect(resolveRuntimeExecutionMode({})).toBe("cloud");
+    });
+
+    it("prefers earlier env keys over later ones", () => {
+      vi.stubEnv("ELIZA_RUNTIME_MODE", "local-safe");
+      vi.stubEnv("RUNTIME_MODE", "cloud");
+      vi.stubEnv("LOCAL_RUNTIME_MODE", "local-yolo");
+      expect(resolveRuntimeExecutionMode(null)).toBe("local-safe");
+    });
+
+    it("skips invalid env values and uses the next valid env key", () => {
+      vi.stubEnv("ELIZA_RUNTIME_MODE", "nope");
+      vi.stubEnv("RUNTIME_MODE", "  ");
+      vi.stubEnv("LOCAL_RUNTIME_MODE", "cloud");
+      expect(resolveRuntimeExecutionMode(null)).toBe("cloud");
+    });
+
+    it("clamps local-yolo to local-safe on iOS, including the empty-queue default", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "ios");
+      expect(resolveRuntimeExecutionMode(null)).toBe("local-safe");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-yolo" }),
+        ),
+      ).toBe("local-safe");
+    });
+
+    it("does not clamp cloud or local-safe on iOS", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "ios");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" }),
+        ),
+      ).toBe("cloud");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-safe" }),
+        ),
+      ).toBe("local-safe");
+    });
+
+    it("does not clamp local-yolo on Android", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "android");
+      expect(
+        resolveRuntimeExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-yolo" }),
+        ),
+      ).toBe("local-yolo");
+    });
+  });
+
+  describe("resolveLocalExecutionMode", () => {
+    it("keeps local-safe and collapses every other resolved mode to local-yolo", () => {
+      expect(
+        resolveLocalExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-safe" }),
+        ),
+      ).toBe("local-safe");
+      expect(
+        resolveLocalExecutionMode(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-yolo" }),
+        ),
+      ).toBe("local-yolo");
+      expect(
+        resolveLocalExecutionMode(sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" })),
+      ).toBe("local-yolo");
+    });
+
+    it("returns local-safe for the iOS-clamped empty queue", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "ios");
+      expect(resolveLocalExecutionMode(null)).toBe("local-safe");
+    });
+  });
+
+  describe("shouldUseSandboxExecution", () => {
+    it("is true only when the resolved runtime mode is local-safe", () => {
+      expect(
+        shouldUseSandboxExecution(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-safe" }),
+        ),
+      ).toBe(true);
+      expect(
+        shouldUseSandboxExecution(
+          sourceFrom({ ELIZA_RUNTIME_MODE: "local-yolo" }),
+        ),
+      ).toBe(false);
+      expect(
+        shouldUseSandboxExecution(sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" })),
+      ).toBe(false);
+      expect(shouldUseSandboxExecution(null)).toBe(false);
+    });
+
+    it("becomes true on iOS because local-yolo is clamped", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "ios");
+      expect(shouldUseSandboxExecution(null)).toBe(true);
+    });
+  });
+
+  describe("isCloudExecutionMode", () => {
+    it("is true only for the cloud runtime mode", () => {
+      expect(
+        isCloudExecutionMode(sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" })),
+      ).toBe(true);
+      expect(
+        isCloudExecutionMode(sourceFrom({ ELIZA_RUNTIME_MODE: "local-safe" })),
+      ).toBe(false);
+      expect(
+        isCloudExecutionMode(sourceFrom({ ELIZA_RUNTIME_MODE: "local-yolo" })),
+      ).toBe(false);
+      expect(isCloudExecutionMode(null)).toBe(false);
+    });
+
+    it("stays true for cloud on iOS", () => {
+      vi.stubEnv("ELIZA_PLATFORM", "ios");
+      expect(
+        isCloudExecutionMode(sourceFrom({ ELIZA_RUNTIME_MODE: "cloud" })),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/agent/src/runtime/local-execution-mode.ts`, the agent-side re-export of the shared runtime execution-mode resolvers. No production code changes.

The suite imports from `./local-execution-mode.ts` and drives the real resolvers (no mocks of the system under test):

- empty setting/env queue defaults to `local-yolo`
- single present setting; earlier setting keys win over later ones; three-key ties take the first key
- invalid, blank, and non-string settings are skipped and the queue continues
- trim/lowercase normalization
- settings are exhausted before env fallback; earlier env keys win; invalid env values are skipped
- iOS clamps `local-yolo` (including the empty-queue default) to `local-safe` and does not clamp `cloud` / `local-safe`; Android does not clamp
- `resolveLocalExecutionMode` keeps `local-safe` and collapses every other resolved mode to `local-yolo`
- `shouldUseSandboxExecution` is true only for `local-safe`
- `isCloudExecutionMode` is true only for `cloud`

## Test plan

- [x] `bunx vitest run packages/agent/src/runtime/local-execution-mode.test.ts` — **1 file, 20 tests passed** (vitest v4.1.10, 9.17s)
- [x] `bunx biome check --write packages/agent/src/runtime/local-execution-mode.test.ts` — clean (Checked 1 file)
- [x] `cd packages/agent && bunx tsc --noEmit` — `local-execution-mode.test.ts` appears **nowhere** in the output (no new errors in this file)
- [x] Diff touches **only** `packages/agent/src/runtime/local-execution-mode.test.ts`

Hosted CI does not run on this fork contributor PR. The counts above are from local bunx on the PR head.

## Evidence

Test-only change; no production behaviour change, so the bug-fix reproduction procedure does not apply.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cb43df7699b026227aaefaec1f66204096c99be4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
