### PR TITLE
fix(devices): persist exact runtime approvals

### DIFF
--- a/packages/agent/src/api/runtime-management-proposal-store.test.ts
+++ b/packages/agent/src/api/runtime-management-proposal-store.test.ts
@@ -1,0 +1,114 @@
+/** Exercises the real filesystem proposal store across restart and concurrent consumers. */
+
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FileRuntimeManagementProposalStore,
+  type RuntimeManagementProposal,
+} from "./runtime-management-proposal-store.ts";
+
+const directories: string[] = [];
+
+async function temporaryStore(): Promise<{
+  directory: string;
+  proposal: RuntimeManagementProposal;
+}> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "runtime-proposal-"));
+  directories.push(directory);
+  return {
+    directory,
+    proposal: {
+      proposalId: "10000000-0000-4000-8000-000000000001",
+      nonce: "nonce-one",
+      clientId: "renderer-one",
+      requestKey: '{"op":"remove","runtimeId":"vps-1"}',
+      expiresAt: Date.now() + 60_000,
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("FileRuntimeManagementProposalStore", () => {
+  it("survives restart and atomically permits one exact consumer", async () => {
+    const { directory, proposal } = await temporaryStore();
+    await new FileRuntimeManagementProposalStore(directory).create(proposal);
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    const [proposalFile] = await readdir(proposalDirectory);
+    if (!proposalFile) throw new Error("proposal file was not persisted");
+    const proposalPath = path.join(proposalDirectory, proposalFile);
+    const serialized = await readFile(proposalPath, "utf8");
+    expect(serialized).not.toContain(proposal.nonce);
+    expect(JSON.parse(serialized)).toMatchObject({
+      proposalId: proposal.proposalId,
+      nonceDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    if (process.platform !== "win32") {
+      expect((await stat(proposalPath)).mode & 0o777).toBe(0o600);
+    }
+
+    const restartedA = new FileRuntimeManagementProposalStore(directory);
+    const restartedB = new FileRuntimeManagementProposalStore(directory);
+    const outcomes = await Promise.all([
+      restartedA.consume(proposal),
+      restartedB.consume(proposal),
+    ]);
+    expect(outcomes.filter(Boolean)).toHaveLength(1);
+    await expect(restartedA.consume(proposal)).resolves.toBe(false);
+  });
+
+  it("fails closed on a malformed partial proposal file", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    await mkdir(proposalDirectory, { recursive: true });
+    await writeFile(
+      path.join(proposalDirectory, `${proposal.proposalId}.json`),
+      '{"proposalId":',
+      { flag: "wx" },
+    );
+    const store = new FileRuntimeManagementProposalStore(directory);
+    await expect(store.consume(proposal)).resolves.toBe(false);
+  });
+
+  it("does not consume authority for a mismatched target, renderer, or nonce", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const store = new FileRuntimeManagementProposalStore(directory);
+    await store.create(proposal);
+
+    await expect(
+      store.consume({
+        ...proposal,
+        requestKey: '{"op":"remove","runtimeId":"vps-2"}',
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      store.consume({ ...proposal, clientId: "renderer-two" }),
+    ).resolves.toBe(false);
+    await expect(
+      store.consume({ ...proposal, nonce: "nonce-two" }),
+    ).resolves.toBe(false);
+    await expect(store.consume(proposal)).resolves.toBe(true);
+  });
+});

--- a/packages/agent/src/api/runtime-management-proposal-store.ts
+++ b/packages/agent/src/api/runtime-management-proposal-store.ts
@@ -1,0 +1,163 @@
+/** Persists one-use runtime mutation proposals with cross-process atomic consumption. */
+
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { constants } from "node:fs";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "@elizaos/core";
+
+export interface RuntimeManagementProposal {
+  proposalId: string;
+  nonce: string;
+  clientId: string;
+  requestKey: string;
+  expiresAt: number;
+}
+
+export interface RuntimeManagementProposalStore {
+  create(proposal: RuntimeManagementProposal): Promise<void>;
+  consume(proposal: RuntimeManagementProposal): Promise<boolean>;
+}
+
+interface StoredProposal extends Omit<RuntimeManagementProposal, "nonce"> {
+  nonceDigest: string;
+}
+
+function nonceDigest(nonce: string): string {
+  return createHash("sha256").update(nonce, "utf8").digest("hex");
+}
+
+function equalDigest(left: string, right: string): boolean {
+  if (!/^[a-f0-9]{64}$/.test(left) || !/^[a-f0-9]{64}$/.test(right))
+    return false;
+  return timingSafeEqual(Buffer.from(left, "hex"), Buffer.from(right, "hex"));
+}
+
+function isStoredProposal(value: unknown): value is StoredProposal {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.proposalId === "string" &&
+    typeof item.nonceDigest === "string" &&
+    typeof item.clientId === "string" &&
+    typeof item.requestKey === "string" &&
+    typeof item.expiresAt === "number" &&
+    Number.isSafeInteger(item.expiresAt)
+  );
+}
+
+export class FileRuntimeManagementProposalStore
+  implements RuntimeManagementProposalStore
+{
+  private readonly directory: string;
+
+  constructor(stateDirectory = resolveStateDir()) {
+    this.directory = path.join(stateDirectory, "runtime-management-proposals");
+  }
+
+  private proposalPath(proposalId: string): string {
+    if (!/^[0-9a-f-]{36}$/i.test(proposalId)) {
+      throw new TypeError("Runtime proposal id must be a UUID.");
+    }
+    return path.join(this.directory, `${proposalId}.json`);
+  }
+
+  async create(proposal: RuntimeManagementProposal): Promise<void> {
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    const stored: StoredProposal = {
+      proposalId: proposal.proposalId,
+      nonceDigest: nonceDigest(proposal.nonce),
+      clientId: proposal.clientId,
+      requestKey: proposal.requestKey,
+      expiresAt: proposal.expiresAt,
+    };
+    const handle = await open(
+      this.proposalPath(proposal.proposalId),
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    try {
+      await handle.writeFile(JSON.stringify(stored), "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private async read(proposalId: string): Promise<StoredProposal | undefined> {
+    try {
+      const parsed = JSON.parse(
+        await readFile(this.proposalPath(proposalId), "utf8"),
+      ) as unknown;
+      return isStoredProposal(parsed) ? parsed : undefined;
+    } catch (error) {
+      // error-policy:J3 missing or malformed proposal files are invalid authority.
+      if (
+        error instanceof SyntaxError ||
+        (error instanceof Error && "code" in error && error.code === "ENOENT")
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async consume(proposal: RuntimeManagementProposal): Promise<boolean> {
+    const stored = await this.read(proposal.proposalId);
+    if (!stored) return false;
+    if (stored.expiresAt <= Date.now()) {
+      await unlink(this.proposalPath(proposal.proposalId)).catch((error) => {
+        // error-policy:J6 another process may have consumed the expired record.
+        if (
+          !(
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          )
+        ) {
+          throw error;
+        }
+      });
+      return false;
+    }
+    if (
+      stored.clientId !== proposal.clientId ||
+      stored.requestKey !== proposal.requestKey ||
+      !equalDigest(stored.nonceDigest, nonceDigest(proposal.nonce))
+    ) {
+      return false;
+    }
+
+    const claimedPath = path.join(
+      this.directory,
+      `${proposal.proposalId}.consumed-${randomUUID()}`,
+    );
+    try {
+      await rename(this.proposalPath(proposal.proposalId), claimedPath);
+    } catch (error) {
+      // error-policy:J3 a concurrent winner makes this consume an explicit miss.
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return false;
+      }
+      throw error;
+    }
+    try {
+      const claimed = JSON.parse(
+        await readFile(claimedPath, "utf8"),
+      ) as unknown;
+      return (
+        isStoredProposal(claimed) &&
+        claimed.expiresAt > Date.now() &&
+        claimed.clientId === proposal.clientId &&
+        claimed.requestKey === proposal.requestKey &&
+        equalDigest(claimed.nonceDigest, nonceDigest(proposal.nonce))
+      );
+    } finally {
+      await unlink(claimedPath);
+    }
+  }
+}

--- a/packages/agent/src/api/runtime-management-routes.test.ts
+++ b/packages/agent/src/api/runtime-management-routes.test.ts
@@ -3,6 +3,10 @@
 import type http from "node:http";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  RuntimeManagementProposal,
+  RuntimeManagementProposalStore,
+} from "./runtime-management-proposal-store.ts";
 import {
   handleRuntimeManagementRoutes,
   type RuntimeManagementRouteContext,
@@ -10,6 +14,31 @@ import {
 } from "./runtime-management-routes.ts";
 
 type Body = Record<string, unknown>;
+
+class MemoryProposalStore implements RuntimeManagementProposalStore {
+  readonly proposals = new Map<string, RuntimeManagementProposal>();
+
+  async create(proposal: RuntimeManagementProposal): Promise<void> {
+    this.proposals.set(proposal.proposalId, proposal);
+  }
+
+  async consume(proposal: RuntimeManagementProposal): Promise<boolean> {
+    const stored = this.proposals.get(proposal.proposalId);
+    if (
+      !stored ||
+      stored.expiresAt <= Date.now() ||
+      stored.nonce !== proposal.nonce ||
+      stored.clientId !== proposal.clientId ||
+      stored.requestKey !== proposal.requestKey
+    ) {
+      return false;
+    }
+    this.proposals.delete(proposal.proposalId);
+    return true;
+  }
+}
+
+const proposalStore = new MemoryProposalStore();
 
 function makeContext(method: string, pathname: string, body: Body | null) {
   const req = Readable.from(
@@ -31,6 +60,7 @@ function makeContext(method: string, pathname: string, body: Body | null) {
     broadcastWs,
     broadcastWsToClientId,
     callerAuthorization: { ok: true, role: "OWNER" },
+    proposalStore,
   };
   return { ctx, json, error, broadcastWs, broadcastWsToClientId };
 }
@@ -43,6 +73,7 @@ async function flushUntil(predicate: () => boolean): Promise<void> {
 
 afterEach(() => {
   runtimeManagementRouteInternals.claims.clear();
+  proposalStore.proposals.clear();
 });
 
 describe("POST /api/runtime/manage", () => {
@@ -75,6 +106,22 @@ describe("POST /api/runtime/manage", () => {
     );
     expect(request.broadcastWs).not.toHaveBeenCalled();
     expect(request.broadcastWsToClientId).not.toHaveBeenCalled();
+  });
+
+  it("rejects proposal minting without owner authority", async () => {
+    const request = makeContext("POST", "/api/runtime/manage/propose", {
+      op: "remove",
+      runtimeId: "vps-1",
+      clientId: "origin-renderer",
+    });
+    request.ctx.callerAuthorization = { ok: true, role: "USER" };
+    await handleRuntimeManagementRoutes(request.ctx);
+    expect(request.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Runtime management requires owner authority.",
+      403,
+    );
+    expect(proposalStore.proposals.size).toBe(0);
   });
 
   it("lets exactly one shell claim and resolve an operation", async () => {
@@ -152,6 +199,85 @@ describe("POST /api/runtime/manage", () => {
       400,
     );
     expect(aliased.broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("binds each destructive request to one server proposal, target, and renderer", async () => {
+    const proposed = makeContext("POST", "/api/runtime/manage/propose", {
+      op: "remove",
+      runtimeId: "vps-1",
+      clientId: "origin-renderer",
+    });
+    await handleRuntimeManagementRoutes(proposed.ctx);
+    const authority = proposed.json.mock.calls[0]?.[1] as {
+      proposalId: string;
+      proposalNonce: string;
+    };
+
+    const wrongTarget = makeContext("POST", "/api/runtime/manage", {
+      op: "remove",
+      runtimeId: "vps-2",
+      clientId: "origin-renderer",
+      ...authority,
+    });
+    await handleRuntimeManagementRoutes(wrongTarget.ctx);
+    expect(wrongTarget.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Runtime proposal is missing, expired, or does not match.",
+      409,
+    );
+
+    const wrongRenderer = makeContext("POST", "/api/runtime/manage", {
+      op: "remove",
+      runtimeId: "vps-1",
+      clientId: "other-renderer",
+      ...authority,
+    });
+    await handleRuntimeManagementRoutes(wrongRenderer.ctx);
+    expect(wrongRenderer.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Runtime proposal is missing, expired, or does not match.",
+      409,
+    );
+
+    const manage = makeContext("POST", "/api/runtime/manage", {
+      op: "remove",
+      runtimeId: "vps-1",
+      clientId: "origin-renderer",
+      ...authority,
+    });
+    const waiting = handleRuntimeManagementRoutes(manage.ctx);
+    await flushUntil(
+      () => manage.broadcastWsToClientId.mock.calls.length === 1,
+    );
+    const frame = manage.broadcastWsToClientId.mock.calls[0]?.[1] as {
+      requestId: string;
+    };
+    const claim = makeContext("POST", "/api/runtime/manage/claim", {
+      requestId: frame.requestId,
+    });
+    await handleRuntimeManagementRoutes(claim.ctx);
+    const claimBody = claim.json.mock.calls[0]?.[1] as { claimToken: string };
+    await handleRuntimeManagementRoutes(
+      makeContext("POST", "/api/runtime/manage/result", {
+        requestId: frame.requestId,
+        claimToken: claimBody.claimToken,
+        ok: true,
+      }).ctx,
+    );
+    await waiting;
+
+    const replay = makeContext("POST", "/api/runtime/manage", {
+      op: "remove",
+      runtimeId: "vps-1",
+      clientId: "origin-renderer",
+      ...authority,
+    });
+    await handleRuntimeManagementRoutes(replay.ctx);
+    expect(replay.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Runtime proposal is missing, expired, or does not match.",
+      409,
+    );
   });
 
   it("targets the renderer that originated an app-chat action", async () => {

--- a/packages/agent/src/api/runtime-management-routes.ts
+++ b/packages/agent/src/api/runtime-management-routes.ts
@@ -10,11 +10,21 @@ import {
 } from "@elizaos/shared";
 import type { AgentHttpRequestAuthorization } from "../runtime/host-bridge.ts";
 import { PendingRequestMap } from "./pending-request-map.ts";
+import {
+  FileRuntimeManagementProposalStore,
+  type RuntimeManagementProposalStore,
+} from "./runtime-management-proposal-store.ts";
 
 const PREFIX = "/api/runtime/manage";
 const SHELL_TIMEOUT_MS = 45_000;
+const PROPOSAL_TIMEOUT_MS = 5 * 60_000;
 const pending = new PendingRequestMap();
 const claims = new Map<string, { token: string | null; expiresAt: number }>();
+let defaultProposalStore: RuntimeManagementProposalStore | undefined;
+const READ_ONLY_OPERATIONS = new Set<RuntimeManagementRequest["op"]>([
+  "list",
+  "inspect_ssh",
+]);
 
 export interface RuntimeManagementRouteContext {
   req: http.IncomingMessage;
@@ -26,6 +36,7 @@ export interface RuntimeManagementRouteContext {
   broadcastWs?: (payload: object) => void;
   broadcastWsToClientId?: (clientId: string, payload: object) => number;
   callerAuthorization: AgentHttpRequestAuthorization;
+  proposalStore?: RuntimeManagementProposalStore;
 }
 
 function boundedString(value: unknown, max = 512): string | undefined {
@@ -76,13 +87,30 @@ function parseRequest(
     apiBase: boundedString(body.apiBase, 2048),
     sessionId: boundedString(body.sessionId, 256),
     code: boundedString(body.code, 32),
+    proposalId: boundedString(body.proposalId, 128),
+    proposalNonce: boundedString(body.proposalNonce, 128),
   };
+}
+
+function requestKey(request: RuntimeManagementRequest): string {
+  return JSON.stringify({
+    ...request,
+    proposalId: undefined,
+    proposalNonce: undefined,
+  });
 }
 
 function purgeExpiredClaims(now = Date.now()): void {
   for (const [requestId, claim] of claims) {
     if (claim.expiresAt <= now) claims.delete(requestId);
   }
+}
+
+function proposalStore(
+  ctx: RuntimeManagementRouteContext,
+): RuntimeManagementProposalStore {
+  defaultProposalStore ??= new FileRuntimeManagementProposalStore();
+  return ctx.proposalStore ?? defaultProposalStore;
 }
 
 export async function handleRuntimeManagementRoutes(
@@ -99,6 +127,38 @@ export async function handleRuntimeManagementRoutes(
     return true;
   }
   purgeExpiredClaims();
+
+  if (method === "POST" && pathname === `${PREFIX}/propose`) {
+    const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
+      () => {
+        // error-policy:J3 malformed transport input remains explicitly invalid.
+        return null;
+      },
+    );
+    if (!body) return true;
+    const request = parseRequest(body);
+    const clientId = boundedString(body.clientId, 128);
+    if (
+      !request ||
+      READ_ONLY_OPERATIONS.has(request.op) ||
+      !clientId ||
+      !/^[A-Za-z0-9._-]{1,128}$/.test(clientId)
+    ) {
+      error(res, "Invalid runtime proposal.", 400);
+      return true;
+    }
+    const proposalId = randomUUID();
+    const proposalNonce = randomUUID();
+    await proposalStore(ctx).create({
+      proposalId,
+      nonce: proposalNonce,
+      clientId,
+      requestKey: requestKey(request),
+      expiresAt: Date.now() + PROPOSAL_TIMEOUT_MS,
+    });
+    json(res, { proposalId, proposalNonce, expiresInMs: PROPOSAL_TIMEOUT_MS });
+    return true;
+  }
 
   if (method === "POST" && pathname === PREFIX) {
     const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
@@ -117,6 +177,29 @@ export async function handleRuntimeManagementRoutes(
     if (clientId && !/^[A-Za-z0-9._-]{1,128}$/.test(clientId)) {
       error(res, "Invalid runtime client id.", 400);
       return true;
+    }
+    if (!READ_ONLY_OPERATIONS.has(request.op)) {
+      const proposalId = boundedString(body.proposalId, 128);
+      const proposalNonce = boundedString(body.proposalNonce, 128);
+      if (
+        !proposalId ||
+        !proposalNonce ||
+        !clientId ||
+        !(await proposalStore(ctx).consume({
+          proposalId,
+          nonce: proposalNonce,
+          clientId,
+          requestKey: requestKey(request),
+          expiresAt: Date.now(),
+        }))
+      ) {
+        error(
+          res,
+          "Runtime proposal is missing, expired, or does not match.",
+          409,
+        );
+        return true;
+      }
     }
     if (!ctx.broadcastWs && !ctx.broadcastWsToClientId) {
       json(res, { ok: false, op: request.op, error: "no-shell" });
@@ -235,4 +318,5 @@ export const runtimeManagementRouteInternals = {
   claims,
   parseRequest,
   purgeExpiredClaims,
+  requestKey,
 };

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -1471,6 +1471,27 @@ describe("remote target durable runner", () => {
     }
   });
 
+  it("drops a terminal staged activation without wedging an active session", async () => {
+    const harness = await createHarness();
+    const runner = await createRunner(harness, () => undefined);
+    const stagedSessionId = "11111111-2222-4111-8111-111111111111";
+    await runner.installActivation({
+      ...harness.activation,
+      sessionId: stagedSessionId,
+      grantId: "11111111-3333-4111-8111-111111111111",
+    });
+    harness.relay.commitFailure = new RemoteTargetTransportError(
+      "HTTP_410",
+      410,
+    );
+
+    await expect(runner.pollOnce()).resolves.toBe("empty");
+    const state = await harness.state.read();
+    expect(state.sessions[stagedSessionId]).toBeUndefined();
+    expect(state.sessions[SESSION_ID]?.activationState).toBe("active");
+    expect(harness.relay.claimRequests).toBe(1);
+  });
+
   it("keeps finalization queued through local-failure compensation", async () => {
     const harness = await createHarness();
     const relay = new DeferredCompensationRelay(harness.activation);

--- a/packages/shared/src/contracts/runtime-management.ts
+++ b/packages/shared/src/contracts/runtime-management.ts
@@ -32,6 +32,9 @@ export interface RuntimeManagementRequest {
   apiBase?: string;
   sessionId?: string;
   code?: string;
+  /** One-use server proposal authority for an exact destructive request. */
+  proposalId?: string;
+  proposalNonce?: string;
 }
 
 export interface RuntimeManagementResult {

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
@@ -1,7 +1,12 @@
 /** Adversarial coverage for fail-closed runtime mutation confirmation. */
 
 import { describe, expect, it } from "vitest";
-import { isUnambiguousRuntimeConfirmation } from "./runtime-management-confirmation.ts";
+import {
+	isBoundRuntimeManagementConfirmation,
+	runtimeManagementConfirmationText,
+} from "./runtime-management-confirmation.ts";
+
+const request = { op: "revoke" as const, targetId: "controller-one" };
 
 describe("runtime mutation confirmation", () => {
 	it.each([
@@ -14,30 +19,32 @@ describe("runtime mutation confirmation", () => {
 		"Don't stop host",
 		"Yes, confirm tomorrow",
 	])("rejects negated or ambiguous text: %s", (text) => {
-		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+		expect(isBoundRuntimeManagementConfirmation(text, request)).toBe(false);
 	});
 
 	it.each([
-		"confirm the revocation",
-		"yes, confirm revoke",
-		"proceed with the revocation",
+		"confirm revoke controller-one",
+		"yes, confirm revoke controller-one",
 	])("accepts an unambiguous complete confirmation: %s", (text) => {
-		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(true);
+		expect(isBoundRuntimeManagementConfirmation(text, request)).toBe(true);
 	});
 
 	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
 		"rejects generic approval that is not bound to the requested operation: %s",
 		(text) => {
-			expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+			expect(isBoundRuntimeManagementConfirmation(text, request)).toBe(false);
 		},
 	);
 
-	it("binds subject-bearing confirmation to the requested operation", () => {
-		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "pair")).toBe(
-			true,
-		);
-		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "revoke")).toBe(
-			false,
+	it("binds confirmation to both operation and target", () => {
+		expect(
+			isBoundRuntimeManagementConfirmation(
+				"confirm revoke controller-two",
+				request,
+			),
+		).toBe(false);
+		expect(runtimeManagementConfirmationText(request)).toBe(
+			"confirm revoke controller-one",
 		);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
@@ -1,53 +1,48 @@
-/** Parses the fail-closed user confirmation required by runtime mutations. */
+/** Builds and validates operation-and-target-bound runtime confirmations. */
 
-import type { RuntimeManagementOperation } from "@elizaos/shared";
+import type { RuntimeManagementRequest } from "@elizaos/shared";
 
-export type ConfirmedRuntimeOperation = Exclude<
-	RuntimeManagementOperation,
-	"list" | "inspect_ssh"
->;
-
-const CONFIRMATION_SUBJECTS: Record<
-	ConfirmedRuntimeOperation,
-	readonly string[]
-> = {
-	pair: ["pair", "pairing"],
-	revoke: ["revoke", "revocation"],
-	remove: ["remove", "removal", "remove it", "removing it"],
-	retry: ["retry"],
-	connect_ssh: ["connect ssh", "ssh connection"],
-	add_direct: ["add direct runtime", "direct runtime"],
-	enroll_host: ["enroll host", "host enrollment"],
-	approve_pairing: ["approve pairing", "pairing approval"],
-	start_host: ["start host", "host start"],
-	stop_host: ["stop host", "host stop"],
-	revoke_host: ["revoke host", "host revocation"],
-};
-
-export function isUnambiguousRuntimeConfirmation(
-	value: string,
-	op: ConfirmedRuntimeOperation,
-): boolean {
-	const text = value.toLowerCase().replace(/[’']/g, "'").trim();
-	if (
-		/\b(?:no|not|never|cancel|wait|hold|don't|dont|cannot|can't|cant|won't|wont)\b/.test(
-			text,
-		) ||
-		/\b(?:but|however|except|unless|after|before|later|tomorrow)\b/.test(text)
-	) {
-		return false;
-	}
-	const normalized = text
+function normalize(value: string): string {
+	return value
+		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, " ")
 		.trim()
 		.replace(/\s+/g, " ");
-	return CONFIRMATION_SUBJECTS[op].some(
-		(subject) =>
-			normalized === `confirm ${subject}` ||
-			normalized === `confirm the ${subject}` ||
-			normalized === `yes confirm ${subject}` ||
-			normalized === `yes confirm the ${subject}` ||
-			normalized === `proceed with ${subject}` ||
-			normalized === `proceed with the ${subject}`,
+}
+
+function confirmationTarget(request: RuntimeManagementRequest): string {
+	if (request.op === "approve_pairing") {
+		return request.sessionId ?? "this pairing";
+	}
+	if (
+		request.op === "enroll_host" ||
+		request.op === "start_host" ||
+		request.op === "stop_host" ||
+		request.op === "revoke_host"
+	) {
+		return "this host";
+	}
+	return (
+		request.targetId ??
+		request.runtimeId ??
+		request.target ??
+		request.apiBase ??
+		request.label ??
+		"this runtime"
 	);
+}
+
+export function runtimeManagementConfirmationText(
+	request: RuntimeManagementRequest,
+): string {
+	return `confirm ${request.op.replaceAll("_", " ")} ${confirmationTarget(request)}`;
+}
+
+export function isBoundRuntimeManagementConfirmation(
+	text: string,
+	request: RuntimeManagementRequest,
+): boolean {
+	const normalized = normalize(text);
+	const expected = normalize(runtimeManagementConfirmationText(request));
+	return normalized === expected || normalized === `yes ${expected}`;
 }

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -25,6 +25,9 @@ describe("RUNTIMES action", () => {
 		expect(action.parameters?.map((parameter) => parameter.name)).not.toContain(
 			"privateKey",
 		);
+		expect(action.parameters?.map((parameter) => parameter.name)).toEqual(
+			expect.arrayContaining(["proposalId", "proposalNonce"]),
+		);
 	});
 
 	it("rejects secret-bearing action options instead of silently discarding them", () => {
@@ -112,26 +115,25 @@ describe("RUNTIMES action", () => {
 		expect(manageRuntime).not.toHaveBeenCalled();
 	});
 
-	it.each([
-		"confirm the removal",
-		"yes, confirm remove",
-		"proceed with the removal",
-	])("accepts exact operation-bound confirmation: %s", async (text) => {
-		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
-			ok: true,
-			op: request.op,
-		}));
-		const action = createRuntimeManagementAction({ manageRuntime });
-		const result = await action.handler(
-			runtime,
-			{ content: { text } } as Memory,
-			undefined,
-			{ op: "remove", runtimeId: "runtime-1", confirm: "true" },
-			callback(),
-		);
-		expect(result?.success).toBe(true);
-		expect(manageRuntime).toHaveBeenCalledTimes(1);
-	});
+	it.each(["confirm remove runtime-1", "yes, confirm remove runtime-1"])(
+		"accepts exact operation-bound confirmation: %s",
+		async (text) => {
+			const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+				ok: true,
+				op: request.op,
+			}));
+			const action = createRuntimeManagementAction({ manageRuntime });
+			const result = await action.handler(
+				runtime,
+				{ content: { text } } as Memory,
+				undefined,
+				{ op: "remove", runtimeId: "runtime-1", confirm: "true" },
+				callback(),
+			);
+			expect(result?.success).toBe(true);
+			expect(manageRuntime).toHaveBeenCalledTimes(1);
+		},
+	);
 
 	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
 		"rejects generic approval that is not bound to the requested operation: %s",
@@ -170,7 +172,7 @@ describe("RUNTIMES action", () => {
 		const action = createRuntimeManagementAction({ manageRuntime });
 		const result = await action.handler(
 			runtime,
-			{ content: { text: "Yes, confirm pairing" } } as Memory,
+			{ content: { text: "confirm pair host:mac" } } as Memory,
 			undefined,
 			{ op: "pair", targetId: "host:mac", confirm: "true" },
 			callback(),
@@ -188,9 +190,33 @@ describe("RUNTIMES action", () => {
 			apiBase: undefined,
 			sessionId: undefined,
 			code: undefined,
+			proposalId: undefined,
+			proposalNonce: undefined,
 		});
 		expect(result?.success).toBe(true);
 		expect(result?.text).toContain("123456");
+	});
+
+	it("rejects a confirmation for the right operation but wrong target", async () => {
+		const manageRuntime = vi.fn();
+		const action = createRuntimeManagementAction({ manageRuntime });
+		const result = await action.handler(
+			runtime,
+			{ content: { text: "confirm remove runtime-2" } } as Memory,
+			undefined,
+			{
+				op: "remove",
+				runtimeId: "runtime-1",
+				confirm: "true",
+			},
+		);
+		expect(result?.success).toBe(false);
+		expect(result?.values).toEqual(
+			expect.objectContaining({
+				confirmationText: "confirm remove runtime-1",
+			}),
+		);
+		expect(manageRuntime).not.toHaveBeenCalled();
 	});
 
 	it("returns every saved runtime in model-visible text and structured data", async () => {
@@ -280,6 +306,75 @@ describe("RUNTIMES action", () => {
 		}
 	});
 
+	it("requires a server proposal before the default destructive handoff", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						proposalId: "proposal-1",
+						proposalNonce: "nonce-1",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ ok: true, op: "remove" }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		try {
+			const action = createRuntimeManagementAction();
+			const first = await action.handler(
+				runtime,
+				{
+					content: {
+						text: "remove runtime-1",
+						metadata: { viewClientId: "origin-renderer" },
+					},
+				} as Memory,
+				undefined,
+				{ op: "remove", runtimeId: "runtime-1" },
+			);
+			expect(first?.values).toEqual(
+				expect.objectContaining({
+					proposalId: "proposal-1",
+					proposalNonce: "nonce-1",
+					confirmationText: "confirm remove runtime-1",
+				}),
+			);
+			expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+				"/api/runtime/manage/propose",
+			);
+
+			const second = await action.handler(
+				runtime,
+				{
+					content: {
+						text: "confirm remove runtime-1",
+						metadata: { viewClientId: "origin-renderer" },
+					},
+				} as Memory,
+				undefined,
+				{
+					op: "remove",
+					runtimeId: "runtime-1",
+					confirm: "true",
+					proposalId: "proposal-1",
+					proposalNonce: "nonce-1",
+				},
+			);
+			expect(second?.success).toBe(true);
+			expect(String(fetchMock.mock.calls[1]?.[0])).toMatch(
+				/\/api\/runtime\/manage$/,
+			);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
 	it("refuses an unbound mutation instead of racing arbitrary connected shells", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
@@ -293,7 +388,7 @@ describe("RUNTIMES action", () => {
 				callback(),
 			);
 			expect(result?.success).toBe(false);
-			expect(result?.text).toContain("bound to that device");
+			expect(result?.text).toContain("Open the Eliza app");
 			expect(fetchMock).not.toHaveBeenCalled();
 		} finally {
 			vi.unstubAllGlobals();

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -22,8 +22,8 @@ import {
 	userRequestMessageText,
 } from "../params.js";
 import {
-	type ConfirmedRuntimeOperation,
-	isUnambiguousRuntimeConfirmation,
+	isBoundRuntimeManagementConfirmation,
+	runtimeManagementConfirmationText,
 } from "./runtime-management-confirmation.js";
 import { readViewInteractionClientId } from "./view-delivery.js";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
@@ -43,12 +43,6 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 			(op) => op !== "list" && op !== "inspect_ssh",
 		),
 	);
-
-function requiresConfirmation(
-	op: RuntimeManagementRequest["op"],
-): op is ConfirmedRuntimeOperation {
-	return CONFIRMATION_REQUIRED.has(op);
-}
 
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",
@@ -110,9 +104,43 @@ export function parseRuntimeManagementRequest(
 		apiBase: readStringOption(options, "apiBase") ?? undefined,
 		sessionId: readStringOption(options, "sessionId") ?? undefined,
 		code: readStringOption(options, "code") ?? undefined,
+		proposalId: readStringOption(options, "proposalId") ?? undefined,
+		proposalNonce: readStringOption(options, "proposalNonce") ?? undefined,
 	};
 }
 
+async function defaultProposeRuntime(
+	request: RuntimeManagementRequest,
+	message: Memory,
+): Promise<{ proposalId: string; proposalNonce: string }> {
+	const clientId = readViewInteractionClientId(message);
+	if (!clientId) {
+		throw new Error(
+			"Open the Eliza app and request this operation from its chat first.",
+		);
+	}
+	const response = await fetch(
+		`${getAppControlApiBase()}/api/runtime/manage/propose`,
+		{
+			method: "POST",
+			headers: createViewsRequestHeaders(),
+			body: JSON.stringify({ ...request, clientId }),
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		},
+	);
+	const body = (await response.json().catch(() => {
+		// error-policy:J3 an invalid proposal response remains explicitly invalid.
+		return null;
+	})) as { proposalId?: unknown; proposalNonce?: unknown } | null;
+	if (
+		!response.ok ||
+		typeof body?.proposalId !== "string" ||
+		typeof body.proposalNonce !== "string"
+	) {
+		throw new Error("The app could not prepare a bound runtime operation.");
+	}
+	return { proposalId: body.proposalId, proposalNonce: body.proposalNonce };
+}
 async function defaultManageRuntime(
 	request: RuntimeManagementRequest,
 	message: Memory,
@@ -318,6 +346,20 @@ export function createRuntimeManagementAction(
 				required: false,
 				schema: { type: "string" },
 			},
+			{
+				name: "proposalId",
+				description:
+					"Opaque proposal id returned by the immediately preceding RUNTIMES confirmation request. Copy it exactly; never invent one.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "proposalNonce",
+				description:
+					"Opaque one-use proposal nonce returned with proposalId. Copy it exactly only after the user's exact confirmation.",
+				required: false,
+				schema: { type: "string" },
+			},
 		],
 		validate: async (): Promise<boolean> => true,
 		handler: async (
@@ -335,22 +377,54 @@ export function createRuntimeManagementAction(
 				return { success: false, text: reply };
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
+			const requiresConfirmation = CONFIRMATION_REQUIRED.has(request.op);
+			const confirmationText = runtimeManagementConfirmationText(request);
+			const userConfirmed = isBoundRuntimeManagementConfirmation(
+				userRequestMessageText(message),
+				request,
+			);
+			const hasProposal = Boolean(request.proposalId && request.proposalNonce);
 			if (
-				requiresConfirmation(request.op) &&
+				requiresConfirmation &&
 				(!isConfirmed(normalized) ||
-					!isUnambiguousRuntimeConfirmation(
-						userRequestMessageText(message),
-						request.op,
-					))
+					!userConfirmed ||
+					(!manageRuntime && !hasProposal))
 			) {
-				const reply = `Please confirm before I run the ${request.op} Devices & Runtimes operation.`;
+				let proposal = hasProposal
+					? {
+							proposalId: request.proposalId as string,
+							proposalNonce: request.proposalNonce as string,
+						}
+					: undefined;
+				if (!manageRuntime && !proposal) {
+					try {
+						proposal = await defaultProposeRuntime(
+							{ ...request, proposalId: undefined, proposalNonce: undefined },
+							message,
+						);
+					} catch (cause) {
+						// error-policy:J1 the action boundary returns a visible proposal failure.
+						const reply =
+							cause instanceof Error && cause.message.trim()
+								? cause.message
+								: "The app could not prepare this runtime operation.";
+						await callback?.({ text: reply });
+						return { success: false, text: reply };
+					}
+				}
+				const reply = `To authorize this exact operation, reply: “${confirmationText}”.`;
 				await callback?.({ text: reply });
 				return {
 					success: false,
 					text: reply,
 					userFacingText: reply,
 					verifiedUserFacing: true,
-					values: { awaitingConfirmation: true, op: request.op },
+					values: {
+						awaitingConfirmation: true,
+						op: request.op,
+						confirmationText,
+						...(proposal ?? {}),
+					},
 				};
 			}
 


### PR DESCRIPTION
## Summary
- persist one-use runtime mutation proposals under the canonical state directory with nonce hashes, exact renderer/request binding, restart survival, and atomic cross-process consumption
- require exact operation-and-target user confirmation before dispatch
- retain authenticated CSRF shell callbacks from #25551 and add a terminal staged-activation isolation regression for #25550

## Verification
- `bunx vitest run packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts packages/agent/src/api/runtime-management-proposal-store.test.ts packages/agent/src/api/runtime-management-routes.test.ts plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts plugins/plugin-app-control/src/actions/runtime-management.test.ts packages/ui/src/state/startup-phase-hydrate.switch.test.ts --config vitest.config.ts --maxWorkers=1` (106 passed)
- proposal storage test inspects 0600 mode, nonce digest at rest, malformed-record fail-closed behavior, restart persistence, and concurrent consume-once
- package typechecks reach only known branch baseline failures (`speaker-name-inference` and unrelated missing optional workspaces)

Stacked on #25427 exact `4fb480f7260602ec32fd66e1acd747ee1f3fb5cd`. No migration is added; #25550 owns migration 0311.