### PR TITLE
fix(shared): propagate authenticated grounding input

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -286,6 +286,45 @@ describe("agent bridge runtime routing", () => {
     expect(getByName).toHaveBeenCalledWith("agent-1:default");
   });
 
+  test("resolved Worker bridge forwards only authenticated message text as capability input", async () => {
+    let coordinatorEnvelope: Record<string, unknown> | undefined;
+    const fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        coordinatorEnvelope = JSON.parse(String(init?.body)) as Record<
+          string,
+          unknown
+        >;
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "rpc-grounding",
+          result: { text: "grounded" },
+        });
+      },
+    );
+    const rpcRequest = {
+      jsonrpc: "2.0",
+      id: "rpc-grounding",
+      method: "message.send",
+      params: { text: "what is the latest BTC price?" },
+    };
+
+    const response = await bridgeRoute.__agentBridgeTestHooks.handlePost(
+      makeJsonRequest("/api/v1/eliza/agents/agent-1/bridge", rpcRequest),
+      { params: Promise.resolve({ agentId: "agent-1" }) },
+      {
+        agent: sharedAgent,
+        namespace: { getByName: () => ({ fetch }) } as never,
+        executionCtx,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(coordinatorEnvelope).toMatchObject({
+      rpc: rpcRequest,
+      trustedUserUtterance: "what is the latest BTC price?",
+    });
+  });
+
   test("resolved Worker bridge preserves cache warming as a retryable 503", async () => {
     const fetch = mock(async () =>
       Response.json(

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
@@ -217,7 +217,7 @@ describe("personal Shared group reminder destinations", () => {
         ownerLabel: "Nubs",
         authority: blooioGroupAuthority,
       },
-      undefined,
+      ownerBlooioGroupTurn.message,
       { type: "GROUP", source: "blooio" },
     );
     // The response's delivery authority and the stored reminder destination

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
@@ -371,7 +371,7 @@ describe("adversarial Personal Shared group routing", () => {
           version: blooioGroupBinding.authority_version,
         },
       },
-      undefined,
+      validBlooioGroup.message,
       { type: "GROUP", source: "blooio" },
     );
   });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -215,6 +215,11 @@ function deliveredMessage(): string {
   return sharedRestMessageSend.mock.calls[0]?.[2] as string;
 }
 
+function deliveredCapabilityText(): unknown {
+  expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  return sharedRestMessageSend.mock.calls[0]?.[9];
+}
+
 describe("blooio inbound media enrichment at the messaging route", () => {
   beforeEach(() => {
     activeTarget = null;
@@ -326,6 +331,7 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n` +
         "A tabby cat sitting on a mechanical keyboard.",
     );
+    expect(deliveredCapabilityText()).toBeUndefined();
     expect(ledgerAdmit).toHaveBeenCalledTimes(1);
     expect(ledgerAdmit.mock.calls[0]?.[0]).toMatchObject({
       platform: "blooio",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -467,6 +467,7 @@ describe("personal Shared messaging deliveries", () => {
         project: "eliza-app",
         chatId: "123456789",
       },
+      "hello",
     );
   });
 
@@ -729,6 +730,7 @@ describe("personal Shared messaging deliveries", () => {
           project: "eliza-app",
           chatId: "123456789",
         },
+        "remember the red bicycle",
       );
       await expect(response.json()).resolves.toMatchObject({
         data: { reply: "hello from Eliza" },
@@ -1118,7 +1120,7 @@ describe("personal Shared messaging deliveries", () => {
           version: canonicalGroupBinding.authority_version,
         },
       },
-      undefined,
+      validGroup.message,
       { type: "GROUP", source: "telegram" },
     );
   });
@@ -1483,6 +1485,7 @@ describe("personal Shared messaging deliveries", () => {
         project: "eliza-app",
         phoneNumber: "+15551234567",
       },
+      "hello from Messages",
     );
   });
 
@@ -1657,6 +1660,7 @@ describe("personal Shared messaging deliveries", () => {
         platform: "discord",
         discordUserId: "123456789012345678",
       },
+      "continue our conversation",
     );
   });
 

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -705,7 +705,7 @@ describe("personal Shared messaging deliveries", () => {
     try {
       const response = await request({
         ...valid,
-        message: undefined,
+        message: "please verify it",
         voiceNote: {
           bytesBase64: bytes.toString("base64"),
           mimeType: "audio/ogg",
@@ -719,7 +719,7 @@ describe("personal Shared messaging deliveries", () => {
       expect(sharedRestMessageSend).toHaveBeenCalledWith(
         expect.anything(),
         expect.stringMatching(/^personal:/),
-        "remember the red bicycle",
+        "please verify it\n\n[Voice note transcript]\nremember the red bicycle",
         "Eliza",
         runtimeExecutionCtx,
         namespace,
@@ -730,7 +730,7 @@ describe("personal Shared messaging deliveries", () => {
           project: "eliza-app",
           chatId: "123456789",
         },
-        "remember the red bicycle",
+        "please verify it\nremember the red bicycle",
       );
       await expect(response.json()).resolves.toMatchObject({
         data: { reply: "hello from Eliza" },

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -47,6 +47,7 @@ const FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
 const GROUP_CLAIM_TTL_MS = 10 * 60_000;
 const GROUP_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 const GROUP_SOURCE_MESSAGE_ID_MAX_LENGTH = 240;
+const GENERATED_MEDIA_ONLY_MESSAGE = /^\[media: https?:\/\/[^\r\n]+\]$/u;
 
 type DeliveryStage =
   | "authentication"
@@ -889,7 +890,12 @@ app.post("/", async (c) => {
     // Public-data capability checks may inspect only authenticated user content,
     // never the actor labels, media descriptions, or other server context that
     // this route appends to the model-facing delivery message below.
-    let capabilityText = parsed.data.message;
+    let capabilityText =
+      (parsed.data.platform === "blooio" ||
+        parsed.data.platform === "twilio") &&
+      GENERATED_MEDIA_ONLY_MESSAGE.test(parsed.data.message)
+        ? undefined
+        : parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
       !isGroupMessage(parsed.data) &&

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -886,6 +886,10 @@ app.post("/", async (c) => {
           return timing;
         })();
     let deliveryMessage = parsed.data.message;
+    // Public-data capability checks may inspect only authenticated user content,
+    // never the actor labels, media descriptions, or other server context that
+    // this route appends to the model-facing delivery message below.
+    let capabilityText = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
       !isGroupMessage(parsed.data) &&
@@ -903,6 +907,9 @@ app.post("/", async (c) => {
       );
       deliveryMessage = parsed.data.message
         ? `${parsed.data.message}\n\n[Voice note transcript]\n${transcript}`
+        : transcript;
+      capabilityText = parsed.data.message
+        ? `${parsed.data.message}\n${transcript}`
         : transcript;
       logger.info(
         "[personal-shared-messaging] Telegram voice note transcribed",
@@ -1225,7 +1232,7 @@ app.post("/", async (c) => {
           parsed.data.messageId,
           "platform",
           groupTrustedDelivery,
-          undefined,
+          capabilityText,
           { type: ChannelType.GROUP, source: parsed.data.platform },
         )
       : await sharedRestMessageSend(
@@ -1238,6 +1245,7 @@ app.post("/", async (c) => {
           parsed.data.messageId,
           "platform",
           trustedDelivery,
+          capabilityText,
         );
     // The same values ship on `Server-Timing` below; a second uncorrelated
     // per-turn log on the hot path would only duplicate them.

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.test.ts
@@ -74,5 +74,7 @@ test("sends personal Shared turns through platform funding", async () => {
     namespace,
     "client-1",
     "platform",
+    undefined,
+    "hello",
   );
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -184,6 +184,8 @@ app.post("/", async (c) => {
       worker.namespace,
       sharedTurnClientMessageId(raw),
       "agentKind" in r ? "platform" : "organization-credits",
+      undefined,
+      text,
     );
   } catch (error) {
     // error-policy:J1 route boundary translates bridge/billing failures to HTTP responses.

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -86,10 +86,17 @@ async function __hono_POST(
     }
 
     const rpcRequest = parsed.data as BridgeRequest;
+    const trustedUserUtterance =
+      rpcRequest.method === "message.send" &&
+      typeof rpcRequest.params?.text === "string" &&
+      rpcRequest.params.text.trim()
+        ? rpcRequest.params.text
+        : undefined;
     const response = await coordinateSharedBridge(resolved.agent, rpcRequest, {
       executionCtx: resolved.executionCtx,
       namespace: resolved.namespace,
       agentKind: resolved.agentKind,
+      ...(trustedUserUtterance ? { trustedUserUtterance } : {}),
     });
 
     return applyCorsHeaders(Response.json(response), CORS_METHODS);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.test.ts
@@ -79,5 +79,6 @@ test("forwards the rowless personal envelope to the coordinator", async () => {
   expect(coordinateSharedStream).toHaveBeenCalledTimes(1);
   expect(coordinateSharedStream.mock.calls[0]?.[2]).toMatchObject({
     agentKind: "personal",
+    trustedUserUtterance: "hello",
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -100,6 +100,7 @@ async function __hono_POST(
         executionCtx: resolved.executionCtx,
         namespace: resolved.namespace,
         agentKind: resolved.agentKind,
+        trustedUserUtterance: parsed.data.params.text,
       },
     );
 

--- a/packages/cloud/shared/src/lib/services/personal-message-delivery.test.ts
+++ b/packages/cloud/shared/src/lib/services/personal-message-delivery.test.ts
@@ -62,6 +62,7 @@ describe("deliverPersonalTextMessage", () => {
       reply: "Shared reply",
     });
     expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend.mock.calls[0]?.[9]).toBe("hello");
     expect(sharedRestMessageSend.mock.calls[0]?.[10]).toEqual({
       type: ChannelType.DM,
       source: "x",

--- a/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
+++ b/packages/cloud/shared/src/lib/services/personal-message-delivery.ts
@@ -190,7 +190,7 @@ export async function deliverPersonalTextMessage(params: {
     params.messageId,
     "platform",
     undefined,
-    undefined,
+    params.message,
     { type: ChannelType.DM, source: params.platform },
   );
   return {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -78,6 +78,7 @@ describe("handleCanonicalScopedAgentStream", () => {
       executionCtx: EXECUTION_CTX,
       agentKind: undefined,
       trustedMessageRole: undefined,
+      trustedUserUtterance: "hello",
       channel: { type: ChannelType.DM, source: MESSAGE_SOURCE_CLIENT_CHAT },
       traceId: "trace-canonical-stream",
       trustedHistoryCutoffAt: undefined,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -156,6 +156,7 @@ export async function handleCanonicalScopedAgentStream(
       executionCtx: request.executionCtx,
       agentKind: request.agentKind,
       trustedMessageRole: request.trustedMessageRole,
+      trustedUserUtterance: text,
       channel: request.channel ?? {
         type: ChannelType.DM,
         source: MESSAGE_SOURCE_CLIENT_CHAT,


### PR DESCRIPTION
## Summary

Post-merge correction for #25433 and repaired successor to #25562.

- propagates only authenticated raw user text into current-public-data authorization across personal Telegram/Blooio/Discord, Twitter personal delivery, non-stream REST, canonical SSE, generic authenticated SSE, and generic authenticated JSON-RPC bridge paths
- keeps connector actor labels, voice transcript labels, generated media descriptions, and generated media-only URL placeholders out of the public-search query
- preserves verified Telegram voice transcripts as authenticated capability input
- leaves non-message JSON-RPC methods without capability authority

## Composition

- Exact base: `b08d6ddd6dcf0161775172138607f2acddbd202f` (#25433 merge)
- Exact head: `ca00d7e33e1b8a801f83196c82d9d95b27172d5a`
- Includes NubsCarson tip patch from #25562, repaired for all remaining production ingress callers and media-only URL privacy.

## Validation

Pinned Bun `1.3.14`, Node `24.15.0`:

- affected caller suites: **121 passed, 0 failed, 499 expectations**
- `bun run --cwd packages/cloud/shared typecheck`: passed
- `bun run --cwd packages/cloud/api typecheck` including Worker production dry-run: passed
- Biome on all 15 changed files: passed
- `git diff --check`: passed

The typechecks ran immediately before the conflict-free rebase from the byte-identical #25433 feature tree to its squash merge; all 121 focused tests, Biome, and diff-check were rerun at the published head.

## Evidence

This corrects deterministic authorization plumbing only. It does not claim live provider/model or signed Telegram delivery evidence. Those remain deployment/promotion evidence requirements for the merged grounding feature.