### PR TITLE
test(shared): cover cloud-secrets store

### DIFF
--- a/packages/shared/src/elizacloud/cloud-secrets.test.ts
+++ b/packages/shared/src/elizacloud/cloud-secrets.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Coverage for the sealed cloud-secret store: env fallback, scrubbing from
+ * process.env, clear-on-disconnect, and the test-only reset. Module state is
+ * reset between tests via vi.resetModules + dynamic import.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CloudSecretsModule = {
+  _resetCloudSecretsForTesting: () => void;
+  clearCloudSecrets: () => void;
+  getCloudSecret: (key: string) => string | undefined;
+  scrubCloudSecretsFromEnv: () => void;
+};
+
+const API_KEY = "ELIZAOS_CLOUD_API_KEY";
+const ENABLED = "ELIZAOS_CLOUD_ENABLED";
+
+async function loadSecrets(): Promise<CloudSecretsModule> {
+  vi.resetModules();
+  const mod = await import("./cloud-secrets.ts");
+  mod._resetCloudSecretsForTesting();
+  return mod;
+}
+
+beforeEach(() => {
+  delete process.env[API_KEY];
+  delete process.env[ENABLED];
+});
+
+afterEach(() => {
+  delete process.env[API_KEY];
+  delete process.env[ENABLED];
+});
+
+describe("getCloudSecret", () => {
+  it("returns undefined when neither store nor env has the key", async () => {
+    const mod = await loadSecrets();
+    expect(mod.getCloudSecret(API_KEY)).toBeUndefined();
+  });
+
+  it("falls back to process.env when not sealed", async () => {
+    process.env[API_KEY] = "sk-live-123";
+    const mod = await loadSecrets();
+    expect(mod.getCloudSecret(API_KEY)).toBe("sk-live-123");
+  });
+});
+
+describe("scrubCloudSecretsFromEnv", () => {
+  it("moves env values into the sealed store and deletes from env", async () => {
+    process.env[API_KEY] = "sk-live-123";
+    process.env[ENABLED] = "true";
+    const mod = await loadSecrets();
+    mod.scrubCloudSecretsFromEnv();
+    expect(process.env[API_KEY]).toBeUndefined();
+    expect(process.env[ENABLED]).toBeUndefined();
+    expect(mod.getCloudSecret(API_KEY)).toBe("sk-live-123");
+    expect(mod.getCloudSecret(ENABLED)).toBe("true");
+  });
+
+  it("is a no-op when the env keys are absent", async () => {
+    const mod = await loadSecrets();
+    mod.scrubCloudSecretsFromEnv();
+    expect(mod.getCloudSecret(API_KEY)).toBeUndefined();
+  });
+});
+
+describe("clearCloudSecrets", () => {
+  it("removes sealed secrets after disconnect", async () => {
+    process.env[API_KEY] = "sk-live-123";
+    const mod = await loadSecrets();
+    mod.scrubCloudSecretsFromEnv();
+    expect(mod.getCloudSecret(API_KEY)).toBe("sk-live-123");
+    mod.clearCloudSecrets();
+    expect(mod.getCloudSecret(API_KEY)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  5 passed (5)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
