### PR TITLE
chore(ci): restore static-smoke formatting closure

### DIFF
--- a/packages/app-core/src/api/dev-compat-routes.surrogate.test.ts
+++ b/packages/app-core/src/api/dev-compat-routes.surrogate.test.ts
@@ -6,15 +6,9 @@
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 
-function isWellFormed(value: string): boolean {
-  const maybe = value as unknown as { isWellFormed?: () => boolean };
-  if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
-  return !value.includes("\uFFFD") || true;
-}
-
 describe("dev-compat-routes surrogate-safe truncation (200)", () => {
   it("does not split astral pair at 200", () => {
-    const text = "a".repeat(199) + "🦊" + "b".repeat(10);
+    const text = `${"a".repeat(199)}🦊${"b".repeat(10)}`;
     const truncated = truncateWellFormed(toWellFormedUnicode(text), 200);
     expect(truncated.length).toBe(199);
     expect(truncated).toBe("a".repeat(199));
@@ -37,7 +31,7 @@ describe("dev-compat-routes surrogate-safe truncation (200)", () => {
   });
 
   it("old slice would split surrogate but guard does not", () => {
-    const text = "a".repeat(199) + "🦊";
+    const text = `${"a".repeat(199)}🦊`;
     const old = text.slice(0, 200);
     // old slice ends on high surrogate (lead half) -> lone surrogate
     expect(old.charCodeAt(199)).toBe(0xd83e);

--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -7,9 +7,12 @@
  * true once it owns a request, false to let the caller keep dispatching.
  */
 import type http from "node:http";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { InferenceTurnSummary, Log } from "@elizaos/core";
-import { INFERENCE_TRACE_ID_PATTERN } from "@elizaos/core";
+import {
+  INFERENCE_TRACE_ID_PATTERN,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import { parseCanonicalInteger } from "@elizaos/shared";
 import { ensureRouteAuthorized } from "./auth.ts";
 import {

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for Discord fetch error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("discord automation surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/core/src/connectors/account-manager.safe-sort.test.ts
+++ b/packages/core/src/connectors/account-manager.safe-sort.test.ts
@@ -41,12 +41,7 @@ describe("InMemoryConnectorAccountStorage safe sort", () => {
 		const accounts = await storage.listAccounts("slack");
 		// NaN and Infinity fall back to 0, so a and c (both 0) come first sorted
 		// by id, then d (50), then b (100).
-		expect(accounts.map((account) => account.id)).toEqual([
-			"a",
-			"c",
-			"d",
-			"b",
-		]);
+		expect(accounts.map((account) => account.id)).toEqual(["a", "c", "d", "b"]);
 	});
 
 	it("produces a total order for a single non-finite entry", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -9,10 +9,10 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearTaskAgentFrameworkStateCache,
+  compareScoredFrameworkCandidates,
   getTaskAgentFrameworkState,
   getTaskAgentModelPrefs,
   type TaskAgentFrameworkProbe,
-  compareScoredFrameworkCandidates,
 } from "../../src/services/task-agent-frameworks.js";
 
 const ENV_KEYS = [

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -325,9 +325,13 @@ export function compareScoredFrameworkCandidates(
   right: { score: number; framework: { id: string } },
 ): number {
   const rightScore =
-    typeof right.score === "number" && Number.isFinite(right.score) ? right.score : 0;
+    typeof right.score === "number" && Number.isFinite(right.score)
+      ? right.score
+      : 0;
   const leftScore =
-    typeof left.score === "number" && Number.isFinite(left.score) ? left.score : 0;
+    typeof left.score === "number" && Number.isFinite(left.score)
+      ? left.score
+      : 0;
   if (rightScore !== leftScore) return rightScore - leftScore;
   return left.framework.id.localeCompare(right.framework.id);
 }
@@ -920,7 +924,8 @@ async function computeTaskAgentFrameworkState(
     frameworks.find((framework) => framework.id !== "kimi") ??
     frameworks[0];
   const preferredCandidate =
-    scoredCandidates.sort(compareScoredFrameworkCandidates)[0]?.framework ?? fallback;
+    scoredCandidates.sort(compareScoredFrameworkCandidates)[0]?.framework ??
+    fallback;
   const preferredSignals =
     scoredCandidates.find(
       (entry) => entry.framework.id === preferredCandidate.id,
@@ -1131,7 +1136,8 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
     frameworks.find((framework) => framework.id !== "kimi") ??
     frameworks[0];
   const preferredCandidate =
-    scoredCandidates.sort(compareScoredFrameworkCandidates)[0]?.framework ?? fallback;
+    scoredCandidates.sort(compareScoredFrameworkCandidates)[0]?.framework ??
+    fallback;
   const preferredSignals =
     scoredCandidates.find(
       (entry) => entry.framework.id === preferredCandidate.id,

--- a/plugins/plugin-trajectory-logger/src/api-client.surrogate.test.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.surrogate.test.ts
@@ -68,7 +68,11 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
       expect(message).toContain("�");
       expect(preview.length).toBeLessThanOrEqual(200);
       // Direct constructor path also well-formed
-      const direct = new TrajectoryHttpError(500, "err", lone + "a".repeat(199));
+      const direct = new TrajectoryHttpError(
+        500,
+        "err",
+        lone + "a".repeat(199),
+      );
       expect(direct.message.isWellFormed()).toBe(true);
       expect(direct.message).not.toContain("\uD800");
       expect(direct.message).toContain("�");

--- a/plugins/plugin-trajectory-logger/src/api-client.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.ts
@@ -66,9 +66,13 @@ export interface TrajectoryDetail {
 }
 
 function toWellFormedUnicodeLocal(text: string): string {
-  const maybe = text as unknown as { toWellFormed?: () => string; isWellFormed?: () => boolean };
+  const maybe = text as unknown as {
+    toWellFormed?: () => string;
+    isWellFormed?: () => boolean;
+  };
   if (typeof maybe.toWellFormed === "function") return maybe.toWellFormed();
-  if (typeof maybe.isWellFormed === "function" && maybe.isWellFormed()) return text;
+  if (typeof maybe.isWellFormed === "function" && maybe.isWellFormed())
+    return text;
   let out = "";
   for (let i = 0; i < text.length; i++) {
     const code = text.charCodeAt(i);
@@ -115,8 +119,12 @@ export class TrajectoryHttpError extends Error {
   readonly status: number;
 
   constructor(status: number, statusText: string, body: string) {
-    const errorBodyPreview = body ? truncateWellFormedLocal(toWellFormedUnicodeLocal(body), 200) : "";
-    super(`[trajectory-logger] ${status} ${statusText}${errorBodyPreview ? `: ${errorBodyPreview}` : ""}`);
+    const errorBodyPreview = body
+      ? truncateWellFormedLocal(toWellFormedUnicodeLocal(body), 200)
+      : "";
+    super(
+      `[trajectory-logger] ${status} ${statusText}${errorBodyPreview ? `: ${errorBodyPreview}` : ""}`,
+    );
     this.name = "TrajectoryHttpError";
     this.status = status;
   }


### PR DESCRIPTION
## Summary

Baseline lint closure for sequential static-smoke failures exposed while validating the reviewed PR queue.

- format the trajectory logger API client and Unicode surrogate regression
- format the Cloud Discord automation surrogate regression
- organize imports and format the task-agent framework comparator baseline
- format the core connector-account safe-sort regression
- organize app-core compat-route imports, format its surrogate regression, and remove one unused no-op test helper
- no runtime behavior, public contract, dependency, or generated-file changes

## Validation

- repository-pinned Biome 2.5.8: all eight changed files clean
- complete touched-package source scan: 1,942 files clean before app-core addition; exact app-core files also clean
- trajectory surrogate regression: 3/3 passed
- core connector safe-sort regression: 4/4 passed
- app-core focused test reaches only an absent generated core validation-keyword artifact in the sparse checkout; hosted workspace setup builds that artifact
- task-agent framework focused test reaches only the sparse checkout's intentionally absent smol-toml dependency; the changes are formatter/import-order only
- Discord surrogate test likewise needs the hosted built workspace
- diff check clean
- hosted static-smoke rerun required before merge

## Why this is separate

The candidate PRs did not touch these files. The affected-workspace gate surfaced the baseline issues sequentially, so this PR restores the common validation baseline without polluting any product candidate diff.