### PR TITLE
fix(plugin-openai): derive a recognized transcription filename for non-canonical audio types

### DIFF
--- a/plugins/plugin-openai/__tests__/transcription-filename.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/transcription-filename.shape.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression tests for the TRANSCRIPTION multipart upload filename. The Node
+ * URL path wraps remote bytes in a Blob whose type is the server's raw
+ * `audio/*` Content-Type, which can be a valid-but-non-canonical alias
+ * (`audio/mp3`, `audio/x-wav`, `audio/aac`). Previously the handler cast that
+ * string straight to `AudioMimeType` and derived `recording.undefined`, which
+ * OpenAI's /audio/transcriptions rejects (HTTP 400, unrecognized extension).
+ * The handler is exercised through its real code path with the guarded Node
+ * fetcher installed; only config, `recordLlmCall`, `fetchRemoteMedia`, and the
+ * global `fetch` are mocked, so no live model or network is required. The pure
+ * `normalizeAudioMimeType` / `getExtensionForMimeType` mapping is asserted
+ * directly for the alias table and unknown inputs.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getExtensionForMimeType,
+  getFilenameForMimeType,
+  normalizeAudioMimeType,
+} from "../utils/audio";
+
+const mocks = vi.hoisted(() => ({
+  recordLlmCall: vi.fn(),
+  fetchRemoteMedia: vi.fn(),
+  getAuthHeader: vi.fn(() => ({ Authorization: "Bearer test-key" })),
+  getBaseURL: vi.fn(() => "https://api.openai.com/v1"),
+  getTranscriptionModel: vi.fn(() => "gpt-4o-mini-transcribe"),
+}));
+
+const coreMockFactory = vi.hoisted(
+  () => async (importActual: () => Promise<Record<string, unknown>>) => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      logger: { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+      recordLlmCall: mocks.recordLlmCall,
+      fetchRemoteMedia: (...args: unknown[]) => mocks.fetchRemoteMedia(...args),
+    };
+  }
+);
+
+vi.mock("@elizaos/core", coreMockFactory);
+vi.mock("@elizaos/core/node", coreMockFactory);
+
+vi.mock("../utils/config", () => ({
+  getAuthHeader: mocks.getAuthHeader,
+  getBaseURL: mocks.getBaseURL,
+  getTranscriptionModel: mocks.getTranscriptionModel,
+  getTTSInstructions: vi.fn(() => undefined),
+  getTTSModel: vi.fn(() => "gpt-4o-mini-tts"),
+  getTTSVoice: vi.fn(() => "nova"),
+}));
+
+import { handleTranscription } from "../models/audio";
+import { installNodeTranscriptionUrlFetcher } from "../models/transcription-url.node";
+
+installNodeTranscriptionUrlFetcher();
+
+// OpenAI /audio/transcriptions determines the audio format from the filename
+// extension and 400s on anything outside this set; the derived name must land
+// inside it for every accepted alias.
+const RECOGNIZED_EXTENSIONS = new Set([
+  "flac",
+  "m4a",
+  "mp3",
+  "mp4",
+  "mpeg",
+  "mpga",
+  "oga",
+  "ogg",
+  "wav",
+  "webm",
+]);
+
+// ID3-tagged MP3 (real magic bytes) so container sniffing is authoritative.
+const MP3_ID3_BYTES = Buffer.from([
+  0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xfb, 0x90, 0x00,
+]);
+// Minimal RIFF/WAVE header (real magic bytes).
+const WAV_BYTES = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+]);
+// AAC-in-a-CDN blob whose bytes do NOT match any sniffer signature, so the
+// handler must fall back to normalizing the declared `audio/aac` header.
+const OPAQUE_AAC_BYTES = Buffer.from([
+  0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+]);
+
+function createRuntime(): IAgentRuntime {
+  return { getSetting: vi.fn(() => null) } as unknown as IAgentRuntime;
+}
+
+async function captureUploadFilename(contentType: string, buffer: Buffer): Promise<string> {
+  mocks.fetchRemoteMedia.mockResolvedValue({ buffer, contentType, fileName: null });
+  let capturedFilename = "";
+  const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+    const formData = init.body as FormData;
+    const file = formData.get("file") as File;
+    capturedFilename = file.name;
+    return new Response(JSON.stringify({ text: "ok" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+  await handleTranscription(createRuntime(), "https://cdn.example.com/voice");
+  return capturedFilename;
+}
+
+describe("TRANSCRIPTION upload filename for non-canonical audio content types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) => fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { contentType: "audio/mp3", buffer: MP3_ID3_BYTES, expected: "recording.mp3" },
+    { contentType: "audio/x-wav", buffer: WAV_BYTES, expected: "recording.wav" },
+    { contentType: "audio/wave", buffer: WAV_BYTES, expected: "recording.wav" },
+    { contentType: "audio/aac", buffer: OPAQUE_AAC_BYTES, expected: "recording.m4a" },
+    { contentType: "audio/x-m4a", buffer: OPAQUE_AAC_BYTES, expected: "recording.m4a" },
+  ])(
+    "uploads a recognized extension for Content-Type $contentType",
+    async ({ contentType, buffer, expected }) => {
+      const filename = await captureUploadFilename(contentType, buffer);
+
+      expect(filename).not.toContain("undefined");
+      expect(filename).toBe(expected);
+      const ext = filename.split(".").pop() ?? "";
+      expect(RECOGNIZED_EXTENSIONS.has(ext)).toBe(true);
+    }
+  );
+
+  it("prefers sniffed container over a mislabeled non-canonical header", async () => {
+    // Bytes are a real MP3 but the CDN mislabeled them audio/x-wav; the sniffer
+    // wins so OpenAI receives the correct .mp3 format hint.
+    const filename = await captureUploadFilename("audio/x-wav", MP3_ID3_BYTES);
+    expect(filename).toBe("recording.mp3");
+  });
+});
+
+describe("normalizeAudioMimeType alias mapping", () => {
+  it.each([
+    ["audio/mp3", "audio/mpeg", "mp3"],
+    ["audio/mpeg", "audio/mpeg", "mp3"],
+    ["audio/x-wav", "audio/wav", "wav"],
+    ["audio/wave", "audio/wav", "wav"],
+    ["audio/x-m4a", "audio/mp4", "m4a"],
+    ["audio/aac", "audio/mp4", "m4a"],
+    ["audio/opus", "audio/ogg", "ogg"],
+    ["audio/x-flac", "audio/flac", "flac"],
+    ["AUDIO/MP3; codecs=mp3", "audio/mpeg", "mp3"],
+  ] as const)("maps %s to canonical %s", (raw, canonical, extension) => {
+    const normalized = normalizeAudioMimeType(raw);
+    expect(normalized).toBe(canonical);
+    expect(getExtensionForMimeType(normalized)).toBe(extension);
+    expect(getFilenameForMimeType(normalized)).toBe(`recording.${extension}`);
+  });
+
+  it.each(["application/pdf", "text/plain", "", "not-a-mime", null, undefined])(
+    "collapses unrecognized input %s to application/octet-stream (recording.bin)",
+    (raw) => {
+      const normalized = normalizeAudioMimeType(raw);
+      expect(normalized).toBe("application/octet-stream");
+      expect(getFilenameForMimeType(normalized)).toBe("recording.bin");
+      expect(getFilenameForMimeType(normalized)).not.toContain("undefined");
+    }
+  );
+});

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -25,7 +25,12 @@ import type {
   TTSOutputFormat,
   TTSVoice,
 } from "../types";
-import { detectAudioMimeType, getFilenameForMimeType } from "../utils/audio";
+import type { AudioMimeType } from "../utils/audio";
+import {
+  detectAudioMimeType,
+  getFilenameForMimeType,
+  normalizeAudioMimeType,
+} from "../utils/audio";
 import {
   getAuthHeader,
   getBaseURL,
@@ -66,6 +71,26 @@ function isCoreTranscriptionParams(value: unknown): value is CoreTranscriptionPa
     "audioUrl" in value &&
     typeof (value as CoreTranscriptionParams).audioUrl === "string"
   );
+}
+
+/** Enough leading bytes for every `detectAudioMimeType` magic-byte probe. */
+const AUDIO_SNIFF_BYTES = 64;
+
+/**
+ * Choose the canonical audio type used to label the multipart upload. The
+ * container bytes are authoritative — a valid MP3 served with a non-canonical
+ * `Content-Type: audio/mp3` still uploads as `recording.mp3` — and only when
+ * sniffing is inconclusive do we fall back to normalizing the declared type.
+ * This keeps the derived extension inside the recognized set OpenAI's
+ * /audio/transcriptions accepts instead of emitting `recording.undefined`.
+ */
+async function resolveUploadMimeType(blob: Blob, declaredType: string): Promise<AudioMimeType> {
+  const header = new Uint8Array(await blob.slice(0, AUDIO_SNIFF_BYTES).arrayBuffer());
+  const sniffed = detectAudioMimeType(header);
+  if (sniffed !== "application/octet-stream") {
+    return sniffed;
+  }
+  return normalizeAudioMimeType(declaredType);
 }
 
 const AUDIO_TRANSCRIPTION_TIMEOUT_MS = 120_000;
@@ -128,13 +153,9 @@ export async function handleTranscription(
   logger.debug(`[OpenAI] Using TRANSCRIPTION model: ${modelName}`);
 
   const mimeType = (blob as File).type || "audio/webm";
+  const providedName = (blob as File).name;
   const filename =
-    (blob as File).name ||
-    getFilenameForMimeType(
-      mimeType.startsWith("audio/")
-        ? (mimeType as ReturnType<typeof detectAudioMimeType>)
-        : "audio/webm"
-    );
+    providedName || getFilenameForMimeType(await resolveUploadMimeType(blob, mimeType));
 
   const formData = new FormData();
   formData.append("file", blob, filename);

--- a/plugins/plugin-openai/utils/audio.ts
+++ b/plugins/plugin-openai/utils/audio.ts
@@ -86,6 +86,48 @@ export function detectAudioMimeType(buffer: Uint8Array): AudioMimeType {
   return "application/octet-stream";
 }
 
+/**
+ * Maps a declared audio Content-Type — including the common non-canonical
+ * aliases servers actually send (`audio/mp3`, `audio/x-wav`, `audio/x-m4a`,
+ * `audio/aac`, …) — onto a canonical `AudioMimeType`. Any unrecognized value
+ * collapses to `application/octet-stream` so callers never build a filename
+ * from an unbounded, untrusted string. The keys are compared against the
+ * lowercased type without its parameter suffix (e.g. `; codecs=...`).
+ */
+const AUDIO_MIME_ALIASES: Readonly<Record<string, AudioMimeType>> = {
+  "audio/wav": "audio/wav",
+  "audio/x-wav": "audio/wav",
+  "audio/wave": "audio/wav",
+  "audio/vnd.wave": "audio/wav",
+  "audio/mpeg": "audio/mpeg",
+  "audio/mp3": "audio/mpeg",
+  "audio/mpeg3": "audio/mpeg",
+  "audio/x-mpeg-3": "audio/mpeg",
+  "audio/mpg": "audio/mpeg",
+  "audio/ogg": "audio/ogg",
+  "audio/opus": "audio/ogg",
+  "audio/oga": "audio/ogg",
+  "audio/vorbis": "audio/ogg",
+  "audio/flac": "audio/flac",
+  "audio/x-flac": "audio/flac",
+  "audio/mp4": "audio/mp4",
+  "audio/m4a": "audio/mp4",
+  "audio/x-m4a": "audio/mp4",
+  "audio/x-m4b": "audio/mp4",
+  "audio/aac": "audio/mp4",
+  "audio/x-aac": "audio/mp4",
+  "audio/webm": "audio/webm",
+  "application/octet-stream": "application/octet-stream",
+} as const;
+
+export function normalizeAudioMimeType(raw: string | null | undefined): AudioMimeType {
+  if (!raw) {
+    return "application/octet-stream";
+  }
+  const base = raw.split(";")[0]?.trim().toLowerCase() ?? "";
+  return AUDIO_MIME_ALIASES[base] ?? "application/octet-stream";
+}
+
 export function getExtensionForMimeType(mimeType: AudioMimeType): string {
   switch (mimeType) {
     case "audio/wav":
@@ -101,6 +143,10 @@ export function getExtensionForMimeType(mimeType: AudioMimeType): string {
     case "audio/webm":
       return "webm";
     case "application/octet-stream":
+      return "bin";
+    default:
+      // Defense in depth: a caller that cast an arbitrary string to
+      // AudioMimeType must still yield a real extension, never `undefined`.
       return "bin";
   }
 }


### PR DESCRIPTION
# Relates to

Closes #25579

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates were run (see **Known gaps / failures** for the one unrelated pre-existing failure and why `bun run verify` was not run in full here).
- [x] A reviewer can confirm the change works without reading the code, from the before/after test evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`695f7b8727`); zero conflicts.
- [ ] `bun run verify` full run not executed on this constrained host; focused `plugin-openai` typecheck + lint + tests were run. One pre-existing, unrelated `plugin-openai` wire test failure is documented in **Known gaps / failures**.

# Risks

Low. The change is confined to how `@elizaos/plugin-openai` derives the multipart **filename** for a transcription upload. It does not alter request routing, auth, the SSRF guard, or the audio bytes. Worst realistic regression is a wrong-but-still-recognized extension for an exotic container, which is strictly better than the previous `recording.undefined` (a guaranteed HTTP 400).

# Background

## What does this PR do?

`handleTranscription` built the upload filename by casting the blob's raw
`audio/*` `Content-Type` straight to the `AudioMimeType` union and switching on
it:

```ts
getFilenameForMimeType(mimeType.startsWith("audio/") ? (mimeType as AudioMimeType) : "audio/webm")
```

`getExtensionForMimeType` is a `switch` over the canonical `AudioMimeType`
union with **no default**. When the runtime value is a valid-but-non-canonical
audio type that servers actually send — `audio/mp3` (canonical is
`audio/mpeg`), `audio/x-wav`, `audio/wave`, `audio/x-m4a`, `audio/aac` — the
cast lies, no case matches, the switch returns `undefined`, and the upload
filename becomes **`recording.undefined`**. This reaches the wire on the URL
transcription path (`toAudioBlob` trusts any remote `audio/*` `Content-Type`)
and on direct `Blob`/`File` input. OpenAI's `/audio/transcriptions` picks the
audio format from the filename extension and rejects an unrecognized
`.undefined` with **HTTP 400 "Invalid file format"**, so transcribing a remote
MP3 served as `Content-Type: audio/mp3` fails even though the bytes are valid.

The fix makes filename derivation **total**:

1. `resolveUploadMimeType(blob, declaredType)` in `models/audio.ts` sniffs the
   container bytes first (`detectAudioMimeType`, authoritative — a real MP3
   mislabeled `audio/x-wav` still uploads as `recording.mp3`), and only when
   sniffing is inconclusive falls back to normalizing the declared header.
2. `normalizeAudioMimeType(raw)` in `utils/audio.ts` maps the common
   non-canonical aliases onto canonical `AudioMimeType` values and collapses
   anything unrecognized to `application/octet-stream`, so a filename is never
   built from an unbounded untrusted string.
3. `getExtensionForMimeType` gains a defensive `default: return "bin"` so no
   future cast can reintroduce a `undefined` extension.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The
plugin guide already lists `utils/audio.ts` as owning MIME/filename derivation;
behavior is corrected, not surface-widened.

# Testing

## Where should a reviewer start?

`plugins/plugin-openai/__tests__/transcription-filename.shape.test.ts`. It drives
the real `handleTranscription` URL path with the guarded Node fetcher installed
(no live network) and captures the `FormData` `file` entry name, plus a direct
unit test of `normalizeAudioMimeType` / `getExtensionForMimeType`.

## Detailed testing steps

```bash
bun run --cwd packages/core build          # provide @elizaos/core for the plugin tests
cd plugins/plugin-openai
bunx vitest run __tests__/transcription-filename.shape.test.ts
bun run typecheck
bun run lint:check
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ac0b4b7a71e5aee19f14d63d84f5f9c0c3382596 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a provider plugin filename-derivation fix.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a provider plugin filename-derivation fix.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; the changed contract is a multipart upload filename, proven by the before/after test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Failing-before and passing-after focused test output is attached in **Evidence Details** (the real `handleTranscription` code path fires; captured `FormData` filename goes from `recording.undefined` to `recording.mp3`).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend; server-side provider plugin only.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model inference changes. The transcription request body is unchanged except the corrected multipart filename; no live-model call is made or altered, and the fetch is mocked to avoid a live network/model. OpenAI's documented 400 on unrecognized extensions is the failure this prevents.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the multipart upload filename; before/after captures (`recording.undefined` → `recording.mp3`) are in **Evidence Details**.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model/prompt/provider inference change; only the multipart upload
filename derivation is corrected. Tests mock the provider fetch so no live
model call is made.`

## Backend + frontend logs

Focused package test output, captured on head `ac0b4b7`.

**Before the fix** (source reverted to `origin/develop`, new regression test retained) — the captured upload filename is `recording.undefined`:

```
 ❯ __tests__/transcription-filename.shape.test.ts (21 tests | 21 failed)
AssertionError: expected 'recording.undefined' not to contain 'undefined'
Received: "recording.undefined"
    131|       expect(filename).not.toContain("undefined");
    132|       expect(filename).toBe(expected);
AssertionError: expected 'recording.undefined' to be 'recording.mp3' // Object.is equality
Received: "recording.undefined"
 Test Files  1 failed (1)
      Tests  21 failed (21)
```

**After the fix** — the same test passes; `audio/mp3` → `recording.mp3`, `audio/x-wav` → `recording.wav`, `audio/aac` → `recording.m4a`:

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Combined with the existing SSRF harness (unchanged behavior):

```
 Test Files  2 passed (2)
      Tests  30 passed (30)
```

`typecheck` (`tsc --noEmit`) and `lint:check` (`biome check`, 67 files) both pass clean.

Frontend logs: `N/A - server-side provider plugin only.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this change.`

### Before

`N/A - no UI.`

### After

`N/A - no UI.`

### Walkthrough video

`N/A - no UI/user flow; the before/after test logs above are the proof.`

## Audio / voice walkthrough

`N/A - this fix is about the transcription upload filename, not audio
round-trip fidelity; no bytes are transformed. The corrected filename is proven
by the before/after captured `FormData` name in the tests above.`

## Known gaps / failures

- `bun run verify` (full repo gate) was not run on this constrained host; the
  owning package's `typecheck`, `lint:check`, and the affected tests were run
  and pass.
- `bun run --cwd plugins/plugin-openai test` (full package suite) has a
  pre-existing, unrelated failure in the Cerebras/wire lanes
  (`wire-well-formed.shape.test.ts` / `text-wire-contract-lane.shape.test.ts`:
  `reasoning_effort` `"none"` vs `undefined` for `gemma-4-31b`, and
  `cerebras-native-tools-walk-bound.shape.test.ts` depth-budget cases in
  `packages/core/src/utils/well-formed.ts`). These fail identically on the
  unmodified `origin/develop` base (verified by stashing this change) and do
  not touch `models/audio.ts` or `utils/audio.ts`. Not a blocker for this PR.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@1805b3b8f1f2aa5dbfeeaaf82026b6808ba1eb99:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@1805b3b8f1f2aa5dbfeeaaf82026b6808ba1eb99:packages/skills/skills/contribute-to-eliza"} -->
