### PR TITLE
test(core): cover trusted local media-store urls

### DIFF
--- a/packages/core/src/media/local-store.test.ts
+++ b/packages/core/src/media/local-store.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Coverage for trusted local media-store URL resolution: canonical handle
+ * acceptance, relative-path handling, own-origin matching, and rejection of
+ * credentials/query/fragment and non-store shapes. getLocalServerUrl is
+ * mocked so origin comparison is deterministic.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getLocalServerUrl: vi.fn(),
+	MediaFetchError: vi.fn(),
+}));
+
+vi.mock("../utils/node.ts", () => ({
+	getLocalServerUrl: mocks.getLocalServerUrl,
+}));
+
+vi.mock("./fetch.ts", () => ({
+	MediaFetchError: mocks.MediaFetchError,
+}));
+
+type LocalStoreModule = {
+	VISION_IMAGE_FETCH_TIMEOUT_MS: number;
+	VISION_IMAGE_MAX_BYTES: number;
+	trustedLocalMediaUrl: (rawUrl: string) => URL | null;
+};
+
+async function loadLocalStore(): Promise<LocalStoreModule> {
+	vi.resetModules();
+	return import("./local-store.ts");
+}
+
+class MockMediaFetchError extends Error {
+	code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.code = code;
+		this.name = "MediaFetchError";
+	}
+}
+
+beforeEach(() => {
+	mocks.getLocalServerUrl.mockReset();
+	mocks.MediaFetchError.mockReset();
+	mocks.MediaFetchError.mockImplementation(function MockError(
+		this: unknown,
+		code: string,
+		message: string,
+	) {
+		const err = new MockMediaFetchError(code, message);
+		return err;
+	});
+});
+
+describe("trustedLocalMediaUrl", () => {
+	it("accepts a canonical relative handle and resolves it against the server url", async () => {
+		mocks.getLocalServerUrl.mockImplementation((path: string) => {
+			return `http://localhost:3000${path}`;
+		});
+		const mod = await loadLocalStore();
+		const url = mod.trustedLocalMediaUrl(
+			"/api/media/" + "a".repeat(64) + ".png",
+		);
+		expect(url?.href).toBe(
+			"http://localhost:3000/api/media/" + "a".repeat(64) + ".png",
+		);
+	});
+
+	it("returns null for non-media relative paths", async () => {
+		const mod = await loadLocalStore();
+		expect(mod.trustedLocalMediaUrl("/api/status")).toBeNull();
+		expect(mod.trustedLocalMediaUrl("/health")).toBeNull();
+	});
+
+	it("throws for media paths that are not canonical store handles", async () => {
+		const mod = await loadLocalStore();
+		expect(() => mod.trustedLocalMediaUrl("/api/media/not-a-sha.png")).toThrow(
+			MockMediaFetchError,
+		);
+		expect(() =>
+			mod.trustedLocalMediaUrl("/api/media/" + "a".repeat(63) + ".png"),
+		).toThrow(MockMediaFetchError);
+	});
+
+	it("returns null for non-local absolute URLs", async () => {
+		mocks.getLocalServerUrl.mockReturnValue("http://localhost:3000/");
+		const mod = await loadLocalStore();
+		expect(
+			mod.trustedLocalMediaUrl(
+				"https://evil.example/api/media/" + "a".repeat(64) + ".png",
+			),
+		).toBeNull();
+	});
+
+	it("accepts an own-origin canonical handle", async () => {
+		mocks.getLocalServerUrl.mockReturnValue("http://localhost:3000/");
+		const mod = await loadLocalStore();
+		const url = mod.trustedLocalMediaUrl(
+			"http://localhost:3000/api/media/" + "b".repeat(64) + ".jpg",
+		);
+		expect(url?.href).toBe(
+			"http://localhost:3000/api/media/" + "b".repeat(64) + ".jpg",
+		);
+	});
+
+	it("throws for own-origin URLs with credentials, query, or fragment", async () => {
+		mocks.getLocalServerUrl.mockReturnValue("http://localhost:3000/");
+		const mod = await loadLocalStore();
+		const handle = "/api/media/" + "c".repeat(64) + ".png";
+		expect(() =>
+			mod.trustedLocalMediaUrl(`http://user:pass@localhost:3000${handle}`),
+		).toThrow(MockMediaFetchError);
+		expect(() =>
+			mod.trustedLocalMediaUrl(`http://localhost:3000${handle}?token=x`),
+		).toThrow(MockMediaFetchError);
+		expect(() =>
+			mod.trustedLocalMediaUrl(`http://localhost:3000${handle}#frag`),
+		).toThrow(MockMediaFetchError);
+	});
+
+	it("returns null for unparseable URLs", async () => {
+		mocks.getLocalServerUrl.mockReturnValue("http://localhost:3000/");
+		const mod = await loadLocalStore();
+		// An invalid URL is not local — callers route it to the remote fetcher.
+		expect(mod.trustedLocalMediaUrl("http://[::1")).toBeNull();
+	});
+
+	it("exposes the shared byte cap and timeout constants", async () => {
+		const mod = await loadLocalStore();
+		expect(mod.VISION_IMAGE_MAX_BYTES).toBe(20 * 1024 * 1024);
+		expect(mod.VISION_IMAGE_FETCH_TIMEOUT_MS).toBe(15_000);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  8 passed (8)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
