### PR TITLE
fix(app-core): safe NaN handling in locale quality, performance metrics, and account pool sort comparators

### DIFF
--- a/packages/app-core/src/api/i18n-locale-routes.test.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.test.ts
@@ -80,6 +80,14 @@ describe("resolveSuggestedUiLanguage", () => {
     expect(resolveSuggestedUiLanguage({ acceptLanguage: "fr-CA" })).toBe("en");
     expect(resolveSuggestedUiLanguage({})).toBe("en");
   });
+
+  it("handles malformed or NaN q-values safely without throwing or corrupting order", () => {
+    expect(
+      resolveSuggestedUiLanguage({
+        acceptLanguage: "es;q=0.9,ja;q=NaN,en;q=0.8",
+      }),
+    ).toBe("es");
+  });
 });
 
 describe("GET /api/i18n/locale", () => {

--- a/packages/app-core/src/api/i18n-locale-routes.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.ts
@@ -34,12 +34,23 @@ function parseAcceptLanguage(value: string | string[] | undefined): string[] {
       ) {
         return null;
       }
-      const q = rawQ === undefined ? 1 : Number(rawQ);
-      if (q === 0) return null;
+      const q =
+        rawQ === undefined
+          ? 1
+          : typeof Number(rawQ) === "number" && Number.isFinite(Number(rawQ))
+            ? Number(rawQ)
+            : 0;
+      if (q <= 0) return null;
       return { index, q, tag };
     })
     .filter((candidate): candidate is LanguageCandidate => candidate != null)
-    .sort((left, right) => right.q - left.q || left.index - right.index)
+    .sort((left, right) => {
+      const rightQ =
+        typeof right.q === "number" && Number.isFinite(right.q) ? right.q : 0;
+      const leftQ =
+        typeof left.q === "number" && Number.isFinite(left.q) ? left.q : 0;
+      return rightQ - leftQ || left.index - right.index;
+    })
     .map((candidate) => candidate.tag);
 }
 

--- a/packages/app-core/src/api/perf-instrument.ts
+++ b/packages/app-core/src/api/perf-instrument.ts
@@ -119,7 +119,11 @@ export interface PerfSnapshot {
 export function getPerfSnapshot(): PerfSnapshot {
   const routes: RouteTimingEntry[] = [];
   for (const [route, stat] of routeStats) {
-    const sorted = [...stat.samples].sort((a, b) => a - b);
+    const sorted = [...stat.samples].sort((a, b) => {
+      const aVal = typeof a === "number" && Number.isFinite(a) ? a : 0;
+      const bVal = typeof b === "number" && Number.isFinite(b) ? b : 0;
+      return aVal - bVal;
+    });
     routes.push({
       route,
       count: stat.count,
@@ -129,7 +133,13 @@ export function getPerfSnapshot(): PerfSnapshot {
       avgMs: round(stat.count > 0 ? stat.totalMs / stat.count : 0),
     });
   }
-  routes.sort((a, b) => b.count - a.count);
+  routes.sort((a, b) => {
+    const bCount =
+      typeof b.count === "number" && Number.isFinite(b.count) ? b.count : 0;
+    const aCount =
+      typeof a.count === "number" && Number.isFinite(a.count) ? a.count : 0;
+    return bCount - aCount || a.route.localeCompare(b.route);
+  });
 
   const caches: CacheCounterEntry[] = [];
   for (const [cache, counters] of cacheStats) {

--- a/packages/app-core/src/services/account-pool-status.ts
+++ b/packages/app-core/src/services/account-pool-status.ts
@@ -405,7 +405,11 @@ function calculateBurn(
   if (candidates.length === 0) {
     return { ratePctPerHour: null, sampleHours: null };
   }
-  candidates.sort((a, b) => a.ts - b.ts);
+  candidates.sort((a, b) => {
+    const aTs = typeof a.ts === "number" && Number.isFinite(a.ts) ? a.ts : 0;
+    const bTs = typeof b.ts === "number" && Number.isFinite(b.ts) ? b.ts : 0;
+    return aTs - bTs;
+  });
   const oldest = candidates[0];
   const hours = (now - oldest.ts) / 3_600_000;
   if (!oldest || hours <= 0) {
@@ -472,12 +476,30 @@ function applyUrgency(
   };
   status.perAccount.sort((a, b) => {
     if (rank[a.state] !== rank[b.state]) return rank[a.state] - rank[b.state];
-    return (b.fableUsedPct ?? -1) - (a.fableUsedPct ?? -1);
+    const bUsed =
+      typeof b.fableUsedPct === "number" && Number.isFinite(b.fableUsedPct)
+        ? b.fableUsedPct
+        : -1;
+    const aUsed =
+      typeof a.fableUsedPct === "number" && Number.isFinite(a.fableUsedPct)
+        ? a.fableUsedPct
+        : -1;
+    return bUsed - aUsed;
   });
   const next = status.perAccount
     .filter((account) => account.weeklyResetAt !== null)
     .filter((account) => (account.weeklyResetAt ?? 0) > now)
-    .sort((a, b) => (a.weeklyResetAt ?? 0) - (b.weeklyResetAt ?? 0))[0];
+    .sort((a, b) => {
+      const aReset =
+        typeof a.weeklyResetAt === "number" && Number.isFinite(a.weeklyResetAt)
+          ? a.weeklyResetAt
+          : 0;
+      const bReset =
+        typeof b.weeklyResetAt === "number" && Number.isFinite(b.weeklyResetAt)
+          ? b.weeklyResetAt
+          : 0;
+      return aReset - bReset;
+    })[0];
   const poolMs =
     totalRate > 0 ? (status.fable.leftPct / totalRate) * 3_600_000 : null;
   status.urgency = {


### PR DESCRIPTION
## Summary

Validates numeric values with `Number.isFinite(...)` across Accept-Language locale quality parsing, route performance instrument percentiles, and account pool exhaustion/reset scheduling (`packages/app-core/src/api/i18n-locale-routes.ts:42`, `packages/app-core/src/api/perf-instrument.ts:122, 132`, `packages/app-core/src/services/account-pool-status.ts:408, 480`) to prevent `NaN` comparator return values from corrupting metrics and schedule order.

## Changes

- In `packages/app-core/src/api/i18n-locale-routes.ts:42`, guard `q` numeric comparisons with `Number.isFinite(...)` and fallback to 0 before index tiebreaking.
- In `packages/app-core/src/api/perf-instrument.ts:122, 132`, guard sample latency and route `count` comparisons with `Number.isFinite(...)` and fallback to 0 before route name tiebreaking.
- In `packages/app-core/src/services/account-pool-status.ts:408, 480`, guard candidate `ts`, account `fableUsedPct`, and `weeklyResetAt` with `Number.isFinite(...)`.
- In `packages/app-core/src/api/i18n-locale-routes.test.ts`, add unit test verifying safe Accept-Language q-value handling when malformed or non-numeric tokens are supplied.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`82c1e1c0f1`) |
| --- | --- | --- |
| `bunx vitest run src/api/i18n-locale-routes.test.ts` (in `packages/app-core`) | 5 pass (5 tests) | 6 pass (6 tests) |
| `bunx @biomejs/biome check packages/app-core/src/api/i18n-locale-routes.ts packages/app-core/src/api/perf-instrument.ts packages/app-core/src/services/account-pool-status.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/api/i18n-locale-routes.ts:35-50`
- `packages/app-core/src/api/perf-instrument.ts:120-135`
- `packages/app-core/src/services/account-pool-status.ts:405-415`
- `packages/app-core/src/services/account-pool-status.ts:470-490`

## Risks

Low. Fallback to 0 / -1 ensures invalid or non-numeric metrics are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (App-core backend locale resolution, performance telemetry, account pool urgency; UI layout untouched)
- [x] `audit:browser` — N/A (Metrics sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 pass in `i18n-locale-routes.test.ts`
- [x] `lint` — Biome clean
