### PR TITLE
test(agent): cover health-checks

### DIFF
--- a/packages/agent/src/runtime/operations/health-checks.test.ts
+++ b/packages/agent/src/runtime/operations/health-checks.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Unit coverage for the built-in runtime-operations health checks. Drives the
+ * real `HealthCheck` objects and `describeError`: identity metadata, every
+ * pass/fail branch, first-failed service ordering, live database-probe
+ * outcomes, provider smoke classification (quota vs empty vs transport), and
+ * the default `builtInHealthChecks` set. Collaborator stubs implement runtime
+ * surfaces; the database probe and credit classifier run unmocked.
+ */
+
+import { type AgentRuntime, ModelType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  builtInHealthChecks,
+  dbConnectionCheck,
+  describeError,
+  essentialServicesCheck,
+  providerSmokeCheck,
+  runtimeReadyCheck,
+} from "./health-checks.ts";
+
+function runtime(overrides: Record<string, unknown> = {}): AgentRuntime {
+  return {
+    agentId: "agent-id",
+    character: { name: "Health Agent" },
+    plugins: [],
+    actions: [],
+    providers: [],
+    evaluators: [],
+    services: new Map(),
+    ...overrides,
+  } as unknown as AgentRuntime;
+}
+
+describe("describeError", () => {
+  it("returns Error.message for Error instances", () => {
+    expect(describeError(new Error("adapter ping failed"))).toBe(
+      "adapter ping failed",
+    );
+    expect(describeError(new Error(""))).toBe("");
+  });
+
+  it("returns a string argument unchanged", () => {
+    expect(describeError("plain")).toBe("plain");
+    expect(describeError("")).toBe("");
+  });
+
+  it("JSON-serializes plain objects and primitives", () => {
+    expect(describeError({ code: "E_TEST" })).toBe('{"code":"E_TEST"}');
+    expect(describeError(null)).toBe("null");
+    expect(describeError(42)).toBe("42");
+    expect(describeError(true)).toBe("true");
+  });
+
+  it("falls back to String() when JSON.stringify throws", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    expect(describeError(circular)).toBe("[object Object]");
+    expect(describeError(1n)).toBe("1");
+  });
+});
+
+describe("runtimeReadyCheck", () => {
+  it("is a required 1000ms identity check", () => {
+    expect(runtimeReadyCheck.name).toBe("runtime-ready");
+    expect(runtimeReadyCheck.required).toBe(true);
+    expect(runtimeReadyCheck.timeoutMs).toBe(1000);
+  });
+
+  it("passes when agentId and character.name are populated", async () => {
+    await expect(runtimeReadyCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("fails when the runtime is missing or not an object", async () => {
+    await expect(
+      runtimeReadyCheck.run(null as unknown as AgentRuntime),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime is not an object",
+    });
+    await expect(
+      runtimeReadyCheck.run(undefined as unknown as AgentRuntime),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime is not an object",
+    });
+    await expect(
+      runtimeReadyCheck.run(1 as unknown as AgentRuntime),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime is not an object",
+    });
+  });
+
+  it("fails when agentId is missing, empty, or not a string", async () => {
+    await expect(
+      runtimeReadyCheck.run(runtime({ agentId: "" })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.agentId is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ agentId: 17 })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.agentId is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ agentId: undefined })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.agentId is empty",
+    });
+  });
+
+  it("fails when character is missing or not an object", async () => {
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: undefined })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character is missing",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: null })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character is missing",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: "Eliza" })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character is missing",
+    });
+  });
+
+  it("fails when character.name is empty after trim or not a string", async () => {
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: { name: "" } })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character.name is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: { name: "   " } })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character.name is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: { name: 3 } })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character.name is empty",
+    });
+    await expect(
+      runtimeReadyCheck.run(runtime({ character: {} })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "runtime.character.name is empty",
+    });
+  });
+});
+
+describe("essentialServicesCheck", () => {
+  it("is a required 2000ms service-registry check", () => {
+    expect(essentialServicesCheck.name).toBe("essential-services");
+    expect(essentialServicesCheck.required).toBe(true);
+    expect(essentialServicesCheck.timeoutMs).toBe(2000);
+  });
+
+  it("passes when the registry enumeration API is absent", async () => {
+    await expect(essentialServicesCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("passes for an empty or non-array service-type list", async () => {
+    await expect(
+      essentialServicesCheck.run(
+        runtime({ getRegisteredServiceTypes: () => [] }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      essentialServicesCheck.run(
+        runtime({ getRegisteredServiceTypes: () => "not-an-array" }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("passes when status lookup is missing even if types are listed", async () => {
+    await expect(
+      essentialServicesCheck.run(
+        runtime({
+          getRegisteredServiceTypes: () => ["task"],
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("passes pending, registering, registered, and unknown statuses", async () => {
+    const statuses: Record<string, string> = {
+      a: "pending",
+      b: "registering",
+      c: "registered",
+      d: "unknown",
+    };
+    await expect(
+      essentialServicesCheck.run(
+        runtime({
+          getRegisteredServiceTypes: () => ["a", "b", "c", "d"],
+          getServiceRegistrationStatus: (type: string) => statuses[type],
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("fails on the first service in failed state and ignores later failures", async () => {
+    const statuses: Record<string, string> = {
+      ok: "registered",
+      bad: "failed",
+      alsoBad: "failed",
+    };
+    await expect(
+      essentialServicesCheck.run(
+        runtime({
+          getRegisteredServiceTypes: () => ["ok", "bad", "alsoBad"],
+          getServiceRegistrationStatus: (type: string) => statuses[type],
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "service bad is in failed state",
+    });
+  });
+
+  it("passes a single registered service", async () => {
+    await expect(
+      essentialServicesCheck.run(
+        runtime({
+          getRegisteredServiceTypes: () => ["task"],
+          getServiceRegistrationStatus: () => "registered",
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+});
+
+describe("dbConnectionCheck", () => {
+  it("is a required 1500ms database probe", () => {
+    expect(dbConnectionCheck.name).toBe("db-connection");
+    expect(dbConnectionCheck.required).toBe(true);
+    expect(dbConnectionCheck.timeoutMs).toBe(1500);
+  });
+
+  it("passes when no adapter is present (probe status unknown)", async () => {
+    await expect(dbConnectionCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("passes a null runtime because the probe reports unknown, not a failure", async () => {
+    await expect(
+      dbConnectionCheck.run(null as unknown as AgentRuntime),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("passes when the live probe succeeds", async () => {
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            async isReady() {
+              return true;
+            },
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            getRawConnection: () => ({
+              async query(sql: string) {
+                expect(sql).toBe("SELECT 1");
+                return { rows: [{ "?column?": 1 }] };
+              },
+            }),
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("fails transient probe errors with the probe status and message", async () => {
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            async isReady() {
+              return false;
+            },
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "transient_error: adapter.isReady() returned false",
+    });
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            getRawConnection: () => ({
+              async query() {
+                throw new Error("temporary probe timeout");
+              },
+            }),
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "transient_error: temporary probe timeout",
+    });
+    await expect(
+      dbConnectionCheck.run(runtime({ adapter: {} })),
+    ).resolves.toEqual({
+      ok: false,
+      reason:
+        "transient_error: database adapter exposes no liveness probe surface",
+    });
+  });
+
+  it("fails terminal closed-database probe errors", async () => {
+    await expect(
+      dbConnectionCheck.run(
+        runtime({
+          adapter: {
+            db: {
+              async execute() {
+                throw new Error("PGlite is closed");
+              },
+            },
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "terminal_error: PGlite is closed",
+    });
+  });
+});
+
+describe("providerSmokeCheck", () => {
+  it("is a required 5000ms provider transport check", () => {
+    expect(providerSmokeCheck.name).toBe("provider-smoke");
+    expect(providerSmokeCheck.required).toBe(true);
+    expect(providerSmokeCheck.timeoutMs).toBe(5000);
+  });
+
+  it("passes when useModel is absent", async () => {
+    await expect(providerSmokeCheck.run(runtime())).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("passes a successful useModel call and sends the ping payload", async () => {
+    const calls: unknown[] = [];
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel(modelType: unknown, params: unknown) {
+            calls.push([modelType, params]);
+            return "pong";
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(calls).toEqual([
+      [ModelType.TEXT_SMALL, { prompt: "ping", maxTokens: 1, temperature: 0 }],
+    ]);
+  });
+
+  it("treats an empty completion as a healthy transport", async () => {
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            return "";
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("treats AI_NoOutputGeneratedError as a healthy empty completion", async () => {
+    const noOutput = new Error("empty");
+    noOutput.name = "AI_NoOutputGeneratedError";
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw noOutput;
+          },
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("does not treat a non-Error duck-typed no-output name as healthy", async () => {
+    const duck = { name: "AI_NoOutputGeneratedError", message: "empty" };
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw duck;
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: `provider unreachable: ${JSON.stringify(duck)}`,
+      cause: duck,
+    });
+  });
+
+  it("fails quota exhaustion before the empty-completion exception name", async () => {
+    const quota = Object.assign(new Error("Payment Required"), {
+      name: "AI_NoOutputGeneratedError",
+      status: 402,
+    });
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw quota;
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider quota exhausted",
+      cause: quota,
+    });
+  });
+
+  it("fails other transport errors with describeError text and the cause", async () => {
+    const transport = new Error("transport down");
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw transport;
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider unreachable: transport down",
+      cause: transport,
+    });
+
+    await expect(
+      providerSmokeCheck.run(
+        runtime({
+          async useModel() {
+            throw "socket hang up";
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider unreachable: socket hang up",
+      cause: "socket hang up",
+    });
+  });
+});
+
+describe("builtInHealthChecks", () => {
+  it("is the four named checks in declaration order, by identity", () => {
+    expect(builtInHealthChecks).toEqual([
+      runtimeReadyCheck,
+      essentialServicesCheck,
+      dbConnectionCheck,
+      providerSmokeCheck,
+    ]);
+    expect(builtInHealthChecks[0]).toBe(runtimeReadyCheck);
+    expect(builtInHealthChecks[1]).toBe(essentialServicesCheck);
+    expect(builtInHealthChecks[2]).toBe(dbConnectionCheck);
+    expect(builtInHealthChecks[3]).toBe(providerSmokeCheck);
+    expect(builtInHealthChecks.map((check) => check.name)).toEqual([
+      "runtime-ready",
+      "essential-services",
+      "db-connection",
+      "provider-smoke",
+    ]);
+    expect(builtInHealthChecks.every((check) => check.required)).toBe(true);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-directory vitest suite for `packages/agent/src/runtime/operations/health-checks.ts`. That module had no same-named test file (`health-checks.test.ts`). This PR changes no production behaviour.

The checks under test are real. Tests import `describeError`, `runtimeReadyCheck`, `essentialServicesCheck`, `dbConnectionCheck`, `providerSmokeCheck`, and `builtInHealthChecks` from `./health-checks.ts` and assert returned `HealthCheckResult` values. They do not mock the module and then assert the mock. The database probe (`probeRuntimeDatabaseLiveness`) and credit classifier (`isInsufficientCreditsError`) run unmocked against real adapter / error shapes.

## What is covered

Exported surface: `describeError`, `runtimeReadyCheck`, `essentialServicesCheck`, `dbConnectionCheck`, `providerSmokeCheck`, `builtInHealthChecks`.

- `describeError`: `Error.message`, passthrough strings, JSON serialization of objects/primitives, and `String()` fallback when `JSON.stringify` throws (circular object, bigint).
- `runtimeReadyCheck`: required 1000ms metadata; pass with populated `agentId` + `character.name`; fail for missing/non-object runtime; empty/non-string `agentId`; missing/non-object `character`; empty-after-trim / non-string `character.name`.
- `essentialServicesCheck`: required 2000ms metadata; pass when the enumeration API is absent, when the type list is empty or not an array, when status lookup is missing, and for `pending` / `registering` / `registered` / `unknown`; fail on the first `failed` service and ignore later failures; pass a single registered service.
- `dbConnectionCheck`: required 1500ms metadata; pass with no adapter (probe `unknown`); pass a null runtime (probe `unknown` with `ok: false` is still treated as ok); pass live probes via `isReady()` and `getRawConnection().query("SELECT 1")`; fail `transient_error` (`isReady() === false`, query throw, adapter with no probe surface); fail `terminal_error` for closed PGlite.
- `providerSmokeCheck`: required 5000ms metadata; pass when `useModel` is absent; pass a successful call and assert the ping payload (`ModelType.TEXT_SMALL`, `prompt: "ping"`, `maxTokens: 1`, `temperature: 0`); pass empty completions and `AI_NoOutputGeneratedError`; do not treat a non-Error duck-typed no-output name as healthy; fail quota exhaustion (`HTTP 402`) *before* the empty-completion exception name; fail other transport errors with `describeError` text and the original cause (Error and string throws).
- `builtInHealthChecks`: the four named checks in declaration order, by object identity, all required.

## Evidence

Test-only change. The heavy bug-fix evidence procedure does not apply. Hosted CI does **not** run on this fork PR; the counts below are local.

1. `bunx vitest run packages/agent/src/runtime/operations/health-checks.test.ts`
   - Test Files  1 passed (1)
   - Tests  32 passed (32)
2. `bunx biome check --write packages/agent/src/runtime/operations/health-checks.test.ts`
   - Config present (`biome.json` and `tsconfig.json` at repo root; `git sparse-checkout list` reports the worktree is not sparse).
   - `Checked 1 file in 16ms. No fixes applied.`
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'health-checks.test.ts'`
   - empty; `GREP_EXIT:1`. The new test file appears nowhere in tsc output. Pre-existing package errors elsewhere are unrelated.
4. `git diff --stat origin/develop...test/agent-health-checks-coverage` touches only `packages/agent/src/runtime/operations/health-checks.test.ts` (502 insertions).

Evidence head: `5721b755b4fdf551424c2a6de2cdb8cb1a97b216`

# Relates to

No issue. Coverage-only addition for a module that lacked a same-named test file.

# Sync with develop

- [x] Branched from latest `origin/develop` (`695f7b8727ccb0c5cf953527077f4de1a03a840d`) with a single test-file commit; zero conflicts.
- `bun run verify` was not run. This is a test-only PR; focused vitest / biome / tsc evidence is quoted above. Hosted CI does not run on fork PRs.

# Risks

Low. Adds tests only. No production behaviour change.

# Background

## What does this PR do?

Adds unit tests for the built-in runtime-operations health checks that gate promotion of a new or re-initialised runtime.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/operations/health-checks.test.ts` and `packages/agent/src/runtime/operations/health-checks.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/runtime/operations/health-checks.test.ts
```

# Evidence Gate

Test-only: no UI, no backend logs, no LLM trajectory, no domain artifacts.

<!-- evidence-head:5721b755b4fdf551424c2a6de2cdb8cb1a97b216 -->

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest output quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] LLM trajectory: N/A - no agent/action/provider/prompt/model production change.
- [x] Domain artifacts: N/A - no DB/memory/schedule/wallet output.
- [x] OCR review: N/A - no rendered visual surface.

## Known gaps / failures

- Hosted CI does not run on this fork PR.
- `bun run verify` was not run; scoped vitest, biome, and tsc are quoted above.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
