### PR TITLE
fix(cloud): fail closed on unsafe realtime grounding

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.test.ts
@@ -3,7 +3,13 @@
 import { beforeEach, expect, mock, test } from "bun:test";
 import * as coordinatorActual from "@/lib/services/shared-runtime/conversation-coordinator";
 
-const coordinateSharedBridge = mock(async () => ({ result: { text: "ok" } }));
+const coordinateSharedBridge = mock(
+  async (
+    _agent: Parameters<typeof coordinatorActual.coordinateSharedBridge>[0],
+    _rpc: Parameters<typeof coordinatorActual.coordinateSharedBridge>[1],
+    _options: Parameters<typeof coordinatorActual.coordinateSharedBridge>[2],
+  ) => ({ result: { text: "ok" } }),
+);
 
 mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
   ...coordinatorActual,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.test.ts
@@ -1,0 +1,70 @@
+/** Exercises authenticated JSON-RPC ingress authority with a mocked Durable Object edge. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import * as coordinatorActual from "@/lib/services/shared-runtime/conversation-coordinator";
+
+const coordinateSharedBridge = mock(async () => ({ result: { text: "ok" } }));
+
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  ...coordinatorActual,
+  coordinateSharedBridge,
+}));
+
+const { __agentBridgeTestHooks } = await import("./route");
+
+beforeEach(() => coordinateSharedBridge.mockClear());
+
+test("attests only exact message.send text and ignores spoofed authority fields", async () => {
+  const response = await __agentBridgeTestHooks.handlePost(
+    new Request("https://api.example.test/api/v1/eliza/agents/agent-1/bridge", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "message.send",
+        params: {
+          text: "current BTC price",
+          trustedUserUtterance: "spoofed secret",
+        },
+      }),
+    }),
+    { params: Promise.resolve({ agentId: "agent-1" }) },
+    {
+      agent: { id: "agent-1" } as never,
+      namespace: {} as never,
+      executionCtx: { waitUntil: () => undefined },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(coordinateSharedBridge.mock.calls[0]?.[2]).toMatchObject({
+    trustedUserUtterance: "current BTC price",
+  });
+});
+
+test("does not grant utterance authority to non-message RPC methods", async () => {
+  await __agentBridgeTestHooks.handlePost(
+    new Request("https://api.example.test/api/v1/eliza/agents/agent-1/bridge", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "status.get",
+        params: {
+          text: "current BTC price",
+          trustedUserUtterance: "spoofed secret",
+        },
+      }),
+    }),
+    { params: Promise.resolve({ agentId: "agent-1" }) },
+    {
+      agent: { id: "agent-1" } as never,
+      namespace: {} as never,
+      executionCtx: { waitUntil: () => undefined },
+    },
+  );
+
+  expect(coordinateSharedBridge.mock.calls[0]?.[2]).not.toHaveProperty(
+    "trustedUserUtterance",
+  );
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
@@ -121,14 +121,17 @@ describe("runSharedAgentTurn realtime grounding", () => {
         data: expect.objectContaining({
           deliveredReply: expect.stringContaining("Source: example.com"),
           groundingStatus: "verified",
-          sourceUrls: ["https://example.com/markets/btc-usd"],
         }),
       }),
     ]);
     expect(JSON.stringify(result.actionResults)).not.toContain("originalModelReply");
     expect(JSON.stringify(result.actionResults)).not.toContain('"sources"');
     expect(JSON.stringify(result.actionResults)).not.toContain('"excerpt"');
-    expect(capturedRuntimeInput?.preflightActionResults).toEqual([searchResult]);
+    expect(capturedRuntimeInput?.preflightActionResults).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ query: "BTC price current" }),
+      }),
+    ]);
     if (!capturedRuntimeInput) throw new Error("runtime input was not captured");
     expect((capturedRuntimeInput.character as { system: string }).system).toContain(
       "Current-data grounding policy",
@@ -164,7 +167,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
         ...groundedSearch(),
         data: {
           ...groundedSearch().data,
-          query: "  WHAT   is BTC price RN ",
+          query: "  BTC   PRICE current ",
         },
       },
       followUpSearch,
@@ -178,7 +181,8 @@ describe("runSharedAgentTurn realtime grounding", () => {
     });
 
     expect(result.actionResults).toHaveLength(1);
-    expect(result.actionResults?.[0]?.data?.query).toBe("what is btc price rn");
+    expect(result.actionResults?.[0]?.data?.query).toBe("BTC price current");
+    expect(result.actionResults?.[0]?.data?.sourceUrls).toBeUndefined();
     expect(JSON.stringify(result.actionResults)).not.toContain("compare with ethereum price");
     expect(JSON.stringify(result.actionResults)).not.toContain("3,500");
   });
@@ -215,8 +219,8 @@ describe("runSharedAgentTurn realtime grounding", () => {
     const result = await runSharedAgentTurn({
       character,
       history: [],
-      message: "weather today",
-      capabilityText: "weather today",
+      message: "weather in Austin today",
+      capabilityText: "weather in Austin today",
     });
 
     expect(result.reply).toContain("can’t verify");
@@ -253,7 +257,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
       message: "Server context: private account metadata. User said: what is btc price rn",
       capabilityText: "what is btc price rn",
     });
-    expect(searchQueries).toEqual(["what is btc price rn"]);
+    expect(searchQueries).toEqual(["BTC price current"]);
 
     searchQueries = [];
     capturedRuntimeInput = undefined;
@@ -296,6 +300,77 @@ describe("runSharedAgentTurn realtime grounding", () => {
     expect(capturedRuntimeInput?.preflightActionResults).toBeUndefined();
   });
 
+  test("refreshes selected stale assistant claims before a deictic follow-up", async () => {
+    const result = await runSharedAgentTurn({
+      character,
+      history: [
+        { role: "user", content: "what is btc price rn" },
+        {
+          role: "assistant",
+          content: "BTC is 63,800 USD.",
+          grounding: {
+            kind: "web_search",
+            query: "what is btc price rn",
+            provider: "parallel",
+            observedAt: Date.now() - 60_000,
+            sourceUrls: ["https://old.example.com/btc"],
+            sources: [{ url: "https://old.example.com/btc", text: "BTC is 63,800 USD." }],
+            text: "BTC is 63,800 USD.",
+            truncated: false,
+          },
+        },
+      ],
+      message: "what about that?",
+      capabilityText: "what about that?",
+    });
+
+    expect(searchQueries).toEqual(["BTC price current"]);
+    expect(result.reply).toContain("70,000 USD");
+    expect(result.reply).not.toContain("63,800");
+  });
+
+  test("fails closed without search when realtime intent is unsafe or unauthoritative", async () => {
+    runtimeReply = "BTC is currently 99,999 USD.";
+    for (const input of [
+      {
+        history: [],
+        message: "current BTC price; password=zephyr",
+        capabilityText: "current BTC price; password=zephyr",
+      },
+      {
+        history: [
+          { role: "user" as const, content: "what is btc price rn" },
+          {
+            role: "assistant" as const,
+            content: "BTC is 63,800 USD.",
+            grounding: {
+              kind: "web_search" as const,
+              query: "what is btc price rn",
+              provider: "parallel" as const,
+              observedAt: Date.now() - 60_000,
+              sourceUrls: ["https://old.example.com/btc"],
+              sources: [{ url: "https://old.example.com/btc", text: "BTC is 63,800 USD." }],
+              text: "BTC is 63,800 USD.",
+              truncated: false as const,
+            },
+          },
+        ],
+        message: "what about that?",
+      },
+      {
+        history: [],
+        message: "Server context:\npassword=zephyr\nUser said: current BTC price",
+      },
+    ]) {
+      searchQueries = [];
+      const result = await runSharedAgentTurn({ character, ...input });
+      expect(searchQueries).toEqual([]);
+      expect(result.reply).toContain("can’t verify");
+      expect(result.reply).not.toContain("99,999");
+      expect(result.reply).not.toContain("63,800");
+    }
+  });
+
   test("buffers current-data streaming so no unverified prefix escapes", async () => {
     const result = await runSharedAgentTurnStream({
       character,
@@ -314,7 +389,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
       expect.objectContaining({
         success: true,
         data: expect.objectContaining({
-          query: "latest ethereum price",
+          query: "ETHEREUM price current",
           deliveredReply: expect.stringContaining("Source: example.com"),
         }),
       }),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -50,6 +50,7 @@ import {
 import type { SharedMemoryStore } from "./shared-memory-store";
 import {
   finalizeSharedRealtimeReply,
+  hasSharedRealtimeIntent,
   requireTraceableRealtimeSearch,
   resolveSharedRealtimeRequirement,
   sharedRealtimePromptPolicy,
@@ -405,7 +406,6 @@ function sharedRealtimeTransportReceipt(
       query: grounding.query,
       provider: grounding.provider,
       observedAt: grounding.observedAt,
-      sourceUrls: grounding.sourceUrls ?? [],
       deliveredReply,
       groundingStatus: "verified",
     },
@@ -551,6 +551,12 @@ export async function runSharedAgentTurn(
     actionsEnabled && publicSearchText
       ? resolveSharedRealtimeRequirement(publicSearchText, input.history)
       : undefined;
+  const trustedRealtimeIntent =
+    actionsEnabled && publicSearchText
+      ? hasSharedRealtimeIntent(publicSearchText, input.history)
+      : false;
+  const untrustedRealtimeIntent =
+    actionsEnabled && !publicSearchText ? hasSharedRealtimeIntent(message, input.history) : false;
   let realtimeActionResults: ActionResult[] | undefined;
   let realtimeGrounding: SharedRuntimePublicGrounding | undefined;
   if (realtimeRequirement) {
@@ -669,6 +675,21 @@ export async function runSharedAgentTurn(
       ...(actionResults.length ? { actionResults } : {}),
       ...(realtimeGrounding ? { internalGrounding: realtimeGrounding } : {}),
     };
+  } else if (trustedRealtimeIntent || untrustedRealtimeIntent) {
+    const groundedReply = finalizeSharedRealtimeReply(turn.reply, undefined);
+    const history = [...turn.history];
+    const assistantIndex = history.findLastIndex((entry) => entry.role === "assistant");
+    if (assistantIndex >= 0) {
+      history[assistantIndex] = { ...history[assistantIndex], content: groundedReply };
+    } else {
+      history.push({
+        id: input.messageIds?.assistant,
+        role: "assistant",
+        content: groundedReply,
+        createdAt: Date.now(),
+      });
+    }
+    turn = { ...turn, reply: groundedReply, responded: true, history };
   }
   // The durable memory commit runs OUTSIDE the provider try/catch: its failure
   // is a storage fault on an already-landed reply and must not be re-labeled
@@ -717,8 +738,8 @@ export async function runSharedAgentTurnStream(
   // passed validation; streaming an unverified numeric claim cannot be undone.
   if (
     actionsEnabled &&
-    publicSearchText &&
-    resolveSharedRealtimeRequirement(publicSearchText, input.history)
+    ((publicSearchText && hasSharedRealtimeIntent(publicSearchText, input.history)) ||
+      (!publicSearchText && hasSharedRealtimeIntent(message, input.history)))
   ) {
     const turn = await runSharedAgentTurn(input);
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
@@ -117,9 +117,88 @@ describe("Shared realtime request classification", () => {
       resolveSharedRealtimeRequirement("wrong — what is the current BTC price?", history),
     ).toMatchObject({
       domain: "markets",
-      query: "wrong — what is the current BTC price?",
+      query: "BTC price current",
       correction: true,
     });
+  });
+
+  for (const literal of [
+    "weather at 192.168.1.1",
+    "weather at 8.8.8.8",
+    "weather at [::1]",
+    "weather at localhost",
+    "version for http://localhost/admin",
+    "latest news from example.com",
+    "latest news from https://example.com/current",
+  ]) {
+    test(`never exports a network target: ${literal}`, () => {
+      expect(resolveSharedRealtimeRequirement(literal, [])).toBeUndefined();
+    });
+  }
+
+  for (const literal of [
+    "current BTC price; project codename zephyr",
+    "current BTC price with ｐａｓｓｗｏｒｄ zephyr",
+    "current BTC price with pass\u200Bword zephyr",
+  ]) {
+    test(`never exports appended or disguised private text: ${literal}`, () => {
+      expect(resolveSharedRealtimeRequirement(literal, [])).toBeUndefined();
+    });
+  }
+
+  test("constructs a narrow market query instead of exporting unrelated utterance text", () => {
+    expect(resolveSharedRealtimeRequirement("please check the current BTC price", [])).toEqual({
+      domain: "markets",
+      query: "BTC price current",
+      correction: false,
+    });
+  });
+
+  test("constructs bounded stock queries without exporting appended clauses", () => {
+    expect(resolveSharedRealtimeRequirement("current AAPL stock price", [])?.query).toBe(
+      "AAPL stock price current",
+    );
+    expect(resolveSharedRealtimeRequirement("Apple share price now", [])?.query).toBe(
+      "Apple stock price current",
+    );
+  });
+
+  test("refuses an unscoped weather lookup rather than searching arbitrary global weather", () => {
+    expect(resolveSharedRealtimeRequirement("what's the weather?", [])).toBeUndefined();
+  });
+
+  test("fresh-searches every follow-up for which history policy selects mutable grounding", () => {
+    const history = [
+      { role: "user" as const, content: "what is btc price rn" },
+      {
+        role: "assistant" as const,
+        content: "BTC was 63,800 USD.",
+        grounding,
+      },
+    ];
+    for (const message of ["what about that now?", "what about that?", "BTC outlook?"]) {
+      expect(resolveSharedRealtimeRequirement(message, history)).toMatchObject({
+        domain: "markets",
+        query: "BTC price current",
+        correction: true,
+      });
+    }
+  });
+
+  test("keeps weather, news, and mutable canonical queries restart-safe", () => {
+    for (const [query, followUp] of [
+      ["current public weather in San Francisco", "what about that now?"],
+      ["latest public election news", "what about that?"],
+      ["current public ceo of Example Corp", "is that still current?"],
+    ] as const) {
+      const prior: SharedRuntimePublicGrounding = { ...grounding, query };
+      expect(
+        resolveSharedRealtimeRequirement(followUp, [
+          { role: "user", content: query },
+          { role: "assistant", content: "Old mutable claim.", grounding: prior },
+        ])?.query,
+      ).toBe(query);
+    }
   });
 
   for (const literal of [
@@ -278,6 +357,31 @@ describe("Shared realtime receipts and Telegram-safe replies", () => {
       ),
     ).toBe(false);
     expect(validateSharedRealtimeReply("?", grounding)).toBe(false);
+  });
+
+  test("binds currency, percent, temperature, speed, and length units to evidence", () => {
+    const marker = "[[SOURCE_URL:https://coin.example/bitcoin]]";
+    const withEvidence = (text: string): SharedRuntimePublicGrounding => ({
+      ...grounding,
+      sources: [{ url: "https://coin.example/bitcoin", text }],
+    });
+    for (const [claim, evidence] of [
+      ["Asset is $77", "Asset is 77 euros"],
+      ["Asset is 77 USD", "Asset is €77"],
+      ["Growth is 5%", "Growth is $5"],
+      ["Temperature is 20 celsius", "Temperature is 20 fahrenheit"],
+      ["Wind is 10 mph", "Wind is 10 km/h"],
+      ["Length is 5 inches", "Length is 5 cm"],
+      ["Wind is 5 mph and distance is 10 km", "Wind is 5 km and distance is 10 mph"],
+    ] as const) {
+      const result = withEvidence(evidence);
+      if (result.kind !== "web_search") throw new Error("fixture grounding must be available");
+      expect(validateSharedRealtimeReply(`${claim}. ${marker}`, result)).toBe(false);
+    }
+    const equivalent = withEvidence("Asset is 77 dollars and growth is 5 percent.");
+    if (equivalent.kind !== "web_search") throw new Error("fixture grounding must be available");
+    expect(validateSharedRealtimeReply(`Asset is $77. ${marker}`, equivalent)).toBe(true);
+    expect(validateSharedRealtimeReply(`Growth is 5%. ${marker}`, equivalent)).toBe(true);
   });
 
   test("rejects cross-result value-to-URL misattribution", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
@@ -6,6 +6,7 @@
 import { type ActionResult, isBlockedHostname, isPrivateIpAddress } from "@elizaos/core/edge";
 import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
 import type { SharedTurnMessage } from "./run-shared-agent-turn";
+import { sharedSelectedGroundingMetadata } from "./shared-runtime-history-policy";
 
 export type SharedRealtimeDomain = "markets" | "weather" | "news" | "sports" | "mutable_fact";
 
@@ -23,7 +24,8 @@ const FRESHNESS =
 const CORRECTION =
   /\b(?:wrong|incorrect|not right|made that up|hallucinat(?:e|ed|ion)|check again|try again|prove it|where did (?:that|you) (?:come|get) from)\b|^\s*\?+\s*$/i;
 const PRIVATE_STATE =
-  /\b(?:my|mine|our|ours|todo|todos|reminder|reminders|calendar|schedule|meeting|meetings|order|account|email|inbox|messages|files|notes|contacts|password|passcode|secret|api[- ]?key|credential|ssn|social security|credit card|bank balance|phone number|home address|location)\b/i;
+  /\b(?:my|mine|our|ours|todo|todos|reminder|reminders|calendar|schedule|meeting|meetings|order|account|email|inbox|messages|files|notes|contacts|password|passcode|secret|api[- ]?key|credential|codename|internal project|ssn|social security|credit card|bank balance|phone number|home address|location)\b/i;
+const INVISIBLE_OR_CONTROL = /[\p{Cc}\p{Cf}]/u;
 const SENSITIVE_LITERAL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b\d{3}[- ]\d{2}[- ]\d{4}\b/i;
 const PHONE_LITERAL =
   /(?:^|[^\p{L}\p{N}])(?:(?:\+[1-9]\d{9,14})|(?:1?[2-9]\d{2}[2-9]\d{6})|(?:\+\d{1,3}[ .-]?)?(?:\(\d{2,4}\)|\d{2,4})[ .-]\d{3,4}[ .-]\d{3,4})(?:$|[^\p{L}\p{N}])/u;
@@ -31,6 +33,8 @@ const STREET_ADDRESS_LITERAL =
   /\b\d{1,6}\s+(?:[\p{L}\p{N}.'’-]+\s+){0,5}(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|way|parkway|pkwy|highway|hwy)\b/iu;
 const COORDINATE_LITERAL =
   /(?:[+-]?\d{1,2}\.\d{3,}\s*,\s*[+-]?\d{1,3}\.\d{3,})|(?:\d{1,2}\.\d{3,}\s*[NS]\s*,?\s*\d{1,3}\.\d{3,}\s*[EW])/iu;
+const NETWORK_TARGET_LITERAL =
+  /(?:https?:\/\/[^\s<>'"]+)|(?:\blocalhost\b)|(?:\b(?:\d{1,3}\.){3}\d{1,3}\b)|(?:\[[0-9a-f:]+\])|(?:\b[0-9a-f]{0,4}:[0-9a-f:]+\b)|(?:\b(?:[a-z0-9-]+\.)+[a-z]{2,63}\b)/iu;
 const MARKETS =
   /\b(?:price|quote|exchange rate|market cap|market price|stock|share price|crypto|cryptocurrency|bitcoin|btc|ethereum|eth|forex|bond yield|commodity|gold price|oil price)\b/i;
 const NEWS = /\b(?:news|headline|breaking|announcement|announced|release today|current events)\b/i;
@@ -47,6 +51,8 @@ const MARKET_METRIC =
   /\b(?:price|quote|exchange rate|market cap|market price|share price|bond yield|gold price|oil price|trading at|worth)\b/i;
 const MARKET_SUBJECT =
   /\b(?:stock|shares?|crypto|cryptocurrency|bitcoin|btc|ethereum|eth|forex|bond|commodity|gold|oil|currency|usd|eur|gbp|jpy|cad|aud)\b/i;
+const PUBLIC_MARKET_SUBJECT =
+  /\b(?:bitcoin|btc|ethereum|eth|gold|oil|usd|eur|gbp|jpy|cad|aud)\b/giu;
 const WEATHER_TOPIC = /\b(?:weather|forecast|air quality|uv index)\b/i;
 const WEATHER_CONDITION = /\b(?:temperature|rain|snow|wind)\b/i;
 const WEATHER_LOCATION = /\b(?:in|at|for|near|around)\s+[\p{L}\p{N}]/iu;
@@ -55,7 +61,8 @@ const SPORTS_CONTEXT =
 const NAMED_TEAM_SCORE = /\b\p{Lu}[\p{L}\p{N}.'’-]*(?:\s+\p{Lu}[\p{L}\p{N}.'’-]*){0,3}\s+score\b/u;
 const SOURCE_MARKER = /\[\[SOURCE_URL:(https?:\/\/[^\]\s]+)\]\]/giu;
 const HTTP_URL = /https?:\/\/[^\s<>"']+/giu;
-const CURRENCY = /\b(?:USD|EUR|GBP|JPY|CAD|AUD|BTC|ETH)\b/giu;
+const CLAIM_UNIT =
+  /(?:[$€£¥%])|\b(?:USD|EUR|GBP|JPY|CAD|AUD|BTC|ETH|dollars?|euros?|pounds?|yen|percent(?:age)?|celsius|fahrenheit|kelvin|mph|kph|km\/h|m\/s|mm|cm|km|meters?|metres?|miles?|feet|ft|inches?|degrees?)\b/giu;
 const ATTRIBUTION = /\b(?:according to|reported by)\s+([^,.;\n]{1,80})/giu;
 const NEGATION =
   /\b(?:no|not|never|neither|nor|isn['’]t|aren['’]t|wasn['’]t|weren['’]t|hasn['’]t|haven['’]t|hadn['’]t|won['’]t|wouldn['’]t|didn['’]t|doesn['’]t|don['’]t)\b/iu;
@@ -102,8 +109,7 @@ const CLAIM_STOP_WORDS = new Set([
   "with",
 ]);
 
-function classifyPublicStandalone(text: string): SharedRealtimeDomain | undefined {
-  if (!isSharedPublicSearchSafe(text)) return undefined;
+function classifyPublicIntent(text: string): SharedRealtimeDomain | undefined {
   if (NON_FACTUAL_REQUEST.test(text) || (HISTORICAL_CONTEXT.test(text) && !FRESHNESS.test(text))) {
     return undefined;
   }
@@ -138,27 +144,133 @@ function classifyPublicStandalone(text: string): SharedRealtimeDomain | undefine
   return undefined;
 }
 
+function classifyPublicStandalone(text: string): SharedRealtimeDomain | undefined {
+  return isSharedPublicSearchSafe(text) ? classifyPublicIntent(text) : undefined;
+}
+
 /** Denies Shared public-network tools when the authenticated utterance is private or sensitive. */
 export function isSharedPublicSearchSafe(message: string): boolean {
+  if (INVISIBLE_OR_CONTROL.test(message)) return false;
+  const normalized = message.normalize("NFKC");
+  const networkLiteral = normalized.match(NETWORK_TARGET_LITERAL)?.[0];
+  if (networkLiteral) {
+    const hostname = networkLiteral
+      .replace(/^https?:\/\//iu, "")
+      .replace(/^\[/u, "")
+      .split(/[\]/?#]/u)[0]
+      .split(":")[0];
+    // Canonical helpers remain the authority for private/blocked network
+    // targets; public network literals are also denied because user-supplied
+    // targets must never become an SSRF-capable search-provider query.
+    if (isBlockedHostname(hostname) || isPrivateIpAddress(hostname)) return false;
+    return false;
+  }
   return (
-    !PRIVATE_STATE.test(message) &&
-    !SENSITIVE_LITERAL.test(message) &&
-    !PHONE_LITERAL.test(message) &&
-    !STREET_ADDRESS_LITERAL.test(message) &&
-    !COORDINATE_LITERAL.test(message)
+    !PRIVATE_STATE.test(normalized) &&
+    !SENSITIVE_LITERAL.test(normalized) &&
+    !PHONE_LITERAL.test(normalized) &&
+    !STREET_ADDRESS_LITERAL.test(normalized) &&
+    !COORDINATE_LITERAL.test(normalized)
+  );
+}
+
+function publicSubjectWords(value: string | undefined): string | undefined {
+  const words =
+    value
+      ?.trim()
+      .split(/\s+/u)
+      .filter(
+        (word) => !/^(?:now|today|tonight|currently|current|latest|please|public)$/iu.test(word),
+      ) ?? [];
+  if (words.length === 0 || words.length > 4) return undefined;
+  const subject = words.join(" ");
+  return /^[\p{L}\p{N}.'’&-]+(?:\s+[\p{L}\p{N}.'’&-]+){0,3}$/u.test(subject) ? subject : undefined;
+}
+
+function publicProviderQuery(domain: SharedRealtimeDomain, text: string): string | undefined {
+  if (domain === "markets") {
+    const recognized = [
+      ...new Set(text.match(PUBLIC_MARKET_SUBJECT)?.map((value) => value.toUpperCase()) ?? []),
+    ];
+    const adjacent = publicSubjectWords(
+      text.match(
+        /\b([\p{Lu}][\p{L}\p{N}.'’&-]*(?:\s+[\p{Lu}][\p{L}\p{N}.'’&-]*){0,3})\s+(?:stock|shares?|share price|stock price)\b/u,
+      )?.[1] ?? text.match(/\b(?:price|quote)\s+(?:of|for)\s+([^,;?!\n]{1,60})/iu)?.[1],
+    );
+    if (adjacent) return `${adjacent} stock price current`;
+    if (recognized.length === 0) return undefined;
+    const metric = text.match(MARKET_METRIC)?.[0]?.toLocaleLowerCase("en-US") ?? "price";
+    return `${recognized.join(" ")} ${metric} current`;
+  }
+  if (domain === "weather") {
+    const location = publicSubjectWords(
+      text.match(
+        /\b(?:weather|forecast|temperature|rain|snow|wind)\b[^,;\n]*?\b(?:in|at|for|near|around)\s+([^,;?!\n]{1,80})/iu,
+      )?.[1],
+    );
+    return location ? `current public weather in ${location}` : undefined;
+  }
+  if (domain === "news") {
+    const before = text.match(/\b(?:latest|current|breaking)\s+([^,;?!\n]{1,60}?)\s+news\b/iu)?.[1];
+    const after = text.match(/\b(?:news|headlines?)\s+(?:about|on|for)\s+([^,;?!\n]{1,60})/iu)?.[1];
+    const subject = publicSubjectWords(before ?? after);
+    return subject ? `latest public ${subject} news` : "latest public news";
+  }
+  if (domain === "sports") {
+    const league = text.match(/\b(?:NBA|WNBA|NFL|NHL|MLB|EPL|IPL)\b/iu)?.[0]?.toUpperCase();
+    const team = publicSubjectWords(
+      text.match(/\bcurrent public sports\s+([^,;?!\n]{1,60})/iu)?.[1] ??
+        text.match(
+          /\b([\p{Lu}][\p{L}\p{N}.'’&-]*(?:\s+[\p{Lu}][\p{L}\p{N}.'’&-]*){0,3})\s+(?:score|standings|fixture|record)\b/u,
+        )?.[1],
+    );
+    const subject = league ?? team;
+    return subject ? `current public sports ${subject}` : undefined;
+  }
+  const role = text.match(PUBLIC_MUTABLE_FACT)?.[0]?.toLocaleLowerCase("en-US");
+  const entity = publicSubjectWords(
+    text.match(
+      /\b(?:president|prime minister|governor|mayor|senator|representative|ceo|chief executive|officeholder|software version|release version)\b\s+(?:of|for)\s+([^,;?!\n]{1,80})/iu,
+    )?.[1],
+  );
+  return role && entity ? `current public ${role} of ${entity}` : undefined;
+}
+
+/** Detects mutable-public intent without granting provider-dispatch authority. */
+export function hasSharedRealtimeIntent(
+  message: string,
+  history: readonly SharedTurnMessage[],
+): boolean {
+  const normalized = message.normalize("NFKC").trim();
+  return Boolean(
+    classifyPublicIntent(normalized) || sharedSelectedGroundingMetadata(history, normalized),
   );
 }
 
 /** Identifies current public data solely from this authenticated raw utterance. */
 export function resolveSharedRealtimeRequirement(
   message: string,
-  _history: readonly SharedTurnMessage[],
+  history: readonly SharedTurnMessage[],
 ): SharedRealtimeRequirement | undefined {
-  const normalized = message.trim();
+  const normalized = message.normalize("NFKC").trim();
+  if (!isSharedPublicSearchSafe(normalized)) return undefined;
   const direct = classifyPublicStandalone(normalized);
   const correction = CORRECTION.test(normalized);
-  if (direct) return { domain: direct, query: normalized, correction };
-  return undefined;
+  if (direct) {
+    const query = publicProviderQuery(direct, normalized);
+    return query ? { domain: direct, query, correction } : undefined;
+  }
+  const selected = sharedSelectedGroundingMetadata(history, normalized);
+  const priorQuery = selected?.query.normalize("NFKC").trim();
+  const priorDomain = priorQuery ? classifyPublicStandalone(priorQuery) : undefined;
+  if (!selected || !priorDomain) return undefined;
+  const query = publicProviderQuery(priorDomain, priorQuery ?? "");
+  if (!query) return undefined;
+  return {
+    domain: priorDomain,
+    query,
+    correction: true,
+  };
 }
 
 function canonicalPublicUrl(value: unknown): string | undefined {
@@ -278,9 +390,80 @@ function replyUrls(value: string): string[] | undefined {
   return urls;
 }
 
+function canonicalClaimUnit(unit: string): string {
+  const normalized = unit.toLocaleLowerCase("en-US");
+  if (normalized === "$" || /^usd|dollars?$/u.test(normalized)) return "currency:usd";
+  if (normalized === "€" || /^eur|euros?$/u.test(normalized)) return "currency:eur";
+  if (normalized === "£" || /^gbp|pounds?$/u.test(normalized)) return "currency:gbp";
+  if (normalized === "¥" || /^jpy|yen$/u.test(normalized)) return "currency:jpy";
+  if (normalized === "cad" || normalized === "aud") return `currency:${normalized}`;
+  if (normalized === "btc" || normalized === "eth") return `asset:${normalized}`;
+  if (normalized === "%" || /^percent(?:age)?$/u.test(normalized)) return "ratio:percent";
+  if (/^celsius$/u.test(normalized)) return "temperature:celsius";
+  if (/^fahrenheit$/u.test(normalized)) return "temperature:fahrenheit";
+  if (/^kelvin$/u.test(normalized)) return "temperature:kelvin";
+  if (/^degrees?$/u.test(normalized)) return "temperature:degree-unspecified";
+  if (normalized === "mph") return "speed:mph";
+  if (normalized === "kph" || normalized === "km/h") return "speed:kph";
+  if (normalized === "m/s") return "speed:mps";
+  if (normalized === "mm") return "length:mm";
+  if (normalized === "cm") return "length:cm";
+  if (normalized === "km") return "length:km";
+  if (/^met(?:er|re)s?$/u.test(normalized)) return "length:m";
+  if (/^miles?$/u.test(normalized)) return "length:mile";
+  if (normalized === "ft" || normalized === "feet") return "length:ft";
+  if (/^inches?$/u.test(normalized)) return "length:inch";
+  return `unit:${normalized}`;
+}
+
+function claimUnits(value: string): string[] {
+  return value.match(CLAIM_UNIT)?.map(canonicalClaimUnit) ?? [];
+}
+
+type NumericUnitTuple = { value: number; unit: string };
+
+function numericUnitTuples(value: string): NumericUnitTuple[] {
+  const unit =
+    "[$€£¥%]|USD|EUR|GBP|JPY|CAD|AUD|BTC|ETH|dollars?|euros?|pounds?|yen|percent(?:age)?|celsius|fahrenheit|kelvin|mph|kph|km\\/h|m\\/s|mm|cm|km|meters?|metres?|miles?|feet|ft|inches?|degrees?";
+  const pattern = new RegExp(
+    `(?:(${unit})\\s*)?(-?\\d[\\d,]*(?:\\.\\d+)?)(?:\\s*(${unit}))?`,
+    "giu",
+  );
+  const tuples: NumericUnitTuple[] = [];
+  for (const match of value.matchAll(pattern)) {
+    const rawUnit = match[1] ?? match[3];
+    const parsed = Number(match[2]?.replaceAll(",", ""));
+    if (rawUnit && Number.isFinite(parsed)) {
+      tuples.push({ value: parsed, unit: canonicalClaimUnit(rawUnit) });
+    }
+  }
+  return tuples;
+}
+
+function orderedNumericUnitsSupported(
+  claims: readonly NumericUnitTuple[],
+  evidence: readonly NumericUnitTuple[],
+): boolean {
+  let cursor = 0;
+  for (const claim of claims) {
+    let matched = false;
+    while (cursor < evidence.length) {
+      const candidate = evidence[cursor];
+      cursor += 1;
+      if (candidate.unit === claim.unit && numericSupported(claim.value, [candidate.value])) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) return false;
+  }
+  return true;
+}
+
 function claimWords(value: string): string[] {
   return (
     value
+      .replace(CLAIM_UNIT, " ")
       .toLowerCase()
       .match(/[\p{L}\p{N}]+/gu)
       ?.filter((word) => !/^\p{N}+$/u.test(word) && !CLAIM_STOP_WORDS.has(word)) ?? []
@@ -370,7 +553,8 @@ function claimSupported(claim: string, source: SourceEvidence): boolean {
     if (url !== canonicalPublicUrl(source.url)) return false;
   }
   const claimNumbers = numericValues(normalized);
-  const claimCurrencies = normalized.toUpperCase().match(CURRENCY) ?? [];
+  const units = claimUnits(normalized);
+  const numericUnits = numericUnitTuples(normalized);
   const attributions = [...normalized.matchAll(ATTRIBUTION)].map((match) =>
     match[1].trim().toLowerCase(),
   );
@@ -378,8 +562,9 @@ function claimSupported(claim: string, source: SourceEvidence): boolean {
   return evidenceClauses(source.text).some((clause) => {
     if (NEGATION.test(normalized) !== NEGATION.test(clause)) return false;
     if (!orderedNumbersSupported(claimNumbers, numericValues(clause))) return false;
-    const evidenceCurrencies = new Set(clause.toUpperCase().match(CURRENCY) ?? []);
-    if (claimCurrencies.some((unit) => !evidenceCurrencies.has(unit))) return false;
+    if (!orderedNumericUnitsSupported(numericUnits, numericUnitTuples(clause))) return false;
+    const evidenceUnits = new Set(claimUnits(clause));
+    if (units.some((unit) => !evidenceUnits.has(unit))) return false;
     const lowerClause = clause.toLowerCase();
     if (attributions.some((attribution) => !lowerClause.includes(attribution))) return false;
     return orderedWordsSupported(words, claimWords(clause));

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -261,8 +261,14 @@ type SelectedGrounding = {
   status: "available" | "unavailable" | "fresh_search_required";
 };
 
+export interface SharedSelectedGroundingMetadata {
+  kind: SharedRuntimePublicGrounding["kind"];
+  query: string;
+  status: SelectedGrounding["status"];
+}
+
 function selectedGrounding(
-  history: SharedRuntimeHistoryMessageLike[],
+  history: readonly SharedRuntimeHistoryMessageLike[],
   queryText: string,
   now: number,
 ): SelectedGrounding | undefined {
@@ -333,6 +339,22 @@ function selectedGrounding(
     return { ...latest, status: "fresh_search_required" };
   }
   return { ...latest, status: "available" };
+}
+
+/** Exposes only validated provenance metadata when history policy selects mutable evidence. */
+export function sharedSelectedGroundingMetadata(
+  history: readonly SharedRuntimeHistoryMessageLike[],
+  queryText: string,
+  now = Date.now(),
+): SharedSelectedGroundingMetadata | undefined {
+  const selected = selectedGrounding(history, queryText, now);
+  return selected
+    ? {
+        kind: selected.grounding.kind,
+        query: selected.grounding.query,
+        status: selected.status,
+      }
+    : undefined;
 }
 
 function groundingAuthorityMarker(selection: SelectedGrounding): ModelMessage {


### PR DESCRIPTION
## Summary

Mandatory post-merge corrective for #25433 after it was merged externally without exact-head deployed Telegram evidence. #25587 already supplied authenticated ingress authority; this PR closes the remaining production privacy and stale-claim paths.

- fresh-search every follow-up that selects durable mutable grounding, and fail closed when no authenticated utterance can authorize search
- reject network targets, private/default-ignorable/confusable text, and construct bounded per-domain public queries instead of exporting raw utterances
- bind numeric values to exact currency/percent/measurement units and omit unselected provider URLs from public receipts
- add restart/deictic, unsafe egress, unit-swap, authority anti-spoof, and streaming fail-closed regressions

## Exact-head validation

Validated at `05b0b657c77ea545787b922b07879ddfaca3406d`, rebased on `462e1742e672196f127d9390759f1334d6b74dc9`:

- grounding/runtime/history: 111 pass, 0 fail, 284 assertions
- JSON-RPC bridge reachability/anti-spoof: 2 pass, 0 fail (the isolated Bun harness retains an existing open handle after reporting results)
- cloud API typecheck and worker-bundle dry run: pass
- Biome: all 6 changed files clean
- diff check: pass
- hosted PR Static Smoke: [run 32634258184](https://github.com/elizaOS/eliza/actions/runs/32634258184) in progress

## Evidence status

The original PR was merged externally despite the documented absence of an authorized Telegram destination and exact-head deployment. No Telegram token/destination/deployment is available in this checkout, so this corrective does not claim deployed Telegram ingress-to-egress evidence.