### PR TITLE
fix(registry): safe NaN handling in curated app order sort comparator

### DIFF
--- a/packages/registry/src/first-party/generate.ts
+++ b/packages/registry/src/first-party/generate.ts
@@ -85,7 +85,22 @@ export function collectCuratedAppDefinitions(
 ): CuratedAppDefinition[] {
   return entries
     .filter((e) => Boolean(e.curatedApp))
-    .sort((a, b) => (a.curatedApp?.order ?? 0) - (b.curatedApp?.order ?? 0))
+    .sort((a, b) => {
+      const aOrder =
+        typeof a.curatedApp?.order === "number" &&
+        Number.isFinite(a.curatedApp.order)
+          ? a.curatedApp.order
+          : 0;
+      const bOrder =
+        typeof b.curatedApp?.order === "number" &&
+        Number.isFinite(b.curatedApp.order)
+          ? b.curatedApp.order
+          : 0;
+      return (
+        aOrder - bOrder ||
+        (a.curatedApp?.slug ?? "").localeCompare(b.curatedApp?.slug ?? "")
+      );
+    })
     .map((e) => ({
       slug: e.curatedApp?.slug ?? "",
       // canonicalName is the entry's npm package; every curated entry declares one.

--- a/packages/registry/src/first-party/personal-assistant-app-registry.test.ts
+++ b/packages/registry/src/first-party/personal-assistant-app-registry.test.ts
@@ -42,4 +42,23 @@ describe("personal-assistant app registry entry", () => {
       },
     });
   });
+
+  it("sorts curated app definitions safely when order contains NaN", async () => {
+    const { collectCuratedAppDefinitions } = await import("./generate");
+    const entries = [
+      {
+        npmName: "pkg-nan",
+        curatedApp: { slug: "app-nan", order: NaN, aliases: [] },
+      },
+      {
+        npmName: "pkg-a",
+        curatedApp: { slug: "app-a", order: 5, aliases: [] },
+      },
+    ];
+
+    const result = collectCuratedAppDefinitions(entries as never);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.slug).toBe("app-nan");
+    expect(result[1]?.slug).toBe("app-a");
+  });
 });


### PR DESCRIPTION
## Summary

Validates numeric `order` values with `Number.isFinite(...)` in `packages/registry/src/first-party/generate.ts:88` to prevent `NaN` comparator return values from corrupting curated app ordering during registry generation.

## Changes

- In `packages/registry/src/first-party/generate.ts:88`, guard `curatedApp.order` numeric comparisons with `Number.isFinite(...)` and fallback to 0 before curated app slug tiebreaking.
- In `packages/registry/src/first-party/personal-assistant-app-registry.test.ts`, add unit test verifying that `collectCuratedAppDefinitions` deterministically orders curated applications when `order` contains `NaN`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2ec0f06a64`) |
| --- | --- | --- |
| `bun run --cwd packages/registry test src/first-party/personal-assistant-app-registry.test.ts` | 1 pass (1 test) | 2 pass (2 tests) |
| `bunx @biomejs/biome check packages/registry/src/first-party/generate.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/registry/src/first-party/generate.ts:80-95`
- `packages/registry/src/first-party/personal-assistant-app-registry.test.ts:40-65`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric ordering numbers are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Registry metadata generation; UI layout untouched)
- [x] `audit:browser` — N/A (Curated app sort comparator)
- [x] `build` — Clean build across workspace
- [x] `test` — 2/2 pass in `personal-assistant-app-registry.test.ts`
- [x] `lint` — Biome clean
