### PR TITLE
test(agent): cover optional-plugin-imports.generated

### DIFF
--- a/packages/agent/src/runtime/optional-plugin-imports.generated.test.ts
+++ b/packages/agent/src/runtime/optional-plugin-imports.generated.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Behavioral coverage for the generated optional-plugin importer map.
+ * Drives the real OPTIONAL_PLUGIN_IMPORTERS export: insertion order, unique
+ * keys, missing-name lookup, unbundled exclusion, and the zero-arg function
+ * values loadOptionalPlugin dispatches through.
+ */
+import { describe, expect, it } from "vitest";
+import { OPTIONAL_PLUGIN_IMPORTERS } from "./optional-plugin-imports.generated.ts";
+import {
+  OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  optionalPluginImportSpecifier,
+  UNBUNDLED_OPTIONAL_PLUGINS,
+} from "./optional-plugins.ts";
+
+const IMPORTER_KEYS = Object.keys(OPTIONAL_PLUGIN_IMPORTERS);
+
+function requiredPackage(index: number): string {
+  const pkg = OPTIONAL_STATIC_PLUGIN_PACKAGES[index];
+  if (pkg === undefined) {
+    throw new Error(`OPTIONAL_STATIC_PLUGIN_PACKAGES[${index}] is missing`);
+  }
+  return pkg;
+}
+
+describe("OPTIONAL_PLUGIN_IMPORTERS", () => {
+  it("preserves source-of-truth package order as own keys", () => {
+    expect(IMPORTER_KEYS).toEqual([...OPTIONAL_STATIC_PLUGIN_PACKAGES]);
+  });
+
+  it("lists each package once with a zero-arg importer function", () => {
+    expect(IMPORTER_KEYS.length).toBeGreaterThan(0);
+    expect(new Set(IMPORTER_KEYS).size).toBe(IMPORTER_KEYS.length);
+    expect(Object.values(OPTIONAL_PLUGIN_IMPORTERS)).toHaveLength(
+      IMPORTER_KEYS.length,
+    );
+    for (const pkg of IMPORTER_KEYS) {
+      const importer = OPTIONAL_PLUGIN_IMPORTERS[pkg];
+      expect(typeof importer, pkg).toBe("function");
+      expect(importer?.length, pkg).toBe(0);
+    }
+  });
+
+  it("returns the same function on repeated lookup of a single known package", () => {
+    const firstPackage = requiredPackage(0);
+    const lastPackage = requiredPackage(
+      OPTIONAL_STATIC_PLUGIN_PACKAGES.length - 1,
+    );
+    const first = OPTIONAL_PLUGIN_IMPORTERS[firstPackage];
+    const again = OPTIONAL_PLUGIN_IMPORTERS[firstPackage];
+    expect(typeof first).toBe("function");
+    expect(again).toBe(first);
+    expect(OPTIONAL_PLUGIN_IMPORTERS[lastPackage]).not.toBe(first);
+  });
+
+  it("gives each package its own importer rather than an aliased shared function", () => {
+    const importers = IMPORTER_KEYS.map(
+      (pkg) => OPTIONAL_PLUGIN_IMPORTERS[pkg],
+    );
+    expect(new Set(importers).size).toBe(importers.length);
+  });
+
+  it("returns undefined for an empty or missing lookup, including unbundled plugins", () => {
+    expect(OPTIONAL_PLUGIN_IMPORTERS[""]).toBeUndefined();
+    expect(OPTIONAL_PLUGIN_IMPORTERS[" "]).toBeUndefined();
+    expect(
+      OPTIONAL_PLUGIN_IMPORTERS["@elizaos/plugin-missing"],
+    ).toBeUndefined();
+    expect(
+      Object.hasOwn(OPTIONAL_PLUGIN_IMPORTERS, "@elizaos/plugin-missing"),
+    ).toBe(false);
+    for (const pkg of UNBUNDLED_OPTIONAL_PLUGINS) {
+      expect(OPTIONAL_PLUGIN_IMPORTERS[pkg], pkg).toBeUndefined();
+      expect(Object.hasOwn(OPTIONAL_PLUGIN_IMPORTERS, pkg), pkg).toBe(false);
+    }
+  });
+
+  it("does not treat import specifiers, case variants, or overflow names as keys", () => {
+    const inbox = "@elizaos/plugin-inbox";
+    const inboxSpecifier = optionalPluginImportSpecifier(inbox);
+    expect(inboxSpecifier).not.toBe(inbox);
+    expect(OPTIONAL_PLUGIN_IMPORTERS[inboxSpecifier]).toBeUndefined();
+    expect(typeof OPTIONAL_PLUGIN_IMPORTERS[inbox]).toBe("function");
+
+    expect(OPTIONAL_PLUGIN_IMPORTERS["@elizaos/plugin-OpenAI"]).toBeUndefined();
+    expect(OPTIONAL_PLUGIN_IMPORTERS["@ElizaOS/plugin-openai"]).toBeUndefined();
+    expect(
+      OPTIONAL_PLUGIN_IMPORTERS["@elizaos/plugin-openai "],
+    ).toBeUndefined();
+    expect(
+      OPTIONAL_PLUGIN_IMPORTERS[String(OPTIONAL_STATIC_PLUGIN_PACKAGES.length)],
+    ).toBeUndefined();
+  });
+
+  it("keeps capacity equal to the source list; deleting a missing key is a no-op", () => {
+    const snapshotKeys = Object.keys(OPTIONAL_PLUGIN_IMPORTERS);
+    const missing = "@elizaos/plugin-does-not-exist";
+    expect(missing in OPTIONAL_PLUGIN_IMPORTERS).toBe(false);
+    expect(delete OPTIONAL_PLUGIN_IMPORTERS[missing]).toBe(true);
+    expect(Object.keys(OPTIONAL_PLUGIN_IMPORTERS)).toEqual(snapshotKeys);
+    expect(Object.keys(OPTIONAL_PLUGIN_IMPORTERS)).toEqual([
+      ...OPTIONAL_STATIC_PLUGIN_PACKAGES,
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/agent/src/runtime/optional-plugin-imports.generated.ts`, which previously had no dedicated test file. Production code is unchanged.

The suite imports the real `OPTIONAL_PLUGIN_IMPORTERS` map (not a mock and not a text parse of the generated source) and covers:

- insertion order of own keys matches `OPTIONAL_STATIC_PLUGIN_PACKAGES`
- each key appears once and maps to a distinct zero-arg importer function
- repeated lookup of a single known package returns the same function
- empty string, whitespace, unknown names, and every `UNBUNDLED_OPTIONAL_PLUGINS` entry return `undefined`
- import specifiers, case variants, trailing whitespace, and overflow numeric names are not keys
- deleting a missing key is a no-op and capacity stays equal to the source list

Hosted CI does not run on this fork contributor PR. The counts below are from local `bunx` on the shared checkout at current `origin/develop` (`695f7b8727ccb0c5cf953527077f4de1a03a840d`).

## What kind of change is this?

Improvements — test-only coverage. No production behavior change.

## Documentation changes needed?

My changes do not require a change to the project documentation.

## Testing

Reviewer start: `packages/agent/src/runtime/optional-plugin-imports.generated.test.ts`.

```bash
bunx vitest run packages/agent/src/runtime/optional-plugin-imports.generated.test.ts --config packages/agent/vitest.config.ts
```

## Evidence

1. `bunx vitest run packages/agent/src/runtime/optional-plugin-imports.generated.test.ts --config packages/agent/vitest.config.ts`: **Test Files 1 passed (1), Tests 7 passed (7)** (156ms). Re-run immediately before filing against current `origin/develop`.
2. `bunx biome check --write packages/agent/src/runtime/optional-plugin-imports.generated.test.ts`: **Checked 1 file in 285ms. Fixed 1 file** (named-import sort). The committed file is that formatted result. `biome.json` and `tsconfig.json` are present; sparse-checkout is not enabled.
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep optional-plugin-imports.generated.test ; echo EXIT:$?` → no matches, `EXIT:1` (this file introduced no TypeScript diagnostics). Pre-existing package errors, if any, are not from this file.
4. Diff vs `origin/develop` is **only** `packages/agent/src/runtime/optional-plugin-imports.generated.test.ts`.

## Evidence rows

- Before screenshots: N/A - test-only change; no UI surface.
- After screenshots: N/A - test-only change; no UI surface.
- Walkthrough video: N/A - test-only change; no UI surface.
- Backend logs: N/A - no production code path changed; vitest output is the proof.
- Frontend logs: N/A - no frontend surface.
- LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- Domain artifacts: N/A - no DB/runtime/on-chain artifact; the passing suite is the domain result.
- OCR review: N/A - no rendered visual surface.

## Known gaps / failures

- Hosted CI does not run on fork contributor PRs.
- `bun run verify` was not run; this is a test-only diff and the scoped vitest / biome / tsc gates above are the requested evidence set.

## Maintainer CI exception record

N/A - no exception requested

## Test plan

- [x] Vitest collects and passes the new file
- [x] Biome clean on the committed test file
- [x] Package `tsc --noEmit` does not name the new file
- [ ] Maintainer review / merge

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a6b84b3a2b24f215e9bb4dc906fdba31f09d0d35 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
