### PR TITLE
test(agent): cover reload-hot

### DIFF
--- a/packages/agent/src/runtime/operations/reload-hot.test.ts
+++ b/packages/agent/src/runtime/operations/reload-hot.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit coverage for the hot reload strategy. Drives the real apply() path:
+ * env skip vs apply, provider-env failure rethrow, best-effort plugin notify,
+ * intent description, default applyConfig iteration, and the default env-pump
+ * rejection for an unknown provider.
+ */
+
+import type { AgentRuntime, Plugin } from "@elizaos/core";
+import type { SecretsManager } from "@elizaos/vault";
+import { describe, expect, it } from "vitest";
+import { createHotStrategy } from "./reload-hot.ts";
+import type {
+  OperationIntent,
+  OperationPhase,
+  ProviderSwitchIntent,
+  ReloadContext,
+} from "./types.ts";
+
+function dummySecrets(): SecretsManager {
+  return {
+    vault: {
+      reveal: async () => {
+        throw new Error("dummy vault.reveal must not be called");
+      },
+    },
+  } as unknown as SecretsManager;
+}
+
+function makeRuntime(plugins: Plugin[] = []): AgentRuntime {
+  return { plugins } as AgentRuntime;
+}
+
+function makePlugin(partial: {
+  name: string;
+  applyConfig?: Plugin["applyConfig"] | string;
+  config?: Record<string, string | number | boolean | null | undefined>;
+}): Plugin {
+  return {
+    name: partial.name,
+    description: partial.name,
+    ...(partial.applyConfig ? { applyConfig: partial.applyConfig } : {}),
+    ...(partial.config ? { config: partial.config } : {}),
+  } as Plugin;
+}
+
+function makeCtx(
+  intent: OperationIntent,
+  plugins: Plugin[] = [],
+): ReloadContext & { phases: OperationPhase[] } {
+  const phases: OperationPhase[] = [];
+  return {
+    runtime: makeRuntime(plugins),
+    intent,
+    phases,
+    reportPhase: async (phase: OperationPhase) => {
+      phases.push(phase);
+    },
+  };
+}
+
+function phaseNames(phases: OperationPhase[]): string[] {
+  return phases.map((phase) => `${phase.name}:${phase.status}`);
+}
+
+describe("createHotStrategy", () => {
+  it("has the hot tier", () => {
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+    });
+    expect(strategy.tier).toBe("hot");
+  });
+
+  it("applies env then notifies plugins for a provider-switch and returns the same runtime", async () => {
+    const applied: ProviderSwitchIntent[] = [];
+    const notifications: Array<{
+      runtime: AgentRuntime;
+      change: { kind: string; detail?: Record<string, unknown> };
+    }> = [];
+    const intent: ProviderSwitchIntent = {
+      kind: "provider-switch",
+      provider: "openai",
+    };
+    const ctx = makeCtx(intent);
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async (next) => {
+        applied.push(next);
+      },
+      notifyConfigChanged: async (runtime, change) => {
+        notifications.push({ runtime, change });
+      },
+    });
+
+    const result = await strategy.apply(ctx);
+
+    expect(result).toBe(ctx.runtime);
+    expect(applied).toEqual([intent]);
+    expect(notifications).toEqual([
+      {
+        runtime: ctx.runtime,
+        change: { kind: "provider-switch", detail: { provider: "openai" } },
+      },
+    ]);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:succeeded",
+      "notify-plugins:succeeded",
+    ]);
+    expect(ctx.phases[0]?.detail).toEqual({ provider: "openai" });
+    expect(ctx.phases[1]?.detail).toEqual({ provider: "openai" });
+    for (const phase of ctx.phases) {
+      expect(typeof phase.startedAt).toBe("number");
+      expect(typeof phase.finishedAt).toBe("number");
+      expect(phase.finishedAt ?? 0).toBeGreaterThanOrEqual(
+        phase.startedAt ?? 0,
+      );
+    }
+  });
+
+  it("is safe to apply twice with the same provider-switch intent", async () => {
+    const applied: string[] = [];
+    const ctx = makeCtx({ kind: "provider-switch", provider: "anthropic" });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async (intent) => {
+        applied.push(intent.provider);
+      },
+      notifyConfigChanged: async () => {},
+    });
+
+    expect(await strategy.apply(ctx)).toBe(ctx.runtime);
+    expect(await strategy.apply(ctx)).toBe(ctx.runtime);
+    expect(applied).toEqual(["anthropic", "anthropic"]);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:succeeded",
+      "notify-plugins:succeeded",
+      "apply-env:succeeded",
+      "notify-plugins:succeeded",
+    ]);
+  });
+
+  it("rethrows provider-env failure after reporting apply-env failed and does not notify plugins", async () => {
+    let notified = 0;
+    const ctx = makeCtx({ kind: "provider-switch", provider: "openai" });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {
+        throw new Error("env pump failed");
+      },
+      notifyConfigChanged: async () => {
+        notified += 1;
+      },
+    });
+
+    await expect(strategy.apply(ctx)).rejects.toThrow("env pump failed");
+    expect(notified).toBe(0);
+    expect(phaseNames(ctx.phases)).toEqual(["apply-env:failed"]);
+    expect(ctx.phases[0]?.error?.message).toContain("env pump failed");
+  });
+
+  it("skips apply-env for every non-provider-switch intent", async () => {
+    const intents: OperationIntent[] = [
+      { kind: "config-reload" },
+      { kind: "config-reload", changedPaths: ["env.OPENAI_API_KEY"] },
+      { kind: "plugin-enable", pluginId: "plugin-sql" },
+      { kind: "plugin-disable", pluginId: "plugin-sql" },
+      { kind: "restart", reason: "manual" },
+    ];
+    let envCalls = 0;
+
+    for (const intent of intents) {
+      const ctx = makeCtx(intent);
+      const strategy = createHotStrategy({
+        secrets: dummySecrets(),
+        applyProviderEnv: async () => {
+          envCalls += 1;
+        },
+        notifyConfigChanged: async () => {},
+      });
+      await strategy.apply(ctx);
+      expect(phaseNames(ctx.phases)).toEqual([
+        "apply-env:skipped",
+        "notify-plugins:succeeded",
+      ]);
+      expect(ctx.phases[0]?.detail).toEqual({
+        reason: `intent=${intent.kind}`,
+      });
+    }
+
+    expect(envCalls).toBe(0);
+  });
+
+  it("describes provider-switch optional fields only when they are present", async () => {
+    const changes: Array<{ kind: string; detail?: Record<string, unknown> }> =
+      [];
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+      notifyConfigChanged: async (_runtime, change) => {
+        changes.push(change);
+      },
+    });
+
+    await strategy.apply(
+      makeCtx({
+        kind: "provider-switch",
+        provider: "openai",
+        primaryModel: "gpt-4.1",
+        apiKeyRef: "providers.openai.api-key",
+      }),
+    );
+    await strategy.apply(
+      makeCtx({
+        kind: "provider-switch",
+        provider: "openai",
+        primaryModel: "",
+        apiKeyRef: "",
+      }),
+    );
+
+    expect(changes).toEqual([
+      {
+        kind: "provider-switch",
+        detail: {
+          provider: "openai",
+          primaryModel: "gpt-4.1",
+          apiKeyChanged: true,
+        },
+      },
+      {
+        kind: "provider-switch",
+        detail: { provider: "openai" },
+      },
+    ]);
+  });
+
+  it("copies config-reload changedPaths into notify detail", async () => {
+    const changedPaths = ["env.FOO", "models.large"];
+    let notifiedDetail: Record<string, unknown> | undefined;
+    const ctx = makeCtx({ kind: "config-reload", changedPaths });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+      notifyConfigChanged: async (_runtime, change) => {
+        notifiedDetail = change.detail;
+      },
+    });
+
+    await strategy.apply(ctx);
+
+    expect(notifiedDetail).toEqual({
+      changedPaths: ["env.FOO", "models.large"],
+    });
+    expect(notifiedDetail?.changedPaths).not.toBe(changedPaths);
+    expect(ctx.phases[1]?.detail).toEqual({
+      changedPaths: ["env.FOO", "models.large"],
+    });
+  });
+
+  it("describes config-reload without changedPaths as an empty detail object", async () => {
+    let notifiedDetail: Record<string, unknown> | undefined;
+    const ctx = makeCtx({ kind: "config-reload" });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+      notifyConfigChanged: async (_runtime, change) => {
+        notifiedDetail = change.detail;
+      },
+    });
+
+    await strategy.apply(ctx);
+
+    expect(notifiedDetail).toEqual({});
+    expect(ctx.phases[1]?.detail).toEqual({});
+  });
+
+  it("describes plugin enable/disable and restart intents", async () => {
+    const changes: Array<{ kind: string; detail?: Record<string, unknown> }> =
+      [];
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+      notifyConfigChanged: async (_runtime, change) => {
+        changes.push(change);
+      },
+    });
+
+    await strategy.apply(makeCtx({ kind: "plugin-enable", pluginId: "p1" }));
+    await strategy.apply(makeCtx({ kind: "plugin-disable", pluginId: "p2" }));
+    await strategy.apply(makeCtx({ kind: "restart", reason: "owner asked" }));
+    await strategy.apply(makeCtx({ kind: "restart", reason: "" }));
+
+    expect(changes).toEqual([
+      { kind: "plugin-enable", detail: { pluginId: "p1" } },
+      { kind: "plugin-disable", detail: { pluginId: "p2" } },
+      { kind: "restart", detail: { reason: "owner asked" } },
+      { kind: "restart", detail: { reason: "" } },
+    ]);
+  });
+
+  it("reports notify-plugins failed but still returns the runtime when notify throws", async () => {
+    const ctx = makeCtx({ kind: "provider-switch", provider: "openai" });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+      notifyConfigChanged: async () => {
+        throw new Error("notify exploded");
+      },
+    });
+
+    const result = await strategy.apply(ctx);
+
+    expect(result).toBe(ctx.runtime);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:succeeded",
+      "notify-plugins:failed",
+    ]);
+    expect(ctx.phases[1]?.error?.message).toContain("notify exploded");
+  });
+});
+
+describe("createHotStrategy default notifyConfigChanged", () => {
+  it("succeeds when the runtime has no plugins", async () => {
+    const ctx = makeCtx({ kind: "config-reload" });
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+    });
+
+    expect(await strategy.apply(ctx)).toBe(ctx.runtime);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:skipped",
+      "notify-plugins:succeeded",
+    ]);
+  });
+
+  it("skips plugins without an applyConfig function and notifies the rest", async () => {
+    const received: Array<{
+      name: string;
+      config: Record<string, string>;
+      runtime: object;
+    }> = [];
+    const plugins = [
+      makePlugin({ name: "no-hook" }),
+      makePlugin({
+        name: "not-a-function",
+        applyConfig: "nope",
+      }),
+      makePlugin({
+        name: "wired",
+        config: {
+          enabled: true,
+          retries: 2,
+          label: "ok",
+          gone: null,
+          missing: undefined,
+        },
+        applyConfig: async (config, runtime) => {
+          received.push({ name: "wired", config, runtime });
+        },
+      }),
+    ];
+    const ctx = makeCtx({ kind: "config-reload" }, plugins);
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+    });
+
+    await strategy.apply(ctx);
+
+    expect(received).toEqual([
+      {
+        name: "wired",
+        config: { enabled: "true", retries: "2", label: "ok" },
+        runtime: ctx.runtime,
+      },
+    ]);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:skipped",
+      "notify-plugins:succeeded",
+    ]);
+  });
+
+  it("keeps notify-plugins succeeded when a plugin applyConfig throws, and continues the queue", async () => {
+    const called: string[] = [];
+    const plugins = [
+      makePlugin({
+        name: "boom",
+        applyConfig: async () => {
+          called.push("boom");
+          throw new Error("applyConfig boom");
+        },
+      }),
+      makePlugin({
+        name: "ok",
+        applyConfig: async () => {
+          called.push("ok");
+        },
+      }),
+    ];
+    const ctx = makeCtx({ kind: "plugin-enable", pluginId: "ok" }, plugins);
+    const strategy = createHotStrategy({
+      secrets: dummySecrets(),
+      applyProviderEnv: async () => {},
+    });
+
+    const result = await strategy.apply(ctx);
+
+    expect(result).toBe(ctx.runtime);
+    expect(called).toEqual(["boom", "ok"]);
+    expect(phaseNames(ctx.phases)).toEqual([
+      "apply-env:skipped",
+      "notify-plugins:succeeded",
+    ]);
+  });
+});
+
+describe("createHotStrategy default applyProviderEnv", () => {
+  it("fails apply-env for an unknown provider without notifying plugins", async () => {
+    const ctx = makeCtx({
+      kind: "provider-switch",
+      provider: "not-a-real-provider",
+    });
+    const strategy = createHotStrategy({ secrets: dummySecrets() });
+
+    await expect(strategy.apply(ctx)).rejects.toThrow(
+      '[runtime-ops] hot reload: invalid provider "not-a-real-provider"',
+    );
+    expect(phaseNames(ctx.phases)).toEqual(["apply-env:failed"]);
+    expect(ctx.phases[0]?.error?.message).toContain(
+      '[runtime-ops] hot reload: invalid provider "not-a-real-provider"',
+    );
+  });
+
+  it("fails apply-env when the vault cannot resolve apiKeyRef", async () => {
+    const secrets = {
+      vault: {
+        reveal: async () => {
+          throw new Error("no such secret");
+        },
+      },
+    } as unknown as SecretsManager;
+    const ctx = makeCtx({
+      kind: "provider-switch",
+      provider: "openai",
+      apiKeyRef: "providers.openai.api-key",
+    });
+    const strategy = createHotStrategy({ secrets });
+
+    await expect(strategy.apply(ctx)).rejects.toThrow(
+      "[runtime-ops:vault] failed to resolve providers.openai.api-key: no such secret",
+    );
+    expect(phaseNames(ctx.phases)).toEqual(["apply-env:failed"]);
+    expect(ctx.phases[0]?.error?.message).toContain(
+      "failed to resolve providers.openai.api-key",
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

Adds same-file unit coverage for `packages/agent/src/runtime/operations/reload-hot.ts`, which had no colocated test. Test-only; no production behavior change.

Definition of Done:

- [x] This PR targets `develop` and is based on the latest `origin/develop` at file time (`git fetch origin develop`, branch created from that tip).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused vitest / biome / tsc evidence is below.
- [x] A reviewer can confirm the change from the quoted command output below without reading the implementation.

# Sync with develop

- [x] Branch `test/agent-reload-hot-coverage` is `origin/develop` plus this test file.
- [ ] Full `bun run verify` was not run. Hosted CI does **not** run on this fork contributor's PRs.

# Risks

Low. Additive test file only. No production code, config, or public API change. Tests assert observed `createHotStrategy` behavior, including that a plugin `applyConfig` throw is swallowed by the default notifier so `notify-plugins` still reports `succeeded`.

# Background

## What does this PR do?

Adds `packages/agent/src/runtime/operations/reload-hot.test.ts` covering `createHotStrategy`:

- hot tier; same-runtime return; apply twice with the same provider-switch intent
- provider-switch applies env then notifies plugins
- apply-env failure rethrows, reports `apply-env:failed`, and does not notify plugins
- non-provider-switch intents skip apply-env (`config-reload`, plugin enable/disable, restart)
- intent description: optional `primaryModel` / `apiKeyRef` (empty strings omitted), `changedPaths` copied not aliased, empty config-reload detail, plugin id, restart reason
- notify throw reports `notify-plugins:failed` but still returns the runtime
- default `notifyConfigChanged`: empty plugin list, skip non-function hooks, stringify plugin config and drop null/undefined, continue after an `applyConfig` throw
- default `applyProviderEnv`: unknown provider rejects; vault `apiKeyRef` resolve failure rejects

## What kind of change is this?

Testing (unit coverage for existing hot-reload strategy).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/operations/reload-hot.test.ts` and the source it covers, `reload-hot.ts`.

## Detailed testing steps

From repo root, after `git fetch origin develop` (counts below are from that current tree; `reload-hot.ts` matched `origin/develop`):

```bash
bunx vitest run packages/agent/src/runtime/operations/reload-hot.test.ts
# Test Files  1 passed (1)
# Tests  15 passed (15)

bunx biome check --write packages/agent/src/runtime/operations/reload-hot.test.ts
# Checked 1 file. No fixes applied.

cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'reload-hot.test.ts' ; echo "GREP_EXIT:$?"
# (empty) GREP_EXIT:1  — this test file introduces zero tsc errors
```

The diff touches only `packages/agent/src/runtime/operations/reload-hot.test.ts`.

We are a fork contributor: hosted CI does **not** run on this PR. Do not treat missing GitHub Actions as a pass.

# Evidence Gate

Test-only PR; no production behavior change. Heavy bug-fix evidence (proof-run, origin reproduction, revert, over-rejection corpus) does not apply.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; test-only TypeScript file
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; test-only TypeScript file
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface; test-only TypeScript file
<!-- evidence-row:backend-logs -->
- [x] N/A - no production runtime path changed; vitest output quoted in Testing
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain records written
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - this PR only adds a unit test file; it does not change agent, action, provider, prompt, or model behavior.

## Backend + frontend logs

N/A - no production server or UI path changed. The vitest run is quoted under Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - not a voice / transcript / TTS / STT change.

## Known gaps / failures

- Full `bun run verify` was not run. Scope is one new test file; evidence is the focused vitest / biome / tsc commands above.
- Hosted GitHub Actions CI does not run on PRs from this fork. Local counts are the verification.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c232e433256d8eb773ac8447b106fe437c605d33 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
