### PR TITLE
fix(vision): safe NaN handling in screen element position and lifecycle lastUsed sort comparators

### DIFF
--- a/plugins/plugin-vision/src/get-screen-elements.test.ts
+++ b/plugins/plugin-vision/src/get-screen-elements.test.ts
@@ -151,4 +151,16 @@ describe("mergeScreenElements (#9105 GET_SCREEN element merge)", () => {
     });
     expect(out).toHaveLength(2);
   });
+
+  it("sorts screen elements safely when bbox coordinates contain NaN", () => {
+    const out = mergeScreenElements({
+      ocr: [
+        ocr("o-nan", "text nan", [NaN, NaN, 10, 10] as never, 0),
+        ocr("o-valid", "text valid", [10, 20, 10, 10], 0),
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]?.id).toBe("o-nan");
+    expect(out[1]?.id).toBe("o-valid");
+  });
 });

--- a/plugins/plugin-vision/src/get-screen-elements.ts
+++ b/plugins/plugin-vision/src/get-screen-elements.ts
@@ -111,9 +111,15 @@ function byPosition(
   a: { bbox: Bbox; id: string },
   b: { bbox: Bbox; id: string },
 ): number {
-  return (
-    a.bbox[1] - b.bbox[1] || a.bbox[0] - b.bbox[0] || a.id.localeCompare(b.id)
-  );
+  const aY =
+    typeof a.bbox[1] === "number" && Number.isFinite(a.bbox[1]) ? a.bbox[1] : 0;
+  const bY =
+    typeof b.bbox[1] === "number" && Number.isFinite(b.bbox[1]) ? b.bbox[1] : 0;
+  const aX =
+    typeof a.bbox[0] === "number" && Number.isFinite(a.bbox[0]) ? a.bbox[0] : 0;
+  const bX =
+    typeof b.bbox[0] === "number" && Number.isFinite(b.bbox[0]) ? b.bbox[0] : 0;
+  return aY - bY || aX - bX || a.id.localeCompare(b.id);
 }
 
 /**

--- a/plugins/plugin-vision/src/lifecycle.ts
+++ b/plugins/plugin-vision/src/lifecycle.ts
@@ -221,7 +221,17 @@ export class VisionServiceLifecycleManager {
     const named = new Set(holders);
     const candidates = Array.from(this.subs.values())
       .filter((s) => s.loaded && (named.size === 0 || named.has(s.handle.id)))
-      .sort((a, b) => a.lastUsed - b.lastUsed);
+      .sort((a, b) => {
+        const aUsed =
+          typeof a.lastUsed === "number" && Number.isFinite(a.lastUsed)
+            ? a.lastUsed
+            : 0;
+        const bUsed =
+          typeof b.lastUsed === "number" && Number.isFinite(b.lastUsed)
+            ? b.lastUsed
+            : 0;
+        return aUsed - bUsed || a.handle.id.localeCompare(b.handle.id);
+      });
 
     for (const sub of candidates) {
       logger.info(`[VisionLifecycle] pressure release: ${sub.handle.id}`);


### PR DESCRIPTION
## Summary

Validates numeric bounding box coordinates and model usage timestamps with `Number.isFinite(...)` across screen element spatial merging and vision model lifecycle memory pressure handling (`plugins/plugin-vision/src/get-screen-elements.ts:110`, `plugins/plugin-vision/src/lifecycle.ts:224`) to prevent `NaN` comparator return values from corrupting screen element ordering and model eviction priorities.

## Changes

- In `plugins/plugin-vision/src/get-screen-elements.ts:110`, guard `bbox[1]` (y) and `bbox[0]` (x) numeric comparisons with `Number.isFinite(...)` and fallback to 0 before element ID tiebreaking.
- In `plugins/plugin-vision/src/lifecycle.ts:224`, guard `lastUsed` numeric comparisons with `Number.isFinite(...)` and fallback to 0 before handle ID tiebreaking.
- In `plugins/plugin-vision/src/get-screen-elements.test.ts`, add unit test verifying that `mergeScreenElements` deterministically sorts elements when bounding box coordinates contain `NaN`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`971b8d84ba`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-vision test src/get-screen-elements.test.ts` | 11 pass (11 tests) | 12 pass (12 tests) |
| `bunx @biomejs/biome check plugins/plugin-vision/src/get-screen-elements.ts plugins/plugin-vision/src/lifecycle.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-vision/src/get-screen-elements.ts:108-120`
- `plugins/plugin-vision/src/lifecycle.ts:218-230`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric coordinates/timestamps are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Vision plugin screen element deduplication and lifecycle eviction; UI layout untouched)
- [x] `audit:browser` — N/A (Spatial and lifecycle sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 12/12 pass in `get-screen-elements.test.ts`
- [x] `lint` — Biome clean
