### PR TITLE
test(agent): cover pglite-error-compat

### DIFF
--- a/packages/agent/src/runtime/pglite-error-compat.test.ts
+++ b/packages/agent/src/runtime/pglite-error-compat.test.ts
@@ -1,6 +1,8 @@
 /**
- * Coverage for the pglite error-compat shim: error code constants, constructor
- * metadata, factory helper, and cause-chain scanning in getPgliteErrorCode.
+ * Behavioral coverage for the agent-local PGlite error-compat shim: canonical
+ * codes, PgliteInitError metadata, the factory helper, and getPgliteErrorCode
+ * cause-chain walking, including duck-typed objects, cycles, ordering, and
+ * non-canonical codes.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -52,6 +54,40 @@ describe("PgliteInitError", () => {
     expect(err.code).toBe(PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED);
     expect(err.dataDir).toBeUndefined();
   });
+
+  it("is an Error subclass and leaves dataDir unset when options are omitted", () => {
+    const err = new PgliteInitError(
+      PGLITE_ERROR_CODES.ACTIVE_LOCK,
+      "dir in use",
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(PgliteInitError);
+    expect(err.dataDir).toBeUndefined();
+    expect(err.cause).toBeUndefined();
+  });
+
+  it("accepts cause and dataDir together", () => {
+    const cause = new Error("sqlite lock");
+    const err = new PgliteInitError(
+      PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED,
+      "reset required",
+      { cause, dataDir: "/var/eliza/pglite" },
+    );
+    expect(err.cause).toBe(cause);
+    expect(err.dataDir).toBe("/var/eliza/pglite");
+  });
+
+  it("forwards cause and dataDir through the factory helper", () => {
+    const cause = new Error("io");
+    const err = createPgliteInitError(
+      PGLITE_ERROR_CODES.CORRUPT_DATA,
+      "bad image",
+      { cause, dataDir: "/tmp/x" },
+    );
+    expect(err).toBeInstanceOf(PgliteInitError);
+    expect(err.cause).toBe(cause);
+    expect(err.dataDir).toBe("/tmp/x");
+  });
 });
 
 describe("getPgliteErrorCode", () => {
@@ -89,5 +125,93 @@ describe("getPgliteErrorCode", () => {
       cause: Object.assign(new Error("inner"), { code: "ECONNREFUSED" }),
     });
     expect(getPgliteErrorCode(err)).toBeNull();
+  });
+
+  it("reads every canonical code from a duck-typed non-Error object", () => {
+    expect(getPgliteErrorCode({ code: PGLITE_ERROR_CODES.ACTIVE_LOCK })).toBe(
+      PGLITE_ERROR_CODES.ACTIVE_LOCK,
+    );
+    expect(getPgliteErrorCode({ code: PGLITE_ERROR_CODES.CORRUPT_DATA })).toBe(
+      PGLITE_ERROR_CODES.CORRUPT_DATA,
+    );
+    expect(
+      getPgliteErrorCode({ code: PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED }),
+    ).toBe(PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED);
+  });
+
+  it("walks a non-Error object's cause to a matching code", () => {
+    const wrapped = {
+      cause: { code: PGLITE_ERROR_CODES.CORRUPT_DATA },
+    };
+    expect(getPgliteErrorCode(wrapped)).toBe(PGLITE_ERROR_CODES.CORRUPT_DATA);
+  });
+
+  it("continues past a non-canonical string code to a nested match", () => {
+    const inner = createPgliteInitError(
+      PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED,
+      "reset",
+    );
+    const outer = Object.assign(new Error("wrapper"), {
+      code: "ECONNREFUSED",
+      cause: inner,
+    });
+    expect(getPgliteErrorCode(outer)).toBe(
+      PGLITE_ERROR_CODES.MANUAL_RESET_REQUIRED,
+    );
+  });
+
+  it("skips a non-string code property and walks cause", () => {
+    const inner = createPgliteInitError(PGLITE_ERROR_CODES.ACTIVE_LOCK, "lock");
+    expect(getPgliteErrorCode({ code: 404, cause: inner })).toBe(
+      PGLITE_ERROR_CODES.ACTIVE_LOCK,
+    );
+  });
+
+  it("returns the first matching code when both outer and inner match", () => {
+    const inner = createPgliteInitError(
+      PGLITE_ERROR_CODES.CORRUPT_DATA,
+      "inner",
+    );
+    const outer = createPgliteInitError(
+      PGLITE_ERROR_CODES.ACTIVE_LOCK,
+      "outer",
+      { cause: inner },
+    );
+    expect(getPgliteErrorCode(outer)).toBe(PGLITE_ERROR_CODES.ACTIVE_LOCK);
+  });
+
+  it("walks a deep Error cause chain", () => {
+    const root = createPgliteInitError(PGLITE_ERROR_CODES.CORRUPT_DATA, "root");
+    const mid = new Error("mid", { cause: root });
+    const outer = new Error("outer", { cause: mid });
+    expect(getPgliteErrorCode(outer)).toBe(PGLITE_ERROR_CODES.CORRUPT_DATA);
+  });
+
+  it("reads a duck-typed code from an Error cause", () => {
+    const wrapper = new Error("wrap", {
+      cause: { code: PGLITE_ERROR_CODES.ACTIVE_LOCK },
+    });
+    expect(getPgliteErrorCode(wrapper)).toBe(PGLITE_ERROR_CODES.ACTIVE_LOCK);
+  });
+
+  it("returns null for empty objects, arrays, and objects with an undefined cause", () => {
+    expect(getPgliteErrorCode({})).toBeNull();
+    expect(getPgliteErrorCode([])).toBeNull();
+    expect(getPgliteErrorCode({ cause: undefined })).toBeNull();
+    expect(getPgliteErrorCode({ code: "ECONNREFUSED" })).toBeNull();
+  });
+
+  it("returns null for primitives that are not objects", () => {
+    expect(getPgliteErrorCode(0)).toBeNull();
+    expect(getPgliteErrorCode(1)).toBeNull();
+    expect(getPgliteErrorCode(true)).toBeNull();
+    expect(getPgliteErrorCode(false)).toBeNull();
+    expect(getPgliteErrorCode("")).toBeNull();
+  });
+
+  it("does not loop forever on a circular non-Error cause", () => {
+    const loop: { cause?: unknown } = {};
+    loop.cause = loop;
+    expect(getPgliteErrorCode(loop)).toBeNull();
   });
 });


### PR DESCRIPTION

# Relates to

No linked issue. Test-only coverage for remaining branches in the existing
agent-local PGlite error-compat shim. #25570 landed the initial colocated
suite; this PR extends it.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation after sync (see Evidence). `bun run verify`
      was not run; this is a single-file test-only change. Hosted CI does not
      run on fork contributor PRs.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Parent is current `origin/develop` (`71ae1858263e8026904faa389933a2a370e58586`);
      zero conflicts.
- [x] Focused verification passed post-sync (see Evidence).

# Risks

Low. Test-only addition to an existing vitest file. No production code is
modified and no runtime behaviour changes.

# Background

## What does this PR do?

Extends `packages/agent/src/runtime/pglite-error-compat.test.ts` so the real
shim is driven through branches the initial suite did not hit:

- `PgliteInitError` with omitted options, and with `cause` plus `dataDir`
  together
- `createPgliteInitError` forwarding both options
- `getPgliteErrorCode` on duck-typed non-Error objects for every canonical code
- walking a non-Error object's `cause`
- continuing past a non-canonical string code or a non-string `code` to a nested match
- first matching code wins when both outer and inner match
- deep Error cause chains and Error wrapping a duck-typed code object
- empty objects, arrays, `{ cause: undefined }`, primitives, and circular
  non-Error objects return `null`

The assertions record observed behaviour of the current module. Nothing in
production is changed.

## What kind of change is this?

Improvements (tests for an existing helper).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/pglite-error-compat.test.ts`, then the focused
vitest command below.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/runtime/pglite-error-compat.test.ts
```

Observed on current `origin/develop` (`71ae1858263e8026904faa389933a2a370e58586`)
with this PR's test file:

```
Test Files  1 passed (1)
     Tests  22 passed (22)
```

Biome: `bunx biome check --write packages/agent/src/runtime/pglite-error-compat.test.ts`
→ `Checked 1 file in 65ms. Fixed 1 file.` then clean. The quoted vitest run is
after that format pass.

Typecheck: `cd packages/agent && bunx tsc --noEmit` — `pglite-error-compat.test.ts`
appears nowhere in the output. Pre-existing package errors remain; this file
added zero.

The diff touches only that test file.

Hosted CI does not run on this fork contributor PR; the counts above are local.

# Evidence Gate

Evidence head: `c1c77549ecc0a3f92247d140c38ad08f85d65c9b`

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path exercised; focused vitest only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path exercised
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests, no model call
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only; the artifact is the passing vitest suite quoted above
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit tests, no model call.

## Backend + frontend logs

N/A - no runtime or frontend path exercised.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- `bun run verify` was not run; the scoped evidence for this test-only PR is
  focused vitest, biome, and `tsc --noEmit` (this file absent from tsc output).
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- `packages/agent` `tsc --noEmit` exits non-zero due to pre-existing errors in
  other files; `pglite-error-compat.test.ts` is not among them.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c1c77549ecc0a3f92247d140c38ad08f85d65c9b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
