### PR TITLE
fix(devices): collect stale runtime approvals safely

### DIFF
--- a/packages/agent/src/api/runtime-management-proposal-store.test.ts
+++ b/packages/agent/src/api/runtime-management-proposal-store.test.ts
@@ -5,8 +5,11 @@ import {
   mkdtemp,
   readdir,
   readFile,
+  rename,
   rm,
   stat,
+  symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -111,4 +114,188 @@ describe("FileRuntimeManagementProposalStore", () => {
     ).resolves.toBe(false);
     await expect(store.consume(proposal)).resolves.toBe(true);
   });
+
+  it("collects expired proposals and abandoned consumed claims on later use", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const store = new FileRuntimeManagementProposalStore(directory);
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    const expired = { ...proposal, expiresAt: Date.now() - 1 };
+    await store.create(expired);
+    const expiredPath = path.join(
+      proposalDirectory,
+      `${proposal.proposalId}.json`,
+    );
+    await utimes(expiredPath, new Date(0), new Date(0));
+
+    const consumedProposal = {
+      ...proposal,
+      proposalId: "20000000-0000-4000-8000-000000000002",
+    };
+    await store.create(consumedProposal);
+    const consumedPath = path.join(
+      proposalDirectory,
+      `${consumedProposal.proposalId}.consumed-30000000-0000-4000-8000-000000000003`,
+    );
+    await rename(
+      path.join(proposalDirectory, `${consumedProposal.proposalId}.json`),
+      consumedPath,
+    );
+    await utimes(consumedPath, new Date(0), new Date(0));
+
+    await store.create({
+      ...proposal,
+      proposalId: "40000000-0000-4000-8000-000000000004",
+    });
+    const names = await readdir(proposalDirectory);
+    expect(names).not.toContain(`${proposal.proposalId}.json`);
+    expect(names).not.toContain(path.basename(consumedPath));
+  });
+
+  it("collects an abandoned partial only after its race-safe age floor", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    await mkdir(proposalDirectory, { recursive: true });
+    const partialPath = path.join(
+      proposalDirectory,
+      `${proposal.proposalId}.json`,
+    );
+    await writeFile(partialPath, '{"proposalId":', { flag: "wx" });
+    const store = new FileRuntimeManagementProposalStore(directory);
+    await store.create({
+      ...proposal,
+      proposalId: "20000000-0000-4000-8000-000000000002",
+    });
+    await expect(stat(partialPath)).resolves.toBeDefined();
+
+    await utimes(partialPath, new Date(0), new Date(0));
+    await store.create({
+      ...proposal,
+      proposalId: "30000000-0000-4000-8000-000000000003",
+    });
+    await expect(stat(partialPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("recovers an unexpired proposal abandoned inside an interrupted cleanup claim", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const store = new FileRuntimeManagementProposalStore(directory);
+    await store.create(proposal);
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    const cleanupPath = path.join(
+      proposalDirectory,
+      `${proposal.proposalId}.cleanup-20000000-0000-4000-8000-000000000002`,
+    );
+    await rename(
+      path.join(proposalDirectory, `${proposal.proposalId}.json`),
+      cleanupPath,
+    );
+    await utimes(cleanupPath, new Date(0), new Date(0));
+
+    await store.create({
+      ...proposal,
+      proposalId: "30000000-0000-4000-8000-000000000003",
+    });
+    await expect(store.consume(proposal)).resolves.toBe(true);
+    await expect(stat(cleanupPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("advances a bounded cleanup cursor past more than 256 earlier entries", async () => {
+    const { directory, proposal } = await temporaryStore();
+    const proposalDirectory = path.join(
+      directory,
+      "runtime-management-proposals",
+    );
+    await mkdir(proposalDirectory, { recursive: true });
+    await Promise.all(
+      Array.from({ length: 300 }, (_, index) =>
+        writeFile(
+          path.join(
+            proposalDirectory,
+            `unrelated-${index.toString().padStart(3, "0")}`,
+          ),
+          "retained",
+        ),
+      ),
+    );
+    const bootstrap = new FileRuntimeManagementProposalStore(directory);
+    await bootstrap.create(proposal);
+    const consumedPath = path.join(
+      proposalDirectory,
+      `${proposal.proposalId}.consumed-20000000-0000-4000-8000-000000000002`,
+    );
+    await rename(
+      path.join(proposalDirectory, `${proposal.proposalId}.json`),
+      consumedPath,
+    );
+    await utimes(consumedPath, new Date(0), new Date(0));
+
+    const restarted = new FileRuntimeManagementProposalStore(directory);
+    for (let index = 1; index <= 8; index += 1) {
+      await restarted.create({
+        ...proposal,
+        proposalId: `40000000-0000-4000-8000-${index.toString().padStart(12, "0")}`,
+      });
+    }
+    await expect(stat(consumedPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "never follows a proposal symlink outside the state directory",
+    async () => {
+      const { directory, proposal } = await temporaryStore();
+      const proposalDirectory = path.join(
+        directory,
+        "runtime-management-proposals",
+      );
+      await mkdir(proposalDirectory, { recursive: true });
+      const outside = path.join(directory, "outside.json");
+      await writeFile(
+        outside,
+        JSON.stringify({
+          proposalId: proposal.proposalId,
+          nonceDigest: "0".repeat(64),
+          clientId: proposal.clientId,
+          requestKey: proposal.requestKey,
+          expiresAt: proposal.expiresAt,
+        }),
+      );
+      await symlink(
+        outside,
+        path.join(proposalDirectory, `${proposal.proposalId}.json`),
+      );
+
+      const store = new FileRuntimeManagementProposalStore(directory);
+      await expect(store.consume(proposal)).resolves.toBe(false);
+      await expect(readFile(outside, "utf8")).resolves.toContain(
+        proposal.proposalId,
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a linked proposal directory before writing authority",
+    async () => {
+      const { directory, proposal } = await temporaryStore();
+      const outside = path.join(directory, "outside-directory");
+      await mkdir(outside);
+      await symlink(
+        outside,
+        path.join(directory, "runtime-management-proposals"),
+      );
+
+      const store = new FileRuntimeManagementProposalStore(directory);
+      await expect(store.create(proposal)).rejects.toThrow(
+        "real local directory",
+      );
+      await expect(readdir(outside)).resolves.toEqual([]);
+    },
+  );
 });

--- a/packages/agent/src/api/runtime-management-proposal-store.ts
+++ b/packages/agent/src/api/runtime-management-proposal-store.ts
@@ -1,10 +1,29 @@
 /** Persists one-use runtime mutation proposals with cross-process atomic consumption. */
 
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
-import { constants } from "node:fs";
-import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import { constants, type Dir } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import {
+  link,
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  rename,
+  unlink,
+} from "node:fs/promises";
 import path from "node:path";
-import { resolveStateDir } from "@elizaos/core";
+import { logger, resolveStateDir } from "@elizaos/core";
+
+const PROPOSAL_FILE_BYTES = 16 * 1024;
+const CLEANUP_SCAN_LIMIT = 64;
+const ABANDONED_FILE_AGE_MS = 10 * 60_000;
+const PROPOSAL_FILE_PATTERN =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.json$/i;
+const CONSUMED_FILE_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.consumed-[0-9a-f-]{36}$/i;
+const CLEANUP_FILE_PATTERN =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.cleanup-[0-9a-f-]{36}$/i;
 
 export interface RuntimeManagementProposal {
   proposalId: string;
@@ -50,20 +69,54 @@ export class FileRuntimeManagementProposalStore
   implements RuntimeManagementProposalStore
 {
   private readonly directory: string;
+  private cleanupDirectory: Dir | undefined;
+  private cleanupTail: Promise<void> = Promise.resolve();
 
   constructor(stateDirectory = resolveStateDir()) {
     this.directory = path.join(stateDirectory, "runtime-management-proposals");
   }
 
   private proposalPath(proposalId: string): string {
-    if (!/^[0-9a-f-]{36}$/i.test(proposalId)) {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        proposalId,
+      )
+    ) {
       throw new TypeError("Runtime proposal id must be a UUID.");
     }
     return path.join(this.directory, `${proposalId}.json`);
   }
 
+  private async prepareDirectory(create: boolean): Promise<boolean> {
+    if (create) {
+      await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    }
+    try {
+      const metadata = await lstat(this.directory);
+      if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+        throw new Error(
+          "Runtime proposal directory must be a real local directory.",
+        );
+      }
+      return true;
+    } catch (error) {
+      // error-policy:J3 an absent store is an explicit consume miss; linked or
+      // non-directory state fails closed instead of redirecting authority I/O.
+      if (
+        !create &&
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   async create(proposal: RuntimeManagementProposal): Promise<void> {
-    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    await this.prepareDirectory(true);
+    await this.cleanupStaleFiles();
     const stored: StoredProposal = {
       proposalId: proposal.proposalId,
       nonceDigest: nonceDigest(proposal.nonce),
@@ -84,25 +137,188 @@ export class FileRuntimeManagementProposalStore
     }
   }
 
-  private async read(proposalId: string): Promise<StoredProposal | undefined> {
+  private async readPath(
+    filePath: string,
+  ): Promise<StoredProposal | undefined> {
+    let handle: FileHandle | undefined;
     try {
-      const parsed = JSON.parse(
-        await readFile(this.proposalPath(proposalId), "utf8"),
-      ) as unknown;
+      handle = await open(
+        filePath,
+        constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+      );
+      const metadata = await handle.stat();
+      if (!metadata.isFile() || metadata.size > PROPOSAL_FILE_BYTES)
+        return undefined;
+      const parsed = JSON.parse(await handle.readFile("utf8")) as unknown;
       return isStoredProposal(parsed) ? parsed : undefined;
     } catch (error) {
-      // error-policy:J3 missing or malformed proposal files are invalid authority.
+      // error-policy:J3 missing, linked, oversized, or malformed proposal files
+      // are invalid authority and are never followed outside the state store.
       if (
         error instanceof SyntaxError ||
-        (error instanceof Error && "code" in error && error.code === "ENOENT")
+        (error instanceof Error &&
+          "code" in error &&
+          (error.code === "ENOENT" || error.code === "ELOOP"))
       ) {
         return undefined;
       }
       throw error;
+    } finally {
+      await handle?.close();
     }
   }
 
+  private read(proposalId: string): Promise<StoredProposal | undefined> {
+    return this.readPath(this.proposalPath(proposalId));
+  }
+
+  private async cleanupProposalFile(
+    fileName: string,
+    now: number,
+  ): Promise<void> {
+    const proposalMatch = PROPOSAL_FILE_PATTERN.exec(fileName);
+    const cleanupMatch = CLEANUP_FILE_PATTERN.exec(fileName);
+    const filePath = path.join(this.directory, fileName);
+    const metadata = await lstat(filePath);
+    if (cleanupMatch) {
+      if (metadata.mtimeMs > now - ABANDONED_FILE_AGE_MS) return;
+      const claimed = await this.readPath(filePath);
+      if (claimed && claimed.expiresAt > now) {
+        try {
+          await link(
+            filePath,
+            path.join(this.directory, `${cleanupMatch[1]}.json`),
+          );
+        } catch (error) {
+          // error-policy:J6 an original path means another recovery or exact
+          // same-id publisher already retained the authoritative proposal.
+          if (
+            !(
+              error instanceof Error &&
+              "code" in error &&
+              error.code === "EEXIST"
+            )
+          ) {
+            throw error;
+          }
+        }
+      }
+      await unlink(filePath);
+      return;
+    }
+    if (CONSUMED_FILE_PATTERN.test(fileName)) {
+      if (metadata.mtimeMs <= now - ABANDONED_FILE_AGE_MS)
+        await unlink(filePath);
+      return;
+    }
+    if (!proposalMatch) return;
+    const stored = await this.readPath(filePath);
+    if (
+      (stored && stored.expiresAt > now) ||
+      (!stored && metadata.mtimeMs > now - ABANDONED_FILE_AGE_MS)
+    ) {
+      return;
+    }
+
+    const claimedPath = path.join(
+      this.directory,
+      `${proposalMatch[1]}.cleanup-${randomUUID()}`,
+    );
+    await rename(filePath, claimedPath);
+    try {
+      const claimedMetadata = await lstat(claimedPath);
+      const claimed = await this.readPath(claimedPath);
+      const stale = claimed
+        ? claimed.expiresAt <= now
+        : claimedMetadata.mtimeMs <= now - ABANDONED_FILE_AGE_MS;
+      if (!stale) {
+        try {
+          await link(claimedPath, filePath);
+        } catch (error) {
+          // error-policy:J6 a concurrent same-id publisher already restored a
+          // proposal path, so the cleanup claim must not replace it.
+          if (
+            !(
+              error instanceof Error &&
+              "code" in error &&
+              error.code === "EEXIST"
+            )
+          ) {
+            throw error;
+          }
+        }
+      }
+    } finally {
+      await unlink(claimedPath).catch((error) => {
+        // error-policy:J6 another cleanup may already have removed the claim.
+        if (
+          !(
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          )
+        ) {
+          throw error;
+        }
+      });
+    }
+  }
+
+  private async cleanupStaleFilesSerialized(now: number): Promise<void> {
+    try {
+      this.cleanupDirectory ??= await opendir(this.directory);
+      let scanned = 0;
+      while (scanned < CLEANUP_SCAN_LIMIT) {
+        const entry = await this.cleanupDirectory.read();
+        if (!entry) {
+          await this.cleanupDirectory.close();
+          this.cleanupDirectory = undefined;
+          break;
+        }
+        scanned += 1;
+        await this.cleanupProposalFile(entry.name, now).catch((error) => {
+          // error-policy:J6 bounded maintenance failure is visible but cannot
+          // prevent an unrelated exact proposal from being created or used.
+          logger.warn(
+            { fileName: entry.name, error },
+            "[RuntimeManagementProposalStore] Stale cleanup failed",
+          );
+        });
+      }
+    } catch (error) {
+      await this.cleanupDirectory?.close().catch((closeError) => {
+        // error-policy:J6 best-effort scan teardown retains a structured
+        // warning while the original scan failure remains authoritative.
+        logger.warn(
+          { closeError },
+          "[RuntimeManagementProposalStore] Cleanup close failed",
+        );
+      });
+      this.cleanupDirectory = undefined;
+      // error-policy:J6 the directory may not exist before the first proposal;
+      // other scan failures are reported without disabling exact authority.
+      if (
+        !(error instanceof Error && "code" in error && error.code === "ENOENT")
+      ) {
+        logger.warn(
+          { error },
+          "[RuntimeManagementProposalStore] Cleanup scan failed",
+        );
+      }
+    }
+  }
+
+  private cleanupStaleFiles(now = Date.now()): Promise<void> {
+    const cleanup = this.cleanupTail.then(() =>
+      this.cleanupStaleFilesSerialized(now),
+    );
+    this.cleanupTail = cleanup;
+    return cleanup;
+  }
+
   async consume(proposal: RuntimeManagementProposal): Promise<boolean> {
+    if (!(await this.prepareDirectory(false))) return false;
+    await this.cleanupStaleFiles();
     const stored = await this.read(proposal.proposalId);
     if (!stored) return false;
     if (stored.expiresAt <= Date.now()) {
@@ -146,11 +362,9 @@ export class FileRuntimeManagementProposalStore
       throw error;
     }
     try {
-      const claimed = JSON.parse(
-        await readFile(claimedPath, "utf8"),
-      ) as unknown;
+      const claimed = await this.readPath(claimedPath);
       return (
-        isStoredProposal(claimed) &&
+        claimed !== undefined &&
         claimed.expiresAt > Date.now() &&
         claimed.clientId === proposal.clientId &&
         claimed.requestKey === proposal.requestKey &&


### PR DESCRIPTION
Stacked correction for the file-backed runtime approval store added at #25427 head `dcf5699b90a51a7d2c0036072598d5a445a0eb93`.

Fixes
- Performs bounded stale maintenance on both create and consume without making cleanup failure authoritative.
- Keeps one serialized directory iterator across calls, so each call scans at most 64 entries while repeated calls eventually progress beyond the first batch instead of starving files after a stable first page.
- Removes expired `.json` proposals and crash-abandoned `.consumed-*` files after a ten-minute race-safety floor.
- Claims stale proposal paths by atomic rename and re-validates the claimed inode before deletion. If the file is still live, it is restored with a no-replace hard link.
- Recovers an unexpired `.cleanup-*` claim left by a process crash, while deleting expired or malformed abandoned claims.
- Rejects a symlinked proposal directory, opens proposal files with `O_NOFOLLOW`, requires regular files, and rejects oversized authority records.
- Tightens proposal ids to canonical UUID structure.

Validation (Bun 1.3.14 / Node 24.15.0)
- Canonical agent Vitest: store + route suites, 2 files, 19/19 passed.
- Store adversarial coverage includes expiry, malformed partial age floor, consumed-claim crash cleanup, cleanup-crash recovery, more-than-256-entry eventual progress, file symlink rejection, directory symlink rejection, restart, exact binding, and concurrent one-use consumption.
- Biome: both changed files clean.
- `git diff --check`: clean.
- Agent package typecheck has no diagnostics in either changed file. The lane remains baseline-blocked by missing built capacitor bridge, wallet diagnostic, optional plugin, todos edge, and cloud-routing declarations.

Evidence boundary
This is a deterministic local filesystem correction. It does not satisfy or claim the physical/deployed evidence still required by the draft parent #25427.
