### PR TITLE
test(agent): cover plugin-action-dedupe

### DIFF
--- a/packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts
+++ b/packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts
@@ -1,31 +1,172 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("@elizaos/core", () => ({
-  logger: { debug: vi.fn() },
-}));
-
+/**
+ * Behavioral coverage for `deduplicatePluginActions`: first-wins action-name
+ * uniqueness across an ordered plugin list, in-place mutation, empty and
+ * missing action arrays, within-plugin duplicates, case-sensitive names, and
+ * the skip-log side effect. Drives the real module; logger.debug is spied only
+ * to assert the duplicate-skip message.
+ */
+import { type Action, logger, type Plugin } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { deduplicatePluginActions } from "../plugin-action-dedupe.ts";
 
+function namedAction(name: string): Action {
+  return {
+    name,
+    description: `${name} fixture`,
+    handler: async () => undefined,
+    validate: async () => true,
+  };
+}
+
+function plugin(name: string, actionNames?: readonly string[]): Plugin {
+  const next: Plugin = {
+    name,
+    description: `${name} fixture`,
+  };
+  if (actionNames !== undefined) {
+    next.actions = actionNames.map(namedAction);
+  }
+  return next;
+}
+
+function actionNamesOf(target: Plugin): string[] {
+  return (target.actions ?? []).map((action) => action.name);
+}
+
 describe("deduplicatePluginActions", () => {
-  it("keeps the first occurrence of each action name", () => {
-    const plugins = [
-      { name: "p1", actions: [{ name: "a" }, { name: "b" }] },
-      { name: "p2", actions: [{ name: "a" }, { name: "c" }] },
-    ] as never;
-    deduplicatePluginActions(plugins);
-    const p1 = plugins[0] as { actions: { name: string }[] };
-    const p2 = plugins[1] as { actions: { name: string }[] };
-    expect(p1.actions.map((a) => a.name)).toEqual(["a", "b"]);
-    expect(p2.actions.map((a) => a.name)).toEqual(["c"]);
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("handles plugins without actions", () => {
+  it("is a no-op on an empty plugin list", () => {
+    const plugins: Plugin[] = [];
+    deduplicatePluginActions(plugins);
+    expect(plugins).toEqual([]);
+  });
+
+  it("keeps a single plugin's single action", () => {
+    const plugins = [plugin("solo", ["ONLY"])];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["ONLY"]);
+  });
+
+  it("preserves unique action order inside a single plugin", () => {
+    const plugins = [plugin("solo", ["A", "B", "C"])];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["A", "B", "C"]);
+  });
+
+  it("drops later duplicates of the same name inside one plugin", () => {
+    const plugins = [plugin("solo", ["A", "B", "A", "C", "B"])];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["A", "B", "C"]);
+  });
+
+  it("keeps the first occurrence of each action name across plugins", () => {
+    const plugins = [plugin("p1", ["a", "b"]), plugin("p2", ["a", "c"])];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["a", "b"]);
+    expect(actionNamesOf(plugins[1])).toEqual(["c"]);
+  });
+
+  it("leaves plugins that never declared actions untouched", () => {
+    const missing = plugin("p1");
+    const plugins = [missing, plugin("p2", ["x"])];
+    deduplicatePluginActions(plugins);
+    expect(missing.actions).toBeUndefined();
+    expect(plugins[0]).toBe(missing);
+    expect(actionNamesOf(plugins[1])).toEqual(["x"]);
+  });
+
+  it("treats an empty actions array as present and leaves it empty", () => {
+    const plugins = [plugin("empty", []), plugin("later", ["x"])];
+    deduplicatePluginActions(plugins);
+    expect(plugins[0].actions).toEqual([]);
+    expect(actionNamesOf(plugins[1])).toEqual(["x"]);
+  });
+
+  it("keeps later unique names when they are mixed with duplicates", () => {
     const plugins = [
-      { name: "p1" },
-      { name: "p2", actions: [{ name: "x" }] },
-    ] as never;
-    expect(() => deduplicatePluginActions(plugins)).not.toThrow();
-    const p2 = plugins[1] as { actions: { name: string }[] };
-    expect(p2.actions.map((a) => a.name)).toEqual(["x"]);
+      plugin("p1", ["SHARED", "KEEP_FIRST"]),
+      plugin("p2", ["SHARED", "UNIQUE", "KEEP_FIRST"]),
+    ];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[1])).toEqual(["UNIQUE"]);
+  });
+
+  it("first-wins across three plugins with the same name", () => {
+    const plugins = [
+      plugin("p1", ["DUP"]),
+      plugin("p2", ["DUP"]),
+      plugin("p3", ["DUP", "OTHER"]),
+    ];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["DUP"]);
+    expect(actionNamesOf(plugins[1])).toEqual([]);
+    expect(actionNamesOf(plugins[2])).toEqual(["OTHER"]);
+  });
+
+  it("treats action names as case-sensitive", () => {
+    const plugins = [plugin("p1", ["Send"]), plugin("p2", ["send", "SEND"])];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(["Send"]);
+    expect(actionNamesOf(plugins[1])).toEqual(["send", "SEND"]);
+  });
+
+  it("does not cap the number of unique action names", () => {
+    const names = Array.from({ length: 64 }, (_, index) => `A${index}`);
+    const plugins = [plugin("p", names)];
+    deduplicatePluginActions(plugins);
+    expect(actionNamesOf(plugins[0])).toEqual(names);
+  });
+
+  it("replaces the actions array in place but keeps surviving Action objects", () => {
+    const keep = namedAction("KEEP");
+    const drop = namedAction("KEEP");
+    const unique = namedAction("UNIQUE");
+    const first: Plugin = {
+      name: "p1",
+      description: "p1 fixture",
+      actions: [keep],
+    };
+    const second: Plugin = {
+      name: "p2",
+      description: "p2 fixture",
+      actions: [drop, unique],
+    };
+    const plugins = [first, second];
+    const pluginsRef = plugins;
+    deduplicatePluginActions(plugins);
+    expect(plugins).toBe(pluginsRef);
+    expect(plugins[0]).toBe(first);
+    expect(plugins[1]).toBe(second);
+    expect(plugins[0].actions).toEqual([keep]);
+    expect(plugins[0].actions?.[0]).toBe(keep);
+    expect(plugins[1].actions).toEqual([unique]);
+    expect(plugins[1].actions?.[0]).toBe(unique);
+  });
+
+  it("logs a debug skip for each duplicate action with plugin and action names", () => {
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
+    const plugins = [
+      plugin("first", ["SHARED"]),
+      plugin("second", ["SHARED", "ALSO", "SHARED"]),
+    ];
+    deduplicatePluginActions(plugins);
+    expect(debug).toHaveBeenCalledTimes(2);
+    expect(debug).toHaveBeenNthCalledWith(
+      1,
+      '[eliza] Skipping duplicate action "SHARED" from plugin "second"',
+    );
+    expect(debug).toHaveBeenNthCalledWith(
+      2,
+      '[eliza] Skipping duplicate action "SHARED" from plugin "second"',
+    );
+  });
+
+  it("does not log when every action name is unique", () => {
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
+    deduplicatePluginActions([plugin("p1", ["A"]), plugin("p2", ["B"])]);
+    expect(debug).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

`packages/agent/src/runtime/plugin-action-dedupe.ts` already had a two-case helper test. This PR replaces that thin suite with real behavioral coverage of `deduplicatePluginActions` — empty plugin lists, single-element and unique-order cases, within-plugin duplicates, first-wins across two and three plugins, missing vs empty `actions` arrays, mixed later unique names, case-sensitive names, unbounded unique-name retention, in-place array replacement with surviving Action identity, and the `logger.debug` skip message. Production code is unchanged.

The helper is a first-wins `Set` over `action.name` that mutates each plugin's `actions` array in place. There is no comparator, capacity, or explicit remove API; the suite records those absences by driving the real module (no mock of the filter). `logger.debug` is spied only to assert the skip-log side effect.

This is a test-only change. Hosted GitHub Actions CI does not run on this fork contributor's PRs; evidence is local.

## Evidence

1. `bunx vitest run packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts` — Test Files 1 passed (1), Tests 14 passed (14). Re-run against current `origin/develop` immediately before filing (source file identical to `origin/develop`).
2. `bunx biome check --write packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts` — clean (Checked 1 file; import sort applied).
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep plugin-action-dedupe.test.ts` — empty (this file introduces no type errors).
4. The diff touches only `packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:73bc37b93841e91d8fac0b8195581d862bef5c18 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
