### PR TITLE
fix(anthropic): sanitize tool sets without failing closed on SDK wrappers

### DIFF
--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -560,7 +560,7 @@ describe("deepToWellFormedUnicode unbounded input", () => {
 		expect(() => deepToWellFormedUnicode(input)).toThrowError(
 			expect.objectContaining({
 				code: "WELL_FORMED_UNSAFE_VALUE",
-				context: { operation: "accessor" },
+				context: { operation: "accessor", propertyName: "hostile" },
 			}),
 		);
 		expect(getterCalls).toBe(0);

--- a/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/wire-well-formed.shape.test.ts
@@ -8,6 +8,7 @@
  */
 import { createServer, type Server } from "node:http";
 import { type ElizaError, type IAgentRuntime, MAX_WELL_FORMED_VISITS } from "@elizaos/core";
+import { jsonSchema } from "ai";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTextSmall } from "../models";
 
@@ -31,14 +32,33 @@ function startCaptureServer(): Promise<string> {
       // native output parser parses the response as JSON; return valid JSON.
       const hasStructuredOutput = /response_format|responseSchema|"schema"/.test(raw);
       const text = hasStructuredOutput ? JSON.stringify({ goodField: "value" }) : "ok";
+      // A prompt containing "force tool use" gets a tool_use reply naming the
+      // first tool from the request, so the SDK parses tool input through the
+      // tool's inputSchema.validate (#24698 r3 F3 behavioral pin).
+      const content: unknown[] = [{ type: "text", text }];
+      if (raw.includes("force tool use")) {
+        let toolName = "unknown_tool";
+        try {
+          const parsed = JSON.parse(raw) as { tools?: Array<{ name?: string }> };
+          toolName = parsed.tools?.[0]?.name ?? toolName;
+        } catch {
+          // keep the fallback name; malformed bodies still need a reply
+        }
+        content.unshift({
+          type: "tool_use",
+          id: "toolu_probe",
+          name: toolName,
+          input: { anything: true },
+        });
+      }
       response.end(
         JSON.stringify({
           id: "msg-test",
           type: "message",
           role: "assistant",
           model: "claude-test",
-          content: [{ type: "text", text }],
-          stop_reason: "end_turn",
+          content,
+          stop_reason: "tool_use",
           stop_sequence: null,
           usage: { input_tokens: 1, output_tokens: 1 },
         })
@@ -185,5 +205,501 @@ describe("#18025: Anthropic request bodies are well-formed strict JSON", () => {
     expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
     const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
     expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  });
+
+  // #24698: the AI SDK jsonSchema() wrapper exposes its schema through
+  // enumerable lazy accessors, so deepToWellFormedUnicode over the assembled
+  // tool set failed closed on the #23159 accessor guard. Caller-controlled
+  // strings are now sanitized pre-wrap inside readToolSet; the assembled set
+  // is never deep-walked. A pre-built SDK tool (lazy inputSchema accessors,
+  // shaped like the real jsonSchema() wrapper) passed through a Record must
+  // reach the wire sanitized instead of throwing WELL_FORMED_UNSAFE_VALUE.
+  it("sanitizes an SDK passthrough tool description without walking its lazy schema accessors (#24698)", async () => {
+    const lazySchema = { type: "object" as const, properties: {} };
+    const sdkTool = {
+      inputSchema: jsonSchema(lazySchema),
+      description: `sdk tool \uD83D`,
+    };
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: { sdk_passthrough: sdkTool },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    const serialized = JSON.stringify(JSON.parse(body));
+    expect(serialized).toContain(`sdk tool ${String.fromCharCode(0xfffd)}`);
+  });
+
+  // #24698: array-form named tools also build through readToolSet; a lone
+  // surrogate in the tool NAME must sanitize without colliding or throwing.
+  it("sanitizes a lone surrogate in an array-form named tool name (#24698)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the named tool",
+      tools: [
+        {
+          name: `named_tool_\uD83D`,
+          description: "clean description",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    const serialized = JSON.stringify(JSON.parse(body));
+    expect(serialized).toContain(`named_tool_${String.fromCharCode(0xfffd)}`);
+  });
+
+  // #24698 review round 1: a pre-built SDK tool's WRAPPED schema can itself
+  // carry a lone surrogate. The passthrough path unwraps the SDK's own
+  // jsonSchema() wrapper (the same getter read enforceAnthropicStrictToolBudget
+  // performs), sanitizes, and rewraps — the surrogate must not reach the wire.
+  it("sanitizes a lone surrogate inside a passthrough tool's wrapped schema (#24698)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: {
+        sdk_dirty_schema: {
+          inputSchema: jsonSchema({ type: "object" as const, description: `dirty \uD83D` }),
+          description: "clean",
+        },
+      },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  });
+
+  // #24698 review round 1: record keys become tool names on the wire.
+  it("sanitizes a lone surrogate in a passthrough record key (#24698)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: {
+        [`bad_key_\uD83D`]: {
+          inputSchema: jsonSchema({ type: "object" as const }),
+          description: "clean",
+        },
+      },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  });
+
+  // #24698 review round 1: two DISTINCT names that collapse onto the same
+  // sanitized form must reject loudly, not silently drop a tool. Exact
+  // duplicates of the same source name keep develop's overwrite semantics.
+  it("rejects distinct tool names that collide after sanitization (#24698)", async () => {
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the tools",
+        tools: [
+          { name: `tool_a_\uD83D`, description: "one", parameters: { type: "object" } },
+          { name: `tool_a_\uDFFF`, description: "two", parameters: { type: "object" } },
+        ],
+      } as never)
+    ).rejects.toMatchObject({
+      code: "ANTHROPIC_TOOL_NAME_COLLISION",
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 2, F4: a non-object entry inside a passthrough
+  // Record must fail closed, not be silently dropped by the rebuild.
+  it("rejects a non-object entry inside a passthrough tool record (#24698)", async () => {
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the tools",
+        tools: {
+          good_tool: {
+            inputSchema: jsonSchema({ type: "object" as const }),
+            description: "clean",
+          },
+          junk: "not a tool" as unknown as never,
+        },
+      } as never)
+    ).rejects.toMatchObject({
+      code: "ANTHROPIC_INVALID_TOOL_ENTRY",
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 2, F2: a custom `validate` on the SDK wrapper must
+  // survive sanitization — the wrapper is rebuilt descriptor-preserving, not
+  // replaced by a default jsonSchema() wrapper.
+  it("preserves a custom validate callback when sanitizing a passthrough tool schema (#24698)", async () => {
+    const customValidate = (): { success: true; value: { ok: boolean } } => ({
+      success: true,
+      value: { ok: true },
+    });
+    const wrapped = jsonSchema(
+      { type: "object" as const, description: `dirty \uD83D` },
+      {
+        validate: customValidate,
+      }
+    );
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: { sdk_custom_validate: { inputSchema: wrapped, description: "clean" } },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    // The sanitized wrapper must still carry the caller's validate reference:
+    // the wrapper was rebuilt descriptor-preserving, not replaced by a
+    // default jsonSchema() wrapper (r2 F2 / r3 F3).
+    expect(wrapped.validate).toBe(customValidate);
+    const validateResult = wrapped.validate?.(undefined);
+    expect(validateResult).toEqual({ success: true, value: { ok: true } });
+  });
+
+  // #24698 review round 3, F3 behavioral pin: the rebuilt wrapper must keep
+  // `validate` SEMANTICALLY live, not just present on the object. A tool_use
+  // reply makes the SDK parse tool input through inputSchema.validate; a
+  // failing validate must surface as an invalid tool call carrying this
+  // probe's marker error. If the rebuild dropped validate (regression back to
+  // a default jsonSchema() wrapper), the call would parse as valid.
+  it("keeps a rebuilt wrapper's validate in the SDK tool-input parse path (#24698)", async () => {
+    let validateCalls = 0;
+    const wrapped = jsonSchema(
+      { type: "object" as const, description: `dirty \uD83D` },
+      {
+        validate: (_value: unknown): { success: false; error: string } => {
+          validateCalls += 1;
+          return { success: false, error: "probe-validate-reject" };
+        },
+      }
+    );
+    const result = (await handleTextSmall(buildRuntime(), {
+      prompt: "force tool use: sdk_custom_validate",
+      tools: { sdk_custom_validate: { inputSchema: wrapped, description: "clean" } },
+    } as never)) as { toolCalls?: Array<Record<string, unknown>> };
+    expect(captured).toHaveLength(1);
+    expect(LONE_SURROGATE_ESCAPE.test(captured[0].toString("utf8"))).toBe(false);
+    expect(validateCalls).toBe(1);
+    const toolCall = result.toolCalls?.[0];
+    expect(toolCall).toMatchObject({
+      toolName: "sdk_custom_validate",
+      invalid: true,
+    });
+    const error = toolCall?.error as { cause?: { cause?: unknown } } | undefined;
+    expect(error?.cause?.cause).toBe("probe-validate-reject");
+  });
+
+  // #24698 review round 2, F1: dirty description (forcing the clone path) +
+  // dirty wrapped schema + an unrelated own `value` property on the tool —
+  // the descriptor selection must still find inputSchema on the cloned tool,
+  // not misread the clone as a descriptor.
+  it("sanitizes a passthrough tool with a dirty description, dirty schema, and a value property (#24698)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: {
+        sdk_mixed: {
+          inputSchema: jsonSchema({ type: "object" as const, description: `dirty \uD83D` }),
+          description: `also dirty \uD83D`,
+          value: "unrelated-own-property",
+        },
+      } as never,
+    });
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  });
+
+  // #24698 review round 3, F1 / round 4, F2: provider-serialized data beyond
+  // description and inputSchema must not bypass sanitization. Two observable
+  // pins at this boundary: (a) a dirty extra string never reaches the captured
+  // wire bytes; (b) a CYCLIC extra field is caught by the whole-tool walk
+  // (WELL_FORMED_UNBOUNDED) before the SDK sees the tool — proving the walk
+  // actually traverses extra fields rather than the SDK silently dropping
+  // them making the test pass vacuously.
+  it("sanitizes a dirty extra field on a passthrough tool before the wire (#24698)", async () => {
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the sdk tool",
+      tools: {
+        sdk_extra_dirty: {
+          inputSchema: jsonSchema({ type: "object" as const }),
+          description: "clean",
+          extraField: `extra dirty \uD83D`,
+        },
+      },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+  });
+
+  it("fails closed on a cyclic extra field on a passthrough tool (#24698)", async () => {
+    const cyclic: Record<string, unknown> = { label: "node" };
+    cyclic.self = cyclic;
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the sdk tool",
+        tools: {
+          sdk_extra_cyclic: {
+            inputSchema: jsonSchema({ type: "object" as const }),
+            description: "clean",
+            extraField: cyclic,
+          },
+        },
+      } as never)
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNBOUNDED",
+      context: { reason: "cycle" },
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 3, F2: accessor-valued tool fields on a passthrough
+  // tool must fail closed with the typed accessor error rather than silently
+  // serializing their getter output to the wire.
+  it("fails closed on an inputSchema accessor on a passthrough tool (#24698)", async () => {
+    const wrapper = jsonSchema({ type: "object" as const, description: `dirty \uD83D` });
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the sdk tool",
+        tools: {
+          accessor_tool: {
+            get inputSchema() {
+              return wrapper;
+            },
+            description: "clean",
+          },
+        } as never,
+      })
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNSAFE_VALUE",
+      context: { operation: "accessor" },
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("fails closed on a description accessor on a passthrough tool (#24698)", async () => {
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the sdk tool",
+        tools: {
+          desc_getter: {
+            get description() {
+              return `dirty \uD83D`;
+            },
+            inputSchema: jsonSchema({ type: "object" as const }),
+          },
+        } as never,
+      })
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNSAFE_VALUE",
+      context: { operation: "accessor" },
+    } satisfies Partial<ElizaError>);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 4, F1: an enumerable accessor on a NAMED tool's
+  // wire-relevant fields must fail closed with a typed error naming the
+  // property — descriptor-safe reads, no getter invocation. The getter body
+  // throws if executed, proving zero-invocation from the plugin side.
+  it("fails closed without invoking a name accessor on a named tool (#24698)", async () => {
+    let getterCalls = 0;
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the tools",
+        tools: [
+          {
+            get name() {
+              getterCalls += 1;
+              return "acc_named";
+            },
+            parameters: { type: "object" },
+          },
+        ],
+      } as never)
+    ).rejects.toMatchObject({
+      code: "ANTHROPIC_UNSAFE_TOOL_FIELD",
+      context: { propertyName: "name" },
+    } satisfies Partial<ElizaError>);
+    expect(getterCalls).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("fails closed without invoking a parameters accessor on a named tool (#24698)", async () => {
+    let getterCalls = 0;
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the tools",
+        tools: [
+          {
+            name: "acc_named",
+            get parameters() {
+              getterCalls += 1;
+              return { type: "object" };
+            },
+          },
+        ],
+      } as never)
+    ).rejects.toMatchObject({
+      code: "ANTHROPIC_UNSAFE_TOOL_FIELD",
+      context: { propertyName: "parameters" },
+    } satisfies Partial<ElizaError>);
+    expect(getterCalls).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 4, F1: an enumerable accessor on the tool-set
+  // CONTAINER must fail closed without invocation; Object.entries would have
+  // executed it silently.
+  it("fails closed without invoking an accessor entry on the tool container (#24698)", async () => {
+    let getterCalls = 0;
+    const tools: Record<string, unknown> = {
+      real_tool: { name: "real_tool", parameters: { type: "object" } },
+    };
+    Object.defineProperty(tools, "hostile_entry", {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return { name: "hostile", parameters: { type: "object" } };
+      },
+    });
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the tools",
+        tools,
+      } as never)
+    ).rejects.toMatchObject({
+      code: "ANTHROPIC_UNSAFE_TOOL_CONTAINER",
+    } satisfies Partial<ElizaError>);
+    expect(getterCalls).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  // #24698 review round 5, F2 / round 6: a Proxy CONTAINER can report a
+  // benign DATA descriptor from getOwnPropertyDescriptor and still run
+  // hostile code when the entry value is re-read as a property
+  // (`container[key]`). The fixed path consumes descriptor.value from the
+  // same single inspection — the container's get trap must never fire.
+  // Proxying the outer tools record (not an inner tool) is what
+  // discriminates: the pre-fix property read fires the trap; the fixed
+  // descriptor read does not.
+  it("does not re-read container entries after descriptor inspection (#24698)", async () => {
+    let valueReads = 0;
+    const proxyEntryTool = { name: "proxy_tool", parameters: { type: "object" } };
+    const proxiedContainer = new Proxy(
+      { real_tool: { name: "real_tool", parameters: { type: "object" } } },
+      {
+        getOwnPropertyDescriptor(target, prop) {
+          if (prop === "proxy_entry") {
+            return {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: proxyEntryTool,
+            };
+          }
+          return Reflect.getOwnPropertyDescriptor(target, prop);
+        },
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "proxy_entry"];
+        },
+        get(target, prop) {
+          valueReads += 1;
+          return Reflect.get(target, prop);
+        },
+      }
+    );
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the tools",
+      tools: proxiedContainer,
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+    // The container's get trap never ran: every entry value was consumed
+    // from the inspected descriptor, never re-read as a property.
+    expect(valueReads).toBe(0);
+    expect(captured).toHaveLength(1);
+    const raw = captured[0].toString("utf8");
+    expect(LONE_SURROGATE_ESCAPE.test(raw)).toBe(false);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(captured[0]);
+    expect((body as unknown as { isWellFormed: () => boolean }).isWellFormed()).toBe(true);
+    expect(raw).toContain("proxy_tool");
+  });
+
+  // #24698 review round 4, F3: a FORGED wrapper carrying the global marker as
+  // an accessor (or with a non-true value) must not be unwrapped; the whole-
+  // tool walk then fails closed on its enumerable accessors without invoking
+  // them. Both the forged-marker getter and the jsonSchema getter must stay
+  // uninvoked from the plugin side.
+  it("fails closed on a forged marker wrapper without invoking its accessors (#24698)", async () => {
+    let markerGets = 0;
+    let schemaGets = 0;
+    const forged = {
+      get [Symbol.for("vercel.ai.schema")]() {
+        markerGets += 1;
+        return true;
+      },
+      get jsonSchema() {
+        schemaGets += 1;
+        return { type: "object", description: `dirty \uD83D` };
+      },
+      _type: "jsonSchema" as const,
+    };
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the sdk tool",
+        tools: { forged_tool: { inputSchema: forged, description: "clean" } },
+      } as never)
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNSAFE_VALUE",
+      context: { operation: "accessor" },
+    } satisfies Partial<ElizaError>);
+    expect(markerGets).toBe(0);
+    expect(schemaGets).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("fails closed on a non-true marker value wrapper (#24698)", async () => {
+    let schemaGets = 0;
+    const forged = {
+      [Symbol.for("vercel.ai.schema")]: "not-boolean-true",
+      get jsonSchema() {
+        schemaGets += 1;
+        return { type: "object", description: `dirty \uD83D` };
+      },
+      _type: "jsonSchema" as const,
+    };
+    await expect(
+      handleTextSmall(buildRuntime(), {
+        prompt: "use the sdk tool",
+        tools: { forged_value_tool: { inputSchema: forged, description: "clean" } },
+      } as never)
+    ).rejects.toMatchObject({
+      code: "WELL_FORMED_UNSAFE_VALUE",
+      context: { operation: "accessor" },
+    } satisfies Partial<ElizaError>);
+    // The marker value is not exactly true, so the unwrap gate must skip the
+    // wrapper entirely: its lazy jsonSchema getter stays uninvoked and the
+    // whole-tool walk fails closed on the accessor instead.
+    expect(schemaGets).toBe(0);
+    expect(captured).toHaveLength(0);
   });
 });

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -33,6 +33,7 @@ import {
   logger,
   ModelType,
   resolveEffectiveSystemPrompt,
+  toWellFormedUnicode,
 } from "@elizaos/core";
 import {
   generateText,
@@ -286,6 +287,94 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
     return undefined;
   }
 
+  // Sanitization for pre-built AI SDK Tool entries (#24698). The SDK's
+  // jsonSchema() wrapper exposes its schema through enumerable lazy getters,
+  // which deepToWellFormedUnicode fails closed on (#23159), so the wrapper's
+  // schema is read once — the same read enforceAnthropicStrictToolBudget
+  // already performs on every tool — sanitized, and reinstalled as a plain
+  // data property on a descriptor-preserving wrapper clone (custom `validate`
+  // survives). The WHOLE rebuilt tool is then passed through the deep walk:
+  // every other caller-controlled field (args, metadata, extra properties)
+  // sanitizes too, and any surviving hostile accessor fails closed rather
+  // than reaching the SDK.
+  const sanitizeSdkTool = (tool: unknown): unknown => {
+    if (!isRecord(tool)) return tool;
+    let sanitized: Record<string, unknown> | undefined;
+    const descriptionDescriptor = Object.getOwnPropertyDescriptor(tool, "description");
+    if (
+      descriptionDescriptor &&
+      "value" in descriptionDescriptor &&
+      typeof descriptionDescriptor.value === "string"
+    ) {
+      const description = toWellFormedUnicode(descriptionDescriptor.value);
+      if (description !== descriptionDescriptor.value) {
+        sanitized = Object.create(Object.getPrototypeOf(tool)) as Record<string, unknown>;
+        Object.defineProperties(sanitized, Object.getOwnPropertyDescriptors(tool));
+        Object.defineProperty(sanitized, "description", {
+          ...descriptionDescriptor,
+          value: description,
+        });
+      }
+    }
+    const source = sanitized ?? tool;
+    const schemaDescriptor = Object.getOwnPropertyDescriptor(source, "inputSchema");
+    let result: Record<string, unknown> = source;
+    if (schemaDescriptor && "value" in schemaDescriptor && isRecord(schemaDescriptor.value)) {
+      const wrapped = schemaDescriptor.value as {
+        jsonSchema?: unknown;
+        _type?: unknown;
+      };
+      // Only the SDK's own wrapper shape is unwrapped: the global registered
+      // marker Symbol.for("vercel.ai.schema") as an OWN DATA descriptor whose
+      // value is exactly true (the pinned SDK always sets it that way), with a
+      // single read of the lazy jsonSchema getter. A wrapper forged to match
+      // the marker exactly still gets its getter invoked here once — this is
+      // the same read develop's readToolStrictAndSchema has always performed
+      // on every tool (`.jsonSchema ?? entry.inputSchema`), so it introduces
+      // no new invocation class; the difference is the result is then
+      // sanitized and reinstalled as a plain data property, so nothing
+      // downstream (SDK included) reads the getter again. Forged markers that
+      // are accessors or non-true values skip the unwrap entirely and the
+      // whole-tool walk fails closed on the surviving accessors without
+      // invoking them.
+      const markerDescriptor = Object.getOwnPropertyDescriptor(
+        wrapped,
+        Symbol.for("vercel.ai.schema")
+      );
+      if (markerDescriptor && "value" in markerDescriptor && markerDescriptor.value === true) {
+        const plainSchema = wrapped.jsonSchema;
+        if (typeof plainSchema === "object" && plainSchema !== null) {
+          const sanitizedSchema = deepToWellFormedUnicode(plainSchema);
+          const rebuiltWrapper = Object.create(Object.getPrototypeOf(wrapped)) as Record<
+            string | symbol,
+            unknown
+          >;
+          Object.defineProperties(rebuiltWrapper, Object.getOwnPropertyDescriptors(wrapped));
+          Object.defineProperty(rebuiltWrapper, "jsonSchema", {
+            value: sanitizedSchema,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
+          const clone = Object.create(Object.getPrototypeOf(source)) as Record<string, unknown>;
+          Object.defineProperties(clone, Object.getOwnPropertyDescriptors(source));
+          Object.defineProperty(clone, "inputSchema", {
+            ...schemaDescriptor,
+            value: rebuiltWrapper,
+          });
+          result = clone;
+        }
+      }
+    }
+    // Whole-tool walk over the (walk-safe) rebuilt tool: sanitizes every
+    // remaining field and fails closed on any accessor the rebuild could not
+    // normalize (r3 review). The rebuilt wrapper is walk-safe because its
+    // jsonSchema property is a plain data descriptor; the marker symbol is
+    // preserved by the descriptor-preserving clone on the (unchanged) clone
+    // the walk returns.
+    return deepToWellFormedUnicode(result);
+  };
+
   // Source can be either an array of ToolDefinition (each with .name) or a
   // Record<string, ...>. ELIZAOS upstream sometimes passes the array as a
   // Record with numeric keys (`{0: tool, 1: tool}`), which makes the AI SDK
@@ -298,48 +387,159 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
   // deterministically over an SDK passthrough at the same key, regardless of
   // iteration order.
   const isArr = Array.isArray(value);
-  const entries: Array<[string, unknown]> = isArr
-    ? (value as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
-    : Object.entries(value as Record<string, unknown>);
+  // Object.entries would invoke enumerable accessors on the tool-set
+  // container, and a re-read after the descriptor check can re-enter a proxy
+  // get trap. Consume the descriptor's own value instead — one inspection per
+  // key, no property reads; an accessor (or a proxy reporting one) fails
+  // closed without its code ever running (#24698 r4/r5).
+  const container = value as unknown as Record<string | symbol, unknown> & { length?: unknown };
+  const readEntryValue = (key: string): unknown => {
+    const descriptor = Object.getOwnPropertyDescriptor(container, key);
+    if (!descriptor || !("value" in descriptor)) {
+      throw new ElizaError("[Anthropic] Tool set container has an accessor entry.", {
+        code: "ANTHROPIC_UNSAFE_TOOL_CONTAINER",
+        severity: "fatal",
+      });
+    }
+    return descriptor.value;
+  };
+  const entries: Array<[string, unknown]> = [];
+  if (isArr) {
+    // Array length is itself a caller-facing property on exotic containers;
+    // consume it from its descriptor too (a Proxy's length trap fires on
+    // inspection, but the value is never re-read as a property).
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(container, "length");
+    const length =
+      lengthDescriptor && "value" in lengthDescriptor ? lengthDescriptor.value : undefined;
+    if (typeof length !== "number") {
+      return undefined;
+    }
+    for (let i = 0; i < length; i += 1) {
+      const key = String(i);
+      entries.push([key, readEntryValue(key)]);
+    }
+  } else {
+    for (const key of Object.keys(container)) {
+      entries.push([key, readEntryValue(key)]);
+    }
+  }
 
   const namedKeys = new Set<string>();
+  // Raw property reads on caller-supplied tools would execute enumerable
+  // accessors. Every wire-relevant field is read through its own descriptor;
+  // an accessor fails closed with a typed error naming the property instead
+  // (#24698 r4). The pinned SDK exposes its schema through exactly such
+  // accessors, so SDK passthrough tools (no .name) never reach this path.
+  const readToolField = (
+    tool: Record<string | symbol, unknown>,
+    key: string
+  ): { present: boolean; value: unknown } => {
+    const descriptor = Object.getOwnPropertyDescriptor(tool, key);
+    if (!descriptor) {
+      return { present: false, value: undefined };
+    }
+    if (!("value" in descriptor)) {
+      throw new ElizaError("[Anthropic] Tool field is an enumerable accessor.", {
+        code: "ANTHROPIC_UNSAFE_TOOL_FIELD",
+        severity: "fatal",
+        context: { propertyName: key },
+      });
+    }
+    return { present: true, value: descriptor.value };
+  };
   for (const [, rawTool] of entries) {
-    if (isRecord(rawTool) && typeof rawTool.name === "string" && rawTool.name) {
-      namedKeys.add(rawTool.name);
+    const nameField = isRecord(rawTool)
+      ? readToolField(rawTool as Record<string | symbol, unknown>, "name")
+      : { present: false, value: undefined };
+    if (nameField.present && typeof nameField.value === "string" && nameField.value) {
+      namedKeys.add(nameField.value);
     }
   }
 
   const tools: Record<string, unknown> = {};
+  const sourceKeysBySanitizedKey = new Map<string, string>();
   let sawNamedTool = false;
+  let sawUnsupportedEntry = false;
+  // Record keys become tool names on the wire, so they sanitize too; two
+  // DISTINCT source keys collapsing onto the same sanitized form must reject
+  // loudly (the openai plugin's OPENAI_TOOL_NAME_COLLISION contract) rather
+  // than silently drop a tool. An exact duplicate of the SAME source key keeps
+  // develop's last-write-wins overwrite semantics (#24698).
+  const sanitizeRecordKey = (key: string): string => toWellFormedUnicode(key);
+  const claimKey = (sanitizedKey: string, sourceKey: string): string => {
+    const previousSource = sourceKeysBySanitizedKey.get(sanitizedKey);
+    if (previousSource !== undefined && previousSource !== sourceKey) {
+      throw new ElizaError("[Anthropic] Native tool names collide after Unicode normalization.", {
+        code: "ANTHROPIC_TOOL_NAME_COLLISION",
+        severity: "ephemeral",
+      });
+    }
+    sourceKeysBySanitizedKey.set(sanitizedKey, sourceKey);
+    return sanitizedKey;
+  };
   for (const [origKey, rawTool] of entries) {
     if (!isRecord(rawTool)) {
+      sawUnsupportedEntry = true;
       continue;
     }
-    if (typeof rawTool.name === "string" && rawTool.name) {
+    const toolRecord = rawTool as Record<string | symbol, unknown>;
+    const nameField = readToolField(toolRecord, "name");
+    const name = nameField.present && typeof nameField.value === "string" ? nameField.value : "";
+    if (name) {
       sawNamedTool = true;
-      const schema = isRecord(rawTool.parameters)
-        ? (rawTool.parameters as JSONSchema7)
-        : isRecord(rawTool.input_schema)
-          ? (rawTool.input_schema as JSONSchema7)
-          : ({ type: "object" } satisfies JSONSchema7);
-      tools[rawTool.name] = {
-        ...(typeof rawTool.description === "string" ? { description: rawTool.description } : {}),
-        inputSchema: jsonSchema(schema),
+      const parametersField = readToolField(toolRecord, "parameters");
+      const inputSchemaField = readToolField(toolRecord, "inputSchema");
+      const inputSchemaUnderscoreField = readToolField(toolRecord, "input_schema");
+      const descriptionField = readToolField(toolRecord, "description");
+      const schema = isRecord(parametersField.value)
+        ? (parametersField.value as JSONSchema7)
+        : isRecord(inputSchemaField.value)
+          ? (inputSchemaField.value as JSONSchema7)
+          : isRecord(inputSchemaUnderscoreField.value)
+            ? (inputSchemaUnderscoreField.value as JSONSchema7)
+            : ({ type: "object" } satisfies JSONSchema7);
+      // Sanitize caller-controlled strings BEFORE the jsonSchema() wrap. The
+      // AI SDK wrapper exposes its schema through enumerable lazy accessors,
+      // so a deepToWellFormedUnicode pass over the assembled set hits the
+      // #23159 accessor guard and fails closed (#24698). Sanitizing the plain
+      // schema/description here keeps the wire guarantee without unwrapping
+      // SDK accessors — the same pre-wrap pattern plugin-openai established.
+      const sanitizedName = toWellFormedUnicode(name);
+      const sanitizedSchema = deepToWellFormedUnicode(schema);
+      tools[claimKey(sanitizedName, name)] = {
+        ...(descriptionField.present && typeof descriptionField.value === "string"
+          ? { description: toWellFormedUnicode(descriptionField.value) }
+          : {}),
+        inputSchema: jsonSchema(sanitizedSchema),
       };
     } else if (!isArr && !namedKeys.has(origKey)) {
       // Pre-built AI SDK Tool entry inside a Record — pass through under its
       // original string key, but only if no named tool will claim that key
       // later in the same pass; otherwise the named tool would silently
       // overwrite (or be overwritten by) this entry depending on order.
-      tools[origKey] = rawTool;
+      tools[claimKey(sanitizeRecordKey(origKey), origKey)] = sanitizeSdkTool(rawTool);
     }
   }
 
   if (sawNamedTool) {
     return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
   }
-  // Fall back to the original Record (already keyed by canonical names).
-  return !isArr && isRecord(value) ? (value as ToolSet) : undefined;
+  // SDK passthrough entries collected above were description-sanitized without
+  // touching their lazy schema accessors (#24698); return the rebuilt record
+  // instead of the original so the sanitized descriptions reach the wire.
+  // A non-record entry must not be silently dropped by the rebuild — fail
+  // closed so downstream callers see the same invalid-shape failure the
+  // original record would have produced (r2 review).
+  if (!isArr) {
+    if (sawUnsupportedEntry) {
+      throw new ElizaError("[Anthropic] Native tool set contains a non-object tool entry.", {
+        code: "ANTHROPIC_INVALID_TOOL_ENTRY",
+        severity: "ephemeral",
+      });
+    }
+    return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
+  }
+  return undefined;
 }
 
 function readToolChoice(value: GenerateTextParams["toolChoice"]): ToolChoice<ToolSet> | undefined {
@@ -1334,12 +1534,16 @@ async function generateTextWithModel(
   const sanitizedStopSequences = deepToWellFormedUnicode(
     resolved.stopSequences as string[] | undefined
   );
+  // Caller-controlled tool strings were already sanitized pre-wrap inside
+  // readToolSet (and the SDK passthrough branch below it): the AI SDK's
+  // jsonSchema() wrapper exposes its schema through enumerable lazy accessors,
+  // so a deepToWellFormedUnicode pass over the assembled set hits the #23159
+  // accessor guard and fails closed (#24698). applyToolsCacheBreakpoint only
+  // stamps providerOptions on the last tool and is walk-free.
   const sanitizedTools = paramsWithAttachments.tools
-    ? deepToWellFormedUnicode(
-        toolsCacheControl
-          ? applyToolsCacheBreakpoint(paramsWithAttachments.tools, toolsCacheControl)
-          : paramsWithAttachments.tools
-      )
+    ? toolsCacheControl
+      ? applyToolsCacheBreakpoint(paramsWithAttachments.tools, toolsCacheControl)
+      : paramsWithAttachments.tools
     : undefined;
   const sanitizedToolChoice = paramsWithAttachments.toolChoice
     ? deepToWellFormedUnicode(paramsWithAttachments.toolChoice)


### PR DESCRIPTION
## Summary

Fixes #24698.

`plugin-anthropic` could not sanitize a tool set containing the AI SDK `jsonSchema()` wrapper: `deepToWellFormedUnicode` over the assembled set hit the #23159 accessor guard (the wrapper exposes its schema through enumerable lazy getters), so **every Anthropic text call carrying tools failed closed** before the request was built — `wire-well-formed.shape.test.ts > sanitizes a lone surrogate in a tool description (#18081)` failed 1/5 on pristine develop with a freshly built core.

The sanitizer now runs **pre-wrap inside `readToolSet`**:

- **Named tools** sanitize `name`/schema/`description` *before* the `jsonSchema()` wrap (same pattern plugin-openai established).
- **SDK passthrough tools** unwrap via the registered marker (`Symbol.for("vercel.ai.schema")` as an own data descriptor with value `true`), read the schema once (the same read `readToolStrictAndSchema` has always performed on every tool), sanitize, and reinstall as a plain data property on a descriptor-preserving clone — custom `validate` survives.
- **Every tool-set read is descriptor-safe**: no accessor getter or proxy `get` trap ever executes. Typed fail-closed errors for accessor tool fields (`ANTHROPIC_UNSAFE_TOOL_FIELD`), accessor container entries (`ANTHROPIC_UNSAFE_TOOL_CONTAINER`), distinct names colliding after sanitization (`ANTHROPIC_TOOL_NAME_COLLISION`), and non-object entries in a passthrough record (`ANTHROPIC_INVALID_TOOL_ENTRY`).
- Repairs the stale `propertyName` assertion in core's `well-formed.test.ts` (the impl emits `context.propertyName` since the diagnosis field was added; the exact-match context failed on pristine develop).

## Root cause

Guard from #23159 (`packages/core/src/utils/well-formed.ts`) routes objects with function-valued or accessor properties to the descriptor-preserving path, which throws on enumerable accessors. AI SDK tool wrappers carry enumerable lazy getters, so `models/text.ts`'s whole-set deep walk failed closed. The #18081 sanitizer and the #23159 guard are each individually right; this PR moves sanitization before the wrap so they stop colliding — the guard itself is untouched.

## Evidence

RED control (pristine `origin/develop` @ `00a4e1c7a76`, fresh `packages/core` build):
```
bun run --cwd packages/core build
bunx vitest run --root plugins/plugin-anthropic __tests__/wire-well-formed.shape.test.ts --environment=node
=> Tests  1 failed | 4 passed (5)   # the reported failure reproduces
core well-formed.test.ts => 1 failed | 45 passed (46)  # stale propertyName assertion
```

GREEN (this branch, same fresh core build):
```
wire-well-formed.shape.test.ts      => 24/24 (18 new tests)
packages/core well-formed (bun test) => 46/46
plugins/plugin-anthropic full lane   => 15 files / 139 tests passed
tsc --noEmit (plugin + core)         => clean
biome check (3 changed files)        => clean
```

Re-verified after rebase onto develop `71ae1858263`: full plugin lane 139/139.

## Verification matrix (execution, not assertion)

| Probe | Result |
|---|---|
| SDK marker identity | `Object.getOwnPropertySymbols(jsonSchema({})) === [Symbol.for("vercel.ai.schema")]`, own enumerable data descriptor, value `true` |
| Exactly-forged marker (data `true` + counting hostile getter) | develop: getter 1x, `WELL_FORMED_UNSAFE_VALUE`, no wire bytes. This branch: getter 1x (same single read — parity), rejected client-side, no wire bytes |
| Forged accessor-marker / non-true-value wrapper | 0 getter invocations, typed `WELL_FORMED_UNSAFE_VALUE`, no wire bytes |
| Named tool with accessor `name`/`parameters` | develop: silent getter invocation (7x), sanitized getter output reached the wire. This branch: typed `ANTHROPIC_UNSAFE_TOOL_FIELD`, 0 invocations |
| Proxy container reporting data descriptors | container `get` trap 0 executions; entry value consumed from the descriptor; wire well-formed |
| Cyclic extra field on passthrough tool | `WELL_FORMED_UNBOUNDED` (`reason: "cycle"`) before the SDK sees the tool |
| Custom `validate` survival | SDK invokes the rebuilt wrapper's `validate` during tool_use parsing; failing validate surfaces `invalid: true` with the probe's cause string |
| Provider-defined tool shapes | `args` never serialize under the pinned SDK (client-side conversion rejects); extra own fields dropped client-side — sanitizer is defense-in-depth at our boundary |

Mutation controls (each reverts one mechanism; the paired test is the only failure):
- Rebuild regressed to a default `jsonSchema()` wrapper (dropping `validate`): `keeps a rebuilt wrapper's validate in the SDK tool-input parse path` fails (16/17 → others green).
- Container read regressed to `container[key]`: `does not re-read container entries after descriptor inspection` fails (23/24 → others green).

Independent review: 7 rounds of external reviewer convergence (rounds 1-3 by a prior session; rounds 4-7 this run). Round 7 verdict: **APPROVE**, no blocking findings. All findings from every round were fixed or resolved with two-tree execution probes as cited above.

## Behavior notes

- Accessor-carrying named tools change from silent getter invocation (develop) to typed fail-closed rejection. I classify silent invocation as develop-parity debt being repaid, not a regression: a provider request must never run caller-controlled code, per the #23159 contract.
- Exact-duplicate record keys keep develop's last-write-wins; only *distinct* keys colliding after sanitization reject.



<!-- evidence-row:backend-logs -->
backend-logs: Executed against a loopback capture server (real @ai-sdk/anthropic client, pinned ai@6.0.256). RED control on pristine develop @00a4e1c7a76 with fresh core build: wire-well-formed.shape.test.ts 1 failed/4 passed (the reported failure: deepToWellFormedUnicode enumerable accessor cannot be serialized safely at well-formed.ts:337 via models/text.ts:1303); core well-formed.test.ts 1 failed/45 passed (stale propertyName assertion). GREEN on branch b8a8da9de06: wire suite 24/24 (18 new tests), core well-formed suite 46/46, full plugin-anthropic lane 15 files/139 tests, tsc --noEmit clean, biome clean. Post-rebase onto develop 71ae1858263 re-verified 139/139. Mutation controls: validate-drop regression fails exactly the behavioral validate test (16/17); container-read regression fails exactly the descriptor-consumption test (23/24). Wire probes: exactly-forged marker getter 1x both trees (parity with develop readToolStrictAndSchema read), forged accessor/non-true markers 0 invocations, proxy container get-trap 0 executions, cyclic extra field rejects WELL_FORMED_UNBOUNDED/cycle, failing custom validate surfaces invalid:true with probe cause through SDK tool_use parsing.
```
RED control — pristine origin/develop @ 00a4e1c7a76, fresh packages/core build:
$ bunx vitest run --root plugins/plugin-anthropic __tests__/wire-well-formed.shape.test.ts --environment=node
 FAIL  __tests__/wire-well-formed.shape.test.ts > #18025: ... > sanitizes a lone surrogate in a tool description (#18081)
 ElizaError: deepToWellFormedUnicode: enumerable accessor cannot be serialized safely
  code: "WELL_FORMED_UNSAFE_VALUE", context: { operation: "accessor" }
 Tests  1 failed | 4 passed (5)

GREEN — branch b8a8da9de06 (same fresh core build):
$ bunx vitest run --root plugins/plugin-anthropic __tests__/wire-well-formed.shape.test.ts --environment=node
 Tests  24 passed (24)   [18 new tests: sanitize/collision/invalid-entry/validate/accessor/forged-marker/proxy-container/cyclic]
$ bun test packages/core/src/utils/well-formed.test.ts
 46 pass  0 fail
$ bun run --cwd plugins/plugin-anthropic test
 Test Files  15 passed (15)  Tests  139 passed (139)

Mutation controls:
 validate-drop regression  => Tests  1 failed | 16 passed (17) — exactly the behavioral validate test
 container-read regression => Tests  1 failed | 23 passed (24) — exactly the descriptor-consumption test
```


<!-- evidence-row:llm-trajectory -->
llm-trajectory: N/A - provider model-handler sanitization fix; no model-call behavior change. Deterministic wire tests against a capture server cover the change; trajectory surface unchanged.

<!-- evidence-row:before-screenshots -->
before-screenshots: N/A - backend-only change (plugin model handler + core test assertion); no UI surface touched.

<!-- evidence-row:after-screenshots -->
after-screenshots: N/A - backend-only change (plugin model handler + core test assertion); no UI surface touched.

<!-- evidence-row:walkthrough-video -->
walkthrough-video: N/A - backend-only change; behavior fully covered by the wire-capture test matrix and mutation controls cited in backend-logs.

<!-- evidence-row:frontend-logs -->
frontend-logs: N/A - no frontend code touched (plugin model handler + core test only).

<!-- evidence-row:domain-artifacts -->
domain-artifacts: N/A - no database, on-chain, scheduled-item, or native/device surface; tool-set sanitization at the Anthropic wire boundary only.

<!-- evidence-head:b8a8da9de06292a0473f8c19b61338f53a5c6a47 -->

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
