### PR TITLE
test(agent): cover project-connector-settings

### DIFF
--- a/packages/agent/src/runtime/project-connector-settings.test.ts
+++ b/packages/agent/src/runtime/project-connector-settings.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Behavioral coverage for projectConnectorSettings. Drives the real module:
+ * empty and missing slack blocks, credential-versus-policy split, vault-ref
+ * stripping, whitespace and non-string omission, settings-over-connectors
+ * merge, account union/override, and skip of non-object accounts.
+ */
+import {
+  connectorAccountCredentialSettingKey,
+  connectorBaseCredentialSettingKey,
+  type JsonValue,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import { formatVaultRef } from "./operations/vault-bridge.ts";
+import { projectConnectorSettings } from "./project-connector-settings.ts";
+
+function baseSecret(field: string): string {
+  return connectorBaseCredentialSettingKey("slack", field);
+}
+
+function accountSecret(accountId: string, field: string): string {
+  return connectorAccountCredentialSettingKey("slack", accountId, field);
+}
+
+describe("projectConnectorSettings", () => {
+  it("passes settings through unchanged when neither lane has a slack object", () => {
+    const settings: Record<string, JsonValue | undefined> = {
+      theme: "dark",
+      slack: undefined,
+    };
+
+    expect(projectConnectorSettings(settings, undefined)).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings(settings, null)).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings(settings, "connectors")).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings(settings, ["slack"])).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(
+      projectConnectorSettings(settings, { discord: { token: "x" } }),
+    ).toEqual({
+      settings,
+      secrets: {},
+    });
+  });
+
+  it("treats a missing, null, array, or scalar slack block as absent", () => {
+    const settings = { keep: true };
+
+    expect(projectConnectorSettings(settings, { slack: null })).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings(settings, { slack: "enabled" })).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings(settings, { slack: ["C123"] })).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(projectConnectorSettings({ ...settings, slack: 1 }, {})).toEqual({
+      settings: { ...settings, slack: 1 },
+      secrets: {},
+    });
+  });
+
+  it("projects a single policy field and leaves the rest of settings intact", () => {
+    const settings = { language: "en", nested: { a: 1 } };
+    const result = projectConnectorSettings(settings, {
+      slack: { enabled: true },
+    });
+
+    expect(result.settings.language).toBe("en");
+    expect(result.settings.nested).toBe(settings.nested);
+    expect(result.settings.slack).toEqual({ enabled: true });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("moves Slack credential strings into secrets and out of settings.slack", () => {
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          appToken: "app-token",
+          botToken: "bot-token",
+          signingSecret: "signing-secret",
+          userToken: "user-token",
+          teamId: "T123",
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({ teamId: "T123" });
+    expect(result.secrets).toEqual({
+      [baseSecret("appToken")]: "app-token",
+      [baseSecret("botToken")]: "bot-token",
+      [baseSecret("signingSecret")]: "signing-secret",
+      [baseSecret("userToken")]: "user-token",
+    });
+  });
+
+  it("omits empty, whitespace, and non-string credentials from secrets", () => {
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          appToken: "",
+          botToken: "   ",
+          signingSecret: 12,
+          userToken: false,
+          extra: null,
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({ extra: null });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("strips vault:// credential refs from both settings and secrets", () => {
+    const botRef = formatVaultRef("connectors.slack.botToken");
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          botToken: botRef,
+          teamId: "Tvault",
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({ teamId: "Tvault" });
+    expect(result.secrets).toEqual({});
+    expect(JSON.stringify(result)).not.toContain(botRef);
+  });
+
+  it("keeps a vault:// prefix with no key because isVaultRef requires a key", () => {
+    const result = projectConnectorSettings(
+      {},
+      { slack: { botToken: "vault://" } },
+    );
+
+    expect(result.settings.slack).toEqual({});
+    expect(result.secrets).toEqual({ [baseSecret("botToken")]: "vault://" });
+  });
+
+  it("does not treat AppToken as a credential because the key set is case-sensitive", () => {
+    const result = projectConnectorSettings(
+      {},
+      { slack: { AppToken: "not-secret" } },
+    );
+
+    expect(result.settings.slack).toEqual({ AppToken: "not-secret" });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("clones nested policy values so later input mutation does not leak", () => {
+    const channels = ["C1", "C2"];
+    const connectors = { slack: { channels } };
+    const result = projectConnectorSettings({}, connectors);
+
+    channels.push("C3");
+    expect(result.settings.slack).toEqual({ channels: ["C1", "C2"] });
+  });
+
+  it("lets settings.slack policy override connectors.slack while keeping base-only keys", () => {
+    const result = projectConnectorSettings(
+      {
+        slack: { enabled: false, region: "us-east" },
+      },
+      {
+        slack: { enabled: true, teamId: "Tbase" },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      enabled: false,
+      teamId: "Tbase",
+      region: "us-east",
+    });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("lets settings credentials override connectors credentials for the same field", () => {
+    const result = projectConnectorSettings(
+      { slack: { botToken: "from-settings" } },
+      { slack: { botToken: "from-connectors", appToken: "from-connectors" } },
+    );
+
+    expect(result.settings.slack).toEqual({});
+    expect(result.secrets).toEqual({
+      [baseSecret("appToken")]: "from-connectors",
+      [baseSecret("botToken")]: "from-settings",
+    });
+  });
+
+  it("places a non-object accounts value on the policy lane instead of splitting it", () => {
+    const result = projectConnectorSettings(
+      {},
+      { slack: { accounts: "all", enabled: true } },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: "all",
+      enabled: true,
+    });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("skips non-object accounts instead of projecting them", () => {
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          accounts: {
+            missing: "not-an-object",
+            alsoMissing: 3,
+            listed: ["C1"],
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({ accounts: {} });
+    expect(result.secrets).toEqual({});
+  });
+
+  it("splits account policy from account credentials and keys secrets by account id", () => {
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          accounts: {
+            support: {
+              teamId: "Tsupport",
+              botToken: "support-bot",
+              userToken: "support-user",
+            },
+            emptyCreds: {
+              teamId: "Tempty",
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: {
+        support: { teamId: "Tsupport" },
+        emptyCreds: { teamId: "Tempty" },
+      },
+    });
+    expect(result.secrets).toEqual({
+      [accountSecret("support", "botToken")]: "support-bot",
+      [accountSecret("support", "userToken")]: "support-user",
+    });
+    expect(result.secrets[baseSecret("botToken")]).toBeUndefined();
+  });
+
+  it("unions account ids and lets the settings account win on overlapping fields", () => {
+    const result = projectConnectorSettings(
+      {
+        slack: {
+          accounts: {
+            east: { teamId: "Teast-settings", locale: "en" },
+            west: { botToken: "west-settings" },
+          },
+        },
+      },
+      {
+        slack: {
+          accounts: {
+            east: { teamId: "Teast-base", region: "us-east" },
+            north: { teamId: "Tnorth" },
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: {
+        east: {
+          teamId: "Teast-settings",
+          region: "us-east",
+          locale: "en",
+        },
+        north: { teamId: "Tnorth" },
+        west: {},
+      },
+    });
+    expect(result.secrets).toEqual({
+      [accountSecret("west", "botToken")]: "west-settings",
+    });
+  });
+
+  it("preserves base-then-override account insertion order when unioning ids", () => {
+    const result = projectConnectorSettings(
+      {
+        slack: {
+          accounts: {
+            zeta: { teamId: "Tz" },
+            alpha: { teamId: "Ta-settings" },
+          },
+        },
+      },
+      {
+        slack: {
+          accounts: {
+            beta: { teamId: "Tb" },
+            alpha: { teamId: "Ta-base" },
+          },
+        },
+      },
+    );
+
+    expect(
+      Object.keys((result.settings.slack as { accounts: object }).accounts),
+    ).toEqual(["beta", "alpha", "zeta"]);
+  });
+
+  it("treats a non-object overlapping account as an empty override", () => {
+    const result = projectConnectorSettings(
+      {
+        slack: {
+          accounts: {
+            east: "override-is-scalar",
+          },
+        },
+      },
+      {
+        slack: {
+          accounts: {
+            east: { teamId: "Teast", locale: "en" },
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: { east: { teamId: "Teast", locale: "en" } },
+    });
+  });
+
+  it("recursively splits nested accounts under an account record", () => {
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          accounts: {
+            parent: {
+              teamId: "Tparent",
+              botToken: "parent-bot",
+              accounts: {
+                child: { botToken: "child-bot", channel: "Cchild" },
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: {
+        parent: {
+          teamId: "Tparent",
+          accounts: { child: { channel: "Cchild" } },
+        },
+      },
+    });
+    expect(result.secrets).toEqual({
+      [accountSecret("parent", "botToken")]: "parent-bot",
+    });
+    expect(result.secrets[accountSecret("child", "botToken")]).toBeUndefined();
+  });
+
+  it("does not project a slack object that contains a non-JSON value", () => {
+    const settings = {
+      slack: { enabled: true, bad: Number.NaN },
+    };
+
+    expect(projectConnectorSettings(settings, {})).toEqual({
+      settings,
+      secrets: {},
+    });
+    expect(
+      projectConnectorSettings(
+        {},
+        { slack: { enabled: true, bad: Number.POSITIVE_INFINITY } },
+      ),
+    ).toEqual({ settings: {}, secrets: {} });
+  });
+
+  it("projects slack from settings alone when connectors have no slack object", () => {
+    const result = projectConnectorSettings(
+      {
+        slack: { enabled: true, botToken: "settings-bot" },
+      },
+      { discord: { token: "ignored" } },
+    );
+
+    expect(result.settings.slack).toEqual({ enabled: true });
+    expect(result.secrets).toEqual({
+      [baseSecret("botToken")]: "settings-bot",
+    });
+  });
+
+  it("omits account vault refs and whitespace account tokens from secrets", () => {
+    const ref = formatVaultRef("connectors.slack.accounts.east.botToken");
+    const result = projectConnectorSettings(
+      {},
+      {
+        slack: {
+          accounts: {
+            east: {
+              botToken: ref,
+              userToken: "  ",
+              appToken: "",
+              teamId: "Teast",
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.settings.slack).toEqual({
+      accounts: { east: { teamId: "Teast" } },
+    });
+    expect(result.secrets).toEqual({});
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/agent/src/runtime/project-connector-settings.ts`, which previously had no dedicated test file.

The production module is unchanged. The suite imports `projectConnectorSettings` and asserts the behaviour the code actually has:

- empty / missing / non-object `connectors` and `slack` blocks pass settings through with no secrets
- Slack credential strings (`appToken`, `botToken`, `signingSecret`, `userToken`) move into `CONNECTOR|…` secrets and out of `settings.slack`
- empty, whitespace, and non-string credentials are omitted from secrets
- `vault://<key>` credential refs are stripped from both settings and secrets; a bare `vault://` prefix is kept because `isVaultRef` requires a key
- settings policy and credentials override connectors on the same key; base-only keys survive
- account records are split recursively; non-object accounts are skipped; account ids are unioned with settings winning on overlap
- a slack object containing `NaN` / `Infinity` is not treated as JSON and is not projected

## Evidence

1. `bunx vitest run packages/agent/src/runtime/project-connector-settings.test.ts` — Test Files 1 passed (1), Tests 21 passed (21). Re-run against current `origin/develop` (`c24952197d6d5ffa05a1df85c3471d39d229e469`) immediately before filing.
2. `bunx biome check --write packages/agent/src/runtime/project-connector-settings.test.ts` — Checked 1 file in 144ms. Fixed 1 file (formatting). Clean after that write.
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep project-connector-settings.test.ts` — empty (this file introduced no TypeScript errors). Pre-existing package errors elsewhere are not from this change.
4. Diff touches only `packages/agent/src/runtime/project-connector-settings.test.ts`.

Hosted CI does not run on this fork contributor's PRs; the counts above are from local `bunx vitest` / `biome` / `tsc`.

## Test plan

- [x] Focused vitest file collected and green
- [x] biome + tsc on the new file
- [ ] Maintainer review of the new assertions

# Relates to

Coverage gap: `packages/agent/src/runtime/project-connector-settings.ts` had no same-named test file.

- [x] This PR targets `develop` and is based on current `origin/develop` (`c24952197d6d5ffa05a1df85c3471d39d229e469`) with a one-file diff and zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change; focused vitest / biome / tsc on the new file are quoted above. Hosted CI does not run on this fork.
- [x] A reviewer can confirm the change works without reading the code from the vitest counts above.

# Sync with develop

- [x] Branch parent is current `origin/develop` (`c24952197d6d5ffa05a1df85c3471d39d229e469`); zero conflicts.
- [ ] `bun run verify` was not run (test-only, no production behaviour change). Focused vitest / biome / tsc quoted in Evidence.

# Risks

Low. Test-only addition. No production behaviour change.

# Background

## What does this PR do?

Adds unit coverage for `projectConnectorSettings` next to the module.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/project-connector-settings.test.ts`

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/runtime/project-connector-settings.test.ts
```

# Evidence Gate

<!-- evidence-head:8aa6f4628e6e4adf083973f9f080447cb96e6fc7 -->

- [x] Before full-page screenshots — `N/A - test-only change; no UI surface`
- [x] After full-page screenshots — `N/A - test-only change; no UI surface`
- [x] Walkthrough video — `N/A - test-only change; no UI surface`
- [x] Backend logs — `N/A - test-only change; no production path change`
- [x] Frontend logs — `N/A - test-only change; no UI surface`
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts — `N/A - test-only change; no persisted domain objects`
- [x] OCR visual-text review — `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only change; no production path change.

## Screenshots (before / after) + video walkthrough

N/A - test-only change; no UI surface.

### Before

N/A - test-only change; no UI surface.

### After

N/A - test-only change; no UI surface.

### Walkthrough video

N/A - test-only change; no UI surface.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds tests only and changes no production behaviour. Focused vitest (21/21), biome, and tsc (new file absent from output) are quoted above.
- Hosted CI does not run on this fork contributor's PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
