### PR TITLE
test(cloud): make first-five fixture self-contained

### DIFF
--- a/packages/cloud/e2e/tests/personal-eliza-first-five-minutes.spec.ts
+++ b/packages/cloud/e2e/tests/personal-eliza-first-five-minutes.spec.ts
@@ -13,18 +13,14 @@
  * Harness notes:
  * - Env passthrough: the Worker only sees env keys sync-api-dev-vars knows
  *   (.env.example keys, real values in cloud/shared/.env[.local], and the
- *   provider-key allowlist). OPENROUTER_BASE_URL is not in .env.example, so
- *   this spec requires an `OPENROUTER_BASE_URL=` line in cloud/shared/.env or
- *   .env.local (any value; the spec's override wins). The worker fixture fails
- *   fast with that instruction instead of letting the Worker dial the real
- *   OpenRouter host with the scripted key.
+ *   provider-key allowlist). OPENROUTER_BASE_URL is an explicit provider
+ *   override, so the loopback route is forwarded without developer-local files.
  * - Request shape: every Telegram delivery carries the connector account id the
  *   gateway sends (required by the route since #24322), and the Steward claim
  *   carries the explicit Telegram claim confirmation marker (#21925).
  */
 
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
 import {
   createServer,
   type IncomingMessage,
@@ -32,15 +28,12 @@ import {
   type ServerResponse,
 } from "node:http";
 import type { AddressInfo } from "node:net";
-import { resolve } from "node:path";
 import { mintStewardTokenFromClaims } from "@elizaos/cloud-shared/lib/auth/steward-client";
 import { personalSharedAgentId } from "@elizaos/cloud-shared/lib/services/shared-runtime/personal-shared-agent";
 // The coverage classifier requires a direct Playwright marker for changed specs.
 import type {} from "@playwright/test";
 import { retrySharedRuntimeWarming } from "../src/helpers/shared-runtime";
 import { test as base, expect } from "../src/helpers/test-fixtures";
-
-const CLOUD_SHARED_DIR = resolve(import.meta.dirname, "../../shared");
 
 const STEWARD_JWT_SECRET = "personal-eliza-first-five-local-secret-32-bytes";
 const STEWARD_USER_ID = "steward-personal-eliza-first-five";
@@ -263,29 +256,6 @@ function close(server: Server): Promise<void> {
   });
 }
 
-/**
- * sync-api-dev-vars forwards a process-env override into the Worker's
- * `.dev.vars` only for keys it already knows. Fail before the stack boots when
- * OPENROUTER_BASE_URL cannot reach the Worker, naming the fix.
- */
-function assertScriptedModelRouteIsForwardable(): void {
-  const known = [".env.example", ".env", ".env.local"].some((name) => {
-    const file = resolve(CLOUD_SHARED_DIR, name);
-    return (
-      existsSync(file) &&
-      /^\s*OPENROUTER_BASE_URL\s*=\s*\S/m.test(readFileSync(file, "utf8"))
-    );
-  });
-  if (!known) {
-    throw new Error(
-      "personal-eliza-first-five-minutes needs the Worker to honour OPENROUTER_BASE_URL, " +
-        "which sync-api-dev-vars only forwards for keys present in cloud/shared/.env[.local]. " +
-        "Add a line `OPENROUTER_BASE_URL=http://127.0.0.1:1/v1` to packages/cloud/shared/.env.local " +
-        "(any value; this spec overrides it with the scripted model URL).",
-    );
-  }
-}
-
 const test = base.extend<
   Record<never, never>,
   { scriptedModel: ScriptedModel }
@@ -296,7 +266,6 @@ const test = base.extend<
   scriptedModel: [
     // biome-ignore lint/correctness/noEmptyPattern: Playwright derives fixture dependencies from this destructuring pattern; the model has none.
     async ({}, use) => {
-      assertScriptedModelRouteIsForwardable();
       const prompts: string[] = [];
       const model = createScriptedModelServer(prompts);
       const origin = await listen(model.server);

--- a/packages/cloud/scripts/admin/sync-api-dev-vars.ts
+++ b/packages/cloud/scripts/admin/sync-api-dev-vars.ts
@@ -110,6 +110,7 @@ const sourceEnvFiles = [
 const env: Record<string, string> = {};
 const providerOverrideKeys = new Set([
   "OPENROUTER_API_KEY",
+  "OPENROUTER_BASE_URL",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
   "ANTHROPIC_API_KEY",


### PR DESCRIPTION
Stacked correction for #25612.

The parent correctly repairs the connector-account and model-voiced capability-wall drift, but its OpenRouter loopback override was not forwarded by `sync-api-dev-vars` on a clean checkout. This adds `OPENROUTER_BASE_URL` to the tracked provider override contract and removes the manual `.env.local` prerequisite from the spec.

Validation at `8535b1bd930099386cb65bb867e4fd6a4bdbc646` with Bun 1.3.14 / Node 24.15.0:
- `OPENROUTER_BASE_URL=http://127.0.0.1:43210/v1 PLAYWRIGHT_TEST_AUTH=true bun packages/cloud/scripts/admin/sync-api-dev-vars.ts` generated `.dev.vars` containing the exact override.
- `bun --conditions=eliza-source playwright test personal-eliza-first-five-minutes.spec.ts --workers=1`: 1 passed.
- `bun run --cwd packages/cloud/e2e typecheck`: passed.
- `bun test packages/cloud/e2e/src/fixtures/mock-llm.test.ts`: 5 passed / 26 expectations.
- Biome on both changed files: passed with only 11 existing undeclared-env warnings in the sync script.
- `git diff --check`: passed.

No paid provider is contacted; the focused E2E continues to exercise the real local Worker, PGlite, Durable Objects, replay, and Steward claim path.