### PR TITLE
fix(plugin-openai): enforce Cerebras schema walk bounds and wire contracts

### DIFF
--- a/packages/core/src/utils/well-formed.ts
+++ b/packages/core/src/utils/well-formed.ts
@@ -398,3 +398,256 @@ export function deepToWellFormedUnicode<T>(value: T): T {
 		return failUnsafeValue("reflection", error);
 	}
 }
+
+/**
+ * JSON-schema keywords whose values are arbitrary caller JSON data rather than
+ * sub-schemas. The Cerebras normalizer and `sanitizeJsonSchema` both leave
+ * these untouched, so the schema-shaped Unicode walk below carries them by
+ * reference as well: annotation getters are never observed, and annotation
+ * depth never consumes the schema walk budget.
+ */
+const SCHEMA_ANNOTATION_KEYS = new Set(["default", "examples", "const"]);
+function isAnnotationKey(key: string): boolean {
+	return SCHEMA_ANNOTATION_KEYS.has(key) || key.startsWith("x-");
+}
+
+type SchemaWalkCtx = WalkCtx & { maxDepth: number };
+
+/**
+ * Well-formed-Unicode pass that follows ONLY the JSON-schema keyword structure.
+ *
+ * `deepToWellFormedUnicode` counts every intermediate container (`properties`
+ * maps, array wrappers) toward its depth budget, so a legal schema at the
+ * Cerebras walk boundary (~64 nested schema nodes) exceeds it long before the
+ * provider contract does. This walker instead uses the SAME accounting as the
+ * Cerebras normalizer: one depth unit per schema node reached through a
+ * schema-bearing keyword, annotation subtrees skipped entirely (carried by
+ * reference), string keys and values sanitized along the walked structure.
+ *
+ * Cycles, accessor properties on walked nodes, reflection failures on revoked
+ * proxies, and exceeding `maxDepth` fail closed with the same typed errors as
+ * {@link deepToWellFormedUnicode} (`WELL_FORMED_UNBOUNDED` /
+ * `WELL_FORMED_UNSAFE_VALUE`) so callers keep one failure contract.
+ */
+export function wellFormedUnicodeSchemaStructure<T>(
+	value: T,
+	options: { maxDepth?: number } = {},
+): T {
+	const ctx: SchemaWalkCtx = {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+		maxDepth: options.maxDepth ?? MAX_WELL_FORMED_DEPTH,
+	};
+	try {
+		return walkSchemaStrings(value, 0, ctx);
+	} catch (error) {
+		if (error instanceof ElizaError) throw error;
+		return failUnsafeValue("reflection", error);
+	}
+}
+
+function failSchemaDepth(depth: number, ctx: SchemaWalkCtx): never {
+	throw new ElizaError("deepToWellFormedUnicode: nesting exceeds cap", {
+		code: "WELL_FORMED_UNBOUNDED",
+		context: { reason: "depth", depth, max: ctx.maxDepth },
+		severity: "fatal",
+	});
+}
+
+const SCHEMA_MAP_KEYWORDS = new Set([
+	"properties",
+	"patternProperties",
+	"$defs",
+	"definitions",
+	"dependentSchemas",
+	"dependencies",
+]);
+const SCHEMA_ARRAY_WRAPPER_KEYWORDS = new Set([
+	"anyOf",
+	"oneOf",
+	"allOf",
+	"prefixItems",
+]);
+
+function walkSchemaStrings<T>(value: T, depth: number, ctx: SchemaWalkCtx): T {
+	reserveVisits(ctx, 1);
+	if (typeof value === "string") {
+		return toWellFormedUnicode(value) as unknown as T;
+	}
+	if (!value || typeof value !== "object") {
+		return value;
+	}
+	if (depth > ctx.maxDepth) {
+		failSchemaDepth(depth, ctx);
+	}
+	if (ctx.visiting.has(value)) {
+		failUnbounded("cycle", { depth });
+	}
+	ctx.visiting.add(value);
+	try {
+		if (Array.isArray(value)) {
+			let changed = false;
+			const next = new Array<unknown>(value.length);
+			for (let index = 0; index < value.length; index += 1) {
+				const descriptor = Object.getOwnPropertyDescriptor(value, index);
+				if (!descriptor || !("value" in descriptor)) continue;
+				const walked = walkSchemaStrings(descriptor.value, depth + 1, ctx);
+				if (walked !== descriptor.value) changed = true;
+				next[index] = walked;
+			}
+			return (changed ? next : value) as unknown as T;
+		}
+		let changed = false;
+		const next = Object.create(Object.getPrototypeOf(value)) as Record<
+			string,
+			unknown
+		>;
+		for (const key of Reflect.ownKeys(value)) {
+			if (typeof key !== "string") continue;
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor?.enumerable) continue;
+			if (!("value" in descriptor)) {
+				failUnsafeValue("accessor", undefined, key);
+			}
+			const sanitizedKey = toWellFormedUnicode(key);
+			// Annotation data is opaque caller JSON: carried by reference, never
+			// descended into, never observed.
+			if (isAnnotationKey(sanitizedKey)) {
+				next[sanitizedKey] = descriptor.value;
+				continue;
+			}
+			// Mirror the Cerebras normalizer depth accounting: a MAP keyword's
+			// container and an ARRAY keyword wrapper consume no level; their
+			// member schemas get depth + 1 directly.
+			let walked: unknown;
+			if (
+				SCHEMA_MAP_KEYWORDS.has(sanitizedKey) &&
+				descriptor.value &&
+				typeof descriptor.value === "object" &&
+				!Array.isArray(descriptor.value)
+			) {
+				walked = walkSchemaMapEntry(descriptor.value as object, depth, ctx);
+			} else if (
+				(SCHEMA_ARRAY_WRAPPER_KEYWORDS.has(sanitizedKey) ||
+					sanitizedKey === "items" ||
+					sanitizedKey === "prefixItems") &&
+				Array.isArray(descriptor.value)
+			) {
+				walked = walkSchemaArrayEntry(descriptor.value, depth, ctx);
+			} else {
+				walked = walkSchemaStrings(descriptor.value, depth + 1, ctx);
+			}
+			if (sanitizedKey !== key || walked !== descriptor.value) changed = true;
+			next[sanitizedKey] = walked;
+		}
+		return (changed ? next : value) as unknown as T;
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}
+
+/**
+ * Typed wire-boundary check for schema annotation data. Descriptor-only:
+ * accessors are detected through `Object.getOwnPropertyDescriptor` and rejected
+ * WITHOUT invocation, cycles are detected through path-local ancestry, and
+ * depth beyond `maxDepth` fails closed — so a hostile annotation cannot run
+ * caller-controlled code during a mere admissibility check. Reflection on a
+ * revoked proxy is translated into the same typed contract.
+ */
+export function assertSchemaAnnotationsSerializable(
+	value: unknown,
+	options: { maxDepth?: number } = {},
+): void {
+	const ctx: SchemaWalkCtx = {
+		visits: 0,
+		visiting: new WeakSet<object>(),
+		maxDepth: options.maxDepth ?? MAX_WELL_FORMED_DEPTH,
+	};
+	try {
+		assertAnnotationsWalk(value, 0, ctx);
+	} catch (error) {
+		if (error instanceof ElizaError) throw error;
+		failUnsafeValue("reflection", error);
+	}
+}
+
+function walkSchemaMapEntry(
+	map: object,
+	depth: number,
+	ctx: SchemaWalkCtx,
+): Record<string, unknown> {
+	if (depth > ctx.maxDepth) failSchemaDepth(depth, ctx);
+	reserveVisits(ctx, 1);
+	let changed = false;
+	const next: Record<string, unknown> = Object.create(
+		Object.getPrototypeOf(map),
+	) as Record<string, unknown>;
+	for (const key of Reflect.ownKeys(map)) {
+		if (typeof key !== "string") continue;
+		const descriptor = Object.getOwnPropertyDescriptor(map, key);
+		if (!descriptor?.enumerable || !("value" in descriptor)) continue;
+		const sanitizedKey = toWellFormedUnicode(key);
+		const walked = walkSchemaStrings(descriptor.value, depth + 1, ctx);
+		if (sanitizedKey !== key || walked !== descriptor.value) changed = true;
+		next[sanitizedKey] = walked;
+	}
+	return (changed ? next : map) as Record<string, unknown>;
+}
+
+function walkSchemaArrayEntry(
+	arr: unknown[],
+	depth: number,
+	ctx: SchemaWalkCtx,
+): unknown[] {
+	if (depth > ctx.maxDepth) failSchemaDepth(depth, ctx);
+	reserveVisits(ctx, arr.length || 1);
+	let changed = false;
+	const next = new Array<unknown>(arr.length);
+	for (let index = 0; index < arr.length; index += 1) {
+		const descriptor = Object.getOwnPropertyDescriptor(arr, index);
+		if (!descriptor || !("value" in descriptor)) continue;
+		const walked = walkSchemaStrings(descriptor.value, depth + 1, ctx);
+		if (walked !== descriptor.value) changed = true;
+		next[index] = walked;
+	}
+	return changed ? next : arr;
+}
+function assertAnnotationsWalk(
+	value: unknown,
+	depth: number,
+	ctx: SchemaWalkCtx,
+): void {
+	reserveVisits(ctx, 1);
+	if (!value || typeof value !== "object") return;
+	if (depth > ctx.maxDepth) {
+		failSchemaDepth(depth, ctx);
+	}
+	if (ctx.visiting.has(value)) {
+		failUnbounded("cycle", { depth });
+	}
+	ctx.visiting.add(value);
+	try {
+		let keys: PropertyKey[] = [];
+		try {
+			keys = Reflect.ownKeys(value);
+		} catch (cause) {
+			failUnsafeValue("reflection", cause);
+		}
+		for (const key of keys) {
+			if (typeof key !== "string") continue;
+			let descriptor: PropertyDescriptor | undefined;
+			try {
+				descriptor = Object.getOwnPropertyDescriptor(value, key);
+			} catch (cause) {
+				failUnsafeValue("reflection", cause, key);
+			}
+			if (!descriptor?.enumerable) continue;
+			if (!("value" in descriptor)) {
+				failUnsafeValue("accessor", undefined, key);
+			}
+			assertAnnotationsWalk(descriptor.value, depth + 1, ctx);
+		}
+	} finally {
+		ctx.visiting.delete(value);
+	}
+}

--- a/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
@@ -121,16 +121,19 @@ describe("Cerebras default reasoning effort", () => {
     ).toBe("low");
   });
 
-  it("defaults to 'none' for gemma-4-31b", () => {
+  it("omits the undocumented reasoning field for gemma-4-31b", () => {
     const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
     const opts = __INTERNAL_resolveProviderOptions(
       { prompt: "hi" } as never,
       runtime,
       "gemma-4-31b"
     );
+    // gemma-4-31b has no documented reasoning contract (#25503): an
+    // undocumented reasoning_effort value reaches the wire and can be
+    // rejected by the endpoint, so no default is emitted at all.
     expect(
       (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
-    ).toBe("none");
+    ).toBeUndefined();
   });
 
   it("preserves an explicit reasoning effort for gemma-4-31b", () => {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -13,6 +13,7 @@ import type {
 } from "@elizaos/core";
 import {
   assertActiveTrajectoryForLlmCall,
+  assertSchemaAnnotationsSerializable,
   attestLlmInputSubstring,
   buildCanonicalSystemPrompt,
   cloneSchemaForBoundedTransport,
@@ -25,6 +26,8 @@ import {
   JSON_SCHEMA_SINGLE_KEYWORDS,
   logActiveTrajectoryLlmCall,
   logger,
+  MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+  MAX_WELL_FORMED_DEPTH,
   ModelType,
   normalizeSchemaForCerebras,
   recordLlmCall,
@@ -32,6 +35,7 @@ import {
   sanitizeFunctionNameForCerebras,
   toWellFormedUnicode,
   truncateWellFormed,
+  wellFormedUnicodeSchemaStructure,
 } from "@elizaos/core";
 import {
   generateText,
@@ -382,9 +386,12 @@ function resolveThinkingOffReasoningEffort(
 }
 
 /**
- * Per-model Cerebras reasoning default. Gemma does not reason unless this
- * field is sent, so its non-surprising default is explicit `"none"`; callers
- * that deliberately configure a different effort remain authoritative.
+ * Per-model Cerebras reasoning default, restricted to models whose provider
+ * documentation declares the field. `gemma-4-31b` has no documented reasoning
+ * contract, so no default is emitted at all — an undocumented
+ * `reasoning_effort` value reaches the wire and can be rejected by the
+ * endpoint; callers that deliberately configure a different effort remain
+ * authoritative.
  */
 function resolveCerebrasDefaultReasoningEffort(
   modelName: string | undefined
@@ -392,7 +399,6 @@ function resolveCerebrasDefaultReasoningEffort(
   if (!modelName) return undefined;
   const id = normalizeCerebrasModelId(modelName);
   if (id === "gpt-oss-120b" || id === "zai-glm-4.7") return "low";
-  if (id === "gemma-4-31b") return "none";
   return undefined;
 }
 
@@ -712,9 +718,10 @@ function normalizeNativeToolsForCall(
   options: { cerebrasMode?: boolean; sanitizeUnicode?: boolean } = {}
 ): NormalizedNativeToolsResult {
   const recordArgTransformsByTool: Record<string, RecordArgTransform[]> = {};
+  const toolNameMap = new Map<string, string>();
 
   if (!tools) {
-    return { recordArgTransformsByTool };
+    return { recordArgTransformsByTool, toolNameMap };
   }
 
   // Existing AI SDK callers already pass a ToolSet keyed by tool name. Keep it
@@ -729,7 +736,7 @@ function normalizeNativeToolsForCall(
     for (const key of Reflect.ownKeys(descriptors)) {
       const descriptor = descriptors[key as keyof typeof descriptors];
       if (!descriptor) continue;
-      const sanitizedKey = typeof key === "string" ? toWellFormedUnicode(key) : key;
+      const sanitizedKey: string = typeof key === "string" ? toWellFormedUnicode(key) : String(key);
       if (Object.hasOwn(sanitized, sanitizedKey)) {
         throw new ElizaError("[OpenAI] Native tool names collide after Unicode normalization.", {
           code: "OPENAI_TOOL_NAME_COLLISION",
@@ -753,17 +760,21 @@ function normalizeNativeToolsForCall(
           }
         }
       }
-      if (sanitizedKey !== key) changed = true;
+      if (sanitizedKey !== key && typeof key === "string") {
+        const originalKey = key as string;
+        toolNameMap.set(originalKey, sanitizedKey);
+        changed = true;
+      }
       Object.defineProperty(sanitized, sanitizedKey, nextDescriptor);
     }
     return {
       tools: changed ? sanitized : toolSet,
       recordArgTransformsByTool,
+      toolNameMap,
     };
   }
 
   const toolSet: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  const toolNameMap = new Map<string, string>();
   const originalNameByRegisteredName = new Map<string, string>();
 
   // Cerebras's grammar compiler treats strictness as request-wide, not
@@ -820,10 +831,20 @@ function normalizeNativeToolsForCall(
     // are applied by the normalizeSchemaForCerebras call after sanitization.
     let rawSchema: unknown = declaredSchema;
     if (options.cerebrasMode) {
+      // The bounded transport clone is the SCHEMA depth authority: after it
+      // passes, the Unicode pass must not re-fail the same graph on a smaller,
+      // container-counting budget. The structure walker uses one depth unit per
+      // schema node (same accounting as normalizeSchemaForCerebras) and carries
+      // annotation subtrees by reference so hostile annotation getters are
+      // never observed here — admissibility is enforced at the wire boundary.
       rawSchema = cloneSchemaForBoundedTransport(rawSchema);
     }
     if (options.sanitizeUnicode) {
-      rawSchema = deepToWellFormedUnicode(rawSchema);
+      rawSchema = options.cerebrasMode
+        ? wellFormedUnicodeSchemaStructure(rawSchema, {
+            maxDepth: MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+          })
+        : deepToWellFormedUnicode(rawSchema);
     }
     let inputSchema: JSONSchema7;
     if (strict === false) {
@@ -883,7 +904,13 @@ function normalizeNativeToolsForCall(
       // so the assembled ToolSet must never be deep-walked afterwards (every
       // child RESPONSE_HANDLER call died on it, live 2026-08-21).
       ...(description ? { description: deepToWellFormedUnicode(description) } : {}),
-      inputSchema: jsonSchema(deepToWellFormedUnicode(inputSchema) as JSONSchema7),
+      inputSchema: jsonSchema(
+        (options.cerebrasMode
+          ? wellFormedUnicodeSchemaStructure(inputSchema, {
+              maxDepth: MAX_CEREBRAS_SCHEMA_WALK_DEPTH,
+            })
+          : deepToWellFormedUnicode(inputSchema)) as JSONSchema7
+      ),
       ...(options.cerebrasMode
         ? { strict: cerebrasRequestStrict }
         : strict === undefined
@@ -2366,6 +2393,16 @@ async function generateTextByModelType(
     // accessor. Existing ToolSets use the descriptor-only branch above.
     sanitizeUnicode: true,
   });
+  // Wire boundary for annotation data: the pre-passes carry annotations by
+  // reference (getters never observed), so admissibility is checked HERE,
+  // descriptor-only, before any provider dispatch. Accessors are detected via
+  // Object.getOwnPropertyDescriptor and rejected without invocation; cycles
+  // and over-depth fail closed with the typed WELL_FORMED_* contract.
+  if (normalizedToolResult.tools) {
+    assertSchemaAnnotationsSerializable(paramsWithAttachments.tools, {
+      maxDepth: MAX_WELL_FORMED_DEPTH,
+    });
+  }
   const normalizedTools = normalizedToolResult.tools;
   const normalizedToolChoice = normalizeToolChoice(paramsWithAttachments.toolChoice, {
     toolNameMap: normalizedToolResult.toolNameMap,


### PR DESCRIPTION
## Summary

Fixes #25503.

The plugin-openai default lane failed 10 assertions across three suites: an undocumented `reasoning_effort: "none"` reached the wire for gemma-4-31b, the eager `deepToWellFormedUnicode` traversal threw on exact-depth, cyclic, accessor, revoked-proxy, and deeply nested annotation cases that the typed wire-boundary contract expects to translate or preserve, and ToolSet normalization dropped its name map.

## Changes

- **gemma-4-31b**: no default reasoning field is emitted - the model has no documented reasoning contract, so an undocumented value can reach the wire and be rejected; explicit caller configuration remains authoritative.
- **`wellFormedUnicodeSchemaStructure`** (core): a Unicode sanitization pass that follows ONLY JSON-schema keyword structure with the same depth accounting as `normalizeSchemaForCerebras` (map/array keyword containers consume no level), carries annotation data (`default`, `examples`, `const`, `x-*`) by reference untouched, and preserves the typed `WELL_FORMED_*` failure contract.
- **`assertSchemaAnnotationsSerializable`** (core): descriptor-only wire-boundary check. Accessors are detected via `getOwnPropertyDescriptor` and rejected WITHOUT invocation; cycles are path-local; over-depth fails closed - all before any provider dispatch.
- **ToolSet path**: normalization now records sanitized key mappings in `toolNameMap`, matching the array path, so toolChoice and returned calls resolve correctly.

The reasoning-effort shape test's gemma expectation is updated to the contract declared by this issue (field omitted, not `"none"`).

## Evidence Gate

<!-- evidence-head:28108e1f8b253eff79e4c3b3a33fe4b3a61ed932 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is provider request assembly and schema walking.
<!-- evidence-row:after-screenshots -->
- [x] N/A - behavior change is proven by executed tests.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; deterministic test coverage proves the contracts.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation run at `28108e1f8b253eff79e4c3b3a33fe4b3a61ed932`:

```
$ bunx vitest run --maxWorkers=1   (plugins/plugin-openai full lane)
 Test Files  31 passed (31)
      Tests  404 passed (404)

$ bunx vitest run __tests__/wire-well-formed.shape.test.ts __tests__/cerebras-native-tools-walk-bound.shape.test.ts
 Test Files  2 passed (2)
      Tests  42 passed (42)
(before fix on develop: 22 failed | 20 passed across these suites)

$ tsc --noEmit   (packages/core)          -> exit 0
$ tsc --noEmit   (plugins/plugin-openai)  -> exit 0
$ biome check models/text.ts __tests__/reasoning-effort.shape.test.ts packages/core/src/utils/well-formed.ts
Checked 3 files in 59ms. No fixes applied.
$ git diff --check
(diff-check OK)
```

Pre-existing failure disclosure: `packages/core/src/utils/well-formed.test.ts` ("rejects an enumerable getter without invoking it") fails identically on clean origin/develop - verified via git stash before/after; context matcher mismatch unrelated to this change.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - wire-contract enforcement; no live LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; unit coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported