### PR TITLE
fix(plugin-pdf): parse PDF-spec D: metadata dates instead of dropping them

### DIFF
--- a/plugins/plugin-pdf/README.md
+++ b/plugins/plugin-pdf/README.md
@@ -83,7 +83,7 @@ extracts pages 2–3.
 
 Returns full document information: page count, per-page dimensions + text, and metadata (title, author, subject, keywords, creator, producer, creation/modification dates).
 
-`creationDate`/`modificationDate` are parsed from the PDF-spec date string that `unpdf` returns (`D:YYYYMMDDHHmmSSOHH'mm'`, ISO 32000-1 §7.9.4) into absolute UTC `Date` objects, applying the document's declared UT offset. A value that is missing or not a valid spec date is omitted (left `undefined`) rather than surfaced as an Invalid Date.
+`creationDate`/`modificationDate` are parsed from the PDF-spec date string that `unpdf` returns (`D:YYYYMMDDHHmmSSOHH'mm'`, ISO 32000-1 §7.9.4). When the string carries a UT relation (`Z`, `+`, or `-`) the declared offset is applied and the field is an absolute UTC `Date`. When the UT relation is omitted the document time zone is unknown and, per PDF Reference 3.8.3, the remaining fields are local time; that case is interpreted as local wall-clock time (a `Date` built with the local constructor) rather than being falsely claimed as UTC. A value that is missing or not a valid spec date is omitted (left `undefined`) rather than surfaced as an Invalid Date.
 
 ## Exported Types
 

--- a/plugins/plugin-pdf/README.md
+++ b/plugins/plugin-pdf/README.md
@@ -83,6 +83,8 @@ extracts pages 2–3.
 
 Returns full document information: page count, per-page dimensions + text, and metadata (title, author, subject, keywords, creator, producer, creation/modification dates).
 
+`creationDate`/`modificationDate` are parsed from the PDF-spec date string that `unpdf` returns (`D:YYYYMMDDHHmmSSOHH'mm'`, ISO 32000-1 §7.9.4) into absolute UTC `Date` objects, applying the document's declared UT offset. A value that is missing or not a valid spec date is omitted (left `undefined`) rather than surfaced as an Invalid Date.
+
 ## Exported Types
 
 ```typescript

--- a/plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts
@@ -6,14 +6,14 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { PdfService } from "../services/pdf";
 
-function buildPdfWithHostileMetadata(text: string): Buffer {
+function buildPdf(text: string, infoDict: string): Buffer {
 	const objects = [
 		"<< /Type /Catalog /Pages 2 0 R >>",
 		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
 		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
 		`<< /Length ${text.length + 25} >>\nstream\nBT /F1 12 Tf 72 720 Td (${text}) Tj ET\nendstream`,
 		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
-		"<< /Title 123 /Author (Ada) /CreationDate 0 /ModDate false >>",
+		infoDict,
 	];
 
 	let body = "%PDF-1.4\n";
@@ -33,6 +33,9 @@ function buildPdfWithHostileMetadata(text: string): Buffer {
 	return Buffer.from(body);
 }
 
+const buildPdfWithHostileMetadata = (text: string): Buffer =>
+	buildPdf(text, "<< /Title 123 /Author (Ada) /CreationDate 0 /ModDate false >>");
+
 describe("PdfService real unpdf boundary", () => {
 	it("extracts text while omitting numeric and boolean metadata dates", async () => {
 		const service = new PdfService({} as IAgentRuntime);
@@ -45,5 +48,37 @@ describe("PdfService real unpdf boundary", () => {
 		expect(info.metadata.title).toBeUndefined();
 		expect(info.metadata.creationDate).toBeUndefined();
 		expect(info.metadata.modificationDate).toBeUndefined();
+	});
+
+	it("parses the PDF-spec `D:` creation date that unpdf actually returns", async () => {
+		const service = new PdfService({} as IAgentRuntime);
+		const info = await service.getDocumentInfo(
+			buildPdf("utc date", "<< /CreationDate (D:20240102030405Z) >>")
+		);
+
+		const creationDate = info.metadata.creationDate;
+		expect(creationDate).toBeInstanceOf(Date);
+		expect(creationDate?.getUTCFullYear()).toBe(2024);
+		expect(creationDate?.getUTCMonth()).toBe(0);
+		expect(creationDate?.getUTCDate()).toBe(2);
+		expect(creationDate?.getUTCHours()).toBe(3);
+		expect(creationDate?.getUTCMinutes()).toBe(4);
+		expect(creationDate?.getUTCSeconds()).toBe(5);
+		expect(creationDate?.toISOString()).toBe("2024-01-02T03:04:05.000Z");
+	});
+
+	it("applies the UT offset of an offset-form `D:` date to yield an absolute instant", async () => {
+		const service = new PdfService({} as IAgentRuntime);
+		const info = await service.getDocumentInfo(
+			buildPdf(
+				"offset date",
+				"<< /CreationDate (D:20200610093121-05'00') /ModDate (D:20200610093121+02'30') >>"
+			)
+		);
+
+		// Local 09:31:21 at UTC-05:00 is 14:31:21Z.
+		expect(info.metadata.creationDate?.toISOString()).toBe("2020-06-10T14:31:21.000Z");
+		// Local 09:31:21 at UTC+02:30 is 07:01:21Z.
+		expect(info.metadata.modificationDate?.toISOString()).toBe("2020-06-10T07:01:21.000Z");
 	});
 });

--- a/plugins/plugin-pdf/__tests__/pdf-service.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.test.ts
@@ -215,8 +215,9 @@ describe("PdfService", () => {
 					Keywords: "pdf,unit",
 					Creator: "suite",
 					Producer: "vitest",
-					CreationDate: "2024-01-02T03:04:05.000Z",
-					ModDate: "2024-02-03T04:05:06.000Z",
+					// pdf.js/unpdf surface PDF-spec `D:` strings, not ISO-8601.
+					CreationDate: "D:20240102030405Z",
+					ModDate: "D:20240203040506Z",
 				}
 			)
 		);
@@ -382,7 +383,7 @@ describe("PdfService", () => {
 		getDocumentProxyMock.mockResolvedValue(
 			makePdf([{ items: [{ str: "content" }] }], {
 				CreationDate: "not-a-date",
-				ModDate: "2024-02-03T04:05:06.000Z",
+				ModDate: "D:20240203040506Z",
 			})
 		);
 
@@ -390,6 +391,53 @@ describe("PdfService", () => {
 
 		expect(info.metadata.creationDate).toBeUndefined();
 		expect(info.metadata.modificationDate).toEqual(new Date("2024-02-03T04:05:06.000Z"));
+	});
+
+	it("parses PDF-spec `D:` dates and applies the declared UT offset", async () => {
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "content" }] }], {
+				// Full UTC form and an offset form with the apostrophe separators.
+				CreationDate: "D:20240102030405Z",
+				ModDate: "D:20200610093121-05'00'",
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+
+		expect(info.metadata.creationDate).toBeInstanceOf(Date);
+		expect(info.metadata.creationDate?.toISOString()).toBe("2024-01-02T03:04:05.000Z");
+		// Local 09:31:21 at UTC-05:00 becomes 14:31:21Z.
+		expect(info.metadata.modificationDate?.toISOString()).toBe("2020-06-10T14:31:21.000Z");
+	});
+
+	it("defaults omitted `D:` date components and clamps out-of-range parts", async () => {
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "content" }] }], {
+				// Year only: month/day default to 1, time to 00:00:00Z.
+				CreationDate: "D:2024",
+				// Out-of-range month (13) and day (40) clamp to defaults, not overflow.
+				ModDate: "D:20241340",
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+
+		expect(info.metadata.creationDate?.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+		expect(info.metadata.modificationDate?.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+	});
+
+	it("omits an unparseable `D:` string rather than surfacing an Invalid Date", async () => {
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "content" }] }], {
+				CreationDate: "D:notadate",
+				ModDate: "D:",
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+
+		expect(info.metadata.creationDate).toBeUndefined();
+		expect(info.metadata.modificationDate).toBeUndefined();
 	});
 
 	it("accepts PDF headers after leading transport bytes within the scan window", async () => {

--- a/plugins/plugin-pdf/__tests__/pdf-service.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.test.ts
@@ -413,10 +413,11 @@ describe("PdfService", () => {
 	it("defaults omitted `D:` date components and clamps out-of-range parts", async () => {
 		getDocumentProxyMock.mockResolvedValue(
 			makePdf([{ items: [{ str: "content" }] }], {
-				// Year only: month/day default to 1, time to 00:00:00Z.
-				CreationDate: "D:2024",
+				// Year only with an explicit UTC relation: month/day default to 1,
+				// time to 00:00:00Z.
+				CreationDate: "D:2024Z",
 				// Out-of-range month (13) and day (40) clamp to defaults, not overflow.
-				ModDate: "D:20241340",
+				ModDate: "D:20241340Z",
 			})
 		);
 
@@ -424,6 +425,43 @@ describe("PdfService", () => {
 
 		expect(info.metadata.creationDate?.toISOString()).toBe("2024-01-01T00:00:00.000Z");
 		expect(info.metadata.modificationDate?.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+	});
+
+	it("treats a `D:` date with an omitted UT relation as local time, not UTC", async () => {
+		getDocumentProxyMock.mockResolvedValue(
+			makePdf([{ items: [{ str: "content" }] }], {
+				// No trailing UT relation: PDF Reference 3.8.3 leaves the zone unknown
+				// and the components are local time. The parser must not fabricate a
+				// `Z` UTC claim, so the wall-clock is read back through local getters
+				// (time-zone independent) rather than asserting an absolute UTC instant.
+				CreationDate: "D:20240102030405",
+				ModDate: "D:20200610093121",
+			})
+		);
+
+		const info = await service().getDocumentInfo(validPdfBuffer());
+
+		const creation = info.metadata.creationDate;
+		expect(creation).toBeInstanceOf(Date);
+		expect(creation?.getFullYear()).toBe(2024);
+		expect(creation?.getMonth()).toBe(0);
+		expect(creation?.getDate()).toBe(2);
+		expect(creation?.getHours()).toBe(3);
+		expect(creation?.getMinutes()).toBe(4);
+		expect(creation?.getSeconds()).toBe(5);
+		// The wall-clock is preserved as local time; it is not silently pinned to
+		// the same numbers in UTC unless the host itself runs in UTC.
+		if (creation && creation.getTimezoneOffset() !== 0) {
+			expect(creation.toISOString()).not.toBe("2024-01-02T03:04:05.000Z");
+		}
+
+		const modification = info.metadata.modificationDate;
+		expect(modification?.getFullYear()).toBe(2020);
+		expect(modification?.getMonth()).toBe(5);
+		expect(modification?.getDate()).toBe(10);
+		expect(modification?.getHours()).toBe(9);
+		expect(modification?.getMinutes()).toBe(31);
+		expect(modification?.getSeconds()).toBe(21);
 	});
 
 	it("omits an unparseable `D:` string rather than surfacing an Invalid Date", async () => {

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -137,12 +137,73 @@ function normalizeExtractionOptions(
   };
 }
 
-function parseMetadataDate(value: unknown): Date | undefined {
-  if (typeof value !== "string" && !(value instanceof Date)) {
+/**
+ * PDF spec (ISO 32000-1, 7.9.4) date string: `D:YYYYMMDDHHmmSSOHH'mm'` where
+ * every component after the year is optional and `O` is the UT relation
+ * (`+`, `-`, or `Z`). This is what `pdf.js`/`unpdf` actually surface in
+ * `info.CreationDate`/`info.ModDate`, not an ISO-8601 string. The groups mirror
+ * `PDFDateString.toDateObject` in pdf.js so real-world documents round-trip.
+ */
+const PDF_SPEC_DATE_REGEX =
+  /^D:(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?([Z+-])?(\d{2})?'?(\d{2})?'?$/;
+
+function clampInt(value: string | undefined, min: number, max: number, fallback: number): number {
+  const parsed = value === undefined ? Number.NaN : Number.parseInt(value, 10);
+  return parsed >= min && parsed <= max ? parsed : fallback;
+}
+
+/**
+ * Parses the PDF-spec `D:` date string into a UTC {@link Date}, applying the
+ * document's declared UT offset so the returned instant is absolute. Returns
+ * undefined for any string that is not a spec date so an unparseable value is
+ * dropped rather than surfaced as an Invalid Date.
+ */
+function parsePdfSpecDate(value: string): Date | undefined {
+  const matches = PDF_SPEC_DATE_REGEX.exec(value);
+  if (!matches) {
     return undefined;
   }
 
-  const date = value instanceof Date ? value : new Date(value);
+  const year = Number.parseInt(matches[1], 10);
+  const monthIndex = clampInt(matches[2], 1, 12, 1) - 1;
+  const day = clampInt(matches[3], 1, 31, 1);
+  let hour = clampInt(matches[4], 0, 23, 0);
+  let minute = clampInt(matches[5], 0, 59, 0);
+  const second = clampInt(matches[6], 0, 59, 0);
+  const relation = matches[7] ?? "Z";
+  const offsetHour = clampInt(matches[8], 0, 23, 0);
+  const offsetMinute = clampInt(matches[9], 0, 59, 0);
+
+  // Convert the document's local wall-clock time to UTC using its UT relation:
+  // `-05'00'` means local is 5h behind UTC, so add the offset to reach UTC.
+  if (relation === "-") {
+    hour += offsetHour;
+    minute += offsetMinute;
+  } else if (relation === "+") {
+    hour -= offsetHour;
+    minute -= offsetMinute;
+  }
+
+  const date = new Date(Date.UTC(year, monthIndex, day, hour, minute, second));
+  return Number.isFinite(date.getTime()) ? date : undefined;
+}
+
+function parseMetadataDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  // Real unpdf/pdf.js output is the PDF-spec `D:` format; only fall back to the
+  // permissive `new Date()` path for actual ISO-8601 / RFC strings.
+  if (value.startsWith("D:")) {
+    return parsePdfSpecDate(value);
+  }
+
+  const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date : undefined;
 }
 

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -153,8 +153,12 @@ function clampInt(value: string | undefined, min: number, max: number, fallback:
 }
 
 /**
- * Parses the PDF-spec `D:` date string into a UTC {@link Date}, applying the
- * document's declared UT offset so the returned instant is absolute. Returns
+ * Parses the PDF-spec `D:` date string into a {@link Date}. When the string
+ * carries a UT relation (`Z`, `+`, or `-`) the declared offset is applied so the
+ * returned instant is absolute UTC. When the UT relation is omitted the zone is
+ * unknown and, per PDF Reference 3.8.3 / ISO 32000-1 7.9.4, the remaining fields
+ * are local time; that case is interpreted as host-local wall-clock via the
+ * local `Date` constructor rather than fabricating a `Z` UTC claim. Returns
  * undefined for any string that is not a spec date so an unparseable value is
  * dropped rather than surfaced as an Invalid Date.
  */
@@ -167,24 +171,37 @@ function parsePdfSpecDate(value: string): Date | undefined {
   const year = Number.parseInt(matches[1], 10);
   const monthIndex = clampInt(matches[2], 1, 12, 1) - 1;
   const day = clampInt(matches[3], 1, 31, 1);
-  let hour = clampInt(matches[4], 0, 23, 0);
-  let minute = clampInt(matches[5], 0, 59, 0);
+  const hour = clampInt(matches[4], 0, 23, 0);
+  const minute = clampInt(matches[5], 0, 59, 0);
   const second = clampInt(matches[6], 0, 59, 0);
-  const relation = matches[7] ?? "Z";
+  const relation = matches[7];
+
+  // Absent UT relation: the document time zone is unknown and the components are
+  // local time. Do not substitute `Z` and claim UTC. Build the instant from the
+  // local `Date` constructor so the wall-clock the document declared is
+  // preserved as-is in the host's local time zone.
+  if (relation === undefined) {
+    const localDate = new Date(year, monthIndex, day, hour, minute, second);
+    return Number.isFinite(localDate.getTime()) ? localDate : undefined;
+  }
+
   const offsetHour = clampInt(matches[8], 0, 23, 0);
   const offsetMinute = clampInt(matches[9], 0, 59, 0);
 
   // Convert the document's local wall-clock time to UTC using its UT relation:
   // `-05'00'` means local is 5h behind UTC, so add the offset to reach UTC.
+  // `Z` is already UTC and needs no adjustment.
+  let hourUtc = hour;
+  let minuteUtc = minute;
   if (relation === "-") {
-    hour += offsetHour;
-    minute += offsetMinute;
+    hourUtc += offsetHour;
+    minuteUtc += offsetMinute;
   } else if (relation === "+") {
-    hour -= offsetHour;
-    minute -= offsetMinute;
+    hourUtc -= offsetHour;
+    minuteUtc -= offsetMinute;
   }
 
-  const date = new Date(Date.UTC(year, monthIndex, day, hour, minute, second));
+  const date = new Date(Date.UTC(year, monthIndex, day, hourUtc, minuteUtc, second));
   return Number.isFinite(date.getTime()) ? date : undefined;
 }
 


### PR DESCRIPTION
# Relates to

Closes #25637

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` is a full-monorepo gate; the owning package's `test` (46 passing), `typecheck`, `lint:check`, and `build` were run green (see logs). Any unrelated blocker is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change from the before/after logs attached below without reading the code.

# Sync with develop

- [x] Branch head is even with the latest `origin/develop` (`c24952197d`); zero conflicts.
- [x] Owning-package gates pass post-sync; the full-repo `bun run verify` blocker is documented under **Known gaps / failures**.

# Risks

Low. The change is confined to one private helper (`parseMetadataDate`) in `plugins/plugin-pdf/services/pdf.ts`. No public type, method signature, or export changes. The permissive ISO-8601 / `Date`-instance fallback path is preserved, and non-string / null / invalid inputs are still dropped exactly as before.

# Background

## What does this PR do?

`PdfService.getDocumentInfo()` advertises (README + the `PdfMetadata.creationDate?: Date` / `modificationDate?: Date` contract) that it returns a document's creation/modification dates. In reality those fields were silently `undefined` for **every real-world PDF**.

The root cause: `unpdf`/`pdf.js` `getMetadata()` returns the raw PDF-spec date string, e.g. `info.CreationDate === "D:20240102030405Z"` (ISO 32000-1 §7.9.4, format `D:YYYYMMDDHHmmSSOHH'mm'`). The old `parseMetadataDate()` did `new Date(value)`, and `new Date("D:20240102030405Z")` is `Invalid Date`, so the value was discarded. The package's own unit tests masked this by feeding ISO-8601 strings (`"2024-01-02T03:04:05.000Z"`) that `pdf.js` never actually produces.

This fix teaches `parseMetadataDate()` the PDF-spec `D:` format (mirroring pdf.js `PDFDateString.toDateObject`): a bounded regex parses the components into a UTC `Date`, applies the document's declared UT offset so the returned instant is absolute, clamps out-of-range components to spec defaults, and returns `undefined` only when the string is genuinely unparseable. The existing `Date`-instance and ISO-string fallback paths, plus all null/non-string guards and the `Number.isFinite(getTime())` validity check, are retained.

Docs: the README `getDocumentInfo` section now documents the `D:` source format and the UTC-offset normalization.

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity/contract break: a documented DTO field that was always empty on real input).

# Documentation changes needed?

Done — `plugins/plugin-pdf/README.md` `getDocumentInfo` section now describes the `D:` date parsing and UTC normalization.

# Testing

## Where should a reviewer start?

`plugins/plugin-pdf/services/pdf.ts` — the new `parsePdfSpecDate` helper and the `parseMetadataDate` dispatch. Then `plugins/plugin-pdf/__tests__/pdf-service.integration.test.ts`, which drives real `unpdf` end to end.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-pdf test        # 46 passed
bun run --cwd plugins/plugin-pdf typecheck    # tsc --noEmit, clean
bun run --cwd plugins/plugin-pdf lint:check   # biome, no fixes
bun run --cwd plugins/plugin-pdf build        # node + browser + d.ts
```

The new real-`unpdf` cases build a minimal PDF whose `Info` dict carries a spec date `(D:20240102030405Z)` and an offset date `(D:20200610093121-05'00')`, then assert `getUTCFullYear/Month/Date/Hours` and the applied timezone offset. Unit cases cover offset application, component defaulting, out-of-range clamping, that a `D:` string whose UT relation is omitted is interpreted as local wall-clock time (not silently claimed as UTC), and that a garbage `D:` string still yields `undefined`. The pre-existing ISO-string unit fixtures were corrected to feed the `D:` strings the library actually emits.

# Evidence Gate

<!-- evidence-head:4f43e33d347df495d912fffabc2935eed0a6760c -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - service-only backend change (metadata date parser); no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - service-only backend change; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; behavior is exercised through the vitest real-unpdf boundary logs below.`
<!-- evidence-row:backend-logs -->
- [x] Real code-path logs: raw `getMetadata().info.CreationDate` proving unpdf returns the `D:` string, plus the before/after `vitest` run showing the parser going from `undefined` to a correct `Date`.

<details>
<summary>Backend output: raw unpdf metadata + before/after vitest run</summary>

```
RAW getMetadata().info.CreationDate = "D:20240102030405Z"
PdfService creationDate = 2024-01-02T03:04:05.000Z
 ✓ raw probe > unpdf returns D: string; PdfService now parses it 133ms
      Tests  1 passed (1)

=== BEFORE FIX (original parseMetadataDate, real unpdf) ===
 FAIL  pdf-service.integration.test.ts > parses the PDF-spec `D:` creation date that unpdf actually returns
 AssertionError: expected undefined to be an instance of Date
 FAIL  pdf-service.integration.test.ts > applies the UT offset of an offset-form `D:` date to yield an absolute instant
 - Expected: "2020-06-10T14:31:21.000Z"
 + Received: undefined
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)

=== AFTER FIX (real unpdf) ===
 ✓ pdf-service.integration.test.ts > parses the PDF-spec `D:` creation date that unpdf actually returns 23ms
 ✓ pdf-service.integration.test.ts > applies the UT offset of an offset-form `D:` date to yield an absolute instant 6ms
 Test Files  2 passed (2)
      Tests  46 passed (46)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/network surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a pure metadata date parser.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: the parsed `Date` objects (as ISO strings) produced from real `D:` inputs through the actual `unpdf` parser — the DTO field that was previously always `undefined`.

<details>
<summary>Domain artifact: parsed metadata dates from real D: inputs</summary>

```
input D:20240102030405Z         -> creationDate.toISOString() = 2024-01-02T03:04:05.000Z
input D:20200610093121-05'00'   -> creationDate.toISOString() = 2020-06-10T14:31:21.000Z  (UTC-05:00 applied)
input D:20200610093121+02'30'   -> modificationDate.toISOString() = 2020-06-10T07:01:21.000Z  (UTC+02:30 applied)
input D:2024Z                   -> creationDate.toISOString() = 2024-01-01T00:00:00.000Z  (components default)
input D:20241340Z (month 13/day 40) -> clamped to 2024-01-01T00:00:00.000Z
input D:20240102030405 (no UT relation) -> local wall-clock: getFullYear()=2024, getMonth()=0, getDate()=2, getHours()=3 (interpreted as local time, NOT pinned to UTC)
input D:notadate                -> creationDate = undefined  (genuinely unparseable dropped)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

**Raw `unpdf` metadata proof** — `unpdf` returns the PDF-spec `D:` string, and the fixed `PdfService` now parses it:

```
RAW getMetadata().info.CreationDate = "D:20240102030405Z"
PdfService creationDate = 2024-01-02T03:04:05.000Z
 ✓ raw probe > unpdf returns D: string; PdfService now parses it 133ms
      Tests  1 passed (1)
```

<details>
<summary>BEFORE fix — real-unpdf integration cases fail (dates dropped as <code>undefined</code>)</summary>

```
=== BEFORE FIX: real-unpdf integration cases against original parseMetadataDate ===

 FAIL  __tests__/pdf-service.integration.test.ts > PdfService real unpdf boundary > parses the PDF-spec `D:` creation date that unpdf actually returns
AssertionError: expected undefined to be an instance of Date
 ❯ __tests__/pdf-service.integration.test.ts:60:24
     59|   const creationDate = info.metadata.creationDate;
     60|   expect(creationDate).toBeInstanceOf(Date);

 FAIL  __tests__/pdf-service.integration.test.ts > PdfService real unpdf boundary > applies the UT offset of an offset-form `D:` date to yield an absolute instant
AssertionError: expected undefined to be '2020-06-10T14:31:21.000Z' // Object.is equality
- Expected: "2020-06-10T14:31:21.000Z"
+ Received: undefined
 ❯ __tests__/pdf-service.integration.test.ts:80:53

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```
</details>

<details>
<summary>AFTER fix — full <code>plugin-pdf</code> vitest run, 46 passing</summary>

```
 ✓ pdf-service.integration.test.ts > parses the PDF-spec `D:` creation date that unpdf actually returns 23ms
 ✓ pdf-service.integration.test.ts > applies the UT offset of an offset-form `D:` date to yield an absolute instant 6ms
 ✓ pdf-service.test.ts > parses PDF-spec `D:` dates and applies the declared UT offset 1ms
 ✓ pdf-service.test.ts > defaults omitted `D:` date components and clamps out-of-range parts 1ms
 ✓ pdf-service.test.ts > treats a `D:` date with an omitted UT relation as local time, not UTC 1ms
 ✓ pdf-service.test.ts > omits an unparseable `D:` string rather than surfacing an Invalid Date 1ms
 ✓ pdf-service.test.ts > returns metadata, dimensions, per-page text, and aggregate text 4ms
 ... (39 more)
 Test Files  2 passed (2)
      Tests  46 passed (46)
```
</details>

Frontend: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - service-only backend change; no UI surface.`

### After

`N/A - service-only backend change; no UI surface.`

### Walkthrough video

`N/A - no UI flow; the real-parser before/after test logs above are the walkthrough.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- The full-monorepo `bun run verify` was not run to completion on this machine: a plain `bun install` is blocked by an unrelated global registry `minimumReleaseAge` policy on freshly published transitive deps (`viem`, `@cloudflare/playwright`) owned by other workspaces, not by `plugin-pdf`. Installation was completed and all owning-package gates (`test` 46/46, `typecheck`, `lint:check`, `build`) were run green against the real `unpdf` boundary. This is unrelated to the one-file metadata-parser change here.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

Closes #25637

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c24952197d6d5ffa05a1df85c3471d39d229e469:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c24952197d6d5ffa05a1df85c3471d39d229e469:packages/skills/skills/contribute-to-eliza"} -->

