### PR TITLE
test(remote): bind cleanup node fixture user

### DIFF
--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -954,6 +954,7 @@ describe("secure remote relay routes", () => {
         id: "9",
         name: "eliza-host-one-cnpx9uop",
         createdAt: new Date("2026-08-22T06:15:01.000Z").toISOString(),
+        user: { name: "tunnel" },
       },
     ]);
     const response = await request(


### PR DESCRIPTION
Stacked correction for #24830 at exact parent head `50efd0269686888850a9f0e5758d46e3ffd32f2d`.

Production managed-network cleanup deliberately selects only nodes owned by the configured Headscale user. The relay cleanup fixture omitted that required `user.name`, so exact-head focused tests failed before `deleteNode("9")`. This adds only the configured fixture identity; production behavior is unchanged.

Pinned Bun 1.3.14 / Node 24.15.0 validation:
- managed-network + relay route suites: 31 passed / 130 expectations
- native managed-network suite: 2 passed / 9 expectations
- cleanup diagnostic suite: 2 passed / 3 expectations
- Biome on changed file: passed
- `git diff --check`: passed

This does not satisfy or bypass the parent draft live Headscale/Postgres/signed-device evidence holds.