### PR TITLE
fix(inbox): safe NaN handling in Gmail normalize priority sort

### DIFF
--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.safe-sort.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.safe-sort.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for safe NaN handling in gmail-normalize priority sort.
+ */
+import type { LifeOpsGmailMessageSummary } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { compareGmailMessagePriority } from "./gmail-normalize";
+
+describe("gmail-normalize safe sort", () => {
+  it("handles NaN receivedAt by falling back to 0", () => {
+    const a = {
+      id: "b",
+      receivedAt: "bad",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+    const b = {
+      id: "a",
+      receivedAt: "bad",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+    const c = {
+      id: "c",
+      receivedAt: "2024-01-02T00:00:00.000Z",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+
+    const sorted = [a, b, c].sort(compareGmailMessagePriority);
+    expect(sorted[0].id).toBe("c");
+    expect(sorted[1].id).toBe("a");
+    expect(sorted[2].id).toBe("b");
+  });
+
+  it("breaks ties deterministically with id comparison when receivedAt dates are both invalid", () => {
+    const a = {
+      id: "z",
+      receivedAt: "bad",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+    const b = {
+      id: "a",
+      receivedAt: "bad",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+
+    expect(compareGmailMessagePriority(a, b)).toBeGreaterThan(0);
+    expect(compareGmailMessagePriority(b, a)).toBeLessThan(0);
+  });
+
+  it("orders valid dates descending", () => {
+    const a = {
+      id: "a",
+      receivedAt: "2024-01-01T00:00:00.000Z",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+    const b = {
+      id: "b",
+      receivedAt: "2024-01-03T00:00:00.000Z",
+      isImportant: false,
+      likelyReplyNeeded: false,
+      isUnread: false,
+    } as LifeOpsGmailMessageSummary;
+
+    const sorted = [a, b].sort(compareGmailMessagePriority);
+    expect(sorted[0].id).toBe("b");
+    expect(sorted[1].id).toBe("a");
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -495,7 +495,12 @@ export function compareGmailMessagePriority(
   if (left.isUnread !== right.isUnread) {
     return right.isUnread ? 1 : -1;
   }
-  return Date.parse(right.receivedAt) - Date.parse(left.receivedAt);
+  const leftTime = Date.parse(left.receivedAt);
+  const rightTime = Date.parse(right.receivedAt);
+  const leftSafe = Number.isFinite(leftTime) ? leftTime : 0;
+  const rightSafe = Number.isFinite(rightTime) ? rightTime : 0;
+  if (rightSafe !== leftSafe) return rightSafe - leftSafe;
+  return left.id.localeCompare(right.id);
 }
 
 export function normalizeGmailDraftTone(


### PR DESCRIPTION
## Summary

`compareGmailMessagePriority` in `plugins/plugin-inbox/src/inbox/gmail-normalize.ts:498` used naive `Date.parse` subtraction for inbox Gmail priority sort. Invalid `receivedAt` → `NaN` comparator → unstable sort, nondeterministic LifeOps inbox ordering.

Sibling guard at `gmail-normalize.ts:630` exists but this exported comparator was missed.

Mirrors `#25343` and `#25647` (96% safe-NaN).

## Changes

- `plugins/plugin-inbox/src/inbox/gmail-normalize.ts:498` guard with `isFinite` + `id` tiebreak
- `plugins/plugin-inbox/src/inbox/gmail-normalize.safe-sort.test.ts` 3 tests

## Exact-head verification

| Check | Base (`origin/develop@c2495219`) | Head (`1ac6efbe`) |
| --- | --- | --- |
| `bunx vitest run gmail-normalize.safe-sort.test.ts` | N/A | 3 pass |

## Risks

Low.

## Attribution

Authored by @byt61.
