### PR TITLE
fix(cloud): use surrogate-safe truncateWellFormed on discord error embeds

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord.surrogate.test.ts
@@ -1,0 +1,27 @@
+/** Surrogate-safe discord error truncation. */
+import { describe, expect, it } from "vitest";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+describe("discord surrogate-safe", () => {
+  it("truncates at 1000 without splitting surrogate", () => {
+    const emoji = "🧪";
+    const text = "a".repeat(999) + emoji + "b".repeat(10);
+    const out = truncateWellFormed(toWellFormedUnicode(text), 1000);
+    expect(out.length).toBeLessThanOrEqual(1000);
+    expect(out).not.toMatch(/\uD83E$/);
+    expect(JSON.stringify(out)).not.toContain("\\u");
+  });
+
+  it("handles lone surrogate", () => {
+    const lone = "error \uD800 detail";
+    const well = toWellFormedUnicode(lone);
+    expect(well).toContain("�");
+    const out = truncateWellFormed(well, 1000);
+    expect(out).toContain("�");
+  });
+
+  it("caps at 1000", () => {
+    const long = "x".repeat(1500);
+    expect(truncateWellFormed(toWellFormedUnicode(long), 1000).length).toBe(1000);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/discord.ts
+++ b/packages/cloud/shared/src/lib/services/discord.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service discord behavior behind route handlers.
+import { truncateWellFormed, toWellFormedUnicode } from "@elizaos/core";
 import { logger } from "../utils/logger";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -311,7 +312,7 @@ class DiscordService {
     const fields: DiscordEmbedField[] = [
       {
         name: "Error Message",
-        value: `\`\`\`${error.message.slice(0, 1000)}\`\`\``,
+        value: `\`\`\`${truncateWellFormed(toWellFormedUnicode(error.message), 1000)}\`\`\``,
         inline: false,
       },
     ];
@@ -319,7 +320,7 @@ class DiscordService {
     if (error.stack) {
       fields.push({
         name: "Stack Trace",
-        value: `\`\`\`${error.stack.slice(0, 1000)}\`\`\``,
+        value: `\`\`\`${truncateWellFormed(toWellFormedUnicode(error.stack), 1000)}\`\`\``,
         inline: false,
       });
     }
@@ -327,7 +328,7 @@ class DiscordService {
     if (error.context) {
       fields.push({
         name: "Context",
-        value: `\`\`\`json\n${JSON.stringify(error.context, null, 2).slice(0, 1000)}\`\`\``,
+        value: `\`\`\`json\n${truncateWellFormed(toWellFormedUnicode(JSON.stringify(error.context, null, 2)), 1000)}\`\`\``,
         inline: false,
       });
     }
@@ -878,7 +879,7 @@ class DiscordService {
     if (warning.context) {
       fields.push({
         name: "Context",
-        value: `\`\`\`json\n${JSON.stringify(warning.context, null, 2).slice(0, 1000)}\`\`\``,
+        value: `\`\`\`json\n${truncateWellFormed(toWellFormedUnicode(JSON.stringify(warning.context, null, 2)), 1000)}\`\`\``,
         inline: false,
       });
     }


### PR DESCRIPTION
## Summary

`packages/cloud/shared/src/lib/services/discord.ts:314,322,330,881` truncated external error `message`/`stack`/`context` JSON with naive `.slice(0,1000)` for Discord embeds. Surrogate pair split → lone surrogate in embed `value` → malformed Unicode sent to Discord API (`JSON.stringify` emits `\uD8xx` escape, strict parsers reject).

Use surrogate-safe `truncateWellFormed(toWellFormedUnicode(...),1000)`.

Mirrors merged surrogate precedent `#25455` (discord duplicate preview).

## Changes

- `packages/cloud/shared/src/lib/services/discord.ts:2` add `truncateWellFormed`, `toWellFormedUnicode` import
- `packages/cloud/shared/src/lib/services/discord.ts:314,322,330,881` four `.slice(0,1000)` → surrogate-safe
- `packages/cloud/shared/src/lib/services/discord.surrogate.test.ts` 3 tests

## Exact-head verification

| Check | Base (`origin/develop@c2495219`) | Head (`efaceb89`) |
| --- | --- | --- |
| `bunx vitest run discord.surrogate.test.ts` | N/A | 3 pass |
| `bunx biome check --write` | 0 | 0 |

## Risks

Low. Same ASCII contract; only surrogate-split case shifts cut -1.

## Attribution

Authored by @byt61.
