### PR TITLE
test(trajectory): type well-formed assertions

### DIFF
--- a/plugins/plugin-trajectory-logger/src/api-client.surrogate.test.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.surrogate.test.ts
@@ -6,6 +6,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchTrajectoryList, TrajectoryHttpError } from "./api-client.js";
 
+function isWellFormed(value: string): boolean {
+  const native = value as unknown as { isWellFormed?: () => boolean };
+  if (typeof native.isWellFormed === "function") return native.isWellFormed();
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) return false;
+  }
+  return true;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -19,7 +33,7 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
     // Verify old slice would be ill-formed: it would split astral
     const oldSlice = body.slice(0, 200);
     expect(oldSlice.charCodeAt(199)).toBe(0xd83e);
-    expect(oldSlice.isWellFormed()).toBe(false);
+    expect(isWellFormed(oldSlice)).toBe(false);
 
     vi.stubGlobal(
       "fetch",
@@ -39,7 +53,7 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
       // Truncate should back off to 199 to avoid splitting astral
       expect(preview).toBe("a".repeat(199));
       expect(preview.length).toBe(199);
-      expect(preview.isWellFormed()).toBe(true);
+      expect(isWellFormed(preview)).toBe(true);
       expect(message).toContain("500 Internal Server Error:");
     }
   });
@@ -47,7 +61,7 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
   it("replaces lone surrogate via toWellFormedUnicode before truncation", async () => {
     const lone = "\uD800";
     const body = lone + "x".repeat(250);
-    expect(body.isWellFormed()).toBe(false);
+    expect(isWellFormed(body)).toBe(false);
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -63,7 +77,7 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
     } catch (error) {
       const message = (error as Error).message;
       const preview = message.split(": ").pop() ?? "";
-      expect(preview.isWellFormed()).toBe(true);
+      expect(isWellFormed(preview)).toBe(true);
       expect(message).not.toContain("\uD800");
       expect(message).toContain("�");
       expect(preview.length).toBeLessThanOrEqual(200);
@@ -73,7 +87,7 @@ describe("trajectory-logger surrogate-safe error preview (#24933)", () => {
         "err",
         lone + "a".repeat(199),
       );
-      expect(direct.message.isWellFormed()).toBe(true);
+      expect(isWellFormed(direct.message)).toBe(true);
       expect(direct.message).not.toContain("\uD800");
       expect(direct.message).toContain("�");
     }


### PR DESCRIPTION
# Relates to

Follow-up baseline closure for #25372 and superseding lint-baseline PR #25595. This extracts the one remaining trajectory-logger typecheck fix from draft #25479.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and was rebased onto latest `origin/develop@462e1742e672196f127d9390759f1334d6b74dc9` with zero conflicts.
- [x] `bun install --frozen-lockfile` ran post-sync; the scoped verification choice and initial fresh-worktree prerequisites are recorded below.
- [x] An independent reviewer confirmed the exact-head change from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop@462e1742e672196f127d9390759f1334d6b74dc9`; zero conflicts.
- [x] Exact package tests, typecheck, lint, build, diff check, and independent review pass post-sync. Root-wide `bun run verify` was not substituted for the narrower failing CI gate; this is recorded below.

# Risks

Low. This changes one regression-test file only. The fallback walks UTF-16 code units and preserves the five existing assertions while avoiding an ES2024 lib declaration requirement under this package's TypeScript configuration.

# Background

## What does this PR do?

Replaces five direct `String.prototype.isWellFormed()` calls with one typed compatibility helper. It uses the native method when declared by the runtime object and otherwise validates surrogate pairs locally.

The runtime code under test is unchanged. The direct calls currently make `@elizaos/plugin-trajectory-logger` typecheck fail because its configured TypeScript lib does not declare the ES2024 method.

This patch is semantically equivalent to the helper already present in broad draft #25479. Landing this focused extraction first should be followed by rebasing/removing that duplicate from #25479.

## What kind of change is this?

Test compatibility fix; non-breaking and runtime-neutral.

# Documentation changes needed?

No. No public behavior, API, or configuration changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-trajectory-logger/src/api-client.surrogate.test.ts`.

## Detailed testing steps

At exact head `6d41ac38c0a5db00b04b0c508880974c3c42d8fd`, Node 24.15.0 and Bun 1.3.14:

- focused Vitest: 1 file, 3/3 tests pass;
- full plugin Vitest: 7 files, 48/48 tests pass;
- plugin `tsc --noEmit -p tsconfig.json`: pass;
- plugin Biome: 25 files checked, pass;
- plugin build (tsup + Vite + declarations): pass;
- `git diff --check origin/develop..HEAD`: pass;
- independent exact-head review: GO, no P0/P1/P2;
- binary patch SHA-256: `be3229355eb02c0acb3f94bb561e2858fa3f5f3f72c463a2030cb7bcbf8fa09c`.

# Evidence Gate

<!-- evidence-head:6d41ac38c0a5db00b04b0c508880974c3c42d8fd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only TypeScript compatibility change; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only TypeScript compatibility change; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or runtime behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime code path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, filesystem, scheduled-task, or generated-domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only compatibility change.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- On the fresh worktree, the first package typecheck stopped before the changed file because generated i18n data and `@elizaos/cloud-routing` dist were absent. After generating the canonical keywords and building that workspace dependency, the identical command passed.
- The first full package test run stopped before tests because `@elizaos/ui/events`, then `@elizaos/shared/events`, had not been built in the fresh worktree. After building the canonical UI/shared workspace packages, the identical full suite passed 48/48.
- Root-wide `bun run verify` was not run for this one-file test-only CI closure. Exact package build, full tests, focused regression, typecheck, lint, diff check, and independent review all pass.
- Draft #25479 overlaps this one-file helper and should rebase/drop its duplicate if this PR lands first.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribution skill unavailable in this session
Attribution status: self-reported
— [codex-trajectory-typecheck-closure]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - contribution skill unavailable in this session"} -->

