### PR TITLE
test(agent): cover sql

### DIFF
--- a/packages/agent/src/services/approval/sql.test.ts
+++ b/packages/agent/src/services/approval/sql.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit coverage for approval-queue raw-SQL encoders, parsers, and runners.
+ *
+ * Drives `./sql.ts` directly. Literal encoding and JSON parsing are pure; row
+ * extraction is asserted through `executeRawSql` / `executeRawSqlTx` against a
+ * fake `adapter.db.execute` while `drizzle-orm`'s real `sql.raw` builds the
+ * query object. No production helper is replaced with a mock.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  executeRawSql,
+  executeRawSqlTx,
+  parseJsonRecord,
+  sqlInteger,
+  sqlJson,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toText,
+} from "./sql.ts";
+
+function runtimeWithExecute(
+  execute: (query: unknown) => Promise<unknown>,
+): IAgentRuntime {
+  return {
+    adapter: { db: { execute } },
+  } as IAgentRuntime;
+}
+
+function txWithExecute(
+  execute: (query: unknown) => Promise<unknown>,
+): TransactionalDb {
+  return { execute };
+}
+
+describe("toText", () => {
+  it("returns strings unchanged", () => {
+    expect(toText("x")).toBe("x");
+    expect(toText("")).toBe("");
+  });
+
+  it("uses the default empty fallback for nullish values", () => {
+    expect(toText(null)).toBe("");
+    expect(toText(undefined)).toBe("");
+  });
+
+  it("uses a caller-supplied fallback for nullish values", () => {
+    expect(toText(null, "fb")).toBe("fb");
+    expect(toText(undefined, "fb")).toBe("fb");
+  });
+
+  it("stringifies non-string values instead of falling back", () => {
+    expect(toText(42)).toBe("42");
+    expect(toText(false, "fb")).toBe("false");
+    expect(toText({ a: 1 })).toBe("[object Object]");
+  });
+});
+
+describe("parseJsonRecord", () => {
+  it("parses a JSON object string", () => {
+    expect(parseJsonRecord('{"k":"v","n":1}')).toEqual({ k: "v", n: 1 });
+  });
+
+  it("passes an already-parsed object through", () => {
+    const value = { k: "v" };
+    expect(parseJsonRecord(value)).toBe(value);
+  });
+
+  it("returns an empty object for missing JSON values", () => {
+    expect(parseJsonRecord(null)).toEqual({});
+    expect(parseJsonRecord(undefined)).toEqual({});
+    expect(parseJsonRecord("")).toEqual({});
+  });
+
+  it("throws when the parsed value is not an object", () => {
+    expect(() => parseJsonRecord("[1]")).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord([])).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord("null")).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord('"x"')).toThrow("Expected JSON object");
+  });
+
+  it("throws on invalid JSON strings and non-object primitives", () => {
+    expect(() => parseJsonRecord("not json")).toThrow("Invalid JSON value");
+    expect(() => parseJsonRecord(42)).toThrow(
+      "Expected JSON string or object, received number",
+    );
+    expect(() => parseJsonRecord(true)).toThrow(
+      "Expected JSON string or object, received boolean",
+    );
+  });
+});
+
+describe("sql literals", () => {
+  it("quotes strings and doubles embedded single quotes", () => {
+    expect(sqlQuote("plain")).toBe("'plain'");
+    expect(sqlQuote("it's")).toBe("'it''s'");
+    expect(sqlQuote("")).toBe("''");
+    expect(sqlQuote("''")).toBe("''''''");
+  });
+
+  it("encodes nullable text as SQL NULL or a quoted literal", () => {
+    expect(sqlText("plain")).toBe("'plain'");
+    expect(sqlText("it's")).toBe("'it''s'");
+    expect(sqlText("")).toBe("''");
+    expect(sqlText(null)).toBe("NULL");
+    expect(sqlText(undefined)).toBe("NULL");
+  });
+
+  it("truncates finite numbers and rejects non-finite values", () => {
+    expect(sqlInteger(5.7)).toBe("5");
+    expect(sqlInteger(-3.9)).toBe("-3");
+    expect(sqlInteger(0)).toBe("0");
+    expect(sqlInteger(null)).toBe("NULL");
+    expect(sqlInteger(undefined)).toBe("NULL");
+    expect(() => sqlInteger(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlInteger(Number.POSITIVE_INFINITY)).toThrow(
+      "invalid numeric SQL literal",
+    );
+    expect(() => sqlInteger(Number.NEGATIVE_INFINITY)).toThrow(
+      "invalid numeric SQL literal",
+    );
+  });
+
+  it("serializes JSON then quotes it as a SQL string", () => {
+    expect(sqlJson({ a: 1 })).toBe("'{\"a\":1}'");
+    expect(sqlJson(null)).toBe("'null'");
+    expect(sqlJson(undefined)).toBe("'null'");
+    expect(sqlJson([1, 2])).toBe("'[1,2]'");
+    expect(sqlJson({ a: "it's" })).toBe("'{\"a\":\"it''s\"}'");
+  });
+});
+
+describe("executeRawSql", () => {
+  it("forwards the SQL text through drizzle sql.raw and extracts object rows from an array result", async () => {
+    const seen: unknown[] = [];
+    const runtime = runtimeWithExecute(async (query) => {
+      seen.push(query);
+      return [{ id: "a" }, { id: "b" }];
+    });
+
+    const rows = await executeRawSql(runtime, "SELECT 1");
+    expect(rows).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(seen).toHaveLength(1);
+    const query = seen[0] as { queryChunks: Array<{ value?: unknown }> };
+    expect(query.queryChunks[0]?.value).toEqual(["SELECT 1"]);
+  });
+
+  it("returns an empty list for an empty array result", async () => {
+    const runtime = runtimeWithExecute(async () => []);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("returns a single-element list for a single object row", async () => {
+    const runtime = runtimeWithExecute(async () => [{ id: "only" }]);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "only" },
+    ]);
+  });
+
+  it("drops non-object entries from an array result", async () => {
+    const runtime = runtimeWithExecute(async () => [
+      { id: "keep" },
+      null,
+      ["skip"],
+      "nope",
+      1,
+    ]);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "keep" },
+    ]);
+  });
+
+  it("extracts object rows from a { rows } envelope", async () => {
+    const runtime = runtimeWithExecute(async () => ({
+      rows: [{ id: "a" }, null, { id: "b" }, "skip"],
+    }));
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "a" },
+      { id: "b" },
+    ]);
+  });
+
+  it("returns an empty list when { rows } is missing or not an array", async () => {
+    const missing = runtimeWithExecute(async () => ({ count: 0 }));
+    const notArray = runtimeWithExecute(async () => ({ rows: "nope" }));
+    await expect(executeRawSql(missing, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(notArray, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list for a non-object, non-array execute result", async () => {
+    const none = runtimeWithExecute(async () => null);
+    const scalar = runtimeWithExecute(async () => 42);
+    await expect(executeRawSql(none, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(scalar, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("throws when the runtime database adapter is unavailable", async () => {
+    const missingDb = { adapter: {} } as IAgentRuntime;
+    const withoutExecute = {
+      adapter: { db: {} },
+    } as IAgentRuntime;
+    await expect(executeRawSql(missingDb, "SELECT 1")).rejects.toThrow(
+      "runtime database adapter unavailable",
+    );
+    await expect(executeRawSql(withoutExecute, "SELECT 1")).rejects.toThrow(
+      "runtime database adapter unavailable",
+    );
+  });
+
+  it("reuses the cached drizzle sql.raw on a subsequent call", async () => {
+    const seen: unknown[] = [];
+    const runtime = runtimeWithExecute(async (query) => {
+      seen.push(query);
+      return [];
+    });
+    await executeRawSql(runtime, "SELECT 2");
+    await executeRawSql(runtime, "SELECT 3");
+    expect(seen).toHaveLength(2);
+    const first = seen[0] as { queryChunks: Array<{ value?: unknown }> };
+    const second = seen[1] as { queryChunks: Array<{ value?: unknown }> };
+    expect(first.queryChunks[0]?.value).toEqual(["SELECT 2"]);
+    expect(second.queryChunks[0]?.value).toEqual(["SELECT 3"]);
+  });
+});
+
+describe("executeRawSqlTx", () => {
+  it("runs against the caller-owned handle and extracts rows", async () => {
+    const seen: unknown[] = [];
+    const tx = txWithExecute(async (query) => {
+      seen.push(query);
+      return { rows: [{ ok: true }] };
+    });
+    await expect(executeRawSqlTx(tx, "UPDATE t SET x = 1")).resolves.toEqual([
+      { ok: true },
+    ]);
+    const query = seen[0] as { queryChunks: Array<{ value?: unknown }> };
+    expect(query.queryChunks[0]?.value).toEqual(["UPDATE t SET x = 1"]);
+  });
+
+  it("returns an empty list for an empty transactional result", async () => {
+    const tx = txWithExecute(async () => ({ rows: [] }));
+    await expect(executeRawSqlTx(tx, "SELECT 1")).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Test-only coverage for `packages/agent/src/services/approval/sql.ts`, which had no same-named test file.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation after sync (see Evidence). `bun run verify`
      was not run; this is a single-file test-only change. Hosted CI does not
      run on fork contributor PRs.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Parent is current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`);
      zero conflicts.
- [x] Focused verification passed post-sync (see Evidence).

# Risks

Low. Test-only addition of a colocated vitest file. No production code is
modified and no runtime behaviour changes.

# Background

## What does this PR do?

Adds `packages/agent/src/services/approval/sql.test.ts` so the real approval-queue
SQL helpers are driven through every exported symbol and branch:

- `toText`: strings, default and caller fallbacks for nullish values, non-string
  stringification (does not use the fallback)
- `parseJsonRecord`: object strings, already-parsed objects, empty fallbacks for
  null/undefined/`""`, non-object JSON (`[]`, `"null"`, primitives), invalid
  JSON, and non-object primitive inputs
- `sqlQuote` / `sqlText`: empty strings, doubled embedded quotes, SQL `NULL`
- `sqlInteger`: truncation of finite values (including negatives), `NULL` for
  nullish, rejection of NaN / ±Infinity
- `sqlJson`: objects, arrays, null, undefined (`JSON.stringify(null)`), and
  quotes inside JSON that must be SQL-escaped
- `executeRawSql`: live `drizzle-orm` `sql.raw` query forwarding; array results
  (empty, single, many); dropping non-object entries; `{ rows }` envelopes;
  missing/`rows` not-an-array; non-object execute results; missing adapter /
  missing `execute`; cached `sql.raw` on a second call
- `executeRawSqlTx`: same extraction against a caller-owned handle

The assertions record observed behaviour of the current module. Nothing in
production is changed.

## What kind of change is this?

Improvements (tests for an existing helper).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/approval/sql.test.ts`, then the focused vitest
command below.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/services/approval/sql.test.ts
```

Observed on current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`)
with this PR's test file, immediately before filing:

```
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

Biome: `bunx biome check --write packages/agent/src/services/approval/sql.test.ts`
→ `Checked 1 file in 313ms. Fixed 1 file.` then clean (import sort). Config
proved present: `biome.json` and `tsconfig.json` exist; sparse-checkout is off.

Typecheck: `cd packages/agent && bunx tsc --noEmit` — `sql.test.ts` appears
nowhere in the output (grep exit 1). Pre-existing package errors remain; this
file added zero.

The diff touches only that test file.

Hosted CI does not run on this fork contributor PR; the counts above are local.

# Evidence Gate

Evidence head: `103a2c809c45c904f23e8e8d4ce2ba147f6b4065`

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path exercised; focused vitest only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path exercised
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests, no model call
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only; the artifact is the passing vitest suite quoted above
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit tests, no model call.

## Backend + frontend logs

N/A - no runtime or frontend path exercised.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- `bun run verify` was not run; the scoped evidence for this test-only PR is
  focused vitest, biome, and `tsc --noEmit` (this file absent from tsc output).
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- `packages/agent` `tsc --noEmit` exits non-zero due to pre-existing errors in
  other files; `sql.test.ts` is not among them.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:103a2c809c45c904f23e8e8d4ce2ba147f6b4065 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
