### PR TITLE
test(agent): cover vault-profile-resolver

### DIFF
--- a/packages/agent/src/runtime/vault-profile-resolver.test.ts
+++ b/packages/agent/src/runtime/vault-profile-resolver.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Behavioral coverage for boot-time vault profile resolution.
+ * Drives the real module against `createTestVault`: opt-out, empty inventory,
+ * unprofiled keys, agent routing (first-match wins; app/skill rules ignored),
+ * skipped empty values, password-manager references, missing-profile failures,
+ * mixed queues, and idempotent re-application. Collaborators are real vault
+ * APIs; process.env is snapshotted and restored.
+ */
+import {
+  createTestVault,
+  profileStorageKey,
+  setEntryMeta,
+  type TestVault,
+  type Vault,
+  writeRoutingConfig,
+} from "@elizaos/vault";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyVaultProfilesForAgent } from "./vault-profile-resolver.ts";
+
+const AGENT_ID = "vault-profile-resolver-agent";
+const OTHER_AGENT_ID = "vault-profile-resolver-other";
+
+const KEY_WORK = "VPR_TEST_WORK_API_KEY";
+const KEY_PERSONAL = "VPR_TEST_PERSONAL_API_KEY";
+const KEY_EMPTY = "VPR_TEST_EMPTY_API_KEY";
+const KEY_FAIL = "VPR_TEST_FAIL_API_KEY";
+const KEY_LEGACY = "VPR_TEST_LEGACY_API_KEY";
+const KEY_REF = "VPR_TEST_REF_API_KEY";
+const KEY_WS = "VPR_TEST_WS_API_KEY";
+const KEY_MALFORMED = "VPR_TEST_MALFORMED_API_KEY";
+
+const DISABLE = "ELIZA_DISABLE_VAULT_PROFILE_RESOLVER";
+
+const ENV_KEYS = [
+  DISABLE,
+  KEY_WORK,
+  KEY_PERSONAL,
+  KEY_EMPTY,
+  KEY_FAIL,
+  KEY_LEGACY,
+  KEY_REF,
+  KEY_WS,
+  KEY_MALFORMED,
+] as const;
+
+function restoreEnv(
+  snapshot: Record<(typeof ENV_KEYS)[number], string | undefined>,
+): void {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+async function seedProfiledKey(
+  vault: Vault,
+  key: string,
+  profiles: Readonly<Record<string, string>>,
+  activeProfile: string,
+): Promise<void> {
+  for (const [id, value] of Object.entries(profiles)) {
+    await vault.set(profileStorageKey(key, id), value, { sensitive: true });
+  }
+  await setEntryMeta(vault, key, {
+    profiles: Object.keys(profiles).map((id) => ({ id, label: id })),
+    activeProfile,
+  });
+}
+
+describe("applyVaultProfilesForAgent", () => {
+  let test: TestVault;
+  let envSnapshot: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(async () => {
+    envSnapshot = Object.fromEntries(
+      ENV_KEYS.map((key) => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    for (const key of ENV_KEYS) delete process.env[key];
+    test = await createTestVault();
+  });
+
+  afterEach(async () => {
+    restoreEnv(envSnapshot);
+    await test.dispose();
+  });
+
+  it("returns an empty result when the vault inventory is empty", async () => {
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result).toEqual({ overridden: 0, skipped: [], failed: [] });
+    expect(Object.isFrozen(result.skipped)).toBe(true);
+    expect(Object.isFrozen(result.failed)).toBe(true);
+    expect(process.env[KEY_WORK]).toBeUndefined();
+  });
+
+  it("leaves keys without profiles alone, including a pre-seeded process.env value", async () => {
+    process.env[KEY_LEGACY] = "env-legacy";
+    await test.vault.set(KEY_LEGACY, "vault-legacy", { sensitive: true });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result).toEqual({ overridden: 0, skipped: [], failed: [] });
+    expect(process.env[KEY_LEGACY]).toBe("env-legacy");
+  });
+
+  it("overrides process.env with the active profile for a single profiled key", async () => {
+    process.env[KEY_WORK] = "stale-env";
+    await seedProfiledKey(
+      test.vault,
+      KEY_WORK,
+      { work: "sk-work", personal: "sk-personal" },
+      "work",
+    );
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+  });
+
+  it("is idempotent: a second apply writes the same env value and recounts the override", async () => {
+    await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");
+
+    const first = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+    const second = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(first).toEqual({ overridden: 1, skipped: [], failed: [] });
+    expect(second).toEqual({ overridden: 1, skipped: [], failed: [] });
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+  });
+
+  it("opts out entirely when ELIZA_DISABLE_VAULT_PROFILE_RESOLVER is the string 1", async () => {
+    process.env[DISABLE] = "1";
+    await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result).toEqual({ overridden: 0, skipped: [], failed: [] });
+    expect(process.env[KEY_WORK]).toBeUndefined();
+  });
+
+  it("still resolves when the disable flag is set to a value other than 1", async () => {
+    process.env[DISABLE] = "true";
+    await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+  });
+
+  it("applies the first matching agent routing rule and ignores later ties", async () => {
+    await seedProfiledKey(
+      test.vault,
+      KEY_WORK,
+      { work: "sk-work", personal: "sk-personal" },
+      "work",
+    );
+    await writeRoutingConfig(test.vault, {
+      rules: [
+        {
+          keyPattern: KEY_WORK,
+          scope: { kind: "agent", agentId: AGENT_ID },
+          profileId: "personal",
+        },
+        {
+          keyPattern: KEY_WORK,
+          scope: { kind: "agent", agentId: AGENT_ID },
+          profileId: "work",
+        },
+      ],
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WORK]).toBe("sk-personal");
+  });
+
+  it("does not apply an agent rule written for a different agentId", async () => {
+    await seedProfiledKey(
+      test.vault,
+      KEY_WORK,
+      { work: "sk-work", personal: "sk-personal" },
+      "work",
+    );
+    await writeRoutingConfig(test.vault, {
+      rules: [
+        {
+          keyPattern: KEY_WORK,
+          scope: { kind: "agent", agentId: OTHER_AGENT_ID },
+          profileId: "personal",
+        },
+      ],
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+  });
+
+  it("ignores app and skill routing rules because the resolver only supplies agentId", async () => {
+    await seedProfiledKey(
+      test.vault,
+      KEY_WORK,
+      { work: "sk-work", forApp: "sk-app", forSkill: "sk-skill" },
+      "work",
+    );
+    await writeRoutingConfig(test.vault, {
+      rules: [
+        {
+          keyPattern: KEY_WORK,
+          scope: { kind: "app", appName: "@elizaos/plugin-feed" },
+          profileId: "forApp",
+        },
+        {
+          keyPattern: KEY_WORK,
+          scope: { kind: "skill", skillId: "code-review" },
+          profileId: "forSkill",
+        },
+      ],
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+  });
+
+  it("skips a profiled key whose resolved value is empty and records the key", async () => {
+    await seedProfiledKey(test.vault, KEY_EMPTY, { empty: "" }, "empty");
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(0);
+    expect(result.skipped).toEqual([KEY_EMPTY]);
+    expect(result.failed).toEqual([]);
+    expect(process.env[KEY_EMPTY]).toBeUndefined();
+  });
+
+  it("overrides with a whitespace-only profile because the live check is length, not trim", async () => {
+    await seedProfiledKey(test.vault, KEY_WS, { ws: "   " }, "ws");
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WS]).toBe("   ");
+  });
+
+  it("records a failed key when profiles are declared but no profile blob or bare value exists", async () => {
+    await setEntryMeta(test.vault, KEY_FAIL, {
+      profiles: [{ id: "ghost", label: "Ghost" }],
+      activeProfile: "ghost",
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(0);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([KEY_FAIL]);
+    expect(process.env[KEY_FAIL]).toBeUndefined();
+  });
+
+  it("falls back to the bare key when the active profile blob is missing", async () => {
+    await test.vault.set(KEY_WORK, "sk-bare", { sensitive: true });
+    await setEntryMeta(test.vault, KEY_WORK, {
+      profiles: [{ id: "phantom", label: "Phantom" }],
+      activeProfile: "phantom",
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_WORK]).toBe("sk-bare");
+  });
+
+  it("skips password-manager reference entries even when they declare profiles", async () => {
+    await test.vault.setReference(KEY_REF, {
+      source: "1password",
+      path: "op://vault/item/credential",
+    });
+    await test.vault.set(profileStorageKey(KEY_REF, "default"), "sk-ref", {
+      sensitive: true,
+    });
+    await setEntryMeta(test.vault, KEY_REF, {
+      profiles: [{ id: "default", label: "Default" }],
+      activeProfile: "default",
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(0);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(process.env[KEY_REF]).toBeUndefined();
+  });
+
+  it("returns empty and writes no env when inventory listing fails on malformed meta JSON", async () => {
+    await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");
+    await test.vault.set(`_meta.${KEY_MALFORMED}`, "not-json");
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result).toEqual({ overridden: 0, skipped: [], failed: [] });
+    expect(process.env[KEY_WORK]).toBeUndefined();
+  });
+
+  it("walks a mixed inventory: override, skip empty, fail missing, leave unprofiled and references", async () => {
+    process.env[KEY_LEGACY] = "env-legacy";
+    await seedProfiledKey(test.vault, KEY_WORK, { work: "sk-work" }, "work");
+    await seedProfiledKey(test.vault, KEY_EMPTY, { empty: "" }, "empty");
+    await setEntryMeta(test.vault, KEY_FAIL, {
+      profiles: [{ id: "ghost", label: "Ghost" }],
+      activeProfile: "ghost",
+    });
+    await test.vault.set(KEY_LEGACY, "vault-legacy", { sensitive: true });
+    await test.vault.setReference(KEY_REF, {
+      source: "protonpass",
+      path: "proton://item",
+    });
+    await setEntryMeta(test.vault, KEY_REF, {
+      profiles: [{ id: "default", label: "Default" }],
+      activeProfile: "default",
+    });
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.overridden).toBe(1);
+    expect(result.skipped).toEqual([KEY_EMPTY]);
+    expect(result.failed).toEqual([KEY_FAIL]);
+    expect(Object.isFrozen(result.skipped)).toBe(true);
+    expect(Object.isFrozen(result.failed)).toBe(true);
+    expect(process.env[KEY_WORK]).toBe("sk-work");
+    expect(process.env[KEY_EMPTY]).toBeUndefined();
+    expect(process.env[KEY_FAIL]).toBeUndefined();
+    expect(process.env[KEY_LEGACY]).toBe("env-legacy");
+    expect(process.env[KEY_REF]).toBeUndefined();
+  });
+
+  it("continues after a failed key so a later profiled key still overrides", async () => {
+    await setEntryMeta(test.vault, KEY_FAIL, {
+      profiles: [{ id: "ghost", label: "Ghost" }],
+      activeProfile: "ghost",
+    });
+    await seedProfiledKey(
+      test.vault,
+      KEY_PERSONAL,
+      { personal: "sk-personal" },
+      "personal",
+    );
+
+    const result = await applyVaultProfilesForAgent(test.vault, AGENT_ID);
+
+    expect(result.failed).toContain(KEY_FAIL);
+    expect(result.overridden).toBe(1);
+    expect(process.env[KEY_PERSONAL]).toBe("sk-personal");
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. `packages/agent/src/runtime/vault-profile-resolver.ts` had no
same-named test file. This PR adds colocated behavioral coverage for the
boot-time vault profile resolver.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation after sync (see Evidence). `bun run verify`
      was not run; this is a single-file test-only change. Hosted CI does not
      run on fork contributor PRs.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Parent is current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`);
      zero conflicts.
- [x] Focused verification passed post-sync (see Evidence).

# Risks

Low. Test-only addition. No production code is modified and no runtime
behaviour changes.

# Background

## What does this PR do?

Adds `packages/agent/src/runtime/vault-profile-resolver.test.ts`, which drives
the real `applyVaultProfilesForAgent` against `createTestVault` (real
`listVaultInventory` / `resolveActiveValue` / routing config). Assertions
record observed behaviour:

- empty inventory returns `{ overridden: 0, skipped: [], failed: [] }` with frozen arrays
- keys without profiles are left alone, including a pre-seeded `process.env` value
- a single profiled key overrides `process.env` with the active profile
- a second apply is idempotent (same env value, same override count)
- `ELIZA_DISABLE_VAULT_PROFILE_RESOLVER=1` opts out; any other value still resolves
- first matching agent routing rule wins; a later tie is ignored
- an agent rule for a different `agentId` does not apply
- app and skill routing rules are ignored because the resolver only supplies `agentId`
- an empty resolved profile is recorded in `skipped` and does not write env
- a whitespace-only profile overrides (the live check is length, not trim)
- declared profiles with no blob and no bare value are recorded in `failed`
- a missing active-profile blob falls back to the bare key
- password-manager reference entries are skipped even when they declare profiles
- malformed inventory meta JSON fails closed (empty result, no env writes)
- a mixed queue still overrides later keys after a failed key

Nothing in production is changed.

## What kind of change is this?

Improvements (tests for an existing helper).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/vault-profile-resolver.test.ts`, then the focused
vitest command below.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/runtime/vault-profile-resolver.test.ts
```

Observed on current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`)
with this PR's test file (parent of head `4eee09ba6dd734b15ec3f480cb9d72b76fee69fe`;
`vault-profile-resolver.ts` is unchanged versus that develop SHA):

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Biome: `bunx biome check --write packages/agent/src/runtime/vault-profile-resolver.test.ts`
→ `Checked 1 file in 174ms. Fixed 1 file.` Checkout is not sparse (`biome.json`
and `tsconfig.json` are present; `git sparse-checkout list` is empty).

Typecheck: `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'vault-profile-resolver.test.ts'`
— empty; the file appears nowhere in the output. Pre-existing package errors
remain; this file added zero.

The diff touches only that test file.

Hosted CI does not run on this fork contributor PR; the counts above are local.

# Evidence Gate

Evidence head: `4eee09ba6dd734b15ec3f480cb9d72b76fee69fe`

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path exercised; focused vitest only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path exercised
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests, no model call
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only; the artifact is the passing vitest suite quoted above
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit tests, no model call.

## Backend + frontend logs

N/A - no runtime or frontend path exercised.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- `bun run verify` was not run; the scoped evidence for this test-only PR is
  focused vitest, biome, and `tsc --noEmit` (this file absent from tsc output).
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- `packages/agent` `tsc --noEmit` may exit non-zero due to pre-existing errors in
  other files; `vault-profile-resolver.test.ts` is not among them.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4eee09ba6dd734b15ec3f480cb9d72b76fee69fe -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
