### PR TITLE
test(agent): cover trajectory-steps-writer

### DIFF
--- a/packages/agent/src/runtime/trajectory-steps-writer.test.ts
+++ b/packages/agent/src/runtime/trajectory-steps-writer.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Behavioral coverage for trajectory-steps-writer.ts CQRS writes. Drives the
+ * real writer: typed storage and parent errors, upsert insert vs in-place
+ * replace, parentStepId override including null, replace sort/ties/empty/
+ * single-element, delete empty-queue and whitespace IDs, ownership SQL, and
+ * clear-all counts. sqlQuote and extractRequiredRows stay real; load, save,
+ * and transaction are stubbed collaborators so writer-owned branches can be
+ * asserted without a SQL engine.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  executeRawSqlTransaction,
+  loadTrajectoryById,
+  type PersistedStep,
+  type PersistedTrajectory,
+  type RawSqlExecutor,
+  saveTrajectory,
+} from "./trajectory-internals.ts";
+import {
+  clearAllSteps,
+  deleteStepsForTrajectories,
+  replaceStepsForTrajectory,
+  upsertStep,
+} from "./trajectory-steps-writer.ts";
+
+vi.mock("./trajectory-internals.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./trajectory-internals.ts")>();
+  return {
+    ...actual,
+    loadTrajectoryById: vi.fn(),
+    saveTrajectory: vi.fn(),
+    executeRawSqlTransaction: vi.fn(),
+  };
+});
+
+const loadTrajectoryByIdMock = vi.mocked(loadTrajectoryById);
+const saveTrajectoryMock = vi.mocked(saveTrajectory);
+const executeRawSqlTransactionMock = vi.mocked(executeRawSqlTransaction);
+
+function runtimeWithDb(agentId = "agent-writer"): IAgentRuntime {
+  return {
+    agentId,
+    adapter: {
+      db: {
+        execute: async () => ({ rows: [] }),
+      },
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function runtimeWithoutDb(agentId = "agent-no-db"): IAgentRuntime {
+  return { agentId } as unknown as IAgentRuntime;
+}
+
+function makeStep(
+  overrides: Partial<PersistedStep> &
+    Pick<PersistedStep, "stepId" | "stepNumber">,
+): PersistedStep {
+  return {
+    timestamp: 1_700_000_000_000,
+    llmCalls: [],
+    providerAccesses: [],
+    ...overrides,
+  };
+}
+
+function makeTrajectory(
+  overrides: Partial<PersistedTrajectory> = {},
+): PersistedTrajectory {
+  return {
+    id: "traj-1",
+    agentId: "agent-writer",
+    source: "test",
+    status: "active",
+    startTime: 1_700_000_000_000,
+    endTime: null,
+    steps: [],
+    metadata: {},
+    metrics: {},
+    rewardComponents: { environmentReward: 0 },
+    totalReward: 0,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function captureSql(result: unknown): { sql: string[] } {
+  const sql: string[] = [];
+  const execute: RawSqlExecutor = async (sqlText) => {
+    sql.push(sqlText);
+    return result;
+  };
+  executeRawSqlTransactionMock.mockImplementation(async (_runtime, work) =>
+    work(execute),
+  );
+  return { sql };
+}
+
+describe("trajectory-steps-writer", () => {
+  beforeEach(() => {
+    loadTrajectoryByIdMock.mockReset();
+    saveTrajectoryMock.mockReset();
+    executeRawSqlTransactionMock.mockReset();
+    saveTrajectoryMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("upsertStep", () => {
+    it("throws TRAJECTORY_DATABASE_UNAVAILABLE when storage is missing", async () => {
+      const step = makeStep({ stepId: "s1", stepNumber: 0 });
+      await expect(
+        upsertStep(runtimeWithoutDb(), "traj-1", step),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_DATABASE_UNAVAILABLE",
+      });
+      expect(loadTrajectoryByIdMock).not.toHaveBeenCalled();
+      expect(saveTrajectoryMock).not.toHaveBeenCalled();
+    });
+
+    it("throws TRAJECTORY_PARENT_NOT_FOUND when the parent trajectory is missing", async () => {
+      const runtime = runtimeWithDb();
+      const step = makeStep({ stepId: "orphan-step", stepNumber: 0 });
+      loadTrajectoryByIdMock.mockResolvedValue(null);
+
+      await expect(
+        upsertStep(runtime, "missing-traj", step),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_PARENT_NOT_FOUND",
+        context: { trajectoryId: "missing-traj", stepId: "orphan-step" },
+      });
+      expect(saveTrajectoryMock).not.toHaveBeenCalled();
+    });
+
+    it("appends a new step onto an empty queue and stamps updatedAt", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-23T12:00:00.000Z"));
+      const runtime = runtimeWithDb();
+      const trajectory = makeTrajectory();
+      const step = makeStep({ stepId: "new-step", stepNumber: 0 });
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, step);
+
+      expect(trajectory.steps).toEqual([step]);
+      expect(trajectory.updatedAt).toBe("2026-08-23T12:00:00.000Z");
+      expect(saveTrajectoryMock).toHaveBeenCalledWith(runtime, trajectory, {
+        changedStepIds: ["new-step"],
+        updateLegacySnapshot: true,
+      });
+    });
+
+    it("appends a new step after existing rows instead of replacing them", async () => {
+      const runtime = runtimeWithDb();
+      const existing = makeStep({ stepId: "keep", stepNumber: 0 });
+      const incoming = makeStep({ stepId: "added", stepNumber: 1 });
+      const trajectory = makeTrajectory({ steps: [existing] });
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, incoming);
+
+      expect(trajectory.steps).toEqual([existing, incoming]);
+      expect(trajectory.steps[0]).toBe(existing);
+    });
+
+    it("replaces the matching step in place, including a middle index", async () => {
+      const runtime = runtimeWithDb();
+      const first = makeStep({ stepId: "a", stepNumber: 0 });
+      const middle = makeStep({
+        stepId: "b",
+        stepNumber: 1,
+        script: "old-script",
+      });
+      const last = makeStep({ stepId: "c", stepNumber: 2 });
+      const replacement = makeStep({
+        stepId: "b",
+        stepNumber: 1,
+        script: "new-script",
+      });
+      const trajectory = makeTrajectory({ steps: [first, middle, last] });
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, replacement);
+
+      expect(trajectory.steps).toHaveLength(3);
+      expect(trajectory.steps[0]).toBe(first);
+      expect(trajectory.steps[1]).toEqual(replacement);
+      expect(trajectory.steps[1]).not.toBe(middle);
+      expect(trajectory.steps[2]).toBe(last);
+      expect(saveTrajectoryMock).toHaveBeenCalledWith(runtime, trajectory, {
+        changedStepIds: ["b"],
+        updateLegacySnapshot: true,
+      });
+    });
+
+    it("leaves parentStepId unchanged when the override argument is omitted", async () => {
+      const runtime = runtimeWithDb();
+      const step = makeStep({
+        stepId: "child",
+        stepNumber: 1,
+        parentStepId: "original-parent",
+      });
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, step);
+
+      expect(trajectory.steps[0]?.parentStepId).toBe("original-parent");
+    });
+
+    it("overrides parentStepId when a parent id is provided", async () => {
+      const runtime = runtimeWithDb();
+      const step = makeStep({
+        stepId: "child",
+        stepNumber: 1,
+        parentStepId: "original-parent",
+      });
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, step, "wired-parent");
+
+      expect(trajectory.steps[0]?.parentStepId).toBe("wired-parent");
+    });
+
+    it("clears parentStepId when the override is null", async () => {
+      const runtime = runtimeWithDb();
+      const step = makeStep({
+        stepId: "child",
+        stepNumber: 1,
+        parentStepId: "original-parent",
+      });
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, step, null);
+
+      expect(trajectory.steps[0]?.parentStepId).toBeUndefined();
+    });
+
+    it("accepts a runtime whose db is only on databaseAdapter", async () => {
+      const runtime = {
+        agentId: "legacy-agent",
+        databaseAdapter: {
+          db: {
+            execute: async () => ({ rows: [] }),
+          },
+        },
+      } as unknown as IAgentRuntime;
+      const trajectory = makeTrajectory({ agentId: "legacy-agent" });
+      const step = makeStep({ stepId: "legacy-step", stepNumber: 0 });
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await upsertStep(runtime, trajectory.id, step);
+
+      expect(saveTrajectoryMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("replaceStepsForTrajectory", () => {
+    it("throws TRAJECTORY_DATABASE_UNAVAILABLE when storage is missing", async () => {
+      await expect(
+        replaceStepsForTrajectory(runtimeWithoutDb(), "traj-1", []),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_DATABASE_UNAVAILABLE",
+      });
+      expect(loadTrajectoryByIdMock).not.toHaveBeenCalled();
+    });
+
+    it("throws TRAJECTORY_PARENT_NOT_FOUND without a stepId in context", async () => {
+      const runtime = runtimeWithDb();
+      loadTrajectoryByIdMock.mockResolvedValue(null);
+
+      await expect(
+        replaceStepsForTrajectory(runtime, "missing-traj", [
+          makeStep({ stepId: "s1", stepNumber: 0 }),
+        ]),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_PARENT_NOT_FOUND",
+        context: { trajectoryId: "missing-traj" },
+      });
+      expect(saveTrajectoryMock).not.toHaveBeenCalled();
+    });
+
+    it("replaces with an empty step list", async () => {
+      const runtime = runtimeWithDb();
+      const trajectory = makeTrajectory({
+        steps: [makeStep({ stepId: "gone", stepNumber: 0 })],
+      });
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await replaceStepsForTrajectory(runtime, trajectory.id, []);
+
+      expect(trajectory.steps).toEqual([]);
+      expect(saveTrajectoryMock).toHaveBeenCalledWith(runtime, trajectory);
+    });
+
+    it("keeps a single-element replacement in the same order", async () => {
+      const runtime = runtimeWithDb();
+      const only = makeStep({ stepId: "only", stepNumber: 7 });
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await replaceStepsForTrajectory(runtime, trajectory.id, [only]);
+
+      expect(trajectory.steps).toEqual([only]);
+      expect(trajectory.steps[0]).toBe(only);
+    });
+
+    it("sorts by stepNumber without mutating the caller array", async () => {
+      const runtime = runtimeWithDb();
+      const late = makeStep({ stepId: "late", stepNumber: 5 });
+      const negative = makeStep({ stepId: "neg", stepNumber: -1 });
+      const zero = makeStep({ stepId: "zero", stepNumber: 0 });
+      const input = [late, negative, zero];
+      const snapshot = [...input];
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await replaceStepsForTrajectory(runtime, trajectory.id, input);
+
+      expect(input).toEqual(snapshot);
+      expect(trajectory.steps.map((step) => step.stepId)).toEqual([
+        "neg",
+        "zero",
+        "late",
+      ]);
+    });
+
+    it("keeps original order for equal stepNumber ties", async () => {
+      const runtime = runtimeWithDb();
+      const first = makeStep({ stepId: "first", stepNumber: 1 });
+      const second = makeStep({ stepId: "second", stepNumber: 1 });
+      const third = makeStep({ stepId: "third", stepNumber: 1 });
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await replaceStepsForTrajectory(runtime, trajectory.id, [
+        first,
+        second,
+        third,
+      ]);
+
+      expect(trajectory.steps.map((step) => step.stepId)).toEqual([
+        "first",
+        "second",
+        "third",
+      ]);
+    });
+
+    it("stamps updatedAt and does not pass upsert save options", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-23T15:30:00.000Z"));
+      const runtime = runtimeWithDb();
+      const trajectory = makeTrajectory();
+      loadTrajectoryByIdMock.mockResolvedValue(trajectory);
+
+      await replaceStepsForTrajectory(runtime, trajectory.id, [
+        makeStep({ stepId: "s", stepNumber: 0 }),
+      ]);
+
+      expect(trajectory.updatedAt).toBe("2026-08-23T15:30:00.000Z");
+      expect(saveTrajectoryMock.mock.calls[0]?.[2]).toBeUndefined();
+    });
+  });
+
+  describe("deleteStepsForTrajectories", () => {
+    it("throws TRAJECTORY_DATABASE_UNAVAILABLE when storage is missing", async () => {
+      await expect(
+        deleteStepsForTrajectories(runtimeWithoutDb(), ["traj-1"]),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_DATABASE_UNAVAILABLE",
+      });
+      expect(executeRawSqlTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 for an empty id list without opening a transaction", async () => {
+      const runtime = runtimeWithDb();
+      await expect(deleteStepsForTrajectories(runtime, [])).resolves.toBe(0);
+      expect(executeRawSqlTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 when every id is blank or whitespace", async () => {
+      const runtime = runtimeWithDb();
+      await expect(
+        deleteStepsForTrajectories(runtime, ["", "   ", "\t", "\n"]),
+      ).resolves.toBe(0);
+      expect(executeRawSqlTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it("trims ids, quotes apostrophes, and scopes delete to the runtime agent", async () => {
+      const runtime = runtimeWithDb("agent's-id");
+      const { sql } = captureSql({
+        rows: [{ trajectory_id: "traj-1" }, { trajectory_id: "traj-2" }],
+      });
+
+      const deleted = await deleteStepsForTrajectories(runtime, [
+        "  traj-1  ",
+        "",
+        "traj-2",
+        "it's",
+      ]);
+
+      expect(deleted).toBe(2);
+      expect(sql).toHaveLength(1);
+      const statement = sql[0] ?? "";
+      expect(statement).toContain("DELETE FROM trajectory_steps");
+      expect(statement).toContain("RETURNING trajectory_id");
+      expect(statement).toContain("agent_id = 'agent''s-id'");
+      expect(statement).toContain("'traj-1'");
+      expect(statement).toContain("'traj-2'");
+      expect(statement).toContain("'it''s'");
+      expect(statement).not.toMatch(/''\s*,/);
+    });
+
+    it("returns 0 when the delete matches no rows", async () => {
+      const runtime = runtimeWithDb();
+      captureSql({ rows: [] });
+
+      await expect(
+        deleteStepsForTrajectories(runtime, ["missing-traj"]),
+      ).resolves.toBe(0);
+    });
+
+    it("counts returned rows rather than unique trajectory ids", async () => {
+      const runtime = runtimeWithDb();
+      captureSql({
+        rows: [
+          { trajectory_id: "dup" },
+          { trajectory_id: "dup" },
+          { trajectory_id: "other" },
+        ],
+      });
+
+      await expect(
+        deleteStepsForTrajectories(runtime, ["dup", "other"]),
+      ).resolves.toBe(3);
+    });
+
+    it("rejects a malformed SQL result instead of reporting an empty delete", async () => {
+      const runtime = runtimeWithDb();
+      captureSql({});
+
+      await expect(
+        deleteStepsForTrajectories(runtime, ["traj-1"]),
+      ).rejects.toMatchObject({
+        code: "TRAJECTORY_ROW_INVALID",
+        context: { operation: "delete trajectory steps" },
+      });
+    });
+  });
+
+  describe("clearAllSteps", () => {
+    it("throws TRAJECTORY_DATABASE_UNAVAILABLE when storage is missing", async () => {
+      await expect(clearAllSteps(runtimeWithoutDb())).rejects.toMatchObject({
+        code: "TRAJECTORY_DATABASE_UNAVAILABLE",
+      });
+      expect(executeRawSqlTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it("deletes every step owned by the runtime agent and returns the row count", async () => {
+      const runtime = runtimeWithDb("clear-agent");
+      const { sql } = captureSql({
+        rows: [{ trajectory_id: "t1" }, { trajectory_id: "t2" }],
+      });
+
+      await expect(clearAllSteps(runtime)).resolves.toBe(2);
+      expect(sql).toHaveLength(1);
+      const statement = sql[0] ?? "";
+      expect(statement).toContain("DELETE FROM trajectory_steps");
+      expect(statement).toContain("trajectory_id IN (");
+      expect(statement).toContain(
+        "SELECT id FROM trajectories WHERE agent_id = 'clear-agent'",
+      );
+      expect(statement).toContain("RETURNING trajectory_id");
+      expect(statement).not.toMatch(/AND id IN \(/);
+    });
+
+    it("returns 0 when the agent owns no step rows", async () => {
+      const runtime = runtimeWithDb();
+      captureSql({ rows: [] });
+      await expect(clearAllSteps(runtime)).resolves.toBe(0);
+    });
+
+    it("rejects a malformed SQL result instead of reporting an empty clear", async () => {
+      const runtime = runtimeWithDb();
+      captureSql({});
+
+      await expect(clearAllSteps(runtime)).rejects.toMatchObject({
+        code: "TRAJECTORY_ROW_INVALID",
+        context: { operation: "clear trajectory steps" },
+      });
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

Operator-selected coverage gap: `packages/agent/src/runtime/trajectory-steps-writer.ts` had no same-named test file anywhere in the repo. The CQRS writer (`upsertStep`, `replaceStepsForTrajectory`, `deleteStepsForTrajectories`, `clearAllSteps`) is the dedicated `trajectory_steps` write path; a regression here silently drops steps, mis-orders replacements, or reports empty deletes on malformed SQL results.

This PR adds one colocated test file and does not change production behavior.

Definition of Done: focused behavioral tests for the exported writer, recorded at the exact pushed head.

- [x] This PR targets `develop` and is based on the latest fetched `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`) with zero conflicts.
- [x] A reviewer can confirm the changed coverage from the committed focused test and inline vitest/biome/tsc output below.
- [ ] `bun run verify` was not run. This is a test-only addition; focused `vitest`, `biome`, and `tsc` on the new file are the complete evidence set. Hosted GitHub Actions CI does **not** run on this fork-authored PR.

# Sync with develop

- [x] Branch parent is current `origin/develop` `462e1742e672196f127d9390759f1334d6b74dc9`; zero conflicts.
- [ ] `bun run verify` was not run (test-only PR; focused checks quoted below).

# Risks

Low. Tests only. No production source, export, or persistence-path change.

# Background

## What does this PR do?

Adds `packages/agent/src/runtime/trajectory-steps-writer.test.ts`, which imports the four writer exports from `./trajectory-steps-writer.ts` (the same relative path production uses) and drives the real writer.

`sqlQuote` and `extractRequiredRows` stay the real internals helpers. `loadTrajectoryById`, `saveTrajectory`, and `executeRawSqlTransaction` are stubbed collaborators so writer-owned branches can be asserted without a SQL engine. The writer is never replaced with a mock: typed errors, in-memory step mutation, sort, ID normalization, and SQL construction all run for real.

Covered branches:

1. `upsertStep` / `replaceStepsForTrajectory` / `deleteStepsForTrajectories` / `clearAllSteps` throw `TRAJECTORY_DATABASE_UNAVAILABLE` when `hasRuntimeDb` is false, without touching load/save/transaction.
2. Missing parent: `TRAJECTORY_PARENT_NOT_FOUND` with `{ trajectoryId, stepId }` on upsert and `{ trajectoryId }` on replace; save is not called.
3. Upsert empty queue: appends, stamps `updatedAt`, saves with `changedStepIds` and `updateLegacySnapshot: true`.
4. Upsert insert vs in-place replace, including a middle index; existing neighbors stay the same object references.
5. `parentStepId` omitted preserves the step field; a string override wins; `null` clears it.
6. Runtime whose db is only on `databaseAdapter` is treated as available.
7. Replace empty list, single element, sort by `stepNumber` without mutating the caller array (including a negative ordinal), and stable order on equal `stepNumber` ties.
8. Replace stamps `updatedAt` and does not pass upsert save options.
9. Delete empty/whitespace ID lists return `0` without opening a transaction.
10. Delete trims IDs, SQL-quotes apostrophes, scopes by `agent_id`, returns the RETURNING row count (including duplicate ids), returns `0` for a missing trajectory, and rejects a malformed SQL container with `TRAJECTORY_ROW_INVALID` instead of reporting an empty delete.
11. `clearAllSteps` deletes every step owned by the runtime agent, returns `0` when none exist, and rejects a malformed SQL container.

## What kind of change is this?

Test-only, non-breaking.

# Documentation changes needed?

No. The public API is unchanged.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/trajectory-steps-writer.test.ts`.

## Detailed testing steps

Focused proof re-run against current `origin/develop` immediately before filing, at pushed head `f8979148b6809b1ee978537237ddd83d71227cae`:

```bash
bunx vitest run packages/agent/src/runtime/trajectory-steps-writer.test.ts
bunx biome check --write packages/agent/src/runtime/trajectory-steps-writer.test.ts
cd packages/agent && bunx tsc --noEmit
```

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/agent/src/runtime/trajectory-steps-writer.test.ts (27 tests) 12ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
   Start at  16:02:21
   Duration  7.22s (transform 5.88s, setup 0ms, import 7.11s, tests 12ms, environment 0ms)
```

`bunx biome check --write packages/agent/src/runtime/trajectory-steps-writer.test.ts` — Checked 1 file in 34ms. No fixes applied. `biome.json` and `tsconfig.json` are present; this worktree is not sparse.

`packages/agent` `tsconfig.json` includes `src`, so this test is typechecked. `bunx tsc --noEmit` in `packages/agent` piped to `grep trajectory-steps-writer.test` was empty (`EXIT:1` from grep). No production file changed, so the typecheck delta versus an untouched control is zero new errors from this PR.

The diff touches only `packages/agent/src/runtime/trajectory-steps-writer.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork-authored PR. This body does not imply CI passed.

# Evidence Gate

<!-- evidence-head:f8979148b6809b1ee978537237ddd83d71227cae -->

Test-only change; no UI, backend log path, or live-model surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only, no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only, no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only; no production path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only; no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/memory/schedule/wallet artifact; unit tests use stubbed load/save/transaction collaborators.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; no production path changed.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI surface.

### Before

N/A - test-only, no UI surface.

### After

N/A - test-only, no UI surface.

### Walkthrough video

N/A - test-only, no UI surface.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Focused vitest/biome/tsc on the new test file are the complete evidence set for this test-only PR.
- Hosted GitHub Actions CI does not run on fork-authored PRs.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
