### PR TITLE
test(agent): cover version

### DIFF
--- a/packages/agent/src/runtime/version.test.ts
+++ b/packages/agent/src/runtime/version.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Behavioral coverage for the runtime VERSION constant. Drives the real
+ * module: import-time resolution from this file's location, package.json
+ * match when no bundle override is set, ELIZA_BUNDLED_VERSION preference on
+ * a fresh load, empty-override fallthrough, whitespace-only override, and
+ * the 0.0.0 fallback when require() cannot see the agent package.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveElizaVersion } from "../version-resolver.ts";
+import { VERSION } from "./version.ts";
+
+const VERSION_MODULE_URL = new URL("./version.ts", import.meta.url).href;
+const AGENT_PACKAGE_JSON = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+);
+const agentPackage = JSON.parse(readFileSync(AGENT_PACKAGE_JSON, "utf8")) as {
+  version: string;
+};
+const originalBundledVersion = process.env.ELIZA_BUNDLED_VERSION;
+
+afterEach(() => {
+  if (originalBundledVersion === undefined) {
+    delete process.env.ELIZA_BUNDLED_VERSION;
+  } else {
+    process.env.ELIZA_BUNDLED_VERSION = originalBundledVersion;
+  }
+});
+
+describe("VERSION", () => {
+  it("exports a non-empty string resolved at import time", () => {
+    expect(typeof VERSION).toBe("string");
+    expect(VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("matches the agent package.json version when no bundle override is set", () => {
+    expect(process.env.ELIZA_BUNDLED_VERSION).toBeUndefined();
+    expect(agentPackage.version.length).toBeGreaterThan(0);
+    expect(VERSION).toBe(agentPackage.version);
+  });
+
+  it("equals resolveElizaVersion for this module's import.meta.url", () => {
+    expect(VERSION).toBe(resolveElizaVersion(VERSION_MODULE_URL));
+  });
+
+  it("is the same constant across a re-import of the cached module", async () => {
+    const again = await import("./version.ts");
+    expect(again.VERSION).toBe(VERSION);
+  });
+
+  it("is not the stripped-bundle 0.0.0 fallback while package.json is visible", () => {
+    expect(VERSION).not.toBe("0.0.0");
+  });
+
+  it("anchors require() at this module so a foreign URL cannot see the agent package.json", () => {
+    expect(resolveElizaVersion("file:///tmp/not-an-agent-module.ts")).toBe(
+      "0.0.0",
+    );
+    expect(VERSION).toBe(agentPackage.version);
+  });
+
+  it("prefers ELIZA_BUNDLED_VERSION when the module is loaded under that env", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "9.9.9-bundled";
+    vi.resetModules();
+    const { VERSION: bundledVersion } = await import("./version.ts");
+    expect(bundledVersion).toBe("9.9.9-bundled");
+  });
+
+  it("falls through an empty ELIZA_BUNDLED_VERSION to package.json", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "";
+    vi.resetModules();
+    const { VERSION: resolved } = await import("./version.ts");
+    expect(resolved).toBe(agentPackage.version);
+  });
+
+  it("uses a whitespace-only ELIZA_BUNDLED_VERSION as a truthy override", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = " ";
+    vi.resetModules();
+    const { VERSION: resolved } = await import("./version.ts");
+    expect(resolved).toBe(" ");
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/runtime/version.ts`, which had no same-named test file. No linked issue; no production change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`) with zero conflicts.
- [x] Focused package checks were run after sync (vitest, biome, tsc). `bun run verify` is N/A for this test-only single-file addition; the scoped counts are quoted below.
- [x] A reviewer can confirm the change from the vitest/biome/tsc counts below without reading production code (there is no production diff).

# Sync with develop

- [x] Commit parent is current `origin/develop` (`462e1742e672196f127d9390759f1334d6b74dc9`); zero conflicts.
- [x] `bun run verify` not re-run at repo scale. Scoped evidence: vitest 9/9, biome clean, tsc grep empty for this file.

# Risks

Low. Test-only addition. No production code, no runtime behavior change, no public API change. Worst case is a brittle assertion if `ELIZA_BUNDLED_VERSION` is set in a future test worker; the suite restores that env in `afterEach`.

# Background

## What does this PR do?

Adds `packages/agent/src/runtime/version.test.ts`, a colocated Vitest suite for the runtime `VERSION` constant. That module has one export: `VERSION = resolveElizaVersion(import.meta.url)`.

The suite drives the real module (no mocks of the SUT) and records observed behavior:

- `VERSION` is a non-empty string resolved at import
- with `ELIZA_BUNDLED_VERSION` unset, it matches `packages/agent/package.json` (`2.0.3-beta.7` on this develop)
- it equals `resolveElizaVersion` called with this module's URL
- re-import of the cached module returns the same constant
- it is not the stripped-bundle `"0.0.0"` fallback while package.json is visible
- a foreign `file://` URL cannot see the agent package.json and falls back to `"0.0.0"` (this is why `version.ts` passes its own `import.meta.url`)
- a fresh load prefers `ELIZA_BUNDLED_VERSION` when that env is set
- an empty `ELIZA_BUNDLED_VERSION` is falsy and falls through to package.json
- a whitespace-only `ELIZA_BUNDLED_VERSION` is truthy and is used as-is

## What kind of change is this?

Improvements — tests for existing behavior. No production code change.

## Why are we doing this? Any context or related work?

`packages/agent/src/runtime/version.ts` had no same-named test file. `VERSION` is consumed by the update checker, config schema, and update routes; a regression in import-time resolution (wrong `import.meta.url` base, env override, or missing package.json fallback) would ship the wrong version string.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/version.test.ts` and the one-export module it covers.

## Detailed testing steps

Automated tests are the acceptance path.

```bash
cd packages/agent && bunx vitest run src/runtime/version.test.ts
```

Observed against current `origin/develop` immediately before filing:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Hosted CI does **not** run on this fork contributor's pull requests. Do not infer that GitHub Actions passed.

# Evidence Gate

Evidence matches exact head `bd1aef8c9047f4ff74e7f5aa8ad7529a271d0570`.

This PR adds tests and changes **no** production behaviour. Frontend screenshots, walkthrough video, backend/frontend logs, LLM trajectory, domain artifacts, and OCR are N/A.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only change; no backend path change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only change; no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact producer changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only change; no runtime path change.

## Screenshots (before / after) + video walkthrough

N/A - test-only change; no UI.

### Before

N/A - test-only change; no UI.

### After

N/A - test-only change; no UI.

### Walkthrough video

N/A - test-only change; no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run at repo scale. Scoped evidence instead:
  1. `bunx vitest run src/runtime/version.test.ts` (from `packages/agent`) — Test Files 1 passed (1), Tests 9 passed (9). Re-run against current `origin/develop` immediately before filing.
  2. `bunx biome check --write packages/agent/src/runtime/version.test.ts` — Checked 1 file in 191ms. No fixes applied. Repo `biome.json` is present; tree is not sparse.
  3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep version.test.ts` — empty (this file introduces no TypeScript errors). Pre-existing package errors elsewhere are not this PR.
  4. Diff touches only `packages/agent/src/runtime/version.test.ts`.
- Hosted CI does not run on this fork contributor's PRs.
- No identity.slop.cash OAuth trace: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bd1aef8c9047f4ff74e7f5aa8ad7529a271d0570 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
