### PR TITLE
test(auth): await Steward token cleanup

### DIFF
--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -103,7 +103,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       branding: {},
       apiBase: "https://api.eliza.app/api/v1/eliza/agents/shared-agent",
     });
-    clearStoredStewardToken();
+    await clearStoredStewardToken();
 
     const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
 
@@ -127,7 +127,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       apiBase,
       accessToken: "shared-agent-token",
     });
-    clearStoredStewardToken();
+    await clearStoredStewardToken();
     setStewardAuthedCookie(true);
     fetchMock.mockResolvedValue(jsonResponse(200, { token: refreshedToken }));
 
@@ -163,7 +163,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       apiBase,
       accessToken: "stale-token-mirror",
     });
-    clearStoredStewardToken();
+    await clearStoredStewardToken();
     setStewardAuthedCookie(true);
     fetchMock.mockResolvedValue(jsonResponse(401, {}));
 
@@ -190,7 +190,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       apiBase,
       accessToken: "shared-agent-token",
     });
-    clearStoredStewardToken();
+    await clearStoredStewardToken();
     setStewardAuthedCookie(true);
     fetchMock.mockResolvedValue(jsonResponse(503, {}));
 
@@ -224,7 +224,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
         apiBase,
         accessToken: "shared-agent-token",
       });
-      clearStoredStewardToken();
+      await clearStoredStewardToken();
       setStewardAuthedCookie(true);
       fetchMock.mockResolvedValue(jsonResponse(status, {}));
 
@@ -252,7 +252,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       apiBase,
       accessToken: "shared-agent-token",
     });
-    clearStoredStewardToken();
+    await clearStoredStewardToken();
     setStewardAuthedCookie(true);
     fetchMock.mockResolvedValue(jsonResponse(200, {}));
 
@@ -272,6 +272,7 @@ describe("primeAuthStatusProbe + activation reuse", () => {
 
   it("preserves a native owner API-key session without a Steward JWT", async () => {
     const apiBase = "https://api.eliza.app/api/v1/eliza/agents/shared-agent";
+    await clearStoredStewardToken();
     (
       window as Window & { __electrobunWindowId?: number }
     ).__electrobunWindowId = 1;
@@ -287,8 +288,6 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       apiBase,
       accessToken: "eliza_native_owner_key",
     });
-    clearStoredStewardToken();
-
     const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary

- await asynchronous Steward token cleanup before Auth status recovery assertions
- clear the stored Steward token before enabling the native protected-storage owner fixture
- keep the change test-only; no runtime, provider, schema, workflow, or deployment behavior changes

`clearStoredStewardToken()` is serialized and asynchronous. The prior unawaited calls could race the status probe, and the native-owner case could enable protected storage before cleanup, producing nondeterministic authentication expectations or an unhandled `StewardTokenRemovalError`.

Review: @lalalune

## Current-base proof

- review head: `b5635b8a2b2dceef7b0c120e23749e48aa275b56`
- reconciled develop checkpoint: `d2cdce0d56b91eea0898841cbfa01f0d8476cb7b` via no-force merges; the intervening account-sort, Agent-test, and Anthropic changes have no Auth-file overlap
- stable patch ID: `ba83eb8a2390fb285989a5bd09b5435d60bb0ebb`
- affected file: 20/20 tests passed again after the current-develop reconciliation
- current Auth UI matrix: 51 files / 450 tests passed before that non-overlapping reconciliation
- touched-file Biome check passed
- gateway common: 54/54 passed
- gateway-discord: 179/179 passed
- isolated gateway-webhook Auth/identity and Docker-context contracts: 31/31 passed
- `git diff --check` passed
- scoped added-line secret scan: zero matches

Develop continued moving after the review head was published. The later commits inspected at this checkpoint were outside Auth/gateway; this branch deliberately preserves the no-force review head instead of repeatedly merging unrelated churn.

## CI status

PR Static Smoke run `32634388315` passed candidate-diff validation, the gitleaks scan, workflow lint, workspace setup, Bun-pin validation, and core build. It then failed UI lint on formatter errors already present in develop commit `2a7359db52` / PR #25564:

- `packages/ui/src/components/accounts/account-table-model.safe-sort.test.ts`
- `packages/ui/src/components/accounts/account-table-model.ts`
- `packages/ui/src/components/accounts/reset-time.ts`

Those files are unchanged by this PR. The Auth-owned file is not in the failure set, and its focused Biome check passed. Typecheck/build were skipped after the upstream lint failure. Re-run static smoke after develop repairs those base formatting errors.

## Local environment note

The fresh current-base checkout exhausted local disk during the unrelated `ffmpeg-static` install script after dependency extraction. The UI tests were therefore run against the current source/config using the repository-pinned Vitest 4.1.10 executable from the preserved clean Auth checkout. Full local package typecheck and webhook build could not resolve generated workspace build outputs because the interrupted install did not complete those build steps. No source failure was observed.

## Rollback

Revert the single test-only commit.
