### PR TITLE
test(app): retain privacy-safe Cloud liveness failure evidence

### DIFF
--- a/packages/app/test/liveness-contract.mjs
+++ b/packages/app/test/liveness-contract.mjs
@@ -161,6 +161,89 @@ export function findAnchoredLiveTurn(lines, { anchorToken } = {}) {
 }
 
 /**
+ * Reduce the first assistant row owned by an anchored user turn to a
+ * privacy-safe diagnostic. This deliberately returns no text, token, indices,
+ * IDs, or failure value. It mirrors {@link findAnchoredLiveTurn}'s ownership
+ * boundary so a hosted failure can distinguish a missing anchor, a missing
+ * assistant row, and an ineligible owner row without persisting conversation
+ * content.
+ *
+ * @param {Array<{
+ *   role?: string,
+ *   text?: string,
+ *   failureKind?: string,
+ *   hasRetry?: boolean,
+ *   interrupted?: boolean,
+ *   hasMessageText?: boolean | null,
+ *   phase?: string | null,
+ * }>} lines ordered thread rows
+ * @param {{ anchorToken?: string }} [options]
+ * @returns {{
+ *   anchorUserPresent: boolean,
+ *   assistantRowPresent: boolean,
+ *   assistantFailurePresent: boolean,
+ *   assistantRetryPresent: boolean,
+ *   assistantInterrupted: boolean,
+ *   assistantHasMessageText: boolean | null,
+ *   assistantPhase: "status" | "reply" | "other" | null,
+ *   assistantHasText: boolean,
+ * }}
+ */
+export function describeAnchoredLiveTurnState(lines, { anchorToken } = {}) {
+  const unavailable = {
+    anchorUserPresent: false,
+    assistantRowPresent: false,
+    assistantFailurePresent: false,
+    assistantRetryPresent: false,
+    assistantInterrupted: false,
+    assistantHasMessageText: null,
+    assistantPhase: null,
+    assistantHasText: false,
+  };
+  const token = String(anchorToken ?? "")
+    .trim()
+    .toLowerCase();
+  if (!token || !Array.isArray(lines)) return unavailable;
+
+  const userLineIndex = lines.findIndex(
+    (line) =>
+      line?.role === "user" &&
+      String(line.text ?? "")
+        .toLowerCase()
+        .includes(token),
+  );
+  if (userLineIndex < 0) return unavailable;
+  const anchorOnly = { ...unavailable, anchorUserPresent: true };
+  for (
+    let assistantLineIndex = userLineIndex + 1;
+    assistantLineIndex < lines.length;
+    assistantLineIndex += 1
+  ) {
+    const line = lines[assistantLineIndex];
+    if (line?.role === "user") return anchorOnly;
+    if (line?.role !== "assistant") continue;
+    const phase = String(line.phase ?? "").trim();
+    return {
+      anchorUserPresent: true,
+      assistantRowPresent: true,
+      assistantFailurePresent: Boolean(String(line.failureKind ?? "").trim()),
+      assistantRetryPresent: line.hasRetry === true,
+      assistantInterrupted: line.interrupted === true,
+      assistantHasMessageText:
+        typeof line.hasMessageText === "boolean" ? line.hasMessageText : null,
+      assistantPhase:
+        phase === "status" || phase === "reply"
+          ? phase
+          : phase
+            ? "other"
+            : null,
+      assistantHasText: Boolean(String(line.text ?? "").trim()),
+    };
+  }
+  return anchorOnly;
+}
+
+/**
  * The challenge suffix shared by every liveness lane that binds the reply to
  * the exact run. The token after the colon is what the harness generates fresh
  * per run and what the reply must echo back. Kept as the one literal so the

--- a/packages/app/test/liveness-contract.test.ts
+++ b/packages/app/test/liveness-contract.test.ts
@@ -13,6 +13,7 @@ import {
   assertLiveChallengeReply,
   assertLiveReply,
   buildLivenessChallenge,
+  describeAnchoredLiveTurnState,
   extractLivenessChallengeToken,
   findAnchoredLiveTurn,
   isLiveReply,
@@ -299,5 +300,71 @@ describe("structural user-turn anchoring", () => {
         { anchorToken: "" },
       ),
     ).toBeNull();
+  });
+
+  it("reduces anchored row states without retaining transcript content", () => {
+    const transcript = [
+      { role: "assistant", text: "private old reply", phase: "reply" },
+      { role: "user", text: `private prompt ${anchorToken}` },
+      {
+        role: "assistant",
+        text: "private failed reply",
+        failureKind: "private_failure_code",
+        hasRetry: true,
+        interrupted: true,
+        hasMessageText: false,
+        phase: "status",
+      },
+    ];
+    const diagnostic = describeAnchoredLiveTurnState(transcript, {
+      anchorToken,
+    });
+
+    expect(diagnostic).toEqual({
+      anchorUserPresent: true,
+      assistantRowPresent: true,
+      assistantFailurePresent: true,
+      assistantRetryPresent: true,
+      assistantInterrupted: true,
+      assistantHasMessageText: false,
+      assistantPhase: "status",
+      assistantHasText: true,
+    });
+    expect(JSON.stringify(diagnostic)).not.toMatch(
+      /private|failure_code|9f8e7d/,
+    );
+  });
+
+  it("distinguishes missing anchors and assistant rows without crossing user turns", () => {
+    expect(
+      describeAnchoredLiveTurnState(
+        [{ role: "assistant", text: `reply ${anchorToken}` }],
+        { anchorToken },
+      ),
+    ).toEqual({
+      anchorUserPresent: false,
+      assistantRowPresent: false,
+      assistantFailurePresent: false,
+      assistantRetryPresent: false,
+      assistantInterrupted: false,
+      assistantHasMessageText: null,
+      assistantPhase: null,
+      assistantHasText: false,
+    });
+    expect(
+      describeAnchoredLiveTurnState(
+        [
+          { role: "user", text: anchorToken },
+          { role: "user", text: "later private turn" },
+          { role: "assistant", text: "later private reply", phase: "reply" },
+        ],
+        { anchorToken },
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        anchorUserPresent: true,
+        assistantRowPresent: false,
+      }),
+    );
   });
 });

--- a/packages/app/test/liveness-contract.ts
+++ b/packages/app/test/liveness-contract.ts
@@ -29,6 +29,7 @@ export {
   assertLiveChallengeReply,
   assertLiveReply,
   buildLivenessChallenge,
+  describeAnchoredLiveTurnState,
   extractLivenessChallengeToken,
   findAnchoredLiveTurn,
   isLiveReply,

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -39,6 +39,7 @@ import {
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
 import {
   assertOnboardingLivenessWithTiming,
+  describeAnchoredLiveTurnState,
   findAnchoredLiveTurn,
   isLiveReply,
   readLivenessThreadLines,
@@ -742,7 +743,7 @@ test.describe("real cloud login + personal identity + chat", () => {
       // to an allowlisted name plus counts/booleans only. Never emit the draft,
       // challenge, response text, request URL, or any account/runtime ID.
       const auditAfterLiveness = await primaryAudit.snapshot();
-      const [domSnapshotResult] = await Promise.allSettled([
+      const [domSnapshotResult, threadLinesResult] = await Promise.allSettled([
         page.evaluate((before) => {
           const userRows = Array.from(
             document.querySelectorAll(
@@ -787,6 +788,7 @@ test.describe("real cloud login + personal identity + chat", () => {
             }),
           };
         }, domBeforeLiveness),
+        readLivenessThreadLines(page),
       ]);
       const domSnapshot =
         domSnapshotResult?.status === "fulfilled"
@@ -799,26 +801,102 @@ test.describe("real cloud login + personal identity + chat", () => {
         )
           ? error.name
           : "UnknownError";
+      const anchoredState = describeAnchoredLiveTurnState(
+        threadLinesResult.status === "fulfilled" ? threadLinesResult.value : [],
+        { anchorToken: turnAnchorToken },
+      );
+      const diagnosticRecord = {
+        originalErrorName,
+        chatSendAttemptDelta: Math.max(
+          0,
+          auditAfterLiveness.chatSendAttemptCount -
+            auditBeforeLiveness.chatSendAttemptCount,
+        ),
+        logicalChatSendDelta: Math.max(
+          0,
+          auditAfterLiveness.logicalChatSendCount -
+            auditBeforeLiveness.logicalChatSendCount,
+        ),
+        unidentifiedChatSendDelta: Math.max(
+          0,
+          auditAfterLiveness.unidentifiedChatSendAttemptCount -
+            auditBeforeLiveness.unidentifiedChatSendAttemptCount,
+        ),
+        namedWarmingResponseDelta: Math.max(
+          0,
+          auditAfterLiveness.namedWarmingResponseCount -
+            auditBeforeLiveness.namedWarmingResponseCount,
+        ),
+        successfulChatResponseDelta: Math.max(
+          0,
+          auditAfterLiveness.successfulChatSendResponseCount -
+            auditBeforeLiveness.successfulChatSendResponseCount,
+        ),
+        clientErrorChatResponseDelta: Math.max(
+          0,
+          auditAfterLiveness.clientErrorChatSendResponseCount -
+            auditBeforeLiveness.clientErrorChatSendResponseCount,
+        ),
+        serverErrorChatResponseDelta: Math.max(
+          0,
+          auditAfterLiveness.serverErrorChatSendResponseCount -
+            auditBeforeLiveness.serverErrorChatSendResponseCount,
+        ),
+        otherChatResponseDelta: Math.max(
+          0,
+          auditAfterLiveness.otherChatSendResponseCount -
+            auditBeforeLiveness.otherChatSendResponseCount,
+        ),
+        retryObservationAvailable: retryObservation.ok,
+        retryChipEverObserved: retryObservation.ok
+          ? retryObservation.retryChipEverObserved
+          : "unavailable",
+        domSnapshotAvailable: domSnapshot !== null,
+        draftCleared: domSnapshot?.draftCleared ?? "unavailable",
+        newUserRowCount: domSnapshot?.newUserRowCount ?? "unavailable",
+        newAssistantRowCount:
+          domSnapshot?.newAssistantRowCount ?? "unavailable",
+        failureRowPresent: domSnapshot?.failureRowPresent ?? "unavailable",
+        retryRowPresent: domSnapshot?.retryRowPresent ?? "unavailable",
+        interruptedRowPresent:
+          domSnapshot?.interruptedRowPresent ?? "unavailable",
+        widgetOnlyReplyRowPresent:
+          domSnapshot?.widgetOnlyReplyRowPresent ?? "unavailable",
+        threadLinesAvailable: threadLinesResult.status === "fulfilled",
+        ...anchoredState,
+      };
+      const diagnosticPath = test
+        .info()
+        .outputPath("privacy-safe-liveness-history-network-diagnostics.json");
+      // error-policy:J2 retain only allowlisted counts, booleans, and enums.
+      // Artifact write failure must not replace the original liveness verdict.
+      const diagnosticArtifactWritten = await mkdir(dirname(diagnosticPath), {
+        recursive: true,
+        mode: 0o700,
+      })
+        .then(() =>
+          writeFile(
+            diagnosticPath,
+            `${JSON.stringify(
+              {
+                schema: "elizaos.cloud.liveness-failure-diagnostics/v1",
+                ...diagnosticRecord,
+              },
+              null,
+              2,
+            )}\n`,
+            { encoding: "utf8", flag: "wx", mode: 0o600 },
+          ),
+        )
+        .then(
+          () => true,
+          () => false,
+        );
       const diagnostic = [
-        `originalErrorName=${originalErrorName}`,
-        `chatSendAttemptDelta=${Math.max(0, auditAfterLiveness.chatSendAttemptCount - auditBeforeLiveness.chatSendAttemptCount)}`,
-        `logicalChatSendDelta=${Math.max(0, auditAfterLiveness.logicalChatSendCount - auditBeforeLiveness.logicalChatSendCount)}`,
-        `unidentifiedChatSendDelta=${Math.max(0, auditAfterLiveness.unidentifiedChatSendAttemptCount - auditBeforeLiveness.unidentifiedChatSendAttemptCount)}`,
-        `namedWarmingResponseDelta=${Math.max(0, auditAfterLiveness.namedWarmingResponseCount - auditBeforeLiveness.namedWarmingResponseCount)}`,
-        `successfulChatResponseDelta=${Math.max(0, auditAfterLiveness.successfulChatSendResponseCount - auditBeforeLiveness.successfulChatSendResponseCount)}`,
-        `clientErrorChatResponseDelta=${Math.max(0, auditAfterLiveness.clientErrorChatSendResponseCount - auditBeforeLiveness.clientErrorChatSendResponseCount)}`,
-        `serverErrorChatResponseDelta=${Math.max(0, auditAfterLiveness.serverErrorChatSendResponseCount - auditBeforeLiveness.serverErrorChatSendResponseCount)}`,
-        `otherChatResponseDelta=${Math.max(0, auditAfterLiveness.otherChatSendResponseCount - auditBeforeLiveness.otherChatSendResponseCount)}`,
-        `retryObservationAvailable=${retryObservation.ok}`,
-        `retryChipEverObserved=${retryObservation.ok ? retryObservation.retryChipEverObserved : "unavailable"}`,
-        `domSnapshotAvailable=${domSnapshot !== null}`,
-        `draftCleared=${domSnapshot?.draftCleared ?? "unavailable"}`,
-        `newUserRowCount=${domSnapshot?.newUserRowCount ?? "unavailable"}`,
-        `newAssistantRowCount=${domSnapshot?.newAssistantRowCount ?? "unavailable"}`,
-        `failureRowPresent=${domSnapshot?.failureRowPresent ?? "unavailable"}`,
-        `retryRowPresent=${domSnapshot?.retryRowPresent ?? "unavailable"}`,
-        `interruptedRowPresent=${domSnapshot?.interruptedRowPresent ?? "unavailable"}`,
-        `widgetOnlyReplyRowPresent=${domSnapshot?.widgetOnlyReplyRowPresent ?? "unavailable"}`,
+        ...Object.entries(diagnosticRecord).map(
+          ([name, value]) => `${name}=${value}`,
+        ),
+        `diagnosticArtifactWritten=${diagnosticArtifactWritten}`,
       ].join("; ");
       throw new Error(
         `Cloud live liveness failed; privacy-safe diagnostic: ${diagnostic}`,


### PR DESCRIPTION
## Summary

- retain a privacy-safe JSON artifact when deployed Cloud chat fails before the later history-continuity phases
- distinguish a missing anchored user row, missing owner assistant row, and ineligible owner state using only booleans and an allowlisted phase enum
- preserve the existing fail-closed liveness predicate and hosted retry behavior unchanged

## Incident

Staging Cloud CF run 32633068830 deployed and verified Worker, Pages, and routing at c2495219, then failed the deployed renderer check after one named warming 503 and one HTTP success. The workflow tried to upload privacy-safe history diagnostics, but no file existed because those artifacts were created only after liveness had already passed. Certification was skipped and Railway correctly remained closed.

## Validation

Final exact branch head 7fbdad346320cd474853c5f292a33fd0a931013a normally merges current base d2cdce0d56b91eea0898841cbfa01f0d8476cb7b; the diagnostic patch is byte-identical to locally proven aa8eb6ce5fc1f5c0f901a21f5936dee0155f89b3:

- linked-workspace build: 60/60 successful
- focused liveness and continuity contracts: 43/43 passed
- deployed Playwright spec compile/list: 1 test discovered
- Biome: clean on all four changed files
- git diff --check: clean
- gitleaks: one commit, no leaks
- app typecheck reaches only the unchanged canonical InboxChat.roomId diagnostic in packages/agent/src/api/inbox-routes.ts; no changed-file diagnostic
- replacement PR Static Smoke 32634397411 has passed secrets, workflow lint, core build, and affected-workspace lint; remaining steps are still running

This PR does not dispatch, retry, deploy, weaken liveness, or expose transcript text, tokens, URLs, IDs, row indices, or failure values.

@lalalune review requested for the privacy boundary and artifact contract.