### PR TITLE
fix(cloud): use surrogate-safe truncateWellFormed on Docker node manager log output

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-node-manager.surrogate-safe.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.surrogate-safe.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Unit tests for surrogate-safe truncation in Docker node manager probe logs.
+ *
+ * Tests that sidecar probe output truncated across UTF-16 surrogate boundaries
+ * remains well-formed without lone surrogates.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+describe("docker-node-manager surrogate-safe output truncation", () => {
+  it("preserves well-formed strings when probe output splits across surrogate pair", () => {
+    const base = "x".repeat(199);
+    const surrogateEmoji = "🐳"; // \uD83D\uDC33
+    const output = `${base}${surrogateEmoji} extra probe output`;
+
+    const truncated = truncateWellFormed(toWellFormedUnicode(output), 200);
+    expect(truncated.length).toBeLessThanOrEqual(200);
+    expect(truncated.endsWith("\uD83D")).toBe(false);
+    expect(truncated.isWellFormed?.() ?? true).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import crypto from "node:crypto";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { parseLinuxBootId } from "../../db/repositories/agent-backup-source-authority";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
@@ -1135,7 +1136,7 @@ export class DockerNodeManager {
     const status = parseEmbeddingSidecarProbe(output);
     if (status === null) {
       logger.warn("[docker-node-manager] Embedding sidecar probe returned no status token", {
-        output: output.slice(0, 200),
+        output: truncateWellFormed(toWellFormedUnicode(output), 200),
       });
     }
     return status;

--- a/packages/cloud/shared/vitest.config.ts
+++ b/packages/cloud/shared/vitest.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       "src/lib/services/steward-platform-users.error-policy.test.ts",
       "src/lib/utils/whatsapp-api.test.ts",
       "src/lib/services/email.port.test.ts",
+      "src/lib/services/docker-node-manager.surrogate-safe.test.ts",
     ],
     environment: "node",
     // PGlite's WASM worker outlives Vitest's fork shutdown grace even after


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` instead of raw `output.slice(0, 200)` in `packages/cloud/shared/src/lib/services/docker-node-manager.ts:1138` to prevent UTF-16 surrogate pairs from being bisected into unpaired surrogates when logging failed embedding sidecar probe output.

## Changes

- In `packages/cloud/shared/src/lib/services/docker-node-manager.ts:1138`, wrap SSH probe output with `truncateWellFormed(toWellFormedUnicode(output), 200)`.
- In `packages/cloud/shared/src/lib/services/docker-node-manager.surrogate-safe.test.ts`, add unit test asserting surrogate-safe truncation at the 200-char boundary.
- In `packages/cloud/shared/vitest.config.ts`, register the new test suite in `test.include`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2c9e7090c1`) |
| --- | --- | --- |
| `bun run --cwd packages/cloud/shared vitest run src/lib/services/docker-node-manager.surrogate-safe.test.ts` | N/A (new test) | 1 pass (1 test) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/docker-node-manager.ts packages/cloud/shared/vitest.config.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/docker-node-manager.ts:1130-1145`

## Risks

Low. Ensures log payloads remain well-formed UTF-16/UTF-8 strings.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud backend service logging; UI untouched)
- [x] `build` — Clean build across workspace
- [x] `test` — 1/1 pass in `docker-node-manager.surrogate-safe.test.ts`
- [x] `lint` — Biome clean
