### PR TITLE
test(agent): cover knowledge-graph sql

### DIFF
--- a/packages/agent/src/services/knowledge-graph/sql.test.ts
+++ b/packages/agent/src/services/knowledge-graph/sql.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Unit coverage for knowledge-graph raw-SQL encoders, parsers, and runners.
+ *
+ * Drives `./sql.ts` directly. Literal encoding and JSON parsing are pure; row
+ * extraction is asserted through `executeRawSql` against a fake
+ * `adapter.db.execute` while `drizzle-orm`'s real `sql.raw` builds the query
+ * object. No production helper is replaced with a mock.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  executeRawSql,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  toBoolean,
+  toNumber,
+  toText,
+} from "./sql.ts";
+
+function runtimeWithExecute(
+  execute: (query: unknown) => Promise<unknown>,
+): IAgentRuntime {
+  return {
+    adapter: { db: { execute } },
+  } as IAgentRuntime;
+}
+
+describe("toText", () => {
+  it("returns strings unchanged", () => {
+    expect(toText("x")).toBe("x");
+    expect(toText("")).toBe("");
+  });
+
+  it("uses the default empty fallback for nullish values", () => {
+    expect(toText(null)).toBe("");
+    expect(toText(undefined)).toBe("");
+  });
+
+  it("uses a caller-supplied fallback for nullish values", () => {
+    expect(toText(null, "fb")).toBe("fb");
+    expect(toText(undefined, "fb")).toBe("fb");
+  });
+
+  it("stringifies non-string values instead of falling back", () => {
+    expect(toText(42)).toBe("42");
+    expect(toText(false, "fb")).toBe("false");
+    expect(toText({ a: 1 })).toBe("[object Object]");
+  });
+});
+
+describe("toNumber", () => {
+  it("returns finite numbers unchanged", () => {
+    expect(toNumber(5)).toBe(5);
+    expect(toNumber(0)).toBe(0);
+    expect(toNumber(-3.25)).toBe(-3.25);
+  });
+
+  it("parses finite numeric strings", () => {
+    expect(toNumber("7.5")).toBe(7.5);
+    expect(toNumber("0")).toBe(0);
+    expect(toNumber("  3  ")).toBe(3);
+    expect(toNumber("")).toBe(0);
+  });
+
+  it("uses the default zero fallback for non-numeric values", () => {
+    expect(toNumber("abc")).toBe(0);
+    expect(toNumber(Number.NaN)).toBe(0);
+    expect(toNumber(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(toNumber(true)).toBe(0);
+    expect(toNumber({ n: 1 })).toBe(0);
+    expect(toNumber(null)).toBe(0);
+    expect(toNumber(undefined)).toBe(0);
+  });
+
+  it("uses a caller-supplied fallback for non-numeric values", () => {
+    expect(toNumber(undefined, 9)).toBe(9);
+    expect(toNumber("abc", 9)).toBe(9);
+    expect(toNumber(Number.NaN, 9)).toBe(9);
+  });
+});
+
+describe("toBoolean", () => {
+  it("returns booleans unchanged", () => {
+    expect(toBoolean(true)).toBe(true);
+    expect(toBoolean(false)).toBe(false);
+  });
+
+  it("treats any non-zero number as true, including NaN", () => {
+    expect(toBoolean(1)).toBe(true);
+    expect(toBoolean(-1)).toBe(true);
+    expect(toBoolean(0)).toBe(false);
+    expect(toBoolean(Number.NaN)).toBe(true);
+  });
+
+  it("parses trimmed case-insensitive truthy and falsy strings", () => {
+    expect(toBoolean("1")).toBe(true);
+    expect(toBoolean("TRUE")).toBe(true);
+    expect(toBoolean(" yes ")).toBe(true);
+    expect(toBoolean("On")).toBe(true);
+    expect(toBoolean("0")).toBe(false);
+    expect(toBoolean("false")).toBe(false);
+    expect(toBoolean("NO")).toBe(false);
+    expect(toBoolean(" off ")).toBe(false);
+  });
+
+  it("uses the fallback for unrecognized strings and other types", () => {
+    expect(toBoolean("maybe")).toBe(false);
+    expect(toBoolean("", true)).toBe(true);
+    expect(toBoolean(null, true)).toBe(true);
+    expect(toBoolean(undefined)).toBe(false);
+    expect(toBoolean({ ok: 1 })).toBe(false);
+  });
+});
+
+describe("parseJsonValue", () => {
+  it("returns the fallback for missing JSON values", () => {
+    expect(parseJsonValue(null, { fallback: true })).toEqual({
+      fallback: true,
+    });
+    expect(parseJsonValue(undefined, 7)).toBe(7);
+    expect(parseJsonValue("", "fb")).toBe("fb");
+  });
+
+  it("passes objects and arrays through without re-parsing", () => {
+    const object = { a: 1 };
+    const array = [1, 2];
+    expect(parseJsonValue(object, null)).toBe(object);
+    expect(parseJsonValue(array, null)).toBe(array);
+  });
+
+  it("parses a JSON string", () => {
+    expect(parseJsonValue('{"a":1}', null)).toEqual({ a: 1 });
+    expect(parseJsonValue("null", { fallback: true })).toBeNull();
+  });
+
+  it("throws on invalid JSON strings and non-object primitives", () => {
+    expect(() => parseJsonValue("not json", null)).toThrow(
+      "Invalid JSON value",
+    );
+    expect(() => parseJsonValue(42, null)).toThrow(
+      "Expected JSON string or object, received number",
+    );
+    expect(() => parseJsonValue(true, null)).toThrow(
+      "Expected JSON string or object, received boolean",
+    );
+  });
+});
+
+describe("parseJsonRecord", () => {
+  it("parses a JSON object string", () => {
+    expect(parseJsonRecord('{"k":"v","n":1}')).toEqual({ k: "v", n: 1 });
+  });
+
+  it("passes an already-parsed object through", () => {
+    const value = { k: "v" };
+    expect(parseJsonRecord(value)).toBe(value);
+  });
+
+  it("returns an empty object for missing JSON values", () => {
+    expect(parseJsonRecord(null)).toEqual({});
+    expect(parseJsonRecord(undefined)).toEqual({});
+    expect(parseJsonRecord("")).toEqual({});
+  });
+
+  it("throws when the parsed value is not an object", () => {
+    expect(() => parseJsonRecord("[1]")).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord([])).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord("null")).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord('"x"')).toThrow("Expected JSON object");
+  });
+
+  it("throws on invalid JSON strings and non-object primitives", () => {
+    expect(() => parseJsonRecord("not json")).toThrow("Invalid JSON value");
+    expect(() => parseJsonRecord(42)).toThrow(
+      "Expected JSON string or object, received number",
+    );
+    expect(() => parseJsonRecord(true)).toThrow(
+      "Expected JSON string or object, received boolean",
+    );
+  });
+});
+
+describe("parseJsonArray", () => {
+  it("parses a JSON array string", () => {
+    expect(parseJsonArray("[1,2]")).toEqual([1, 2]);
+  });
+
+  it("passes an already-parsed array through", () => {
+    const value = [{ id: "a" }];
+    expect(parseJsonArray(value)).toBe(value);
+  });
+
+  it("returns an empty array for missing JSON values", () => {
+    expect(parseJsonArray(null)).toEqual([]);
+    expect(parseJsonArray(undefined)).toEqual([]);
+    expect(parseJsonArray("")).toEqual([]);
+  });
+
+  it("throws when the parsed value is not an array", () => {
+    expect(() => parseJsonArray('{"a":1}')).toThrow("Expected JSON array");
+    expect(() => parseJsonArray({ a: 1 })).toThrow("Expected JSON array");
+    expect(() => parseJsonArray("null")).toThrow("Expected JSON array");
+    expect(() => parseJsonArray('"x"')).toThrow("Expected JSON array");
+  });
+});
+
+describe("sql literals", () => {
+  it("quotes strings and doubles embedded single quotes", () => {
+    expect(sqlQuote("plain")).toBe("'plain'");
+    expect(sqlQuote("it's")).toBe("'it''s'");
+    expect(sqlQuote("")).toBe("''");
+    expect(sqlQuote("''")).toBe("''''''");
+  });
+
+  it("encodes nullable text as SQL NULL or a quoted literal", () => {
+    expect(sqlText("plain")).toBe("'plain'");
+    expect(sqlText("it's")).toBe("'it''s'");
+    expect(sqlText("")).toBe("''");
+    expect(sqlText(null)).toBe("NULL");
+    expect(sqlText(undefined)).toBe("NULL");
+  });
+
+  it("truncates finite integers and rejects non-finite values", () => {
+    expect(sqlInteger(5.7)).toBe("5");
+    expect(sqlInteger(-3.9)).toBe("-3");
+    expect(sqlInteger(0)).toBe("0");
+    expect(sqlInteger(null)).toBe("NULL");
+    expect(sqlInteger(undefined)).toBe("NULL");
+    expect(() => sqlInteger(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlInteger(Number.POSITIVE_INFINITY)).toThrow(
+      "invalid numeric SQL literal",
+    );
+    expect(() => sqlInteger(Number.NEGATIVE_INFINITY)).toThrow(
+      "invalid numeric SQL literal",
+    );
+  });
+
+  it("encodes finite numbers without truncation and rejects non-finite values", () => {
+    expect(sqlNumber(3.14)).toBe("3.14");
+    expect(sqlNumber(-2.5)).toBe("-2.5");
+    expect(sqlNumber(0)).toBe("0");
+    expect(sqlNumber(null)).toBe("NULL");
+    expect(sqlNumber(undefined)).toBe("NULL");
+    expect(() => sqlNumber(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlNumber(Number.POSITIVE_INFINITY)).toThrow(
+      "invalid numeric SQL literal",
+    );
+  });
+
+  it("serializes JSON then quotes it as a SQL string", () => {
+    expect(sqlJson({ a: 1 })).toBe("'{\"a\":1}'");
+    expect(sqlJson(null)).toBe("'null'");
+    expect(sqlJson(undefined)).toBe("'null'");
+    expect(sqlJson([1, 2])).toBe("'[1,2]'");
+    expect(sqlJson({ a: "it's" })).toBe("'{\"a\":\"it''s\"}'");
+  });
+});
+
+describe("executeRawSql", () => {
+  it("forwards the SQL text through drizzle sql.raw and extracts object rows from an array result", async () => {
+    const seen: unknown[] = [];
+    const runtime = runtimeWithExecute(async (query) => {
+      seen.push(query);
+      return [{ id: "a" }, { id: "b" }];
+    });
+
+    const rows = await executeRawSql(runtime, "SELECT 1");
+    expect(rows).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(seen).toHaveLength(1);
+    const query = seen[0] as { queryChunks: Array<{ value?: unknown }> };
+    expect(query.queryChunks[0]?.value).toEqual(["SELECT 1"]);
+  });
+
+  it("returns an empty list for an empty array result", async () => {
+    const runtime = runtimeWithExecute(async () => []);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("returns a single-element list for a single object row", async () => {
+    const runtime = runtimeWithExecute(async () => [{ id: "only" }]);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "only" },
+    ]);
+  });
+
+  it("drops non-object entries from an array result", async () => {
+    const runtime = runtimeWithExecute(async () => [
+      { id: "keep" },
+      null,
+      ["skip"],
+      "nope",
+      1,
+    ]);
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "keep" },
+    ]);
+  });
+
+  it("extracts object rows from a { rows } envelope", async () => {
+    const runtime = runtimeWithExecute(async () => ({
+      rows: [{ id: "a" }, null, { id: "b" }, "skip"],
+    }));
+    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
+      { id: "a" },
+      { id: "b" },
+    ]);
+  });
+
+  it("returns an empty list when { rows } is missing or not an array", async () => {
+    const missing = runtimeWithExecute(async () => ({ count: 0 }));
+    const notArray = runtimeWithExecute(async () => ({ rows: "nope" }));
+    await expect(executeRawSql(missing, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(notArray, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list for a non-object, non-array execute result", async () => {
+    const none = runtimeWithExecute(async () => null);
+    const scalar = runtimeWithExecute(async () => 42);
+    await expect(executeRawSql(none, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(scalar, "SELECT 1")).resolves.toEqual([]);
+  });
+
+  it("throws when the runtime database adapter is unavailable", async () => {
+    const missingDb = { adapter: {} } as IAgentRuntime;
+    const withoutExecute = {
+      adapter: { db: {} },
+    } as IAgentRuntime;
+    await expect(executeRawSql(missingDb, "SELECT 1")).rejects.toThrow(
+      "runtime database adapter unavailable",
+    );
+    await expect(executeRawSql(withoutExecute, "SELECT 1")).rejects.toThrow(
+      "runtime database adapter unavailable",
+    );
+  });
+
+  it("reuses the cached drizzle sql.raw on a subsequent call", async () => {
+    const seen: unknown[] = [];
+    const runtime = runtimeWithExecute(async (query) => {
+      seen.push(query);
+      return [];
+    });
+    await executeRawSql(runtime, "SELECT 2");
+    await executeRawSql(runtime, "SELECT 3");
+    expect(seen).toHaveLength(2);
+    const first = seen[0] as { queryChunks: Array<{ value?: unknown }> };
+    const second = seen[1] as { queryChunks: Array<{ value?: unknown }> };
+    expect(first.queryChunks[0]?.value).toEqual(["SELECT 2"]);
+    expect(second.queryChunks[0]?.value).toEqual(["SELECT 3"]);
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Test-only coverage for `packages/agent/src/services/knowledge-graph/sql.ts`, which had no same-named test file. `__tests__/kg-sql.test.ts` already exists on develop and covers a subset of the pure helpers; it does not drive `executeRawSql` or the row-extraction / adapter-unavailable branches. This PR adds the colocated same-named suite.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation after sync (see Evidence). `bun run verify`
      was not run; this is a single-file test-only change. Hosted CI does not
      run on fork contributor PRs.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Parent is current `origin/develop` (`48e3484e963c8b789fe5282dce4af18f0754f83c`);
      zero conflicts.
- [x] Focused verification passed post-sync (see Evidence).

# Risks

Low. Test-only addition of a colocated vitest file. No production code is
modified and no runtime behaviour changes.

# Background

## What does this PR do?

Adds `packages/agent/src/services/knowledge-graph/sql.test.ts` so the real
knowledge-graph SQL helpers are driven through every exported symbol and branch:

- `toText`: strings, default and caller fallbacks for nullish values, non-string
  stringification (does not use the fallback)
- `toNumber`: finite numbers unchanged; numeric strings (including `""` → `0` and
  whitespace); default and caller fallbacks for non-numeric strings, `NaN`,
  `Infinity`, booleans, objects, and nullish values
- `toBoolean`: booleans unchanged; any non-zero number is true, including `NaN`
  (`NaN !== 0`); trimmed case-insensitive `"1"/"true"/"yes"/"on"` and
  `"0"/"false"/"no"/"off"`; fallback for unrecognized strings and other types
- `parseJsonValue`: fallback for null/undefined/`""`; objects and arrays passed
  through by identity; JSON strings; JSON `"null"` parses to `null` rather than
  the fallback; throws on invalid JSON and on number/boolean primitives
- `parseJsonRecord`: object strings, already-parsed objects, empty fallbacks for
  null/undefined/`""`, non-object JSON (`[]`, `"null"`, primitives), invalid
  JSON, and non-object primitive inputs
- `parseJsonArray`: array strings, already-parsed arrays by identity, empty
  fallbacks for missing values, throws on objects / `"null"` / string primitives
- `sqlQuote` / `sqlText`: empty strings, doubled embedded quotes, SQL `NULL`
- `sqlInteger`: truncation of finite values via `Math.trunc` (including
  negatives, so `-3.9` → `"-3"`), `NULL` for nullish, rejection of NaN / ±Infinity
- `sqlNumber`: finite values without truncation, `NULL` for nullish, rejection of
  non-finite values
- `sqlJson`: objects, arrays, null, undefined (`JSON.stringify(null)`), and
  quotes inside JSON that must be SQL-escaped
- `executeRawSql`: live `drizzle-orm` `sql.raw` query forwarding; array results
  (empty, single, many); dropping non-object entries; `{ rows }` envelopes;
  missing/`rows` not-an-array; non-object execute results; missing adapter /
  missing `execute`; cached `sql.raw` on a second call

The assertions record observed behaviour of the current module. Nothing in
production is changed.

## What kind of change is this?

Improvements (tests for an existing helper).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/knowledge-graph/sql.test.ts`, then the focused
vitest command below.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/services/knowledge-graph/sql.test.ts
```

Observed on current `origin/develop` (`48e3484e963c8b789fe5282dce4af18f0754f83c`)
with this PR's test file, immediately before filing:

```
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

Biome: `bunx biome check --write packages/agent/src/services/knowledge-graph/sql.test.ts`
→ first run fixed import order (`Checked 1 file in 81ms. Fixed 1 file.`); recheck
immediately before filing: `Checked 1 file in 65ms. No fixes applied.` Config
proved present: `biome.json` and `tsconfig.json` exist; sparse-checkout is off
(`fatal: this worktree is not sparse`).

Typecheck: `cd packages/agent && bunx tsc --noEmit` — `sql.test.ts` appears
nowhere in the output (grep exit 1). Pre-existing package errors remain; this
file added zero.

The diff touches only that test file.

Hosted CI does not run on this fork contributor PR; the counts above are local.

# Evidence Gate

Evidence head: `3356ef90d7c32d456a712b45d33f60e5c5627acc`

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path exercised; focused vitest only
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path exercised
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests, no model call
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only; the artifact is the passing vitest suite quoted above
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit tests, no model call.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3356ef90d7c32d456a712b45d33f60e5c5627acc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
