### PR TITLE
fix(cloud): settle streamed memory mirror off path

### DIFF
--- a/packages/cloud/api/v1/generate-video/route.surrogate.test.ts
+++ b/packages/cloud/api/v1/generate-video/route.surrogate.test.ts
@@ -2,9 +2,10 @@
  * Regression: provider error strings are external and may contain lone surrogates;
  * route must use truncateWellFormed(toWellFormedUnicode(...),500).
  */
-import { describe, expect, it } from "vitest";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 import { readFileSync } from "node:fs";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 function formatError(message: string): string {
   return truncateWellFormed(toWellFormedUnicode(message), 500);
@@ -31,11 +32,16 @@ describe("generate-video surrogate-safe", () => {
     expect(formatError(long).length).toBe(500);
   });
   it("route file imports and uses truncateWellFormed", () => {
-    const src = readFileSync(new URL("./route.ts", import.meta.url).pathname, "utf8");
+    const src = readFileSync(
+      new URL("./route.ts", import.meta.url).pathname,
+      "utf8",
+    );
     expect(src).toContain('from "@elizaos/core"');
     expect(src).toContain("truncateWellFormed");
     expect(src).toContain("toWellFormedUnicode");
     // ensure not inside generative-route-auth block
-    expect(src).not.toMatch(/import \{[^}]*toWellFormedUnicode[^}]*from "@\/api-app\/lib\/generative-route-auth"/s);
+    expect(src).not.toMatch(
+      /import \{[^}]*toWellFormedUnicode[^}]*from "@\/api-app\/lib\/generative-route-auth"/s,
+    );
   });
 });

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -1,4 +1,6 @@
 /** Handles authenticated video generation, billing, and pending-job reconciliation. */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -13,7 +15,6 @@ import {
   failureResponse,
   jsonError,
 } from "@/lib/api/cloud-worker-errors";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   collectVideoProviderApiKeys,
   getConfiguredVideoProviderCandidates,
@@ -575,7 +576,10 @@ app.post("/", async (c) => {
           provider: unknownAttempt.provider,
           prompt: unknownAttempt.prompt,
           status: "failed",
-          error: truncateWellFormed(toWellFormedUnicode(redactProviderErrorMessage(error.message)), 500),
+          error: truncateWellFormed(
+            toWellFormedUnicode(redactProviderErrorMessage(error.message)),
+            500,
+          ),
           parameters: unknownAttempt.parameters,
           metadata: { ...settlement },
           dimensions: { duration: unknownAttempt.durationSeconds },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -308,8 +308,10 @@ type TestMemoryPair = {
 };
 const memoryPairs: TestMemoryPair[] = [];
 const memoryScopes: Array<{ agentKey: string; roomKey: string }> = [];
+let memoryCommitGate: Promise<void> | null = null;
 const recordTurnPair = mock(async (pair: TestMemoryPair) => {
   memoryPairs.push(pair);
+  if (memoryCommitGate) await memoryCommitGate;
 });
 const createSharedMemoryStore = mock((scope: { agentKey: string; roomKey: string }) => {
   memoryScopes.push(scope);
@@ -514,6 +516,7 @@ beforeEach(() => {
   delete process.env.SHARED_MEMORY_TABLES_ENABLED;
   memoryPairs.length = 0;
   memoryScopes.length = 0;
+  memoryCommitGate = null;
   recordTurnPair.mockClear();
   createSharedMemoryStore.mockClear();
   turn = {
@@ -1195,6 +1198,81 @@ describe("SharedRuntimeChatService", () => {
     expect(memoryScopes[0]?.roomKey).not.toBe(agent.id);
     await Promise.all(h.background);
     expect(settleCalls).toEqual([0.004]);
+  });
+
+  test("does not hold the terminal frame behind a stalled long-term memory mirror", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
+    const memoryCommit = Promise.withResolvers<void>();
+    memoryCommitGate = memoryCommit.promise;
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    let collectedMemoryPromise: Promise<unknown> | undefined;
+    h.executionCtx.waitUntil = (promise: Promise<unknown>) => {
+      h.background.push(promise);
+      if (memoryPairs.length === 1 && !collectedMemoryPromise) {
+        collectedMemoryPromise = promise;
+      }
+    };
+
+    const response = await service.stream(agent, rpc, h);
+    const body = await response.text();
+
+    expect(body).toContain("event: done");
+    expect(h.history()).toEqual([
+      { role: "assistant", content: "prior" },
+      expect.objectContaining({ role: "user", content: "hello" }),
+      expect.objectContaining({ role: "assistant", content: "hello back" }),
+    ]);
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({
+        userMessage: "hello",
+        assistantReply: "hello back",
+        interrupted: false,
+      }),
+    ]);
+    expect(collectedMemoryPromise).toBeDefined();
+    let memoryPromiseSettled = false;
+    void collectedMemoryPromise?.then(() => {
+      memoryPromiseSettled = true;
+    });
+    await Promise.resolve();
+    expect(memoryPromiseSettled).toBe(false);
+
+    memoryCommit.resolve();
+    await collectedMemoryPromise;
+    expect(memoryPromiseSettled).toBe(true);
+    await Promise.all(h.background);
+
+    const inlineMemoryCommit = Promise.withResolvers<void>();
+    memoryCommitGate = inlineMemoryCommit.promise;
+    const inlineHarness = harness();
+    streamTurn = {
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "hello " };
+        yield {
+          type: "finish",
+          text: "hello back",
+          usage: { inputTokens: 12, outputTokens: 4 },
+        };
+      })(),
+    };
+
+    const inlineResponse = await service.stream(agent, rpc, {
+      ...inlineHarness,
+      executionCtx: undefined,
+    });
+    const bodyPromise = inlineResponse.text();
+    let bodySettled = false;
+    void bodyPromise.then(() => {
+      bodySettled = true;
+    });
+    await Promise.resolve();
+    expect(bodySettled).toBe(false);
+
+    inlineMemoryCommit.resolve();
+    expect(await bodyPromise).toContain("event: done");
+    expect(bodySettled).toBe(true);
   });
 
   test("keeps a trusted transient prompt out of history and long-term memory", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -704,6 +704,40 @@ function extractSharedTurnFactsOffPath(
   });
 }
 
+/**
+ * Mirror one already-landed streamed turn into the long-term memory tables
+ * without holding the terminal SSE frame behind Hyperdrive or the optional
+ * embeddings sidecar. Conversation history and the idempotency claim remain
+ * the authoritative pre-terminal durability boundary; this mirror uses those
+ * same deterministic message ids. The mirror is detached from the response
+ * stream. Production DurableObjectState.waitUntil is API compatibility only
+ * and has no lifecycle effect; real pending Hyperdrive/embedding I/O keeps the
+ * object active automatically. Without an execution context the helper remains
+ * awaited. A Queue/outbox is the stronger guaranteed-delivery architecture
+ * across process/platform termination.
+ */
+function recordSharedTurnMemoryOffPath(
+  executionCtx: BridgeExecutionContext | undefined,
+  store: SharedMemoryStore | null,
+  agentId: string,
+  pair: Parameters<SharedMemoryStore["recordTurnPair"]>[0],
+): Promise<void> {
+  if (!store) return Promise.resolve();
+  return settleOffResponsePath(executionCtx, async () => {
+    try {
+      await store.recordTurnPair(pair);
+    } catch (error) {
+      // error-policy:J7 the authoritative conversation history already landed;
+      // a secondary memory-mirror failure stays observable without converting
+      // a real model reply into an endless in-flight turn.
+      logger.warn("[SharedRuntimeChatService] streamed memory mirror failed", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}
+
 function stableUuid(raw: string): string {
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(raw)) {
     return raw;
@@ -1719,7 +1753,7 @@ export class SharedRuntimeChatService {
           options.historyStore,
         );
         if (streamMemoryStore && !isProviderFreeTurn(turn)) {
-          await streamMemoryStore.recordTurnPair({
+          await recordSharedTurnMemoryOffPath(options.executionCtx, streamMemoryStore, agent.id, {
             userMessage: text.trim(),
             assistantReply: reply,
             messageIds,


### PR DESCRIPTION
Fixes #25689

## What changed

- keep authoritative conversation history and idempotency claim on the pre-terminal path
- move the deterministic long-term-memory mirror under the existing Worker `waitUntil` boundary
- keep mirror failures observable without turning a real reply into a permanently busy chat
- add a regression whose memory mirror never settles while the terminal SSE frame still completes

## Evidence

- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts` — 40 pass
- `bun run --cwd packages/cloud/shared typecheck`
- focused Biome check and `git diff --check`

## Staging diagnosis

Run 32633068830 produced a real persisted reply after one expected named-warming retry but stayed in-flight until the 120s Durable Object stream-stall boundary. This change removes only the secondary mirror from that response-critical path.