### PR TITLE
test(agent): cover calendar

### DIFF
--- a/packages/agent/src/services/permissions/probers/calendar.test.ts
+++ b/packages/agent/src/services/permissions/probers/calendar.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Behavioral coverage for the calendar EventKit permission prober. Drives the
+ * real calendarProber with live buildState / mapNativePrivacyAuthStatus mapping:
+ * non-Darwin short-circuit, native auth codes including write-only (4), TCC
+ * fallback when the dylib is missing, and request() lastRequested stamping.
+ * Native dylib, TCC, and System Settings are stubbed OS collaborators.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const darwin = vi.hoisted(() => ({ current: true }));
+const getNativeDylib = vi.hoisted(() => vi.fn());
+const queryTccStatus = vi.hoisted(() => vi.fn());
+const resolveBundleId = vi.hoisted(() =>
+  vi.fn(() => "ai.elizaos.calendar-test"),
+);
+const openPrivacyPane = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    getNativeDylib,
+    queryTccStatus,
+    resolveBundleId,
+    openPrivacyPane,
+  };
+});
+
+import { calendarProber } from "./calendar.js";
+
+const CALENDAR_TCC_SERVICE = "kTCCServiceCalendar";
+const BUNDLE_ID = "ai.elizaos.calendar-test";
+
+function nativeCalendar(check: number, request = check) {
+  return {
+    checkCalendarPermission: () => check,
+    requestCalendarPermission: () => request,
+  };
+}
+
+describe("calendarProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    getNativeDylib.mockReset();
+    queryTccStatus.mockReset();
+    resolveBundleId.mockReset();
+    resolveBundleId.mockReturnValue(BUNDLE_ID);
+    openPrivacyPane.mockReset();
+    openPrivacyPane.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    darwin.current = true;
+  });
+
+  it("exports id calendar", () => {
+    expect(calendarProber.id).toBe("calendar");
+  });
+});
+
+describe("calendarProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    getNativeDylib.mockReset();
+    queryTccStatus.mockReset();
+    resolveBundleId.mockReset();
+    resolveBundleId.mockReturnValue(BUNDLE_ID);
+    openPrivacyPane.mockReset();
+  });
+
+  it("returns platform-unsupported on non-Darwin without probing native or TCC", async () => {
+    darwin.current = false;
+    const state = await calendarProber.check();
+    expect(state.id).toBe("calendar");
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(getNativeDylib).not.toHaveBeenCalled();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+  });
+
+  it("maps native granted (2) without consulting TCC", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(2));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+  });
+
+  it("maps native denied (1) without consulting TCC", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(1));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+  });
+
+  it("maps native not-determined (0) as requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(0));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+  });
+
+  it("maps native restricted (3) with os_policy and canRequest false", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(3));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("os_policy");
+  });
+
+  it("maps native write-only (4) as restricted but still requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(4));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBe("os_policy");
+  });
+
+  it("maps unknown native codes to not-determined", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(99));
+    const state = await calendarProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+  });
+
+  it("falls back to TCC granted when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("granted");
+    const state = await calendarProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      CALENDAR_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+
+  it("falls back to TCC denied when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("denied");
+    const state = await calendarProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      CALENDAR_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+
+  it("treats a missing TCC row as not-determined and requestable", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue(null);
+    const state = await calendarProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      CALENDAR_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+});
+
+describe("calendarProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    getNativeDylib.mockReset();
+    queryTccStatus.mockReset();
+    resolveBundleId.mockReset();
+    resolveBundleId.mockReturnValue(BUNDLE_ID);
+    openPrivacyPane.mockReset();
+    openPrivacyPane.mockResolvedValue(undefined);
+  });
+
+  it("returns platform-unsupported on non-Darwin without lastRequested", async () => {
+    darwin.current = false;
+    const state = await calendarProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(getNativeDylib).not.toHaveBeenCalled();
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("uses the native request result and stamps lastRequested", async () => {
+    const requestCalendarPermission = vi.fn(() => 2);
+    const checkCalendarPermission = vi.fn(() => {
+      throw new Error("checkCalendarPermission must not run on native request");
+    });
+    getNativeDylib.mockResolvedValue({
+      checkCalendarPermission,
+      requestCalendarPermission,
+    });
+    const before = Date.now();
+    const state = await calendarProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(requestCalendarPermission).toHaveBeenCalledTimes(1);
+    expect(checkCalendarPermission).not.toHaveBeenCalled();
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+  });
+
+  it("maps a native write-only request (4) as restricted and requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeCalendar(0, 4));
+    const state = await calendarProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBe("os_policy");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("opens the Calendars privacy pane and re-checks TCC when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("denied");
+    const before = Date.now();
+    const state = await calendarProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(openPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(openPrivacyPane).toHaveBeenCalledWith("Calendars");
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      CALENDAR_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+  });
+
+  it("stamps lastRequested on the TCC granted fallback after opening settings", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("granted");
+    const state = await calendarProber.request({ reason: "unit-test" });
+    expect(openPrivacyPane).toHaveBeenCalledWith("Calendars");
+    expect(state.status).toBe("granted");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+});


### PR DESCRIPTION

# Relates to

No issue. Test-only coverage for `packages/agent/src/services/permissions/probers/calendar.ts`, which had no same-named vitest file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest, biome, and package `tsc --noEmit` were run in isolation after sync; see evidence. Full `bun run verify` was not re-run: this diff adds one test file and changes no production behaviour.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

- AI assistance: `yes`
- Model(s) used: `grok-4.6`
- Agent tooling: `grok`
- Provider: `xai`
- Skill path: `N/A - factory test-coverage lane; no contribution-skill receipt minted`
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `aaa11031b64411cd94c1b1580cb7cad3fccdb153`; zero conflicts.
- [x] Focused verification re-run against that same `origin/develop` tree immediately before filing (see evidence).

# Risks

Low. Test-only addition: one new vitest file exercising the existing `calendarProber` check/request branches. No production code is modified and no runtime behaviour changes.

# Background

## What does this PR do?

Adds `packages/agent/src/services/permissions/probers/calendar.test.ts`, a same-named unit suite for `calendarProber`. It drives the real module with live `buildState` / `mapNativePrivacyAuthStatus` mapping (native dylib, TCC, and System Settings are stubbed OS collaborators, not stand-ins for the prober) and covers:

- `id` is `calendar`
- non-Darwin `check()` and `request()` return `not-applicable` / `platform_unsupported` without probing native or TCC, and `request()` does not stamp `lastRequested`
- native EventKit codes: granted (2), denied (1), not-determined (0), restricted (3), write-only (4) which stays `restricted` with `canRequest: true`, and unknown codes (99) as not-determined
- TCC fallback when the dylib is missing: granted, denied, and missing-row `null` as not-determined, always querying `kTCCServiceCalendar` with the resolved bundle id
- native `request()` uses `requestCalendarPermission` (not a follow-up check), stamps `lastRequested`, and does not open System Settings
- missing-dylib `request()` opens the `Calendars` privacy pane, re-checks TCC, and stamps `lastRequested`

## What kind of change is this?

Improvements (tests for existing behaviour). No production behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/calendar.test.ts`. Run:

```bash
bunx vitest run packages/agent/src/services/permissions/probers/calendar.test.ts
```

## Detailed testing steps

None: automated tests are acceptable. Hosted CI does **not** run on this fork contributor's PRs; the counts below were observed locally on the exact head.

# Evidence Gate

Evidence matches the exact commit reviewed.

<!-- evidence-head:bb4f1dd8e19e18d323085226d59b49da73144b8e -->

This PR adds tests and changes no production behaviour, so the heavy bug-fix evidence procedure does not apply.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; no UI surface`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - test-only change; no UI surface`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime/service path exercised; deterministic unit tests`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path exercised`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic unit tests; no model call`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: Concrete: the new test file is the only diff
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - test-only change; no rendered visual surface`

# Evidence Details

## Focused tests (vitest, isolated)

Re-fetched `origin/develop` (`aaa11031b64411cd94c1b1580cb7cad3fccdb153`) immediately before filing. `packages/agent/src/services/permissions/probers/calendar.ts` is byte-identical to that tip. Then:

```text
bunx vitest run packages/agent/src/services/permissions/probers/calendar.test.ts

 ✓ packages/agent/src/services/permissions/probers/calendar.test.ts (16 tests) 4ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  16:15:58
   Duration  5.04s (transform 3.85s, setup 0ms, import 4.92s, tests 4ms, environment 0ms)
```

## biome

`ls biome.json` and `git sparse-checkout list` confirmed the checkout is not sparse and biome config is present (`fatal: this worktree is not sparse`).

```text
bunx biome check --write packages/agent/src/services/permissions/probers/calendar.test.ts
Checked 1 file in 42ms. Fixed 1 file.
```

The committed file is the biome-formatted result (argument wrapping on `toHaveBeenCalledWith`).

## tsc

From `packages/agent`:

```text
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'calendar.test.ts' ; echo "EXIT:$?"
EXIT:1
```

`EXIT:1` is grep finding no matches: the new test file introduces zero TypeScript errors. Pre-existing errors elsewhere in the package are unchanged.

The diff touches only `packages/agent/src/services/permissions/probers/calendar.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
