### PR TITLE
test(agent): cover overlay-app-presence

### DIFF
--- a/packages/agent/src/services/overlay-app-presence.test.ts
+++ b/packages/agent/src/services/overlay-app-presence.test.ts
@@ -66,4 +66,94 @@ describe("overlay-app-presence", () => {
     vi.advanceTimersByTime(1_001);
     expect(mod.isOverlayAppPresenceActive("companion", 1_000)).toBe(false);
   });
+
+  it("exports a 60s default TTL", async () => {
+    const mod = await loadPresence();
+    expect(mod.OVERLAY_APP_PRESENCE_TTL_MS).toBe(60_000);
+  });
+
+  it("treats name matching as case-sensitive identity, not a canonical fold", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("Companion");
+    expect(mod.isOverlayAppPresenceActive("Companion")).toBe(true);
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("does not trim the query name when comparing", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    expect(mod.isOverlayAppPresenceActive("  companion  ")).toBe(false);
+  });
+
+  it("stores the raw name when trim is truthy, not the trimmed value", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("  companion  ");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+    expect(mod.isOverlayAppPresenceActive("  companion  ")).toBe(true);
+  });
+
+  it("replaces the previous name so only the last writer is active", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    mod.setOverlayAppPresence("@elizaos/plugin-phone");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+    expect(mod.isOverlayAppPresenceActive("@elizaos/plugin-phone")).toBe(true);
+  });
+
+  it("clears a previously active name when set to null", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(true);
+    mod.setOverlayAppPresence(null);
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("clears a previously active name when set to an empty string", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    mod.setOverlayAppPresence("");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("clears a previously active name when set to whitespace-only", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    mod.setOverlayAppPresence("   \t");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("stays active at exactly the default TTL boundary (inclusive <=)", async () => {
+    vi.useFakeTimers();
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    vi.advanceTimersByTime(mod.OVERLAY_APP_PRESENCE_TTL_MS);
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("treats maxAgeMs 0 as active only in the same millisecond as the report", async () => {
+    vi.useFakeTimers();
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    expect(mod.isOverlayAppPresenceActive("companion", 0)).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(mod.isOverlayAppPresenceActive("companion", 0)).toBe(false);
+  });
+
+  it("is inactive for a negative maxAgeMs even at the report instant", async () => {
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    expect(mod.isOverlayAppPresenceActive("companion", -1)).toBe(false);
+  });
+
+  it("refreshes lastReportAt on a later heartbeat of the same name", async () => {
+    vi.useFakeTimers();
+    const mod = await loadPresence();
+    mod.setOverlayAppPresence("companion");
+    vi.advanceTimersByTime(mod.OVERLAY_APP_PRESENCE_TTL_MS + 1);
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(false);
+    mod.setOverlayAppPresence("companion");
+    expect(mod.isOverlayAppPresenceActive("companion")).toBe(true);
+  });
 });


### PR DESCRIPTION

## Summary

Extends the colocated Vitest suite for `packages/agent/src/services/overlay-app-presence.ts`. `#25568` already landed a thin six-test file; this PR keeps those cases and adds the remaining observed branches. No production source changes.

The module is a process-global heartbeat (`setOverlayAppPresence` / `isOverlayAppPresenceActive` / `OVERLAY_APP_PRESENCE_TTL_MS`). Tests drive the real module via `vi.resetModules()` + dynamic import. Fake timers control `Date.now()` only.

Added coverage (observed behaviour, not aspirational):

- last-writer replacement so only the latest name is active
- case-sensitive identity match; query names are not trimmed
- `setOverlayAppPresence` stores the raw string when `trim()` is truthy, not the trimmed value
- clearing a previously active name with `null`, `""`, and whitespace-only
- inclusive default TTL (`<=`): still active at exactly 60s, inactive at 60s+1ms
- `maxAgeMs === 0` is active only in the report millisecond; negative `maxAgeMs` is inactive even at the report instant
- a later heartbeat of the same name refreshes `lastReportAt`
- `OVERLAY_APP_PRESENCE_TTL_MS === 60_000`

## Verification

Exact head: `416b2c289c83832facb1aa3cdc6650a3760f6015` (parent is current `origin/develop` `aaa11031b64411cd94c1b1580cb7cad3fccdb153`, re-fetched immediately before filing)

1. Vitest (re-run against current `origin/develop` sources immediately before filing):

```text
bunx vitest run packages/agent/src/services/overlay-app-presence.test.ts
 ✓ packages/agent/src/services/overlay-app-presence.test.ts (18 tests) 10ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  16:16:39
   Duration  113ms (transform 27ms, setup 0ms, import 29ms, tests 10ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/agent/src/services/overlay-app-presence.test.ts` — `Checked 1 file in 93ms. No fixes applied.` Config exists at repo-root `biome.json`; this checkout is not sparse.

3. Package typecheck: `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'overlay-app-presence.test.ts'` produced no matches (grep EXIT:1). This file introduced zero TypeScript errors.

4. Diff touches only `packages/agent/src/services/overlay-app-presence.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are from local `bunx vitest` / `biome` / `tsc` on this head.

## Notes

Test-only change. No production behaviour is modified. Assertions record what the code does (untrimmed stored names, inclusive TTL, last-writer wins), not a desired redesign.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:416b2c289c83832facb1aa3cdc6650a3760f6015 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
