### PR TITLE
test(agent): cover camera

### DIFF
--- a/packages/agent/src/services/permissions/probers/camera.test.ts
+++ b/packages/agent/src/services/permissions/probers/camera.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit coverage for the camera permission prober. Drives the real module
+ * through Darwin AVCaptureDevice status mapping, the missing-dylib fallback,
+ * the non-Darwin renderer hand-off, and request() including the denied-state
+ * privacy-pane open. Native FFI and System Settings are stubbed; mapAVAuthStatus
+ * and buildState stay the production helpers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { darwin, mockGetNativeDylib, mockOpenPrivacyPane } = vi.hoisted(() => ({
+  darwin: { current: true },
+  mockGetNativeDylib: vi.fn(),
+  mockOpenPrivacyPane: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    getNativeDylib: mockGetNativeDylib,
+    openPrivacyPane: mockOpenPrivacyPane,
+  };
+});
+
+import { cameraProber } from "./camera.ts";
+
+function nativeLib(status: number, request = vi.fn()) {
+  return {
+    checkCameraPermission: () => status,
+    requestCameraPermission: request,
+  };
+}
+
+describe("cameraProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("exports id camera", () => {
+    expect(cameraProber.id).toBe("camera");
+    expect(typeof cameraProber.check).toBe("function");
+    expect(typeof cameraProber.request).toBe("function");
+  });
+});
+
+describe("cameraProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("returns not-determined with canRequest on non-Darwin without touching native", async () => {
+    darwin.current = false;
+    const before = Date.now();
+    const state = await cameraProber.check();
+    expect(state).toMatchObject({
+      id: "camera",
+      status: "not-determined",
+      canRequest: true,
+      platform: process.platform,
+    });
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing dylib as AV status 0 (not-determined)", async () => {
+    mockGetNativeDylib.mockResolvedValue(null);
+    const state = await cameraProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.id).toBe("camera");
+    expect(mockGetNativeDylib).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [0, "not-determined", true],
+    [1, "denied", false],
+    [2, "granted", false],
+    [3, "restricted", false],
+  ] as const)(
+    "maps native AV status %i to %s (canRequest=%s)",
+    async (code, status, canRequest) => {
+      mockGetNativeDylib.mockResolvedValue(nativeLib(code));
+      const state = await cameraProber.check();
+      expect(state.status).toBe(status);
+      expect(state.canRequest).toBe(canRequest);
+      expect(state.id).toBe("camera");
+      expect(state.platform).toBe(process.platform);
+    },
+  );
+
+  it.each([4, -1, 99])(
+    "maps unknown native AV status %i to not-determined",
+    async (code) => {
+      mockGetNativeDylib.mockResolvedValue(nativeLib(code));
+      const state = await cameraProber.check();
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+    },
+  );
+
+  it("does not invoke requestCameraPermission from check()", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(2, request));
+    await cameraProber.check();
+    expect(request).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("cameraProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("returns not-determined on non-Darwin without lastRequested or native I/O", async () => {
+    darwin.current = false;
+    const state = await cameraProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.id).toBe("camera");
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("invokes native request and stamps lastRequested without opening settings when granted", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(2, request));
+    const before = Date.now();
+    const state = await cameraProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("opens the Camera privacy pane only when the re-check is denied", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(1, request));
+    const state = await cameraProber.request({ reason: "unit-test" });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("Camera");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("does not open the privacy pane when status is not-determined", async () => {
+    mockGetNativeDylib.mockResolvedValue(nativeLib(0));
+    const state = await cameraProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("does not open the privacy pane when status is restricted", async () => {
+    mockGetNativeDylib.mockResolvedValue(nativeLib(3));
+    const state = await cameraProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("tolerates a missing dylib on Darwin request (optional chaining)", async () => {
+    mockGetNativeDylib.mockResolvedValue(null);
+    const state = await cameraProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.lastRequested).toBeTypeOf("number");
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

## Summary

Adds colocated unit coverage for `packages/agent/src/services/permissions/probers/camera.ts`, which previously had no same-named test file.

The suite drives the real `cameraProber` (real `buildState` / `mapAVAuthStatus`). Native FFI and System Settings are the only stubs. Assertions record observed behaviour:

- `id` is `"camera"`
- non-Darwin `check()` / `request()` return `not-determined` with `canRequest: true` and do not call native code; `request()` does not set `lastRequested`
- Darwin missing dylib maps through `?? 0` to `not-determined`
- Darwin AV codes `0/1/2/3` map to `not-determined` / `denied` / `granted` / `restricted` with matching `canRequest`
- unknown AV codes (`4`, `-1`, `99`) map to `not-determined`
- `check()` is read-only (does not call `requestCameraPermission`)
- Darwin `request()` calls the native request, stamps `lastRequested`, and opens the Camera privacy pane only when the re-check is `denied`

No production code changes.

## Evidence

Hosted CI does not run on this fork's pull requests. Local checks against current `origin/develop` (camera.ts / `_bridge.ts` unchanged at this head):

1. `bunx vitest run packages/agent/src/services/permissions/probers/camera.test.ts`

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

2. `bunx biome check --write packages/agent/src/services/permissions/probers/camera.test.ts` — Checked 1 file. No fixes applied. `biome.json` is present; this checkout is not sparse.

3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'camera.test.ts'` — empty (this file introduces no TypeScript errors). Pre-existing package errors, if any, are unchanged.

4. Diff touches only `packages/agent/src/services/permissions/probers/camera.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:36c773f1e051cdc90bfc8a95e4d2d3d09b261dc4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
