### PR TITLE
test(agent): cover automation

### DIFF
--- a/packages/agent/src/services/permissions/probers/automation.test.ts
+++ b/packages/agent/src/services/permissions/probers/automation.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit coverage for the automation permission prober: Darwin Apple Events
+ * TCC classification for System Events, the null→not-determined fallback,
+ * non-Darwin platform-unsupported short-circuit, and the request() osascript
+ * path. TCC.db and osascript collaborators are faked so Darwin branches run
+ * on any host; `buildState` and `platformUnsupportedState` stay real.
+ * `buildState` drops the free-text `reason` option, so that field is asserted
+ * absent on returned states.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isDarwin: true,
+  queryAppleEventsTccStatus: vi.fn(),
+  runOsascript: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return mocks.isDarwin;
+    },
+    queryAppleEventsTccStatus: mocks.queryAppleEventsTccStatus,
+    runOsascript: mocks.runOsascript,
+  };
+});
+
+import { platformUnsupportedState } from "./_bridge.js";
+import { automationProber } from "./automation.ts";
+
+const SYSTEM_EVENTS_BUNDLE_ID = "com.apple.systemevents";
+const SYSTEM_EVENTS_SCRIPT =
+  'tell application "System Events" to get name of current user';
+
+function expectPlatform(platform: string): void {
+  expect(["darwin", "win32", "linux", "ios", "android", "web"]).toContain(
+    platform,
+  );
+}
+
+describe("automationProber", () => {
+  beforeEach(() => {
+    mocks.isDarwin = true;
+    mocks.queryAppleEventsTccStatus.mockReset();
+    mocks.runOsascript.mockReset();
+    mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+    mocks.runOsascript.mockResolvedValue("user");
+  });
+
+  it("exports id automation", () => {
+    expect(automationProber.id).toBe("automation");
+    expect(automationProber.openSettings).toBeUndefined();
+  });
+
+  describe("check", () => {
+    it("returns platform-unsupported without querying TCC when not Darwin", async () => {
+      mocks.isDarwin = false;
+      const state = await automationProber.check();
+      const expected = platformUnsupportedState("automation");
+      expect(state).toEqual({
+        ...expected,
+        lastChecked: state.lastChecked,
+      });
+      expect(state.status).toBe("not-applicable");
+      expect(state.canRequest).toBe(false);
+      expect(state.restrictedReason).toBe("platform_unsupported");
+      expect(mocks.queryAppleEventsTccStatus).not.toHaveBeenCalled();
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+    });
+
+    it("treats a missing Apple Events row as not-determined and requestable", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const before = Date.now();
+      const state = await automationProber.check();
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledWith(
+        SYSTEM_EVENTS_BUNDLE_ID,
+      );
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+      expect(state.id).toBe("automation");
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+      expect(state.lastRequested).toBeUndefined();
+      expect(state.reason).toBeUndefined();
+      expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+      expectPlatform(state.platform);
+    });
+
+    it("reports granted as not requestable and does not surface reason", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("granted");
+      const state = await automationProber.check();
+      expect(state.status).toBe("granted");
+      expect(state.canRequest).toBe(false);
+      expect(state.reason).toBeUndefined();
+      expect(state.restrictedReason).toBeUndefined();
+      expect(state.lastRequested).toBeUndefined();
+    });
+
+    it("reports denied as not requestable", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await automationProber.check();
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+      expect(state.reason).toBeUndefined();
+      expect(state.lastRequested).toBeUndefined();
+    });
+  });
+
+  describe("request", () => {
+    it("returns platform-unsupported without running osascript when not Darwin", async () => {
+      mocks.isDarwin = false;
+      const state = await automationProber.request({ reason: "need control" });
+      const expected = platformUnsupportedState("automation");
+      expect(state).toEqual({
+        ...expected,
+        lastChecked: state.lastChecked,
+      });
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+      expect(mocks.queryAppleEventsTccStatus).not.toHaveBeenCalled();
+    });
+
+    it("prompts System Events then re-reads TCC, stamping lastRequested", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("granted");
+      const before = Date.now();
+      const state = await automationProber.request({ reason: "need control" });
+      const after = Date.now();
+      expect(mocks.runOsascript).toHaveBeenCalledTimes(1);
+      expect(mocks.runOsascript).toHaveBeenCalledWith(SYSTEM_EVENTS_SCRIPT);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledWith(
+        SYSTEM_EVENTS_BUNDLE_ID,
+      );
+      expect(state.status).toBe("granted");
+      expect(state.canRequest).toBe(false);
+      expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+      expect(state.lastRequested).toBeLessThanOrEqual(after);
+      expect(state.reason).toBeUndefined();
+      expectPlatform(state.platform);
+    });
+
+    it("keeps denied requestable=false after the prompt", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await automationProber.request({ reason: "need control" });
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+      expect(state.lastRequested).toEqual(expect.any(Number));
+    });
+
+    it("keeps a missing TCC row requestable after the prompt", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const state = await automationProber.request({ reason: "need control" });
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+      expect(state.lastRequested).toEqual(expect.any(Number));
+    });
+
+    it("ignores osascript failure and still classifies from the TCC re-read", async () => {
+      mocks.runOsascript.mockResolvedValue(null);
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await automationProber.request({ reason: "need control" });
+      expect(mocks.runOsascript).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+    });
+
+    it("does not copy the caller reason onto the returned state", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const state = await automationProber.request({
+        reason: "distinct-caller-reason",
+      });
+      expect(state.reason).toBeUndefined();
+      expect(state.status).toBe("not-determined");
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/services/permissions/probers/automation.ts`, which had no same-named test file. No product issue; this is a behavior-preserving unit suite.

- [x] This PR targets `develop` (branch is based on current `origin/develop` `14fb46bc5fbbfe587ab4b4c5ed72aa03c489eef5`).
- [ ] `bun install` and `bun run verify` were not re-run for this single-file test addition. Focused vitest, biome, and package tsc are quoted below.
- [x] A reviewer can confirm the suite without reading production code: the vitest counts below are from the live file.

# Sync with develop

- [x] Branch tip is `origin/develop` plus one test-file commit; zero conflicts.
- [ ] `bun run verify` not re-run (test-only; hosted CI does not run on this fork PR). Focused checks below.

# Risks

Low. Adds tests only. No production behaviour change. Darwin branches fake TCC.db / osascript collaborators so the suite cannot raise a macOS Automation prompt; `buildState` and `platformUnsupportedState` stay the real helpers.

# Background

## What does this PR do?

Adds `packages/agent/src/services/permissions/probers/automation.test.ts`, a same-named vitest suite for the real `automationProber`. The module had no same-named test file. This PR changes no production behaviour.

The prober under test is real. Tests import `automationProber` from `./automation.ts` and assert returned `PermissionState` values. They do not mock `buildState` and then re-assert the mock.

## What kind of change is this?

Testing (non-breaking; coverage only).

## What is covered

Exported surface: `automationProber` (`id`, `check()`, `request()`). `openSettings` is absent.

`check()` / `request()`:

- non-Darwin → real `platformUnsupportedState("automation")` (`not-applicable`, `canRequest: false`, `restrictedReason: "platform_unsupported"`); no TCC query and no osascript.
- Darwin + TCC `null` (missing Apple Events row) → `not-determined`, `canRequest: true`. `queryAppleEventsTccStatus` is called with `com.apple.systemevents`. `check()` never calls `runOsascript`.
- Darwin + TCC `granted` → `granted`, `canRequest: false`.
- Darwin + TCC `denied` → `denied`, `canRequest: false`.
- `request()` on Darwin runs `tell application "System Events" to get name of current user`, then re-reads TCC, and stamps `lastRequested`.
- osascript returning `null` does not override the TCC re-read.
- caller `reason` is not copied onto the returned state.
- the free-text `reason` option passed into `buildState` from `check()` is dropped by that helper, matching live behaviour (it is not a `PermissionState` field the helper copies).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/automation.test.ts` and:

```bash
bunx vitest run packages/agent/src/services/permissions/probers/automation.test.ts --config packages/agent/vitest.config.ts --coverage.enabled=false
```

## Detailed testing steps

None: automated tests are acceptable.

# Evidence Gate

Test-only change. The heavy bug-fix evidence procedure does not apply. Hosted CI does **not** run on this fork PR; the counts below are local, re-run after re-fetching current `origin/develop` (`14fb46bc5fbbfe587ab4b4c5ed72aa03c489eef5`). `automation.ts` on that revision is identical to the file the suite exercised.

1. `bunx vitest run packages/agent/src/services/permissions/probers/automation.test.ts --config packages/agent/vitest.config.ts --coverage.enabled=false`
   - Test Files  1 passed (1)
   - Tests  11 passed (11)
2. `bunx biome check --write packages/agent/src/services/permissions/probers/automation.test.ts`
   - Config present (`biome.json` and `tsconfig.json` at repo root; `git sparse-checkout list` reports the worktree is not sparse).
   - `Checked 1 file in 495ms. No fixes applied.`
3. `cd packages/agent && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep 'automation.test.ts'`
   - empty; `GREP_EXIT:1`. The new test file appears nowhere in tsc output. Pre-existing package errors, if any, are unrelated.
4. `git diff --name-only origin/develop...test/agent-automation-coverage` touches only `packages/agent/src/services/permissions/probers/automation.test.ts`.

<!-- evidence-head:55827b24ae28b1124dc49321b47c76bf5183a8cc -->

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`
- [x] After full-page screenshots: `N/A - test-only, no UI surface`
- [x] Walkthrough video: `N/A - test-only, no UI surface`
- [x] Backend logs: `N/A - unit tests, no server path`
- [x] Frontend logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB/memory/schedule/wallet output`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - unit tests only; no HTTP or UI path.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI surface.

### Before

N/A - test-only, no UI surface.

### After

N/A - test-only, no UI surface.

### Walkthrough video

N/A - test-only, no UI surface.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Hosted GitHub Actions CI does not run on this fork PR.
- `bun run verify` was not re-run for this single-file test addition. Focused vitest (11/11), biome (clean), and package tsc (this file absent from output) are the checks for this PR.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
