### PR TITLE
test(agent): cover contacts

### DIFF
--- a/packages/agent/src/services/permissions/probers/contacts.test.ts
+++ b/packages/agent/src/services/permissions/probers/contacts.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit coverage for the contacts permission prober. Drives the real
+ * `contactsProber` so Darwin native-status mapping, TCC AddressBook
+ * fallback, request() lastRequested stamping, and the non-Darwin
+ * short-circuit are asserted against live `buildState` output. Only the
+ * dylib, TCC, bundle-id, and privacy-pane collaborators are stubbed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getNativeDylib,
+  openPrivacyPane,
+  queryTccStatus,
+  resolveBundleId,
+} from "./_bridge.ts";
+import { contactsProber } from "./contacts.ts";
+
+const darwin = vi.hoisted(() => ({ value: true }));
+
+vi.mock("./_bridge.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.ts")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.value;
+    },
+    getNativeDylib: vi.fn(),
+    queryTccStatus: vi.fn(),
+    resolveBundleId: vi.fn(),
+    openPrivacyPane: vi.fn(),
+  };
+});
+
+const mockGetNativeDylib = vi.mocked(getNativeDylib);
+const mockQueryTcc = vi.mocked(queryTccStatus);
+const mockResolveBundleId = vi.mocked(resolveBundleId);
+const mockOpenPrivacyPane = vi.mocked(openPrivacyPane);
+
+const BUNDLE_ID = "ai.elizaos.contacts-test";
+
+function stubNativeLib(options: { check: number; request?: number }) {
+  return {
+    checkContactsPermission: () => options.check,
+    requestContactsPermission: () => options.request ?? options.check,
+  };
+}
+
+describe("contactsProber", () => {
+  beforeEach(() => {
+    darwin.value = true;
+    mockGetNativeDylib.mockReset();
+    mockQueryTcc.mockReset();
+    mockResolveBundleId.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockGetNativeDylib.mockResolvedValue(null);
+    mockQueryTcc.mockResolvedValue(null);
+    mockResolveBundleId.mockReturnValue(BUNDLE_ID);
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    darwin.value = true;
+  });
+
+  it("exposes the contacts permission id", () => {
+    expect(contactsProber.id).toBe("contacts");
+  });
+
+  it("check() returns platform-unsupported on non-Darwin without probing", async () => {
+    darwin.value = false;
+    const state = await contactsProber.check();
+    expect(state).toMatchObject({
+      id: "contacts",
+      status: "not-applicable",
+      canRequest: false,
+      restrictedReason: "platform_unsupported",
+    });
+    expect(typeof state.lastChecked).toBe("number");
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockQueryTcc).not.toHaveBeenCalled();
+  });
+
+  it("check() maps native granted (2) and skips TCC", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 2 }) as never);
+    const state = await contactsProber.check();
+    expect(state.id).toBe("contacts");
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(mockQueryTcc).not.toHaveBeenCalled();
+    expect(mockResolveBundleId).not.toHaveBeenCalled();
+  });
+
+  it("check() maps native denied (1)", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 1 }) as never);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+  });
+
+  it("check() maps native restricted (3) to os_policy and cannot re-request", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 3 }) as never);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.restrictedReason).toBe("os_policy");
+    expect(state.canRequest).toBe(false);
+  });
+
+  it("check() maps native write-only (4) to restricted without canRequest", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 4 }) as never);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.restrictedReason).toBe("os_policy");
+    // Contacts, unlike calendar/reminders, does not treat write-only as requestable.
+    expect(state.canRequest).toBe(false);
+  });
+
+  it("check() maps native not-determined (0) as requestable", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 0 }) as never);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+  });
+
+  it("check() maps an unknown native code to not-determined", async () => {
+    mockGetNativeDylib.mockResolvedValue(stubNativeLib({ check: 99 }) as never);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+  });
+
+  it("check() falls back to TCC granted when the dylib is missing", async () => {
+    mockQueryTcc.mockResolvedValue("granted");
+    const state = await contactsProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(mockQueryTcc).toHaveBeenCalledTimes(1);
+    expect(mockQueryTcc).toHaveBeenCalledWith(
+      "kTCCServiceAddressBook",
+      BUNDLE_ID,
+    );
+  });
+
+  it("check() falls back to TCC denied when the dylib is missing", async () => {
+    mockQueryTcc.mockResolvedValue("denied");
+    const state = await contactsProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(mockQueryTcc).toHaveBeenCalledWith(
+      "kTCCServiceAddressBook",
+      BUNDLE_ID,
+    );
+  });
+
+  it("check() treats a missing TCC row as not-determined", async () => {
+    mockQueryTcc.mockResolvedValue(null);
+    const state = await contactsProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(mockQueryTcc).toHaveBeenCalledWith(
+      "kTCCServiceAddressBook",
+      BUNDLE_ID,
+    );
+  });
+
+  it("request() returns platform-unsupported on non-Darwin without prompting", async () => {
+    darwin.value = false;
+    const state = await contactsProber.request({ reason: "sync contacts" });
+    expect(state.status).toBe("not-applicable");
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("request() uses the native prompt and stamps lastRequested", async () => {
+    const lib = stubNativeLib({ check: 0, request: 2 });
+    mockGetNativeDylib.mockResolvedValue(lib as never);
+    const before = Date.now();
+    const state = await contactsProber.request({ reason: "sync contacts" });
+    const after = Date.now();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeTypeOf("number");
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(mockQueryTcc).not.toHaveBeenCalled();
+  });
+
+  it("request() without a dylib opens the Contacts privacy pane then re-checks", async () => {
+    mockQueryTcc.mockResolvedValue("denied");
+    const before = Date.now();
+    const state = await contactsProber.request({ reason: "sync contacts" });
+    const after = Date.now();
+    expect(mockOpenPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("Contacts");
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(mockQueryTcc).toHaveBeenCalledWith(
+      "kTCCServiceAddressBook",
+      BUNDLE_ID,
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/agent/src/services/permissions/probers/contacts.ts`, which previously had no dedicated test file.

The production module is unchanged. The suite imports `contactsProber` and asserts the behaviour the code actually has:

- `id` is `contacts`
- non-Darwin `check()` and `request()` return `not-applicable` / `platform_unsupported` and do not load the native dylib, query TCC, or open a privacy pane; `request()` does not stamp `lastRequested`
- a present native dylib maps EventKit/Contacts codes through live `mapNativePrivacyAuthStatus` / `buildState`: `2` granted, `1` denied, `3` restricted/`os_policy`, `4` write-only restricted/`os_policy` with `canRequest: false` (contacts does not treat write-only as requestable), `0` and unknown codes not-determined/`canRequest: true`; TCC is not consulted
- a missing dylib falls back to `queryTccStatus("kTCCServiceAddressBook", bundleId)`: granted, denied, and a missing row (`null`) → not-determined
- native `request()` stamps `lastRequested` from the native prompt result and does not open System Settings
- dylib-less `request()` opens the Contacts privacy pane, re-checks TCC, and stamps `lastRequested`

## Evidence

1. `bunx vitest run packages/agent/src/services/permissions/probers/contacts.test.ts` — Test Files 1 passed (1), Tests 14 passed (14). Re-run against current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`) immediately before filing.
2. `bunx biome check --write packages/agent/src/services/permissions/probers/contacts.test.ts` — Checked 1 file in 279ms. No fixes applied.
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep contacts.test.ts` — empty (this file introduced no TypeScript errors). Pre-existing package errors elsewhere are not from this change.
4. Diff touches only `packages/agent/src/services/permissions/probers/contacts.test.ts`.

Hosted CI does not run on this fork contributor's PRs; the counts above are from local `bunx vitest` / `biome` / `tsc`.

## Test plan

- [x] Focused vitest file collected and green
- [x] biome + tsc on the new file
- [ ] Maintainer review of the new assertions

# Relates to

Coverage gap: `packages/agent/src/services/permissions/probers/contacts.ts` had no same-named test file.

- [x] This PR targets `develop` and is based on current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`) with a one-file diff and zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change; focused vitest / biome / tsc on the new file are quoted above. Hosted CI does not run on this fork.
- [x] A reviewer can confirm the change works without reading the code from the vitest counts above.

# Sync with develop

- [x] Branch parent is current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`); zero conflicts.
- [ ] `bun run verify` was not run (test-only, no production behaviour change). Focused vitest / biome / tsc quoted in Evidence.

# Risks

Low. Test-only addition. No production behaviour change.

# Background

## What does this PR do?

Adds unit coverage for `contactsProber` next to the module.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/contacts.test.ts`

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/services/permissions/probers/contacts.test.ts
```

# Evidence Gate

<!-- evidence-head:d39b8ba3c89fa494765d49db26adf83a137e9312 -->

- [x] Before full-page screenshots — `N/A - test-only change; no UI surface`
- [x] After full-page screenshots — `N/A - test-only change; no UI surface`
- [x] Walkthrough video — `N/A - test-only change; no UI surface`
- [x] Backend logs — `N/A - test-only change; no production path change`
- [x] Frontend logs — `N/A - test-only change; no UI surface`
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts — `N/A - test-only change; no persisted domain objects`
- [x] OCR visual-text review — `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only change; no production path change.

## Screenshots (before / after) + video walkthrough

N/A - test-only change; no UI surface.

### Before

N/A - test-only change; no UI surface.

### After

N/A - test-only change; no UI surface.

### Walkthrough video

N/A - test-only change; no UI surface.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds tests only and changes no production behaviour. Focused vitest (14/14), biome, and tsc (new file absent from output) are quoted above.
- Hosted CI does not run on this fork contributor's PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
