### PR TITLE
fix(settings): mount cloud account footer destinations

### DIFF
--- a/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
+++ b/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
@@ -115,7 +115,7 @@ export function ContributeCredentialDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="bg-popover border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
+      <DialogContent className="bg-bg border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
         {result ? (
           <>
             <DialogHeader>
@@ -208,7 +208,7 @@ export function ContributeCredentialDialog({
                   >
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent className="bg-popover border-border">
+                  <SelectContent className="bg-bg border-border">
                     {POOLED_PROVIDERS.map((id) => (
                       <SelectItem key={id} value={id}>
                         <span className="font-mono text-txt-strong">

--- a/packages/ui/src/cloud/organization/credentials-list.tsx
+++ b/packages/ui/src/cloud/organization/credentials-list.tsx
@@ -226,7 +226,7 @@ export function CredentialsList({
                         <Trash2 className="h-4 w-4 text-danger" />
                       </Button>
                     </AlertDialogTrigger>
-                    <AlertDialogContent className="bg-popover border border-brand-surface">
+                    <AlertDialogContent className="bg-bg border border-brand-surface">
                       <AlertDialogHeader>
                         <AlertDialogTitle className="text-txt-strong font-mono">
                           {t("cloud.credentialsList.removeTitle", {

--- a/packages/ui/src/cloud/organization/credentials-tab.test.tsx
+++ b/packages/ui/src/cloud/organization/credentials-tab.test.tsx
@@ -13,6 +13,13 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const apiMock = vi.hoisted(() => vi.fn());
+const sessionState = vi.hoisted(() => ({
+  current: {
+    ready: true,
+    authenticated: true,
+    user: null as { id: string; email: string } | null,
+  },
+}));
 vi.mock("../lib/api-client", async () => {
   const actual =
     await vi.importActual<typeof import("../lib/api-client")>(
@@ -20,6 +27,9 @@ vi.mock("../lib/api-client", async () => {
     );
   return { ...actual, api: (...args: unknown[]) => apiMock(...args) };
 });
+vi.mock("../lib/use-session-auth", () => ({
+  useSessionAuth: () => sessionState.current,
+}));
 vi.mock("../shell/CloudI18nProvider", () => ({
   // t() returns defaultValue with {{param}} interpolation so assertions read
   // the real rendered copy.
@@ -117,6 +127,11 @@ function mockListOnly() {
 }
 
 function renderTab(user: UserWithOrganizationDto, autoContribute = false) {
+  sessionState.current = {
+    ready: true,
+    authenticated: true,
+    user: { id: user.id, email: user.email ?? `${user.id}@example.test` },
+  };
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },

--- a/packages/ui/src/cloud/organization/data/auth-scoped-queries.test.tsx
+++ b/packages/ui/src/cloud/organization/data/auth-scoped-queries.test.tsx
@@ -1,0 +1,201 @@
+/** Tenant-isolation coverage for every Organization React Query hook. */
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const sessionState = vi.hoisted(() => ({
+  current: {
+    ready: false,
+    authenticated: false,
+    user: null as { id: string; email: string } | null,
+  },
+}));
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return { ...actual, api: apiMock };
+});
+vi.mock("../../lib/use-session-auth", () => ({
+  useSessionAuth: () => sessionState.current,
+}));
+
+import {
+  credentialsQueryKey,
+  useOrganizationCredentials,
+} from "./use-credentials";
+import {
+  organizationQueryKeys,
+  useOrganizationInvites,
+  useOrganizationMembers,
+  useOrganizationUser,
+} from "./use-organization";
+
+function authenticatedAs(userId: string): void {
+  sessionState.current = {
+    ready: true,
+    authenticated: true,
+    user: { id: userId, email: `${userId}@example.test` },
+  };
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+}
+
+function queryWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function mockOrganizationApi(): void {
+  apiMock.mockImplementation((path: string) => {
+    const userId = sessionState.current.user?.id;
+    if (!userId) return Promise.reject(new Error("missing test identity"));
+
+    const data = (() => {
+      switch (path) {
+        case "/api/v1/user":
+          return { id: userId, email: `${userId}@example.test` };
+        case "/api/organizations/members":
+          return [{ id: `${userId}-member` }];
+        case "/api/organizations/invites":
+          return [{ id: `${userId}-invite` }];
+        case "/api/organizations/credentials":
+          return [{ id: `${userId}-credential` }];
+        default:
+          throw new Error(`unexpected call: ${path}`);
+      }
+    })();
+
+    return Promise.resolve({ success: true, data });
+  });
+}
+
+beforeEach(() => {
+  apiMock.mockReset();
+  sessionState.current = {
+    ready: false,
+    authenticated: false,
+    user: null,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Organization queries — authenticated cache isolation", () => {
+  it("does not reuse Organization data when the authenticated identity changes", async () => {
+    authenticatedAs("user-one");
+    mockOrganizationApi();
+    const client = createQueryClient();
+
+    const { result, rerender } = renderHook(
+      () => ({
+        user: useOrganizationUser(),
+        members: useOrganizationMembers(true),
+        invites: useOrganizationInvites(true),
+        credentials: useOrganizationCredentials(),
+      }),
+      { wrapper: queryWrapper(client) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.user.data?.id).toBe("user-one");
+      expect(result.current.members.data?.[0]?.id).toBe("user-one-member");
+      expect(result.current.invites.data?.[0]?.id).toBe("user-one-invite");
+      expect(result.current.credentials.data?.[0]?.id).toBe(
+        "user-one-credential",
+      );
+    });
+
+    authenticatedAs("user-two");
+    rerender();
+
+    expect(result.current.user.data).toBeUndefined();
+    expect(result.current.members.data).toBeUndefined();
+    expect(result.current.invites.data).toBeUndefined();
+    expect(result.current.credentials.data).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.user.data?.id).toBe("user-two");
+      expect(result.current.members.data?.[0]?.id).toBe("user-two-member");
+      expect(result.current.invites.data?.[0]?.id).toBe("user-two-invite");
+      expect(result.current.credentials.data?.[0]?.id).toBe(
+        "user-two-credential",
+      );
+    });
+    expect(apiMock).toHaveBeenCalledTimes(8);
+
+    const keys = client
+      .getQueryCache()
+      .getAll()
+      .map((query) => query.queryKey);
+    for (const identity of ["user-one", "user-two"]) {
+      expect(keys).toContainEqual([
+        ...organizationQueryKeys.user,
+        "auth",
+        identity,
+      ]);
+      expect(keys).toContainEqual([
+        ...organizationQueryKeys.members,
+        "auth",
+        identity,
+      ]);
+      expect(keys).toContainEqual([
+        ...organizationQueryKeys.invites,
+        "auth",
+        identity,
+      ]);
+      expect(keys).toContainEqual([...credentialsQueryKey, "auth", identity]);
+    }
+  });
+
+  it("does not request Organization data while signed out", () => {
+    const { result } = renderHook(
+      () => ({
+        user: useOrganizationUser(),
+        members: useOrganizationMembers(true),
+        invites: useOrganizationInvites(true),
+        credentials: useOrganizationCredentials(),
+      }),
+      { wrapper: queryWrapper(createQueryClient()) },
+    );
+
+    expect(result.current.user.fetchStatus).toBe("idle");
+    expect(result.current.members.fetchStatus).toBe("idle");
+    expect(result.current.invites.fetchStatus).toBe("idle");
+    expect(result.current.credentials.fetchStatus).toBe("idle");
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the caller RBAC gate for members and invites", () => {
+    authenticatedAs("user-one");
+    mockOrganizationApi();
+
+    const { result } = renderHook(
+      () => ({
+        members: useOrganizationMembers(false),
+        invites: useOrganizationInvites(false),
+      }),
+      { wrapper: queryWrapper(createQueryClient()) },
+    );
+
+    expect(result.current.members.fetchStatus).toBe("idle");
+    expect(result.current.invites.fetchStatus).toBe("idle");
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/organization/data/use-credentials.ts
+++ b/packages/ui/src/cloud/organization/data/use-credentials.ts
@@ -12,6 +12,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../lib/api-client";
+import {
+  authenticatedQueryKey,
+  useAuthenticatedQueryGate,
+} from "../../lib/auth-query";
 import type { PooledCredentialDto } from "./cloud-org-types";
 
 interface Envelope<T> {
@@ -28,8 +32,10 @@ export const credentialsQueryKey = [
 
 /** Pooled credentials, masked. Member-readable — no RBAC gate on the read. */
 export function useOrganizationCredentials() {
+  const gate = useAuthenticatedQueryGate();
   return useQuery<PooledCredentialDto[]>({
-    queryKey: credentialsQueryKey,
+    queryKey: authenticatedQueryKey(credentialsQueryKey, gate),
+    enabled: gate.enabled,
     queryFn: async () => {
       const res = await api<Envelope<PooledCredentialDto[]>>(
         "/api/organizations/credentials",

--- a/packages/ui/src/cloud/organization/data/use-organization.ts
+++ b/packages/ui/src/cloud/organization/data/use-organization.ts
@@ -15,6 +15,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ApiError, api } from "../../lib/api-client";
+import {
+  authenticatedQueryKey,
+  useAuthenticatedQueryGate,
+} from "../../lib/auth-query";
 import type {
   CreatedInviteDto,
   InviteRole,
@@ -37,8 +41,10 @@ export const organizationQueryKeys = {
 
 /** Current user (with organization) used to scope the org surface + RBAC. */
 export function useOrganizationUser() {
+  const gate = useAuthenticatedQueryGate();
   return useQuery<UserWithOrganizationDto>({
-    queryKey: organizationQueryKeys.user,
+    queryKey: authenticatedQueryKey(organizationQueryKeys.user, gate),
+    enabled: gate.enabled,
     queryFn: async () => {
       const res = await api<Envelope<UserWithOrganizationDto>>("/api/v1/user");
       return res.data;
@@ -48,9 +54,10 @@ export function useOrganizationUser() {
 
 /** Organization members. Backend gates this to owner/admin (403 otherwise). */
 export function useOrganizationMembers(enabled: boolean) {
+  const gate = useAuthenticatedQueryGate(enabled);
   return useQuery<OrgMemberDto[]>({
-    queryKey: organizationQueryKeys.members,
-    enabled,
+    queryKey: authenticatedQueryKey(organizationQueryKeys.members, gate),
+    enabled: gate.enabled,
     queryFn: async () => {
       const res = await api<Envelope<OrgMemberDto[]>>(
         "/api/organizations/members",
@@ -62,9 +69,10 @@ export function useOrganizationMembers(enabled: boolean) {
 
 /** Pending + historical invites. Backend gates this to owner/admin. */
 export function useOrganizationInvites(enabled: boolean) {
+  const gate = useAuthenticatedQueryGate(enabled);
   return useQuery<OrgInviteDto[]>({
-    queryKey: organizationQueryKeys.invites,
-    enabled,
+    queryKey: authenticatedQueryKey(organizationQueryKeys.invites, gate),
+    enabled: gate.enabled,
     queryFn: async () => {
       const res = await api<Envelope<OrgInviteDto[]>>(
         "/api/organizations/invites",

--- a/packages/ui/src/cloud/organization/dialog-portal-surface.test.tsx
+++ b/packages/ui/src/cloud/organization/dialog-portal-surface.test.tsx
@@ -1,0 +1,207 @@
+/** Portal-theme coverage for the Organization dialogs and their selects. */
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (key: string, options?: Record<string, unknown>) =>
+    (options?.defaultValue as string) ?? key,
+}));
+
+import { ContributeCredentialDialog } from "./contribute-credential-dialog";
+import { CredentialsList } from "./credentials-list";
+import { InviteMemberDialog } from "./invite-member-dialog";
+import { MembersList } from "./members-list";
+import { PendingInvitesList } from "./pending-invites-list";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+});
+
+function renderInsideNuphyScope(ui: ReactElement): void {
+  const scope = document.createElement("div");
+  scope.className = "nuphy-scope";
+  document.body.append(scope);
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>, {
+    container: scope,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+  document.documentElement.classList.remove("dark");
+});
+
+describe.each([
+  {
+    name: "invite member",
+    selectName: "Role",
+    renderDialog: () => (
+      <InviteMemberDialog
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        organizationName="IQ Labs"
+      />
+    ),
+  },
+  {
+    name: "contribute credential",
+    selectName: "Provider",
+    renderDialog: () => (
+      <ContributeCredentialDialog
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+      />
+    ),
+  },
+])("$name dialog portal surface", ({ renderDialog, selectName }) => {
+  it("uses a globally defined opaque surface outside .nuphy-scope", () => {
+    document.documentElement.classList.remove("dark");
+    renderInsideNuphyScope(renderDialog());
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.closest(".nuphy-scope")).toBeNull();
+    expect(dialog.classList.contains("bg-bg")).toBe(true);
+    expect(dialog.classList.contains("bg-popover")).toBe(false);
+  });
+
+  it("keeps its portalled select menu on the same global surface", () => {
+    renderInsideNuphyScope(renderDialog());
+
+    fireEvent.pointerDown(screen.getByRole("combobox", { name: selectName }), {
+      button: 0,
+      ctrlKey: false,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.closest(".nuphy-scope")).toBeNull();
+    expect(listbox.classList.contains("bg-bg")).toBe(true);
+    expect(listbox.classList.contains("bg-popover")).toBe(false);
+  });
+});
+
+function expectGlobalOpaquePortal(element: HTMLElement): void {
+  expect(element.closest(".nuphy-scope")).toBeNull();
+  expect(element.classList.contains("bg-bg")).toBe(true);
+  expect(element.classList.contains("bg-popover")).toBe(false);
+}
+
+describe("Organization row action portal surfaces", () => {
+  it("keeps the member role menu and removal dialog globally opaque", () => {
+    renderInsideNuphyScope(
+      <MembersList
+        members={[
+          {
+            id: "member-1",
+            name: "Member One",
+            email: "member@example.test",
+            wallet_address: null,
+            wallet_chain_type: null,
+            role: "member",
+            is_active: true,
+            created_at: "2026-08-23T08:00:00.000Z",
+            updated_at: "2026-08-23T08:00:00.000Z",
+          },
+        ]}
+        currentUserId="owner-1"
+        currentUserRole="owner"
+        isOwner
+        onUpdateRole={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("combobox"), {
+      button: 0,
+      ctrlKey: false,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    expectGlobalOpaquePortal(screen.getByRole("listbox"));
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Member" }));
+    expectGlobalOpaquePortal(screen.getByRole("alertdialog"));
+  });
+
+  it("keeps the revoke-invite dialog globally opaque", () => {
+    renderInsideNuphyScope(
+      <PendingInvitesList
+        invites={[
+          {
+            id: "invite-1",
+            email: "invitee@example.test",
+            role: "member",
+            status: "pending",
+            expires_at: "2099-08-24T08:00:00.000Z",
+            created_at: "2026-08-23T08:00:00.000Z",
+            inviter: {
+              id: "owner-1",
+              name: "Owner One",
+              email: "owner@example.test",
+            },
+            accepted_at: null,
+          },
+        ]}
+        onRevoke={() => {}}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Revoke invitation for invitee@example.test",
+      }),
+    );
+    expectGlobalOpaquePortal(screen.getByRole("alertdialog"));
+  });
+
+  it("keeps the credential-removal dialog globally opaque", () => {
+    renderInsideNuphyScope(
+      <CredentialsList
+        credentials={[
+          {
+            id: "credential-1",
+            provider: "openai-api",
+            label: "OpenAI key",
+            last4: "1234",
+            enabled: true,
+            priority: 0,
+            health: "ok",
+            healthDetail: null,
+            usage: null,
+            contributedBy: { id: "owner-1", name: "Owner One" },
+            callsToday: 0,
+            lastUsedAt: null,
+            createdAt: "2026-08-23T08:00:00.000Z",
+          },
+        ]}
+        currentUserId="owner-1"
+        canManage
+        onToggle={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expectGlobalOpaquePortal(screen.getByRole("alertdialog"));
+  });
+});

--- a/packages/ui/src/cloud/organization/invite-member-dialog.tsx
+++ b/packages/ui/src/cloud/organization/invite-member-dialog.tsx
@@ -119,7 +119,7 @@ export function InviteMemberDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="bg-popover border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
+      <DialogContent className="bg-bg border border-brand-surface p-4 sm:p-6 max-w-[95vw] sm:max-w-md">
         {inviteLink ? (
           <>
             <DialogHeader>
@@ -240,7 +240,7 @@ export function InviteMemberDialog({
                   >
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent className="bg-popover border-border">
+                  <SelectContent className="bg-bg border-border">
                     <SelectItem value="member">
                       <div className="flex flex-col items-start">
                         <span className="font-mono font-medium text-txt-strong">

--- a/packages/ui/src/cloud/organization/members-list.tsx
+++ b/packages/ui/src/cloud/organization/members-list.tsx
@@ -205,7 +205,7 @@ export function MembersList({
                           </div>
                         </SelectValue>
                       </SelectTrigger>
-                      <SelectContent className="bg-popover border-border">
+                      <SelectContent className="bg-bg border-border">
                         <SelectItem value="admin">
                           <div className="flex items-center gap-1.5">
                             <Shield className="h-4 w-4" />
@@ -243,12 +243,15 @@ export function MembersList({
                         <Button
                           variant="ghost"
                           type="button"
+                          aria-label={t("cloud.membersList.removeMember", {
+                            defaultValue: "Remove Member",
+                          })}
                           className="p-2 hover:bg-surface transition-colors border border-border"
                         >
                           <UserMinus className="h-4 w-4 text-danger" />
                         </Button>
                       </AlertDialogTrigger>
-                      <AlertDialogContent className="bg-popover border border-brand-surface">
+                      <AlertDialogContent className="bg-bg border border-brand-surface">
                         <AlertDialogHeader>
                           <AlertDialogTitle className="text-txt-strong font-mono">
                             {t("cloud.membersList.removeMember", {

--- a/packages/ui/src/cloud/organization/pending-invites-list.tsx
+++ b/packages/ui/src/cloud/organization/pending-invites-list.tsx
@@ -171,12 +171,13 @@ export function PendingInvitesList({
                     <Button
                       variant="ghost"
                       type="button"
+                      aria-label={`Revoke invitation for ${invite.email}`}
                       className="p-2 hover:bg-surface transition-colors border border-border"
                     >
                       <X className="h-4 w-4 text-danger" />
                     </Button>
                   </AlertDialogTrigger>
-                  <AlertDialogContent className="bg-popover border border-brand-surface">
+                  <AlertDialogContent className="bg-bg border border-brand-surface">
                     <AlertDialogHeader>
                       <AlertDialogTitle className="text-txt-strong font-mono">
                         Revoke Invitation

--- a/packages/ui/src/cloud/settings/CloudSettingsSectionShell.test.tsx
+++ b/packages/ui/src/cloud/settings/CloudSettingsSectionShell.test.tsx
@@ -1,0 +1,159 @@
+/** Verifies that lifted cloud sections keep their contextual header actions. */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSetPageHeader } from "../../cloud-ui/components/layout";
+import { CloudSettingsSectionShell } from "./CloudSettingsSectionShell";
+
+const invoiceRouteParam = vi.hoisted(() => ({
+  current: null as string | null,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  CloudI18nProvider: ({ children }: { children: ReactNode }) => children,
+  resolveInitialCloudLang: () => "en",
+  useCloudT: () => (key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? key,
+}));
+
+vi.mock("../shell/StewardProvider", () => ({
+  StewardAuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("../billing/data/billing-data", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBillingUser: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: "user-1", organization_id: "org-1" },
+  }),
+  useInvoice: (id: string | undefined) => {
+    invoiceRouteParam.current = id ?? null;
+    return {
+      data: {
+        id: "invoice-42",
+        organization_id: "org-1",
+        stripe_invoice_id: "stripe-invoice-42",
+        stripe_customer_id: "stripe-customer-1",
+        stripe_payment_intent_id: null,
+        amount_due: 42,
+        amount_paid: 42,
+        currency: "usd",
+        status: "paid",
+        invoice_type: "one_time_purchase",
+        invoice_number: "INV-0042",
+        invoice_pdf: null,
+        hosted_invoice_url: null,
+        credits_added: 42,
+        metadata: {},
+        created_at: "2026-08-23T08:00:00.000Z",
+        updated_at: "2026-08-23T08:00:00.000Z",
+        due_date: null,
+        paid_at: "2026-08-23T08:00:00.000Z",
+      },
+      error: null,
+      isLoading: false,
+    };
+  },
+}));
+
+function SectionWithHeaderAction({ onAction }: { onAction: () => void }) {
+  useSetPageHeader(
+    {
+      title: "API Keys",
+      actions: (
+        <button type="button" onClick={onAction}>
+          Generate key
+        </button>
+      ),
+    },
+    [onAction],
+  );
+
+  return <div>API key settings</div>;
+}
+
+function BillingInvoiceNavigationProbe() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <span>Billing settings</span>
+      <button
+        type="button"
+        onClick={() => navigate("/cloud/invoices/invoice-42")}
+      >
+        View invoice
+      </button>
+    </div>
+  );
+}
+
+describe("CloudSettingsSectionShell", () => {
+  afterEach(() => cleanup());
+
+  it("renders actions published through the cloud page-header context", async () => {
+    const onAction = vi.fn();
+    const view = render(
+      <CloudSettingsSectionShell>
+        <SectionWithHeaderAction onAction={onAction} />
+      </CloudSettingsSectionShell>,
+    );
+
+    expect(screen.getByText("API key settings")).toBeTruthy();
+    const action = await screen.findByRole("button", { name: "Generate key" });
+    fireEvent.click(action);
+    expect(onAction).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <CloudSettingsSectionShell>
+        <div>Organization settings</div>
+      </CloudSettingsSectionShell>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Generate key" })).toBeNull();
+    });
+  });
+
+  it("renders the canonical invoice detail route after in-settings navigation", async () => {
+    render(
+      <CloudSettingsSectionShell>
+        <BillingInvoiceNavigationProbe />
+      </CloudSettingsSectionShell>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View invoice" }));
+
+    expect(
+      await screen.findByRole(
+        "heading",
+        {
+          level: 1,
+          name: "Invoice Details",
+        },
+        { timeout: 10_000 },
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("INV-0042")).toBeTruthy();
+    expect(invoiceRouteParam.current).toBe("invoice-42");
+    expect(screen.queryByText("Billing settings")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Billing" }));
+    expect(await screen.findByText("Billing settings")).toBeTruthy();
+  }, 15_000);
+});

--- a/packages/ui/src/cloud/settings/CloudSettingsSectionShell.tsx
+++ b/packages/ui/src/cloud/settings/CloudSettingsSectionShell.tsx
@@ -15,8 +15,9 @@
  *
  *  - **Router:** only a fallback `MemoryRouter` when no router context exists
  *    ({@link useInRouterContext}). Bodies that call `useNavigate` (billing →
- *    invoice) navigate the memory history; nesting a router inside an existing
- *    one is avoided.
+ *    invoice) navigate the memory history; that fallback mounts the canonical
+ *    invoice-detail route registered by the billing domain. Nesting a router
+ *    inside an existing one is avoided.
  *  - **QueryClientProvider:** the shared cloud {@link queryClient}. Re-providing
  *    the same client under an existing provider is a harmless no-op.
  *  - **CloudI18nProvider:** so `useCloudT()` resolves.
@@ -24,26 +25,97 @@
  *    gates read. It lazy-loads the heavy `@stwd/*` runtime only when a token is
  *    present (see `StewardAuthProvider`), so signed-out users pay nothing.
  *  - **PageHeaderProvider:** surfaces that call `useSetPageHeader` (api-keys,
- *    account, …) need an ancestor; the Settings view renders its own header, so
- *    the cloud page header is captured here and discarded — the body still
- *    renders its content.
+ *    account, …) need an ancestor. The Settings view owns the title, while this
+ *    shell renders any contextual header actions published by the cloud body.
  */
 
 import { QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
-import { MemoryRouter, useInRouterContext } from "react-router-dom";
-import { PageHeaderProvider } from "../../cloud-ui/components/layout";
+import { type ComponentType, type ReactNode, Suspense } from "react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useInRouterContext,
+} from "react-router-dom";
+import {
+  PageHeaderProvider,
+  usePageHeader,
+} from "../../cloud-ui/components/layout";
+import "../billing/routes";
 import { queryClient } from "../lib/query-client";
 import {
   CloudI18nProvider,
   resolveInitialCloudLang,
 } from "../shell/CloudI18nProvider";
+import { getCloudRoute } from "../shell/cloud-route-registry";
 import { StewardAuthProvider } from "../shell/StewardProvider";
+
+const BILLING_INVOICE_ROUTE_PATH = "cloud/invoices/:id";
+
+function SettingsSectionProviders({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CloudI18nProvider initialLang={resolveInitialCloudLang()}>
+        <StewardAuthProvider>
+          <PageHeaderProvider>{children}</PageHeaderProvider>
+        </StewardAuthProvider>
+      </CloudI18nProvider>
+    </QueryClientProvider>
+  );
+}
+
+function SettingsMemoryRoutes({ children }: { children: ReactNode }) {
+  const invoiceRoute = getCloudRoute(BILLING_INVOICE_ROUTE_PATH);
+  if (!invoiceRoute) {
+    throw new Error(
+      `Canonical Cloud route "${BILLING_INVOICE_ROUTE_PATH}" is not registered`,
+    );
+  }
+  const InvoiceDetailRoute = invoiceRoute.element as ComponentType;
+
+  return (
+    <Routes>
+      <Route
+        path={`/${invoiceRoute.path}`}
+        element={
+          <Suspense
+            fallback={
+              <div
+                aria-label="Loading invoice"
+                aria-live="polite"
+                role="status"
+              />
+            }
+          >
+            <InvoiceDetailRoute />
+          </Suspense>
+        }
+      />
+      <Route path="*" element={children} />
+    </Routes>
+  );
+}
 
 function MaybeRouter({ children }: { children: ReactNode }) {
   const inRouter = useInRouterContext();
-  if (inRouter) return <>{children}</>;
-  return <MemoryRouter>{children}</MemoryRouter>;
+  if (inRouter) {
+    return <SettingsSectionProviders>{children}</SettingsSectionProviders>;
+  }
+  return (
+    <MemoryRouter>
+      <SettingsSectionProviders>
+        <SettingsMemoryRoutes>{children}</SettingsMemoryRoutes>
+      </SettingsSectionProviders>
+    </MemoryRouter>
+  );
+}
+
+function SettingsSectionHeaderActions() {
+  const { pageInfo } = usePageHeader();
+
+  if (pageInfo?.actions == null) return null;
+
+  return <div className="mb-4 flex justify-end">{pageInfo.actions}</div>;
 }
 
 /**
@@ -57,13 +129,8 @@ export function CloudSettingsSectionShell({
 }): React.JSX.Element {
   return (
     <MaybeRouter>
-      <QueryClientProvider client={queryClient}>
-        <CloudI18nProvider initialLang={resolveInitialCloudLang()}>
-          <StewardAuthProvider>
-            <PageHeaderProvider>{children}</PageHeaderProvider>
-          </StewardAuthProvider>
-        </CloudI18nProvider>
-      </QueryClientProvider>
+      <SettingsSectionHeaderActions />
+      {children}
     </MaybeRouter>
   );
 }

--- a/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.account-footer.test.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.account-footer.test.tsx
@@ -1,0 +1,441 @@
+/** Exercises connected-account footer navigation in the real wide and narrow cloud-panel shells with stub section bodies. */
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const appState = vi.hoisted(() => ({
+  connected: true,
+  handleInteractiveCloudLogin: vi.fn(async () => undefined),
+  handleCloudSignOut: vi.fn(async () => undefined),
+  setActionNotice: vi.fn(),
+}));
+const mediaState = vi.hoisted(() => ({ wide: true }));
+const credentialState = vi.hoisted(() => ({ present: false }));
+
+vi.mock("../../../hooks/useMediaQuery", () => ({
+  useMediaQuery: () => mediaState.wide,
+}));
+
+vi.mock("../../../state", () => ({
+  useAppSelector: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      elizaCloudConnected: appState.connected,
+      handleInteractiveCloudLogin: appState.handleInteractiveCloudLogin,
+      handleCloudSignOut: appState.handleCloudSignOut,
+      setActionNotice: appState.setActionNotice,
+    }),
+}));
+
+vi.mock("./cloud-management-auth", () => ({
+  useHasCloudManagementCredential: () => credentialState.present,
+}));
+
+vi.mock("./cloud-panel-sections", () => {
+  const Icon = () => <span aria-hidden="true" />;
+  const primarySection = {
+    id: "general",
+    label: "General",
+    subtitle: "Desktop behavior",
+    icon: Icon,
+    placement: "navigation",
+    group: "general",
+    order: 0,
+    Component: () => <div data-testid="section-general">General section</div>,
+  };
+  const footerSections = [
+    {
+      id: "cloud-billing",
+      label: "Billing & Credits",
+      subtitle: "Plans, credits, and invoices",
+      footerLabel: "Manage billing",
+    },
+    {
+      id: "cloud-api-keys",
+      label: "API Keys",
+      subtitle: "Cloud API credentials",
+      footerLabel: "API keys",
+    },
+    {
+      id: "cloud-security",
+      label: "Sessions & Privacy",
+      subtitle: "Sessions, privacy, and audit",
+      footerLabel: "Sessions & privacy",
+    },
+    {
+      id: "cloud-organization",
+      label: "Organization",
+      subtitle: "Members and organization settings",
+      footerLabel: "Organization",
+    },
+  ].map((section) => ({
+    ...section,
+    icon: Icon,
+    placement: "account-footer",
+    Component: () => (
+      <div data-testid={`section-${section.id}`}>{section.label} section</div>
+    ),
+  }));
+  const sections = [primarySection, ...footerSections];
+  return {
+    CLOUD_PANEL_SECTIONS: sections,
+    cloudPanelAccountFooterSections: () => footerSections,
+    groupedCloudPanelSections: () => ({ general: [primarySection] }),
+    resolveCloudPanelSection: (id: string) =>
+      sections.some((section) => section.id === id) ? id : "general",
+  };
+});
+
+import { CloudSettingsPanel } from "./CloudSettingsPanel";
+
+const ACCOUNT_DESTINATIONS = [
+  ["Manage billing", "cloud-billing", "Billing & Credits"],
+  ["API keys", "cloud-api-keys", "API Keys"],
+  ["Sessions & privacy", "cloud-security", "Sessions & Privacy"],
+  ["Organization", "cloud-organization", "Organization"],
+] as const;
+
+describe("CloudSettingsPanel account footer navigation", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    appState.connected = true;
+    mediaState.wide = true;
+    credentialState.present = false;
+    appState.handleInteractiveCloudLogin.mockReset();
+    appState.handleInteractiveCloudLogin.mockResolvedValue(undefined);
+    appState.handleCloudSignOut.mockReset();
+    appState.handleCloudSignOut.mockResolvedValue(undefined);
+    appState.setActionNotice.mockClear();
+    window.history.replaceState(null, "", "/settings");
+  });
+
+  it.each(ACCOUNT_DESTINATIONS)(
+    "opens %s in its mounted canonical section on wide screens",
+    (label, sectionId, sectionLabel) => {
+      render(<CloudSettingsPanel />);
+
+      const accountButton = screen.getByRole("button", { name: "Connected" });
+      expect(accountButton.className).toContain("keyboard-focus-surface");
+      expect(accountButton.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(accountButton);
+      expect(accountButton.getAttribute("aria-expanded")).toBe("true");
+      const link = screen.getByRole("link", { name: label });
+      expect(link.className).toContain("keyboard-focus-surface");
+      expect(link.getAttribute("href")).toBe(`#${sectionId}`);
+      fireEvent.click(link);
+
+      const sectionBody = screen.getByTestId(`section-${sectionId}`);
+      expect(sectionBody).toBeTruthy();
+      const themeBoundary = sectionBody.closest(
+        '[data-cloud-section-theme="eliza"]',
+      );
+      expect(themeBoundary).toBeTruthy();
+      expect(themeBoundary?.closest(".nuphy-scope")).toBeTruthy();
+      expect(themeBoundary?.getAttribute("style")).toBeNull();
+      expect(
+        screen.getByRole("heading", { level: 1, name: sectionLabel }),
+      ).toBeTruthy();
+      expect(window.location.hash).toBe(`#${sectionId}`);
+      expect(link.getAttribute("aria-current")).toBe("page");
+    },
+  );
+
+  it.each(ACCOUNT_DESTINATIONS)(
+    "opens a direct narrow-screen deep link for %s and returns to the account hub",
+    (_label, sectionId, sectionLabel) => {
+      mediaState.wide = false;
+      window.history.replaceState(null, "", `/settings#${sectionId}`);
+
+      render(<CloudSettingsPanel />);
+
+      expect(screen.getByTestId(`section-${sectionId}`)).toBeTruthy();
+      expect(
+        screen.getByRole("heading", { level: 1, name: sectionLabel }),
+      ).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Connected" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+      expect(screen.getByRole("button", { name: /General/ })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Connected" })).toBeTruthy();
+    },
+  );
+
+  it.each(ACCOUNT_DESTINATIONS)(
+    "opens %s from the narrow connected-account menu and returns to the hub",
+    (label, sectionId) => {
+      mediaState.wide = false;
+
+      render(<CloudSettingsPanel />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+      fireEvent.click(screen.getByRole("link", { name: label }));
+      expect(screen.getByTestId(`section-${sectionId}`)).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+      expect(screen.getByRole("button", { name: "Connected" })).toBeTruthy();
+    },
+  );
+
+  it.each([true, false])(
+    "keeps account-only destinations hidden while disconnected in the %s layout",
+    (wide) => {
+      mediaState.wide = wide;
+      appState.connected = false;
+
+      render(<CloudSettingsPanel />);
+
+      expect(
+        screen.getByRole("button", { name: "Connect Cloud" }),
+      ).toBeTruthy();
+      for (const [label] of ACCOUNT_DESTINATIONS) {
+        expect(screen.queryByRole("link", { name: label })).toBeNull();
+      }
+      fireEvent.click(screen.getByRole("button", { name: "Connect Cloud" }));
+      expect(appState.handleInteractiveCloudLogin).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByRole("button", { name: "Connect Cloud" }).className,
+      ).toContain("keyboard-focus-surface");
+    },
+  );
+
+  it("replaces a disconnected account deep link with General before mounting it", async () => {
+    appState.connected = false;
+    window.history.replaceState(null, "", "/settings#cloud-security");
+
+    render(<CloudSettingsPanel />);
+
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-security")).toBeNull();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "General" }),
+    ).toBeTruthy();
+    await waitFor(() => expect(window.location.hash).toBe("#general"));
+  });
+
+  it("keeps prior account history entries gated after credentials disappear", async () => {
+    const view = render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    fireEvent.click(screen.getByRole("link", { name: "Manage billing" }));
+    fireEvent.click(screen.getByRole("link", { name: "API keys" }));
+    expect(screen.getByTestId("section-cloud-api-keys")).toBeTruthy();
+
+    appState.connected = false;
+    view.rerender(<CloudSettingsPanel />);
+
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-api-keys")).toBeNull();
+    await waitFor(() => expect(window.location.hash).toBe("#general"));
+
+    const backNavigation = new Promise<void>((resolve) => {
+      window.addEventListener("hashchange", () => resolve(), { once: true });
+    });
+    await act(async () => {
+      window.history.back();
+      await backNavigation;
+    });
+    await waitFor(() => expect(window.location.hash).toBe("#general"));
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-billing")).toBeNull();
+  });
+
+  it("unmounts an account destination when its sole credential disappears", async () => {
+    appState.connected = false;
+    credentialState.present = true;
+    window.history.replaceState(null, "", "/settings#cloud-organization");
+    const view = render(<CloudSettingsPanel />);
+
+    expect(screen.getByTestId("section-cloud-organization")).toBeTruthy();
+
+    credentialState.present = false;
+    view.rerender(<CloudSettingsPanel />);
+
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-organization")).toBeNull();
+    await waitFor(() => expect(window.location.hash).toBe("#general"));
+  });
+
+  it("returns to General before a pending sign-out settles", async () => {
+    let resolveSignOut: (() => void) | undefined;
+    appState.handleCloudSignOut.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveSignOut = () => resolve(undefined);
+        }),
+    );
+    window.history.replaceState(null, "", "/settings#cloud-security");
+
+    render(<CloudSettingsPanel />);
+
+    expect(screen.getByTestId("section-cloud-security")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    const signOutButton = screen.getByRole("button", { name: "Sign out" });
+    expect(signOutButton.className).toContain("keyboard-focus-surface");
+    fireEvent.click(signOutButton);
+
+    expect(appState.handleCloudSignOut).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(window.location.hash).toBe("#general");
+    expect(screen.getByRole("status").textContent).toContain("Signing out");
+    expect(screen.queryByRole("button", { name: "Connect Cloud" })).toBeNull();
+
+    await act(async () => resolveSignOut?.());
+  });
+
+  it("keeps narrow sign-out status and recovery visible in the settings hub", async () => {
+    mediaState.wide = false;
+    let rejectSignOut: ((reason?: unknown) => void) | undefined;
+    appState.handleCloudSignOut.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((_resolve, reject) => {
+          rejectSignOut = reject;
+        }),
+    );
+
+    render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(screen.getByRole("status").textContent).toContain("Signing out");
+    expect(screen.getByRole("button", { name: /General/ })).toBeTruthy();
+    expect(screen.queryByTestId("section-general")).toBeNull();
+    expect(window.location.hash).toBe("#general");
+
+    await act(async () => {
+      rejectSignOut?.(new Error("credential store unavailable"));
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Retry sign out" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Cloud sign-out didn't finish.",
+    );
+  });
+
+  it("keeps every prior account history entry gated while sign-out is pending", async () => {
+    let resolveSignOut: (() => void) | undefined;
+    appState.handleCloudSignOut.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveSignOut = () => resolve(undefined);
+        }),
+    );
+
+    render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    fireEvent.click(screen.getByRole("link", { name: "Manage billing" }));
+    fireEvent.click(screen.getByRole("link", { name: "API keys" }));
+    expect(screen.getByTestId("section-cloud-api-keys")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connected" })).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Signing out");
+    expect(screen.queryByRole("button", { name: "Connect Cloud" })).toBeNull();
+
+    const backNavigation = new Promise<void>((resolve) => {
+      window.addEventListener("hashchange", () => resolve(), { once: true });
+    });
+    await act(async () => {
+      window.history.back();
+      await backNavigation;
+    });
+
+    await waitFor(() => expect(window.location.hash).toBe("#general"));
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-billing")).toBeNull();
+
+    await act(async () => resolveSignOut?.());
+  });
+
+  it("keeps account data unmounted when sign-out fails", async () => {
+    appState.handleCloudSignOut.mockRejectedValueOnce(
+      new Error("credential store unavailable"),
+    );
+    window.history.replaceState(null, "", "/settings#cloud-security");
+
+    render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    await waitFor(() => {
+      expect(appState.setActionNotice).toHaveBeenCalledWith(
+        "Could not sign out of Eliza Cloud.",
+        "error",
+        5000,
+      );
+    });
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByTestId("section-cloud-security")).toBeNull();
+    expect(window.location.hash).toBe("#general");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Cloud sign-out didn't finish.",
+    );
+    expect(screen.getByRole("button", { name: "Retry sign out" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connect Cloud" })).toBeNull();
+  });
+
+  it("offers retry when a resolved sign-out leaves the session observed", async () => {
+    appState.handleCloudSignOut.mockResolvedValueOnce(undefined);
+
+    render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Retry sign out" }),
+    ).toBeTruthy();
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connected" })).toBeNull();
+  });
+
+  it("recovers from a rejected sign-out through retry once the session disappears", async () => {
+    let resolveRetry: (() => void) | undefined;
+    appState.handleCloudSignOut
+      .mockRejectedValueOnce(new Error("credential store unavailable"))
+      .mockImplementationOnce(
+        () =>
+          new Promise<undefined>((resolve) => {
+            resolveRetry = () => resolve(undefined);
+          }),
+      );
+    const view = render(<CloudSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connected" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Retry sign out" }),
+    );
+
+    expect(appState.handleCloudSignOut).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("status").textContent).toContain("Signing out");
+    expect(screen.queryByRole("button", { name: "Connected" })).toBeNull();
+
+    appState.connected = false;
+    view.rerender(<CloudSettingsPanel />);
+    expect(screen.getByRole("button", { name: "Connect Cloud" })).toBeTruthy();
+
+    await act(async () => resolveRetry?.());
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect Cloud" }),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: "Retry sign out" })).toBeNull();
+    expect(screen.queryByTestId("section-cloud-billing")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.narrow.test.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.narrow.test.tsx
@@ -10,9 +10,19 @@ vi.mock("../../../hooks/useMediaQuery", () => ({
   useMediaQuery: () => false,
 }));
 
+vi.mock("../../../state", () => ({
+  useAppSelector: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ elizaCloudConnected: false }),
+}));
+
+vi.mock("./cloud-management-auth", () => ({
+  useHasCloudManagementCredential: () => false,
+}));
+
 vi.mock("./cloud-panel-routing", () => ({
   navigateCloudPanel: vi.fn(),
   readCloudPanelHash: () => "general",
+  replaceCloudPanel: vi.fn(),
   subscribeCloudPanelHash: () => () => {},
 }));
 

--- a/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.tsx
@@ -7,14 +7,22 @@
  * with a back button.
  */
 import { ArrowLeft } from "lucide-react";
-import { Suspense, useEffect, useState } from "react";
+import { type ReactNode, Suspense, useEffect, useState } from "react";
 import { useMediaQuery } from "../../../hooks/useMediaQuery";
 import { cn } from "../../../lib/utils";
+import { useAppSelector } from "../../../state";
 import { ErrorBoundary } from "../../ui/error-boundary";
-import { CloudSettingsSidebar } from "./CloudSettingsSidebar";
+import {
+  CloudAccountMenu,
+  type CloudAccountNavigationState,
+  type CloudPanelNavigationOptions,
+  CloudSettingsSidebar,
+} from "./CloudSettingsSidebar";
+import { useHasCloudManagementCredential } from "./cloud-management-auth";
 import {
   navigateCloudPanel,
   readCloudPanelHash,
+  replaceCloudPanel,
   subscribeCloudPanelHash,
 } from "./cloud-panel-routing";
 import {
@@ -82,9 +90,18 @@ function SectionError({
   );
 }
 
+function ElizaCloudSectionTheme({ children }: { children: ReactNode }) {
+  return (
+    // Lifted Cloud bodies use Eliza's `text-muted` and `text-accent`
+    // semantics. The marker lets nuphy-scope.css restore only those text
+    // utilities without changing the same tokens used by NuPhy fills.
+    <div data-cloud-section-theme="eliza">{children}</div>
+  );
+}
+
 function SectionContent({ section }: { section: CloudPanelSection }) {
   const Component = section.Component;
-  return (
+  const body = (
     <ErrorBoundary
       key={section.id}
       fallback={(error: Error, reset: () => void) => (
@@ -96,14 +113,30 @@ function SectionContent({ section }: { section: CloudPanelSection }) {
       </Suspense>
     </ErrorBoundary>
   );
+  return (
+    <>
+      <h1 className="sr-only">{section.label}</h1>
+      {section.placement === "account-footer" ? (
+        <ElizaCloudSectionTheme>{body}</ElizaCloudSectionTheme>
+      ) : (
+        body
+      )}
+    </>
+  );
 }
 
 function HubList({
+  accountState,
   activeSection,
+  onSignOutAttemptFinish,
+  onSignOutAttemptStart,
   onSelect,
 }: {
+  accountState: CloudAccountNavigationState;
   activeSection: string;
-  onSelect: (id: string) => void;
+  onSignOutAttemptFinish: () => void;
+  onSignOutAttemptStart: () => void;
+  onSelect: (id: string, options?: CloudPanelNavigationOptions) => void;
 }) {
   const grouped = groupedCloudPanelSections();
   return (
@@ -158,7 +191,23 @@ function HubList({
           </div>
         ))}
       </div>
+      <CloudAccountMenu
+        accountState={accountState}
+        activeSection={activeSection}
+        onSignOutAttemptFinish={onSignOutAttemptFinish}
+        onSignOutAttemptStart={onSignOutAttemptStart}
+        onSelect={onSelect}
+      />
     </div>
+  );
+}
+
+function documentUsesDarkTheme(): boolean {
+  if (typeof document === "undefined") return false;
+  const root = document.documentElement;
+  return (
+    root.getAttribute("data-theme") === "dark" ||
+    root.classList.contains("dark")
   );
 }
 
@@ -170,7 +219,33 @@ export function CloudSettingsPanel() {
   const [narrowView, setNarrowView] = useState<"hub" | "section">(() =>
     typeof window !== "undefined" && window.location.hash ? "section" : "hub",
   );
-  const [isDark, setIsDark] = useState(false);
+  const [isDark, setIsDark] = useState(documentUsesDarkTheme);
+  const [accountSignOutAttempt, setAccountSignOutAttempt] = useState<
+    "idle" | "pending" | "finished"
+  >("idle");
+  const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
+  const hasManagementCredential = useHasCloudManagementCredential();
+  const observedAccountSessionAvailable =
+    elizaCloudConnected || hasManagementCredential;
+  const accountDestinationsAvailable =
+    observedAccountSessionAvailable && accountSignOutAttempt === "idle";
+  const accountNavigationState: CloudAccountNavigationState =
+    !observedAccountSessionAvailable
+      ? "disconnected"
+      : accountSignOutAttempt === "idle"
+        ? "connected"
+        : accountSignOutAttempt === "pending"
+          ? "signing-out"
+          : "sign-out-failed";
+
+  // Keep account routes fail-closed throughout an attempt. A settled attempt
+  // with a still-observed session becomes an explicit retry state; only an
+  // observably absent credential may clear the suppression automatically.
+  useEffect(() => {
+    if (!observedAccountSessionAvailable && accountSignOutAttempt !== "idle") {
+      setAccountSignOutAttempt("idle");
+    }
+  }, [accountSignOutAttempt, observedAccountSessionAvailable]);
 
   // Sync with URL hash.
   useEffect(() => {
@@ -184,10 +259,7 @@ export function CloudSettingsPanel() {
     if (typeof document === "undefined") return;
     const root = document.documentElement;
     const update = () => {
-      setIsDark(
-        root.getAttribute("data-theme") === "dark" ||
-          root.classList.contains("dark"),
-      );
+      setIsDark(documentUsesDarkTheme());
     };
     update();
     const observer = new MutationObserver(update);
@@ -198,15 +270,44 @@ export function CloudSettingsPanel() {
     return () => observer.disconnect();
   }, []);
 
-  const handleSelect = (id: string) => {
-    const resolved = resolveCloudPanelSection(id);
+  const handleSelect = (id: string, options?: CloudPanelNavigationOptions) => {
+    const requested = resolveCloudPanelSection(id);
+    const requestedSection = CLOUD_PANEL_SECTIONS.find(
+      (candidate) => candidate.id === requested,
+    );
+    const resolved =
+      requestedSection?.placement === "account-footer" &&
+      !accountDestinationsAvailable
+        ? "general"
+        : requested;
     setSectionId(resolved);
-    setNarrowView("section");
-    navigateCloudPanel(resolved);
+    if (options?.showSection !== false) setNarrowView("section");
+    if (options?.replace) {
+      replaceCloudPanel(resolved);
+    } else {
+      navigateCloudPanel(resolved);
+    }
   };
 
-  const section = CLOUD_PANEL_SECTIONS.find((s) => s.id === sectionId);
+  const requestedSection = CLOUD_PANEL_SECTIONS.find(
+    (candidate) => candidate.id === sectionId,
+  );
+  const accountDestinationBlocked =
+    requestedSection?.placement === "account-footer" &&
+    !accountDestinationsAvailable;
+  const section = accountDestinationBlocked
+    ? CLOUD_PANEL_SECTIONS.find((candidate) => candidate.id === "general")
+    : requestedSection;
+  const activeSectionId = section?.id ?? "general";
   const scopeClass = isDark ? "nuphy-scope nuphy-dark" : "nuphy-scope";
+
+  // Account-only bodies must never survive credential loss or a disconnected
+  // deep link. Replace (rather than push) so Back cannot revive the route.
+  useEffect(() => {
+    if (!accountDestinationBlocked) return;
+    setSectionId("general");
+    replaceCloudPanel("general");
+  }, [accountDestinationBlocked]);
 
   // Narrow layout: hub list → back-button subview.
   if (!isWide) {
@@ -220,7 +321,13 @@ export function CloudSettingsPanel() {
       >
         <CloudSettingsDragStrip />
         {showHub ? (
-          <HubList activeSection={sectionId} onSelect={handleSelect} />
+          <HubList
+            accountState={accountNavigationState}
+            activeSection={activeSectionId}
+            onSignOutAttemptFinish={() => setAccountSignOutAttempt("finished")}
+            onSignOutAttemptStart={() => setAccountSignOutAttempt("pending")}
+            onSelect={handleSelect}
+          />
         ) : (
           <div className="flex flex-1 flex-col overflow-hidden">
             <button
@@ -244,7 +351,13 @@ export function CloudSettingsPanel() {
   return (
     <div className={cn(scopeClass, "flex h-full bg-[var(--canvas)]")}>
       <CloudSettingsDragStrip />
-      <CloudSettingsSidebar activeSection={sectionId} onSelect={handleSelect} />
+      <CloudSettingsSidebar
+        accountState={accountNavigationState}
+        activeSection={activeSectionId}
+        onSignOutAttemptFinish={() => setAccountSignOutAttempt("finished")}
+        onSignOutAttemptStart={() => setAccountSignOutAttempt("pending")}
+        onSelect={handleSelect}
+      />
       <main className="flex-1 overflow-y-auto bg-[var(--canvas)] bg-dotted pt-8">
         <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-12">
           {section ? (

--- a/packages/ui/src/components/settings/cloud-panel/CloudSettingsSidebar.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/CloudSettingsSidebar.tsx
@@ -4,19 +4,42 @@
  * Renders grouped section items with an account footer pinned to the bottom.
  * Uses NuPhy UI design tokens for the macOS settings aesthetic.
  */
-import { Check, ChevronUp, Circle } from "lucide-react";
+import { Check, ChevronUp, Circle, Loader2, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { cn } from "../../../lib/utils";
 import { useAppSelector } from "../../../state";
-import { hasCloudManagementCredential } from "./cloud-management-auth";
 import { CLOUD_PANEL_GROUPS } from "./cloud-panel-groups";
 import {
+  type CloudPanelAccountFooterSection,
   type CloudPanelSection,
+  cloudPanelAccountFooterSections,
   groupedCloudPanelSections,
 } from "./cloud-panel-sections";
 
-function CloudAccountFooter() {
-  const elizaCloudConnected = useAppSelector((s) => s.elizaCloudConnected);
+export type CloudAccountNavigationState =
+  | "connected"
+  | "disconnected"
+  | "signing-out"
+  | "sign-out-failed";
+
+export interface CloudPanelNavigationOptions {
+  replace?: boolean;
+  showSection?: boolean;
+}
+
+export function CloudAccountMenu({
+  accountState,
+  activeSection,
+  onSignOutAttemptFinish,
+  onSignOutAttemptStart,
+  onSelect,
+}: {
+  accountState: CloudAccountNavigationState;
+  activeSection: string;
+  onSignOutAttemptFinish: () => void;
+  onSignOutAttemptStart: () => void;
+  onSelect: (id: string, options?: CloudPanelNavigationOptions) => void;
+}) {
   const handleInteractiveCloudLogin = useAppSelector(
     (s) => s.handleInteractiveCloudLogin,
   );
@@ -24,12 +47,30 @@ function CloudAccountFooter() {
   const setActionNotice = useAppSelector((s) => s.setActionNotice);
   const [open, setOpen] = useState(false);
 
-  if (!elizaCloudConnected && !hasCloudManagementCredential()) {
+  const startSignOut = () => {
+    setOpen(false);
+    // Account-only data is unmounted synchronously and remains unavailable
+    // until the session is observably absent. A resolved disconnect can still
+    // mean the backend-owned helper reported its failure through app state, so
+    // every settled attempt is handed back to the panel for an explicit retry
+    // decision rather than being treated as success optimistically.
+    onSignOutAttemptStart();
+    onSelect("general", { replace: true, showSection: false });
+    void handleCloudSignOut()
+      .catch(() => {
+        // error-policy:J4 sign-out failure surfaces as a visible notice in
+        // addition to the persistent inline retry affordance below.
+        setActionNotice?.("Could not sign out of Eliza Cloud.", "error", 5000);
+      })
+      .finally(onSignOutAttemptFinish);
+  };
+
+  if (accountState === "disconnected") {
     return (
       <div className="border-t border-[var(--hairline)] px-3 py-3">
         <button
           type="button"
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--fill)]"
+          className="keyboard-focus-surface flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--fill)]"
           onClick={() => {
             void handleInteractiveCloudLogin().catch((error: unknown) => {
               // error-policy:J4 login failure surfaces as a visible notice.
@@ -50,11 +91,49 @@ function CloudAccountFooter() {
     );
   }
 
+  if (accountState === "signing-out") {
+    return (
+      <div className="border-t border-[var(--hairline)] px-3 py-3">
+        <div
+          aria-live="polite"
+          className="flex min-h-9 items-center gap-2 px-2 py-1.5 text-sm text-[var(--muted-foreground)]"
+          role="status"
+        >
+          <Loader2
+            aria-hidden="true"
+            className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none"
+          />
+          Signing out…
+        </div>
+      </div>
+    );
+  }
+
+  if (accountState === "sign-out-failed") {
+    return (
+      <div className="space-y-2 border-t border-[var(--hairline)] px-3 py-3">
+        <p className="px-2 text-xs text-[var(--destructive)]" role="alert">
+          Cloud sign-out didn&apos;t finish.
+        </p>
+        <button
+          type="button"
+          className="keyboard-focus-surface flex min-h-9 w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--fill)]"
+          onClick={startSignOut}
+        >
+          <RotateCcw aria-hidden="true" className="h-3.5 w-3.5" />
+          Retry sign out
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="border-t border-[var(--hairline)] px-3 py-2">
       <button
         type="button"
-        className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-[var(--fill)]"
+        aria-controls="cloud-account-menu"
+        aria-expanded={open}
+        className="keyboard-focus-surface flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-[var(--fill)]"
         onClick={() => setOpen(!open)}
       >
         <span className="flex items-center gap-2 truncate">
@@ -71,26 +150,23 @@ function CloudAccountFooter() {
         />
       </button>
       {open && (
-        <div className="mt-1 space-y-0.5 rounded-md border border-[var(--hairline)] bg-[var(--surface)] p-1">
-          <FooterLink label="Manage billing" href="billing" />
-          <FooterLink label="API keys" href="api-keys" />
-          <FooterLink label="Sessions & privacy" href="security" />
-          <FooterLink label="Organization" href="organization" />
+        <div
+          id="cloud-account-menu"
+          className="mt-1 space-y-0.5 rounded-md border border-[var(--hairline)] bg-[var(--surface)] p-1"
+        >
+          {cloudPanelAccountFooterSections().map((section) => (
+            <FooterLink
+              key={section.id}
+              section={section}
+              active={section.id === activeSection}
+              onSelect={onSelect}
+            />
+          ))}
           <div className="my-1 border-t border-[var(--hairline)]" />
           <button
             type="button"
-            className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-sm text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
-            onClick={() => {
-              setOpen(false);
-              void handleCloudSignOut().catch(() => {
-                // error-policy:J4 sign-out failure surfaces as a visible notice.
-                setActionNotice?.(
-                  "Could not sign out of Eliza Cloud.",
-                  "error",
-                  5000,
-                );
-              });
-            }}
+            className="keyboard-focus-surface flex w-full items-center rounded-sm px-2 py-1.5 text-left text-sm text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
+            onClick={startSignOut}
           >
             Sign out
           </button>
@@ -100,13 +176,31 @@ function CloudAccountFooter() {
   );
 }
 
-function FooterLink({ label, href }: { label: string; href: string }) {
+function FooterLink({
+  section,
+  active,
+  onSelect,
+}: {
+  section: CloudPanelAccountFooterSection;
+  active: boolean;
+  onSelect: (id: string, options?: CloudPanelNavigationOptions) => void;
+}) {
   return (
     <a
-      href={`#cloud-${href}`}
-      className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--fill)] hover:text-[var(--foreground)]"
+      href={`#${section.id}`}
+      onClick={(event) => {
+        event.preventDefault();
+        onSelect(section.id);
+      }}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "keyboard-focus-surface flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors",
+        active
+          ? "bg-[var(--accent)] font-medium text-[var(--foreground)]"
+          : "text-[var(--muted-foreground)] hover:bg-[var(--fill)] hover:text-[var(--foreground)]",
+      )}
     >
-      {label}
+      {section.footerLabel}
     </a>
   );
 }
@@ -118,7 +212,7 @@ function SectionItem({
 }: {
   section: CloudPanelSection;
   active: boolean;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, options?: CloudPanelNavigationOptions) => void;
 }) {
   const Icon = section.icon;
   return (
@@ -127,7 +221,7 @@ function SectionItem({
       onClick={() => onSelect(section.id)}
       aria-current={active ? "page" : undefined}
       className={cn(
-        "flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors",
+        "keyboard-focus-surface flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors",
         active
           ? "bg-[var(--accent)] font-medium text-[var(--foreground)]"
           : "text-[var(--muted-foreground)] hover:bg-[var(--fill)] hover:text-[var(--foreground)]",
@@ -150,11 +244,17 @@ function SectionItem({
 }
 
 export function CloudSettingsSidebar({
+  accountState,
   activeSection,
+  onSignOutAttemptFinish,
+  onSignOutAttemptStart,
   onSelect,
 }: {
+  accountState: CloudAccountNavigationState;
   activeSection: string;
-  onSelect: (id: string) => void;
+  onSignOutAttemptFinish: () => void;
+  onSignOutAttemptStart: () => void;
+  onSelect: (id: string, options?: CloudPanelNavigationOptions) => void;
 }) {
   const grouped = groupedCloudPanelSections();
 
@@ -186,7 +286,13 @@ export function CloudSettingsSidebar({
           );
         })}
       </div>
-      <CloudAccountFooter />
+      <CloudAccountMenu
+        accountState={accountState}
+        activeSection={activeSection}
+        onSignOutAttemptFinish={onSignOutAttemptFinish}
+        onSignOutAttemptStart={onSignOutAttemptStart}
+        onSelect={onSelect}
+      />
     </nav>
   );
 }

--- a/packages/ui/src/components/settings/cloud-panel/cloud-management-auth.test.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-management-auth.test.ts
@@ -1,8 +1,31 @@
 /** Verifies the credential precedence used by native Cloud settings. */
-import { describe, expect, it } from "vitest";
-import { resolveCloudManagementToken } from "./cloud-management-auth";
+// @vitest-environment jsdom
+
+import {
+  STEWARD_SESSION_CHANGE_EVENT,
+  STEWARD_TOKEN_KEY,
+} from "@elizaos/shared/steward-session-client";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/shared")>()),
+  getElizaApiToken: () => null,
+}));
+
+vi.mock("../../../config/boot-config", () => ({
+  getBootConfig: () => ({}),
+}));
+
+import {
+  resolveCloudManagementToken,
+  useHasCloudManagementCredential,
+} from "./cloud-management-auth";
 
 describe("resolveCloudManagementToken", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => cleanup());
+
   it("prefers the independently scoped Steward session", () => {
     expect(
       resolveCloudManagementToken({
@@ -31,5 +54,28 @@ describe("resolveCloudManagementToken", () => {
         runtimeApiToken: "not-an-owner-key",
       }),
     ).toBe("");
+  });
+
+  it("reacts to same-document and cross-document Steward token removal", () => {
+    const { result } = renderHook(() => useHasCloudManagementCredential());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+      window.dispatchEvent(new CustomEvent(STEWARD_SESSION_CHANGE_EVENT));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      localStorage.removeItem(STEWARD_TOKEN_KEY);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STEWARD_TOKEN_KEY,
+          oldValue: "steward-token",
+          newValue: null,
+        }),
+      );
+    });
+    expect(result.current).toBe(false);
   });
 });

--- a/packages/ui/src/components/settings/cloud-panel/cloud-management-auth.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-management-auth.ts
@@ -1,6 +1,10 @@
 /** Resolves the credential forms accepted by native Cloud management routes. */
 import { getElizaApiToken } from "@elizaos/shared";
-import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+import {
+  readStoredStewardToken,
+  STEWARD_SESSION_CHANGE_EVENT,
+} from "@elizaos/shared/steward-session-client";
+import { useSyncExternalStore } from "react";
 import { normalizeCloudApiKeyToken } from "../../../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../../../config/boot-config";
 
@@ -36,4 +40,38 @@ export function currentCloudManagementToken(): string {
 
 export function hasCloudManagementCredential(): boolean {
   return currentCloudManagementToken().length > 0;
+}
+
+function subscribeToCloudManagementCredential(
+  onStoreChange: () => void,
+): () => void {
+  if (typeof window === "undefined") return () => undefined;
+
+  const handleCredentialChange = () => onStoreChange();
+  window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, handleCredentialChange);
+  window.addEventListener("steward-token-sync", handleCredentialChange);
+  // Cross-document storage events cover Steward removal and persisted runtime
+  // token changes without coupling this boundary to every storage key name.
+  window.addEventListener("storage", handleCredentialChange);
+  return () => {
+    window.removeEventListener(
+      STEWARD_SESSION_CHANGE_EVENT,
+      handleCredentialChange,
+    );
+    window.removeEventListener("steward-token-sync", handleCredentialChange);
+    window.removeEventListener("storage", handleCredentialChange);
+  };
+}
+
+function noCloudManagementCredential(): boolean {
+  return false;
+}
+
+/** Reactively track every credential form accepted by Cloud management. */
+export function useHasCloudManagementCredential(): boolean {
+  return useSyncExternalStore(
+    subscribeToCloudManagementCredential,
+    hasCloudManagementCredential,
+    noCloudManagementCredential,
+  );
 }

--- a/packages/ui/src/components/settings/cloud-panel/cloud-panel-routing.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-panel-routing.ts
@@ -23,6 +23,16 @@ export function navigateCloudPanel(sectionId: string): void {
   }
 }
 
+/** Replace the current history entry with a section hash. */
+export function replaceCloudPanel(sectionId: string): void {
+  if (typeof window === "undefined") return;
+  const resolved = resolveCloudPanelSection(sectionId);
+  const target = `#${resolved}`;
+  if (window.location.hash !== target) {
+    window.history.replaceState(window.history.state, "", target);
+  }
+}
+
 /** Subscribe to hash changes. Returns an unsubscribe function. */
 export function subscribeCloudPanelHash(
   listener: (sectionId: string) => void,

--- a/packages/ui/src/components/settings/cloud-panel/cloud-panel-sections.test.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-panel-sections.test.ts
@@ -1,0 +1,37 @@
+/** Verifies that connected-account footer routes resolve to mounted canonical Cloud sections. */
+import { describe, expect, it } from "vitest";
+import {
+  cloudPanelAccountFooterSections,
+  groupedCloudPanelSections,
+  resolveCloudPanelSection,
+} from "./cloud-panel-sections";
+
+const ACCOUNT_FOOTER_SECTION_IDS = [
+  "cloud-billing",
+  "cloud-api-keys",
+  "cloud-security",
+  "cloud-organization",
+] as const;
+
+describe("cloud panel account footer sections", () => {
+  it("registers every account action as a resolvable mounted section", () => {
+    const footerSections = cloudPanelAccountFooterSections();
+
+    expect(footerSections.map((section) => section.id)).toEqual(
+      ACCOUNT_FOOTER_SECTION_IDS,
+    );
+    for (const sectionId of ACCOUNT_FOOTER_SECTION_IDS) {
+      expect(resolveCloudPanelSection(sectionId)).toBe(sectionId);
+    }
+  });
+
+  it("keeps account-only destinations out of the primary sidebar and narrow hub", () => {
+    const primaryIds = Object.values(groupedCloudPanelSections())
+      .flat()
+      .map((section) => section.id);
+
+    expect(primaryIds).not.toEqual(
+      expect.arrayContaining([...ACCOUNT_FOOTER_SECTION_IDS]),
+    );
+  });
+});

--- a/packages/ui/src/components/settings/cloud-panel/cloud-panel-sections.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-panel-sections.ts
@@ -1,16 +1,20 @@
 /**
  * Cloud panel section registry.
  *
- * Declares the 8 sections of the cloud-only desktop settings panel. Each
- * section is lazy-loaded so only the active section's body is in the initial
- * chunk. The registry is a static array (not the dynamic global-symbol-backed
- * registry used by the legacy settings) because the cloud panel has a fixed,
- * curated set of sections.
+ * Declares the curated navigation and connected-account destinations for the
+ * cloud-only desktop settings panel. Each section is lazy-loaded so only the
+ * active section's body is in the initial chunk. The registry is a static
+ * array (not the dynamic global-symbol-backed registry used by the legacy
+ * settings) because the cloud panel has a fixed set of sections.
  */
 import type { LucideIcon } from "lucide-react";
 import {
   Bell,
+  Building2,
+  CreditCard,
   Keyboard,
+  KeyRound,
+  Lock,
   Mic,
   Monitor,
   Plug,
@@ -22,22 +26,36 @@ import type { ComponentType, LazyExoticComponent } from "react";
 import { lazy } from "react";
 import type { CloudPanelGroupId } from "./cloud-panel-groups";
 
-export interface CloudPanelSection {
+interface CloudPanelSectionBase {
   /** Stable id — also the URL hash. */
   id: string;
-  /** Display label in the sidebar. */
+  /** Display label for the section heading or navigation entry. */
   label: string;
-  /** One-line subtitle shown in the narrow hub list. */
+  /** One-line section description. */
   subtitle: string;
-  /** Sidebar icon. */
+  /** Section icon. */
   icon: LucideIcon;
+  /** Lazy-loaded section body. */
+  Component: LazyExoticComponent<ComponentType>;
+}
+
+export interface CloudPanelNavigationSection extends CloudPanelSectionBase {
+  placement: "navigation";
   /** Sidebar group. */
   group: CloudPanelGroupId;
   /** Sort priority within a group (lower first). */
   order: number;
-  /** Lazy-loaded section body. */
-  Component: LazyExoticComponent<ComponentType>;
 }
+
+export interface CloudPanelAccountFooterSection extends CloudPanelSectionBase {
+  placement: "account-footer";
+  /** Action label rendered in the connected-account menu. */
+  footerLabel: string;
+}
+
+export type CloudPanelSection =
+  | CloudPanelNavigationSection
+  | CloudPanelAccountFooterSection;
 
 // Lazy-load each section so only the active one is in the initial chunk.
 const GeneralSection = lazy(() =>
@@ -76,6 +94,26 @@ const AdvancedSection = lazy(() =>
     default: m.AdvancedSection,
   })),
 );
+const CloudBillingSection = lazy(() =>
+  import("../../../cloud/settings/sections").then((m) => ({
+    default: m.CloudBillingSection,
+  })),
+);
+const CloudApiKeysSection = lazy(() =>
+  import("../../../cloud/settings/sections").then((m) => ({
+    default: m.CloudApiKeysSection,
+  })),
+);
+const CloudSecuritySection = lazy(() =>
+  import("../../../cloud/settings/sections").then((m) => ({
+    default: m.CloudSecuritySection,
+  })),
+);
+const CloudOrganizationSection = lazy(() =>
+  import("../../../cloud/settings/sections").then((m) => ({
+    default: m.CloudOrganizationSection,
+  })),
+);
 
 export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
   {
@@ -83,6 +121,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "General",
     subtitle: "Desktop integration",
     icon: Monitor,
+    placement: "navigation",
     group: "general",
     order: 0,
     Component: GeneralSection,
@@ -92,6 +131,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Voice",
     subtitle: "TTS, STT, conversation",
     icon: Volume2,
+    placement: "navigation",
     group: "agent",
     order: 0,
     Component: VoiceSection,
@@ -101,6 +141,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Agent",
     subtitle: "Active agent, cloud agents",
     icon: Mic,
+    placement: "navigation",
     group: "agent",
     order: 1,
     Component: AgentSection,
@@ -110,6 +151,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Connections",
     subtitle: "Discord, TG, MCP servers",
     icon: Plug,
+    placement: "navigation",
     group: "agent",
     order: 2,
     Component: ConnectionsSection,
@@ -119,6 +161,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Permissions",
     subtitle: "Mic, notif, accessibility",
     icon: Shield,
+    placement: "navigation",
     group: "system",
     order: 0,
     Component: PermissionsSection,
@@ -128,6 +171,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Notifications",
     subtitle: "Push, sound, badge",
     icon: Bell,
+    placement: "navigation",
     group: "system",
     order: 1,
     Component: NotificationsSection,
@@ -137,6 +181,7 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Shortcuts",
     subtitle: "Hotkeys, mouse",
     icon: Keyboard,
+    placement: "navigation",
     group: "system",
     order: 2,
     Component: ShortcutsSection,
@@ -146,9 +191,46 @@ export const CLOUD_PANEL_SECTIONS: readonly CloudPanelSection[] = [
     label: "Advanced",
     subtitle: "Dev mode, backups, reset",
     icon: SlidersHorizontal,
+    placement: "navigation",
     group: "advanced",
     order: 0,
     Component: AdvancedSection,
+  },
+  {
+    id: "cloud-billing",
+    label: "Billing & Credits",
+    subtitle: "Plans, credits, and invoices",
+    icon: CreditCard,
+    placement: "account-footer",
+    footerLabel: "Manage billing",
+    Component: CloudBillingSection,
+  },
+  {
+    id: "cloud-api-keys",
+    label: "API Keys",
+    subtitle: "Cloud API credentials",
+    icon: KeyRound,
+    placement: "account-footer",
+    footerLabel: "API keys",
+    Component: CloudApiKeysSection,
+  },
+  {
+    id: "cloud-security",
+    label: "Sessions & Privacy",
+    subtitle: "Sessions, privacy, and audit",
+    icon: Lock,
+    placement: "account-footer",
+    footerLabel: "Sessions & privacy",
+    Component: CloudSecuritySection,
+  },
+  {
+    id: "cloud-organization",
+    label: "Organization",
+    subtitle: "Members and organization settings",
+    icon: Building2,
+    placement: "account-footer",
+    footerLabel: "Organization",
+    Component: CloudOrganizationSection,
   },
 ] as const;
 
@@ -185,10 +267,11 @@ export function resolveCloudPanelSection(
 /** Sections grouped by group id, in display order. */
 export function groupedCloudPanelSections(): Record<
   string,
-  CloudPanelSection[]
+  CloudPanelNavigationSection[]
 > {
-  const groups: Record<string, CloudPanelSection[]> = {};
+  const groups: Record<string, CloudPanelNavigationSection[]> = {};
   for (const section of CLOUD_PANEL_SECTIONS) {
+    if (section.placement !== "navigation") continue;
     const group = groups[section.group] ?? [];
     group.push(section);
     groups[section.group] = group;
@@ -197,4 +280,12 @@ export function groupedCloudPanelSections(): Record<
     groups[key].sort((a, b) => a.order - b.order);
   }
   return groups;
+}
+
+/** Account-menu destinations, in their authored display order. */
+export function cloudPanelAccountFooterSections(): CloudPanelAccountFooterSection[] {
+  return CLOUD_PANEL_SECTIONS.filter(
+    (section): section is CloudPanelAccountFooterSection =>
+      section.placement === "account-footer",
+  );
 }

--- a/packages/ui/src/components/settings/cloud-panel/cloud-section-theme.test.ts
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-section-theme.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Verifies the NuPhy-to-Eliza Cloud text bridge keeps lifted section text
+ * readable without mutating the shared fill tokens used by the Settings shell.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const NUPHY_SCOPE_CSS = readFileSync(
+  fileURLToPath(new URL("../../../styles/nuphy-scope.css", import.meta.url)),
+  "utf8",
+);
+
+type Rgb = readonly [number, number, number];
+
+function hexToRgb(value: string): Rgb {
+  return [1, 3, 5].map((index) =>
+    Number.parseInt(value.slice(index, index + 2), 16),
+  ) as unknown as Rgb;
+}
+
+function rgbaOver(value: string, background: Rgb): Rgb {
+  const match = value.match(
+    /^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)$/,
+  );
+  if (!match) throw new Error(`Unsupported rgba color: ${value}`);
+  const alpha = Number(match[4]);
+  return [1, 2, 3].map(
+    (index) =>
+      Number(match[index]) * alpha + background[index - 1] * (1 - alpha),
+  ) as unknown as Rgb;
+}
+
+function relativeLuminance(color: Rgb): number {
+  const [red, green, blue] = color.map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: Rgb, background: Rgb): number {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+function ruleBody(selector: string): string {
+  const start = NUPHY_SCOPE_CSS.indexOf(selector);
+  if (start < 0) throw new Error(`Missing selector: ${selector}`);
+  const open = NUPHY_SCOPE_CSS.indexOf("{", start);
+  const close = NUPHY_SCOPE_CSS.indexOf("}", open);
+  return NUPHY_SCOPE_CSS.slice(open + 1, close);
+}
+
+function token(rule: string, name: string): string {
+  const match = rule.match(new RegExp(`${name}:\\s*([^;]+);`));
+  if (!match) throw new Error(`Missing ${name}`);
+  return match[1].trim();
+}
+
+describe("Eliza Cloud section text bridge", () => {
+  it.each([
+    {
+      selector: ".nuphy-scope {",
+      surfaces: ["#ebebeb", "#ffffff"],
+      expectedMutedFill: "rgba(29, 29, 31, 0.04)",
+      expectedAccentFill: "rgba(29, 29, 31, 0.04)",
+    },
+    {
+      selector: ".nuphy-scope.nuphy-dark {",
+      surfaces: ["#141414", "#1e1e1e", "#262626"],
+      expectedMutedFill: "rgba(255, 255, 255, 0.05)",
+      expectedAccentFill: "rgba(255, 255, 255, 0.06)",
+    },
+  ])(
+    "keeps readable inherited text colors and unchanged NuPhy fills in $selector",
+    ({ selector, surfaces, expectedMutedFill, expectedAccentFill }) => {
+      const rule = ruleBody(selector);
+      const mutedText = token(rule, "--cloud-section-muted-fg");
+      const accentText = token(rule, "--cloud-section-accent-fg");
+
+      expect(token(rule, "--muted")).toBe(expectedMutedFill);
+      expect(token(rule, "--accent")).toBe(expectedAccentFill);
+
+      for (const surfaceValue of surfaces) {
+        const surface = hexToRgb(surfaceValue);
+        expect(
+          contrastRatio(rgbaOver(mutedText, surface), surface),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(hexToRgb(accentText), surface),
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    },
+  );
+
+  it("limits the section bridge to text color utilities", () => {
+    const bridgeRules = [
+      ...NUPHY_SCOPE_CSS.matchAll(
+        /([^{}]*data-cloud-section-theme="eliza"[^{}]*)\{([^{}]*)\}/g,
+      ),
+    ];
+
+    expect(bridgeRules).toHaveLength(5);
+    expect(NUPHY_SCOPE_CSS).toContain(
+      ":is(.text-muted, .text-muted-foreground)",
+    );
+    expect(NUPHY_SCOPE_CSS).toContain(".text-accent");
+    expect(NUPHY_SCOPE_CSS).toContain(".placeholder\\:text-muted::placeholder");
+    expect(NUPHY_SCOPE_CSS).toContain(".hover\\:text-accent:hover");
+    expect(NUPHY_SCOPE_CSS).toContain(".disabled\\:text-muted:disabled");
+
+    for (const [, , declarations] of bridgeRules) {
+      expect(declarations).toMatch(
+        /^\s*color:\s*var\(--cloud-section-[^)]+\);\s*$/,
+      );
+      expect(declarations).not.toMatch(
+        /(?:background|border|ring)(?:-color)?\s*:|--(?:muted|accent)\s*:/,
+      );
+    }
+  });
+});

--- a/packages/ui/src/styles/nuphy-scope.css
+++ b/packages/ui/src/styles/nuphy-scope.css
@@ -33,6 +33,12 @@
   --muted: rgba(29, 29, 31, 0.04);
   --muted-foreground: rgba(29, 29, 31, 0.5);
 
+  /* Lifted Eliza Cloud bodies use `text-muted` / `text-accent`, while NuPhy
+     intentionally uses the same base tokens as translucent fills. Keep
+     readable text aliases separate so bg-muted/bg-accent stay lightweight. */
+  --cloud-section-muted-fg: rgba(0, 0, 0, 0.58);
+  --cloud-section-accent-fg: #b83d00;
+
   --fill: rgba(29, 29, 31, 0.04);
   --fill-strong: rgba(29, 29, 31, 0.08);
   --accent: rgba(29, 29, 31, 0.04);
@@ -85,6 +91,9 @@
   --popover-foreground: rgba(255, 255, 255, 0.92);
   --muted: rgba(255, 255, 255, 0.05);
   --muted-foreground: rgba(255, 255, 255, 0.45);
+
+  --cloud-section-muted-fg: rgba(255, 255, 255, 0.56);
+  --cloud-section-accent-fg: #ff7d3a;
 
   --fill: rgba(255, 255, 255, 0.06);
   --fill-strong: rgba(255, 255, 255, 0.1);
@@ -169,6 +178,29 @@
 }
 .nuphy-scope .placeholder\:text-muted-foreground::placeholder {
   color: var(--muted-foreground);
+}
+
+/* Eliza Cloud section text bridge. The low-specificity :where() boundary lets
+   state variants such as hover:text-txt-strong continue to win, while these
+   exact color-only overrides never affect NuPhy fills, borders, or rings. */
+:where(.nuphy-scope [data-cloud-section-theme="eliza"])
+:is(.text-muted, .text-muted-foreground) {
+  color: var(--cloud-section-muted-fg);
+}
+:where(.nuphy-scope [data-cloud-section-theme="eliza"]) .text-accent {
+  color: var(--cloud-section-accent-fg);
+}
+:where(.nuphy-scope [data-cloud-section-theme="eliza"])
+  .placeholder\:text-muted::placeholder {
+  color: var(--cloud-section-muted-fg);
+}
+:where(.nuphy-scope [data-cloud-section-theme="eliza"])
+  .hover\:text-accent:hover {
+  color: var(--cloud-section-accent-fg);
+}
+:where(.nuphy-scope [data-cloud-section-theme="eliza"])
+  .disabled\:text-muted:disabled {
+  color: var(--cloud-section-muted-fg);
 }
 .nuphy-scope .focus-visible\:ring-ring:focus-visible {
   --tw-ring-color: var(--ring);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Closes #25257
- Related to #24495

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased without conflicts.
- [x] The affected tests, typecheck, formatting, builds, exact-renderer
      walkthrough, telemetry scan, and OCR review pass.
- [x] A reviewer can confirm the behavior from the inline evidence without
      reading the implementation.

# Sync with develop

- [x] Rebased onto `origin/develop`
      `2a7359db52ad7526ef82bf194bedea16d324eea0`; zero conflicts.
- [x] `bun run verify` reached the repository-wide lint/typecheck matrix. Its
      unrelated `plugin-trajectory-logger` formatting failure is recorded in
      **Known gaps / failures**.

# Risks

Medium. This changes Settings route composition, account-session gating, and
tenant-sensitive Organization query keys on desktop and narrow layouts. It does
not change cloud APIs, billing calculations, persistence, infrastructure, or
backend behavior. Account bodies unmount synchronously at sign-out start,
queries are partitioned by authenticated user, and the fallback Settings router
mounts the canonical invoice-detail route.

# Background

## What does this PR do?

- Mounts Billing, API Keys, Sessions & privacy, and Organization as explicit
  account-footer destinations in cloud-only Settings instead of silently
  falling back to General.
- Keeps those entries out of the normal groups and exposes them through the
  same account menu on wide and narrow layouts, preserving canonical hashes,
  active state, narrow back navigation, and header actions.
- Reactively gates the destinations on either a connected cloud session or a
  restored management credential, including same-document token changes.
- Suppresses every prior account history entry as soon as sign-out starts, so
  Back cannot remount account data while disconnect is pending or has failed;
  a still-observed session gets a persistent, explicit retry affordance.
- Mounts the registered `cloud/invoices/:id` route inside the Settings fallback
  router, making invoice “View” and “Back to Billing” functional.
- Partitions all Organization reads by authenticated user and preserves RBAC
  gates, preventing stale tenant data from appearing after an account switch.
- Bridges only lifted Cloud text utilities to AA-readable Eliza colors without
  mutating the NuPhy fill, border, or ring tokens.
- Uses the globally defined opaque surface token for Organization invite,
  member, credential, revoke, and Select portals rendered outside
  `.nuphy-scope`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. This restores existing Settings destinations and hardens their client-side
session boundaries; the behavior is covered by tests and reviewer-facing UI
evidence.

# Testing

## Where should a reviewer start?

1. `packages/ui/src/components/settings/cloud-panel/cloud-panel-sections.ts`
2. `packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.tsx`
3. `packages/ui/src/components/settings/cloud-panel/CloudSettingsSidebar.tsx`
4. `packages/ui/src/cloud/settings/CloudSettingsSectionShell.tsx`
5. `packages/ui/src/cloud/organization/data/use-organization.ts`
6. `packages/ui/src/cloud/organization/data/auth-scoped-queries.test.tsx`

## Detailed testing steps

Run from the repository root at exact head
`1d9b9e9f6d76d6c0931bb6b07d2ce98c959cd3c1`:

- `bun install --frozen-lockfile` — pass.
- Twelve focused UI test files covering footer destinations, desktop/narrow
  routing, auth removal, sign-out history and retry, text-token contrast,
  invoice drill-down, Organization cache isolation/RBAC, and portalled dialog
  surfaces — 68 tests, all pass.
- `bun run --cwd packages/ui typecheck` — pass.
- Biome over all 23 changed files — pass.
- `packages/shared`, `packages/core` (including packed contracts), and
  `packages/ui` builds — pass; UI verifies 46 runtime exports.
- `git diff --check` — pass.
- Exact-head cloud-only Settings Playwright run — pass on desktop 1280×800 and
  narrow 390×844. It opens both account menus, navigates all four destinations
  through their links, and exercises invoice detail plus the Organization
  Invite/Role portals.
- OCR review — 28/28 screenshots accepted; zero failures.
- Frontend telemetry — no `pageerror`, `requestfailed`, `console:error`, or
  HTTP 4xx/5xx entries.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1d9b9e9f6d76d6c0931bb6b07d2ce98c959cd3c1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25701-eliza-25257-before-contact.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25701-eliza-25257-1d9-after-contact.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25701-eliza-25257-1d9-after-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only Settings route mounting and cache gating; no backend code path changed.
<!-- evidence-row:frontend-logs -->
- [x] [25701-eliza-25257-1d9-frontend-telemetry.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25701-eliza-25257-1d9-frontend-telemetry.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, wallet, scheduler, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] [25701-eliza-25257-1d9-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25701-eliza-25257-1d9-ocr-review.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend: N/A - this is client-only Settings routing and cache gating; no backend
code path changed.

Frontend: the attached telemetry covers both production-renderer viewports and
all exercised routes. Every observed response is 2xx and there are no page
errors, failed requests, console errors, or 4xx/5xx responses.

## Screenshots (before / after) + video walkthrough

The before producer ran from detached exact pre-fix base
`08a654a7e8f144ecc3770ac52ac80963976c053f`. The after producer ran from exact
head `1d9b9e9f6d76d6c0931bb6b07d2ce98c959cd3c1`. Both use the production
renderer in cloud-only mode, deterministic API routing, desktop 1280×800, and
narrow 390×844.

### Before

The contact sheet shows all four account-footer actions falling back to General
on desktop and narrow layouts.

### After

The contact sheet shows the canonical Billing, API Keys, Sessions & privacy,
and Organization bodies on both layouts, with the connected account menu
reachable from both layouts and readable Cloud text on the unchanged NuPhy
surfaces. It also shows the functional invoice detail view and opaque Invite
Member / Role portal surfaces. Original JPGs are attached in the evidence
comment for individual inspection.

### Walkthrough video

The H.264 MP4 walks the desktop and narrow destinations, including invoice and
Organization interactions. Representative frames were manually inspected.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- Repository-wide `mise exec -- bun run verify` reaches the global Turbo
  lint/typecheck matrix and fails in untouched
  `plugins/plugin-trajectory-logger/src/api-client.ts` and
  `src/api-client.surrogate.test.ts`, where Biome requests formatting. The
  affected UI package typecheck, Biome check, builds, and focused tests pass.
- The i18n checker reports existing translation-coverage warnings across seven
  non-English locales but explicitly completes `OK`; no translation file or
  newly introduced copy is part of this PR.
- A prior full app audit executed 227 cases: 223 passed, including every
  `builtin-settings` case. Four unrelated `plugin-cloud-gui` viewport cases
  timed out; two regular Settings overlay findings were outside the cloud-only
  panel changed here.

These gaps are outside the affected files and behavior. Exact-head focused
tests, typecheck, formatting, builds, rendered evidence, telemetry, and OCR pass.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


