### PR TITLE
test(agent): cover full-disk

### DIFF
--- a/packages/agent/src/services/permissions/probers/full-disk.test.ts
+++ b/packages/agent/src/services/permissions/probers/full-disk.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit coverage for the Full Disk Access prober. Drives the real module
+ * through Darwin probe ordering (Mail → Safari bookmarks → TCC.db),
+ * directory versus file targets, EACCES/EPERM denial, missing-path and
+ * non-access fallthrough, non-Darwin unsupported, and request() which
+ * always opens the AllFiles pane. System Settings is stubbed; buildState
+ * and platformUnsupportedState stay the production helpers.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { darwin, mockOpenPrivacyPane } = vi.hoisted(() => ({
+  darwin: { current: true },
+  mockOpenPrivacyPane: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    openPrivacyPane: mockOpenPrivacyPane,
+  };
+});
+
+import { fullDiskProber } from "./full-disk.ts";
+
+function ioError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+function mailDir(home: string): string {
+  return path.join(home, "Library", "Mail");
+}
+
+function bookmarksFile(home: string): string {
+  return path.join(home, "Library", "Safari", "Bookmarks.plist");
+}
+
+function tccDbFile(home: string): string {
+  return path.join(
+    home,
+    "Library",
+    "Application Support",
+    "com.apple.TCC",
+    "TCC.db",
+  );
+}
+
+let tmpHome: string;
+
+describe("fullDiskProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    tmpHome = mkdtempSync(path.join(os.tmpdir(), "eliza-fda-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("exports id full-disk", () => {
+    expect(fullDiskProber.id).toBe("full-disk");
+    expect(typeof fullDiskProber.check).toBe("function");
+    expect(typeof fullDiskProber.request).toBe("function");
+  });
+});
+
+describe("fullDiskProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    tmpHome = mkdtempSync(path.join(os.tmpdir(), "eliza-fda-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns not-applicable on non-Darwin without probing the filesystem", async () => {
+    darwin.current = false;
+    const stat = vi.spyOn(fs, "stat");
+    const before = Date.now();
+    const state = await fullDiskProber.check();
+    expect(state).toMatchObject({
+      id: "full-disk",
+      status: "not-applicable",
+      canRequest: false,
+      restrictedReason: "platform_unsupported",
+      platform: process.platform,
+    });
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(stat).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(os.homedir).not.toHaveBeenCalled();
+  });
+
+  it("returns not-determined with canRequest false when no FDA probe exists", async () => {
+    const stat = vi.spyOn(fs, "stat");
+    const state = await fullDiskProber.check();
+    expect(state.id).toBe("full-disk");
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(stat).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("grants when Library/Mail exists as a readable directory", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    writeFileSync(path.join(mailDir(tmpHome), "Accounts.plist"), "mail");
+    const open = vi.spyOn(fs, "open");
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.id).toBe("full-disk");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("does not consult later probes once Mail grants", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    vi.spyOn(fs, "open").mockRejectedValue(ioError("EACCES"));
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("skips a missing Mail directory and grants via Safari Bookmarks.plist", async () => {
+    mkdirSync(path.dirname(bookmarksFile(tmpHome)), { recursive: true });
+    writeFileSync(bookmarksFile(tmpHome), "plist");
+    const open = vi.spyOn(fs, "open");
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(open).toHaveBeenCalledWith(bookmarksFile(tmpHome), "r");
+  });
+
+  it("skips the first two missing probes and grants via TCC.db", async () => {
+    mkdirSync(path.dirname(tccDbFile(tmpHome)), { recursive: true });
+    writeFileSync(tccDbFile(tmpHome), "db");
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+  });
+
+  it("treats Library/Mail as a file probe when it is not a directory", async () => {
+    mkdirSync(path.dirname(mailDir(tmpHome)), { recursive: true });
+    writeFileSync(mailDir(tmpHome), "not-a-dir");
+    const readdir = vi.spyOn(fs, "readdir");
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("treats Bookmarks.plist as a directory probe when it is a directory", async () => {
+    mkdirSync(bookmarksFile(tmpHome), { recursive: true });
+    const open = vi.spyOn(fs, "open");
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it.each(["EACCES", "EPERM"] as const)(
+    "returns denied when the Mail directory listing throws %s (does not fall through)",
+    async (code) => {
+      mkdirSync(mailDir(tmpHome), { recursive: true });
+      mkdirSync(path.dirname(bookmarksFile(tmpHome)), { recursive: true });
+      writeFileSync(bookmarksFile(tmpHome), "plist");
+      vi.spyOn(fs, "readdir").mockRejectedValueOnce(ioError(code));
+      const state = await fullDiskProber.check();
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+    },
+  );
+
+  it.each(["EACCES", "EPERM"] as const)(
+    "returns denied when a file probe open throws %s (does not fall through)",
+    async (code) => {
+      mkdirSync(path.dirname(bookmarksFile(tmpHome)), { recursive: true });
+      writeFileSync(bookmarksFile(tmpHome), "plist");
+      mkdirSync(path.dirname(tccDbFile(tmpHome)), { recursive: true });
+      writeFileSync(tccDbFile(tmpHome), "db");
+      vi.spyOn(fs, "open").mockRejectedValueOnce(ioError(code));
+      const state = await fullDiskProber.check();
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+    },
+  );
+
+  it.each(["ENOENT", "EIO"] as const)(
+    "falls through to the next probe when stat throws %s",
+    async (code) => {
+      mkdirSync(mailDir(tmpHome), { recursive: true });
+      mkdirSync(path.dirname(bookmarksFile(tmpHome)), { recursive: true });
+      writeFileSync(bookmarksFile(tmpHome), "plist");
+      vi.spyOn(fs, "stat").mockRejectedValueOnce(ioError(code));
+      const state = await fullDiskProber.check();
+      expect(state.status).toBe("granted");
+    },
+  );
+
+  it("falls through when the error has no errno code", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    mkdirSync(path.dirname(bookmarksFile(tmpHome)), { recursive: true });
+    writeFileSync(bookmarksFile(tmpHome), "plist");
+    vi.spyOn(fs, "stat").mockRejectedValueOnce(new Error("unexpected"));
+    const state = await fullDiskProber.check();
+    expect(state.status).toBe("granted");
+  });
+
+  it("does not invoke openPrivacyPane from check()", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    await fullDiskProber.check();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("fullDiskProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    tmpHome = mkdtempSync(path.join(os.tmpdir(), "eliza-fda-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns not-applicable on non-Darwin without lastRequested or a pane open", async () => {
+    darwin.current = false;
+    const state = await fullDiskProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.id).toBe("full-disk");
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("always opens the AllFiles pane then re-checks, even when already granted", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    const before = Date.now();
+    const state = await fullDiskProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(mockOpenPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("AllFiles");
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+  });
+
+  it("opens the AllFiles pane when the re-check is not-determined", async () => {
+    const state = await fullDiskProber.request({ reason: "unit-test" });
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("AllFiles");
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("opens the AllFiles pane when the re-check is denied", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    vi.spyOn(fs, "readdir").mockRejectedValue(ioError("EACCES"));
+    const state = await fullDiskProber.request({ reason: "unit-test" });
+    expect(mockOpenPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("AllFiles");
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("ignores the unused reason argument", async () => {
+    mkdirSync(mailDir(tmpHome), { recursive: true });
+    const state = await fullDiskProber.request({
+      reason: "any-caller-supplied-reason",
+    });
+    expect(state.status).toBe("granted");
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("AllFiles");
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated Vitest suite for `packages/agent/src/services/permissions/probers/full-disk.ts`, which previously had no same-named test file. Production code is unchanged.

The suite drives the real `fullDiskProber` against a temporary homedir (real `existsSync` / `stat` / `readdir` / `open`). `IS_DARWIN` and `openPrivacyPane` are stubbed so System Settings is never opened; `buildState` and `platformUnsupportedState` stay the production helpers.

Covered behaviour, as observed in the source:

- **id** is `full-disk`; `check` and `request` are functions.
- **non-Darwin `check`/`request`:** `not-applicable` + `restrictedReason: platform_unsupported` + `canRequest: false`. No filesystem probe, no privacy pane, no `lastRequested`.
- **empty probe set:** all three FDA paths missing → `not-determined` with `canRequest: false` (explicit; FDA cannot be requested programmatically).
- **ordering:** Mail directory grants without consulting later probes; missing Mail falls through to Safari `Bookmarks.plist`; first two missing falls through to `TCC.db`.
- **directory vs file:** `isDirectory()` uses `readdir`; otherwise `open(..., "r")` then close. Mail-as-file and Bookmarks-as-directory follow that split.
- **EACCES / EPERM** on the first existing probe return `denied` immediately (no fallthrough). Other errno codes (`ENOENT`, `EIO`) and errors with no `code` continue to the next probe.
- **`request()` on Darwin** always calls `openPrivacyPane("AllFiles")` then re-checks, and stamps `lastRequested`, including when the re-check is granted, denied, or not-determined.

## Evidence

Test-only change. No production behaviour is modified. Hosted CI does **not** run on this fork contributor's PRs; the counts below were produced locally against current `origin/develop` (`1e63232fe08a`) at head `edc3ef615183`.

1. `bunx vitest run src/services/permissions/probers/full-disk.test.ts` (from `packages/agent`, after refetching `origin/develop`):
   **Test Files  1 passed (1)** / **Tests  22 passed (22)**.
2. `bunx biome check --write packages/agent/src/services/permissions/probers/full-disk.test.ts` (repo `biome.json` present; worktree is not sparse): clean (1 file, import grouping applied).
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'full-disk.test.ts'`: empty (our file appears nowhere in `tsc` output). `tsconfig.json` `"include": ["src"]` covers this test.
4. Diff vs `origin/develop` touches **only** `packages/agent/src/services/permissions/probers/full-disk.test.ts`.

N/A for origin reproduction, load-bearing revert, over-rejection corpus, screenshots, and live-model trajectories: this PR adds tests and does not change production behaviour.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:edc3ef6151839e7f58832f6129e165661d2e1449 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
