### PR TITLE
test(agent): cover owner entity resolution

### DIFF
--- a/packages/agent/src/runtime/__tests__/owner-entity.test.ts
+++ b/packages/agent/src/runtime/__tests__/owner-entity.test.ts
@@ -16,7 +16,7 @@ vi.mock("@elizaos/core", () => ({
 import {
   resolveFallbackOwnerEntityId,
   resolveOwnerEntityId,
-} from "./owner-entity.ts";
+} from "../owner-entity.ts";
 
 describe("resolveFallbackOwnerEntityId", () => {
   it("derives a synthetic id from the character name", () => {

--- a/packages/agent/src/runtime/__tests__/owner-entity.test.ts
+++ b/packages/agent/src/runtime/__tests__/owner-entity.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveCanonicalOwnerId: vi.fn(),
+  stringToUuid: vi.fn((s: string) => `uuid(${s})`),
+  logger: { debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@elizaos/core", () => ({
+  resolveCanonicalOwnerId: (...a: unknown[]) =>
+    mocks.resolveCanonicalOwnerId(...a),
+  stringToUuid: (...a: unknown[]) => mocks.stringToUuid(...a),
+  logger: mocks.logger,
+}));
+
+import {
+  resolveFallbackOwnerEntityId,
+  resolveOwnerEntityId,
+} from "./owner-entity.ts";
+
+describe("resolveFallbackOwnerEntityId", () => {
+  it("derives a synthetic id from the character name", () => {
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Alice" },
+    } as never;
+    expect(resolveFallbackOwnerEntityId(runtime)).toBe(
+      "uuid(Alice-admin-entity)",
+    );
+  });
+
+  it("falls back to agentId when the name is blank", () => {
+    const runtime = { agentId: "agent-1", character: { name: "  " } } as never;
+    expect(resolveFallbackOwnerEntityId(runtime)).toBe(
+      "uuid(agent-1-admin-entity)",
+    );
+  });
+});
+
+describe("resolveOwnerEntityId", () => {
+  it("returns the canonical owner id when configured", async () => {
+    mocks.resolveCanonicalOwnerId.mockReturnValue("owner-42");
+    const runtime = {} as never;
+    expect(await resolveOwnerEntityId(runtime)).toBe("owner-42");
+  });
+
+  it("resolves owner from world metadata", async () => {
+    mocks.resolveCanonicalOwnerId.mockReturnValue(null);
+    const runtime = {
+      agentId: "a1",
+      getRoomsForParticipant: async () => ["room-1"],
+      getRoom: async () => ({ worldId: "world-1" }),
+      getWorld: async () => ({
+        metadata: { ownership: { ownerId: "owner-world" } },
+      }),
+    } as never;
+    expect(await resolveOwnerEntityId(runtime)).toBe("owner-world");
+  });
+
+  it("falls back to the synthetic id when nothing matches", async () => {
+    mocks.resolveCanonicalOwnerId.mockReturnValue(null);
+    const runtime = {
+      agentId: "a1",
+      character: { name: "Bob" },
+      getRoomsForParticipant: async () => [],
+    } as never;
+    expect(await resolveOwnerEntityId(runtime)).toBe("uuid(Bob-admin-entity)");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 5 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
