### PR TITLE
fix(agent): sort inbox chats by their stable id

### DIFF
--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -2596,7 +2596,7 @@ async function loadInboxChats(
       typeof a.lastMessageAt === "number" && Number.isFinite(a.lastMessageAt)
         ? a.lastMessageAt
         : 0;
-    return bLast - aLast || a.roomId.localeCompare(b.roomId);
+    return bLast - aLast || a.id.localeCompare(b.id);
   });
   return chats;
 }


### PR DESCRIPTION
## Summary

- repair the current-develop app typecheck regression introduced by merged PR #25594
- use the existing `InboxChat.id` stable room selection key for the equal-timestamp tie-break
- keep the NaN-safe last-message timestamp ordering from #25594 unchanged

## Failure

Both local App typecheck and PR #25674 Static Smoke 32634397411 failed at packages/agent/src/api/inbox-routes.ts:2599 because `InboxChat` has no `roomId` property. The interface documents `id` as the stable room selection key.

## Validation

Exact commit a56ab4efe0f95f5263ef3f52dbb3134f8ec7b54c on current base 1e63232fe08a25a7ebce3d408a6b986647b2a10f:

- App typecheck: passed
- Agent typecheck: passed
- seven focused inbox suites: 70/70 passed
- Biome: passed
- git diff --check: passed
- staged gitleaks: no leaks

One source line changed. This PR does not touch Shared diagnostics, Cloudflare, Railway, workflows, or provider behavior.

@byt61 please confirm the intended stable tie-break from #25594. @lalalune review requested because this is a canonical release gate.