### PR TITLE
test(agent): cover notes

### DIFF
--- a/packages/agent/src/services/permissions/probers/notes.test.ts
+++ b/packages/agent/src/services/permissions/probers/notes.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit coverage for the Notes.app Apple Events permission prober. Drives the
+ * real `notesProber` so Darwin TCC classification, the null→not-determined
+ * fallback, non-Darwin platform-unsupported short-circuit, and the request()
+ * osascript path are asserted against live `buildState` /
+ * `platformUnsupportedState` output. TCC.db and osascript collaborators are
+ * faked so Darwin branches run on any host. `buildState` drops the free-text
+ * `reason` option, so that field is asserted absent on returned states.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isDarwin: true,
+  queryAppleEventsTccStatus: vi.fn(),
+  runOsascript: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return mocks.isDarwin;
+    },
+    queryAppleEventsTccStatus: mocks.queryAppleEventsTccStatus,
+    runOsascript: mocks.runOsascript,
+  };
+});
+
+import { platformUnsupportedState } from "./_bridge.js";
+import { notesProber } from "./notes.ts";
+
+const NOTES_BUNDLE_ID = "com.apple.Notes";
+const NOTES_SCRIPT = 'tell application "Notes" to count of folders';
+
+function expectPlatform(platform: string): void {
+  expect(["darwin", "win32", "linux", "ios", "android", "web"]).toContain(
+    platform,
+  );
+}
+
+describe("notesProber", () => {
+  beforeEach(() => {
+    mocks.isDarwin = true;
+    mocks.queryAppleEventsTccStatus.mockReset();
+    mocks.runOsascript.mockReset();
+    mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+    mocks.runOsascript.mockResolvedValue("1");
+  });
+
+  it("exports id notes", () => {
+    expect(notesProber.id).toBe("notes");
+    expect(notesProber.openSettings).toBeUndefined();
+    expect(typeof notesProber.check).toBe("function");
+    expect(typeof notesProber.request).toBe("function");
+  });
+
+  describe("check", () => {
+    it("returns platform-unsupported without querying TCC when not Darwin", async () => {
+      mocks.isDarwin = false;
+      const state = await notesProber.check();
+      const expected = platformUnsupportedState("notes");
+      expect(state).toEqual({
+        ...expected,
+        lastChecked: state.lastChecked,
+      });
+      expect(state.status).toBe("not-applicable");
+      expect(state.canRequest).toBe(false);
+      expect(state.restrictedReason).toBe("platform_unsupported");
+      expect(state.lastRequested).toBeUndefined();
+      expect(mocks.queryAppleEventsTccStatus).not.toHaveBeenCalled();
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+    });
+
+    it("treats a missing Apple Events row as not-determined and requestable", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const before = Date.now();
+      const state = await notesProber.check();
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledWith(
+        NOTES_BUNDLE_ID,
+      );
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+      expect(state.id).toBe("notes");
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+      expect(state.lastRequested).toBeUndefined();
+      expect(state.reason).toBeUndefined();
+      expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+      expectPlatform(state.platform);
+    });
+
+    it("reports granted as not requestable and does not surface reason", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("granted");
+      const state = await notesProber.check();
+      expect(state.status).toBe("granted");
+      expect(state.canRequest).toBe(false);
+      expect(state.reason).toBeUndefined();
+      expect(state.restrictedReason).toBeUndefined();
+      expect(state.lastRequested).toBeUndefined();
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+    });
+
+    it("reports denied as not requestable", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await notesProber.check();
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+      expect(state.reason).toBeUndefined();
+      expect(state.lastRequested).toBeUndefined();
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("request", () => {
+    it("returns platform-unsupported without running osascript when not Darwin", async () => {
+      mocks.isDarwin = false;
+      const state = await notesProber.request({ reason: "need notes" });
+      const expected = platformUnsupportedState("notes");
+      expect(state).toEqual({
+        ...expected,
+        lastChecked: state.lastChecked,
+      });
+      expect(state.lastRequested).toBeUndefined();
+      expect(mocks.runOsascript).not.toHaveBeenCalled();
+      expect(mocks.queryAppleEventsTccStatus).not.toHaveBeenCalled();
+    });
+
+    it("prompts Notes.app then re-reads TCC, stamping lastRequested", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("granted");
+      const before = Date.now();
+      const state = await notesProber.request({ reason: "need notes" });
+      const after = Date.now();
+      expect(mocks.runOsascript).toHaveBeenCalledTimes(1);
+      expect(mocks.runOsascript).toHaveBeenCalledWith(NOTES_SCRIPT);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.queryAppleEventsTccStatus).toHaveBeenCalledWith(
+        NOTES_BUNDLE_ID,
+      );
+      expect(state.status).toBe("granted");
+      expect(state.canRequest).toBe(false);
+      expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+      expect(state.lastRequested).toBeLessThanOrEqual(after);
+      expect(state.reason).toBeUndefined();
+      expectPlatform(state.platform);
+    });
+
+    it("keeps denied requestable=false after the prompt", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await notesProber.request({ reason: "need notes" });
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+      expect(state.lastRequested).toEqual(expect.any(Number));
+      expect(mocks.runOsascript).toHaveBeenCalledWith(NOTES_SCRIPT);
+    });
+
+    it("keeps a missing TCC row requestable after the prompt", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const state = await notesProber.request({ reason: "need notes" });
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+      expect(state.lastRequested).toEqual(expect.any(Number));
+    });
+
+    it("ignores osascript failure and still classifies from the TCC re-read", async () => {
+      mocks.runOsascript.mockResolvedValue(null);
+      mocks.queryAppleEventsTccStatus.mockResolvedValue("denied");
+      const state = await notesProber.request({ reason: "need notes" });
+      expect(mocks.runOsascript).toHaveBeenCalledTimes(1);
+      expect(state.status).toBe("denied");
+      expect(state.canRequest).toBe(false);
+      expect(state.lastRequested).toEqual(expect.any(Number));
+    });
+
+    it("does not copy the caller reason onto the returned state", async () => {
+      mocks.queryAppleEventsTccStatus.mockResolvedValue(null);
+      const state = await notesProber.request({
+        reason: "distinct-caller-reason",
+      });
+      expect(state.reason).toBeUndefined();
+      expect(state.status).toBe("not-determined");
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/services/permissions/probers/notes.ts`, which had no same-named test file. No production behavior change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`) with zero conflicts.
- [ ] `bun run verify` was not re-run for this test-only addition. Focused gates below were run at this head.
- [x] A reviewer can confirm the change from the quoted vitest/biome/tsc output without reading production code.

# Sync with develop

- [x] Branch parent is current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`); zero conflicts. Re-fetched immediately before filing.
- [ ] `bun run verify` not re-run; test-only diff. Focused vitest, biome, and package `tsc` are quoted below.

# Risks

Low. Adds a unit test file only. No production source, contracts, or runtime behavior change. `notesProber` is driven for real; only TCC.db and osascript OS collaborators are stubbed, matching sibling prober suites.

# Background

## What does this PR do?

Adds `packages/agent/src/services/permissions/probers/notes.test.ts` covering the exported `notesProber`:

- `id` is `notes`; `openSettings` is absent.
- `check()` on non-Darwin returns `platformUnsupportedState` and does not query Apple Events TCC or run osascript.
- `check()` treats a missing Apple Events row (`null`) as `not-determined` and requestable, querying `com.apple.Notes`.
- `check()` maps `granted` and `denied` with `canRequest: false` and does not run osascript.
- `buildState` drops the free-text `reason` option, so returned states do not surface `reason` (observed, not aspirational).
- `request()` on non-Darwin is platform-unsupported, does not stamp `lastRequested`, and does not prompt.
- `request()` runs `tell application "Notes" to count of folders`, re-reads TCC, and stamps `lastRequested`.
- `request()` after osascript failure still classifies from the TCC re-read.
- Caller `reason` is not copied onto the returned state.

## What kind of change is this?

Improvements (test coverage for an existing prober; no production edit).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/notes.test.ts` and the quoted vitest run.

## Detailed testing steps

None: automated tests are the proof.

```bash
bunx vitest run packages/agent/src/services/permissions/probers/notes.test.ts
```

Re-fetched `origin/develop` and re-ran at this head immediately before filing. Observed:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Vitest v4.1.10. Duration ~4.7s.

```bash
bunx biome check --write packages/agent/src/services/permissions/probers/notes.test.ts
```

Observed: `Checked 1 file in 20ms. No fixes applied.` (`biome.json` is present; sparse-checkout is not enabled.)

```bash
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'notes.test.ts' ; echo "EXIT:$?"
```

Observed: empty grep (EXIT:1). `notes.test.ts` appears nowhere in `tsc` output.

The diff touches only `packages/agent/src/services/permissions/probers/notes.test.ts`.

Hosted CI does **not** run on this fork contributor PR. Do not infer a GitHub Actions pass from this body.

# Evidence Gate

<!-- evidence-head:421ff8d42d4540ca143a7aff91258a2d69516d2a -->

Test-only change; no UI, backend path, or agent-loop behavior.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production path change; vitest is the proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - unit tests only; no DB/wallet/scheduled-item artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only unit coverage; no HTTP or UI path.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run; this PR adds one test file and changes no production behavior. Focused vitest (11 passed / 1 file), biome (clean), and package `tsc` (no hits on `notes.test.ts`) were run instead.
- Fork contributor: hosted CI does not run on this PR.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
