### PR TITLE
test(agent): cover microphone

### DIFF
--- a/packages/agent/src/services/permissions/probers/microphone.test.ts
+++ b/packages/agent/src/services/permissions/probers/microphone.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit coverage for the microphone permission prober. Drives the real module
+ * through Darwin AVCaptureDevice status mapping, the missing-dylib fallback,
+ * the non-Darwin renderer hand-off, and request() including the denied-state
+ * privacy-pane open. Native FFI and System Settings are stubbed; mapAVAuthStatus
+ * and buildState stay the production helpers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { darwin, mockGetNativeDylib, mockOpenPrivacyPane } = vi.hoisted(() => ({
+  darwin: { current: true },
+  mockGetNativeDylib: vi.fn(),
+  mockOpenPrivacyPane: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    getNativeDylib: mockGetNativeDylib,
+    openPrivacyPane: mockOpenPrivacyPane,
+  };
+});
+
+import { microphoneProber } from "./microphone.ts";
+
+function nativeLib(status: number, request = vi.fn()) {
+  return {
+    checkMicrophonePermission: () => status,
+    requestMicrophonePermission: request,
+  };
+}
+
+describe("microphoneProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("exports id microphone", () => {
+    expect(microphoneProber.id).toBe("microphone");
+    expect(typeof microphoneProber.check).toBe("function");
+    expect(typeof microphoneProber.request).toBe("function");
+  });
+});
+
+describe("microphoneProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("returns not-determined with canRequest on non-Darwin without touching native", async () => {
+    darwin.current = false;
+    const before = Date.now();
+    const state = await microphoneProber.check();
+    expect(state).toMatchObject({
+      id: "microphone",
+      status: "not-determined",
+      canRequest: true,
+      platform: process.platform,
+    });
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing dylib as AV status 0 (not-determined)", async () => {
+    mockGetNativeDylib.mockResolvedValue(null);
+    const state = await microphoneProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.id).toBe("microphone");
+    expect(mockGetNativeDylib).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [0, "not-determined", true],
+    [1, "denied", false],
+    [2, "granted", false],
+    [3, "restricted", false],
+  ] as const)(
+    "maps native AV status %i to %s (canRequest=%s)",
+    async (code, status, canRequest) => {
+      mockGetNativeDylib.mockResolvedValue(nativeLib(code));
+      const state = await microphoneProber.check();
+      expect(state.status).toBe(status);
+      expect(state.canRequest).toBe(canRequest);
+      expect(state.id).toBe("microphone");
+      expect(state.platform).toBe(process.platform);
+    },
+  );
+
+  it.each([4, -1, 99])(
+    "maps unknown native AV status %i to not-determined",
+    async (code) => {
+      mockGetNativeDylib.mockResolvedValue(nativeLib(code));
+      const state = await microphoneProber.check();
+      expect(state.status).toBe("not-determined");
+      expect(state.canRequest).toBe(true);
+    },
+  );
+
+  it("does not invoke requestMicrophonePermission from check()", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(2, request));
+    await microphoneProber.check();
+    expect(request).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("microphoneProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockGetNativeDylib.mockReset();
+    mockOpenPrivacyPane.mockReset();
+    mockOpenPrivacyPane.mockResolvedValue(undefined);
+    mockGetNativeDylib.mockResolvedValue(null);
+  });
+
+  it("returns not-determined on non-Darwin without lastRequested or native I/O", async () => {
+    darwin.current = false;
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.id).toBe("microphone");
+    expect(state.lastRequested).toBeUndefined();
+    expect(mockGetNativeDylib).not.toHaveBeenCalled();
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("invokes native request and stamps lastRequested without opening settings when granted", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(2, request));
+    const before = Date.now();
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("opens the Microphone privacy pane only when the re-check is denied", async () => {
+    const request = vi.fn();
+    mockGetNativeDylib.mockResolvedValue(nativeLib(1, request));
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(mockOpenPrivacyPane).toHaveBeenCalledWith("Microphone");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("does not open the privacy pane when status is not-determined", async () => {
+    mockGetNativeDylib.mockResolvedValue(nativeLib(0));
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("does not open the privacy pane when status is restricted", async () => {
+    mockGetNativeDylib.mockResolvedValue(nativeLib(3));
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("tolerates a missing dylib on Darwin request (optional chaining)", async () => {
+    mockGetNativeDylib.mockResolvedValue(null);
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.lastRequested).toBeTypeOf("number");
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("re-checks after request so a grant that lands during the prompt is returned", async () => {
+    let status = 0;
+    const request = vi.fn(() => {
+      status = 2;
+    });
+    mockGetNativeDylib.mockResolvedValue({
+      checkMicrophonePermission: () => status,
+      requestMicrophonePermission: request,
+    });
+    const state = await microphoneProber.request({ reason: "unit-test" });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(mockOpenPrivacyPane).not.toHaveBeenCalled();
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage gap: `packages/agent/src/services/permissions/probers/microphone.ts` had no same-named test file. No linked issue; test-only addition.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

Head `8ad2fcd019851fb1facba5d5d1398837a1e52b63` is one commit on
`origin/develop` `1e63232fe08a25a7ebce3d408a6b986647b2a10f` (re-fetched
immediately before filing). `bun run verify` was not run: this is a
test-only single-file addition and hosted CI does not run on fork PRs.

# Risks

Low. Adds a colocated unit test; no production source, contract, or runtime
behavior changes.

# Background

## What does this PR do?

Adds `packages/agent/src/services/permissions/probers/microphone.test.ts`,
driving the real `microphoneProber` export. Native FFI (`getNativeDylib`) and
System Settings (`openPrivacyPane`) are stubbed; production `mapAVAuthStatus`
and `buildState` stay live.

Covered branches in `microphone.ts`:

- `id` is `"microphone"` with `check`/`request` functions
- `check()` on non-Darwin returns `not-determined` / `canRequest: true` without
  native I/O
- Darwin missing dylib maps as AV status `0` (`not-determined`, `canRequest`)
- Darwin AV status `0/1/2/3` → `not-determined` / `denied` / `granted` /
  `restricted` with matching `canRequest`
- Unknown AV codes (`4`, `-1`, `99`) map to `not-determined`
- `check()` never calls `requestMicrophonePermission`
- `request()` on non-Darwin does not stamp `lastRequested` or touch native
- Darwin `request()` stamps `lastRequested` and skips the privacy pane when
  granted, not-determined, or restricted
- Darwin `request()` opens `openPrivacyPane("Microphone")` only when the
  re-check is `denied`
- Missing dylib on Darwin `request()` (optional chaining) stays
  `not-determined` and still stamps `lastRequested`
- `request()` re-checks after the native prompt so a grant that lands during
  the prompt is returned

## What kind of change is this?

Improvements (test coverage for existing behavior). No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/microphone.test.ts` and
`bunx vitest run packages/agent/src/services/permissions/probers/microphone.test.ts`.

## Detailed testing steps

Re-fetched `origin/develop` at `1e63232fe08a25a7ebce3d408a6b986647b2a10f` and
re-ran immediately before filing:

```
bunx vitest run packages/agent/src/services/permissions/probers/microphone.test.ts
```

Observed: `Test Files  1 passed (1)` / `Tests  18 passed (18)`.

```
bunx biome check --write packages/agent/src/services/permissions/probers/microphone.test.ts
```

Observed: `Checked 1 file in 170ms. No fixes applied.` `biome.json` is present
and the checkout is not sparse, so this is a configured check.

```
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'microphone.test.ts' ; echo "EXIT:$?"
```

Observed: empty grep (`EXIT:1` from grep = no matches). This test file
introduced zero TypeScript errors.

The diff touches only `packages/agent/src/services/permissions/probers/microphone.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR; do not
treat missing checks as a pass.

# Evidence Gate

<!-- evidence-head:8ad2fcd019851fb1facba5d5d1398837a1e52b63 -->

Test-only change; no UI, backend route, agent prompt, or domain-record path.

- [x] Before full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] After full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] Walkthrough video: `N/A - test-only, no user flow`
- [x] Backend logs: `N/A - no production path change; vitest output quoted above`
- [x] Frontend console/network logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB/memory/schedule/wallet/audio output`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; production behavior unchanged. Vitest counts quoted in Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only, no rendered UI surface.

### After

N/A - test-only, no rendered UI surface.

### Walkthrough video

N/A - test-only, no user flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT/omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds one test file and changes no
  production behavior. Full-workspace verify is out of scope for a test-only
  coverage PR on a shared checkout.
- Hosted CI does not run on fork contributor PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
