### PR TITLE
test(agent): cover health

### DIFF
--- a/packages/agent/src/services/permissions/probers/health.test.ts
+++ b/packages/agent/src/services/permissions/probers/health.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit coverage for the HealthKit permission prober. Drives the real
+ * `healthProber` through Darwin entitlement gating (unsigned-dev restricted
+ * vs signed not-determined bridge), request() lastRequested stamping, and
+ * the non-Darwin platform-unsupported short-circuit. Platform and entitlement
+ * detection are stubbed OS collaborators; `buildState` and
+ * `platformUnsupportedState` stay the production helpers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { darwin, mockHasEmbeddedProvisioningEntitlement } = vi.hoisted(() => ({
+  darwin: { current: true },
+  mockHasEmbeddedProvisioningEntitlement: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    hasEmbeddedProvisioningEntitlement: mockHasEmbeddedProvisioningEntitlement,
+  };
+});
+
+import { platformUnsupportedState } from "./_bridge.js";
+import { healthProber } from "./health.ts";
+
+const HEALTHKIT_ENTITLEMENT = "com.apple.developer.healthkit";
+
+describe("healthProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("exports id health without an openSettings helper", () => {
+    expect(healthProber.id).toBe("health");
+    expect(typeof healthProber.check).toBe("function");
+    expect(typeof healthProber.request).toBe("function");
+    expect(healthProber.openSettings).toBeUndefined();
+  });
+});
+
+describe("healthProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("returns platform-unsupported on non-Darwin without reading entitlements", async () => {
+    darwin.current = false;
+    const before = Date.now();
+    const state = await healthProber.check();
+    const expected = platformUnsupportedState("health");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.id).toBe("health");
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.lastBlockedFeature).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.platform).toBe(process.platform);
+    expect(mockHasEmbeddedProvisioningEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("reports restricted/entitlement_required when Darwin has no HealthKit entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+    const before = Date.now();
+    const state = await healthProber.check();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledTimes(1);
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      HEALTHKIT_ENTITLEMENT,
+    );
+    expect(state).toMatchObject({
+      id: "health",
+      status: "restricted",
+      canRequest: false,
+      restrictedReason: "entitlement_required",
+      platform: process.platform,
+    });
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.lastBlockedFeature).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+  });
+
+  it("surfaces not-determined with canRequest when Darwin has the HealthKit entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const before = Date.now();
+    const state = await healthProber.check();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      HEALTHKIT_ENTITLEMENT,
+    );
+    expect(state.id).toBe("health");
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.platform).toBe(process.platform);
+  });
+
+  it("does not stamp lastRequested from check() even when entitlement is present", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const state = await healthProber.check();
+    expect(state.lastRequested).toBeUndefined();
+  });
+});
+
+describe("healthProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("returns platform-unsupported on non-Darwin without lastRequested or entitlement I/O", async () => {
+    darwin.current = false;
+    const state = await healthProber.request({ reason: "sync sleep data" });
+    const expected = platformUnsupportedState("health");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(mockHasEmbeddedProvisioningEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("stamps lastRequested on Darwin without entitlement while remaining restricted", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+    const before = Date.now();
+    const state = await healthProber.request({ reason: "sync sleep data" });
+    const after = Date.now();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledTimes(1);
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      HEALTHKIT_ENTITLEMENT,
+    );
+    expect(state.id).toBe("health");
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("entitlement_required");
+    expect(state.lastRequested).toBeTypeOf("number");
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.reason).toBeUndefined();
+  });
+
+  it("mirrors the requestable not-determined state when Darwin has the entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const before = Date.now();
+    const state = await healthProber.request({ reason: "sync sleep data" });
+    const after = Date.now();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(state.id).toBe("health");
+    expect(state.platform).toBe(process.platform);
+  });
+
+  it("drops the free-text request reason rather than copying it onto the state", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const state = await healthProber.request({
+      reason: "this string must not leak",
+    });
+    expect(state.reason).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-directory Vitest suite for `packages/agent/src/services/permissions/probers/health.ts`. That module had no same-named test file. This is a test-only change: production behaviour is unchanged.

`healthProber` is a Darwin HealthKit permission probe. It does not talk to HKHealthStore. It branches on platform and the `com.apple.developer.healthkit` embedded-profile entitlement, then returns a `PermissionState` via the real `buildState` / `platformUnsupportedState` helpers:

- non-Darwin `check()` / `request()` → `not-applicable` / `platform_unsupported`, `canRequest: false`, no entitlement read, no `lastRequested`
- Darwin without the entitlement → `restricted` / `entitlement_required`, `canRequest: false`; `request()` still stamps `lastRequested`
- Darwin with the entitlement → `not-determined`, `canRequest: true` (native HKHealthStore bridge is not present yet); `request()` stamps `lastRequested`
- `check()` never stamps `lastRequested`; the free-text `reason` argument is not copied onto the returned state; `openSettings` is absent

The suite drives the real `healthProber` export. Only `IS_DARWIN` and `hasEmbeddedProvisioningEntitlement` are stubbed so Darwin and entitlement branches run on any host. Assertions use live `buildState` output (id, status, `canRequest`, `restrictedReason`, timestamps, `platform`), not mock echo.

## Evidence

Test-only PR. Hosted GitHub Actions does **not** run on this fork's PRs; the counts below are from the contributor checkout against current `origin/develop` (`1e63232fe08a`).

1. **Vitest** (re-run immediately before filing, against current `origin/develop`):

```
bunx vitest run packages/agent/src/services/permissions/probers/health.test.ts

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

2. **Biome** (config present: `biome.json`; sparse-checkout is not enabled):

```
bunx biome check --write packages/agent/src/services/permissions/probers/health.test.ts
Checked 1 file in 16ms. No fixes applied.
```

3. **tsc** from `packages/agent` (`bunx tsc --noEmit`). Grep for `health.test.ts` in that output is empty — this file introduces no type errors. Pre-existing errors elsewhere in the package are unrelated.

4. **Diff** touches only `packages/agent/src/services/permissions/probers/health.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ac6e0ada880e69c57fcfc5530bb2b8310521c4a0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
