### PR TITLE
test(settings): include Vault in visible rail fixture

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -193,6 +193,7 @@ const VISIBLE_SECTIONS = [
   "connectors",
   "appearance",
   "advanced",
+  "secrets",
   "permissions",
   "cloud-overview",
 ];
@@ -205,7 +206,6 @@ const HIDDEN_SECTIONS = [
   "background",
   "runtime",
   "wallet-rpc",
-  "secrets",
   "app-permissions",
 ];
 


### PR DESCRIPTION
## Summary
- update the Settings browser fixture to match the canonical user-visible Privacy & Security rail
- assert the Vault/Secrets destination as visible and navigable
- remove the stale hidden-section expectation

## Root cause
The product registration intentionally exposes the Vault as a secondary owner entry point, but the UI-extended fixture still classified secrets as hidden. Canonical Develop Full therefore failed at Settings page e2e after the product behavior changed.

## Proof
- bun run --cwd packages/ui test:settings-e2e
- bun run --cwd packages/ui test -- src/components/settings/settings-sections.registration.test.ts (15/15)
- git diff --check
- gitleaks dir --no-banner --redact packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs

Biome intentionally ignores this E2E .mjs path; the repository-native Settings runner is green and the patch is a one-line list move only.

## Scope
Test-only owner repair for the canonical release gate. No Shared runtime, Auth, provider, Cloudflare, Railway, or production behavior changes.

@lalalune please review when convenient.