### PR TITLE
test(linux): document CEF sequencing guard

### DIFF
--- a/packages/app-core/scripts/__tests__/desktop-build-linux-cef-profile.test.ts
+++ b/packages/app-core/scripts/__tests__/desktop-build-linux-cef-profile.test.ts
@@ -1,3 +1,5 @@
+/** Guards the production desktop builder's Linux CEF hotfix sequencing. */
+
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
## Summary

Stacked corrective follow-up for #25427 at parent `3892762fa7748edef6451ea4f3b28d0786a65d9f`.

Adds the repository-required responsibility header to the new Linux CEF desktop-build sequencing test. No executable tokens or production behavior change.

## Validation

Pinned Bun 1.3.14 and Node 24.15.0:

- focused desktop-build Linux CEF Vitest: 2/2 passed
- Biome on the production builder and focused test: passed
- `git diff --check`: passed

The existing test is a structural source-sequencing guard. It does not replace the real Linux package/install/relaunch evidence still required by #25427.
