### PR TITLE
test(agent): cover reminders

### DIFF
--- a/packages/agent/src/services/permissions/probers/reminders.test.ts
+++ b/packages/agent/src/services/permissions/probers/reminders.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Behavioral coverage for the reminders EventKit permission prober. Drives the
+ * real remindersProber with live buildState / mapNativePrivacyAuthStatus
+ * mapping: non-Darwin short-circuit, native auth codes including write-only
+ * (4), TCC fallback when the dylib is missing, and request() lastRequested
+ * stamping. Native dylib, TCC, and System Settings are stubbed OS
+ * collaborators.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const darwin = vi.hoisted(() => ({ current: true }));
+const getNativeDylib = vi.hoisted(() => vi.fn());
+const queryTccStatus = vi.hoisted(() => vi.fn());
+const resolveBundleId = vi.hoisted(() =>
+  vi.fn(() => "ai.elizaos.reminders-test"),
+);
+const openPrivacyPane = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    getNativeDylib,
+    queryTccStatus,
+    resolveBundleId,
+    openPrivacyPane,
+  };
+});
+
+import { platformUnsupportedState } from "./_bridge.js";
+import { remindersProber } from "./reminders.ts";
+
+const REMINDERS_TCC_SERVICE = "kTCCServiceReminders";
+const BUNDLE_ID = "ai.elizaos.reminders-test";
+
+function nativeReminders(check: number, request = check) {
+  return {
+    checkRemindersPermission: () => check,
+    requestRemindersPermission: () => request,
+  };
+}
+
+function resetCollaborators(): void {
+  darwin.current = true;
+  getNativeDylib.mockReset();
+  queryTccStatus.mockReset();
+  resolveBundleId.mockReset();
+  resolveBundleId.mockReturnValue(BUNDLE_ID);
+  openPrivacyPane.mockReset();
+  openPrivacyPane.mockResolvedValue(undefined);
+}
+
+describe("remindersProber", () => {
+  beforeEach(resetCollaborators);
+
+  afterEach(() => {
+    darwin.current = true;
+  });
+
+  it("exports id reminders without openSettings", () => {
+    expect(remindersProber.id).toBe("reminders");
+    expect(remindersProber.openSettings).toBeUndefined();
+    expect(typeof remindersProber.check).toBe("function");
+    expect(typeof remindersProber.request).toBe("function");
+  });
+});
+
+describe("remindersProber.check", () => {
+  beforeEach(resetCollaborators);
+
+  it("returns platform-unsupported on non-Darwin without probing native or TCC", async () => {
+    darwin.current = false;
+    const state = await remindersProber.check();
+    const expected = platformUnsupportedState("reminders");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.id).toBe("reminders");
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(getNativeDylib).not.toHaveBeenCalled();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+    expect(resolveBundleId).not.toHaveBeenCalled();
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("maps native granted (2) without consulting TCC", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(2));
+    const before = Date.now();
+    const state = await remindersProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.id).toBe("reminders");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(queryTccStatus).not.toHaveBeenCalled();
+    expect(resolveBundleId).not.toHaveBeenCalled();
+  });
+
+  it("maps native denied (1) without consulting TCC", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(1));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+  });
+
+  it("maps native not-determined (0) as requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(0));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+  });
+
+  it("maps native restricted (3) with os_policy and canRequest false", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(3));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("os_policy");
+  });
+
+  it("maps native write-only (4) as restricted but still requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(4));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBe("os_policy");
+  });
+
+  it("maps unknown native codes to not-determined", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(99));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+  });
+
+  it("maps a negative native code to not-determined", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(-1));
+    const state = await remindersProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+  });
+
+  it("falls back to TCC granted when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("granted");
+    const state = await remindersProber.check();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      REMINDERS_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+
+  it("falls back to TCC denied when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("denied");
+    const state = await remindersProber.check();
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      REMINDERS_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+
+  it("treats a missing TCC row as not-determined and requestable", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue(null);
+    const state = await remindersProber.check();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.lastRequested).toBeUndefined();
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      REMINDERS_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+  });
+});
+
+describe("remindersProber.request", () => {
+  beforeEach(resetCollaborators);
+
+  it("returns platform-unsupported on non-Darwin without lastRequested", async () => {
+    darwin.current = false;
+    const state = await remindersProber.request({ reason: "unit-test" });
+    const expected = platformUnsupportedState("reminders");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(getNativeDylib).not.toHaveBeenCalled();
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+  });
+
+  it("uses the native request result and stamps lastRequested", async () => {
+    const requestRemindersPermission = vi.fn(() => 2);
+    const checkRemindersPermission = vi.fn(() => {
+      throw new Error(
+        "checkRemindersPermission must not run on native request",
+      );
+    });
+    getNativeDylib.mockResolvedValue({
+      checkRemindersPermission,
+      requestRemindersPermission,
+    });
+    const before = Date.now();
+    const state = await remindersProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(requestRemindersPermission).toHaveBeenCalledTimes(1);
+    expect(checkRemindersPermission).not.toHaveBeenCalled();
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+    expect(queryTccStatus).not.toHaveBeenCalled();
+    expect(state.status).toBe("granted");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+  });
+
+  it("maps a native write-only request (4) as restricted and requestable", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(0, 4));
+    const state = await remindersProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBe("os_policy");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("maps a native denied request without opening System Settings", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(0, 1));
+    const state = await remindersProber.request({ reason: "unit-test" });
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeTypeOf("number");
+    expect(openPrivacyPane).not.toHaveBeenCalled();
+  });
+
+  it("opens the Reminders privacy pane and re-checks TCC when the dylib is missing", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("denied");
+    const before = Date.now();
+    const state = await remindersProber.request({ reason: "unit-test" });
+    const after = Date.now();
+    expect(openPrivacyPane).toHaveBeenCalledTimes(1);
+    expect(openPrivacyPane).toHaveBeenCalledWith("Reminders");
+    expect(queryTccStatus).toHaveBeenCalledWith(
+      REMINDERS_TCC_SERVICE,
+      BUNDLE_ID,
+    );
+    expect(state.status).toBe("denied");
+    expect(state.canRequest).toBe(false);
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+  });
+
+  it("stamps lastRequested on the TCC granted fallback after opening settings", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue("granted");
+    const state = await remindersProber.request({ reason: "unit-test" });
+    expect(openPrivacyPane).toHaveBeenCalledWith("Reminders");
+    expect(state.status).toBe("granted");
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("keeps a missing TCC row requestable after opening settings", async () => {
+    getNativeDylib.mockResolvedValue(null);
+    queryTccStatus.mockResolvedValue(null);
+    const state = await remindersProber.request({ reason: "need reminders" });
+    expect(openPrivacyPane).toHaveBeenCalledWith("Reminders");
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.lastRequested).toBeTypeOf("number");
+  });
+
+  it("does not copy the caller reason onto the returned state", async () => {
+    getNativeDylib.mockResolvedValue(nativeReminders(2));
+    const state = await remindersProber.request({
+      reason: "distinct-caller-reason",
+    });
+    expect(state.reason).toBeUndefined();
+    expect(state.status).toBe("granted");
+  });
+});


### PR DESCRIPTION

## Summary

Adds colocated unit coverage for `packages/agent/src/services/permissions/probers/reminders.ts`. The production prober is unchanged. The suite drives the real `remindersProber` (`check`, `request`, exported `id`) and asserts the live `buildState` / `mapNativePrivacyAuthStatus` / `platformUnsupportedState` output. Native dylib, TCC.db, and System Settings are stubbed OS collaborators only.

Covered branches, as implemented:

- non-Darwin `check()` / `request()` short-circuit to `not-applicable` + `platform_unsupported` with no native/TCC/settings calls and no `lastRequested`
- native EventKit codes: 0 not-determined (requestable), 1 denied, 2 granted, 3 restricted/`os_policy` (not requestable), 4 write-only restricted/`os_policy` but still requestable, unknown and negative codes → not-determined
- missing dylib falls back to `kTCCServiceReminders` (granted / denied / missing row)
- native `request()` uses `requestRemindersPermission` (not `checkRemindersPermission`), stamps `lastRequested`, does not open System Settings
- missing-dylib `request()` opens the Reminders privacy pane, re-checks TCC, stamps `lastRequested`
- caller `reason` is not copied onto the returned state

This module has no queue, comparator, capacity, or removal path.

## Evidence

1. `bunx vitest run packages/agent/src/services/permissions/probers/reminders.test.ts` against current `origin/develop` (`1e63232fe08a25a7ebce3d408a6b986647b2a10f`): **Test Files 1 passed (1), Tests 20 passed (20)**.
2. `bunx biome check --write packages/agent/src/services/permissions/probers/reminders.test.ts`: clean (`Checked 1 file`). `biome.json` is present; checkout is not sparse.
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep reminders.test.ts`: empty (this file introduces zero type errors). Pre-existing package errors, if any, are unrelated.
4. Diff touches **only** `packages/agent/src/services/permissions/probers/reminders.test.ts`.

Hosted CI does not run on this fork contributor PR. Do not treat missing GitHub Actions as a pass or a fail.

No production behaviour change; `--unproven` is the honest path for this test-only diff.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:644f16912a9b9c4def246783c2333688fa07036a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
