### PR TITLE
test(agent): cover push-types

### DIFF
--- a/packages/agent/src/services/push/push-types.test.ts
+++ b/packages/agent/src/services/push/push-types.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Covers the remote-push shared types: PushUnregisteredError construction,
+ * Error inheritance, token/message fields, name, instanceof across throw and
+ * rejection, and the PushProvider/PushMessage contract as exercised by a
+ * real in-process provider. No mocks of the module under test.
+ */
+import { describe, expect, it } from "vitest";
+import type { PushMessage, PushProvider } from "./push-types.ts";
+import { PushUnregisteredError } from "./push-types.ts";
+
+/**
+ * In-process PushProvider that records deliveries and throws the real
+ * PushUnregisteredError for tokens marked dead. Mirrors how
+ * NotificationPushService branches on `instanceof PushUnregisteredError`.
+ */
+class InProcessProvider implements PushProvider {
+  readonly sent: Array<{ token: string; message: PushMessage }> = [];
+
+  constructor(
+    readonly name: string,
+    private configured: boolean,
+    private readonly deadTokens: ReadonlySet<string> = new Set(),
+  ) {}
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  async send(token: string, message: PushMessage): Promise<void> {
+    if (this.deadTokens.has(token)) {
+      throw new PushUnregisteredError(
+        token,
+        `[${this.name}] token rejected (status=410 reason=Unregistered)`,
+      );
+    }
+    this.sent.push({ token, message });
+  }
+}
+
+/** Same branch NotificationPushService.dispatch uses for dead-token removal. */
+async function classifySend(
+  send: () => Promise<void>,
+): Promise<"ok" | "dropped" | "failed"> {
+  try {
+    await send();
+    return "ok";
+  } catch (error) {
+    if (error instanceof PushUnregisteredError) {
+      return "dropped";
+    }
+    return "failed";
+  }
+}
+
+describe("PushUnregisteredError", () => {
+  it("stores the token and message from the constructor", () => {
+    const error = new PushUnregisteredError(
+      "device-token-1",
+      "[ApnsProvider] token rejected (status=410 reason=Unregistered)",
+    );
+    expect(error.token).toBe("device-token-1");
+    expect(error.message).toBe(
+      "[ApnsProvider] token rejected (status=410 reason=Unregistered)",
+    );
+  });
+
+  it("sets name to PushUnregisteredError", () => {
+    const error = new PushUnregisteredError("tok", "dead");
+    expect(error.name).toBe("PushUnregisteredError");
+  });
+
+  it("is an Error and a PushUnregisteredError", () => {
+    const error = new PushUnregisteredError("tok", "dead");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(PushUnregisteredError);
+  });
+
+  it("is distinct from a generic Error with the same message", () => {
+    const generic = new Error("dead");
+    expect(generic).not.toBeInstanceOf(PushUnregisteredError);
+    expect(generic.name).toBe("Error");
+  });
+
+  it("is distinct from a generic Error whose name was overwritten", () => {
+    const spoofed = new Error("dead");
+    spoofed.name = "PushUnregisteredError";
+    expect(spoofed).not.toBeInstanceOf(PushUnregisteredError);
+    expect(spoofed instanceof PushUnregisteredError).toBe(false);
+  });
+
+  it("survives throw/catch with token intact", () => {
+    let caught: unknown;
+    try {
+      throw new PushUnregisteredError("ios-dead", "unregistered");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PushUnregisteredError);
+    expect((caught as PushUnregisteredError).token).toBe("ios-dead");
+    expect((caught as PushUnregisteredError).message).toBe("unregistered");
+  });
+
+  it("survives promise rejection with instanceof intact", async () => {
+    const rejected = Promise.reject(
+      new PushUnregisteredError("fcm-dead", "UNREGISTERED"),
+    );
+    await expect(rejected).rejects.toBeInstanceOf(PushUnregisteredError);
+    await expect(rejected).rejects.toMatchObject({
+      token: "fcm-dead",
+      message: "UNREGISTERED",
+      name: "PushUnregisteredError",
+    });
+  });
+
+  it("stores an empty token and empty message as given", () => {
+    const error = new PushUnregisteredError("", "");
+    expect(error.token).toBe("");
+    expect(error.message).toBe("");
+    expect(error).toBeInstanceOf(PushUnregisteredError);
+  });
+
+  it("stores a unicode token as-is with no truncation", () => {
+    const token = `tok-${"🎯".repeat(8)}-${"x".repeat(4096)}`;
+    const error = new PushUnregisteredError(token, "dead");
+    expect(error.token).toBe(token);
+    expect(error.token.length).toBe(token.length);
+  });
+
+  it("keeps two errors with the same token as distinct instances", () => {
+    const a = new PushUnregisteredError("shared", "first");
+    const b = new PushUnregisteredError("shared", "second");
+    expect(a).not.toBe(b);
+    expect(a.token).toBe(b.token);
+    expect(a.message).toBe("first");
+    expect(b.message).toBe("second");
+  });
+
+  it("exposes token as an own property", () => {
+    const error = new PushUnregisteredError("own-token", "dead");
+    expect(Object.hasOwn(error, "token")).toBe(true);
+    expect(error.token).toBe("own-token");
+  });
+
+  it("renders name and message through Error#toString", () => {
+    const error = new PushUnregisteredError(
+      "tok",
+      "[FcmProvider] token rejected (status=404 code=UNREGISTERED)",
+    );
+    expect(error.toString()).toBe(
+      "PushUnregisteredError: [FcmProvider] token rejected (status=404 code=UNREGISTERED)",
+    );
+  });
+
+  it("captures a stack string", () => {
+    const error = new PushUnregisteredError("tok", "dead");
+    expect(typeof error.stack).toBe("string");
+    expect(error.stack).toContain("PushUnregisteredError");
+  });
+});
+
+describe("PushProvider and PushMessage", () => {
+  it("reports unconfigured when credentials are absent", () => {
+    const provider = new InProcessProvider("apns", false);
+    expect(provider.name).toBe("apns");
+    expect(provider.isConfigured()).toBe(false);
+  });
+
+  it("reports configured when credentials are present", () => {
+    const provider = new InProcessProvider("fcm", true);
+    expect(provider.isConfigured()).toBe(true);
+  });
+
+  it("delivers a title-only message to a live token", async () => {
+    const provider = new InProcessProvider("apns", true);
+    const message: PushMessage = { title: "Hello" };
+    await provider.send("live-token", message);
+    expect(provider.sent).toEqual([{ token: "live-token", message }]);
+  });
+
+  it("delivers body and nested JsonValue data without dropping keys", async () => {
+    const provider = new InProcessProvider("fcm", true);
+    const message: PushMessage = {
+      title: "Task due",
+      body: "Review the agenda",
+      data: {
+        notificationId: "n-1",
+        category: "task",
+        deepLink: "/tasks/n-1",
+        count: 2,
+        urgent: true,
+        note: null,
+        tags: ["work", "today"],
+        extra: { nested: "ok" },
+      },
+    };
+    await provider.send("android-1", message);
+    expect(provider.sent).toHaveLength(1);
+    expect(provider.sent[0].token).toBe("android-1");
+    expect(provider.sent[0].message).toEqual(message);
+    expect(provider.sent[0].message.data).toEqual({
+      notificationId: "n-1",
+      category: "task",
+      deepLink: "/tasks/n-1",
+      count: 2,
+      urgent: true,
+      note: null,
+      tags: ["work", "today"],
+      extra: { nested: "ok" },
+    });
+  });
+
+  it("rejects a dead token with PushUnregisteredError carrying that token", async () => {
+    const provider = new InProcessProvider(
+      "apns",
+      true,
+      new Set(["dead-token"]),
+    );
+    await expect(provider.send("dead-token", { title: "Hi" })).rejects.toEqual(
+      expect.objectContaining({
+        name: "PushUnregisteredError",
+        token: "dead-token",
+        message: "[apns] token rejected (status=410 reason=Unregistered)",
+      }),
+    );
+    await expect(
+      provider.send("dead-token", { title: "Hi" }),
+    ).rejects.toBeInstanceOf(PushUnregisteredError);
+    expect(provider.sent).toEqual([]);
+  });
+
+  it("classifies an unregistered throw as dropped, not a generic failure", async () => {
+    const provider = new InProcessProvider("fcm", true, new Set(["gone"]));
+    expect(
+      await classifySend(() => provider.send("gone", { title: "x" })),
+    ).toBe("dropped");
+    expect(
+      await classifySend(() => provider.send("live", { title: "x" })),
+    ).toBe("ok");
+  });
+
+  it("does not treat a generic send failure as unregistered", async () => {
+    const outcome = await classifySend(async () => {
+      throw new Error(
+        "[ApnsProvider] APNs request failed (status=500 reason=n/a)",
+      );
+    });
+    expect(outcome).toBe("failed");
+  });
+
+  it("does not treat a missing live token as unregistered", async () => {
+    const provider = new InProcessProvider("apns", true, new Set(["dead"]));
+    const message: PushMessage = { title: "ping" };
+    expect(await classifySend(() => provider.send("other", message))).toBe(
+      "ok",
+    );
+    expect(provider.sent).toEqual([{ token: "other", message }]);
+  });
+
+  it("keeps an empty send queue until the first live delivery", async () => {
+    const provider = new InProcessProvider("apns", true, new Set(["dead"]));
+    expect(provider.sent).toEqual([]);
+    await expect(provider.send("dead", { title: "x" })).rejects.toBeInstanceOf(
+      PushUnregisteredError,
+    );
+    expect(provider.sent).toEqual([]);
+    await provider.send("live", { title: "x" });
+    expect(provider.sent).toHaveLength(1);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/agent/src/services/push/push-types.ts`, which previously had no colocated test file. The module exports the remote-push shared types (`PushMessage`, `PushProvider`) and the runtime `PushUnregisteredError` class that APNs/FCM providers throw so `NotificationPushService` can drop dead tokens via `instanceof`. This PR drives that real class and the provider contract. No production source changes.

Covered behaviour (observed, not aspirational):

- constructor stores `token` and `message`; `name` is `PushUnregisteredError`
- instance is both `Error` and `PushUnregisteredError`; a generic `Error` (including one whose `name` was overwritten) is not
- throw/catch and promise rejection keep `token` and `instanceof` intact
- empty token/message are stored as given; unicode and long tokens are not truncated
- two errors with the same token remain distinct instances; `token` is an own property
- `Error#toString` renders `PushUnregisteredError: <message>`; `stack` is a string containing the class name
- an in-process `PushProvider` reports configured/unconfigured, delivers a title-only message, and preserves nested `JsonValue` data
- a dead token rejects with `PushUnregisteredError` carrying that token and is classified as dropped; a generic send failure is not treated as unregistered
- empty send queue stays empty until the first live delivery; a missing (non-dead) token is not treated as unregistered

## Verification

Exact head: `2db386c9ab24cf27e5f901ae4226a8d38f6d9f3b` (parent is current `origin/develop` `1e63232fe08a25a7ebce3d408a6b986647b2a10f`, re-fetched immediately before filing)

1. Vitest (re-run against current `origin/develop` sources immediately before filing):

```text
bunx vitest run packages/agent/src/services/push/push-types.test.ts
 ✓ packages/agent/src/services/push/push-types.test.ts (22 tests) 6ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  16:29:12
   Duration  126ms (transform 33ms, setup 0ms, import 40ms, tests 6ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/agent/src/services/push/push-types.test.ts` — `Checked 1 file in 25ms. Fixed 1 file.` The committed file is that formatted result. Config exists at repo-root `biome.json`; this checkout is not sparse.

3. Package typecheck: `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'push-types.test.ts'` produced no matches (grep EXIT:1). This file introduced zero TypeScript errors.

4. Diff touches only `packages/agent/src/services/push/push-types.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are from local `bunx vitest` / `biome` / `tsc` on this head.

## Notes

Test-only change. No production behaviour is modified. Assertions record what the code does (`instanceof` is the dead-token signal; tokens and messages are stored as given), not a desired redesign.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2db386c9ab24cf27e5f901ae4226a8d38f6d9f3b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
