### PR TITLE
fix(app-core): use surrogate-safe truncateWellFormed on shell sync relay command error

### DIFF
--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts
@@ -268,4 +268,46 @@ describe("ShellControllerAuthority data paths", () => {
     target.release();
     other.release();
   });
+
+  it("truncates error messages with surrogate safety", async () => {
+    const authority = new ShellControllerAuthority();
+    const owner = authority.register("main", vi.fn());
+    const follower = authority.register("tray", vi.fn());
+    const ownerState = owner.connect({
+      protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
+    });
+    const followerState = follower.connect({
+      protocolVersion: SHELL_SYNC_PROTOCOL_VERSION,
+    });
+
+    const longError = `${"a".repeat(1999)}😀${"b".repeat(10)}`;
+    const outcomePromise = follower.dispatchCommand({
+      commandId: "cmd-err-1",
+      command: {
+        kind: "routeOsIntent",
+        intent: {
+          type: "start-voice",
+          intentId: "launch-1",
+          source: "desktop-deep-link",
+          mode: "converse",
+        },
+        deliveryPolicy: "execute",
+      },
+    });
+
+    owner.completeCommand({
+      generation: ownerState.generation,
+      commandId: "cmd-err-1",
+      fromEndpointId: followerState.endpointId,
+      ok: false,
+      error: longError,
+    });
+
+    const res = await outcomePromise;
+    expect(res.ok).toBe(false);
+    expect(typeof res.error).toBe("string");
+    expect(res.error?.length).toBeLessThanOrEqual(2000);
+    expect(res.error?.endsWith("😀")).toBe(false);
+    expect(res.error?.endsWith("a")).toBe(true);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
@@ -6,6 +6,7 @@
  * idempotent redelivery. Renderer heartbeats are driven by native pings so a
  * hidden/throttled webview cannot accidentally create split-brain ownership.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "./logger";
 
 import type { SendToWebview } from "./types";
@@ -530,7 +531,7 @@ export class ShellControllerAuthority {
           ok: false,
           error:
             typeof params.error === "string" && params.error
-              ? params.error.slice(0, 2_000)
+              ? truncateWellFormed(toWellFormedUnicode(params.error), 2_000)
               : "owner-command-failed",
         };
     this.rememberOutcome(key, result);


### PR DESCRIPTION
## Summary

Uses `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` when bounding `params.error` strings in `ShellControllerAuthority.completeCommand` (`packages/app-core/platforms/electrobun/src/shell-sync-relay.ts:533`) to prevent raw character slicing from splitting UTF-16 surrogate pairs into malformed lone surrogates when terminal command error messages exceed length boundaries.

## Changes

- In `packages/app-core/platforms/electrobun/src/shell-sync-relay.ts:533`, replace `params.error.slice(0, 2_000)` with `truncateWellFormed(toWellFormedUnicode(params.error), 2_000)`.
- In `packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts`, add unit test verifying that long error messages containing emoji/astral unicode characters at the 2,000-character boundary are truncated without splitting surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`efa47b37fa`) |
| --- | --- | --- |
| `bun test platforms/electrobun/src/shell-sync-relay.test.ts` (in `packages/app-core`) | 7 pass (7 tests) | 8 pass (8 tests) |
| `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/shell-sync-relay.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/platforms/electrobun/src/shell-sync-relay.ts:525-540`
- `packages/app-core/platforms/electrobun/src/shell-sync-relay.test.ts:270-305`

## Risks

Low. `truncateWellFormed` preserves intact unicode code points up to the specified boundary.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (App-core Electrobun shell sync relay error handling; UI layout untouched)
- [x] `audit:browser` — N/A (Terminal command error truncation)
- [x] `build` — Clean build across workspace
- [x] `test` — 8/8 pass in `shell-sync-relay.test.ts`
- [x] `lint` — Biome clean
