### PR TITLE
test(agent): cover screentime

### DIFF
--- a/packages/agent/src/services/permissions/probers/screentime.test.ts
+++ b/packages/agent/src/services/permissions/probers/screentime.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit coverage for the Screen Time permission prober. Drives the real
+ * `screentimeProber` through Darwin FamilyControls entitlement gating
+ * (unsigned-dev restricted vs signed not-determined bridge), request()
+ * lastRequested stamping, and the non-Darwin platform-unsupported
+ * short-circuit. Platform and entitlement detection are stubbed OS
+ * collaborators; `buildState` and `platformUnsupportedState` stay the
+ * production helpers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { darwin, mockHasEmbeddedProvisioningEntitlement } = vi.hoisted(() => ({
+  darwin: { current: true },
+  mockHasEmbeddedProvisioningEntitlement: vi.fn(),
+}));
+
+vi.mock("./_bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./_bridge.js")>();
+  return {
+    ...actual,
+    get IS_DARWIN() {
+      return darwin.current;
+    },
+    hasEmbeddedProvisioningEntitlement: mockHasEmbeddedProvisioningEntitlement,
+  };
+});
+
+import { platformUnsupportedState } from "./_bridge.js";
+import { screentimeProber } from "./screentime.ts";
+
+const FAMILY_CONTROLS_ENTITLEMENT = "com.apple.developer.family-controls";
+
+describe("screentimeProber", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("exports id screentime without an openSettings helper", () => {
+    expect(screentimeProber.id).toBe("screentime");
+    expect(typeof screentimeProber.check).toBe("function");
+    expect(typeof screentimeProber.request).toBe("function");
+    expect(screentimeProber.openSettings).toBeUndefined();
+  });
+});
+
+describe("screentimeProber.check", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("returns platform-unsupported on non-Darwin without reading entitlements", async () => {
+    darwin.current = false;
+    const before = Date.now();
+    const state = await screentimeProber.check();
+    const expected = platformUnsupportedState("screentime");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.id).toBe("screentime");
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.lastBlockedFeature).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.platform).toBe(process.platform);
+    expect(mockHasEmbeddedProvisioningEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("reports restricted/entitlement_required when Darwin has no FamilyControls entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+    const before = Date.now();
+    const state = await screentimeProber.check();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledTimes(1);
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      FAMILY_CONTROLS_ENTITLEMENT,
+    );
+    expect(state).toMatchObject({
+      id: "screentime",
+      status: "restricted",
+      canRequest: false,
+      restrictedReason: "entitlement_required",
+      platform: process.platform,
+    });
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.lastBlockedFeature).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+  });
+
+  it("surfaces not-determined with canRequest when Darwin has the FamilyControls entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const before = Date.now();
+    const state = await screentimeProber.check();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      FAMILY_CONTROLS_ENTITLEMENT,
+    );
+    expect(state.id).toBe("screentime");
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.platform).toBe(process.platform);
+  });
+
+  it("does not stamp lastRequested from check() even when entitlement is present", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const state = await screentimeProber.check();
+    expect(state.lastRequested).toBeUndefined();
+  });
+});
+
+describe("screentimeProber.request", () => {
+  beforeEach(() => {
+    darwin.current = true;
+    mockHasEmbeddedProvisioningEntitlement.mockReset();
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+  });
+
+  it("returns platform-unsupported on non-Darwin without lastRequested or entitlement I/O", async () => {
+    darwin.current = false;
+    const state = await screentimeProber.request({
+      reason: "need screen time limits",
+    });
+    const expected = platformUnsupportedState("screentime");
+    expect(state).toEqual({
+      ...expected,
+      lastChecked: state.lastChecked,
+    });
+    expect(state.status).toBe("not-applicable");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("platform_unsupported");
+    expect(state.lastRequested).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(mockHasEmbeddedProvisioningEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("stamps lastRequested on Darwin without entitlement while remaining restricted", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(false);
+    const before = Date.now();
+    const state = await screentimeProber.request({
+      reason: "need screen time limits",
+    });
+    const after = Date.now();
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledTimes(1);
+    expect(mockHasEmbeddedProvisioningEntitlement).toHaveBeenCalledWith(
+      FAMILY_CONTROLS_ENTITLEMENT,
+    );
+    expect(state.id).toBe("screentime");
+    expect(state.status).toBe("restricted");
+    expect(state.canRequest).toBe(false);
+    expect(state.restrictedReason).toBe("entitlement_required");
+    if (state.lastRequested === undefined) {
+      throw new Error("expected lastRequested on Darwin request()");
+    }
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(state.lastChecked).toBeGreaterThanOrEqual(before);
+    expect(state.reason).toBeUndefined();
+  });
+
+  it("mirrors the requestable not-determined state when Darwin has the entitlement", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const before = Date.now();
+    const state = await screentimeProber.request({
+      reason: "need screen time limits",
+    });
+    const after = Date.now();
+    expect(state.status).toBe("not-determined");
+    expect(state.canRequest).toBe(true);
+    expect(state.restrictedReason).toBeUndefined();
+    if (state.lastRequested === undefined) {
+      throw new Error("expected lastRequested when entitlement is present");
+    }
+    expect(state.lastRequested).toBeGreaterThanOrEqual(before);
+    expect(state.lastRequested).toBeLessThanOrEqual(after);
+    expect(state.id).toBe("screentime");
+    expect(state.platform).toBe(process.platform);
+  });
+
+  it("drops the free-text request reason rather than copying it onto the state", async () => {
+    mockHasEmbeddedProvisioningEntitlement.mockReturnValue(true);
+    const state = await screentimeProber.request({
+      reason: "this string must not leak",
+    });
+    expect(state.reason).toBeUndefined();
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/services/permissions/probers/screentime.ts`, which had no same-named test file on `origin/develop`. No product-behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`1e63232fe08a`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only addition; focused vitest, biome, and package `tsc` are quoted below.
- [x] A reviewer can confirm the change from the evidence below without reading production code: one new test file, 9 passing tests.

# Sync with develop

- [x] Branch parent is current `origin/develop` `1e63232fe08a25a7ebce3d408a6b986647b2a10f`; zero conflicts.
- [ ] Full `bun run verify` is N/A for a single new test file; focused gates are quoted in **Evidence Gate**.

# Risks

Low. Adds a colocated vitest suite only. No production path, permission prompt, or entitlement check is changed.

# Background

## What does this PR do?

Adds real unit coverage for `screentimeProber`. The suite drives the exported prober. `IS_DARWIN` and `hasEmbeddedProvisioningEntitlement` are stubbed OS collaborators so Darwin vs non-Darwin and FamilyControls entitlement branches can run on any host. Production `buildState` and `platformUnsupportedState` are used as-is — the tests do not reimplement those helpers.

Covered behaviour (what the module actually does):

- Export: `id` is `screentime`; `check`/`request` are functions; `openSettings` is absent.
- `check()` on non-Darwin returns `not-applicable` / `platform_unsupported`, does not read entitlements, and does not stamp `lastRequested`.
- `check()` on Darwin without `com.apple.developer.family-controls` returns `restricted` / `entitlement_required` and `canRequest: false`.
- `check()` on Darwin with that entitlement returns `not-determined` / `canRequest: true` and does not stamp `lastRequested`.
- `request()` on non-Darwin is the same unsupported short-circuit (no `lastRequested`).
- `request()` on Darwin without the entitlement stays restricted and stamps `lastRequested`.
- `request()` on Darwin with the entitlement returns requestable `not-determined` and stamps `lastRequested`.
- The caller `reason` string is not copied onto the returned state (`buildState` has no `reason` option).

## What kind of change is this?

Improvements (tests for existing behaviour). Test-only; no production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/permissions/probers/screentime.test.ts` against `packages/agent/src/services/permissions/probers/screentime.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```bash
bunx vitest run packages/agent/src/services/permissions/probers/screentime.test.ts
```

# Evidence Gate

Evidence matches head `5c78a26ee5d45abad442c3c35ed1d9783ad680f9` on current `origin/develop` `1e63232fe08a25a7ebce3d408a6b986647b2a10f`.

1. `bunx vitest run packages/agent/src/services/permissions/probers/screentime.test.ts` — Test Files **1 passed (1)**, Tests **9 passed (9)** (Vitest v4.1.10). Re-run after re-fetching `origin/develop`; the parent SHA is unchanged.
2. `bunx biome check --write packages/agent/src/services/permissions/probers/screentime.test.ts` — Checked 1 file in 247ms. No fixes applied. `biome.json` is present; the checkout is not sparse.
3. `cd packages/agent && bunx tsc --noEmit` — `screentime.test.ts` appears nowhere in the output.
4. Diff touches only `packages/agent/src/services/permissions/probers/screentime.test.ts`.

Hosted CI does **not** run on this fork's pull requests. The counts above are local, not GitHub Actions.

Origin reproduction, proof-run, load-bearing revert, and over-rejection corpus are N/A: this PR adds tests and changes no production behaviour.

# Known gaps / failures

N/A — test-only addition. Full-workspace `bun run verify` was not required for this scoped change.

# Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests are included
- [x] Documentation is N/A (test-only)
- [x] Code follows repository style (biome clean)

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5c78a26ee5d45abad442c3c35ed1d9783ad680f9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
