### PR TITLE
test(agent): cover relationships-graph

### DIFF
--- a/packages/agent/src/services/relationships-graph.test.ts
+++ b/packages/agent/src/services/relationships-graph.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit coverage for resolveRelationshipsGraphService: on-demand enable,
+ * duck-typed graph-method checks, owner-resolver wiring, and identity of the
+ * core re-exports. Drives the real module against in-memory runtime and
+ * service stand-ins — no mocks of the module under test.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  createNativeRelationshipsGraphService as coreCreateNativeRelationshipsGraphService,
+  getMemoriesForCluster as coreGetMemoriesForCluster,
+  searchMemoriesForCluster as coreSearchMemoriesForCluster,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  createNativeRelationshipsGraphService,
+  getMemoriesForCluster,
+  resolveRelationshipsGraphService,
+  searchMemoriesForCluster,
+} from "./relationships-graph.ts";
+
+const GRAPH_METHODS = [
+  "getGraphSnapshot",
+  "getPersonDetail",
+  "getCandidateMerges",
+  "acceptMerge",
+  "rejectMerge",
+  "proposeMerge",
+] as const;
+
+const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+type CallLog = string[];
+
+type GraphStandIn = Record<string, unknown> & {
+  setGraphResolvers?: (resolvers: {
+    resolveOwnerEntityId: (runtime: IAgentRuntime) => Promise<string | null>;
+    fetchConfiguredOwnerName: () => Promise<string | null>;
+  }) => void;
+};
+
+function graphService(extras: Record<string, unknown> = {}): GraphStandIn {
+  const service: GraphStandIn = {};
+  for (const method of GRAPH_METHODS) {
+    service[method] = async () => undefined;
+  }
+  return Object.assign(service, extras);
+}
+
+function makeRuntime(options: {
+  service: unknown;
+  isRelationshipsEnabled?: unknown;
+  enableRelationships?: unknown;
+  getSetting?: (key: string) => unknown;
+  callLog?: CallLog;
+}): IAgentRuntime {
+  const callLog = options.callLog;
+  const runtime = {
+    getService: (name: string) => {
+      callLog?.push(`getService:${name}`);
+      return options.service;
+    },
+    getSetting:
+      options.getSetting ??
+      ((key: string) =>
+        key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ID : undefined),
+  } as Record<string, unknown>;
+
+  if ("isRelationshipsEnabled" in options) {
+    runtime.isRelationshipsEnabled = options.isRelationshipsEnabled;
+  }
+  if ("enableRelationships" in options) {
+    runtime.enableRelationships = options.enableRelationships;
+  }
+
+  return runtime as unknown as IAgentRuntime;
+}
+
+describe("relationships-graph re-exports", () => {
+  it("re-exports createNativeRelationshipsGraphService from @elizaos/core", () => {
+    expect(createNativeRelationshipsGraphService).toBe(
+      coreCreateNativeRelationshipsGraphService,
+    );
+    expect(typeof createNativeRelationshipsGraphService).toBe("function");
+  });
+
+  it("re-exports getMemoriesForCluster from @elizaos/core", () => {
+    expect(getMemoriesForCluster).toBe(coreGetMemoriesForCluster);
+    expect(typeof getMemoriesForCluster).toBe("function");
+  });
+
+  it("re-exports searchMemoriesForCluster from @elizaos/core", () => {
+    expect(searchMemoriesForCluster).toBe(coreSearchMemoriesForCluster);
+    expect(typeof searchMemoriesForCluster).toBe("function");
+  });
+});
+
+describe("resolveRelationshipsGraphService", () => {
+  it("returns the relationships service when it implements every graph method", async () => {
+    const service = graphService();
+    const resolved = await resolveRelationshipsGraphService(
+      makeRuntime({ service }),
+    );
+    expect(resolved).toBe(service);
+  });
+
+  it("asks getService for the relationships service name", async () => {
+    const callLog: CallLog = [];
+    await resolveRelationshipsGraphService(
+      makeRuntime({ service: graphService(), callLog }),
+    );
+    expect(callLog).toEqual(["getService:relationships"]);
+  });
+
+  it("returns null when getService returns null", async () => {
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service: null })),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when getService returns undefined", async () => {
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service: undefined })),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a primitive getService result", async () => {
+    await expect(
+      resolveRelationshipsGraphService(
+        makeRuntime({ service: "relationships" }),
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service: 0 })),
+    ).resolves.toBeNull();
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service: false })),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for an empty object that has none of the graph methods", async () => {
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service: {} })),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when any required graph method is missing", async () => {
+    for (const missing of GRAPH_METHODS) {
+      const service = graphService();
+      delete service[missing];
+      await expect(
+        resolveRelationshipsGraphService(makeRuntime({ service })),
+      ).resolves.toBeNull();
+    }
+  });
+
+  it("returns null when a required graph method is present but not a function", async () => {
+    const service = graphService({ getPersonDetail: "not-a-function" });
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service })),
+    ).resolves.toBeNull();
+  });
+
+  it("accepts graph methods inherited from a prototype", async () => {
+    class PrototypeGraph {
+      async getGraphSnapshot() {
+        return undefined;
+      }
+      async getPersonDetail() {
+        return undefined;
+      }
+      async getCandidateMerges() {
+        return undefined;
+      }
+      async acceptMerge() {
+        return undefined;
+      }
+      async rejectMerge() {
+        return undefined;
+      }
+      async proposeMerge() {
+        return undefined;
+      }
+    }
+    const service = new PrototypeGraph();
+    const resolved = await resolveRelationshipsGraphService(
+      makeRuntime({ service }),
+    );
+    expect(resolved).toBe(service);
+  });
+
+  it("does not enable relationships when isRelationshipsEnabled is absent", async () => {
+    const callLog: CallLog = [];
+    let enabled = false;
+    await resolveRelationshipsGraphService(
+      makeRuntime({
+        service: graphService(),
+        enableRelationships: async () => {
+          enabled = true;
+          callLog.push("enable");
+        },
+        callLog,
+      }),
+    );
+    expect(enabled).toBe(false);
+    expect(callLog).toEqual(["getService:relationships"]);
+  });
+
+  it("does not enable relationships when they are already enabled", async () => {
+    const callLog: CallLog = [];
+    let enabled = false;
+    await resolveRelationshipsGraphService(
+      makeRuntime({
+        service: graphService(),
+        isRelationshipsEnabled: () => true,
+        enableRelationships: async () => {
+          enabled = true;
+          callLog.push("enable");
+        },
+        callLog,
+      }),
+    );
+    expect(enabled).toBe(false);
+    expect(callLog).toEqual(["getService:relationships"]);
+  });
+
+  it("awaits enableRelationships before getService when the feature is disabled", async () => {
+    const callLog: CallLog = [];
+    const service = graphService();
+    const resolved = await resolveRelationshipsGraphService(
+      makeRuntime({
+        service,
+        isRelationshipsEnabled: () => false,
+        enableRelationships: async () => {
+          callLog.push("enable");
+        },
+        callLog,
+      }),
+    );
+    expect(callLog).toEqual(["enable", "getService:relationships"]);
+    expect(resolved).toBe(service);
+  });
+
+  it("does not call enableRelationships when that property is not a function", async () => {
+    const callLog: CallLog = [];
+    await resolveRelationshipsGraphService(
+      makeRuntime({
+        service: graphService(),
+        isRelationshipsEnabled: () => false,
+        enableRelationships: true,
+        callLog,
+      }),
+    );
+    expect(callLog).toEqual(["getService:relationships"]);
+  });
+
+  it("does not treat a non-function isRelationshipsEnabled as a disable signal", async () => {
+    const callLog: CallLog = [];
+    let enabled = false;
+    await resolveRelationshipsGraphService(
+      makeRuntime({
+        service: graphService(),
+        isRelationshipsEnabled: false,
+        enableRelationships: async () => {
+          enabled = true;
+          callLog.push("enable");
+        },
+        callLog,
+      }),
+    );
+    expect(enabled).toBe(false);
+    expect(callLog).toEqual(["getService:relationships"]);
+  });
+
+  it("propagates enableRelationships rejection and never calls getService", async () => {
+    const callLog: CallLog = [];
+    await expect(
+      resolveRelationshipsGraphService(
+        makeRuntime({
+          service: graphService(),
+          isRelationshipsEnabled: () => false,
+          enableRelationships: async () => {
+            callLog.push("enable");
+            throw new Error("enable failed");
+          },
+          callLog,
+        }),
+      ),
+    ).rejects.toThrow("enable failed");
+    expect(callLog).toEqual(["enable"]);
+  });
+
+  it("wires setGraphResolvers with owner resolvers that hit the real owner-entity path", async () => {
+    let captured:
+      | {
+          resolveOwnerEntityId: (
+            runtime: IAgentRuntime,
+          ) => Promise<string | null>;
+          fetchConfiguredOwnerName: () => Promise<string | null>;
+        }
+      | undefined;
+    const service = graphService({
+      setGraphResolvers: (resolvers: {
+        resolveOwnerEntityId: (
+          runtime: IAgentRuntime,
+        ) => Promise<string | null>;
+        fetchConfiguredOwnerName: () => Promise<string | null>;
+      }) => {
+        captured = resolvers;
+      },
+    });
+
+    const resolved = await resolveRelationshipsGraphService(
+      makeRuntime({ service }),
+    );
+    expect(resolved).toBe(service);
+    expect(captured).toBeDefined();
+    if (captured === undefined) {
+      throw new Error("setGraphResolvers was not called");
+    }
+
+    const ownerRuntime = makeRuntime({ service: null });
+    await expect(captured.resolveOwnerEntityId(ownerRuntime)).resolves.toBe(
+      OWNER_ID,
+    );
+
+    const ownerName = await captured.fetchConfiguredOwnerName();
+    expect(ownerName === null || typeof ownerName === "string").toBe(true);
+  });
+
+  it("still returns the service when setGraphResolvers is absent", async () => {
+    const service = graphService();
+    expect("setGraphResolvers" in service).toBe(false);
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service })),
+    ).resolves.toBe(service);
+  });
+
+  it("still returns the service when setGraphResolvers is not a function", async () => {
+    const service = graphService({ setGraphResolvers: "not-a-function" });
+    await expect(
+      resolveRelationshipsGraphService(makeRuntime({ service })),
+    ).resolves.toBe(service);
+  });
+});


### PR DESCRIPTION

# Relates to

Operator-selected coverage gap: `packages/agent/src/services/relationships-graph.ts` had no same-named test file anywhere in the repo. That module is the agent-side wrapper around the merged relationships graph: it re-exports core helpers and `resolveRelationshipsGraphService` enables the feature on demand, duck-types the `relationships` service for the required graph methods, and wires owner resolvers.

This PR adds one colocated test file and does not change production behavior.

Definition of Done: focused behavioral tests for the exported helper and re-exports, recorded at the exact pushed head.

- [x] Targets `develop` and was rebased onto the latest fetched `origin/develop` before the final proof.
- [x] Reviewers can confirm the changed behavior from the committed focused test and inline red/green output.

# Risks

Low. Tests only. No production source, export, or handler change.

# Background

## What does this PR do?

Adds `packages/agent/src/services/relationships-graph.test.ts`, which imports from `./relationships-graph.ts` (the same relative path production uses) and drives the real module against in-memory runtime and service stand-ins. The module under test is never replaced with a mock.

Covered branches:

1. Re-export identity: `createNativeRelationshipsGraphService`, `getMemoriesForCluster`, and `searchMemoriesForCluster` are the same functions as `@elizaos/core`.
2. Happy path: a service that implements all six required graph methods is returned; `getService` is called with `"relationships"`.
3. Rejects: `null`, `undefined`, primitives, empty objects, any missing required method, and a required method that is not a function.
4. Prototype methods: a class with the graph methods on the prototype is accepted.
5. Enable-on-demand: skipped when `isRelationshipsEnabled` is absent, already true, or not a function; skipped when `enableRelationships` is not a function; awaited before `getService` when the feature is disabled; rejection from `enableRelationships` propagates and `getService` is never called.
6. Resolver wiring: `setGraphResolvers` receives real owner resolvers; `resolveOwnerEntityId` returns the configured `ELIZA_ADMIN_ENTITY_ID`; missing or non-function `setGraphResolvers` still returns the service.

## What kind of change is this?

Test-only, non-breaking.

# Documentation changes needed?

No. The public API is unchanged.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/relationships-graph.test.ts`.

## Detailed testing steps

Focused proof at the pushed head (`b21cdc8d3d9367ef1a010706139494d403c5bf87`), re-run after refetching current `origin/develop` (the production file is unchanged versus that develop tip):

```bash
bunx vitest run packages/agent/src/services/relationships-graph.test.ts
bunx biome check --write packages/agent/src/services/relationships-graph.test.ts
cd packages/agent && bunx tsc --noEmit
```

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/agent/src/services/relationships-graph.test.ts (21 tests) 15ms

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  16:38:25
   Duration  11.16s (transform 8.96s, setup 0ms, import 11.00s, tests 15ms, environment 0ms)
```

`bunx biome check --write packages/agent/src/services/relationships-graph.test.ts` — Checked 1 file in 209ms. Fixed 1 file (formatter wrap). The committed file is that output. Tooling is real: `biome.json` and `tsconfig.json` exist at the checkout root; sparse-checkout is not enabled.

`packages/agent` `tsconfig.json` includes `src`, so this test is typechecked. `bunx tsc --noEmit` in `packages/agent` piped to `grep relationships-graph.test.ts` printed no lines (grep exit 1). **None** of the typecheck diagnostics named `relationships-graph.test.ts`. No production file changed, so the typecheck delta versus an untouched control is zero new errors.

The diff touches only `packages/agent/src/services/relationships-graph.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork-authored PR. This body does not imply CI passed.

# Evidence Gate

<!-- evidence-head:b21cdc8d3d9367ef1a010706139494d403c5bf87 -->

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
