### PR TITLE
test(agent): cover send-handler-availability

### DIFF
--- a/packages/agent/src/services/send-handler-availability.test.ts
+++ b/packages/agent/src/services/send-handler-availability.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Behavioral coverage for send-handler availability gating: Map registry
+ * lookups, non-Map fail-closed, once-per-context:source logging, and the
+ * test-only reset that clears the module-level seen set. Drives the real
+ * module; logger.info is spied only to observe the once-log contract.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetMissingSendHandlerLogsForTests,
+  hasRuntimeSendHandler,
+  logMissingSendHandlerOnce,
+} from "./send-handler-availability.ts";
+
+function runtimeWith(sendHandlers: unknown): IAgentRuntime {
+  return { sendHandlers } as unknown as IAgentRuntime;
+}
+
+function missingLog(context: string, source: string): string {
+  return `[${context}] Send handler "${source}" is not registered yet; skipping delivery until runtime wiring completes`;
+}
+
+describe("hasRuntimeSendHandler", () => {
+  it("returns false for an empty Map", () => {
+    expect(hasRuntimeSendHandler(runtimeWith(new Map()), "telegram")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for a single registered source", () => {
+    const sendHandlers = new Map<string, unknown>([["telegram", {}]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for a registered map that does not contain the source", () => {
+    const sendHandlers = new Map<string, unknown>([["telegram", {}]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "discord")).toBe(
+      false,
+    );
+  });
+
+  it("looks up by exact source string, not case-folded identity", () => {
+    const sendHandlers = new Map<string, unknown>([["Telegram", {}]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "Telegram")).toBe(
+      true,
+    );
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      false,
+    );
+  });
+
+  it("returns true when the source is present even if the stored handler is undefined", () => {
+    const sendHandlers = new Map<string, unknown>([["telegram", undefined]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for an empty-string source that is actually registered", () => {
+    const sendHandlers = new Map<string, unknown>([["", {}]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "")).toBe(true);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      false,
+    );
+  });
+
+  it("returns false after the registered source is deleted", () => {
+    const sendHandlers = new Map<string, unknown>([
+      ["telegram", {}],
+      ["discord", {}],
+    ]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      true,
+    );
+    expect(sendHandlers.delete("missing")).toBe(false);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      true,
+    );
+    expect(sendHandlers.delete("telegram")).toBe(true);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      false,
+    );
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "discord")).toBe(
+      true,
+    );
+  });
+
+  it("treats a Map subclass as a registry", () => {
+    class HandlerMap extends Map<string, unknown> {}
+    const sendHandlers = new HandlerMap([["telegram", {}]]);
+    expect(hasRuntimeSendHandler(runtimeWith(sendHandlers), "telegram")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when sendHandlers is absent", () => {
+    expect(
+      hasRuntimeSendHandler({} as unknown as IAgentRuntime, "telegram"),
+    ).toBe(false);
+  });
+
+  it("returns false when sendHandlers is not a Map, even if it has a has() method", () => {
+    expect(hasRuntimeSendHandler(runtimeWith(undefined), "telegram")).toBe(
+      false,
+    );
+    expect(hasRuntimeSendHandler(runtimeWith(null), "telegram")).toBe(false);
+    expect(hasRuntimeSendHandler(runtimeWith([]), "telegram")).toBe(false);
+    expect(
+      hasRuntimeSendHandler(runtimeWith({ telegram: {} }), "telegram"),
+    ).toBe(false);
+    expect(
+      hasRuntimeSendHandler(
+        runtimeWith({ has: (source: string) => source === "telegram" }),
+        "telegram",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("logMissingSendHandlerOnce", () => {
+  let info: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetMissingSendHandlerLogsForTests();
+    info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    info.mockRestore();
+    _resetMissingSendHandlerLogsForTests();
+  });
+
+  it("logs the skip message on the first call for a context:source pair", () => {
+    logMissingSendHandlerOnce("escalation", "telegram");
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(missingLog("escalation", "telegram"));
+  });
+
+  it("does not log again for the same context:source pair", () => {
+    logMissingSendHandlerOnce("escalation", "telegram");
+    logMissingSendHandlerOnce("escalation", "telegram");
+    logMissingSendHandlerOnce("escalation", "telegram");
+    expect(info).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs separately for different sources under the same context", () => {
+    logMissingSendHandlerOnce("escalation", "telegram");
+    logMissingSendHandlerOnce("escalation", "discord");
+    expect(info).toHaveBeenCalledTimes(2);
+    expect(info).toHaveBeenNthCalledWith(
+      1,
+      missingLog("escalation", "telegram"),
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      missingLog("escalation", "discord"),
+    );
+  });
+
+  it("logs separately for the same source under different contexts", () => {
+    logMissingSendHandlerOnce("escalation", "telegram");
+    logMissingSendHandlerOnce("client-chat", "telegram");
+    expect(info).toHaveBeenCalledTimes(2);
+    expect(info).toHaveBeenNthCalledWith(
+      1,
+      missingLog("escalation", "telegram"),
+    );
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      missingLog("client-chat", "telegram"),
+    );
+  });
+
+  it("treats context:source as a single concatenated key, so overlapping colons collide", () => {
+    logMissingSendHandlerOnce("a", "b:c");
+    logMissingSendHandlerOnce("a:b", "c");
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(missingLog("a", "b:c"));
+  });
+
+  it("re-logs the same pair after the test-only reset clears the seen set", () => {
+    logMissingSendHandlerOnce("escalation", "telegram");
+    _resetMissingSendHandlerLogsForTests();
+    logMissingSendHandlerOnce("escalation", "telegram");
+    expect(info).toHaveBeenCalledTimes(2);
+    expect(info).toHaveBeenNthCalledWith(
+      2,
+      missingLog("escalation", "telegram"),
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds colocated unit coverage for `packages/agent/src/services/send-handler-availability.ts`. That module gates outbound delivery on whether `runtime.sendHandlers` is a `Map` that contains the requested source, and it logs a missing handler once per `context:source` pair so boot-time wiring gaps are visible without flooding the log.

A nested suite already exists at `src/services/__tests__/send-handler-availability.test.ts`. This PR adds the same-named colocated file used by every other service in the package, drives the real module (no `vi.mock` of `@elizaos/core`), and covers branches the nested file does not: empty Map, Map subclass, non-Map duck-typed `has()`, exact-string lookup, empty-string source, delete of a missing then present key, distinct contexts, the concatenated-key collision, and the exact skip-log message.

Production code is unchanged.

## Coverage (observed behaviour)

`hasRuntimeSendHandler`
- empty Map → false
- single registered source → true; a different source → false
- lookup is exact-string, not case-folded
- `Map.has` is true even when the stored handler value is `undefined`
- empty-string source is a real key when registered
- deleting a missing key is a no-op; deleting the registered key then returns false
- a `Map` subclass is accepted (`instanceof Map`)
- absent / `undefined` / `null` / array / plain object / duck-typed `{ has() }` → false (unknown registry is fail-closed)

`logMissingSendHandlerOnce` / `_resetMissingSendHandlerLogsForTests`
- first call for a pair logs the skip message
- repeats of the same pair do not log
- different sources or different contexts log separately
- `context:source` is a single concatenated key, so overlapping colons collide
- the test-only reset clears the seen set and allows a re-log

## Evidence

Hosted CI does not run on fork contributor PRs. Counts below are from the local shared checkout against current `origin/develop` immediately before filing.

1. `bunx vitest run packages/agent/src/services/send-handler-availability.test.ts`
   - Test Files  1 passed (1)
   - Tests  16 passed (16)
2. `bunx biome check --write packages/agent/src/services/send-handler-availability.test.ts`
   - Checked 1 file. Clean after write.
3. `cd packages/agent && bunx tsc --noEmit`
   - `src/services/send-handler-availability.test.ts` (the colocated file this PR adds) appears nowhere in the output.
4. Diff touches only `packages/agent/src/services/send-handler-availability.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e8050e0908357ced7ecf6b8e9cf2abb273d46634 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
