### PR TITLE
test(inbox): drop stale five-thread chip cap assertion

### DIFF
--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -1000,7 +1000,7 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       expect(parseInteractionBlocks(texts[0] ?? "").blocks).toHaveLength(0);
     });
 
-    it("appends per-thread reply/snooze/archive chips to the triage queue, capped at five threads, with entry ids in the values", async () => {
+    it("appends per-thread reply/snooze/archive chips to the triage queue for every returned thread, with entry ids in the values", async () => {
       const rows = ["e1", "e2", "e3", "e4", "e5", "e6"].map((id, index) =>
         makeTriageRow({
           id,
@@ -1026,7 +1026,11 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       expect(result.success).toBe(true);
       const text = texts[0] ?? "";
       const { blocks } = parseInteractionBlocks(text);
-      expect(blocks).toHaveLength(5);
+      // Every returned entry stays actionable: appendInboxTriageChoiceMarkers
+      // must not cap the count (plugins/plugin-inbox/CLAUDE.md, "Complete
+      // planner choices"). A capped reply silently strands the trailing
+      // threads with no control the owner can tap.
+      expect(blocks).toHaveLength(rows.length);
       blocks.forEach((block, index) => {
         const id = `e${index + 1}`;
         expect(block).toMatchObject({
@@ -1045,7 +1049,6 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
         // The reply chip names the sender so each block reads attributably.
         expect(block.options[0]?.label).toBe(`Reply to Sender ${index + 1}`);
       });
-      expect(text).not.toContain("e6");
     });
 
     it("an archive chip value round-trips into a successful archive of that entry", async () => {


### PR DESCRIPTION
## What

`plugins/plugin-inbox/test/inbox-action.test.ts` still asserted the old five-thread cap on triage choice chips. It now asserts one choice block per returned row.

## Why

#24630 (`fix(prompts): preserve complete choice candidates`) removed `.slice(0, 5)` from `appendInboxTriageChoiceMarkers` and recorded the rule in `plugins/plugin-inbox/CLAUDE.md`:

> Triage responses emit an actionable choice block for every returned entry. Do not cap the entry count in `appendInboxTriageChoiceMarkers`.

That PR updated `inbox-choice-markers.test.ts` but missed this older assertion in `inbox-action.test.ts`, which fed six rows and expected five blocks plus `expect(text).not.toContain("e6")`. The result is a real red lane on `develop`:

```
FAIL test/inbox-action.test.ts > ... capped at five threads ...
AssertionError: expected [ …(6) ] to have a length of 5 but got 6
error: script "test:plugins" exited with code 1
```

The production behaviour is correct and intentional; only the stale test needed updating.

## Verification

```
vitest run plugins/plugin-inbox/test/inbox-action.test.ts
Test Files  1 passed (1)
     Tests  34 passed (34)
```

Mutation check — restoring `entries.slice(0, 5)` in `choice-markers.ts`:

```
Tests  1 failed | 33 passed (34)
```

so the assertion genuinely covers the behaviour rather than passing regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)