### PR TITLE
test(agent): cover sandbox-engine

### DIFF
--- a/packages/agent/src/services/sandbox-engine.test.ts
+++ b/packages/agent/src/services/sandbox-engine.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Behavioral coverage for the sandbox engine factory, platform notes, and
+ * argv tokenization. Drives the real module: no engine mock, no daemon.
+ * Missing-binary paths are asserted only when the host actually lacks docker
+ * or Apple Container; present-binary paths observe inspect/list on names that
+ * cannot exist.
+ */
+
+import { arch, platform } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  AppleContainerEngine,
+  buildContainerExecArgs,
+  createEngine,
+  DockerEngine,
+  detectBestEngine,
+  getAllEngineInfo,
+  getPlatformSetupNotes,
+  type SandboxEngineType,
+} from "./sandbox-engine.ts";
+
+const MISSING_CONTAINER = "eliza-sandbox-engine-coverage-missing";
+const MISSING_IMAGE = "eliza-sandbox-engine-coverage-missing:tag";
+const UNIQUE_LIST_PREFIX = "eliza-sandbox-engine-coverage-prefix-no-match";
+
+function expectExecArgs(command: string, expected: string[]): void {
+  expect(
+    buildContainerExecArgs({
+      containerId: "sandbox-1",
+      command,
+    }),
+  ).toEqual(["exec", "sandbox-1", ...expected]);
+}
+
+describe("buildContainerExecArgs", () => {
+  it("tokenizes a single unquoted command", () => {
+    expectExecArgs("pwd", ["pwd"]);
+  });
+
+  it("trims surrounding whitespace before tokenizing", () => {
+    expectExecArgs("  ls  -la  ", ["ls", "-la"]);
+  });
+
+  it("splits on tabs as well as spaces", () => {
+    expectExecArgs("echo\thello", ["echo", "hello"]);
+  });
+
+  it("preserves spaces inside single quotes, including empty quotes", () => {
+    expectExecArgs("echo 'hello world'", ["echo", "hello world"]);
+    expectExecArgs("echo ''", ["echo", ""]);
+  });
+
+  it("preserves spaces inside double quotes, including empty quotes", () => {
+    expectExecArgs('echo "hello world"', ["echo", "hello world"]);
+    expectExecArgs('echo ""', ["echo", ""]);
+  });
+
+  it("treats a quoted-empty command as one empty argument, not a missing command", () => {
+    expectExecArgs("''", [""]);
+    expectExecArgs('""', [""]);
+  });
+
+  it("keeps shell metacharacters literal inside single quotes", () => {
+    expectExecArgs("echo 'a|$HOME;'", ["echo", "a|$HOME;"]);
+  });
+
+  it("keeps an unescaped dollar inside double quotes", () => {
+    expectExecArgs('echo "foo$bar"', ["echo", "foo$bar"]);
+  });
+
+  it("unescapes double-quote, backslash, dollar, and backtick inside double quotes", () => {
+    expectExecArgs(String.raw`echo "a\"b"`, ["echo", 'a"b']);
+    expectExecArgs(String.raw`echo "a\\b"`, ["echo", "a\\b"]);
+    expectExecArgs(String.raw`echo "a\$b"`, ["echo", "a$b"]);
+    expectExecArgs(String.raw`echo "a\`b"`, ["echo", "a`b"]);
+  });
+
+  it("keeps a backslash inside double quotes when the next character is not special", () => {
+    expectExecArgs(String.raw`echo "a\nb"`, ["echo", String.raw`a\nb`]);
+  });
+
+  it("does not emit -w when workdir is omitted or empty", () => {
+    expect(
+      buildContainerExecArgs({ containerId: "c1", command: "true" }),
+    ).toEqual(["exec", "c1", "true"]);
+    expect(
+      buildContainerExecArgs({
+        containerId: "c1",
+        command: "true",
+        workdir: "",
+      }),
+    ).toEqual(["exec", "c1", "true"]);
+  });
+
+  it("does not emit -e flags for an empty environment object", () => {
+    expect(
+      buildContainerExecArgs({
+        containerId: "c1",
+        command: "true",
+        env: {},
+      }),
+    ).toEqual(["exec", "c1", "true"]);
+  });
+
+  it("rejects an empty or whitespace-only command", () => {
+    expect(() =>
+      buildContainerExecArgs({ containerId: "c1", command: "" }),
+    ).toThrow("Container exec command is required");
+    expect(() =>
+      buildContainerExecArgs({ containerId: "c1", command: "   " }),
+    ).toThrow("Container exec command is required");
+  });
+
+  it("rejects unterminated single and double quotes", () => {
+    expect(() => expectExecArgs("echo 'hello", [])).toThrow(
+      "Container exec command has unterminated quotes",
+    );
+    expect(() => expectExecArgs('echo "hello', [])).toThrow(
+      "Container exec command has unterminated quotes",
+    );
+  });
+
+  it("rejects a dangling backslash at the end of the command", () => {
+    expect(() => expectExecArgs("echo \\", [])).toThrow(
+      "Container exec command cannot end with dangling escape",
+    );
+  });
+
+  it.each(["&", "|", ";", "<", ">", "$", "`", "(", ")", "{", "}"])(
+    "rejects unquoted shell syntax %s",
+    (char) => {
+      expect(() => expectExecArgs(`echo ${char}x`, [])).toThrow(
+        "Container exec command contains unsupported shell syntax",
+      );
+    },
+  );
+
+  it("treats embedded newlines and carriage returns as argument separators", () => {
+    // /\s/ matches before the unsupported-syntax table, so \n and \r split
+    // tokens instead of throwing even though they appear in that table.
+    expectExecArgs("echo\nfoo", ["echo", "foo"]);
+    expectExecArgs("echo\rfoo", ["echo", "foo"]);
+  });
+});
+
+describe("createEngine", () => {
+  it("returns DockerEngine for docker", () => {
+    const engine = createEngine("docker");
+    expect(engine).toBeInstanceOf(DockerEngine);
+    expect(engine.engineType).toBe("docker");
+  });
+
+  it("returns AppleContainerEngine for apple-container", () => {
+    const engine = createEngine("apple-container");
+    expect(engine).toBeInstanceOf(AppleContainerEngine);
+    expect(engine.engineType).toBe("apple-container");
+  });
+
+  it("returns the same engine class as detectBestEngine for auto", () => {
+    const auto = createEngine("auto");
+    const detected = detectBestEngine();
+    expect(auto.constructor).toBe(detected.constructor);
+    expect(auto.engineType).toBe(detected.engineType);
+  });
+
+  it("falls through to DockerEngine for an unknown type", () => {
+    const engine = createEngine("not-an-engine" as SandboxEngineType);
+    expect(engine).toBeInstanceOf(DockerEngine);
+    expect(engine.engineType).toBe("docker");
+  });
+});
+
+describe("detectBestEngine", () => {
+  it("prefers Apple Container only on ARM Mac when that binary is available", () => {
+    const detected = detectBestEngine();
+    const apple = new AppleContainerEngine();
+    if (platform() === "darwin" && arch() === "arm64" && apple.isAvailable()) {
+      expect(detected).toBeInstanceOf(AppleContainerEngine);
+      expect(detected.engineType).toBe("apple-container");
+    } else {
+      expect(detected).toBeInstanceOf(DockerEngine);
+      expect(detected.engineType).toBe("docker");
+    }
+  });
+});
+
+describe("getAllEngineInfo", () => {
+  it("reports docker then apple-container with the observed platform fields", () => {
+    const infos = getAllEngineInfo();
+    expect(infos).toHaveLength(2);
+
+    const docker = infos[0];
+    const apple = infos[1];
+    expect(docker?.type).toBe("docker");
+    expect(docker?.platform).toBe(platform());
+    expect(docker?.arch).toBe(arch());
+    expect(typeof docker?.available).toBe("boolean");
+    expect(typeof docker?.version).toBe("string");
+    expect(docker?.version.length).toBeGreaterThan(0);
+    expect(typeof docker?.details).toBe("string");
+
+    expect(apple?.type).toBe("apple-container");
+    expect(apple?.platform).toBe("darwin");
+    expect(apple?.arch).toBe(arch());
+    expect(apple?.details).toBe(
+      `Apple Silicon: ${arch() === "arm64" ? "yes" : "no"}`,
+    );
+    expect(typeof apple?.available).toBe("boolean");
+    expect(typeof apple?.version).toBe("string");
+    expect(apple?.version.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getPlatformSetupNotes", () => {
+  it("returns the notes for the live host platform and architecture", () => {
+    const notes = getPlatformSetupNotes();
+    const os = platform();
+    const cpu = arch();
+
+    if (os === "darwin" && cpu === "arm64") {
+      expect(notes).toContain("macOS Apple Silicon detected.");
+      expect(notes).toContain(
+        "Preferred: Apple Container (install via: brew install apple/apple/container-tools)",
+      );
+      expect(notes).toContain("Fallback: Docker Desktop for Mac");
+    } else if (os === "darwin") {
+      expect(notes).toContain("macOS Intel detected.");
+      expect(notes).toContain("Use: Docker Desktop for Mac");
+      expect(notes).toContain(
+        "Apple Container is not available on Intel Macs.",
+      );
+    } else if (os === "linux") {
+      expect(notes).toContain("Linux detected.");
+      expect(notes).toContain("Use: Docker (install via your package manager)");
+    } else if (os === "win32") {
+      expect(notes).toContain("Windows detected.");
+      expect(notes).toContain("Use: Docker Desktop with WSL2 backend");
+    } else {
+      expect(notes).toBe(
+        `Unsupported platform: ${os}. Docker may work if installed.`,
+      );
+    }
+  });
+});
+
+describe("DockerEngine", () => {
+  const engine = new DockerEngine();
+
+  it("identifies as docker and matches getInfo availability", () => {
+    expect(engine.engineType).toBe("docker");
+    const info = engine.getInfo();
+    expect(info.type).toBe("docker");
+    expect(info.available).toBe(engine.isAvailable());
+    expect(info.platform).toBe(platform());
+    expect(info.arch).toBe(arch());
+    if (!info.available) {
+      expect(info.version).toBe("unknown");
+      expect(info.details).toBe("default");
+    }
+  });
+
+  it("lists no containers for a prefix that cannot match, and reports missing ids unhealthy", async () => {
+    expect(engine.listContainers(UNIQUE_LIST_PREFIX)).toEqual([]);
+    expect(await engine.healthCheck(MISSING_CONTAINER)).toBe(false);
+    expect(engine.isContainerRunning(MISSING_CONTAINER)).toBe(false);
+    expect(engine.imageExists(MISSING_IMAGE)).toBe(false);
+  });
+
+  it("swallows stop and remove failures for a missing container", async () => {
+    await expect(
+      engine.stopContainer(MISSING_CONTAINER),
+    ).resolves.toBeUndefined();
+    await expect(
+      engine.removeContainer(MISSING_CONTAINER),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws from run, exec, and pull when docker is not on the host PATH", async () => {
+    if (engine.isAvailable()) {
+      return;
+    }
+    await expect(
+      engine.runContainer({
+        image: MISSING_IMAGE,
+        name: MISSING_CONTAINER,
+        detach: true,
+        mounts: [],
+        env: {},
+        network: "",
+        user: "",
+        capDrop: [],
+      }),
+    ).rejects.toThrow("Docker executable unavailable");
+    await expect(
+      engine.execInContainer({
+        containerId: MISSING_CONTAINER,
+        command: "true",
+      }),
+    ).rejects.toThrow("Docker executable unavailable");
+    await expect(engine.pullImage(MISSING_IMAGE)).rejects.toThrow(
+      "Docker executable unavailable",
+    );
+  });
+});
+
+describe("AppleContainerEngine", () => {
+  const engine = new AppleContainerEngine();
+
+  it("identifies as apple-container and hard-codes platform darwin", () => {
+    expect(engine.engineType).toBe("apple-container");
+    const info = engine.getInfo();
+    expect(info.type).toBe("apple-container");
+    expect(info.available).toBe(engine.isAvailable());
+    expect(info.platform).toBe("darwin");
+    expect(info.arch).toBe(arch());
+    expect(info.details).toBe(
+      `Apple Silicon: ${arch() === "arm64" ? "yes" : "no"}`,
+    );
+    if (!info.available) {
+      expect(info.version).toBe("unknown");
+    }
+  });
+
+  it("lists no containers for a prefix that cannot match, and reports missing ids unhealthy", async () => {
+    expect(engine.listContainers(UNIQUE_LIST_PREFIX)).toEqual([]);
+    expect(await engine.healthCheck(MISSING_CONTAINER)).toBe(false);
+    expect(engine.isContainerRunning(MISSING_CONTAINER)).toBe(false);
+    expect(engine.imageExists(MISSING_IMAGE)).toBe(false);
+  });
+
+  it("swallows stop and remove failures for a missing container", async () => {
+    await expect(
+      engine.stopContainer(MISSING_CONTAINER),
+    ).resolves.toBeUndefined();
+    await expect(
+      engine.removeContainer(MISSING_CONTAINER),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws from exec and pull when Apple Container is not on the host PATH", async () => {
+    if (engine.isAvailable()) {
+      return;
+    }
+    await expect(
+      engine.execInContainer({
+        containerId: MISSING_CONTAINER,
+        command: "true",
+      }),
+    ).rejects.toThrow("Apple Container executable unavailable");
+    await expect(engine.pullImage(MISSING_IMAGE)).rejects.toThrow(
+      "Apple Container executable unavailable",
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage-only PR. `packages/agent/src/services/sandbox-engine.ts` had no same-named test file. Existing `sandbox-engine-env.test.ts` and `sandbox-engine-run-container.test.ts` cover exec argv forwarding and Apple Container inherited stdio; they do not cover the factory, platform notes, remaining tokenizer branches, or missing-binary engine behaviour.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Head `3fc77726bc9bd2128826188259e4a4784f2c5413` is one commit on
      `origin/develop` `c3f070a5ee1e45204df4a447d4592bc8d0bf416e` (re-fetched
      immediately before filing).
- [ ] `bun run verify` was not run. This is a test-only addition of one file;
      focused vitest / biome / tsc on that file are quoted below. Hosted CI
      does not run on this fork PR.

# Risks

Low. Adds `packages/agent/src/services/sandbox-engine.test.ts` only. No
production source, exports, or behaviour change.

# Background

## What does this PR do?

Adds a same-named Vitest suite that drives the real `sandbox-engine` module
(no engine mock, no container daemon):

- `buildContainerExecArgs` / tokenizer: single token, trim, tab split, single
  and double quotes (including empty quotes), metacharacters kept literal
  inside quotes, double-quote escapes, empty workdir/env, empty/whitespace
  command, unterminated quotes, dangling backslash, unquoted shell syntax,
  and the observed newline/CR behaviour (`/\s/` splits `\n`/`\r` before the
  unsupported-syntax table, so `echo\nfoo` tokenizes as `["echo", "foo"]`
  rather than throwing).
- `createEngine` for `docker`, `apple-container`, `auto`, and the unknown-type
  fallthrough to `DockerEngine`.
- `detectBestEngine` on the live host (Apple Container only when darwin+arm64
  and that binary is actually available; otherwise Docker).
- `getAllEngineInfo` shape (docker then apple-container; apple `platform` is
  hard-coded `"darwin"`).
- `getPlatformSetupNotes` for the live `platform()`/`arch()`.
- `DockerEngine` / `AppleContainerEngine`: identity, missing-id list/health/
  inspect/image, swallowed stop/remove, and run/exec/pull throws only when
  the host binary is actually absent.

Expectations match what the code does on this host, not aspirational behaviour.

## What kind of change is this?

Improvements (tests for existing behaviour). No production change.

## Why are we doing this? Any context or related work?

The production module had no same-named test file. Test-only coverage of the
real factory, tokenizer, and missing-binary paths.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/sandbox-engine.test.ts`. Run:

```bash
bunx vitest run packages/agent/src/services/sandbox-engine.test.ts --config packages/agent/vitest.config.ts
```

## Detailed testing steps

None: automated tests. Re-ran against current `origin/develop` immediately
before filing.

# Evidence Gate

Evidence matches exact head `3fc77726bc9bd2128826188259e4a4784f2c5413`.

<!-- evidence-head:3fc77726bc9bd2128826188259e4a4784f2c5413 -->

- Vitest (re-run on current `origin/develop`, source file hash-identical to
  that tip): **Test Files 1 passed (1), Tests 42 passed (42)** (vitest 4.1.10,
  duration 6.30s).
- Biome: `bunx biome check --write packages/agent/src/services/sandbox-engine.test.ts`
  against real `biome.json` (worktree is not sparse): **Checked 1 file in 27ms.
  Fixed 1 file.** The committed file is that formatted result.
- Typecheck: `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'sandbox-engine.test.ts'`
  produced **no matches**. This file introduced zero TypeScript errors.
- Diff touches **only** `packages/agent/src/services/sandbox-engine.test.ts`
  (354 insertions).

Hosted CI does not run on this fork PR; do not infer GitHub Actions passed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production path change; vitest output is the executable proof.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, schedule, wallet, or generated artifact change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; no production path change. Vitest counts above are the run.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no UI surface.

### After

N/A - test-only change; no UI surface.

### Walkthrough video

N/A - test-only change; no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT/omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. Scoped to one new test file; vitest, biome, and
  tsc on that file are quoted above.
- Hosted GitHub Actions CI does not run on fork PRs from `ss251/eliza`.
- Receipt / identity.slop.cash OAuth trace was not minted: unattended session
  cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
