### PR TITLE
style(cloud): unblock #25690 affected Biome closure

### DIFF
--- a/packages/cloud/api/v1/generate-video/route.surrogate.test.ts
+++ b/packages/cloud/api/v1/generate-video/route.surrogate.test.ts
@@ -2,9 +2,10 @@
  * Regression: provider error strings are external and may contain lone surrogates;
  * route must use truncateWellFormed(toWellFormedUnicode(...),500).
  */
-import { describe, expect, it } from "vitest";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 import { readFileSync } from "node:fs";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 function formatError(message: string): string {
   return truncateWellFormed(toWellFormedUnicode(message), 500);
@@ -31,11 +32,16 @@ describe("generate-video surrogate-safe", () => {
     expect(formatError(long).length).toBe(500);
   });
   it("route file imports and uses truncateWellFormed", () => {
-    const src = readFileSync(new URL("./route.ts", import.meta.url).pathname, "utf8");
+    const src = readFileSync(
+      new URL("./route.ts", import.meta.url).pathname,
+      "utf8",
+    );
     expect(src).toContain('from "@elizaos/core"');
     expect(src).toContain("truncateWellFormed");
     expect(src).toContain("toWellFormedUnicode");
     // ensure not inside generative-route-auth block
-    expect(src).not.toMatch(/import \{[^}]*toWellFormedUnicode[^}]*from "@\/api-app\/lib\/generative-route-auth"/s);
+    expect(src).not.toMatch(
+      /import \{[^}]*toWellFormedUnicode[^}]*from "@\/api-app\/lib\/generative-route-auth"/s,
+    );
   });
 });

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -1,4 +1,6 @@
 /** Handles authenticated video generation, billing, and pending-job reconciliation. */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -13,7 +15,6 @@ import {
   failureResponse,
   jsonError,
 } from "@/lib/api/cloud-worker-errors";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   collectVideoProviderApiKeys,
   getConfiguredVideoProviderCandidates,
@@ -575,7 +576,10 @@ app.post("/", async (c) => {
           provider: unknownAttempt.provider,
           prompt: unknownAttempt.prompt,
           status: "failed",
-          error: truncateWellFormed(toWellFormedUnicode(redactProviderErrorMessage(error.message)), 500),
+          error: truncateWellFormed(
+            toWellFormedUnicode(redactProviderErrorMessage(error.message)),
+            500,
+          ),
           parameters: unknownAttempt.parameters,
           metadata: { ...settlement },
           dimensions: { duration: unknownAttempt.durationSeconds },


### PR DESCRIPTION
## Summary

- applies the exact mechanical Biome fixes from closed-unmerged #25730
- unblocks the affected Cloud API lint closure for #25690
- no runtime semantics change

## Validation

- `bunx @biomejs/biome check --write packages/cloud/api/v1/generate-video/route.ts packages/cloud/api/v1/generate-video/route.surrogate.test.ts`
- `git diff --check`

Stacked into #25690; this is unrelated pre-existing formatting debt exposed by its affected workspace closure.