### PR TITLE
test(agent): cover sandbox-engine-run-container.harness

### DIFF
--- a/packages/agent/src/services/sandbox-engine-run-container.harness.test.ts
+++ b/packages/agent/src/services/sandbox-engine-run-container.harness.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Process-boundary coverage for the Apple Container run-container subprocess
+ * harness. Nothing is exported — the file runs at load — so this suite spawns
+ * the real harness and asserts mode→name mapping, resolve vs reject stdout,
+ * and the exit-code contract. Inherited-stdio forwarding of the engine is
+ * owned by `sandbox-engine-run-container.test.ts`.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const SERVICE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = resolve(SERVICE_DIRECTORY, "../../../..");
+const HARNESS_PATH = join(
+  SERVICE_DIRECTORY,
+  "sandbox-engine-run-container.harness.ts",
+);
+const STDOUT_NAME = "eliza-sandbox-stdout";
+const IMMEDIATE_EXIT_NAME = "eliza-sandbox-immediate-exit";
+const IMAGE = "eliza-sandbox:test";
+const TYPED_EXIT_CODE = 23;
+
+let binDirectory: string | undefined;
+let previousBaseline: string | undefined;
+
+type HarnessRejection = {
+  kind: string;
+  isElizaError: boolean;
+  code?: string;
+  context?: {
+    containerName?: string;
+    engine?: string;
+    exitCode?: number | null;
+  };
+  message: string;
+};
+
+function argvPath(): string {
+  if (!binDirectory) {
+    throw new Error("container stub directory was not installed");
+  }
+  return join(binDirectory, "argv.json");
+}
+
+function createBaselineDirectory(): string {
+  binDirectory = mkdtempSync(join(tmpdir(), "eliza-container-harness-"));
+  return binDirectory;
+}
+
+function writeExecutableStub(directory: string, body: string): void {
+  const stub = join(directory, "container");
+  writeFileSync(stub, `#!${process.execPath}\n${body}\n`);
+  chmodSync(stub, 0o755);
+}
+
+function installStayAliveStub(): void {
+  const directory = createBaselineDirectory();
+  writeExecutableStub(
+    directory,
+    [
+      `require("node:fs").writeFileSync(${JSON.stringify(join(directory, "argv.json"))}, JSON.stringify(process.argv.slice(2)));`,
+      "setTimeout(() => process.exit(0), 3000);",
+    ].join("\n"),
+  );
+}
+
+function installImmediateExitStub(exitCode: number): void {
+  const directory = createBaselineDirectory();
+  writeExecutableStub(
+    directory,
+    [
+      `require("node:fs").writeFileSync(${JSON.stringify(join(directory, "argv.json"))}, JSON.stringify(process.argv.slice(2)));`,
+      `process.exit(${exitCode});`,
+    ].join("\n"),
+  );
+}
+
+function installEmptyBaseline(): void {
+  createBaselineDirectory();
+}
+
+function installUnspawnableContainer(): void {
+  const directory = createBaselineDirectory();
+  const stub = join(directory, "container");
+  mkdirSync(stub);
+  chmodSync(stub, 0o755);
+}
+
+function recordedArgv(): string[] {
+  return JSON.parse(readFileSync(argvPath(), "utf8")) as string[];
+}
+
+function runHarness(
+  mode?: string,
+  extraArgs: string[] = [],
+): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const args = ["--conditions=eliza-source", "--import", "tsx", HARNESS_PATH];
+  if (mode !== undefined) {
+    args.push(mode, ...extraArgs);
+  }
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: REPOSITORY_ROOT,
+      env: {
+        ...process.env,
+        ELIZA_HOST_EXECUTION_BASELINE_PATH: binDirectory,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("sandbox-engine-run-container harness timed out"));
+    }, 45_000);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      resolveResult({
+        code,
+        stdout: Buffer.concat(stdout).toString(),
+        stderr: Buffer.concat(stderr).toString(),
+      });
+    });
+  });
+}
+
+function parseRejection(stdout: string): HarnessRejection {
+  const line = stdout.trim().split("\n").filter(Boolean).at(-1);
+  if (!line) {
+    throw new Error(
+      `harness produced no stdout rejection line: ${JSON.stringify(stdout)}`,
+    );
+  }
+  return JSON.parse(line) as HarnessRejection;
+}
+
+describe.skipIf(process.platform === "win32")(
+  "sandbox-engine-run-container.harness",
+  () => {
+    beforeAll(() => {
+      previousBaseline = process.env.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+    });
+
+    afterEach(() => {
+      if (binDirectory) {
+        rmSync(binDirectory, { recursive: true, force: true });
+        binDirectory = undefined;
+      }
+    });
+
+    afterAll(() => {
+      if (previousBaseline === undefined) {
+        delete process.env.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+      } else {
+        process.env.ELIZA_HOST_EXECUTION_BASELINE_PATH = previousBaseline;
+      }
+    });
+
+    it.each([
+      {
+        label: "stdout mode",
+        mode: "stdout",
+        extraArgs: [] as string[],
+        name: STDOUT_NAME,
+        exitCode: 0,
+      },
+      {
+        label: "stdout mode ignoring trailing argv",
+        mode: "stdout",
+        extraArgs: ["ignored"],
+        name: STDOUT_NAME,
+        exitCode: 0,
+      },
+      {
+        label: "immediate-exit mode that stays alive",
+        mode: "immediate-exit",
+        extraArgs: [],
+        name: IMMEDIATE_EXIT_NAME,
+        exitCode: 1,
+      },
+      {
+        label: "omitted argv",
+        mode: undefined,
+        extraArgs: [],
+        name: IMMEDIATE_EXIT_NAME,
+        exitCode: 1,
+      },
+      {
+        label: "unknown mode",
+        mode: "garbage",
+        extraArgs: [],
+        name: IMMEDIATE_EXIT_NAME,
+        exitCode: 1,
+      },
+      {
+        label: "uppercase STDOUT",
+        mode: "STDOUT",
+        extraArgs: [],
+        name: IMMEDIATE_EXIT_NAME,
+        exitCode: 1,
+      },
+      {
+        label: "empty-string mode",
+        mode: "",
+        extraArgs: [],
+        name: IMMEDIATE_EXIT_NAME,
+        exitCode: 1,
+      },
+    ])(
+      "resolves $label with HARNESS_RESOLVED:$name and exit $exitCode",
+      async ({ mode, extraArgs, name, exitCode }) => {
+        installStayAliveStub();
+        const result = await runHarness(mode, extraArgs);
+        expect(result.code).toBe(exitCode);
+        expect(result.stdout).toBe(`HARNESS_RESOLVED:${name}\n`);
+        expect(recordedArgv()).toEqual(["run", "--name", name, IMAGE]);
+      },
+      90_000,
+    );
+
+    it("rejects stdout mode with a typed start-exit error and exit 1", async () => {
+      installImmediateExitStub(TYPED_EXIT_CODE);
+      const result = await runHarness("stdout");
+      expect(result.code).toBe(1);
+      expect(parseRejection(result.stdout)).toEqual({
+        kind: "rejected",
+        isElizaError: true,
+        code: "SANDBOX_APPLE_CONTAINER_START_EXITED",
+        context: {
+          containerName: STDOUT_NAME,
+          engine: "apple-container",
+          exitCode: TYPED_EXIT_CODE,
+        },
+        message: "Apple Container exited before startup completed",
+      });
+      expect(recordedArgv()).toEqual(["run", "--name", STDOUT_NAME, IMAGE]);
+    }, 90_000);
+
+    it("rejects immediate-exit mode with a typed start-exit error and exit 0", async () => {
+      installImmediateExitStub(TYPED_EXIT_CODE);
+      const result = await runHarness("immediate-exit");
+      expect(result.code).toBe(0);
+      expect(parseRejection(result.stdout)).toEqual({
+        kind: "rejected",
+        isElizaError: true,
+        code: "SANDBOX_APPLE_CONTAINER_START_EXITED",
+        context: {
+          containerName: IMMEDIATE_EXIT_NAME,
+          engine: "apple-container",
+          exitCode: TYPED_EXIT_CODE,
+        },
+        message: "Apple Container exited before startup completed",
+      });
+    }, 90_000);
+
+    it("rejects an unknown mode with a typed start-exit error and exit 1", async () => {
+      installImmediateExitStub(TYPED_EXIT_CODE);
+      const result = await runHarness("not-a-mode");
+      expect(result.code).toBe(1);
+      const rejection = parseRejection(result.stdout);
+      expect(rejection.isElizaError).toBe(true);
+      expect(rejection.context?.containerName).toBe(IMMEDIATE_EXIT_NAME);
+    }, 90_000);
+
+    it("rejects omitted argv with a typed start-exit error and exit 1", async () => {
+      installImmediateExitStub(TYPED_EXIT_CODE);
+      const result = await runHarness();
+      expect(result.code).toBe(1);
+      expect(parseRejection(result.stdout).context?.containerName).toBe(
+        IMMEDIATE_EXIT_NAME,
+      );
+    }, 90_000);
+
+    it("rejects a missing container binary as an untyped error with exit 1 in stdout mode", async () => {
+      installEmptyBaseline();
+      const result = await runHarness("stdout");
+      expect(result.code).toBe(1);
+      const rejection = parseRejection(result.stdout);
+      expect(rejection).toMatchObject({
+        kind: "rejected",
+        isElizaError: false,
+        message: "Apple Container executable unavailable",
+      });
+      expect(rejection.code).toBeUndefined();
+    }, 90_000);
+
+    it("rejects a missing container binary as an untyped error with exit 1 in immediate-exit mode", async () => {
+      installEmptyBaseline();
+      const result = await runHarness("immediate-exit");
+      expect(result.code).toBe(1);
+      expect(parseRejection(result.stdout).isElizaError).toBe(false);
+    }, 90_000);
+
+    it("rejects an unspawnable container as a typed spawn failure with exit 1 in stdout mode", async () => {
+      installUnspawnableContainer();
+      const result = await runHarness("stdout");
+      expect(result.code).toBe(1);
+      const rejection = parseRejection(result.stdout);
+      expect(rejection).toMatchObject({
+        kind: "rejected",
+        isElizaError: true,
+        code: "SANDBOX_APPLE_CONTAINER_SPAWN_FAILED",
+        context: {
+          containerName: STDOUT_NAME,
+          engine: "apple-container",
+        },
+        message: "Apple Container process could not be spawned",
+      });
+    }, 90_000);
+
+    it("rejects an unspawnable container as a typed spawn failure with exit 0 in immediate-exit mode", async () => {
+      installUnspawnableContainer();
+      const result = await runHarness("immediate-exit");
+      expect(result.code).toBe(0);
+      expect(parseRejection(result.stdout)).toMatchObject({
+        kind: "rejected",
+        isElizaError: true,
+        code: "SANDBOX_APPLE_CONTAINER_SPAWN_FAILED",
+        context: {
+          containerName: IMMEDIATE_EXIT_NAME,
+          engine: "apple-container",
+        },
+      });
+    }, 90_000);
+  },
+);


### PR DESCRIPTION

# Relates to

Adds same-file unit coverage for `packages/agent/src/services/sandbox-engine-run-container.harness.ts`, which had no `*.harness.test.ts` sibling. No product issue; test-only PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`c3f070a5ee1e45204df4a447d4592bc8d0bf416e`) with zero conflicts.
- [x] Focused package checks were run after sync. `bun run verify` was not run; this is a test-only addition with no production change. Hosted CI does **not** run on this fork contributor PR.
- [x] A reviewer can confirm the suite from the quoted Vitest / Biome / `tsc` counts below.

# Sync with develop

- [x] Branch tip is `origin/develop` plus one test file; zero conflicts.
- [x] `bun run verify` was not run. Known gaps record that below. Focused Vitest, Biome, and `tsc` are quoted.

# Risks

Low. Test-only. No production code, types, routes, or exports change. The suite spawns the existing harness subprocess against a temp `container` stub (same process-boundary approach as `sandbox-engine-run-container.test.ts`) and does not talk to a real Apple Container daemon.

# Background

## What does this PR do?

Adds `packages/agent/src/services/sandbox-engine-run-container.harness.test.ts`. The harness has no exports — it runs at load — so the suite spawns the real file and asserts observed behaviour:

- `argv[2] === "stdout"` names the container `eliza-sandbox-stdout`; every other mode (including omitted argv, `""`, `STDOUT`, and garbage) names it `eliza-sandbox-immediate-exit`.
- A trailing extra argv after `stdout` is ignored.
- Resolve path writes `HARNESS_RESOLVED:<name>\n` and exits `0` only for `stdout`; non-stdout resolve exits `1`.
- Typed `ElizaError` reject JSON is `{ kind: "rejected", isElizaError, code, context, message }`. Exit is `0` only when `mode === "immediate-exit"` **and** the error is an `ElizaError`; otherwise exit `1`.
- A missing `container` binary is a plain `Error` (`isElizaError: false`) and exits `1` even in `immediate-exit` mode.
- An unspawnable `container` path is typed `SANDBOX_APPLE_CONTAINER_SPAWN_FAILED`.

Inherited-stdio forwarding of the engine remains owned by `sandbox-engine-run-container.test.ts`.

## What kind of change is this?

Improvements (tests for existing harness behaviour). No production behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/sandbox-engine-run-container.harness.test.ts`, then the harness it spawns.

## Detailed testing steps

Re-run against current `origin/develop` immediately before filing (harness bytes on `origin/develop` match the working tree; `git diff` vs `origin/develop` is this test file only):

```bash
bunx vitest run packages/agent/src/services/sandbox-engine-run-container.harness.test.ts
```

Observed on this head (`72a7712181846b8206629aaa8c685790f0eea1de`), Vitest 4.1.10:

```
Test Files  1 passed (1)
     Tests  15 passed (15)
  Duration  46.76s
```

```bash
bunx biome check --write packages/agent/src/services/sandbox-engine-run-container.harness.test.ts
```

Clean (config at repo-root `biome.json`; checkout is not sparse). Biome reported: `Checked 1 file in 137ms. Fixed 1 file.` then the formatted file is what landed.

```bash
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'sandbox-engine-run-container.harness.test' ; echo "EXIT:$?"
```

Empty grep (EXIT:1 from grep = no matches). This test file introduced zero `tsc` errors.

This is a fork contributor PR: hosted GitHub Actions CI does **not** run on our PRs. Do not infer CI green from this body.

# Evidence Gate

Evidence matches exact head `72a7712181846b8206629aaa8c685790f0eea1de`.

<!-- evidence-head:72a7712181846b8206629aaa8c685790f0eea1de -->

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`
- [x] After full-page screenshots: `N/A - test-only, no UI surface`
- [x] Walkthrough video: `N/A - test-only, no UI surface`
- [x] Backend logs: `N/A - no production behaviour change; Vitest output is the proof`
- [x] Frontend console/network logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB/memory/schedule/wallet/audio output`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - this PR only adds a Vitest file for a subprocess harness. No model path.

## Backend + frontend logs

N/A - no production path change. Quoted Vitest counts above.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; production code is untouched.
- Hosted CI does not run on this fork contributor PR.
- Windows is skipped (`describe.skipIf(process.platform === "win32")`), matching the sibling `sandbox-engine-run-container.test.ts` spawn harness.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
