### PR TITLE
test(app): report liveness artifact write degradation

### DIFF
--- a/packages/app/test/privacy-safe-liveness-diagnostic-artifact.mjs
+++ b/packages/app/test/privacy-safe-liveness-diagnostic-artifact.mjs
@@ -1,0 +1,54 @@
+/**
+ * Persists the closed-schema liveness diagnostic used by the opt-in Cloud
+ * Playwright lane. Artifact persistence is secondary evidence: its failure is
+ * reported without retaining an exception or changing the primary verdict.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA =
+  "elizaos.cloud.liveness-failure-diagnostics/v1";
+export const LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION = Object.freeze({
+  type: "privacy-safe-liveness-diagnostic-artifact",
+  description: "write-failed",
+});
+
+export async function writePrivacySafeLivenessDiagnostic({
+  diagnosticPath,
+  diagnosticRecord,
+  annotations,
+  mkdirFn = mkdir,
+  writeFileFn = writeFile,
+}) {
+  try {
+    await mkdirFn(dirname(diagnosticPath), {
+      recursive: true,
+      mode: 0o700,
+    });
+    await writeFileFn(
+      diagnosticPath,
+      `${JSON.stringify(
+        {
+          schema: LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
+          ...diagnosticRecord,
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", flag: "wx", mode: 0o600 },
+    );
+    return true;
+  } catch {
+    // error-policy:J4 diagnostic persistence is an ancillary evidence channel.
+    // Report only a content-free unavailable state and preserve the primary
+    // liveness failure as the authoritative Playwright verdict.
+    try {
+      annotations.push({ ...LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION });
+    } catch {
+      // error-policy:J4 an unavailable annotation sink is another ancillary
+      // reporting degrade and must not replace the primary liveness failure.
+    }
+    return false;
+  }
+}

--- a/packages/app/test/privacy-safe-liveness-diagnostic-artifact.test.ts
+++ b/packages/app/test/privacy-safe-liveness-diagnostic-artifact.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Pins the privacy and failure semantics of the Cloud liveness diagnostic
+ * writer without touching the filesystem or a live provider.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
+  LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION,
+  writePrivacySafeLivenessDiagnostic,
+} from "./privacy-safe-liveness-diagnostic-artifact.mjs";
+
+describe("privacy-safe liveness diagnostic artifact", () => {
+  it("writes the exact closed schema with private file permissions", async () => {
+    const mkdirFn = vi.fn(async () => undefined);
+    const writeFileFn = vi.fn(async () => undefined);
+    const annotations: Array<{ type: string; description: string }> = [];
+    const diagnosticRecord = {
+      historyGetDelta: 1,
+      retryObservationAvailable: true,
+      phase: "terminal",
+    };
+
+    await expect(
+      writePrivacySafeLivenessDiagnostic({
+        diagnosticPath: "/tmp/eliza-run/diagnostic.json",
+        diagnosticRecord,
+        annotations,
+        mkdirFn,
+        writeFileFn,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mkdirFn).toHaveBeenCalledWith("/tmp/eliza-run", {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(writeFileFn).toHaveBeenCalledWith(
+      "/tmp/eliza-run/diagnostic.json",
+      `${JSON.stringify(
+        {
+          schema: LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
+          ...diagnosticRecord,
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", flag: "wx", mode: 0o600 },
+    );
+    expect(annotations).toEqual([]);
+  });
+
+  it.each(["directory creation", "exclusive artifact write"])(
+    "reports %s failure without retaining the rejected value",
+    async (boundary) => {
+      const privateMarker = "private-model-output-must-not-escape";
+      const hostileRejection = Object.defineProperties(
+        {},
+        {
+          message: {
+            get: () => {
+              throw new Error(privateMarker);
+            },
+          },
+          toString: {
+            value: () => {
+              throw new Error(privateMarker);
+            },
+          },
+        },
+      );
+      const mkdirFn = vi.fn(async () => {
+        if (boundary === "directory creation") {
+          throw hostileRejection;
+        }
+      });
+      const writeFileFn = vi.fn(async () => {
+        if (boundary === "exclusive artifact write") {
+          throw hostileRejection;
+        }
+      });
+      const annotations: Array<{ type: string; description: string }> = [];
+
+      await expect(
+        writePrivacySafeLivenessDiagnostic({
+          diagnosticPath: "/tmp/eliza-run/diagnostic.json",
+          diagnosticRecord: { phase: "terminal" },
+          annotations,
+          mkdirFn,
+          writeFileFn,
+        }),
+      ).resolves.toBe(false);
+
+      expect(annotations).toEqual([
+        LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION,
+      ]);
+      expect(JSON.stringify(annotations)).not.toContain(privateMarker);
+    },
+  );
+
+  it("does not let an unavailable annotation sink replace the primary verdict", async () => {
+    const annotations = Object.freeze([]);
+
+    await expect(
+      writePrivacySafeLivenessDiagnostic({
+        diagnosticPath: "/tmp/eliza-run/diagnostic.json",
+        diagnosticRecord: { phase: "terminal" },
+        annotations,
+        mkdirFn: async () => {
+          throw new Error("write unavailable");
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -44,6 +44,7 @@ import {
   isLiveReply,
   readLivenessThreadLines,
 } from "../liveness-contract";
+import { writePrivacySafeLivenessDiagnostic } from "../privacy-safe-liveness-diagnostic-artifact.mjs";
 import { writeStagingCloudChatLatencyEvidence } from "../staging-cloud-chat-latency-evidence";
 import { openAppPath } from "./helpers";
 
@@ -868,30 +869,12 @@ test.describe("real cloud login + personal identity + chat", () => {
       const diagnosticPath = test
         .info()
         .outputPath("privacy-safe-liveness-history-network-diagnostics.json");
-      // error-policy:J2 retain only allowlisted counts, booleans, and enums.
-      // Artifact write failure must not replace the original liveness verdict.
-      const diagnosticArtifactWritten = await mkdir(dirname(diagnosticPath), {
-        recursive: true,
-        mode: 0o700,
-      })
-        .then(() =>
-          writeFile(
-            diagnosticPath,
-            `${JSON.stringify(
-              {
-                schema: "elizaos.cloud.liveness-failure-diagnostics/v1",
-                ...diagnosticRecord,
-              },
-              null,
-              2,
-            )}\n`,
-            { encoding: "utf8", flag: "wx", mode: 0o600 },
-          ),
-        )
-        .then(
-          () => true,
-          () => false,
-        );
+      const diagnosticArtifactWritten =
+        await writePrivacySafeLivenessDiagnostic({
+          diagnosticPath,
+          diagnosticRecord,
+          annotations: test.info().annotations,
+        });
       const diagnostic = [
         ...Object.entries(diagnosticRecord).map(
           ([name, value]) => `${name}=${value}`,


### PR DESCRIPTION
## Summary
- follow up on the maintainer review of merged #25674 without changing the closed-schema liveness predicate or diagnostic payload
- classify diagnostic persistence as an ancillary J4 degrade instead of a J2 context-preserving failure
- make artifact-write rejection observable as a content-free Playwright annotation while preserving the original liveness verdict
- inject the filesystem boundary and cover directory, write, hostile rejection, and annotation-sink failures deterministically

## Privacy and behavior
- no caught error value, path content, transcript, model output, or provider response enters the annotation
- the annotation is fixed to `privacy-safe-liveness-diagnostic-artifact: write-failed`
- the original `diagnosticArtifactWritten=false` signal and liveness failure remain authoritative
- successful artifacts retain schema `elizaos.cloud.liveness-failure-diagnostics/v1`, directory mode `0700`, exclusive file mode `0600`

## Verification
- `bun test packages/app/test/privacy-safe-liveness-diagnostic-artifact.test.ts packages/app/test/liveness-contract.test.ts` (27/27)
- `node --check packages/app/test/privacy-safe-liveness-diagnostic-artifact.mjs`
- `bun x @biomejs/biome check` on all three changed files
- `git diff --check`
- exact changed-content gitleaks scan: no leaks

The isolated worktree has no repository dependency install because the host volume had about 576 MiB free. A direct repository Vitest invocation therefore cannot resolve the intentionally absent dependency tree; the dependency-free Bun runner executes the focused Vitest-style files cleanly. CI remains the authoritative installed-workspace proof.

No workflow was manually dispatched. No Cloudflare, Railway, provider, production, or credential action was taken.
