### PR TITLE
test(agent): cover tee-evidence

### DIFF
--- a/packages/agent/src/services/tee-evidence.test.ts
+++ b/packages/agent/src/services/tee-evidence.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Covers the TEE attestation-evidence normalizer and digest helpers:
+ * isTeeEvidence, normalizeTeeEvidence, teeMeasurementDigestMatches, and
+ * normalizeDigest. Asserts boundary validation, optional-field omission, and
+ * digest comparison over the real module — no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isTeeEvidence,
+  normalizeDigest,
+  normalizeTeeEvidence,
+  teeMeasurementDigestMatches,
+} from "./tee-evidence.ts";
+
+describe("isTeeEvidence", () => {
+  it("rejects non-objects, arrays, and null", () => {
+    expect(isTeeEvidence(undefined)).toBe(false);
+    expect(isTeeEvidence(null)).toBe(false);
+    expect(isTeeEvidence("tdx")).toBe(false);
+    expect(isTeeEvidence(1)).toBe(false);
+    expect(isTeeEvidence(true)).toBe(false);
+    expect(isTeeEvidence([{ kind: "tdx" }])).toBe(false);
+  });
+
+  it("rejects a record whose kind is missing, non-string, or blank", () => {
+    expect(isTeeEvidence({})).toBe(false);
+    expect(isTeeEvidence({ kind: 1 })).toBe(false);
+    expect(isTeeEvidence({ kind: "" })).toBe(false);
+    expect(isTeeEvidence({ kind: "   " })).toBe(false);
+  });
+
+  it("accepts a record with a non-empty kind string, ignoring other fields", () => {
+    expect(isTeeEvidence({ kind: "tdx" })).toBe(true);
+    expect(isTeeEvidence({ kind: "  cove  " })).toBe(true);
+    expect(
+      isTeeEvidence({ kind: "custom-vendor", measurements: "not-an-object" }),
+    ).toBe(true);
+  });
+});
+
+describe("normalizeTeeEvidence", () => {
+  it("throws when the value is not a record", () => {
+    expect(() => normalizeTeeEvidence(undefined)).toThrow(
+      "TEE evidence must be an object.",
+    );
+    expect(() => normalizeTeeEvidence(null)).toThrow(
+      "TEE evidence must be an object.",
+    );
+    expect(() => normalizeTeeEvidence([])).toThrow(
+      "TEE evidence must be an object.",
+    );
+    expect(() => normalizeTeeEvidence("tdx")).toThrow(
+      "TEE evidence must be an object.",
+    );
+  });
+
+  it("requires a non-empty trimmed kind string", () => {
+    expect(() => normalizeTeeEvidence({})).toThrow(
+      'TEE evidence field "kind" is required.',
+    );
+    expect(() => normalizeTeeEvidence({ kind: "" })).toThrow(
+      'TEE evidence field "kind" is required.',
+    );
+    expect(() => normalizeTeeEvidence({ kind: "   " })).toThrow(
+      'TEE evidence field "kind" is required.',
+    );
+    expect(() => normalizeTeeEvidence({ kind: 7 })).toThrow(
+      'TEE evidence field "kind" must be a string.',
+    );
+  });
+
+  it("returns kind plus raw and omits empty optional fields", () => {
+    const input = { kind: "  tdx  " };
+    expect(normalizeTeeEvidence(input)).toEqual({
+      kind: "tdx",
+      raw: input,
+    });
+  });
+
+  it("trims optional strings and omits blank ones", () => {
+    const input = {
+      kind: "nitro",
+      provider: "  dstack  ",
+      hardwareVendor: "intel",
+      platformVersion: "",
+      quote: "   ",
+      certificatePem: "-----BEGIN CERT-----\n",
+      reportData: "aabb",
+    };
+    expect(normalizeTeeEvidence(input)).toEqual({
+      kind: "nitro",
+      provider: "dstack",
+      hardwareVendor: "intel",
+      certificatePem: "-----BEGIN CERT-----",
+      reportData: "aabb",
+      raw: input,
+    });
+  });
+
+  it("rejects a non-string optional string field", () => {
+    expect(() => normalizeTeeEvidence({ kind: "tdx", provider: 1 })).toThrow(
+      'TEE evidence field "provider" must be a string.',
+    );
+    expect(() => normalizeTeeEvidence({ kind: "tdx", quote: true })).toThrow(
+      'TEE evidence field "quote" must be a string.',
+    );
+  });
+
+  it("keeps integer securityVersion including zero and negatives", () => {
+    const zero = { kind: "tdx", securityVersion: 0 };
+    expect(normalizeTeeEvidence(zero)).toEqual({
+      kind: "tdx",
+      securityVersion: 0,
+      raw: zero,
+    });
+    const negative = { kind: "tdx", securityVersion: -1 };
+    expect(normalizeTeeEvidence(negative)).toEqual({
+      kind: "tdx",
+      securityVersion: -1,
+      raw: negative,
+    });
+  });
+
+  it("rejects a non-integer securityVersion", () => {
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", securityVersion: 1.5 }),
+    ).toThrow('TEE evidence field "securityVersion" must be an integer.');
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", securityVersion: Number.NaN }),
+    ).toThrow('TEE evidence field "securityVersion" must be an integer.');
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", securityVersion: "7" }),
+    ).toThrow('TEE evidence field "securityVersion" must be an integer.');
+  });
+
+  it("normalizes measurements, dropping blank values and empty maps", () => {
+    const empty = { kind: "tdx", measurements: {} };
+    expect(normalizeTeeEvidence(empty)).toEqual({ kind: "tdx", raw: empty });
+
+    const blanks = { kind: "tdx", measurements: { boot: "  ", os: "" } };
+    expect(normalizeTeeEvidence(blanks)).toEqual({ kind: "tdx", raw: blanks });
+
+    const mixed = {
+      kind: "tdx",
+      measurements: {
+        boot: "  ABC  ",
+        os: "",
+        customProbe: "deadbeef",
+      },
+    };
+    expect(normalizeTeeEvidence(mixed)).toEqual({
+      kind: "tdx",
+      measurements: { boot: "ABC", customProbe: "deadbeef" },
+      raw: mixed,
+    });
+  });
+
+  it("rejects non-object measurements and non-string measurement values", () => {
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", measurements: "boot" }),
+    ).toThrow("TEE evidence measurements must be an object.");
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", measurements: [] }),
+    ).toThrow("TEE evidence measurements must be an object.");
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", measurements: { boot: 1 } }),
+    ).toThrow('TEE measurement "boot" must be a string.');
+  });
+
+  it("normalizes freshness, dropping empty maps and unknown keys", () => {
+    const empty = { kind: "tdx", freshness: {} };
+    expect(normalizeTeeEvidence(empty)).toEqual({ kind: "tdx", raw: empty });
+
+    const blanks = {
+      kind: "tdx",
+      freshness: { nonce: "  ", timestamp: "", extra: "ignored" },
+    };
+    expect(normalizeTeeEvidence(blanks)).toEqual({ kind: "tdx", raw: blanks });
+
+    const full = {
+      kind: "tdx",
+      freshness: {
+        nonce: "  n1  ",
+        timestamp: "2026-05-20T12:00:00.000Z",
+        verifier: "intel-pcs",
+      },
+    };
+    expect(normalizeTeeEvidence(full)).toEqual({
+      kind: "tdx",
+      freshness: {
+        nonce: "n1",
+        timestamp: "2026-05-20T12:00:00.000Z",
+        verifier: "intel-pcs",
+      },
+      raw: full,
+    });
+  });
+
+  it("rejects non-object freshness", () => {
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", freshness: "now" }),
+    ).toThrow("TEE evidence freshness must be an object.");
+  });
+
+  it("normalizes known boolean claims and ignores unknown keys", () => {
+    const empty = { kind: "tdx", claims: { extra: true } };
+    expect(normalizeTeeEvidence(empty)).toEqual({ kind: "tdx", raw: empty });
+
+    const mixed = {
+      kind: "tdx",
+      claims: {
+        debugDisabled: true,
+        productionLifecycle: false,
+        extra: true,
+      },
+    };
+    expect(normalizeTeeEvidence(mixed)).toEqual({
+      kind: "tdx",
+      claims: {
+        debugDisabled: true,
+        productionLifecycle: false,
+      },
+      raw: mixed,
+    });
+  });
+
+  it("copies every recognized claim key when boolean", () => {
+    const input = {
+      kind: "cove",
+      claims: {
+        debugDisabled: true,
+        productionLifecycle: true,
+        secureBoot: true,
+        memoryEncrypted: true,
+        ioProtected: true,
+        gpuProtected: false,
+        npuProtected: true,
+        monitorMeasured: true,
+      },
+    };
+    expect(normalizeTeeEvidence(input).claims).toEqual(input.claims);
+  });
+
+  it("rejects non-object claims and non-boolean recognized claim values", () => {
+    expect(() => normalizeTeeEvidence({ kind: "tdx", claims: [] })).toThrow(
+      "TEE evidence claims must be an object.",
+    );
+    expect(() =>
+      normalizeTeeEvidence({ kind: "tdx", claims: { debugDisabled: "yes" } }),
+    ).toThrow('TEE claim "debugDisabled" must be boolean.');
+  });
+
+  it("preserves the original input as raw, including extra fields", () => {
+    const input = { kind: "none", extra: 42 };
+    const evidence = normalizeTeeEvidence(input);
+    expect(evidence.raw).toBe(input);
+    expect(evidence).toEqual({ kind: "none", raw: input });
+  });
+});
+
+describe("normalizeDigest", () => {
+  it("trims, lowercases, and strips a leading sha256: prefix", () => {
+    expect(normalizeDigest("  SHA256:AbC  ")).toBe("abc");
+    expect(normalizeDigest("sha256:deadbeef")).toBe("deadbeef");
+    expect(normalizeDigest("DEADBEEF")).toBe("deadbeef");
+  });
+
+  it("does not strip sha256: when it is not a prefix", () => {
+    expect(normalizeDigest("digest-sha256:tail")).toBe("digest-sha256:tail");
+  });
+});
+
+describe("teeMeasurementDigestMatches", () => {
+  it("treats an undefined expected digest as a match", () => {
+    expect(teeMeasurementDigestMatches(undefined, undefined)).toBe(true);
+    expect(teeMeasurementDigestMatches("abc", undefined)).toBe(true);
+  });
+
+  it("rejects a missing actual when expected is defined, including empty string", () => {
+    expect(teeMeasurementDigestMatches(undefined, "abc")).toBe(false);
+    expect(teeMeasurementDigestMatches(undefined, "")).toBe(false);
+  });
+
+  it("compares after digest normalization, so prefix and case do not matter", () => {
+    expect(teeMeasurementDigestMatches("  SHA256:AbC  ", "sha256:abc")).toBe(
+      true,
+    );
+    expect(teeMeasurementDigestMatches("abc", "sha256:abc")).toBe(true);
+    expect(teeMeasurementDigestMatches("aaa", "bbb")).toBe(false);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/services/tee-evidence.ts`, which had no same-named test file on `origin/develop`. No product-behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`c3f070a5ee1e45204df4a447d4592bc8d0bf416e`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only addition; focused vitest, biome, and package `tsc` are quoted below.
- [x] A reviewer can confirm the change from the evidence below without reading production code: one new test file, 23 passing tests.

# Sync with develop

- [x] Branch parent is current `origin/develop` `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`; zero conflicts.
- [ ] Full `bun run verify` is N/A for a single new test file; focused gates are quoted in **Evidence Gate**.

# Risks

Low. Adds a colocated vitest suite only. No production TEE path, policy evaluator, or boot-gate is changed.

# Background

## What does this PR do?

Adds real unit coverage for the TEE attestation-evidence data model helpers in `tee-evidence.ts`. The suite imports the live module and drives `isTeeEvidence`, `normalizeTeeEvidence`, `normalizeDigest`, and `teeMeasurementDigestMatches` — no mocks.

Covered behaviour (what the module actually does):

- `isTeeEvidence` rejects non-objects, arrays, null, missing/non-string/blank `kind`, and accepts a record whose trimmed `kind` is non-empty even when other fields are invalid.
- `normalizeTeeEvidence` throws for non-records, missing/blank/non-string `kind`, non-string optional string fields, non-integer `securityVersion`, non-object measurements/freshness/claims, non-string measurement values, and non-boolean recognized claims.
- Optional strings are trimmed; blanks are omitted. Integer `securityVersion` keeps `0` and negatives.
- Empty or all-blank measurements/freshness/claims maps are omitted. Unknown freshness/claim keys are ignored; extra measurement names are kept. `raw` is the original input object.
- `normalizeDigest` trims, lowercases, and strips a leading `sha256:` prefix only.
- `teeMeasurementDigestMatches` treats `expected === undefined` as a match; a missing actual fails when expected is defined (including `""`); otherwise it compares after digest normalization.

## What kind of change is this?

Improvements (tests for existing behaviour). Test-only; no production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/tee-evidence.test.ts` against `packages/agent/src/services/tee-evidence.ts`.

## Detailed testing steps

None: Automated tests are acceptable.

```bash
bunx vitest run packages/agent/src/services/tee-evidence.test.ts
```

# Evidence Gate

Evidence matches head `28a15fb8edeb8bbcb5dd2f9b7b90b93a16d2a33b` on current `origin/develop` `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`.

1. `bunx vitest run packages/agent/src/services/tee-evidence.test.ts` — Test Files **1 passed (1)**, Tests **23 passed (23)** (Vitest v4.1.10). Re-run after re-fetching `origin/develop`; `tee-evidence.ts` is unchanged vs that parent.
2. `bunx biome check --write packages/agent/src/services/tee-evidence.test.ts` — Checked 1 file in 231ms. Fixed 1 file (line wrapping). The committed file is the post-biome result. `biome.json` is present; the checkout is not sparse.
3. `cd packages/agent && bunx tsc --noEmit` — `tee-evidence.test.ts` appears nowhere in the output.
4. Diff touches only `packages/agent/src/services/tee-evidence.test.ts`.

Hosted CI does **not** run on this fork's pull requests. The counts above are local, not GitHub Actions.

Origin reproduction, proof-run, load-bearing revert, and over-rejection corpus are N/A: this PR adds tests and changes no production behaviour.

- Before screenshots: N/A - test-only, no UI surface.
- After screenshots: N/A - test-only, no UI surface.
- Walkthrough video: N/A - test-only, no UI surface.
- Backend logs: N/A - pure functions, no server path.
- Frontend logs: N/A - no frontend change.
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- Domain artifacts: N/A - no DB/wallet/scheduled-item output.
- OCR review: N/A - no rendered visual surface.

# Known gaps / failures

N/A — test-only addition. Full-workspace `bun run verify` was not required for this scoped change.

# Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests are included
- [x] Documentation is N/A (test-only)
- [x] Code follows repository style (biome clean)

# Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:28a15fb8edeb8bbcb5dd2f9b7b90b93a16d2a33b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
