### PR TITLE
test(agent): cover task-executor

### DIFF
--- a/packages/agent/src/services/task-executor.test.ts
+++ b/packages/agent/src/services/task-executor.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Behavioral coverage for TaskExecutorRegistry: register/get/unregister, empty
+ * and single-element queues, explicit-type preference over capability probing,
+ * fall-through when the typed executor refuses or is missing, insertion-order
+ * ties, empty spec.type, overwrite of the same type, and removal of a missing
+ * key. Drives the real registry with in-process TaskExecutor collaborators.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { TaskExecutor, TaskResult, TaskSpec } from "./task-executor.ts";
+import { TaskExecutorRegistry } from "./task-executor.ts";
+
+const runtime = { agentId: "runtime-1" } as unknown as IAgentRuntime;
+
+function spec(
+  overrides: {
+    id?: string;
+    description?: string;
+    type?: string;
+    metadata?: Record<string, unknown>;
+    agentType?: string;
+  } = {},
+): TaskSpec {
+  const next: TaskSpec = {
+    id: overrides.id ?? "task-1",
+    description: overrides.description ?? "do the work",
+    type: overrides.type ?? "coding",
+  };
+  if (overrides.metadata !== undefined) {
+    next.metadata = overrides.metadata;
+  }
+  if (overrides.agentType !== undefined) {
+    next.agentType = overrides.agentType;
+  }
+  return next;
+}
+
+function makeExecutor(
+  type: string,
+  accept: (task: TaskSpec, agentRuntime: IAgentRuntime) => boolean = (task) =>
+    task.type === type,
+): TaskExecutor {
+  return {
+    type,
+    description: `${type} executor`,
+    canHandle(task, agentRuntime) {
+      return accept(task, agentRuntime);
+    },
+    async execute(task): Promise<TaskResult> {
+      return { taskId: task.id, success: true, output: type };
+    },
+    async abort() {},
+  };
+}
+
+describe("TaskExecutorRegistry", () => {
+  it("starts empty: getAll is [], get and findExecutor miss", () => {
+    const registry = new TaskExecutorRegistry();
+
+    expect(registry.getAll()).toEqual([]);
+    expect(registry.get("coding")).toBeUndefined();
+    expect(registry.findExecutor(spec(), runtime)).toBeUndefined();
+  });
+
+  it("register then get and getAll return that single executor", () => {
+    const registry = new TaskExecutorRegistry();
+    const coding = makeExecutor("coding");
+    registry.register(coding);
+
+    expect(registry.get("coding")).toBe(coding);
+    expect(registry.getAll()).toEqual([coding]);
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      coding,
+    );
+  });
+
+  it("register of the same type replaces the previous executor", () => {
+    const registry = new TaskExecutorRegistry();
+    const first = makeExecutor("coding");
+    const second = makeExecutor("coding");
+    registry.register(first);
+    registry.register(second);
+
+    expect(registry.get("coding")).toBe(second);
+    expect(registry.getAll()).toEqual([second]);
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      second,
+    );
+  });
+
+  it("overwrite of an existing type keeps the original Map insertion slot", () => {
+    const registry = new TaskExecutorRegistry();
+    const research = makeExecutor("research");
+    const firstCoding = makeExecutor("coding");
+    const secondCoding = makeExecutor("coding");
+    registry.register(research);
+    registry.register(firstCoding);
+    registry.register(secondCoding);
+
+    expect(registry.getAll()).toEqual([research, secondCoding]);
+  });
+
+  it("unregister removes a registered type and leaves others in place", () => {
+    const registry = new TaskExecutorRegistry();
+    const coding = makeExecutor("coding");
+    const research = makeExecutor("research");
+    registry.register(coding);
+    registry.register(research);
+    registry.unregister("coding");
+
+    expect(registry.get("coding")).toBeUndefined();
+    expect(registry.get("research")).toBe(research);
+    expect(registry.getAll()).toEqual([research]);
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      undefined,
+    );
+  });
+
+  it("unregister of a missing type is a no-op", () => {
+    const registry = new TaskExecutorRegistry();
+    const coding = makeExecutor("coding");
+    registry.register(coding);
+    registry.unregister("missing");
+
+    expect(registry.getAll()).toEqual([coding]);
+    expect(registry.get("coding")).toBe(coding);
+  });
+
+  it("unregister on an empty registry does not throw", () => {
+    const registry = new TaskExecutorRegistry();
+    expect(() => registry.unregister("coding")).not.toThrow();
+    expect(registry.getAll()).toEqual([]);
+  });
+
+  it("prefers the explicit type match over an earlier catch-all", () => {
+    const registry = new TaskExecutorRegistry();
+    const catchAll = makeExecutor("research", () => true);
+    const coding = makeExecutor("coding");
+    registry.register(catchAll);
+    registry.register(coding);
+
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      coding,
+    );
+  });
+
+  it("falls through when the explicit executor exists but canHandle is false", () => {
+    const registry = new TaskExecutorRegistry();
+    const catchAll = makeExecutor("research", () => true);
+    const refusing = makeExecutor("coding", () => false);
+    registry.register(catchAll);
+    registry.register(refusing);
+
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      catchAll,
+    );
+  });
+
+  it("falls through when spec.type is not a registered key", () => {
+    const registry = new TaskExecutorRegistry();
+    const byDescription = makeExecutor("research", (task) =>
+      task.description.includes("cite"),
+    );
+    registry.register(byDescription);
+
+    expect(
+      registry.findExecutor(
+        spec({ type: "unknown", description: "cite sources" }),
+        runtime,
+      ),
+    ).toBe(byDescription);
+  });
+
+  it("skips explicit lookup when spec.type is empty and uses insertion order", () => {
+    const registry = new TaskExecutorRegistry();
+    const coding = makeExecutor("coding");
+    const catchAll = makeExecutor("research", () => true);
+    registry.register(coding);
+    registry.register(catchAll);
+
+    expect(registry.findExecutor(spec({ type: "" }), runtime)).toBe(catchAll);
+  });
+
+  it("returns the first insertion-order executor that canHandle when no explicit match", () => {
+    const registry = new TaskExecutorRegistry();
+    const refusing = makeExecutor("coding", () => false);
+    const first = makeExecutor("research", () => true);
+    const second = makeExecutor("content", () => true);
+    registry.register(refusing);
+    registry.register(first);
+    registry.register(second);
+
+    expect(registry.findExecutor(spec({ type: "unregistered" }), runtime)).toBe(
+      first,
+    );
+  });
+
+  it("returns undefined when every executor refuses", () => {
+    const registry = new TaskExecutorRegistry();
+    registry.register(makeExecutor("coding", () => false));
+    registry.register(makeExecutor("research", () => false));
+
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      undefined,
+    );
+  });
+
+  it("returns undefined when the only typed executor refuses and nothing else is registered", () => {
+    const registry = new TaskExecutorRegistry();
+    registry.register(makeExecutor("coding", () => false));
+
+    expect(registry.findExecutor(spec({ type: "coding" }), runtime)).toBe(
+      undefined,
+    );
+  });
+
+  it("forwards the provided runtime into canHandle", () => {
+    const registry = new TaskExecutorRegistry();
+    const seen: IAgentRuntime[] = [];
+    registry.register(
+      makeExecutor("coding", (_task, agentRuntime) => {
+        seen.push(agentRuntime);
+        return true;
+      }),
+    );
+
+    const found = registry.findExecutor(spec({ type: "coding" }), runtime);
+
+    expect(found?.type).toBe("coding");
+    expect(seen).toEqual([runtime]);
+  });
+
+  it("matches a probe-only executor on agentType when spec.type is not registered", () => {
+    const registry = new TaskExecutorRegistry();
+    const researcher = makeExecutor(
+      "worker",
+      (task) => task.agentType === "researcher",
+    );
+    registry.register(researcher);
+
+    expect(
+      registry.findExecutor(
+        spec({ type: "ad-hoc", agentType: "researcher" }),
+        runtime,
+      ),
+    ).toBe(researcher);
+    expect(
+      registry.findExecutor(
+        spec({ type: "ad-hoc", agentType: "coder" }),
+        runtime,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("get misses a type that was never registered even after other inserts", () => {
+    const registry = new TaskExecutorRegistry();
+    registry.register(makeExecutor("coding"));
+
+    expect(registry.get("research")).toBeUndefined();
+    expect(registry.get("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/agent/src/services/task-executor.ts`, which had
no same-named test file. No production issue; no behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop`
      (`c3f070a5ee1e45204df4a447d4592bc8d0bf416e`) with zero conflicts. Parent of
      the PR head is that SHA.
- [ ] Full `bun run verify` was not run. Focused evidence for this test-only
      diff is vitest, biome, and package `tsc --noEmit` quoted below.
- [x] A reviewer can confirm the suite without reading production code: the
      quoted vitest run exercises the real `TaskExecutorRegistry`.

# Sync with develop

- [x] Branch parent is current `origin/develop` at
      `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`; zero conflicts.
- [ ] `bun run verify` not run (test-only; see **Known gaps / failures**).

# Risks

Low. Adds one Vitest file next to the existing source. No production code, no
exports, no runtime wiring.

# Background

## What does this PR do?

Adds `packages/agent/src/services/task-executor.test.ts`. It drives the real
`TaskExecutorRegistry` with in-process `TaskExecutor` collaborators whose
`canHandle` logic is real (type match, catch-all, refuse, `agentType` probe).
It does not mock the registry and then assert the mock.

Covered behaviour, observed from the source:

- empty registry: `getAll()` is `[]`; `get` and `findExecutor` miss
- single-element register round-trip via `get` / `getAll` / `findExecutor`
- same-type overwrite: last executor wins; Map insertion slot is preserved
- unregister of a present type; unregister of a missing type is a no-op;
  unregister on an empty registry does not throw
- `findExecutor` prefers an explicit type match over an earlier catch-all
- fall-through when the typed executor exists but `canHandle` is false
- fall-through when `spec.type` is not a registered key
- empty `spec.type` is falsy, so explicit lookup is skipped and insertion-order
  probing runs
- first insertion-order executor that `canHandle`s wins when there is no
  explicit match
- `undefined` when every executor refuses, including a lone typed refuser
- the provided `runtime` is forwarded into `canHandle`
- probe-only match on `agentType` when `spec.type` is unregistered

There is no capacity/overflow bound and no comparator; the registry is an
unbounded `Map`. Tests record what the code does.

## What kind of change is this?

Improvements (tests for existing behaviour; no production change).

## Why are we doing this? Any context or related work?

The module had no same-named test file. Coverage of the registry's empty,
single, overwrite, missing-unregister, explicit-vs-probe, and insertion-order
branches is behaviour-preserving.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/task-executor.test.ts` and the quoted vitest run.

## Detailed testing steps

None: automated tests are acceptable.

```bash
bunx vitest run packages/agent/src/services/task-executor.test.ts
```

Re-fetched `origin/develop` and re-ran immediately before filing.

Hosted CI does **not** run on this fork contributor's PRs. Do not treat missing
GitHub Actions as a pass.

# Evidence Gate

Evidence matches PR head `0e017aa6ac3608377753323a8d17d3b8ba2b80e8`.

<!-- evidence-head:0e017aa6ac3608377753323a8d17d3b8ba2b80e8 -->

Focused evidence for this test-only PR:

1. `bunx vitest run packages/agent/src/services/task-executor.test.ts`

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  122ms
```

Re-run against current `origin/develop`
(`c3f070a5ee1e45204df4a447d4592bc8d0bf416e`) immediately before filing: same
**1 file / 17 tests passed**.

2. `bunx biome check --write packages/agent/src/services/task-executor.test.ts`

```
Checked 1 file in 117ms. Fixed 1 file.
```

Repo-root `biome.json` and `tsconfig.json` are present; `git sparse-checkout list`
is not sparse (`fatal: this worktree is not sparse`). The write applied formatter
wrapping only.

3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'task-executor.test.ts'`

empty (`GREP_EXIT:1`). The new file appears nowhere in tsc output.

4. Diff touches only `packages/agent/src/services/task-executor.test.ts`.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production behaviour change; vitest is the path under test.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory registry unit tests; no DB/wallet/schedule artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only registry unit tests; no server or UI path.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not run. This PR adds one test file and changes no
  production behaviour; the required bar is the quoted vitest, biome, and tsc
  results.
- Hosted GitHub Actions CI does not run on PRs from this fork. Local vitest is
  the execution proof.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
