### PR TITLE
fix(remote): fence managed Headscale ownership

### DIFF
--- a/packages/app-core/platforms/electrobun/biome.json
+++ b/packages/app-core/platforms/electrobun/biome.json
@@ -6,6 +6,6 @@
     "includes": ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"]
   },
   "formatter": {
-    "indentStyle": "tab"
+    "indentStyle": "space"
   }
 }

--- a/packages/app-core/platforms/electrobun/src/remote-target-managed-network.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-managed-network.test.ts
@@ -159,10 +159,44 @@ describe("native managed-network enrollment", () => {
           BackendState: "Running",
           Self: { HostName: "eliza-host-one-cafebabe" },
         }),
+      async () =>
+        JSON.stringify({ ControlURL: "https://headscale.example.test/" }),
     );
 
-    await joiner.leave({ hostname: "eliza-host-one" });
+    await joiner.leave({
+      hostname: "eliza-host-one",
+      loginServer: "https://headscale.example.test",
+    });
     expect(observedArgs).toEqual(["logout"]);
+  });
+
+  it("does not log out a same-hostname profile from another control server", async () => {
+    let spawned = false;
+    const joiner = new TailscaleCliManagedNetworkJoiner(
+      async () => "/test/tailscale",
+      () => {
+        spawned = true;
+        return new FakeChild() as unknown as ChildProcess;
+      },
+      os.tmpdir(),
+      () => 2_000_000_000_000,
+      async () => undefined,
+      async () =>
+        JSON.stringify({
+          BackendState: "Running",
+          Self: { HostName: "eliza-host-one" },
+        }),
+      async () =>
+        JSON.stringify({ ControlURL: "https://controlplane.tailscale.com" }),
+    );
+
+    await expect(
+      joiner.leave({
+        hostname: "eliza-host-one",
+        loginServer: "https://headscale.example.test",
+      }),
+    ).rejects.toThrow("does not use the managed Eliza control server");
+    expect(spawned).toBe(false);
   });
 
   it("does not log out a profile that no longer matches the managed host", async () => {
@@ -183,9 +217,12 @@ describe("native managed-network enrollment", () => {
         }),
     );
 
-    await expect(joiner.leave({ hostname: "eliza-host-one" })).rejects.toThrow(
-      "not the managed Eliza membership",
-    );
+    await expect(
+      joiner.leave({
+        hostname: "eliza-host-one",
+        loginServer: "https://headscale.example.test",
+      }),
+    ).rejects.toThrow("not the managed Eliza membership");
     expect(spawned).toBe(false);
   });
 
@@ -204,7 +241,10 @@ describe("native managed-network enrollment", () => {
         JSON.stringify({ BackendState: "NeedsLogin", TailscaleIPs: [] }),
     );
 
-    await joiner.leave({ hostname: "eliza-host-one" });
+    await joiner.leave({
+      hostname: "eliza-host-one",
+      loginServer: "https://headscale.example.test",
+    });
     expect(spawned).toBe(false);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/remote-target-managed-network.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-managed-network.test.ts
@@ -4,7 +4,10 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { TailscaleCliManagedNetworkJoiner } from "./remote-target-managed-network";
+import {
+  remoteTargetManagedNetworkInternals,
+  TailscaleCliManagedNetworkJoiner,
+} from "./remote-target-managed-network";
 
 class FakeChild extends EventEmitter {
   killed = false;
@@ -43,6 +46,7 @@ describe("native managed-network enrollment", () => {
         },
         temporaryRoot,
         () => 2_000_000_000_000,
+        async () => undefined,
       );
       const authKey = "hskey-auth-one-use-secret";
       await joiner.join({
@@ -89,6 +93,118 @@ describe("native managed-network enrollment", () => {
         expiresAt: 1_999_999_999_999,
       }),
     ).rejects.toThrow("expired");
+    expect(spawned).toBe(false);
+  });
+
+  it("refuses to switch an existing personal tailnet before spawning up", async () => {
+    let spawned = false;
+    const joiner = new TailscaleCliManagedNetworkJoiner(
+      async () => "/test/tailscale",
+      () => {
+        spawned = true;
+        return new FakeChild() as unknown as ChildProcess;
+      },
+      os.tmpdir(),
+      () => 2_000_000_000_000,
+      async () =>
+        remoteTargetManagedNetworkInternals.assertVacantTailscaleStatus(
+          JSON.stringify({
+            BackendState: "Running",
+            CurrentTailnet: { Name: "personal.example" },
+            Self: { HostName: "personal-laptop" },
+            TailscaleIPs: ["100.64.0.1"],
+          }),
+        ),
+    );
+
+    await expect(
+      joiner.join({
+        loginServer: "https://headscale.example",
+        authKey: "hskey-auth-one-use-secret",
+        hostname: "eliza-host-one",
+        expiresAt: 2_000_000_030_000,
+      }),
+    ).rejects.toThrow("cannot replace an existing Tailscale tailnet");
+    expect(spawned).toBe(false);
+  });
+
+  it("accepts only a vacant daemon status", () => {
+    expect(() =>
+      remoteTargetManagedNetworkInternals.assertVacantTailscaleStatus(
+        JSON.stringify({ BackendState: "NeedsLogin", TailscaleIPs: [] }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      remoteTargetManagedNetworkInternals.assertVacantTailscaleStatus(
+        "not-json",
+      ),
+    ).toThrow("could not be verified safely");
+  });
+
+  it("logs out only the durable managed hostname", async () => {
+    let observedArgs: readonly string[] = [];
+    const joiner = new TailscaleCliManagedNetworkJoiner(
+      async () => "/test/tailscale",
+      (_command, args) => {
+        observedArgs = args;
+        const child = new FakeChild();
+        queueMicrotask(() => child.emit("close", 0));
+        return child as unknown as ChildProcess;
+      },
+      os.tmpdir(),
+      () => 2_000_000_000_000,
+      async () => undefined,
+      async () =>
+        JSON.stringify({
+          BackendState: "Running",
+          Self: { HostName: "eliza-host-one-cafebabe" },
+        }),
+    );
+
+    await joiner.leave({ hostname: "eliza-host-one" });
+    expect(observedArgs).toEqual(["logout"]);
+  });
+
+  it("does not log out a profile that no longer matches the managed host", async () => {
+    let spawned = false;
+    const joiner = new TailscaleCliManagedNetworkJoiner(
+      async () => "/test/tailscale",
+      () => {
+        spawned = true;
+        return new FakeChild() as unknown as ChildProcess;
+      },
+      os.tmpdir(),
+      () => 2_000_000_000_000,
+      async () => undefined,
+      async () =>
+        JSON.stringify({
+          BackendState: "Running",
+          Self: { HostName: "personal-laptop" },
+        }),
+    );
+
+    await expect(joiner.leave({ hostname: "eliza-host-one" })).rejects.toThrow(
+      "not the managed Eliza membership",
+    );
+    expect(spawned).toBe(false);
+  });
+
+  it("treats an already-vacant daemon as idempotently left", async () => {
+    let spawned = false;
+    const joiner = new TailscaleCliManagedNetworkJoiner(
+      async () => "/test/tailscale",
+      () => {
+        spawned = true;
+        return new FakeChild() as unknown as ChildProcess;
+      },
+      os.tmpdir(),
+      () => 2_000_000_000_000,
+      async () => undefined,
+      async () =>
+        JSON.stringify({ BackendState: "NeedsLogin", TailscaleIPs: [] }),
+    );
+
+    await joiner.leave({ hostname: "eliza-host-one" });
     expect(spawned).toBe(false);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
@@ -172,9 +172,12 @@ const readSystemDaemonPreferences: ReadDaemonPreferences = (executable) =>
           // error-policy:J2 preferences failure is wrapped because logout
           // must never target a profile whose control server is unknown.
           reject(
-            new Error("Managed Tailscale control server could not be verified.", {
-              cause: error,
-            }),
+            new Error(
+              "Managed Tailscale control server could not be verified.",
+              {
+                cause: error,
+              },
+            ),
           );
           return;
         }
@@ -325,8 +328,7 @@ export class TailscaleCliManagedNetworkJoiner
     private readonly now: () => number = Date.now,
     private readonly inspectDaemon: InspectDaemon = inspectVacantSystemDaemon,
     private readonly readDaemonStatus: ReadDaemonStatus = readSystemDaemonStatus,
-    private readonly readDaemonPreferences: ReadDaemonPreferences =
-      readSystemDaemonPreferences,
+    private readonly readDaemonPreferences: ReadDaemonPreferences = readSystemDaemonPreferences,
   ) {}
 
   private async run(

--- a/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
@@ -1,6 +1,6 @@
 /** Native, explicit opt-in enrollment into the managed Headscale network. */
 
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { promises as fs, constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -17,6 +17,9 @@ export interface RemoteTargetManagedNetworkEnrollment {
 
 export interface RemoteTargetManagedNetworkJoiner {
   join(input: RemoteTargetManagedNetworkEnrollment): Promise<void>;
+  leave(
+    input: Pick<RemoteTargetManagedNetworkEnrollment, "hostname">,
+  ): Promise<void>;
 }
 
 type SpawnProcess = (
@@ -27,6 +30,142 @@ type SpawnProcess = (
     stdio: ["ignore", "ignore", "ignore"];
   },
 ) => ChildProcess;
+
+type InspectDaemon = (executable: string) => Promise<void>;
+
+type ReadDaemonStatus = (executable: string) => Promise<string>;
+
+function assertVacantTailscaleStatus(rawStatus: string): void {
+  let status: unknown;
+  try {
+    status = JSON.parse(rawStatus);
+  } catch (cause) {
+    // error-policy:J3 an unreadable daemon response cannot authorize a
+    // control-server switch on the user's system Tailscale profile.
+    throw new Error("Tailscale status could not be verified safely.", {
+      cause,
+    });
+  }
+  if (typeof status !== "object" || status === null || Array.isArray(status)) {
+    throw new Error("Tailscale status could not be verified safely.");
+  }
+  const value = status as Record<string, unknown>;
+  const backendState = value.BackendState;
+  const currentTailnet = value.CurrentTailnet;
+  const self = value.Self;
+  const addresses = value.TailscaleIPs;
+  const hasAddresses = Array.isArray(addresses) && addresses.length > 0;
+  const vacantState =
+    backendState === "NeedsLogin" ||
+    backendState === "NoState" ||
+    backendState === "Stopped";
+  if (
+    !vacantState ||
+    (currentTailnet !== undefined && currentTailnet !== null) ||
+    (self !== undefined && self !== null) ||
+    hasAddresses
+  ) {
+    throw new Error(
+      "Managed enrollment cannot replace an existing Tailscale tailnet. Disconnect and remove the existing local profile, or use a dedicated device.",
+    );
+  }
+}
+
+const inspectVacantSystemDaemon: InspectDaemon = (executable) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      executable,
+      ["status", "--json"],
+      {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          // error-policy:J2 status failure is wrapped because an unknown
+          // daemon profile must fail closed before any `tailscale up`.
+          reject(
+            new Error("Tailscale status could not be verified safely.", {
+              cause: error,
+            }),
+          );
+          return;
+        }
+        try {
+          assertVacantTailscaleStatus(stdout);
+          resolve();
+        } catch (cause) {
+          // error-policy:J2 preserve the typed preflight cause at the native
+          // command boundary without running a mutating CLI command.
+          reject(cause);
+        }
+      },
+    );
+  });
+
+const readSystemDaemonStatus: ReadDaemonStatus = (executable) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      executable,
+      ["status", "--json"],
+      {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          // error-policy:J2 status failure is wrapped because logout must
+          // never target an unknown system Tailscale profile.
+          reject(
+            new Error("Managed Tailscale membership could not be verified.", {
+              cause: error,
+            }),
+          );
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+
+function assertManagedTailscaleStatus(
+  rawStatus: string,
+  hostname: string,
+): void {
+  let status: unknown;
+  try {
+    status = JSON.parse(rawStatus);
+  } catch (cause) {
+    // error-policy:J3 an unreadable daemon response cannot authorize logout.
+    throw new Error("Managed Tailscale membership could not be verified.", {
+      cause,
+    });
+  }
+  if (typeof status !== "object" || status === null || Array.isArray(status)) {
+    throw new Error("Managed Tailscale membership could not be verified.");
+  }
+  const value = status as Record<string, unknown>;
+  const self = value.Self;
+  const observedHostname =
+    typeof self === "object" && self !== null && !Array.isArray(self)
+      ? Reflect.get(self, "HostName")
+      : undefined;
+  const escapedHostname = hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const collisionHostname = new RegExp(`^${escapedHostname}-[a-z0-9]{8}$`);
+  if (
+    value.BackendState !== "Running" ||
+    typeof observedHostname !== "string" ||
+    (observedHostname !== hostname && !collisionHostname.test(observedHostname))
+  ) {
+    throw new Error(
+      "The active Tailscale profile is not the managed Eliza membership; it was left unchanged.",
+    );
+  }
+}
 
 function validateEnrollment(
   input: RemoteTargetManagedNetworkEnrollment,
@@ -90,7 +229,8 @@ async function resolveTailscaleExecutable(): Promise<string> {
       await fs.access(candidate, fsConstants.X_OK);
       return candidate;
     } catch {
-      // Continue through fixed, non-shell executable locations.
+      // error-policy:J3 an unavailable fixed candidate is an explicit miss;
+      // resolution continues without consulting PATH or a shell.
     }
   }
   throw new Error(
@@ -106,69 +246,129 @@ export class TailscaleCliManagedNetworkJoiner
     private readonly spawnProcess: SpawnProcess = spawn,
     private readonly temporaryRoot = os.tmpdir(),
     private readonly now: () => number = Date.now,
+    private readonly inspectDaemon: InspectDaemon = inspectVacantSystemDaemon,
+    private readonly readDaemonStatus: ReadDaemonStatus = readSystemDaemonStatus,
   ) {}
+
+  private async run(
+    executable: string,
+    args: readonly string[],
+    failureMessage: string,
+  ): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const child = this.spawnProcess(executable, args, {
+        shell: false,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (error) reject(error);
+        else resolve();
+      };
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        finish(new Error(`${failureMessage} timed out.`));
+      }, JOIN_TIMEOUT_MS);
+      child.once("error", (cause) =>
+        finish(new Error(failureMessage, { cause })),
+      );
+      child.once("close", (code) =>
+        finish(code === 0 ? undefined : new Error(failureMessage)),
+      );
+    });
+  }
 
   async join(input: RemoteTargetManagedNetworkEnrollment): Promise<void> {
     validateEnrollment(input, this.now());
     const executable = await this.resolveExecutable();
+    await this.inspectDaemon(executable);
     const temporaryDirectory = await fs.mkdtemp(
       path.join(this.temporaryRoot, "eliza-managed-network-"),
     );
     await fs.chmod(temporaryDirectory, 0o700);
     const authKeyPath = path.join(temporaryDirectory, "auth-key");
+    let primaryFailure: unknown;
+    let joined = false;
     try {
       await fs.writeFile(authKeyPath, input.authKey, {
         encoding: "utf8",
         mode: 0o600,
         flag: "wx",
       });
-      await new Promise<void>((resolve, reject) => {
-        const child = this.spawnProcess(
-          executable,
-          [
-            "up",
-            `--login-server=${input.loginServer}`,
-            `--auth-key=file:${authKeyPath}`,
-            `--hostname=${input.hostname}`,
-            "--accept-dns=false",
-            "--accept-routes=false",
-            "--shields-up",
-            "--timeout=30s",
-          ],
-          { shell: false, stdio: ["ignore", "ignore", "ignore"] },
-        );
-        let settled = false;
-        const finish = (error?: Error) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          if (error) reject(error);
-          else resolve();
-        };
-        const timer = setTimeout(() => {
-          child.kill("SIGTERM");
-          finish(new Error("Managed network enrollment timed out."));
-        }, JOIN_TIMEOUT_MS);
-        child.once("error", (cause) =>
-          finish(
-            new Error("Tailscale could not start managed enrollment.", {
-              cause,
-            }),
-          ),
-        );
-        child.once("close", (code) =>
-          finish(
-            code === 0
-              ? undefined
-              : new Error(
-                  "Tailscale rejected managed enrollment. Existing tailnet state was not reset.",
-                ),
-          ),
-        );
-      });
-    } finally {
-      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+      await this.run(
+        executable,
+        [
+          "up",
+          `--login-server=${input.loginServer}`,
+          `--auth-key=file:${authKeyPath}`,
+          `--hostname=${input.hostname}`,
+          "--accept-dns=false",
+          "--accept-routes=false",
+          "--shields-up",
+          "--timeout=30s",
+        ],
+        "Tailscale rejected managed enrollment. Existing tailnet state was not reset.",
+      );
+      joined = true;
+    } catch (cause) {
+      // error-policy:J1 the native enrollment boundary preserves the primary
+      // mutation failure while still attempting secret-file teardown below.
+      primaryFailure = cause;
     }
+    let teardownFailure: unknown;
+    try {
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    } catch (cause) {
+      // error-policy:J6 secret-file teardown is best effort but must remain
+      // visible and must never replace the primary enrollment failure.
+      teardownFailure = cause;
+    }
+    if (joined && teardownFailure !== undefined) {
+      try {
+        await this.leave({ hostname: input.hostname });
+      } catch (membershipCleanupFailure) {
+        throw new AggregateError(
+          [teardownFailure, membershipCleanupFailure],
+          "Managed enrollment joined successfully, but local cleanup failed.",
+          { cause: teardownFailure },
+        );
+      }
+    }
+    if (primaryFailure !== undefined && teardownFailure !== undefined) {
+      throw new AggregateError(
+        [primaryFailure, teardownFailure],
+        "Managed enrollment failed and its temporary key cleanup also failed.",
+        { cause: primaryFailure },
+      );
+    }
+    if (primaryFailure !== undefined) throw primaryFailure;
+    if (teardownFailure !== undefined) throw teardownFailure;
+  }
+
+  async leave(
+    input: Pick<RemoteTargetManagedNetworkEnrollment, "hostname">,
+  ): Promise<void> {
+    if (!HOSTNAME_PATTERN.test(input.hostname)) {
+      throw new Error("Managed network hostname is invalid.");
+    }
+    const executable = await this.resolveExecutable();
+    const rawStatus = await this.readDaemonStatus(executable);
+    try {
+      assertVacantTailscaleStatus(rawStatus);
+      return;
+    } catch {
+      // error-policy:J3 only a verified app-owned managed membership may
+      // proceed to logout; a vacant daemon makes teardown idempotent.
+    }
+    assertManagedTailscaleStatus(rawStatus, input.hostname);
+    await this.run(
+      executable,
+      ["logout"],
+      "Tailscale could not leave the managed network",
+    );
   }
 }
 
@@ -176,5 +376,7 @@ export const remoteTargetManagedNetworkInternals = {
   HOSTNAME_PATTERN,
   JOIN_TIMEOUT_MS,
   executableCandidates,
+  assertVacantTailscaleStatus,
+  assertManagedTailscaleStatus,
   validateEnrollment,
 };

--- a/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-managed-network.ts
@@ -18,7 +18,10 @@ export interface RemoteTargetManagedNetworkEnrollment {
 export interface RemoteTargetManagedNetworkJoiner {
   join(input: RemoteTargetManagedNetworkEnrollment): Promise<void>;
   leave(
-    input: Pick<RemoteTargetManagedNetworkEnrollment, "hostname">,
+    input: Pick<
+      RemoteTargetManagedNetworkEnrollment,
+      "hostname" | "loginServer"
+    >,
   ): Promise<void>;
 }
 
@@ -34,6 +37,27 @@ type SpawnProcess = (
 type InspectDaemon = (executable: string) => Promise<void>;
 
 type ReadDaemonStatus = (executable: string) => Promise<string>;
+
+type ReadDaemonPreferences = (executable: string) => Promise<string>;
+
+function canonicalLoginServer(value: string): string {
+  const loginServer = new URL(value);
+  const loopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(
+    loginServer.hostname.toLowerCase(),
+  );
+  if (
+    (loginServer.protocol !== "https:" &&
+      !(loginServer.protocol === "http:" && loopback)) ||
+    loginServer.username ||
+    loginServer.password ||
+    loginServer.search ||
+    loginServer.hash ||
+    loginServer.pathname.replace(/\/+$/, "")
+  ) {
+    throw new Error("Managed network login server is invalid.");
+  }
+  return loginServer.origin;
+}
 
 function assertVacantTailscaleStatus(rawStatus: string): void {
   let status: unknown;
@@ -132,6 +156,33 @@ const readSystemDaemonStatus: ReadDaemonStatus = (executable) =>
     );
   });
 
+const readSystemDaemonPreferences: ReadDaemonPreferences = (executable) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      executable,
+      ["debug", "prefs"],
+      {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          // error-policy:J2 preferences failure is wrapped because logout
+          // must never target a profile whose control server is unknown.
+          reject(
+            new Error("Managed Tailscale control server could not be verified.", {
+              cause: error,
+            }),
+          );
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+
 function assertManagedTailscaleStatus(
   rawStatus: string,
   hostname: string,
@@ -167,25 +218,51 @@ function assertManagedTailscaleStatus(
   }
 }
 
+function assertManagedTailscalePreferences(
+  rawPreferences: string,
+  loginServer: string,
+): void {
+  let preferences: unknown;
+  try {
+    preferences = JSON.parse(rawPreferences);
+  } catch (cause) {
+    // error-policy:J3 unreadable daemon preferences cannot authorize logout.
+    throw new Error("Managed Tailscale control server could not be verified.", {
+      cause,
+    });
+  }
+  if (
+    typeof preferences !== "object" ||
+    preferences === null ||
+    Array.isArray(preferences) ||
+    typeof Reflect.get(preferences, "ControlURL") !== "string"
+  ) {
+    throw new Error("Managed Tailscale control server could not be verified.");
+  }
+  let observedControlUrl: string;
+  try {
+    observedControlUrl = canonicalLoginServer(
+      Reflect.get(preferences, "ControlURL") as string,
+    );
+  } catch (cause) {
+    // error-policy:J2 malformed control-server preferences are preserved as
+    // a fail-closed ownership mismatch at the native command boundary.
+    throw new Error("Managed Tailscale control server could not be verified.", {
+      cause,
+    });
+  }
+  if (observedControlUrl !== canonicalLoginServer(loginServer)) {
+    throw new Error(
+      "The active Tailscale profile does not use the managed Eliza control server; it was left unchanged.",
+    );
+  }
+}
+
 function validateEnrollment(
   input: RemoteTargetManagedNetworkEnrollment,
   now = Date.now(),
 ): void {
-  const loginServer = new URL(input.loginServer);
-  const loopback = ["127.0.0.1", "localhost", "[::1]", "::1"].includes(
-    loginServer.hostname.toLowerCase(),
-  );
-  if (
-    (loginServer.protocol !== "https:" &&
-      !(loginServer.protocol === "http:" && loopback)) ||
-    loginServer.username ||
-    loginServer.password ||
-    loginServer.search ||
-    loginServer.hash ||
-    loginServer.pathname.replace(/\/+$/, "")
-  ) {
-    throw new Error("Managed network login server is invalid.");
-  }
+  canonicalLoginServer(input.loginServer);
   if (!HOSTNAME_PATTERN.test(input.hostname)) {
     throw new Error("Managed network hostname is invalid.");
   }
@@ -248,6 +325,8 @@ export class TailscaleCliManagedNetworkJoiner
     private readonly now: () => number = Date.now,
     private readonly inspectDaemon: InspectDaemon = inspectVacantSystemDaemon,
     private readonly readDaemonStatus: ReadDaemonStatus = readSystemDaemonStatus,
+    private readonly readDaemonPreferences: ReadDaemonPreferences =
+      readSystemDaemonPreferences,
   ) {}
 
   private async run(
@@ -328,7 +407,10 @@ export class TailscaleCliManagedNetworkJoiner
     }
     if (joined && teardownFailure !== undefined) {
       try {
-        await this.leave({ hostname: input.hostname });
+        await this.leave({
+          hostname: input.hostname,
+          loginServer: input.loginServer,
+        });
       } catch (membershipCleanupFailure) {
         throw new AggregateError(
           [teardownFailure, membershipCleanupFailure],
@@ -349,11 +431,15 @@ export class TailscaleCliManagedNetworkJoiner
   }
 
   async leave(
-    input: Pick<RemoteTargetManagedNetworkEnrollment, "hostname">,
+    input: Pick<
+      RemoteTargetManagedNetworkEnrollment,
+      "hostname" | "loginServer"
+    >,
   ): Promise<void> {
     if (!HOSTNAME_PATTERN.test(input.hostname)) {
       throw new Error("Managed network hostname is invalid.");
     }
+    canonicalLoginServer(input.loginServer);
     const executable = await this.resolveExecutable();
     const rawStatus = await this.readDaemonStatus(executable);
     try {
@@ -364,6 +450,8 @@ export class TailscaleCliManagedNetworkJoiner
       // proceed to logout; a vacant daemon makes teardown idempotent.
     }
     assertManagedTailscaleStatus(rawStatus, input.hostname);
+    const rawPreferences = await this.readDaemonPreferences(executable);
+    assertManagedTailscalePreferences(rawPreferences, input.loginServer);
     await this.run(
       executable,
       ["logout"],
@@ -378,5 +466,7 @@ export const remoteTargetManagedNetworkInternals = {
   executableCandidates,
   assertVacantTailscaleStatus,
   assertManagedTailscaleStatus,
+  assertManagedTailscalePreferences,
+  canonicalLoginServer,
   validateEnrollment,
 };

--- a/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
@@ -342,45 +342,75 @@ export class RemoteTargetDesktopService {
       createdAt: response.createdAt,
     });
     if (managedNetwork) {
+      let joinedManagedNetwork = false;
       try {
         // The response was validated before committing credentials, so this
         // assertion only narrows the discriminated managed path for TypeScript.
         if (!managedEnrollment)
           throw new Error("Managed enrollment is missing.");
         await this.managedNetworkJoiner.join(managedEnrollment);
+        joinedManagedNetwork = true;
+        await this.vault.recordManagedNetwork({
+          hostId: enrolled.identity.runtimeId,
+          hostname: managedEnrollment.hostname,
+        });
         await this.transport.activateManagedNetwork({
           enrollment: enrolled,
           expectedHostname: managedEnrollment.hostname,
         });
       } catch (cause) {
+        const cleanupFailures: unknown[] = [];
+        if (joinedManagedNetwork && managedEnrollment) {
+          try {
+            await this.managedNetworkJoiner.leave({
+              hostname: managedEnrollment.hostname,
+            });
+          } catch (cleanupCause) {
+            // error-policy:J6 Cloud cleanup must still run if native
+            // membership teardown fails after a partial activation.
+            cleanupFailures.push(cleanupCause);
+          }
+        }
         try {
+          let cloudCleanupComplete = false;
           for (let pageNumber = 0; pageNumber < 10; pageNumber += 1) {
             const page = await this.transport.revokeHost({
               enrollment: enrolled,
             });
             if (!page.cleanup.more) {
-              if (!(await this.vault.delete())) {
+              if (
+                cleanupFailures.length === 0 &&
+                !(await this.vault.delete())
+              ) {
                 throw new Error(
                   "Managed enrollment was revoked, but local credentials could not be removed.",
                 );
               }
-              throw cause;
+              cloudCleanupComplete = true;
+              break;
             }
             if (page.cleanup.sessions === 0 && page.cleanup.commands === 0) {
               throw new Error("Managed enrollment cleanup made no progress.");
             }
           }
-          throw new Error(
-            "Managed enrollment cleanup exceeded its retry bound.",
-          );
+          if (!cloudCleanupComplete) {
+            throw new Error(
+              "Managed enrollment cleanup exceeded its retry bound.",
+            );
+          }
         } catch (cleanupCause) {
-          if (cleanupCause === cause) throw cause;
+          // error-policy:J6 native and Cloud cleanup failures are retained
+          // together without suppressing the primary activation failure.
+          cleanupFailures.push(cleanupCause);
+        }
+        if (cleanupFailures.length > 0) {
           throw new AggregateError(
-            [cause, cleanupCause],
+            [cause, ...cleanupFailures],
             "Managed enrollment failed and cleanup must be retried from Devices & Runtimes.",
             { cause },
           );
         }
+        throw cause;
       }
     }
     return {
@@ -628,6 +658,11 @@ export class RemoteTargetDesktopService {
             },
           );
         }
+      }
+      if (enrollment.managedNetwork) {
+        await this.managedNetworkJoiner.leave({
+          hostname: enrollment.managedNetwork.hostname,
+        });
       }
       await this.runner?.stop();
       this.runner = null;

--- a/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
@@ -353,6 +353,7 @@ export class RemoteTargetDesktopService {
         await this.vault.recordManagedNetwork({
           hostId: enrolled.identity.runtimeId,
           hostname: managedEnrollment.hostname,
+          loginServer: managedEnrollment.loginServer,
         });
         await this.transport.activateManagedNetwork({
           enrollment: enrolled,
@@ -364,6 +365,7 @@ export class RemoteTargetDesktopService {
           try {
             await this.managedNetworkJoiner.leave({
               hostname: managedEnrollment.hostname,
+              loginServer: managedEnrollment.loginServer,
             });
           } catch (cleanupCause) {
             // error-policy:J6 Cloud cleanup must still run if native
@@ -662,6 +664,7 @@ export class RemoteTargetDesktopService {
       if (enrollment.managedNetwork) {
         await this.managedNetworkJoiner.leave({
           hostname: enrollment.managedNetwork.hostname,
+          loginServer: enrollment.managedNetwork.loginServer,
         });
       }
       await this.runner?.stop();

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -1676,7 +1676,10 @@ describe("remote target durable runner", () => {
     expect(relay.activateManagedCalls).toBe(1);
     await expect(vault.load()).resolves.toMatchObject({
       status: "enrolled",
-      managedNetwork: { hostname: "eliza-host-one" },
+      managedNetwork: {
+        hostname: "eliza-host-one",
+        loginServer: "https://headscale.example.test",
+      },
     });
     relay.revocations.push({
       hostId: HOST_ID,
@@ -1749,8 +1752,9 @@ describe("remote target durable runner", () => {
       () => NOW,
       {
         join: async () => undefined,
-        leave: async ({ hostname }) => {
+        leave: async ({ hostname, loginServer }) => {
           expect(hostname).toBe("eliza-host-one");
+          expect(loginServer).toBe("https://headscale.example.test");
           leaveCalls += 1;
         },
       },

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -384,6 +384,7 @@ class DeferredCompensationRelay extends ImmediateActivationRelay {
 
 class ManagedEnrollmentRelay extends FakeRelay {
   activateManagedCalls = 0;
+  activateManagedFailure: Error | null = null;
 
   override async enroll(
     input: RemoteTargetEnrollmentRequest,
@@ -406,6 +407,7 @@ class ManagedEnrollmentRelay extends FakeRelay {
 
   override async activateManagedNetwork(): Promise<{ hostname: string }> {
     this.activateManagedCalls += 1;
+    if (this.activateManagedFailure) throw this.activateManagedFailure;
     return { hostname: "eliza-host-one-cnpx9uop" };
   }
 }
@@ -1645,6 +1647,7 @@ describe("remote target durable runner", () => {
     );
     const relay = new ManagedEnrollmentRelay();
     let joined = false;
+    let left = false;
     const service = new RemoteTargetDesktopService(
       vault,
       new MemoryRemoteTargetStateStore(),
@@ -1653,6 +1656,9 @@ describe("remote target durable runner", () => {
       {
         join: async () => {
           joined = true;
+        },
+        leave: async () => {
+          left = true;
         },
       },
     );
@@ -1668,7 +1674,20 @@ describe("remote target durable runner", () => {
     ).resolves.toMatchObject({ hostId: HOST_ID, status: "active" });
     expect(joined).toBe(true);
     expect(relay.activateManagedCalls).toBe(1);
-    await expect(vault.load()).resolves.toMatchObject({ status: "enrolled" });
+    await expect(vault.load()).resolves.toMatchObject({
+      status: "enrolled",
+      managedNetwork: { hostname: "eliza-host-one" },
+    });
+    relay.revocations.push({
+      hostId: HOST_ID,
+      status: "revoked",
+      alreadyRevoked: false,
+      cleanup: { sessions: 0, commands: 0, more: false },
+    });
+    await expect(
+      service.finalizeHostRevoke({ hostId: HOST_ID }),
+    ).resolves.toEqual({ cleaned: true });
+    expect(left).toBe(true);
   });
 
   it("revokes pending Cloud authority and deletes local credentials after a native join failure", async () => {
@@ -1692,6 +1711,7 @@ describe("remote target durable runner", () => {
         join: async () => {
           throw new Error("Tailscale unavailable");
         },
+        leave: async () => undefined,
       },
     );
     await expect(
@@ -1705,6 +1725,47 @@ describe("remote target durable runner", () => {
       }),
     ).rejects.toThrow("Tailscale unavailable");
     expect(relay.activateManagedCalls).toBe(0);
+    await expect(vault.load()).resolves.toBeNull();
+  });
+
+  it("leaves the managed membership when Cloud activation fails", async () => {
+    const vault = new RemoteTargetVault(
+      new MemorySecureStore(),
+      "managed-activation-failure-target",
+    );
+    const relay = new ManagedEnrollmentRelay();
+    relay.activateManagedFailure = new Error("Headscale node unavailable");
+    relay.revocations.push({
+      hostId: HOST_ID,
+      status: "revoked",
+      alreadyRevoked: false,
+      cleanup: { sessions: 0, commands: 0, more: false },
+    });
+    let leaveCalls = 0;
+    const service = new RemoteTargetDesktopService(
+      vault,
+      new MemoryRemoteTargetStateStore(),
+      relay,
+      () => NOW,
+      {
+        join: async () => undefined,
+        leave: async ({ hostname }) => {
+          expect(hostname).toBe("eliza-host-one");
+          leaveCalls += 1;
+        },
+      },
+    );
+
+    await expect(
+      service.enroll({
+        apiBaseUrl: "https://api.example.test",
+        ownerId: "owner-1",
+        ownerAccessToken: "owner-token-123456789",
+        displayName: "Linux target",
+        managedNetwork: true,
+      }),
+    ).rejects.toThrow("Headscale node unavailable");
+    expect(leaveCalls).toBe(1);
     await expect(vault.load()).resolves.toBeNull();
   });
 });

--- a/packages/app-core/platforms/electrobun/src/remote-target-same-host.integration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-same-host.integration.test.ts
@@ -212,7 +212,9 @@ class DeterministicRelay implements RemoteTargetRelayTransport {
   }
 
   async activateManagedNetwork(): Promise<{ hostname: string }> {
-    throw new Error("unused");
+    throw new Error(
+      "Managed-network activation is outside this relay harness.",
+    );
   }
 
   async activate(input: {

--- a/packages/app-core/platforms/electrobun/src/remote-target-vault.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-vault.ts
@@ -38,6 +38,9 @@ export interface EnrolledRemoteTargetVaultRecord {
   deviceId: string;
   signingPrivateKeyJwk: JsonWebKey;
   encryptionPrivateKeyJwk: JsonWebKey;
+  managedNetwork?: {
+    hostname: string;
+  };
 }
 
 type RemoteTargetVaultRecord =
@@ -99,6 +102,19 @@ function canonicalApiBase(value: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
+function isManagedNetworkRecord(value: unknown): boolean {
+  if (value === undefined) return true;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof Reflect.get(value, "hostname") === "string" &&
+    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(
+      Reflect.get(value, "hostname") as string,
+    )
+  );
+}
+
 export function remoteTargetVaultId(
   canonicalStateDir = resolveCanonicalStateDir(),
 ): string {
@@ -158,7 +174,8 @@ function parseRecord(raw: string): RemoteTargetVaultRecord {
     typeof Reflect.get(value, "apiBaseUrl") !== "string" ||
     typeof Reflect.get(value, "hostToken") !== "string" ||
     !HOST_TOKEN_PATTERN.test(Reflect.get(value, "hostToken") as string) ||
-    !isRemoteTargetPublicIdentity(Reflect.get(value, "identity"))
+    !isRemoteTargetPublicIdentity(Reflect.get(value, "identity")) ||
+    !isManagedNetworkRecord(Reflect.get(value, "managedNetwork"))
   ) {
     throw new Error("Stored remote target identity is corrupt.");
   }
@@ -327,6 +344,42 @@ export class RemoteTargetVault {
         throw new Error("Secure remote target storage is unavailable.");
       }
       return enrolled;
+    });
+  }
+
+  async recordManagedNetwork(input: {
+    hostId: string;
+    hostname: string;
+  }): Promise<EnrolledRemoteTargetVaultRecord> {
+    if (
+      !isIdentifier(input.hostId) ||
+      !isManagedNetworkRecord({ hostname: input.hostname })
+    ) {
+      throw new Error("Managed network identity is invalid.");
+    }
+    return this.serialize(async () => {
+      const existing = await this.load();
+      if (
+        existing?.status !== "enrolled" ||
+        existing.identity.runtimeId !== input.hostId
+      ) {
+        throw new Error(
+          "Managed network enrollment does not match stored state.",
+        );
+      }
+      const updated: EnrolledRemoteTargetVaultRecord = {
+        ...existing,
+        managedNetwork: { hostname: input.hostname },
+      };
+      const stored = await this.secureStore.set(
+        this.vaultId,
+        TARGET_VAULT_KIND,
+        JSON.stringify(updated),
+      );
+      if (!stored.ok) {
+        throw new Error("Secure remote target storage is unavailable.");
+      }
+      return updated;
     });
   }
 

--- a/packages/app-core/platforms/electrobun/src/remote-target-vault.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-vault.ts
@@ -40,6 +40,7 @@ export interface EnrolledRemoteTargetVaultRecord {
   encryptionPrivateKeyJwk: JsonWebKey;
   managedNetwork?: {
     hostname: string;
+    loginServer: string;
   };
 }
 
@@ -102,17 +103,36 @@ function canonicalApiBase(value: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
+function canonicalManagedNetworkLoginServer(value: string): string {
+  const canonical = canonicalApiBase(value);
+  const url = new URL(canonical);
+  if (url.pathname !== "/") {
+    throw new Error("Stored managed network login server is invalid.");
+  }
+  return url.origin;
+}
+
 function isManagedNetworkRecord(value: unknown): boolean {
   if (value === undefined) return true;
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    typeof Reflect.get(value, "hostname") === "string" &&
-    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(
-      Reflect.get(value, "hostname") as string,
-    )
-  );
+  try {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof Reflect.get(value, "hostname") === "string" &&
+      typeof Reflect.get(value, "loginServer") === "string" &&
+      /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(
+        Reflect.get(value, "hostname") as string,
+      ) &&
+      canonicalManagedNetworkLoginServer(
+        Reflect.get(value, "loginServer") as string,
+      ) === Reflect.get(value, "loginServer")
+    );
+  } catch {
+    // error-policy:J3 malformed secure-store authority is an explicit invalid
+    // record and is never normalized into a usable managed profile.
+    return false;
+  }
 }
 
 export function remoteTargetVaultId(
@@ -350,10 +370,12 @@ export class RemoteTargetVault {
   async recordManagedNetwork(input: {
     hostId: string;
     hostname: string;
+    loginServer: string;
   }): Promise<EnrolledRemoteTargetVaultRecord> {
+    const loginServer = canonicalManagedNetworkLoginServer(input.loginServer);
     if (
       !isIdentifier(input.hostId) ||
-      !isManagedNetworkRecord({ hostname: input.hostname })
+      !isManagedNetworkRecord({ hostname: input.hostname, loginServer })
     ) {
       throw new Error("Managed network identity is invalid.");
     }
@@ -369,7 +391,7 @@ export class RemoteTargetVault {
       }
       const updated: EnrolledRemoteTargetVaultRecord = {
         ...existing,
-        managedNetwork: { hostname: input.hostname },
+        managedNetwork: { hostname: input.hostname, loginServer },
       };
       const stored = await this.secureStore.set(
         this.vaultId,
@@ -403,4 +425,5 @@ export const remoteTargetVaultInternals = {
   parseRecord,
   publicJwk,
   canonicalApiBase,
+  canonicalManagedNetworkLoginServer,
 };

--- a/packages/cloud/api/v1/remote/managed-network.ts
+++ b/packages/cloud/api/v1/remote/managed-network.ts
@@ -3,6 +3,7 @@ import {
   HeadscaleClient,
   type HeadscaleNode,
 } from "@/lib/services/headscale-client";
+import { logger } from "@/lib/utils/logger";
 
 const REMOTE_HOST_TAG = "tag:eliza-remote-host";
 const ENROLLMENT_TTL_MS = 15 * 60 * 1_000;
@@ -198,15 +199,19 @@ export async function enrollManagedNetwork(input: {
       preAuthKeyId: preAuthKey.id,
     });
   } catch (cause) {
+    // error-policy:J6 enrollment failed before authority was returned; both
+    // external cleanup operations are attempted and aggregated below.
     const cleanupFailures: unknown[] = [];
     try {
       await client.expirePreAuthKey(preAuthKey.id);
     } catch (cleanupCause) {
+      // error-policy:J6 best-effort compensation continues to key deletion.
       cleanupFailures.push(cleanupCause);
     }
     try {
       await client.deletePreAuthKey(preAuthKey.id);
     } catch (cleanupCause) {
+      // error-policy:J6 best-effort compensation is retained in the aggregate.
       cleanupFailures.push(cleanupCause);
     }
     if (cleanupFailures.length > 0) {
@@ -220,6 +225,8 @@ export async function enrollManagedNetwork(input: {
           message: "Managed-network enrollment compensation is pending retry.",
         });
       } catch (trackingCause) {
+        // error-policy:J6 failure to persist cleanup state is preserved beside
+        // the primary and external compensation failures.
         cleanupFailures.push(trackingCause);
       }
       throw new AggregateError(
@@ -254,6 +261,8 @@ export async function cleanupManagedNetwork(input: {
     try {
       await client.expirePreAuthKey(keyId);
     } catch (cause) {
+      // error-policy:J6 cleanup continues so every independent resource gets
+      // one bounded removal attempt before the aggregate is returned.
       failures.push(cause);
     }
   }
@@ -273,6 +282,7 @@ export async function cleanupManagedNetwork(input: {
       );
       for (const node of cleanupNodes) await client.deleteNode(node.id);
     } catch (cause) {
+      // error-policy:J6 node cleanup failure does not skip pre-auth key removal.
       failures.push(cause);
     }
   }
@@ -280,6 +290,7 @@ export async function cleanupManagedNetwork(input: {
     try {
       await client.deletePreAuthKey(keyId);
     } catch (cause) {
+      // error-policy:J6 key deletion failure is retained in the cleanup aggregate.
       failures.push(cause);
     }
   }
@@ -390,10 +401,15 @@ export async function reconcileManagedNetworkCleanup(input: {
         client: input.client,
       });
       completed += 1;
-    } catch {
-      // cleanupManagedNetwork durably records external cleanup failures. A
-      // revoke/storage failure already leaves the candidate selected for the
-      // next bounded sweep; aggregate only counts at this orchestration layer.
+    } catch (error) {
+      // error-policy:J7 one tenant's cleanup diagnostics must not prevent the
+      // bounded worker from attempting unrelated candidates.
+      logger.error("[ManagedNetworkCleanup] Candidate reconciliation failed", {
+        error,
+        hostId: candidate.id,
+        organizationId: candidate.organization_id,
+        userId: candidate.user_id,
+      });
       failed += 1;
     }
   }


### PR DESCRIPTION
## Summary

Stacked corrective for #25427 after #25714. This carries only the managed-network safety and recovery gaps that remained on exact parent `b590c302fbba9`.

- refuses `tailscale up` before mutation when the system daemon already owns a personal/unknown tailnet
- passes the one-use auth key only through a mode-0600 file
- stores the managed hostname and canonical Headscale control URL in the OS secure vault
- permits `tailscale logout` only when both the active hostname and `tailscale debug prefs` ControlURL match the durable managed authority; a same-hostname personal Tailscale profile is left unchanged
- compensates native membership and pending Cloud authority without masking primary failures
- preserves exact managed cleanup authority and non-authoritative pending/activating database states
- aligns the Electrobun nested Biome setting with the actual repository-wide space-indented source, closing the package lint gate without reformat churn

The control-server check follows the upstream Tailscale preferences contract (`Prefs.ControlURL`) and the current `tailscale debug prefs` CLI implementation. Tailscale supports only one active tailnet, so silently switching a users existing daemon is not safe: https://tailscale.com/kb/1225/fast-user-switching

## Verification

Exact head: `70ddf120d57e1b3b0f3c44b23868723c24acda68`
Exact stacked base: `b590c302fbba950e921f6ce109e33203c0db564a`

- Electrobun package Biome: 272 files checked, clean
- managed-network + runner + UI focused Vitest: 3 files, 52 tests passed
- plugin-app-control semantic action Vitest: 1 file, 29 tests passed
- same-host real in-process relay integration: 1 test passed
- Cloud managed-network and relay routes: 37 tests passed
- migration/repository PGlite: 20 tests passed
- Electrobun Linux CEF build sequencing: 5 tests passed
- `git diff --check`: clean

The package typecheck reaches unresolved optional workspace exports on the parent checkout (`@elizaos/auth/*` and optional plugins); it reports no error in the corrective files. Hosted affected checks are required before merge.

## Evidence boundary

This stacked source corrective can merge into the draft parent when its exact hosted checks are green. It does **not** provide the parent PRs missing physical Headscale/GNOME/VPS/packaged-app evidence, so #25427 must remain draft and must not merge to `develop` until that real-target evidence exists.

The reopened #24830 explicitly says it must not merge independently. Once this corrective is present in #25427 and exact-head checks are green, #24830 is superseded by the canonical parent composition.