### PR TITLE
fix(test): repair three broken test fixtures reddening develop

### DIFF
--- a/packages/agent/src/providers/relevant-conversations.test.ts
+++ b/packages/agent/src/providers/relevant-conversations.test.ts
@@ -135,9 +135,14 @@ const EMPTY_STATE = { values: {}, data: {}, text: "" } as unknown as State;
 
 describe("relevantConversationsProvider — shared recall embed fail-open", () => {
   beforeEach(() => {
+    // A resolved role is required: `filterByAccessContext` folds an absent
+    // `role` into the `UNRESOLVED` actor, which every scope denies, so a
+    // roleless context would read as "recall is broken" rather than "a
+    // non-owner reader". These cases model an ordinary authenticated USER.
     buildAccessContext.mockResolvedValue({
       requesterEntityId: "00000000-0000-0000-0000-0000000000e0",
       isOwner: false,
+      role: "USER",
     });
   });
 

--- a/packages/core/src/actions/recent-context.test.ts
+++ b/packages/core/src/actions/recent-context.test.ts
@@ -15,14 +15,24 @@ describe("recentConversationTextsFromState", () => {
 	it("preserves identical wording across mixed sources (#24858)", () => {
 		// Identical text arriving via state.values.recentMessages and via a
 		// memory row must both be preserved, not collapsed.
+		// The memory row must sit on the canonical provider path that
+		// `getRecentMessagesData` reads; no other location is populated.
 		const state = {
 			values: { recentMessages: "repeat this" },
-			recentMessages: [
-				{
-					id: "m1",
-					content: { text: "repeat this" },
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						data: {
+							recentMessages: [
+								{
+									id: "m1",
+									content: { text: "repeat this" },
+								},
+							],
+						},
+					},
 				},
-			],
+			},
 		} as never;
 
 		const result = recentConversationTextsFromState(state);

--- a/packages/core/src/testing/__tests__/loopback.test.ts
+++ b/packages/core/src/testing/__tests__/loopback.test.ts
@@ -32,7 +32,7 @@ describe("canBindLoopback", () => {
 	});
 
 	it("resolves false on server error", async () => {
-		const { canBindLoopback } = await import("./loopback.ts");
+		const { canBindLoopback } = await import("../loopback.ts");
 		const s = fakeServer();
 		mocks.createServer.mockReturnValue(s);
 		const p = canBindLoopback();
@@ -41,7 +41,7 @@ describe("canBindLoopback", () => {
 	});
 
 	it("resolves true when binding succeeds", async () => {
-		const { canBindLoopback } = await import("./loopback.ts");
+		const { canBindLoopback } = await import("../loopback.ts");
 		const s = fakeServer();
 		mocks.createServer.mockReturnValue(s);
 		expect(await canBindLoopback()).toBe(true);


### PR DESCRIPTION
Three unit tests are red on `develop` after the merge sweep. In all three the production code is correct and the **test fixture** is wrong, so only test files change here.

## The three bugs

**1. `packages/core/src/testing/__tests__/loopback.test.ts`** — added by #25262 (`8fd190ff55`). The test lives in `__tests__/` but dynamically imports `"./loopback.ts"`; the module is at `packages/core/src/testing/loopback.ts`. Fixed to `"../loopback.ts"`.

**2. `packages/core/src/actions/recent-context.test.ts`** — added by #24951 (`c96b00e6c1`). The "mixed sources" case puts the memory row at `state.recentMessages`, but `getRecentMessagesData` (`packages/core/src/recent-messages-state.ts`) only reads the canonical provider path `state.data.providers.RECENT_MESSAGES.data.recentMessages` — "the provider system does not populate any other location". So the memory row was never read and the case only ever saw one occurrence. Fixture moved to the canonical path; the contract under test (no dedupe, every occurrence preserved, #24858) is unchanged.

**3. `packages/agent/src/providers/relevant-conversations.test.ts`** — the `beforeEach` mocks `buildAccessContext` to `{ requesterEntityId, isOwner: false }` with **no `role`**. `actorFromAccessContext` (`packages/core/src/access-control/filter.ts`) folds an absent `role` into the `UNRESOLVED` actor, and `canReadScope` denies *every* scope for `UNRESOLVED` (documented fail-closed behaviour). Result: `filterByAccessContext` stripped all recall rows and `result.text` was `""` for 7 of 14 cases. The fixture now models an ordinary authenticated `USER`, matching the OWNER context already used later in the same file (line ~547). The owner-private-denial assertion still holds because a `USER` actor cannot read `owner-private`.

## Before

```
$ ./node_modules/.bin/vitest run packages/core/src/actions/recent-context.test.ts \
    packages/core/src/testing/__tests__/loopback.test.ts \
    packages/agent/src/providers/relevant-conversations.test.ts

 Test Files  3 failed (3)
      Tests  10 failed | 10 passed (20)
```

Representative failures:

```
FAIL recent-context.test.ts > preserves identical wording across mixed sources (#24858)
AssertionError: expected [ 'repeat this' ] to deeply equal [ 'repeat this', 'repeat this' ]

FAIL loopback.test.ts > resolves true when binding succeeds
Error: Cannot find module '/packages/core/src/testing/__tests__/loopback.ts'

FAIL relevant-conversations.test.ts > uses the shared embed vector to search when it resolves
AssertionError: expected '' to contain 'Relevant past conversations:'
```

## After

```
 Test Files  3 passed (3)
      Tests  20 passed (20)
```

## Mutation check

Each fixed test was re-run against a reversed production behaviour to prove it is load-bearing (all mutations reverted afterwards; the diff contains only test files):

| Mutation | Result |
| --- | --- |
| `recent-context.ts`: `return collected` → `return [...new Set(collected)]` (reintroduce the dedupe #24951 removed) | **2 failed** / 4 (both #24858 cases) |
| `testing/loopback.ts`: `server.once("error", …)` → `server.once("errorX", …)` | **1 failed** / 2 (`resolves false on server error`) |
| `access-control/filter.ts`: `case "owner-private": return actor.role === "OWNER" \|\| actor.role === "RUNTIME"` → `return true` | **1 failed** / 14 (`omits owner-private pendant memories from a non-owner recall` — the canary leaked) |

Baselines: 6 passed for the two core files, 14 passed for the agent provider file.

## Notes

No production code is touched. The remaining red files in this area of the sweep are sandbox artifacts (unbuilt plugin `dist/`, `mise` shim for `bun`) and are not addressed here.
