### PR TITLE
chore(ci): allow manual platform smoke evidence

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,7 +58,10 @@ the previously compared base at the mutation boundary. An advanced develop tip
 is a neutral stale reconciliation; a behind or divergent main fails instead of
 creating an untested merge commit.
 The delegated `platform-smoke.yml` family preserves macOS and Windows core
-proof without a separate periodic authority.
+proof without a separate periodic authority. Its manual dispatch is the
+read-only route for exact-ref pre-merge platform evidence; it adds no automatic
+pull-request or push authority and does not replace PR Static Smoke or Develop
+Full.
 
 `.github/rulesets/required-branches.json` is the reviewed no-bypass ruleset
 manifest for `develop` and `main`. `scripts/security/apply-branch-protection.sh`

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -1,9 +1,10 @@
-# This reusable workflow preserves deterministic macOS and Windows runtime proof
-# inside the single Develop Full authority.
+# This read-only workflow preserves deterministic macOS and Windows runtime
+# proof inside Develop Full and supports explicit exact-ref evidence runs.
 name: Platform Smoke
 
 on:
   workflow_call:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/packages/scripts/__tests__/platform-smoke-workflow.test.ts
+++ b/packages/scripts/__tests__/platform-smoke-workflow.test.ts
@@ -1,0 +1,38 @@
+/** Verifies the platform smoke workflow remains callable and manually dispatchable without automatic authority. */
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const workflow = Bun.YAML.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../../../.github/workflows/platform-smoke.yml", import.meta.url),
+    ),
+    "utf8",
+  ),
+) as {
+  on?: Record<string, unknown>;
+  permissions?: Record<string, string>;
+  jobs?: Record<
+    string,
+    {
+      strategy?: { matrix?: { os?: string[] } };
+      "runs-on"?: string;
+    }
+  >;
+};
+
+test("platform smoke exposes only callable and explicit manual triggers", () => {
+  expect(Object.keys(workflow.on ?? {}).sort()).toEqual([
+    "workflow_call",
+    "workflow_dispatch",
+  ]);
+  expect(workflow.permissions).toEqual({ contents: "read" });
+});
+
+test("manual evidence retains both hosted platform cells", () => {
+  const job = workflow.jobs?.["platform-smoke"];
+  expect(job?.strategy?.matrix?.os).toEqual(["macos-15", "windows-2025"]);
+  expect(job?.["runs-on"]).toBe("${{ matrix.os }}");
+});


### PR DESCRIPTION
Closes #25750.

## Summary

- makes the existing read-only `platform-smoke.yml` callable by explicit manual dispatch against a selected exact ref
- preserves PR Static Smoke and Develop Full as the only automatic validation authorities
- adds a static contract that pins the callable/manual trigger pair, read-only permissions, and both hosted OS matrix cells
- documents the pre-merge evidence boundary

This adds no pull-request, push, schedule, deployment, secret, or production authority. The dispatch runs the existing macOS 15 and Windows 2025 watchdog/core proof only.

## Validation

- pinned `actionlint` 1.7.12: pass
- platform smoke + workflow trigger policy: 19 tests passed, 0 failed, 24 assertions
- checked-in workflow trigger audit: 61 workflows, exactly 1 develop-push authority
- Windows command coverage contract: 4 lane commands, all 3 inventoried commands present
- changed-test Biome: pass
- Markdown link validation: pass
- frozen install: pass
- `git diff --check`: pass

## Evidence

N/A for screenshots/video/model/provider artifacts: this is a read-only CI trigger contract. The required real artifact is a manual exact-ref `windows-2025` platform-smoke run after this trigger lands on the default branch; #25733 remains draft until that run passes.
