### PR TITLE
test(scenario-runner): isolate app-control fixture trees per runner process

### DIFF
--- a/packages/scenario-runner/src/__tests__/app-control-scenario-fixture-isolation.test.ts
+++ b/packages/scenario-runner/src/__tests__/app-control-scenario-fixture-isolation.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Pins fixture-tree isolation for the two app-control scenarios.
+ *
+ * Both scenarios `rm -rf` their fixture root in the seed step and again in
+ * cleanup. When that root was a shared constant (`/tmp/eliza-app-control-*`),
+ * two runner processes on one host owned the same path: whichever seeded second
+ * deleted the first run's seeded apps and plugin sources mid-run, and the
+ * losing run failed with `Not a directory: <root>/apps` from the
+ * load_from_directory discovery and `Could not locate the source directory ...`
+ * from the view/app edit paths. Keying the root on the process id keeps
+ * concurrent runs isolated, so this test asserts the root is process-scoped
+ * rather than a constant any other process could also claim.
+ */
+
+import { realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+
+import actionsScenario from "../../test/scenarios/deterministic-app-control-actions.scenario.ts";
+import nlRoutingScenario from "../../test/scenarios/deterministic-app-control-nl-routing.scenario.ts";
+
+/**
+ * The apps directory each scenario actually drives its load_from_directory
+ * turn against — read from the authored turn rather than re-derived here, so
+ * the assertions cover the value the runner really uses.
+ */
+function appLoadDirectoryOf(scenario: ScenarioDefinition): string {
+  for (const turn of scenario.turns ?? []) {
+    const options = (turn as { options?: unknown }).options;
+    if (options && typeof options === "object" && !Array.isArray(options)) {
+      const record = options as Record<string, unknown>;
+      if (
+        record.action === "load_from_directory" &&
+        typeof record.directory === "string"
+      ) {
+        return record.directory;
+      }
+    }
+    const text = (turn as { text?: unknown }).text;
+    if (typeof text === "string") {
+      const match = /^Load apps from (.+) directory$/.exec(text);
+      if (match?.[1]) return match[1];
+    }
+  }
+  throw new Error(
+    `scenario ${scenario.id} has no load_from_directory turn to read a fixture root from`,
+  );
+}
+
+const scenarios: Array<[string, ScenarioDefinition]> = [
+  ["deterministic-app-control-actions", actionsScenario as ScenarioDefinition],
+  [
+    "deterministic-app-control-nl-routing",
+    nlRoutingScenario as ScenarioDefinition,
+  ],
+];
+
+describe("app-control scenario fixture isolation", () => {
+  it.each(scenarios)(
+    "%s owns a process-scoped fixture root under the OS temp dir",
+    (_id, scenario) => {
+      const appsDirectory = appLoadDirectoryOf(scenario);
+      const fixtureRoot = path.dirname(appsDirectory);
+
+      // Under the OS temp dir, not a hand-written absolute path.
+      expect(
+        fixtureRoot.startsWith(`${realpathSync(os.tmpdir())}${path.sep}`),
+      ).toBe(true);
+
+      // Process-scoped: a second concurrent runner resolves a different root,
+      // so its seed/cleanup `rm -rf` cannot reach this run's fixtures.
+      const rootName = path.basename(fixtureRoot);
+      expect(rootName).toContain(String(process.pid));
+      const otherProcessRoot = rootName.replace(
+        String(process.pid),
+        String(process.pid + 1),
+      );
+      expect(otherProcessRoot).not.toBe(rootName);
+    },
+  );
+
+  it("gives the two app-control scenarios distinct fixture roots", () => {
+    const [actionsRoot, nlRoutingRoot] = scenarios.map(([, scenario]) =>
+      path.dirname(appLoadDirectoryOf(scenario)),
+    );
+    expect(actionsRoot).not.toBe(nlRoutingRoot);
+  });
+});

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -2,7 +2,8 @@
  * Keyless catalog coverage for the plugin-app-control action surface against a
  * seeded set of scenario views. Runs on the pr-deterministic lane under the model provider.
  */
-import { promises as fs } from "node:fs";
+import { promises as fs, realpathSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type {
   CapturedAction,
@@ -85,8 +86,21 @@ function expectActionTurn(
   return undefined;
 }
 
-const appLoadDirectory = "/tmp/eliza-app-control-scenario-load/apps";
-const repoRoot = "/tmp/eliza-app-control-scenario-load/repo";
+/**
+ * Fixture tree for this scenario. The seed and cleanup steps `rm -rf` this
+ * root, so it must never be a path a second runner process could also own:
+ * a shared constant under /tmp let two concurrent runs on one host delete
+ * each other's seeded apps and plugin sources mid-run, which surfaced as
+ * "Not a directory" / "Could not locate the source directory" failures on
+ * whichever run lost the race. Keying the root on the process id keeps
+ * concurrent runs isolated without adding module-load filesystem work.
+ */
+const fixtureRoot = path.join(
+  realpathSync(os.tmpdir()),
+  `eliza-app-control-scenario-load-${process.pid}`,
+);
+const appLoadDirectory = path.join(fixtureRoot, "apps");
+const repoRoot = path.join(fixtureRoot, "repo");
 const feedPluginDir = path.join(repoRoot, "plugins", "plugin-feed");
 const remoteLedgerPluginDir = path.join(
   repoRoot,
@@ -392,7 +406,7 @@ export default scenario({
           return "runtime actions unavailable";
         }
 
-        await fs.rm(path.dirname(appLoadDirectory), {
+        await fs.rm(fixtureRoot, {
           force: true,
           recursive: true,
         });
@@ -562,7 +576,7 @@ export default scenario({
       type: "custom",
       name: "remove app-control source fixtures",
       apply: async () => {
-        await fs.rm(path.dirname(appLoadDirectory), {
+        await fs.rm(fixtureRoot, {
           force: true,
           recursive: true,
         });

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -3,7 +3,8 @@
  * plugin-app-control action against seeded scenario views. Runs on the
  * pr-deterministic lane under the model provider (fixtures pin the routing).
  */
-import { promises as fs } from "node:fs";
+import { promises as fs, realpathSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { ModelType } from "@elizaos/core";
 import { matchesScenarioInput } from "@elizaos/core/testing";
@@ -201,8 +202,21 @@ const views = [
   },
 ];
 
-const appLoadDirectory = "/tmp/eliza-app-control-nl-routing/apps";
-const repoRoot = "/tmp/eliza-app-control-nl-routing/repo";
+/**
+ * Fixture tree for this scenario. The seed and cleanup steps `rm -rf` this
+ * root, so it must never be a path a second runner process could also own:
+ * a shared constant under /tmp let two concurrent runs on one host delete
+ * each other's seeded apps and plugin sources mid-run, which surfaced as
+ * "Not a directory" / "Could not locate the source directory" failures on
+ * whichever run lost the race. Keying the root on the process id keeps
+ * concurrent runs isolated without adding module-load filesystem work.
+ */
+const fixtureRoot = path.join(
+  realpathSync(os.tmpdir()),
+  `eliza-app-control-nl-routing-${process.pid}`,
+);
+const appLoadDirectory = path.join(fixtureRoot, "apps");
+const repoRoot = path.join(fixtureRoot, "repo");
 const feedPluginDir = path.join(repoRoot, "plugins", "plugin-feed");
 const loadAppsInput = `Load apps from ${appLoadDirectory} directory`;
 const editFeedBoardInput = "Edit view feed-board plugin";
@@ -315,7 +329,7 @@ export default scenario({
         previousEvaluators = runtime.evaluators;
         runtime.evaluators = [];
 
-        await fs.rm(path.dirname(appLoadDirectory), {
+        await fs.rm(fixtureRoot, {
           force: true,
           recursive: true,
         });
@@ -716,7 +730,7 @@ export default scenario({
           previousEvaluators = null;
         }
         scenarioRuntime = null;
-        await fs.rm(path.dirname(appLoadDirectory), {
+        await fs.rm(fixtureRoot, {
           force: true,
           recursive: true,
         });


### PR DESCRIPTION
# Relates to

Scenario-lane reliability. Found while investigating two reported app-control failures — the investigation is reported honestly below, including the part where the reported bugs turned out not to exist.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`c3f070a5ee1`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** Two scenario fixture files and one new test. No product code.

# Background

## What does this PR do?

`deterministic-app-control-actions.scenario.ts` and `deterministic-app-control-nl-routing.scenario.ts` pinned their fixture trees to shared constant paths (`/tmp/eliza-app-control-scenario-load`, `/tmp/eliza-app-control-nl-routing`) and `rm -rf`'d them in **both** the seed and the cleanup step. Two runners executing the same scenario concurrently — different worktrees, CI shards, or two developers on one box — therefore delete each other's fixtures mid-run. The victim fails only on filesystem-touching turns (`Not a directory: /tmp/eliza-app-control-nl-routing/apps`, `Could not locate the source directory for Feed Board`), and because a failed action then has no matching deterministic fixture for its structured failure reply, the run surfaces the canned `Something went wrong on my end.` — which reads exactly like a planner or routing fault and sends you hunting in the wrong place.

The fix derives each fixture root from `realpathSync(os.tmpdir())` plus `process.pid`, so seed and cleanup can only ever reach the current process's tree. Eight other scenarios in this directory already use `mkdtemp`/`os.tmpdir()`; these two were the outliers.

Reproduced deterministically with two overlapping runs staggered 5 s:
- pristine `origin/develop`: run A passed, run B **failed** with the signature above
- this branch: both runs passed

## What kind of change is this?

Tests / harness reliability (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation; both scenario files now carry a header comment explaining why the root is process-scoped.

# Testing

## Where should a reviewer start?

The two `fixtureRoot` definitions and the seed/cleanup `rm -rf` calls that consume them, then `app-control-scenario-fixture-isolation.test.ts`.

## Detailed testing steps

- `cd packages/scenario-runner && bunx vitest run src/__tests__/app-control-scenario-fixture-isolation.test.ts` → 3 pass. It asserts each root is under the real tmpdir, contains this process's pid, and that a sibling process's root (pid + 1) is a different path that this run's `rm -rf` cannot reach. Mutation check: revert the two scenario files → 2 of 3 fail; restore → 3 pass.
- Both scenarios run individually (one `--scenario` per invocation): 1 passed / 0 failed each.
- `bun x vitest run` in scenario-runner: 507 passed, 1 failed — `src/echo-assertion-integrity.test.ts`, pre-existing and reproduced on pristine `origin/develop` (it fails on five `packages/test/scenarios/conversation-quality/convq.*` files this PR does not touch).
- Biome clean on all three files. Package typecheck: 121 `TS2307 Cannot find module` errors before and after, all from unbuilt sibling packages, none in a touched file.

# Evidence Gate

<!-- evidence-head:5f19db53769198ddffb3af2d2a2ad8b23db99e1c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The scenario runner's own output for the staged race: victim run's turns fail with `Not a directory: /tmp/eliza-app-control-nl-routing/apps` on pristine develop, and pass on this branch.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The fixture trees themselves — previously one shared path per scenario, now one per runner process.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The scenario runner's own output for the staged race: victim run's turns fail with `Not a directory: /tmp/eliza-app-control-nl-routing/apps` on pristine develop, and pass on this branch.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- **Two reported bugs turned out not to be bugs, and no product change was made for them.** They are recorded here because the investigation is the useful part:
  1. "Raw effect JSON reaches the user instead of human text" — it does not. Those turns are `kind: "action"`, which call `validate`/`handler` directly and bypass the message pipeline; the JSON is a deliberate internal tool receipt (`transcriptVisibility: "internal"`, documented in `views-show.ts` as *"Internal tool receipt for post-tool reasoning; never assistant prose"*), and `packages/core/src/services/message.ts` drops such content before it can reach a user. The same operations through `kind: "message"` return exactly `Opened Settings.` and `Launched Feed. Run ID: run-feed-nl-1.` Making the "fix" would have been a regression: `resolveActionResultTranscriptVisibility` suppresses a model reply whose text matches an internal result's `text`, so moving human prose into that field would have made the user see nothing at all.
  2. "NL routing dies with a synthetic failure reply" — the two turns named in the report pass; the failing turns were the filesystem ones, which is this PR's race.
- Noted but deliberately not changed: `packages/scenario-runner/src/executor.ts` derives an action turn's `responseText` from `actionResult.text` without consulting `transcriptVisibility`, which is what makes internal receipts look like user-visible replies in scenario reports. Fixing that would require rewriting the three assertions that currently pin the JSON receipt — a call worth making deliberately, not as a side effect of this PR.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

