### PR TITLE
test(app-core): cover bun-ffi

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__stubs__/bun-ffi.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__stubs__/bun-ffi.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Exercises the Vitest-only bun:ffi stub: FFIType constants, CString,
+ * ptr(), and dlopen()'s no-op symbol proxy. The real bun:ffi builtin is
+ * unavailable under Node/Vite, so this suite drives the stub module
+ * itself rather than the native implementation.
+ */
+import { describe, expect, it } from "vitest";
+import { CString, dlopen, FFIType, type Pointer, ptr } from "./bun-ffi.ts";
+
+describe("FFIType", () => {
+  it("assigns distinct sequential integer tags", () => {
+    expect(FFIType).toEqual({
+      ptr: 0,
+      bool: 1,
+      f64: 2,
+      i32: 3,
+      cstring: 4,
+      void: 5,
+    });
+    expect(new Set(Object.values(FFIType)).size).toBe(6);
+  });
+
+  it("exposes only the documented keys", () => {
+    expect(Object.keys(FFIType).sort()).toEqual(
+      ["bool", "cstring", "f64", "i32", "ptr", "void"].sort(),
+    );
+  });
+});
+
+describe("CString", () => {
+  it("is constructible from any pointer-shaped value", () => {
+    expect(new CString(0)).toBeInstanceOf(CString);
+    expect(new CString(null)).toBeInstanceOf(CString);
+    expect(new CString(undefined)).toBeInstanceOf(CString);
+    expect(new CString({})).toBeInstanceOf(CString);
+  });
+
+  it("stringifies to an empty string regardless of the stored pointer", () => {
+    expect(new CString(0).toString()).toBe("");
+    expect(new CString(1).toString()).toBe("");
+    expect(new CString("not-a-pointer").toString()).toBe("");
+    expect(new CString(null).toString()).toBe("");
+    expect(new CString(undefined).toString()).toBe("");
+    expect(new CString({ addr: 42 }).toString()).toBe("");
+  });
+});
+
+describe("ptr", () => {
+  it("returns the zero pointer for every ArrayBufferView", () => {
+    const views: ArrayBufferView[] = [
+      new Uint8Array(0),
+      new Uint8Array([1, 2, 3]),
+      new Int32Array([9]),
+      new Float64Array([1.5]),
+      new DataView(new ArrayBuffer(8)),
+    ];
+    for (const view of views) {
+      const p: Pointer = ptr(view);
+      expect(p).toBe(0);
+    }
+  });
+});
+
+describe("dlopen", () => {
+  it("returns a handle with a close method and a symbols object", () => {
+    const handle = dlopen("/tmp/missing.dylib", {});
+    expect(typeof handle.close).toBe("function");
+    expect(handle.symbols).toEqual({});
+    expect(handle.close()).toBeUndefined();
+  });
+
+  it("ignores the library path and the declared symbol table", () => {
+    const empty = dlopen("", {});
+    const named = dlopen("/does/not/exist.so", {
+      create_window: { args: [], returns: FFIType.void },
+    });
+    expect(empty.symbols.create_window()).toBe(false);
+    expect(named.symbols.create_window()).toBe(false);
+    expect(named.symbols.never_declared()).toBe(false);
+  });
+
+  it("returns false from every proxied symbol, including missing names", () => {
+    const { symbols } = dlopen("libtest", { open: {}, close: {} });
+    expect(symbols.open()).toBe(false);
+    expect(symbols.close()).toBe(false);
+    expect(symbols.missing()).toBe(false);
+    expect(symbols.open("arg", 1, { nested: true })).toBe(false);
+  });
+
+  it("yields a fresh function on each symbols property access", () => {
+    const { symbols } = dlopen("libtest", { once: {} });
+    const first = symbols.once;
+    const second = symbols.once;
+    expect(typeof first).toBe("function");
+    expect(typeof second).toBe("function");
+    expect(first).not.toBe(second);
+    expect(first()).toBe(false);
+    expect(second()).toBe(false);
+  });
+
+  it("does not throw when close is called more than once", () => {
+    const handle = dlopen("libtest", {});
+    handle.close();
+    expect(() => handle.close()).not.toThrow();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a real Vitest suite for the Electrobun Vitest-only `bun:ffi` stub at `packages/app-core/platforms/electrobun/src/__stubs__/bun-ffi.ts`. That stub had no same-named test file. The suite imports the stub module directly and asserts the behavior the code actually implements:

- `FFIType` exposes six distinct sequential integer tags (`ptr` through `void`)
- `CString` is constructible from any pointer-shaped value and always stringifies to `""`
- `ptr()` returns the zero pointer for empty and non-empty `ArrayBufferView`s
- `dlopen()` returns a handle whose `close()` is a no-op (including a second call) and whose `symbols` proxy returns `false` for declared names, missing names, extra arguments, and every property access (each access yields a fresh function)

No production code changed.

This is a fork-contributor PR. Hosted CI does not run on our PRs; do not treat GitHub check status as evidence.

## Evidence

1. **Vitest** (re-run after re-fetching current `origin/develop` at `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`, the parent of this branch):

   ```text
   cd packages/app-core/platforms/electrobun && bunx vitest run --config vitest.electrobun.config.ts src/__stubs__/bun-ffi.test.ts
   ✓ src/__stubs__/bun-ffi.test.ts (10 tests)
   Test Files  1 passed (1)
   Tests       10 passed (10)
   ```

   Electrobun tests are excluded from `@elizaos/app-core`'s default `vitest.config.ts` (`platforms/electrobun/**`), so the suite is run with `vitest.electrobun.config.ts`.

2. **Biome:** `bunx biome check --write packages/app-core/platforms/electrobun/src/__stubs__/bun-ffi.test.ts` — checked 1 file, clean after import-order write.

3. **tsc:** `cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'bun-ffi.test.ts'` — empty (this file introduces no type errors). Pre-existing errors in other packages remain.

4. **Diff:** this pull request touches only `packages/app-core/platforms/electrobun/src/__stubs__/bun-ffi.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b9e4865cfb8218b23489add01b9e2111ec9f69a4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
