### PR TITLE
test: repin prompt assertions to the complete-content contract

### DIFF
--- a/packages/agent/src/providers/ui-catalog.prompt-assembly.test.ts
+++ b/packages/agent/src/providers/ui-catalog.prompt-assembly.test.ts
@@ -103,7 +103,7 @@ describe("composed planner state — the [FORM] vocabulary reaches the prompt", 
     expect(state.text).toContain("### [FORM]");
     expect(state.text).toContain('"type":"datetime"');
     expect(state.text).toContain("checkbox | date | time |");
-    expect(state.text).toContain("Prefer date/time/datetime for schedules");
+    expect(state.text).toContain("prefer temporal types for schedules");
   });
 
   it("does not leak the generative-UI catalog into a non-admin composition", async () => {

--- a/packages/core/src/actions/__tests__/promote-subactions.test.ts
+++ b/packages/core/src/actions/__tests__/promote-subactions.test.ts
@@ -494,7 +494,17 @@ describe("MESSAGE umbrella planner tools footprint (real surface)", () => {
 			expect(tool.description).not.toContain(
 				parent.descriptionCompressed ?? "<none>",
 			);
-			expect(tool.description.length).toBeLessThan(300);
+			// No length cap: a planner tool description is model-facing context and
+			// renders completely (packages/core/CLAUDE.md — "Tool, provider, and
+			// parameter descriptions plus examples render completely"). The real
+			// contract is that a virtual adds only its own subaction blurb on top of
+			// the parent's complete description — it never re-stuffs the routing
+			// hint or the keyword-stuffed retrieval blurb.
+			expect(tool.description).toBe(
+				`${parent.description} — subaction = ${tool.name
+					.slice("MESSAGE_".length)
+					.toLowerCase()}`,
+			);
 		}
 	});
 });

--- a/packages/core/src/runtime/__tests__/compress-mode.test.ts
+++ b/packages/core/src/runtime/__tests__/compress-mode.test.ts
@@ -1,8 +1,8 @@
 /**
  * Exercises `ELIZA_PROMPT_COMPRESS` token-budget mode: the optimized-prompt
- * resolver drops few-shot demonstrations and the planner-loop routing-hints
- * block is skipped when the env flag is set. Deterministic — toggles the env var
- * directly, no model.
+ * resolver keeps every few-shot demonstration regardless of the flag, and the
+ * planner-loop routing-hints block is skipped when the env flag is set.
+ * Deterministic — toggles the env var directly, no model.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import type { OptimizedPromptService } from "../../services/optimized-prompt";
@@ -58,7 +58,7 @@ describe("Wave 2-D compress mode (ELIZA_PROMPT_COMPRESS)", () => {
 		delete process.env.ELIZA_PROMPT_COMPRESS;
 	});
 
-	it("drops few-shot demonstrations from the resolved prompt when enabled", () => {
+	it("keeps every few-shot demonstration in the resolved prompt even when enabled", () => {
 		const service = makeService({
 			prompt: "Base optimized prompt body.",
 			fewShot: 4,
@@ -69,15 +69,22 @@ describe("Wave 2-D compress mode (ELIZA_PROMPT_COMPRESS)", () => {
 		expect(before).toContain("Demonstrations:");
 		expect(before).toContain("example user 0");
 
+		// Prompt integrity (repository CLAUDE.md): model-facing content is never
+		// dropped to fit a token budget. `ELIZA_PROMPT_COMPRESS` used to strip the
+		// in-context demonstrations here; #24134 removed that so the flag can no
+		// longer change what the model is taught from.
 		process.env.ELIZA_PROMPT_COMPRESS = "1";
 		const compressed = resolveOptimizedPrompt(
 			service,
 			"message-handler",
 			baseline,
 		);
-		expect(compressed).toBe("Base optimized prompt body.");
-		expect(compressed).not.toContain("Demonstrations:");
-		expect(compressed).not.toContain("example user 0");
+		expect(compressed).toBe(before);
+		expect(compressed).toContain("Demonstrations:");
+		for (let i = 0; i < 4; i += 1) {
+			expect(compressed).toContain(`example user ${i}`);
+			expect(compressed).toContain(`example out ${i}`);
+		}
 	});
 
 	it("falls back to baseline when no service is registered", () => {


### PR DESCRIPTION
Three tests on `develop` still assert model-facing prompt text that develop intentionally changed. Production code is untouched; only the stale assertions move.

## Failing output before (origin/develop @ c3f070a5ee)

```
 FAIL  packages/core/src/runtime/__tests__/compress-mode.test.ts > Wave 2-D compress mode (ELIZA_PROMPT_COMPRESS) > drops few-shot demonstrations from the resolved prompt when enabled
AssertionError: expected 'Base optimized prompt body.\n\nDemons…' to be 'Base optimized prompt body.'

 FAIL  packages/core/src/actions/__tests__/promote-subactions.test.ts > MESSAGE umbrella planner tools footprint (real surface) > virtual tool descriptions no longer duplicate the parent's routing hint and blurb
AssertionError: expected 409 to be less than 300

 FAIL  packages/agent/src/providers/ui-catalog.prompt-assembly.test.ts > composed planner state — the [FORM] vocabulary reaches the prompt > carries the FORM grammar and native date/time field types for a GUEST scheduling turn
AssertionError: expected '…' to contain 'Prefer date/time/datetime for schedules'

 Test Files  3 failed (3)
      Tests  3 failed | 31 passed (34)
```

## Cause per file

| Test | Commit that changed the contract |
| --- | --- |
| `compress-mode.test.ts` | `423aea34a0` — `fix: preserve complete model context (#24134)` removed the `ELIZA_PROMPT_COMPRESS=1` branch in `resolveOptimizedPrompt` that dropped few-shot demonstrations, plus the 600/400/200-char truncation in `trimDemonstrationInput`. Per the repository `CLAUDE.md` prompt-integrity rule, a token budget must never silently remove model-facing content, so the flag can no longer change what the model is taught from. The PR did not update this older test. |
| `promote-subactions.test.ts` | `1c98cbde50` — `feat(core): add authorized cross-world continuity (#24842)` grew the MESSAGE umbrella `description` from ~248 to 393 chars. Promoted virtuals compose `${parent.description} — subaction = x`, so every child tool description is now ~409–424 chars and trips the old `< 300` guard. `def3aca0f1` (`fix(core): preserve complete action prompt metadata (#24772)`) also made `packages/core/CLAUDE.md` explicit: "Tool, provider, and parameter descriptions plus examples render completely; compressed fields are compatibility metadata only." A byte cap on a planner tool description is exactly the model-facing cap that rule forbids. |
| `ui-catalog.prompt-assembly.test.ts` | `bd82c29466` — `feat(ui): inline connector cards + secure secret UX in chat (#24633)` reworded the `[FORM]` field-type line to fit `[CONNECTOR:pluginId]` inside the guide's 60-line budget: `Prefer date/time/datetime for schedules.` → `(prefer temporal types for schedules; …)`. Same semantics, new wording. |

## What changed here

- `compress-mode.test.ts`: the first case now asserts the demonstrations **survive** `ELIZA_PROMPT_COMPRESS=1` — the resolved prompt is byte-identical with and without the flag and still contains every `example user N` / `example out N`. Header updated.
- `promote-subactions.test.ts`: the `< 300` length cap is replaced by the assertion the test was really about — each virtual's description is exactly `${parent.description} — subaction = <sub>`, so it adds only its own blurb and still never re-stuffs the parent's `routingHint` or `descriptionCompressed` (both `not.toContain` assertions are kept).
- `ui-catalog.prompt-assembly.test.ts`: assertion repinned to `prefer temporal types for schedules`.

## Passing output after

```
 Test Files  3 passed (3)
      Tests  34 passed (34)
```

## Mutation check

Reversed the production behaviour each assertion covers, all three at once:

1. Re-added the `process.env.ELIZA_PROMPT_COMPRESS === "1" ||` short-circuit in `optimized-prompt-resolver.ts`.
2. Appended `.slice(0, 280)` to the composed virtual description in `promote-subactions.ts`.
3. Changed `prefer temporal types for schedules` → `use any type for schedules` in `ui-catalog.ts`.

Result with the mutations applied: **3 failed | 31 passed (34)** — one failure per repinned test. Production files restored (`git checkout --`) and re-run: **34 passed (34)**.

## Not included

`packages/core/src/services/optimized-prompt-resolver.test.ts` is red on develop for the same `#24134` cause (`keeps surrogate pairs intact at the 600 candidate boundary` and `keeps surrogate pairs intact in rawInput head/tail fallback` still assert the removed 600/400/200-char truncation). Left out of this PR to avoid colliding with a concurrent fix on that file.
