### PR TITLE
test(app-core): cover electrobun-bun

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__stubs__/electrobun-bun.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__stubs__/electrobun-bun.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Exercises the electrobun/bun Vitest stub that stands in for the native module.
+ * Imports the stub file directly and records its no-op named-export contract.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ApplicationMenu,
+  BrowserView,
+  BrowserWindow,
+  BuildConfig,
+  Electrobun,
+  Updater,
+  Utils,
+  WGPU,
+  webgpu,
+} from "./electrobun-bun";
+
+const EMPTY_NAMESPACE_EXPORTS = {
+  ApplicationMenu,
+  BrowserView,
+  BrowserWindow,
+  BuildConfig,
+  Updater,
+  WGPU,
+  webgpu,
+} as const;
+
+describe("electrobun/bun vitest stub", () => {
+  it("exports exactly the named namespaces the alias is written to provide", async () => {
+    const module = await import("./electrobun-bun");
+    expect(Object.keys(module).sort()).toEqual([
+      "ApplicationMenu",
+      "BrowserView",
+      "BrowserWindow",
+      "BuildConfig",
+      "Electrobun",
+      "Updater",
+      "Utils",
+      "WGPU",
+      "webgpu",
+    ]);
+  });
+
+  it("exposes Utils.quit as a no-op that returns undefined on every call", () => {
+    expect(Object.keys(Utils)).toEqual(["quit"]);
+    expect(typeof Utils.quit).toBe("function");
+    expect(Utils.quit()).toBeUndefined();
+    expect(Utils.quit()).toBeUndefined();
+  });
+
+  it("exposes Electrobun.events.on as a no-op that never invokes a listener", () => {
+    expect(Object.keys(Electrobun)).toEqual(["events"]);
+    expect(Object.keys(Electrobun.events)).toEqual(["on"]);
+    expect(typeof Electrobun.events.on).toBe("function");
+    expect(Electrobun.events.on()).toBeUndefined();
+
+    let invoked = false;
+    const on = Electrobun.events.on as (
+      event?: string,
+      handler?: () => void,
+    ) => unknown;
+    expect(
+      on("ready", () => {
+        invoked = true;
+      }),
+    ).toBeUndefined();
+    expect(invoked).toBe(false);
+  });
+
+  it("exports empty, distinct placeholder objects for the remaining namespaces", () => {
+    const seen = new Set<object>();
+    for (const [name, value] of Object.entries(EMPTY_NAMESPACE_EXPORTS)) {
+      expect({ name, value }).toEqual({ name, value: {} });
+      expect(Object.keys(value)).toEqual([]);
+      expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+      expect(seen.has(value)).toBe(false);
+      seen.add(value);
+    }
+  });
+
+  it("does not treat the empty namespace objects as constructors", () => {
+    for (const value of Object.values(EMPTY_NAMESPACE_EXPORTS)) {
+      const Ctor = value as unknown as new () => unknown;
+      expect(() => new Ctor()).toThrow(TypeError);
+    }
+  });
+
+  it("returns the same module instance on re-import", async () => {
+    const again = await import("./electrobun-bun");
+    expect(again.Utils).toBe(Utils);
+    expect(again.Electrobun).toBe(Electrobun);
+    expect(again.BrowserWindow).toBe(BrowserWindow);
+    expect(again.webgpu).toBe(webgpu);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a real Vitest suite for the Electrobun Vitest-only `electrobun/bun` stub at `packages/app-core/platforms/electrobun/src/__stubs__/electrobun-bun.ts`. That stub had no same-named test file. The suite imports the stub module directly and asserts the behavior the code actually implements:

- Named exports are exactly `Utils`, `BrowserWindow`, `BrowserView`, `ApplicationMenu`, `BuildConfig`, `Updater`, `WGPU`, `webgpu`, and `Electrobun`
- `Utils.quit` is a no-op that returns `undefined` on every call
- `Electrobun.events.on` is a no-op that returns `undefined` and never invokes a listener
- The remaining namespaces are empty, distinct, non-constructable placeholder objects
- Re-importing the module returns the same live bindings

No production code changed.

This is a fork-contributor PR. Hosted CI does not run on our PRs; do not treat GitHub check status as evidence.

## Evidence

1. **Vitest** (re-run after re-fetching current `origin/develop` at `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`, the parent of this branch):

   ```text
   cd packages/app-core/platforms/electrobun && bunx vitest run --config vitest.electrobun.config.ts src/__stubs__/electrobun-bun.test.ts
   ✓ src/__stubs__/electrobun-bun.test.ts (6 tests)
   Test Files  1 passed (1)
   Tests       6 passed (6)
   ```

   Electrobun tests are excluded from `@elizaos/app-core`'s default `vitest.config.ts` (`platforms/electrobun/**`), so the suite is run with `vitest.electrobun.config.ts`.

2. **Biome:** `bunx biome check --write packages/app-core/platforms/electrobun/src/__stubs__/electrobun-bun.test.ts` — Checked 1 file, no fixes applied.

3. **tsc:** `cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'electrobun-bun.test.ts'` — empty (this file introduces no type errors). Pre-existing errors in other packages remain.

4. **Diff:** this pull request touches only `packages/app-core/platforms/electrobun/src/__stubs__/electrobun-bun.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8b907033716a91ffca49bd9b5b4b0fe820c76243 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
