### PR TITLE
test(core): align stale caps with the lossless-content contract

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -88,7 +88,7 @@ describe("TrajectoriesService", () => {
 		await service.stop();
 	});
 
-	it("persists LLM calls with bounded JSON-safe payloads", async () => {
+	it("persists LLM calls with complete JSON-safe payloads", async () => {
 		const trajectoryId = "00000000-0000-4000-8000-000000000010";
 		const stepId = "00000000-0000-4000-8000-000000000011";
 		const runtimeSecret = "SYNTH-CORE-DB-RUNTIME-SECRET-1111";
@@ -182,7 +182,6 @@ describe("TrajectoriesService", () => {
 		await service.flushWriteQueue(trajectoryId);
 
 		expect(updates).toHaveLength(1);
-		expect(updates[0].length).toBeLessThan(350_000);
 
 		const persisted = JSON.parse(row.steps_json);
 		const persistedJson = JSON.stringify(persisted);
@@ -190,7 +189,11 @@ describe("TrajectoriesService", () => {
 		expect(persistedJson).not.toContain(flagCanary);
 		expect(persistedJson).not.toContain(uriCanary);
 		const call = persisted[0].llmCalls[0];
-		expect(call.messages[0].content).toMatch(/\.{3}\[truncated\]$/);
+		// A recorded model call is training/evaluation input: CLAUDE.md forbids
+		// compacting or truncating it, so the 120k-character message body is
+		// persisted whole (only the secret canaries are redacted).
+		expect(call.messages[0].content).not.toContain("[truncated]");
+		expect(call.messages[0].content).toContain("m".repeat(120_000));
 		expect(call.tools.circular.self).toBe("[REDACTED]");
 		expect(call.tools.circular.fn).toBe("[Function toolHandler]");
 		expect(call.providerMetadata.self).toBe("[REDACTED]");
@@ -504,7 +507,7 @@ describe("TrajectoriesService", () => {
 		});
 	});
 
-	it("keeps the step envelope readable when payload exhausts the sanitization budget", async () => {
+	it("keeps the step envelope readable across repeated oversized planner captures", async () => {
 		const trajectoryId = "00000000-0000-4000-8000-000000000040";
 		const stepId = "00000000-0000-4000-8000-000000000041";
 		const row = makeTrajectoryRow(trajectoryId, stepId);
@@ -529,10 +532,11 @@ describe("TrajectoriesService", () => {
 			return { rows: [], columns: [] };
 		};
 
-		// Two planner-style calls whose tool schemas together cross the shared
-		// node budget at write time — the live incident shape (2026-08-10: the
-		// second call's tools broke out of the step object mid-walk and the
-		// dropped trailing keys made every subsequent read of the row throw).
+		// Two planner-style calls carrying large tool schemas — the live incident
+		// shape (2026-08-10: the second call's tools broke out of the step object
+		// mid-walk and the dropped trailing keys made every subsequent read of the
+		// row throw). Sanitization is now lossless, so both calls persist whole
+		// and the envelope's required keys are always written.
 		const bigTools = Array.from({ length: 200 }, (_, i) => ({
 			name: `tool${i}`,
 			description: "d",
@@ -572,7 +576,10 @@ describe("TrajectoriesService", () => {
 		expect(afterOverflow[0].reward).toBe(0);
 		expect(afterOverflow[0].done).toBe(false);
 		expect(Array.isArray(afterOverflow[0].providerAccesses)).toBe(true);
-		expect(afterOverflow[0].metadata.truncatedLlmCalls).toBe(1);
+		// No call is dropped, so no truncation counter is minted.
+		expect(afterOverflow[0].llmCalls).toHaveLength(2);
+		expect(afterOverflow[0].llmCalls[1].tools).toHaveLength(bigTools.length);
+		expect(afterOverflow[0].metadata?.truncatedLlmCalls).toBeUndefined();
 
 		// The row must still accept captures — pre-fix this write was lost to
 		// TRAJECTORY_ROW_INVALID and the trajectory could never terminalize.
@@ -580,10 +587,10 @@ describe("TrajectoriesService", () => {
 		await service.flushWriteQueue(trajectoryId);
 
 		const persisted = JSON.parse(row.steps_json);
-		expect(persisted[0].llmCalls).toHaveLength(2);
+		expect(persisted[0].llmCalls).toHaveLength(3);
 		expect(persisted[0].reward).toBe(0);
 		expect(persisted[0].done).toBe(false);
-		expect(persisted[0].metadata.truncatedLlmCalls).toBe(1);
+		expect(persisted[0].metadata?.truncatedLlmCalls).toBeUndefined();
 	});
 
 	it("reads legacy rows whose steps lost trailing keys to budget truncation", async () => {

--- a/packages/core/src/services/message.surrogate.test.ts
+++ b/packages/core/src/services/message.surrogate.test.ts
@@ -1,5 +1,9 @@
 /**
- * Regression for message `cleanPriorDialogueSpeakerName` surrogate-safe truncation (80/77).
+ * Regression for message `cleanPriorDialogueSpeakerName` surrogate-safe
+ * normalization. The speaker name is prefixed onto prior-dialogue lines that go
+ * into the prompt, so CLAUDE.md's prompt-integrity rule forbids capping it: the
+ * helper only trims, collapses whitespace, and repairs lone surrogates. These
+ * cases pin that a long or emoji-bearing name survives complete and well-formed.
  */
 
 import { describe, expect, it } from "vitest";
@@ -25,19 +29,17 @@ function isWellFormed(value: string): boolean {
 }
 
 describe("cleanPriorDialogueSpeakerName well-formed", () => {
-	it("keeps surrogate pairs intact at 80 boundary (77+...)", () => {
+	it("keeps a long emoji-bearing name complete and well-formed", () => {
 		const emoji = String.fromCharCode(0xd83d, 0xde00);
 		const input = `${"a".repeat(76)}${emoji}${"b".repeat(20)}`;
 		const out = cleanPriorDialogueSpeakerName(input) ?? "";
 		expect(isWellFormed(out)).toBe(true);
-		expect(out.length).toBeLessThanOrEqual(80);
-		// Should back off, not split emoji
-		expect(out.endsWith("...")).toBe(true);
-		expect(out.slice(0, -3).length).toBeLessThanOrEqual(77);
-		expect(out.slice(0, -3).length).toBeGreaterThanOrEqual(76);
+		// No cap and no ellipsis: the name reaches the prompt intact.
+		expect(out).toBe(input);
+		expect(out.endsWith("...")).toBe(false);
 	});
 
-	it("preserves fitting emoji under 80", () => {
+	it("preserves a well-formed emoji name of exactly 80 units", () => {
 		const emoji = String.fromCharCode(0xd83d, 0xde00);
 		const input = `${"a".repeat(78)}${emoji}`;
 		const out = cleanPriorDialogueSpeakerName(input) ?? "";
@@ -59,13 +61,13 @@ describe("cleanPriorDialogueSpeakerName well-formed", () => {
 		expect(isWellFormed(out)).toBe(true);
 	});
 
-	it("sweep around 80 all well-formed", () => {
+	it("sweep around 80 stays complete and well-formed", () => {
 		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
 		for (let n = 75; n <= 85; n++) {
 			const input = `${"x".repeat(n)}${emoji}${"y".repeat(20)}`;
 			const out = cleanPriorDialogueSpeakerName(input) ?? "";
 			expect(isWellFormed(out)).toBe(true);
-			expect(out.length).toBeLessThanOrEqual(80);
+			expect(out).toBe(input);
 		}
 	});
 

--- a/packages/core/src/truncation-suffix-reserve-3.test.ts
+++ b/packages/core/src/truncation-suffix-reserve-3.test.ts
@@ -44,24 +44,26 @@ describe("truncation suffix reserve batch3 (ship 11) — 7 sites", () => {
 		expect(fixedTrunc(s, MAX, suffix).length).toBe(400);
 	});
 
-	it("TR-4 message subAgentCompletionRelayBody 1500+1: caps at 1500", () => {
+	it("TR-4 message subAgentCompletionRelayBody delivers the complete relay body", () => {
 		const MAX = 1500;
 		const suffix = "…";
 		const s = "a".repeat(1510);
-		// math proof
+		// The reserve arithmetic itself still holds wherever a real hard limit
+		// forces a suffix-bearing cap.
 		expect(oldTrunc(s, MAX, suffix).length).toBe(1501);
 		expect(fixedTrunc(s, MAX, suffix).length).toBe(1500);
-		// real function proof: subAgentCompletionRelayBody trims header then caps body at 1500
+		// subAgentCompletionRelayBody is NOT such a site: the relay body it returns
+		// becomes the delivered reply text on a degraded planner turn, so the
+		// prompt-integrity rule in CLAUDE.md ("never use a character/token cap,
+		// prefix or suffix slice … to make model-facing content fit") forbids
+		// capping it. It trims the header and returns the body complete.
 		const header = "[sub-agent:task_complete]";
 		const body = "a".repeat(2000);
 		const input = `${header} ${body}`;
 		const out = subAgentCompletionRelayBody(input);
-		expect(out).toBeDefined();
-		expect(out?.length).toBeLessThanOrEqual(1500);
-		expect(out?.length).toBe(1500); // 1499 'a' + '…'
-		// sabotage: old would be 1501
-		const oldBody = `${body.slice(0, MAX).trimEnd()}…`;
-		expect(oldBody.length).toBe(1501);
+		expect(out).toBe(body);
+		expect(out?.length).toBe(2000);
+		expect(out?.endsWith(suffix)).toBe(false);
 	});
 
 	it("TR-5 media fetch readErrorBodySnippet 200+1: old 201 vs fixed 200", () => {


### PR DESCRIPTION
`develop` is red on three core tests that still assert caps the production code
deliberately no longer applies. Per CLAUDE.md's prompt-integrity rule — *"Never
use a character/token cap, prefix or suffix slice, item-count limit, rolling
buffer, summary, compaction, or 'most recent' window to make model-facing
content fit"* — the production side is correct and the tests are stale.

Three sites:

| Helper | Why it must stay complete |
| --- | --- |
| `subAgentCompletionRelayBody` (`packages/core/src/services/message.ts`) | Its return value becomes the delivered reply text on a degraded planner turn (the `error-policy:J4` path in `plannerLoop`). |
| `cleanPriorDialogueSpeakerName` (same file) | The name is prefixed onto prior-dialogue lines that go into the prompt (`priorDialogueContent`). |
| `sanitizeTrajectoryJsonValue*` (`packages/core/src/services/trajectory-json.ts`) | Its own header states the contract: *"Lossless JSON normalization shared by every trajectory persistence owner. Strings and collection members are preserved completely."* CLAUDE.md names recorded requests/responses explicitly. |

Only the tests changed. The suffix-reserve arithmetic (`MAX - suffix.length`) is
still pinned in `truncation-suffix-reserve-3.test.ts` for the sites that do have
a real hard limit — only the `subAgentCompletionRelayBody` case, which is not
such a site, was reframed.

### Failing before

```
 FAIL  packages/core/src/truncation-suffix-reserve-3.test.ts > TR-4 message subAgentCompletionRelayBody 1500+1: caps at 1500
AssertionError: expected 2000 to be less than or equal to 1500

 FAIL  packages/core/src/services/message.surrogate.test.ts > keeps surrogate pairs intact at 80 boundary (77+...)
AssertionError: expected 98 to be less than or equal to 80

 FAIL  packages/core/src/services/message.surrogate.test.ts > sweep around 80 all well-formed
AssertionError: expected 97 to be less than or equal to 80

 FAIL  packages/core/src/features/trajectories/TrajectoriesService.test.ts > persists LLM calls with bounded JSON-safe payloads
AssertionError: expected 481746 to be less than 350000

 FAIL  packages/core/src/features/trajectories/TrajectoriesService.test.ts > keeps the step envelope readable when payload exhausts the sanitization budget
TypeError: Cannot read properties of undefined (reading 'truncatedLlmCalls')

 Test Files  3 failed (3)
      Tests  5 failed | 22 passed (27)
```

### Passing after

```
 Test Files  3 passed (3)
      Tests  27 passed (27)
```

### Mutation check

Reversing the production behaviour each rewritten assertion covers, then
restoring:

1. Re-added `body.length > 1500 ? body.slice(0, 1499) + '…' : body` to
   `subAgentCompletionRelayBody`, `normalized.length > 80 ? … + '...'` to
   `cleanPriorDialogueSpeakerName`, and a 2000-char `…[truncated]` cap to
   `normalizedScalar` in `trajectory-json.ts`:
   **`Tests  4 failed | 23 passed (27)`** — TR-4, both surrogate cases, and
   "persists LLM calls with complete JSON-safe payloads".
2. Separately forced `boundStepsForPersistence` to drop every llmCall after the
   first (restoring the old budget-drop behaviour):
   **`Tests  2 failed | 11 passed (13)`** — "keeps the step envelope readable
   across repeated oversized planner captures" (plus the legacy-row sibling).
3. Restored production, re-ran: **`Tests  27 passed (27)`**.

### Introducing commit

Not attributable from this checkout: `git log -S` for every removed cap bottoms
out at `f884500c2a` ("fix(cloud): fence agent compute billing authority
(#24195)"), which is the **root commit** of the available history (`%p` is
empty) — the uncapped production code and the stale assertions both first appear
together there. The direction of the fix is settled by CLAUDE.md and by
`trajectory-json.ts`'s own header rather than by blame.
