### PR TITLE
test(agent): refresh agent-surface and public-route guards after view/route sweep

### DIFF
--- a/packages/agent/src/__tests__/view-agent-surface-coverage.test.ts
+++ b/packages/agent/src/__tests__/view-agent-surface-coverage.test.ts
@@ -47,11 +47,21 @@ function walkTsx(dir: string): string[] {
   return out;
 }
 
+/**
+ * A view is agent-addressable either by calling `useAgentElement` directly or by
+ * handing a spatial primitive its `agent` prop — `@elizaos/ui/spatial` normalizes
+ * that prop and emits the same `data-agent-id` anchor the hook registers, so the
+ * floating pill can address it. Views that own their controls through spatial
+ * primitives (Messages, Phone) carry no direct hook call.
+ */
+const SPATIAL_AGENT_PROP = /\bagent=(?:\{|")/;
+
 function registersAgentElement(pluginDir: string): boolean {
   const srcDir = path.join(PLUGINS_DIR, pluginDir, "src");
-  return walkTsx(srcDir).some((file) =>
-    readFileSync(file, "utf8").includes("useAgentElement"),
-  );
+  return walkTsx(srcDir).some((file) => {
+    const src = readFileSync(file, "utf8");
+    return src.includes("useAgentElement") || SPATIAL_AGENT_PROP.test(src);
+  });
 }
 
 const UI_COMPONENTS_DIR = path.resolve(here, "../../../ui/src/components");

--- a/packages/agent/src/api/__tests__/public-route-allowlist.test.ts
+++ b/packages/agent/src/api/__tests__/public-route-allowlist.test.ts
@@ -283,8 +283,12 @@ const ALLOWLIST: Record<string, string> = {
     "browser-extension companion revoke; companion-token auth, not dashboard JWT",
   "/api/browser-bridge/companions/sessions/:id/complete":
     "browser-extension companion session complete; companion-token auth",
+  "/api/browser-bridge/companions/sessions/:id/actions/begin":
+    "browser-extension companion session action begin; companion-token auth (getBrowserCompanionAuth + pairing token), rate limited",
   "/api/browser-bridge/companions/sessions/:id/progress":
     "browser-extension companion session progress; companion-token auth",
+  "/api/browser-bridge/companions/preflight":
+    "browser-extension companion preflight; companion-token auth, same gate as /companions/sync",
   "/api/browser-bridge/companions/sync":
     "browser-extension companion sync; companion-token auth",
 
@@ -331,10 +335,6 @@ const ALLOWLIST: Record<string, string> = {
   "/api/whatsapp/webhook (whatsapp-webhook-event)":
     "Meta webhook delivery must bypass auth",
 
-  // plugin-bluebubbles
-  "bluebubbles-webhook":
-    "BlueBubbles webhook delivery must bypass auth (path is a runtime const)",
-
   // @elizaos/ui cloud public pages — reachable by external/unauthenticated users.
   "payment/:paymentRequestId":
     "cloud public page: external payer; the request id is the capability link",
@@ -365,6 +365,8 @@ const ALLOWLIST: Record<string, string> = {
     "cloud public page: resumes the OpenID Provider authorization request after login; must render before authentication so the API origin can validate the parked request",
   "terms-of-service": "cloud public page: legal page, no auth",
   "privacy-policy": "cloud public page: legal page, no auth",
+  "account-deletion":
+    "cloud public page: legal page (store-mandated deletion instructions), no auth",
   bsc: "cloud public page: BSC landing page, no auth",
 };
 


### PR DESCRIPTION
Two repo-scanning guards in `packages/agent` went red after the merge sweep.
Neither production behaviour is wrong; both guards are out of date with the tree
they scan. No production file changes in this PR.

### 1. `view-agent-surface-coverage.test.ts`

`fix(views): remove duplicate plugin operations (#24400)` (`92e7cc9cd4`)
canonicalized Phone and Messages interaction ownership onto the spatial
primitives, deleting the duplicate direct `useAgentElement` registrations in
`MessagesView.tsx` / `PhoneView.tsx` and moving the descriptors onto the
primitives' `agent` prop, e.g.

```tsx
agent={{ id: "messages-send", role: "button", label: "Send SMS" }}
```

`@elizaos/ui/spatial` `normalizeAgent` / `agentDataProps`
(`packages/ui/src/spatial/primitives.tsx`) turns that prop into the same
`data-agent-id` / `data-agent-role` / `data-agent-label` anchor
`useAgentElement` registers, so both views remain agent-addressable. The guard's
grep for the literal string `useAgentElement` simply could not see it. It now
accepts either form.

### 2. `public-route-allowlist.test.ts`

Three routes that already set `public: true` in the tree were not enumerated,
and one enumerated entry no longer matches anything.

- `/api/browser-bridge/companions/preflight` and
  `/api/browser-bridge/companions/sessions/:id/actions/begin` — both handlers in
  `plugins/plugin-browser/src/routes/bridge.ts` gate on
  `getBrowserCompanionAuth(ctx)` plus the pairing token and go through
  `rateLimitRequest`, exactly like the already-allowlisted
  `/companions/sync`, `/companions/sessions/:id/progress` and `/complete`. Their
  declarations carry the same `publicReason` / `publicWrite` strings as their
  allowlisted siblings.
- `account-deletion` (`packages/ui/src/cloud/public-pages/register.ts`) — a
  cloud legal page registered with the same `PUBLIC_ROUTE_ACCESS` spread as the
  already-allowlisted `terms-of-service` and `privacy-policy`.
- `bluebubbles-webhook` — stale. `plugins/plugin-bluebubbles` is gone from the
  tree; the only remaining reference is a fixture literal in
  `packages/agent/src/api/runtime-plugin-routes.test.ts`.

These routes were already public before this PR; the allowlist only records that
they were reviewed. A security reviewer should still confirm the two
browser-companion entries.

### Failing before

```
 FAIL  packages/agent/src/__tests__/view-agent-surface-coverage.test.ts > plugin-messages registers at least one agent-surface element
 FAIL  packages/agent/src/__tests__/view-agent-surface-coverage.test.ts > plugin-phone registers at least one agent-surface element
AssertionError: expected false to be true // Object.is equality

 FAIL  packages/agent/src/api/__tests__/public-route-allowlist.test.ts > every public:true route is enumerated in the allowlist
AssertionError: Unlisted public:true route(s) found...
+   "/api/browser-bridge/companions/preflight  [plugins/plugin-browser/src/plugin.ts]",
+   "/api/browser-bridge/companions/sessions/:id/actions/begin  [plugins/plugin-browser/src/plugin.ts]",
+   "account-deletion  [packages/ui/src/cloud/public-pages/register.ts]",

 FAIL  packages/agent/src/api/__tests__/public-route-allowlist.test.ts > has no stale allowlist entries
AssertionError: Allowlist entries no longer match any public:true route; remove them:
+   "bluebubbles-webhook",

      Tests  4 failed | 57 passed (61)
```

### Passing after

```
 Test Files  2 passed (2)
      Tests  61 passed (61)
```

### Mutation check

Reversed both guarded behaviours at once:

- stripped every `agent=` prop from `plugins/plugin-phone/src/components/PhoneSpatialView.tsx`
  (making the view genuinely unaddressable), and
- added `public: true` to `{ type: "GET", path: "/api/browser-bridge/tabs" }` in
  `plugins/plugin-browser/src/plugin.ts` without an allowlist entry.

Result: **`Tests  2 failed | 59 passed (61)`** — "plugin-phone registers at
least one agent-surface element" and "every public:true route is enumerated in
the allowlist". Both production files restored; re-ran clean:
**`Tests  61 passed (61)`**.

### Introducing commits

- Agent-surface guard: `92e7cc9cd4` `fix(views): remove duplicate plugin operations (#24400)`.
- Public-route allowlist: not attributable — the three unlisted routes and the
  stale entry all already have their current shape at `f884500c2a`, the **root
  commit** of the available history (`%p` empty), so the drift predates the
  grafted history in this checkout.
