### PR TITLE
fix(core): coalesce limit-less room messages-scans

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11385,20 +11385,34 @@ ${section_end}`;
 		) {
 			return null;
 		}
-		const requested = params.limit ?? params.count;
+		const requestedLimit = params.limit ?? params.count;
+		// A caller that pins no limit asks for the room's complete retained
+		// window — the shape the prompt-integrity providers (RECENT_MESSAGES,
+		// FACTS, ATTACHMENTS) now use after they stopped capping model-facing
+		// history. Treat it as an infinite request so it still coalesces: the
+		// superset fetch drops the limit, `meta` records an unbounded window,
+		// and no bounded cache entry can ever serve it (Infinity fails the
+		// superset check), so coalescing can never shorten a complete read.
+		const unbounded = requestedLimit === undefined;
 		if (
-			typeof requested !== "number" ||
-			!Number.isFinite(requested) ||
-			requested <= 0
+			!unbounded &&
+			(typeof requestedLimit !== "number" ||
+				!Number.isFinite(requestedLimit) ||
+				requestedLimit <= 0)
 		) {
 			return null;
 		}
+		const requested = unbounded
+			? Number.POSITIVE_INFINITY
+			: (requestedLimit as number);
 		const roomId = params.roomId;
-		const supersetLimit = Math.max(
-			requested,
-			this.getConversationLength(),
-			AgentRuntime.ROOM_MESSAGES_MEMO_MIN_WINDOW,
-		);
+		const supersetLimit = unbounded
+			? Number.POSITIVE_INFINITY
+			: Math.max(
+					requested,
+					this.getConversationLength(),
+					AgentRuntime.ROOM_MESSAGES_MEMO_MIN_WINDOW,
+				);
 		const cached = this.roomMessagesMemo.peek(roomId);
 		const window =
 			cached && cached.meta >= requested
@@ -11409,7 +11423,7 @@ ${section_end}`;
 						this.adapter.getMemories({
 							tableName: "messages",
 							roomId,
-							limit: supersetLimit,
+							...(unbounded ? {} : { limit: supersetLimit }),
 							unique: false,
 						}),
 					);


### PR DESCRIPTION
## Problem

`packages/core/src/__tests__/turn-read-coalescing.test.ts` is red on `develop`.

```
FAIL  packages/core/src/__tests__/turn-read-coalescing.test.ts > composeState over real providers
      > runs RECENT_MESSAGES + ATTACHMENTS + FACTS with a single room messages-scan
AssertionError: expected 3 to be 1 // Object.is equality
 ❯ packages/core/src/__tests__/turn-read-coalescing.test.ts:340:52
    340|   expect(counts.messagesScans - countsAfterIntake).toBe(1);

 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

## Cause

`423aea34a0` — `fix: preserve complete model context (#24134)` — removed the row
caps from the RECENT_MESSAGES / FACTS / ATTACHMENTS providers so the planner
prompt keeps the room's complete retained history (root `CLAUDE.md`, "Prompt
integrity: never discard model context"). That is correct and stays.

The side effect: those providers now call `runtime.getMemories` with **no**
`limit`/`count`. `AgentRuntime.coalesceRoomMessagesScan` was written assuming a
limit always exists:

```ts
const requested = params.limit ?? params.count;
if (typeof requested !== "number" || !Number.isFinite(requested) || requested <= 0) {
  return null;   // memo bypassed
}
```

so every limit-less scan fell straight through to the adapter. Instrumenting the
adapter during the failing test shows three separate, byte-identical queries per
compose:

```
DBG scan {"tableName":"messages","roomId":"3333...3331","unique":false}
DBG scan {"tableName":"messages","roomId":"3333...3331","unique":false}
DBG scan {"roomId":"3333...3331","unique":false,"tableName":"messages"}
```

The test is not asserting a cap — it asserts the read-coalescing contract, which
genuinely regressed: one turn now costs 3 full-room scans instead of 1. On a
single-threaded store (PGlite WASM) those serialize, so this is real
composeState latency, not a bookkeeping detail. The production code is the bug.

## Fix

Treat a limit-less request as an infinite one in `coalesceRoomMessagesScan`:

- the superset fetch omits `limit` (a complete read stays complete);
- `meta` records the unbounded window as `Infinity`;
- a bounded cache entry can never serve an infinite request (`meta >= requested`
  fails), so coalescing can never shorten a complete read;
- bounded callers keep slicing the shared newest-first window exactly as before.

No test file was modified.

## After

```
 ✓ packages/core/src/__tests__/turn-read-coalescing.test.ts (11 tests) 30ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

No new failures elsewhere in core (same sandbox, same commit, with/without the patch):

| suite | before | after |
| --- | --- | --- |
| `src/__tests__` + `src/features/basic-capabilities` + `src/features/advanced-capabilities` | 36 failed / 1564 passed | **35 failed / 1565 passed** |
| `src/services` | 20 failed / 1227 passed | **18 failed / 1229 passed** |
| `src/runtime` | 5 failed / 1676 passed | 5 failed / 1676 passed |

(The remaining failures are pre-existing on `develop` and unrelated to this change.)

## Also fixed by the same root cause

`packages/core/src/services/message.deliver-then-persist.test.ts` (and
`message-planner-rescue-lane.test.ts`, which imports it) failed for the same
reason: with coalescing disabled, the delivery callback's `storedReplies()` read
paid a full adapter round-trip, during which the concurrent reply persist
completed, so `repliesVisibleAtDelivery` came back `1` instead of `0`.

Before:
```
FAIL packages/core/src/services/message.deliver-then-persist.test.ts
     > fires the delivery callback before the reply persist completes, then still persists it
AssertionError: expected 1 to be +0
 Tests  1 failed | 8 passed (9)
```
After:
```
 Test Files  1 passed (1)
      Tests  9 passed (9)

 packages/core/src/services/message-planner-rescue-lane.test.ts
      Tests  284 passed (284)
```

## Mutation check

Reversed the production behaviour the test covers — forced the memo lookup to
always miss (`const cached = null` in `coalesceRoomMessagesScan`) while keeping
the rest of the patch:

```
 Test Files  1 failed (1)
      Tests  3 failed | 8 passed (11)
```

Restored:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
