### PR TITLE
fix(tests): repair stale develop-red tests after the merge sweep

### DIFF
--- a/packages/agent/src/api/chat-augmentation.access-context.test.ts
+++ b/packages/agent/src/api/chat-augmentation.access-context.test.ts
@@ -96,8 +96,18 @@ function makeRuntime(fragments: Memory[]): {
     // returning EVERY fragment regardless of requester keeps the suite's
     // point sharp — access control must come from the service's own
     // AccessContext post-filter, never from the storage query.
+    // The stub honors the adapter's `limit`/`offset` contract so the service's
+    // exhaustive traversal can prove it read the COMPLETE fragment set (see
+    // CLAUDE.md prompt integrity: model-facing content is never capped). A stub
+    // that ignored the window would look like a source-imposed cap and be
+    // rejected outright.
     adapter: {
-      queryDocumentFragments: vi.fn(async () => fragments),
+      queryDocumentFragments: vi.fn(
+        async (params: { limit: number; offset?: number }) => {
+          const offset = params.offset ?? 0;
+          return fragments.slice(offset, offset + params.limit);
+        },
+      ),
     },
     getModel: vi.fn(() => undefined),
     getMemories: vi.fn(async () => fragments),

--- a/packages/agent/src/runtime/trajectory-bridge.test.ts
+++ b/packages/agent/src/runtime/trajectory-bridge.test.ts
@@ -884,19 +884,30 @@ describe("installDatabaseTrajectoryLogger (capture bridge)", () => {
     });
 
     execute.mockClear();
-    standalone.logLlmCall({
-      stepId: childStepId,
-      model: "late-standalone",
-      response: "must be rejected",
-      purpose: "action",
-      actionType: "runtime.useModel",
-    });
-    standalone.logProviderAccess({
-      stepId: childStepId,
-      providerName: "late-standalone-provider",
-      purpose: "context",
-      data: {},
-    });
+    // Sub-2s rejects are the designed delivery/terminalization race and are
+    // quieted to debug logging; only an aged capture is the real leak signal
+    // this assertion is about, so the two rejects land 10s after close.
+    const realNow = Date.now.bind(Date);
+    const agedNow = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() => realNow() + 10_000);
+    try {
+      standalone.logLlmCall({
+        stepId: childStepId,
+        model: "late-standalone",
+        response: "must be rejected",
+        purpose: "action",
+        actionType: "runtime.useModel",
+      });
+      standalone.logProviderAccess({
+        stepId: childStepId,
+        providerName: "late-standalone-provider",
+        purpose: "context",
+        data: {},
+      });
+    } finally {
+      agedNow.mockRestore();
+    }
     await standalone.flushWriteQueue();
     expect(execute).not.toHaveBeenCalled();
     // Both captures are rejected, but only the first reports: repeats for the

--- a/packages/core/src/__tests__/message-v5-widget-markers.test.ts
+++ b/packages/core/src/__tests__/message-v5-widget-markers.test.ts
@@ -122,6 +122,9 @@ function makeRuntime(opts: {
 		actions: opts.actions,
 		providers: [],
 		getRoom: vi.fn(async () => null),
+		// Stage 1's ambient-turn gate reads the structural response-bypass
+		// settings; an unconfigured runtime answers undefined for all of them.
+		getSetting: vi.fn(() => undefined),
 		reportError: vi.fn(),
 		responseHandlerFieldRegistry,
 		responseHandlerFieldEvaluators: [

--- a/packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts
@@ -189,7 +189,11 @@ describe("MESSAGE list ops — counts stay complete past the render cap", () => 
 		),
 	});
 
-	it("list_channels reports the full channel + muted counts and annotates the capped listing", async () => {
+	// The action result is model-facing context, so the listing is complete:
+	// CLAUDE.md forbids capping, slicing, or item-limiting what the model reads.
+	// The former `MAX_LISTED_CHANNELS = 50` render cap (and its `truncated`
+	// annotation) was deliberately deleted; every channel must now be rendered.
+	it("list_channels renders every channel with complete channel + muted counts", async () => {
 		const runtime = mockRuntime([bigConnector()], seed());
 		const result = await runOp(runtime, { action: "list_channels" });
 		const data = result.data as {
@@ -199,11 +203,12 @@ describe("MESSAGE list ops — counts stay complete past the render cap", () => 
 		};
 		expect(result.success).toBe(true);
 		expect(data.channelCount).toBe(60);
-		expect(data.truncated).toBe(true);
-		expect(data.channels).toHaveLength(50);
+		expect(data.truncated).toBeUndefined();
+		expect(data.channels).toHaveLength(60);
+		expect(data.channels.map((c) => c.label)).toContain("#chan-59");
 		expect(result.text).toContain("Listed 60 channels");
 		expect(result.text).toContain("(3 muted)");
-		expect(result.text).toContain("showing the first 50");
+		expect(result.text).not.toContain("showing the first");
 	});
 
 	it("list_connections counts every room and every muted room, not just the first 50", async () => {

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3933,8 +3933,8 @@ async function handleListChannels(
 		const targets = await listRooms(context);
 		// Muted visibility: without the flag "which channels are you muted in"
 		// is unanswerable — the participant/world mute state is queryable
-		// nowhere else. Flags cover the FULL set so mutedCount stays correct
-		// even when the rendered listing below is capped.
+		// nowhere else. Flags cover the FULL set, matching the complete listing
+		// rendered below.
 		const mutedFlags = await resolveMutedTargetFlags(runtime, targets);
 		const mutedCount = mutedFlags.filter(Boolean).length;
 		return opSuccess(

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -290,10 +290,14 @@ describe("EvaluatorService", () => {
 				error: "Evaluator output section did not validate",
 			}),
 		]);
+		// The log payload carries a bounded PREVIEW of the section, not the
+		// section itself — a diagnostic surface, never model-facing context, so
+		// CLAUDE.md's prompt-integrity rule permits the bound and requires the
+		// field to name itself a preview.
 		expect(warnSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				evaluator: "circular",
-				rawSection: expect.any(String),
+				rawSectionPreview: expect.any(String),
 			}),
 			"Evaluator output section did not validate",
 		);


### PR DESCRIPTION
`develop` is red after the merge sweep. Five of the failing test files assert contracts their production code no longer has, or stub a runtime narrower than the code now requires. In every case the production code is correct and the **test** is the bug.

## Failures before (on `origin/develop` @ `c3f070a5ee`)

```
packages/agent/src/api/chat-augmentation.access-context.test.ts (4 tests | 2 failed)
  × privileged owner gets the owner-private secret; unprivileged user does not
    AssertionError: expected 'what is the denver launch codeword?' to contain 'the denver launch codeword is mallard'
  × the AccessContext is the causal lever at the search post-filter (non-bypassable)
    ElizaError: Document fragment source returned a capped page
      at DocumentService.scanDocumentFragments packages/core/src/features/documents/service.ts:1969

packages/agent/src/runtime/trajectory-bridge.test.ts (31 tests | 1 failed)
  × keeps standalone late child capture closed and shutdown permanently inert
    AssertionError: expected [] to have a length of 1 but got +0

packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts (7 tests | 1 failed)
  × list_channels reports the full channel + muted counts and annotates the capped listing
    AssertionError: expected undefined to be true   // data.truncated

packages/core/src/services/evaluator.test.ts (14 tests | 1 failed)
  × logs an unserializable invalid section without aborting the run
    expected "warn" to be called with { rawSection: Any<String> }
    received                            { rawSectionPreview: "{ \"big\": \"1n\", ... }" }

packages/core/src/__tests__/message-v5-widget-markers.test.ts (3 tests | 3 failed)
  × TypeError: runtime.getSetting is not a function
      at messageBypassesResponseEvaluation packages/core/src/services/message.ts:612
      at isAmbientStage1Turn packages/core/src/services/message.ts:660
```

## Cause, per file

| Test | Introducing commit | What changed |
| --- | --- | --- |
| `chat-augmentation.access-context.test.ts` | `6e67161aae` — *fix(core): traverse complete model-facing retrieval (#24869)* | `DocumentService` now traverses fragments exhaustively and **rejects a source-imposed cap** (`DOCUMENT_SEARCH_SOURCE_INCOMPLETE`). The test's `queryDocumentFragments` stub ignored the `limit`/`offset` window and returned the same fragment for every page, which the traversal correctly reads as a cap. The PR updated its own `documents/__tests__/search.test.ts` stub but not this one. |
| `trajectory-bridge.test.ts` | `f991f1b70d` — *"…race rejects quiet…"* | The late-capture reporter's quieting was widened from `purpose === "voice-gate-rephrase" && ageMs < 5_000` to `ageMs < 2_000 \|\| (…)`. The test's late capture lands at age ≈ 0, so it is now debug-logged rather than reported. |
| `message.list-muted.test.ts` | `423aea34a0` — *fix: preserve complete model context (#24134)* | Deleted `MAX_LISTED_CHANNELS = 50`, the `targets.slice(0, 50)` render cap and the `truncated` annotation from `handleListChannels`. An action result is model-facing context, so per `CLAUDE.md` ("never use a … item-count limit … to make model-facing content fit") the uncapped listing is correct. The older test still asserted the cap. |
| `evaluator.test.ts` | `423aea34a0` | Renamed the diagnostic log field `rawSection` → `rawSectionPreview`. That bound is legitimate — it is a log preview, never model context, and `CLAUDE.md` requires such surfaces to *name themselves* previews. |
| `message-v5-widget-markers.test.ts` | `57548bcb30` — *fix(core): preserve reply bypasses in ambient triage (#25341)* | `isAmbientStage1Turn` now calls `messageBypassesResponseEvaluation`, which reads `runtime.getSetting("ALWAYS_RESPOND_CHANNELS")`. The test's hand-rolled runtime has no `getSetting`. |

## Changes

Test-only, plus one now-false comment in `message.ts` (the code said the listing "below is capped"; it no longer is).

## Passing after

```
$ ./node_modules/.bin/vitest run \
    packages/agent/src/api/chat-augmentation.access-context.test.ts \
    packages/agent/src/runtime/trajectory-bridge.test.ts \
    packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts \
    packages/core/src/services/evaluator.test.ts \
    packages/core/src/__tests__/message-v5-widget-markers.test.ts

 Test Files  5 passed (5)
      Tests  59 passed (59)
```

## Mutation checks

Each fixed test was re-run against a reversed production behaviour to prove it still bites:

| Test | Mutation applied to production code | Result |
| --- | --- | --- |
| `chat-augmentation.access-context` | `service.ts:1920` `return filterByAccessContext(...)` → `return results` | **3 failed / 1 passed** (was 4 passed) |
| `trajectory-bridge` | `trajectory-storage.ts:191` quiet window `ageMs < 2_000` → `ageMs < 60_000` | **1 failed / 30 passed** (was 31 passed) |
| `message.list-muted` | reinstated `targets.slice(0, 50)` for the rendered channel listing | **1 failed / 6 passed** (was 7 passed) |
| `evaluator` | `evaluator.ts:625` `rawSectionPreview:` → `rawSection:` | **1 failed / 13 passed** (was 14 passed) |
| `message-v5-widget-markers` | `runtime/evaluator.ts:1005` strip `[FORM]`/`[CHOICE]` markers from `messageToUser` | **1 failed / 2 passed** (was 3 passed) |

All mutations were reverted; `git status` shows only the intended files.

## Not addressed here (sandbox artifacts, not regressions)

Three more files in the same red batch fail only because workspace dependencies are unbuilt in this checkout — `@elizaos/plugin-scheduling`, `@elizaos/plugin-discord`, and `@elizaos/plugin-local-inference` have no `dist/index.js`, so Vite cannot resolve the package entry:
`conversation-message-around.test.ts`, `inbox-account-routing.test.ts`, `deferred-watchdog-config.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
