### PR TITLE
test(app-core): cover electrobun-stub

### DIFF
--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `ensureElectrobunGlobal` against a real `window` object: missing
+ * and explicit-undefined globals, already-defined values (including `null`),
+ * idempotent re-entry, and the installed no-op message handlers.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import { ensureElectrobunGlobal } from "../electrobun-stub.ts";
 
@@ -6,12 +11,14 @@ afterEach(() => {
   delete globalThis.window;
 });
 
+type ElectrobunHandlers = {
+  receiveMessageFromBun: (m: unknown) => unknown;
+  receiveInternalMessageFromBun: (m: unknown) => unknown;
+};
+
 function makeWindow() {
   const w = {} as Window & {
-    __electrobun?: {
-      receiveMessageFromBun: (m: unknown) => void;
-      receiveInternalMessageFromBun: (m: unknown) => void;
-    };
+    __electrobun?: ElectrobunHandlers | null;
   };
   (globalThis as { window?: typeof w }).window = w;
   return w;
@@ -20,6 +27,16 @@ function makeWindow() {
 describe("ensureElectrobunGlobal", () => {
   it("creates the global when missing", () => {
     const w = makeWindow();
+    ensureElectrobunGlobal();
+    expect(typeof w.__electrobun?.receiveMessageFromBun).toBe("function");
+    expect(typeof w.__electrobun?.receiveInternalMessageFromBun).toBe(
+      "function",
+    );
+  });
+
+  it("creates the global when the property is explicitly undefined", () => {
+    const w = makeWindow();
+    w.__electrobun = undefined;
     ensureElectrobunGlobal();
     expect(typeof w.__electrobun?.receiveMessageFromBun).toBe("function");
     expect(typeof w.__electrobun?.receiveInternalMessageFromBun).toBe(
@@ -36,5 +53,33 @@ describe("ensureElectrobunGlobal", () => {
     w.__electrobun = existing;
     ensureElectrobunGlobal();
     expect(w.__electrobun).toBe(existing);
+  });
+
+  it("is idempotent and keeps the same stub object on a second call", () => {
+    const w = makeWindow();
+    ensureElectrobunGlobal();
+    const first = w.__electrobun;
+    ensureElectrobunGlobal();
+    expect(w.__electrobun).toBe(first);
+  });
+
+  it("leaves a null placeholder untouched because typeof null is object", () => {
+    const w = makeWindow();
+    w.__electrobun = null;
+    ensureElectrobunGlobal();
+    expect(w.__electrobun).toBeNull();
+  });
+
+  it("installed handlers accept a message and return undefined without throwing", () => {
+    const w = makeWindow();
+    ensureElectrobunGlobal();
+    const bun = w.__electrobun;
+    if (bun === undefined || bun === null) {
+      throw new Error("ensureElectrobunGlobal did not install the stub");
+    }
+    expect(bun.receiveMessageFromBun("payload")).toBeUndefined();
+    expect(
+      bun.receiveInternalMessageFromBun({ kind: "internal" }),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION

# Relates to

No issue. Test-only expansion of existing coverage for
`ensureElectrobunGlobal` in
`packages/app-core/platforms/electrobun/src/bridge/electrobun-stub.ts`.
The merged suite (#25114 / #25331) covered only "missing global" and
"existing global untouched". This PR adds the remaining observed branches
without changing production code.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`c3f070a5ee1e45204df4a447d4592bc8d0bf416e`) with zero conflicts.
- [x] Focused vitest / biome / tsc were run in isolation after that sync; see evidence.
      Hosted CI does **not** run on this fork contributor PR; do not infer a
      GitHub Actions pass.
- [x] A reviewer can confirm the change from the evidence below: one test file,
      six passing cases, clean biome, and tsc output that does not mention the
      test file.

# Sync with develop

- [x] Branch parent is current `origin/develop` `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`.
- [x] Focused verification re-run against that head immediately before filing.

# Risks

Low. Test-only. The diff touches only
`packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts`.
No production behaviour change.

# Background

## What does this PR do?

Drives the real `ensureElectrobunGlobal` export against a real `window` object
and records what the code actually does:

- still creates the stub when `__electrobun` is missing
- also creates it when the property is explicitly `undefined` (`typeof === "undefined"`)
- still leaves an already-configured object untouched (same reference)
- a second call is idempotent (same stub object)
- a `null` placeholder is left untouched because `typeof null === "object"`
- installed handlers accept a message, do not throw, and return `undefined`

Expectations match observed runtime behaviour, not an aspirational contract.

## What kind of change is this?

Improvements: additional unit tests for an existing helper.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts`
and the source it imports, `../electrobun-stub.ts`.

## Detailed testing steps

From the repo root, after checking out this PR head:

```
bunx vitest run packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
```

# Evidence Gate

Evidence matches head `727f2bc0a33d6c481329117e786698eae3cbd6c0` (the SHA
this PR files). Test-only; no production behaviour change, so no origin
reproduction, load-bearing revert, or over-rejection corpus.

| Row | Status |
|---|---|
| Focused tests (vitest, isolated, re-run on current origin/develop immediately before filing) | Concrete: `bunx vitest run packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts` → Test Files 1 passed (1), Tests 6 passed (6), Duration 112ms |
| biome | Concrete: `ls biome.json` exists; worktree is not sparse; `bunx biome check --write packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts` → Checked 1 file in 27ms. No fixes applied. |
| tsc | Concrete: `cd packages/app-core && bunx tsc --noEmit 2>&1 \| grep electrobun-stub.test.ts` is empty (grep EXIT:1). The new/edited test file appears nowhere in tsc output. Pre-existing package errors, if any, are not from this file. |
| Diff scope | Concrete: `git diff --stat origin/develop` → 1 file changed (`electrobun-stub.test.ts` only), 49 insertions, 4 deletions |
| before-screenshots | N/A - unit tests for a window-global stub, no UI |
| after-screenshots | N/A - unit tests for a window-global stub, no UI |
| walkthrough-video | N/A - unit tests for a window-global stub, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

Hosted CI does not run on this fork PR. Reviewers should run the vitest command above at this head.

# Known gaps / failures

None in this test-only scope. Full `bun run verify` was not re-run; focused
vitest + biome + package tsc-grep are the required evidence for this change.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:727f2bc0a33d6c481329117e786698eae3cbd6c0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
