### PR TITLE
test(app-core): cover database-mode

### DIFF
--- a/packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts
+++ b/packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Verifies Electrobun database-mode resolution, credential redaction, and
+ * child-env application against the real resolver with deterministic inputs.
+ */
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applyDatabaseResolutionToEnv,
+  type DatabaseModeResolution,
+  type DatabaseModeResolverOptions,
+  redactDatabaseTarget,
+  resolveDatabaseMode,
+} from "../database-mode.ts";
+
+function options(
+  overrides: Partial<DatabaseModeResolverOptions> = {},
+): DatabaseModeResolverOptions {
+  return {
+    env: {},
+    packagedDesktop: false,
+    appStateDir: "/tmp/app-state",
+    ...overrides,
+  };
+}
+
+describe("redactDatabaseTarget", () => {
+  it("returns null for missing, empty, and whitespace-only values", () => {
+    expect(redactDatabaseTarget(undefined)).toBeNull();
+    expect(redactDatabaseTarget("")).toBeNull();
+    expect(redactDatabaseTarget("   ")).toBeNull();
+  });
+
+  it("redacts username and password on a parseable URL", () => {
+    expect(
+      redactDatabaseTarget("postgres://user:secret@localhost:5432/eliza"),
+    ).toBe("postgres://%5Buser%5D:%5Bpassword%5D@localhost:5432/eliza");
+  });
+
+  it("redacts only the username when the URL has no password", () => {
+    expect(redactDatabaseTarget("postgres://owner@localhost/eliza")).toBe(
+      "postgres://%5Buser%5D@localhost/eliza",
+    );
+  });
+
+  it("leaves parseable URLs without credentials unchanged", () => {
+    expect(redactDatabaseTarget("postgres://localhost:5432/eliza")).toBe(
+      "postgres://localhost:5432/eliza",
+    );
+  });
+
+  it("trims input before parsing", () => {
+    expect(redactDatabaseTarget("  postgres://localhost:5432/eliza  ")).toBe(
+      "postgres://localhost:5432/eliza",
+    );
+  });
+
+  it("falls back to regex redaction when URL parsing fails", () => {
+    expect(redactDatabaseTarget("not a url://alice:bob@host/db")).toBe(
+      "not a url://[user]:[password]@host/db",
+    );
+  });
+
+  it("returns the trimmed string when parsing fails and no userinfo is present", () => {
+    expect(redactDatabaseTarget("  not-a-url  ")).toBe("not-a-url");
+  });
+});
+
+describe("resolveDatabaseMode", () => {
+  it("selects POSTGRES_URL over every other source", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: {
+          POSTGRES_URL: "  postgres://user:secret@localhost:5432/eliza  ",
+          DATABASE_URL: "postgres://other:secret@localhost:5432/other",
+          ELIZA_DB_MODE: "memory",
+          PGLITE_DATA_DIR: "/tmp/ignored",
+        },
+        packagedDesktop: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      mode: "postgres",
+      postgresUrl: "postgres://user:secret@localhost:5432/eliza",
+      source: "POSTGRES_URL",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
+
+  it("treats whitespace-only POSTGRES_URL as absent", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: {
+          POSTGRES_URL: "   ",
+          DATABASE_URL: "postgres://user:secret@localhost:5432/eliza",
+        },
+      }),
+    );
+
+    expect(result.source).toBe("DATABASE_URL");
+    expect(result.postgresUrl).toBe(
+      "postgres://user:secret@localhost:5432/eliza",
+    );
+    expect(result.databaseUrlMapped).toBe(true);
+  });
+
+  it("maps DATABASE_URL to postgres with a warning", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: {
+          DATABASE_URL: " postgres://mapped:secret@localhost:5432/eliza ",
+          ELIZA_DB_MODE: "memory",
+          PGLITE_DATA_DIR: "/tmp/ignored",
+        },
+        packagedDesktop: true,
+      }),
+    );
+
+    expect(result.mode).toBe("postgres");
+    expect(result.source).toBe("DATABASE_URL");
+    expect(result.postgresUrl).toBe(
+      "postgres://mapped:secret@localhost:5432/eliza",
+    );
+    expect(result.databaseUrlMapped).toBe(true);
+    expect(result.warnings).toEqual([
+      "DATABASE_URL is mapped to POSTGRES_URL for the agent runtime.",
+    ]);
+  });
+
+  it("uses explicit memory mode for memory and pglite-memory, case-insensitively", () => {
+    for (const value of [
+      "memory",
+      "MEMORY",
+      " pglite-memory ",
+      "PGLITE-MEMORY",
+    ]) {
+      const result = resolveDatabaseMode(
+        options({
+          env: { ELIZA_DB_MODE: value, PGLITE_DATA_DIR: "/tmp/ignored" },
+          packagedDesktop: true,
+        }),
+      );
+      expect(result).toEqual({
+        mode: "pglite-memory",
+        pgliteDataDir: "memory://",
+        source: "explicit-memory",
+        warnings: [],
+        databaseUrlMapped: false,
+      });
+    }
+  });
+
+  it("does not treat other ELIZA_DB_MODE values as explicit memory", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: { ELIZA_DB_MODE: "pglite", PGLITE_DATA_DIR: "/abs/db" },
+      }),
+    );
+
+    expect(result.mode).toBe("pglite-persistent");
+    expect(result.source).toBe("PGLITE_DATA_DIR");
+  });
+
+  it("resolves a persistent PGLITE_DATA_DIR relative to cwd", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: { PGLITE_DATA_DIR: "  data/pglite  " },
+        cwd: "/tmp/project",
+      }),
+    );
+
+    expect(result).toEqual({
+      mode: "pglite-persistent",
+      pgliteDataDir: path.resolve("/tmp/project", "data/pglite"),
+      source: "PGLITE_DATA_DIR",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
+
+  it("keeps an absolute persistent PGLITE_DATA_DIR", () => {
+    const result = resolveDatabaseMode(
+      options({ env: { PGLITE_DATA_DIR: "/abs/db" } }),
+    );
+
+    expect(result.mode).toBe("pglite-persistent");
+    expect(result.pgliteDataDir).toBe("/abs/db");
+    expect(result.source).toBe("PGLITE_DATA_DIR");
+  });
+
+  it("maps a memory:// PGLITE_DATA_DIR to pglite-memory", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: { PGLITE_DATA_DIR: "  memory://  " },
+        packagedDesktop: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      mode: "pglite-memory",
+      pgliteDataDir: "memory://",
+      source: "PGLITE_DATA_DIR",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
+
+  it("treats MEMORY:// as a filesystem path because the sentinel is case-sensitive", () => {
+    const result = resolveDatabaseMode(
+      options({
+        env: { PGLITE_DATA_DIR: "MEMORY://" },
+        cwd: "/tmp/project",
+      }),
+    );
+
+    expect(result.mode).toBe("pglite-persistent");
+    expect(result.pgliteDataDir).toBe(
+      path.resolve("/tmp/project", "MEMORY://"),
+    );
+    expect(result.source).toBe("PGLITE_DATA_DIR");
+  });
+
+  it("uses the packaged-desktop default when no env source is set", () => {
+    const appStateDir = "/Users/example/Library/Application Support/Eliza";
+    const result = resolveDatabaseMode(
+      options({ packagedDesktop: true, appStateDir }),
+    );
+
+    expect(result).toEqual({
+      mode: "pglite-persistent",
+      pgliteDataDir: path.join(appStateDir, "database", "pglite"),
+      source: "packaged-desktop-default",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
+
+  it("returns unknown with a development-policy warning when unpackaged and unset", () => {
+    const result = resolveDatabaseMode(options());
+
+    expect(result).toEqual({
+      mode: "unknown",
+      source: "unknown",
+      warnings: [
+        "No desktop database env was set; the child runtime will use its development database policy.",
+      ],
+      databaseUrlMapped: false,
+    });
+    expect(result.postgresUrl).toBeUndefined();
+    expect(result.pgliteDataDir).toBeUndefined();
+  });
+
+  it("resolves a relative PGLITE_DATA_DIR against process.cwd when cwd is omitted", () => {
+    const result = resolveDatabaseMode(
+      options({ env: { PGLITE_DATA_DIR: "rel/db" } }),
+    );
+
+    expect(result.mode).toBe("pglite-persistent");
+    expect(result.pgliteDataDir).toBe(path.resolve(process.cwd(), "rel/db"));
+  });
+});
+
+describe("applyDatabaseResolutionToEnv", () => {
+  it("writes POSTGRES_URL and removes PGLITE_DATA_DIR for postgres mode", () => {
+    const childEnv: Record<string, string> = {
+      PGLITE_DATA_DIR: "/tmp/old",
+      DATABASE_URL: "postgres://keep-me",
+    };
+    const resolution: DatabaseModeResolution = {
+      mode: "postgres",
+      postgresUrl: "postgres://user:secret@localhost:5432/eliza",
+      source: "POSTGRES_URL",
+      warnings: [],
+      databaseUrlMapped: false,
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, resolution);
+
+    expect(childEnv.POSTGRES_URL).toBe(
+      "postgres://user:secret@localhost:5432/eliza",
+    );
+    expect(childEnv.PGLITE_DATA_DIR).toBeUndefined();
+    expect(childEnv.DATABASE_URL).toBe("postgres://keep-me");
+  });
+
+  it("writes PGLITE_DATA_DIR and removes POSTGRES_URL for persistent pglite", () => {
+    const childEnv: Record<string, string> = {
+      POSTGRES_URL: "postgres://old",
+    };
+    const resolution: DatabaseModeResolution = {
+      mode: "pglite-persistent",
+      pgliteDataDir: "/state/database/pglite",
+      source: "packaged-desktop-default",
+      warnings: [],
+      databaseUrlMapped: false,
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, resolution);
+
+    expect(childEnv.PGLITE_DATA_DIR).toBe("/state/database/pglite");
+    expect(childEnv.POSTGRES_URL).toBeUndefined();
+  });
+
+  it("writes the memory sentinel for pglite-memory mode", () => {
+    const childEnv: Record<string, string> = {
+      POSTGRES_URL: "postgres://old",
+    };
+    const resolution: DatabaseModeResolution = {
+      mode: "pglite-memory",
+      pgliteDataDir: "memory://",
+      source: "explicit-memory",
+      warnings: [],
+      databaseUrlMapped: false,
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, resolution);
+
+    expect(childEnv.PGLITE_DATA_DIR).toBe("memory://");
+    expect(childEnv.POSTGRES_URL).toBeUndefined();
+  });
+
+  it("leaves the child env unchanged for unknown mode", () => {
+    const childEnv: Record<string, string> = {
+      POSTGRES_URL: "postgres://keep",
+      PGLITE_DATA_DIR: "/tmp/keep",
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, {
+      mode: "unknown",
+      source: "unknown",
+      warnings: [
+        "No desktop database env was set; the child runtime will use its development database policy.",
+      ],
+      databaseUrlMapped: false,
+    });
+
+    expect(childEnv).toEqual({
+      POSTGRES_URL: "postgres://keep",
+      PGLITE_DATA_DIR: "/tmp/keep",
+    });
+  });
+
+  it("does not mutate env when postgres mode is missing a url", () => {
+    const childEnv: Record<string, string> = {
+      PGLITE_DATA_DIR: "/tmp/old",
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, {
+      mode: "postgres",
+      source: "POSTGRES_URL",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+
+    expect(childEnv).toEqual({ PGLITE_DATA_DIR: "/tmp/old" });
+  });
+
+  it("does not mutate env when pglite mode is missing a data dir", () => {
+    const childEnv: Record<string, string> = {
+      POSTGRES_URL: "postgres://keep",
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, {
+      mode: "pglite-persistent",
+      source: "PGLITE_DATA_DIR",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+
+    expect(childEnv).toEqual({ POSTGRES_URL: "postgres://keep" });
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage gap: `packages/app-core/platforms/electrobun/src/database/database-mode.ts` had no same-named test file. This PR adds one. No production issue is being closed.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Parent is `c3f070a5ee1e45204df4a447d4592bc8d0bf416e` (`origin/develop` at
      fetch immediately before filing).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition. No production code, exports, env handling, or
desktop boot policy changes. The suite drives the real module and records
observed behaviour (including the case-sensitive `memory://` sentinel).

# Background

## What does this PR do?

Adds
`packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts`
covering every exported function in `database-mode.ts`:

- `redactDatabaseTarget` — missing/empty/whitespace, parseable URLs with and
  without credentials, trim-before-parse, WHATWG percent-encoding of the
  redaction placeholders, and the regex fallback when `new URL` throws.
- `resolveDatabaseMode` — source priority (`POSTGRES_URL` then `DATABASE_URL`
  then explicit `ELIZA_DB_MODE` memory then `PGLITE_DATA_DIR` then packaged
  desktop default then unknown), whitespace-as-absent env values,
  case-insensitive explicit memory, case-sensitive `memory://` sentinel,
  relative/absolute/cwd path resolution, and the development-policy warning.
- `applyDatabaseResolutionToEnv` — postgres writes `POSTGRES_URL` and deletes
  `PGLITE_DATA_DIR`, pglite modes write `PGLITE_DATA_DIR` and delete
  `POSTGRES_URL`, unknown and missing-url/dir resolutions are no-ops.

## What kind of change is this?

Improvements (test coverage for existing desktop database-mode resolution).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts`

Re-run against current `origin/develop` (parent `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`):

```bash
cd packages/app-core/platforms/electrobun
bunx vitest run --config vitest.electrobun.config.ts src/database/__tests__/database-mode.test.ts
```

Observed immediately before filing:

```
Test Files  1 passed (1)
     Tests  25 passed (25)
```

Hosted CI does **not** run on this PR (fork contributor). The counts above
are from a local `bunx vitest run` on this exact head.

## Detailed testing steps

None: Automated tests are acceptable.

```
bunx biome check --write packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts
```

Observed: `Checked 1 file in 23ms. Fixed 1 file.` (import-type ordering). The
committed file is the post-biome result. Checkout is not sparse (`biome.json`
and `tsconfig.json` are present at the repo root).

```
cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'database-mode.test' ; echo "EXIT:$?"
```

Observed: empty grep (EXIT:1). The new test file introduced zero TypeScript
errors. Pre-existing errors in unrelated packages remain and are not from this
diff.

The diff touches only that one test file.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:37a08e07532dcff32e70934bb73c9766b93e387c -->

- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface.
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface.
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only change; no user flow.
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - unit tests of a pure resolver; no server process.
- [x] Frontend console and network logs show the request/response and state
      change, or marked `N/A - <reason>`.
      N/A - no frontend change.
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain state change; tests construct resolver inputs in-memory.
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only change; no server or frontend path.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no rendered UI surface.

### After

N/A - test-only change; no rendered UI surface.

### Walkthrough video

N/A - test-only change; no user flow.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. This is a single-file test-only PR. Focused
  evidence is the vitest / biome / tsc commands quoted above.
- Hosted GitHub Actions CI does not run on fork-contributor PRs. Do not treat
  missing checks as a test failure.
- `bunx tsc --noEmit` in `@elizaos/electrobun` reports pre-existing errors in
  unrelated files (app-core coding-account-bridge, ui nuphy imports, plugin-sql).
  `grep database-mode.test` is empty.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
