### PR TITLE
test(core): give the Stage 1 catalog fake runtime a getSetting

### DIFF
--- a/packages/core/src/__tests__/message-stage1-context-catalog.test.ts
+++ b/packages/core/src/__tests__/message-stage1-context-catalog.test.ts
@@ -109,6 +109,10 @@ function makeRuntimeWithContexts(
 		actions: [],
 		providers: [],
 		getRoom: vi.fn(async () => null),
+		// Stage 1 resolves the structural always-respond bypass through
+		// `runtime.getSetting`, which every real runtime implements; the fake
+		// answers "unconfigured" so only the built-in bypass list applies.
+		getSetting: vi.fn(() => undefined),
 		reportError: vi.fn(),
 		contexts: registry,
 		responseHandlerFieldRegistry,
@@ -240,6 +244,7 @@ describe("Stage 1 prompt — available contexts catalog", () => {
 			actions: [],
 			providers: [],
 			getRoom: vi.fn(async () => null),
+			getSetting: vi.fn(() => undefined),
 			reportError: vi.fn(),
 			contexts: undefined,
 			responseHandlerFieldRegistry,


### PR DESCRIPTION
## Problem

`develop` is red on `packages/core/src/__tests__/message-stage1-context-catalog.test.ts`.

### Before

```
 FAIL  packages/core/src/__tests__/message-stage1-context-catalog.test.ts > Stage 1 prompt — available contexts catalog > includes USER-accessible contexts and excludes OWNER-only contexts for a USER sender
TypeError: runtime.getSetting is not a function
 ❯ messageBypassesResponseEvaluation packages/core/src/services/message.ts:612:11
 ❯ isAmbientStage1Turn packages/core/src/services/message.ts:660:6
 ❯ runV5MessageRuntimeStage1 packages/core/src/services/message.ts:8072:22

 FAIL  ... > falls back to the placeholder line when no context registry is attached
TypeError: runtime.getSetting is not a function

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

## Cause

`57548bcb30 fix(core): preserve reply bypasses in ambient triage (#25341)` introduced
`messageBypassesResponseEvaluation`, which reads `ALWAYS_RESPOND_CHANNELS` /
`SHOULD_RESPOND_BYPASS_TYPES` / `ALWAYS_RESPOND_SOURCES` through `runtime.getSetting`,
and wired it into `isAmbientStage1Turn` on the `runV5MessageRuntimeStage1` path.

That PR updated its own tests but left this older suite behind. The suite builds a
deliberately partial fake runtime cast to `IAgentRuntime` and never supplied
`getSetting`, so Stage 1 now throws before rendering the context catalog.

`getSetting` is a required member of `IAgentRuntime` and every real runtime implements
it, so the production call is correct and the stale fake is the bug. The fake now
answers "unconfigured" (`undefined`), which is exactly what a runtime with no bypass
configuration returns — only the built-in bypass list applies, which is what these
context-catalog assertions already assume.

No production code changed.

### After

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Mutation check

Temporarily reversed the production behaviour these tests cover in
`packages/core/src/services/message.ts` — changed the empty-catalog placeholder in
`formatAvailableContextsForPrompt` from `"(no contexts registered)"` to a sentinel and
dropped the `roleGate` metadata segment:

```
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

Restored, back to `5 passed (5)`. The suite is still load-bearing.

Run command: `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts src/__tests__/message-stage1-context-catalog.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)