### PR TITLE
fix(core): repair stale planner and stable-prefix test fixtures

### DIFF
--- a/packages/core/src/__tests__/message-stable-prefix.test.ts
+++ b/packages/core/src/__tests__/message-stable-prefix.test.ts
@@ -30,6 +30,10 @@ function makeRuntime(): IAgentRuntime {
 		},
 		actions: [],
 		providers: [],
+		// Stage-1 triage reads the reply-bypass channel settings before it can
+		// decide which providers an ambient turn excludes, so a runtime without
+		// `getSetting` cannot render the prefix at all.
+		getSetting: vi.fn(() => undefined),
 		composeState: vi.fn(async () => makeState()),
 		logger: {
 			debug: vi.fn(),

--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -953,6 +953,20 @@ describe("planner-loop failed-operation correlation", () => {
 							},
 						],
 					})
+					// A successful FILE write is a coding mutation, so the loop
+					// refuses to accept a completion claim until a real SHELL
+					// verification has run (#24654). The verification round is part
+					// of the scenario, not an extra allowance for the model.
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-verify",
+								name: "SHELL",
+								arguments: { command: "bun test", cwd: "/workspace" },
+							},
+						],
+					})
 					.mockResolvedValueOnce({
 						text: "Done! The page is live.",
 					}),
@@ -975,6 +989,11 @@ describe("planner-loop failed-operation correlation", () => {
 						success: true,
 						text: "Wrote index.html (74 lines).",
 						userFacingText: "Wrote index.html (74 lines).",
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						text: "2 tests passed.",
+						userFacingText: "2 tests passed.",
 					}),
 				evaluate,
 			});


### PR DESCRIPTION
Two `@elizaos/core` suites are red on `develop`. In both cases the production change was deliberate and correct; the fixture was left describing the old runtime. Test-only change — no production file is touched.

## 1. `packages/core/src/__tests__/message-stable-prefix.test.ts`

`makeRuntime()` builds a `vi`-mocked `IAgentRuntime` without `getSetting`. Since **57548bcb30** — `fix(core): preserve reply bypasses in ambient triage (#25341)` — Stage-1 triage reads `ALWAYS_RESPOND_CHANNELS` / `SHOULD_RESPOND_BYPASS_TYPES` via `runtime.getSetting` on the ambient path that `renderMessageHandlerStablePrefix` walks, so all five cases died before rendering anything.

### Before
```
 ❯ packages/core/src/__tests__/message-stable-prefix.test.ts (5 tests | 5 failed)
     × renders the system + tool-schema stable prefix for a room
     × is deterministic across repeated renders for the same room
     × renders chat style directions exactly once, excluding post style
     × omits the style block when the character declares no chat style
     × calls composeState once per render (so providers are sampled)

TypeError: runtime.getSetting is not a function
 ❯ messageBypassesResponseEvaluation packages/core/src/services/message.ts:612:11
 ❯ isAmbientStage1Turn packages/core/src/services/message.ts:660:6
 ❯ ambientTurnProviderExclusions packages/core/src/services/message.ts:1035:9
 ❯ stage1ResponseStateProviderNames packages/core/src/services/message.ts:1161:27
 ❯ composeResponseState packages/core/src/services/message.ts:1174:20
 ❯ renderMessageHandlerStablePrefix packages/core/src/services/message.ts:5153:22
```

### After
```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## 2. `packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts`

`reports tool-owned recovery evidence after an unresolved coding failure` drives a coding turn: a failed `SHELL`, then a successful `FILE`/`write`, then a text-only completion claim — three `useModel` responses.

Since **0ccc63a8e9** — `fix(core): bound unverified coding completion loops (#24654)` — `codingMutationRequiresVerification` treats a successful `FILE` call with `action: "write"` as a coding mutation (it previously matched only the `WRITE`/`EDIT` tool names). The loop therefore refuses the completion claim until a real SHELL verification has run and asks for a fourth planner round, which the three-response mock could not answer, so `parsePlannerOutput` dereferenced `undefined`.

The production side is right — a file write is a mutation and must be verified — so the fixture now runs the verification round the scenario is required to run (`SHELL bun test` → success). Every original assertion is unchanged: the failure keeps the lead, the tool-owned write is reported as recovery evidence, and the model's contradicting prose stays out.

### Before
```
 ❯ packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts (19 tests | 1 failed)
     × reports tool-owned recovery evidence after an unresolved coding failure

TypeError: Cannot read properties of undefined (reading 'toolCalls')
 ❯ parsePlannerOutput packages/core/src/runtime/planner-loop.ts:2283:49
 ❯ callPlanner packages/core/src/runtime/planner-loop.ts:2679:17
 ❯ callPlannerWithToolChoiceRetry packages/core/src/runtime/planner-loop.ts:605:13
 ❯ runPlannerLoopIterations packages/core/src/runtime/planner-loop.ts:632:21
 ❯ runPlannerLoop packages/core/src/runtime/planner-loop.ts:323:17
```

### After
```
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Neighbouring suites still green: `planner-loop.test.ts` + `planner-happy-path.test.ts` → **222 passed**.

## Mutation check

Both fixtures were proven to still bind real production behaviour by reversing that behaviour and confirming a failure, then restoring it.

**1. `renderMessageHandlerStablePrefix`** — renamed the appended Stage-1 segment label from `message_handler_stage:` to `MUTATED_stage:` in `packages/core/src/services/message.ts`:

- before mutation: 5 passed / 0 failed
- with mutation: **4 passed / 1 failed** — `AssertionError: expected 'You are concise and helpful.\n\n# Abo…' to contain 'message_handler_stage:'`
- after restore: 5 passed / 0 failed

**2. `terminalMessageWithFailureAuthority`** — made the failure never take the lead by returning `candidate` unconditionally in `packages/core/src/runtime/planner-loop.ts`:

- before mutation: 19 passed / 0 failed
- with mutation: **7 passed / 12 failed**, including the repaired case (`AssertionError: expected false to be true` on `result.finalMessage?.startsWith(shellFailure)`)
- after restore: 19 passed / 0 failed

## Commits that introduced the breakage

- `57548bcb30` `fix(core): preserve reply bypasses in ambient triage (#25341)` — added the `runtime.getSetting` read; updated `message-runtime-stage1.test.ts` and `bot-noise-triage.test.ts` but not `message-stable-prefix.test.ts`.
- `0ccc63a8e9` `fix(core): bound unverified coding completion loops (#24654)` — extended the mutation-verification gate to `FILE` writes; updated `planner-loop.test.ts` and `planner-happy-path.test.ts` but not `planner-loop-failure-correlation.test.ts`.
