### PR TITLE
test: realign stale tests with current authorization and view contracts

### DIFF
--- a/packages/agent/src/runtime/view-capability-audit.test.ts
+++ b/packages/agent/src/runtime/view-capability-audit.test.ts
@@ -54,13 +54,15 @@ const repoRoot = path.resolve(here, "../../../..");
 
 /**
  * Map each audited view id → the plugin directory that owns its view source.
- * Only views whose `.tsx` actually live in a `plugins/<dir>/src` tree AND are
- * declared as a dashboard `views:` entry by their plugin are listed — host/
- * built-in views (`lifeops`, `training`, `settings`) have no plugin source to
- * scan and are exercised through `validateViewCoverage` below instead.
- * Every key here must declare relatedActions in its plugin entry (asserted in
- * the suite) so this stays a meaningful subset of the registered surface, not a
- * parallel list.
+ * Only views whose `.tsx` actually live in a `plugins/<dir>/src` tree are
+ * listed — host/built-in views with no plugin source at all (`lifeops`,
+ * `training`, `settings`) have nothing to scan and are exercised through
+ * `validateViewCoverage` below instead.
+ * Every key here must declare relatedActions (asserted in the suite) so this
+ * stays a meaningful subset of the registered surface, not a parallel list.
+ * The declaration normally lives on the owning plugin entry; a view whose
+ * `.tsx` lives in a plugin while the host owns the `ViewDeclaration` is listed
+ * in `HOST_VIEW_DECLARATIONS` below.
  */
 const VIEW_SOURCE_DIRS: Readonly<Record<string, string>> = {
   calendar: "plugin-calendar",
@@ -74,6 +76,20 @@ const VIEW_SOURCE_DIRS: Readonly<Record<string, string>> = {
   relationships: "plugin-relationships",
   documents: "plugin-documents",
   orchestrator: "plugin-task-coordinator",
+};
+
+/**
+ * Audited views whose `ViewDeclaration` is owned by the HOST registry rather
+ * than by the plugin that ships the view `.tsx`. `documents` is the standing
+ * case: `plugins/plugin-documents` deliberately registers no view of its own
+ * (a second `documents` declaration collided with the shell's built-in
+ * Knowledge view and presented a smaller duplicate surface at `/documents`),
+ * so its relatedActions live on the built-in entry while its spatial source —
+ * and therefore its instrumentation density — still lives under the plugin.
+ * Values are repo-relative paths to the file holding the declaration.
+ */
+const HOST_VIEW_DECLARATIONS: Readonly<Record<string, string>> = {
+  documents: "packages/agent/src/api/builtin-views.ts",
 };
 
 /**
@@ -146,6 +162,27 @@ function readPluginEntry(pluginDir: string): string {
   return firstExisting;
 }
 
+/**
+ * The single `ViewDeclaration` object literal for `viewId` inside a host
+ * registry file that declares many of them. Slicing to the one entry keeps
+ * `relatedActionCount` from reading a neighbouring view's declaration.
+ */
+function extractHostDeclaration(source: string, viewId: string): string {
+  const start = source.indexOf(`id: "${viewId}",`);
+  if (start === -1) return "";
+  const end = source.indexOf("\n  {", start);
+  return end === -1 ? source.slice(start) : source.slice(start, end);
+}
+
+/** Declaration source for a view: its host entry when the host owns it. */
+function readViewDeclaration(viewId: string, pluginDir: string): string {
+  const hostFile = HOST_VIEW_DECLARATIONS[viewId];
+  if (!hostFile) return readPluginEntry(pluginDir);
+  const full = path.join(repoRoot, hostFile);
+  if (!existsSync(full)) return "";
+  return extractHostDeclaration(readFileSync(full, "utf8"), viewId);
+}
+
 // Interactive-control surface, both dialects — a conservative lower-bound proxy:
 //   DOM handler / native control: onClick= / onSubmit= / onInput= / onChange= / <button
 //   spatial interactive primitives: <Button / <Field (their onPress/onChange
@@ -211,7 +248,7 @@ const coverage: ViewCoverage[] = Object.entries(VIEW_SOURCE_DIRS).map(
     const viewSrc = path.join(repoRoot, "plugins", pluginDir, "src");
     const files = collectViewTsx(viewSrc);
     const joined = files.map((f) => readFileSync(f, "utf8")).join("\n");
-    const entry = readPluginEntry(pluginDir);
+    const entry = readViewDeclaration(viewId, pluginDir);
     const measure = measureSource(joined);
     return {
       viewId,
@@ -258,7 +295,9 @@ describe("static view-capability audit (#8798)", () => {
     for (const c of coverage) {
       expect(
         c.relatedActions,
-        `audited view "${c.viewId}" must declare relatedActions in plugins/${c.pluginDir}/src`,
+        `audited view "${c.viewId}" must declare relatedActions in ${
+          HOST_VIEW_DECLARATIONS[c.viewId] ?? `plugins/${c.pluginDir}/src`
+        }`,
       ).toBeGreaterThan(0);
     }
   });

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -87,6 +87,9 @@ function makeRuntime(opts: {
 		actions: opts.actions,
 		providers: [],
 		getRoom: vi.fn(async () => null),
+		// Stage 1 reads the response-bypass channel/source settings before it can
+		// classify a turn as ambient; the fixture configures none of them.
+		getSetting: vi.fn(() => undefined),
 		reportError: vi.fn(),
 		responseHandlerFieldRegistry,
 		responseHandlerFieldEvaluators: [

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -350,6 +350,19 @@ describe("DocumentService list semantics", () => {
 			metadata: { pinned: true, scope: "owner-private" },
 		});
 		await seedDocuments(runtime, [...documents, privatePinned]);
+		// The requester role must resolve to a real tier: an unresolvable world
+		// leaves the requester UNRESOLVED, which the storage authorization
+		// boundary denies outright (#24255).
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
 
 		const composed = await service.composeProviderDocuments(userMessage(), {
 			limit: 25,
@@ -509,10 +522,10 @@ describe("DocumentService list semantics", () => {
 			metadata: { roles: { [USER_ID]: "USER" } },
 		} as World);
 
-		await expect(
-			service.deleteDocument(hiddenDocument.id as UUID, userMessage()),
-		).rejects.toMatchObject({ code: "DOCUMENT_MUTATION_FORBIDDEN" });
-		for (const memory of [foreignDocument, nonDocument]) {
+		// A document this requester cannot see is indistinguishable from a missing
+		// UUID: the delete path reports DOCUMENT_NOT_FOUND rather than confirming
+		// the row exists through a forbidden-mutation error (#24272).
+		for (const memory of [hiddenDocument, foreignDocument, nonDocument]) {
 			await expect(
 				service.deleteDocument(memory.id as UUID, userMessage()),
 			).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
@@ -618,6 +631,19 @@ describe("DocumentService list semantics", () => {
 				},
 			}),
 		]);
+		// Same requirement as the pinned-composition case: without a resolvable
+		// world the requester stays UNRESOLVED and nothing is visible, so the
+		// visibility-before-filter classification could never be exercised.
+		vi.spyOn(runtime, "getRoom").mockResolvedValue({
+			id: ROOM_A,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		} as Room);
+		vi.spyOn(runtime, "getWorld").mockResolvedValue({
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			metadata: { roles: { [USER_ID]: "USER" } },
+		} as World);
 
 		const result = await service.listDocumentsDetailed(userMessage(), {
 			tags: ["missing-tag"],

--- a/packages/core/src/services/message.planner-provider-selection.test.ts
+++ b/packages/core/src/services/message.planner-provider-selection.test.ts
@@ -22,7 +22,14 @@ function provider(overrides: Partial<Provider> & { name: string }): Provider {
 }
 
 function makeRuntime(providers: Provider[]): IAgentRuntime {
-	return { providers } as unknown as IAgentRuntime;
+	// `getSetting` is a required IAgentRuntime collaborator: ambient-turn
+	// selection reads the response-bypass channel/source settings before it can
+	// decide whether a turn is ambient. The fixture answers "nothing configured"
+	// so selection exercises the built-in bypass set only.
+	return {
+		providers,
+		getSetting: () => undefined,
+	} as unknown as IAgentRuntime;
 }
 
 function msg(): Memory {


### PR DESCRIPTION
## Summary

Four suites are red on `develop`. In every case a later commit deliberately changed a contract, updated the tests it knew about, and left an older suite asserting the previous behaviour. This PR realigns the stale tests. **No production code changes.**

## Before (on `origin/develop` @ c3f070a5ee)

```
❯ packages/core/src/features/documents/service-list.test.ts (16 tests | 3 failed)
  × composes visible pinned documents beyond the recent page without leaking private pins
      AssertionError: expected [] to have a length of 25 but got +0
  × does not expose foreign-agent or non-document rows through delete errors
      expected ElizaError { code: 'DOCUMENT_NOT_FOUND' } to match { code: 'DOCUMENT_MUTATION_FORBIDDEN' }
  × applies visibility before classifying filter misses
      expected { status: 'empty_store', totalVisible: 0 } to match { status: 'filter_miss', totalVisible: 2 }

❯ packages/core/src/services/message.planner-provider-selection.test.ts (13 tests | 13 failed)
      TypeError: runtime.getSetting is not a function
        at messageBypassesResponseEvaluation packages/core/src/services/message.ts:612:11

❯ packages/core/src/__tests__/tiered-action-surface.test.ts (14 tests | 14 failed)
      TypeError: runtime.getSetting is not a function

❯ packages/agent/src/runtime/view-capability-audit.test.ts (17 tests | 1 failed)
  × every audited plugin view declares relatedActions
      audited view "documents" must declare relatedActions in plugins/plugin-documents/src: expected 0 to be greater than 0
```

## Causes

| Suite | Commit that changed the contract | What changed |
| --- | --- | --- |
| `service-list.test.ts` (2 tests) | `b85b6ccf68` — *fix(documents): preserve exact requester roles (#24255)* | `resolveDocumentRequesterRole` no longer fabricates `USER` when the role cannot be resolved; it returns `UNRESOLVED`, which `isDocumentVisibleToRequester` denies. The two tests never established a world, so nothing is visible any more. Their siblings in the same file already mock `getRoom`/`getWorld`. |
| `service-list.test.ts` (1 test) | `0076c563ff` — *fix(documents): centralize route mutations (#24272)* | That commit removed the unscoped `getMemoryById` probe that turned a hidden-but-owned document into `DOCUMENT_MUTATION_FORBIDDEN`, and updated `service-authorization.real.test.ts` to expect `DOCUMENT_NOT_FOUND`. This older assertion was missed. The new behaviour is the stricter one (no existence oracle) and matches the test's own name. |
| `message.planner-provider-selection.test.ts`, `tiered-action-surface.test.ts` | `57548bcb30` — *fix(core): preserve reply bypasses in ambient triage (#25341)* | Added `messageBypassesResponseEvaluation`, which reads `ALWAYS_RESPOND_CHANNELS` / `ALWAYS_RESPOND_SOURCES` via `runtime.getSetting`. Both suites build minimal fake runtimes that omit that required `IAgentRuntime` collaborator. |
| `view-capability-audit.test.ts` | pre-existing | `plugins/plugin-documents/src/plugin.ts` deliberately registers **no** view (`"declaring a second plugin view here previously collided on the `documents` id"`). The `documents` `ViewDeclaration`, including `relatedActions: ["OWNER_DOCUMENTS", "DOCUMENT"]`, lives on the host entry in `packages/agent/src/api/builtin-views.ts`. The audit only looked in the plugin dir. |

The `documents` regressions were located by `git bisect` against the suite (`b85b6ccf68` for the two visibility tests, `0076c563ff` for the delete-error test).

## After

```
 Test Files  4 passed (4)
      Tests  60 passed (60)
```

## Mutation checks

Each fix was verified by reversing the production behaviour it covers and confirming the test fails.

1. `isDocumentVisibleToRequester` — add `if (snapshot.scope === "owner-private") return true;`
   → `service-list.test.ts`: **13 passed / 3 failed** (restored: 16 passed).
2. `deleteDocumentForRequester` — emit `DOCUMENT_MUTATION_FORBIDDEN` instead of `DOCUMENT_NOT_FOUND`
   → `service-list.test.ts`: **15 passed / 1 failed** (restored: 16 passed).
3. `messageBypassesResponseEvaluation` — return `true` unconditionally
   → `message.planner-provider-selection.test.ts`: **12 passed / 1 failed** (`excludes RECENT_ERRORS from the planner recompose of an unaddressed group turn`) (restored: 13 passed).
4. `builtin-views.ts` — remove `relatedActions` from the `documents` entry
   → `view-capability-audit.test.ts`: **16 passed / 1 failed** (restored: 17 passed).

All mutations were reverted; `git diff` contains test files only.

## Not addressed here

`packages/core/src/features/documents/action-context-gate.test.ts` (2 failures) is also red on `develop` for an unrelated reason, and the `*.real.test.ts` pglite suites need a database this environment lacks. Neither is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
