### PR TITLE
test(core): realign three stale core tests with develop

### DIFF
--- a/packages/core/src/__tests__/stage1-provider-execution.test.ts
+++ b/packages/core/src/__tests__/stage1-provider-execution.test.ts
@@ -1,13 +1,18 @@
 /**
  * Proves the Stage-1 provider exclusions are EXECUTION exclusions, not just
  * render exclusions: `stage1ResponseStateProviderNames` subtracts the
- * stage-1-excluded providers from the compose include list (so ENTITIES
- * never runs for a turn that dies at Stage 1), while the planner pass still
- * composes them via composeState's cached-state merge. Also pins that
- * CURRENT_TIME is unconditionally composed — the system prompt promises a
- * time signal in every runtime context, so no message phrasing may drop it.
- * Uses a real in-memory AgentRuntime with call-counting providers; no
- * database or model.
+ * excluded providers from the compose include list, so an excluded provider
+ * never runs for the turn. Since #24134 ("preserve complete model context")
+ * the only Stage-1 exclusion is the ambient-turn one (RECENT_ERRORS on
+ * unaddressed group traffic) — the blanket ENTITIES/DOCUMENTS exclusion was
+ * removed because dropping composed context from a model-facing prompt is
+ * exactly what the repository's prompt-integrity rule forbids. The core
+ * response providers and every `alwaysInResponseState` plugin provider
+ * therefore compose at Stage 1 and are reused from the turn cache by the
+ * planner recompose. Also pins that CURRENT_TIME is unconditionally
+ * composed — the system prompt promises a time signal in every runtime
+ * context, so no message phrasing may drop it. Uses a real in-memory
+ * AgentRuntime with call-counting providers; no database or model.
  */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
@@ -57,16 +62,19 @@ function countingProvider(name: string): {
 }
 
 describe("stage1ResponseStateProviderNames", () => {
-	it("subtracts the stage-1 exclusions from the compose include list", () => {
-		const runtime = { providers: [] } as unknown as IAgentRuntime;
+	it("keeps the core response providers complete on an unexcluded turn", () => {
+		const runtime = {
+			providers: [],
+			getSetting: () => undefined,
+		} as unknown as IAgentRuntime;
 		const names = stage1ResponseStateProviderNames(
 			runtime,
 			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"),
 		);
 
-		expect(names).not.toContain("ENTITIES");
-		expect(names).not.toContain("DOCUMENTS");
-		// Stage 1 still composes what it renders and routes on.
+		// #24134 removed the blanket ENTITIES/DOCUMENTS stage-1 exclusion: a
+		// cheaper prompt is not a licence to drop composed model context.
+		expect(names).toContain("ENTITIES");
 		expect(names).toContain("RECENT_MESSAGES");
 		expect(names).toContain("FACTS");
 		expect(names).toContain("ATTACHMENTS");
@@ -77,7 +85,10 @@ describe("stage1ResponseStateProviderNames", () => {
 		// messages that "looked like" time questions, so the apostrophe-free
 		// "whats todays date and time?" lost the time block and the model
 		// hallucinated a stale date. The signal must not depend on prose.
-		const runtime = { providers: [] } as unknown as IAgentRuntime;
+		const runtime = {
+			providers: [],
+			getSetting: () => undefined,
+		} as unknown as IAgentRuntime;
 		for (const text of [
 			"gm",
 			"whats todays date and time?",
@@ -89,12 +100,13 @@ describe("stage1ResponseStateProviderNames", () => {
 				makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", text),
 			);
 			expect(names).toContain("CURRENT_TIME");
-			expect(names).not.toContain("ENTITIES");
+			expect(names).toContain("ENTITIES");
 		}
 	});
 
-	it("includes always-on plugin providers unless they are stage-1-excluded", () => {
+	it("includes every always-on plugin provider", () => {
 		const runtime = {
+			getSetting: () => undefined,
 			providers: [
 				{
 					name: "PLUGIN_CTX",
@@ -114,10 +126,12 @@ describe("stage1ResponseStateProviderNames", () => {
 		);
 
 		expect(names).toContain("PLUGIN_CTX");
-		expect(names).not.toContain("DOCUMENTS");
+		// DOCUMENTS opts in via `alwaysInResponseState`; honoring that opt-in is
+		// the whole contract, and #24134 removed the special case that dropped it.
+		expect(names).toContain("DOCUMENTS");
 	});
 
-	it("skips excluded providers at stage 1 and defers them to the planner recompose", async () => {
+	it("composes the core providers once and reuses them in the planner recompose", async () => {
 		const runtime = new AgentRuntime({
 			character: { name: "stage1-exec-test" } as Character,
 		});
@@ -132,30 +146,29 @@ describe("stage1ResponseStateProviderNames", () => {
 		const message = makeMessage("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 		const stage1Names = stage1ResponseStateProviderNames(runtime, message);
 
-		// Stage-1 compose: excluded providers never execute, so a turn that
-		// ends at Stage 1 (group noise → IGNORE) does none of their work and
-		// its prompt footprint drops accordingly. CURRENT_TIME is NOT excluded
-		// — it composes on every turn so the simple path can honor the system
-		// prompt's promise of a live time signal.
+		// Stage-1 compose: every core response provider executes exactly once
+		// and reaches the Stage-1 prompt. CURRENT_TIME in particular composes on
+		// every turn so the simple path can honor the system prompt's promise of
+		// a live time signal.
 		const stage1State = await runtime.composeState(
 			message,
 			stage1Names,
 			true,
 			false,
 		);
-		expect(entities.calls()).toBe(0);
+		expect(entities.calls()).toBe(1);
 		expect(currentTime.calls()).toBe(1);
 		expect(facts.calls()).toBe(1);
 		expect(recent.calls()).toBe(1);
-		expect(stage1State.text).not.toContain("ENTITIES#");
+		expect(stage1State.text).toContain("ENTITIES#1");
 		expect(stage1State.text).toContain("CURRENT_TIME#1");
 		expect(stage1State.text).toContain("FACTS#1");
 
 		// Planner recompose (mirrors selectV5PlannerStateProviderNames re-adding
-		// the core response providers, with RECENT_MESSAGES refreshed): the
-		// excluded providers are not in the turn cache, so they run now — once —
-		// and reach the planner prompt; the already-composed FACTS and
-		// CURRENT_TIME are reused from the turn cache.
+		// the core response providers, with RECENT_MESSAGES refreshed): every
+		// already-composed provider is served from the turn cache — only the
+		// explicitly refreshed RECENT_MESSAGES runs a second time — and the
+		// planner prompt still carries all of them.
 		const plannerState = await runtime.composeState(
 			message,
 			[...stage1Names, "ENTITIES", "CURRENT_TIME"],
@@ -189,6 +202,7 @@ describe("RECENT_ERRORS stage-1 exclusion on unaddressed group turns", () => {
 	function runtimeWithRecentErrors(): IAgentRuntime {
 		return {
 			character: { name: AGENT_NAME },
+			getSetting: () => undefined,
 			providers: [
 				{
 					name: "RECENT_ERRORS",

--- a/packages/core/src/features/documents/action-context-gate.test.ts
+++ b/packages/core/src/features/documents/action-context-gate.test.ts
@@ -92,6 +92,9 @@ function makeService() {
 		listDocumentsDetailed: vi.fn(async () => listResult()),
 		searchDocuments: vi.fn(async () => []),
 		getDocumentById: vi.fn(async () => null),
+		// The `read` subaction goes through the bounded progressive-read API
+		// (#24305), not getDocumentById; a missing document is the null case.
+		readDocumentRange: vi.fn(async () => null),
 		addDocument: vi.fn(async () => ({
 			clientDocumentId: DOC_ID,
 			fragmentCount: 1,
@@ -176,7 +179,7 @@ describe("DOCUMENT handler operation gate on knowledge-routed turns", () => {
 	it.each([
 		["list", {}, "listDocumentsDetailed"],
 		["search", { query: "launch notes" }, "searchDocuments"],
-		["read", { id: DOC_ID }, "getDocumentById"],
+		["read", { id: DOC_ID }, "readDocumentRange"],
 	] as const)(
 		"allows the read-only %s subaction when routed to knowledge",
 		async (action, extraParams, method) => {
@@ -254,7 +257,7 @@ describe("DOCUMENT handler operation gate on knowledge-routed turns", () => {
 describe("DOCUMENT handler operation gate on app-path merged routing", () => {
 	it.each([
 		["list", {}, "listDocumentsDetailed"],
-		["read", { id: DOC_ID }, "getDocumentById"],
+		["read", { id: DOC_ID }, "readDocumentRange"],
 	] as const)(
 		"allows the read-only %s subaction when state is knowledge and message is general (app-path)",
 		async (action, extraParams, method) => {

--- a/packages/core/src/services/message.deliver-then-persist.test.ts
+++ b/packages/core/src/services/message.deliver-then-persist.test.ts
@@ -248,7 +248,7 @@ async function createHarness(opts: HarnessOptions = {}) {
 describe("simple-path deliver-then-persist ordering", () => {
 	it("fires the delivery callback before the reply persist completes, then still persists it", async () => {
 		const h = await createHarness();
-		let repliesVisibleAtDelivery = -1;
+		let orderAtDelivery: string[] | undefined;
 		let deliveryActionName: string | undefined;
 
 		const result = await h.service.handleMessage(
@@ -257,9 +257,14 @@ describe("simple-path deliver-then-persist ordering", () => {
 			async (_content, actionName) => {
 				h.order.push("callback");
 				deliveryActionName = actionName;
-				// Direct proof delivery precedes persistence: at delivery time the
-				// reply row is not yet readable from the real adapter.
-				repliesVisibleAtDelivery = (await h.storedReplies()).length;
+				// Direct proof delivery precedes persistence: the reply-row write
+				// is started only after the delivery callback has been entered, so
+				// no persist marker exists yet at this synchronous point. Read it
+				// synchronously — the two tasks then run CONCURRENTLY (see the
+				// Promise.allSettled in the simple-path branch), so awaiting an
+				// adapter read here would hand the in-memory persist a scheduling
+				// window and prove nothing about the ordering contract.
+				orderAtDelivery = [...h.order];
 				return [];
 			},
 		);
@@ -268,7 +273,7 @@ describe("simple-path deliver-then-persist ordering", () => {
 		expect(result.mode).toBe("simple");
 		expect(result.responseContent?.text).toBe(h.replyText);
 		expect(deliveryActionName).toBeUndefined();
-		expect(repliesVisibleAtDelivery).toBe(0);
+		expect(orderAtDelivery).toEqual(["stage1:1", "callback"]);
 		expect(h.order).toEqual(["stage1:1", "callback", "persist:reply"]);
 		expect(result.persistedResponseMessageIds).toHaveLength(1);
 


### PR DESCRIPTION
`develop` is red after the merge sweep. Three `packages/core` test files assert contracts their own production code no longer implements. **No production behaviour changes in this PR** — only the stale assertions move.

## 1. `packages/core/src/__tests__/stage1-provider-execution.test.ts`

Two regressions stacked on this file.

**Cause A — 423aea34a0 `fix: preserve complete model context (#24134)`** deleted

```ts
const STAGE1_EXTRA_PROVIDER_EXCLUSIONS = ["ENTITIES", "DOCUMENTS"] as const;
```

from `packages/core/src/services/message.ts` and updated its own tests, but not this one. Dropping composed providers out of a model-facing include list is exactly what `CLAUDE.md` → *Prompt integrity: never discard model context* forbids, so the **production side is right** and the test is stale.

**Cause B — 57548bcb30 `fix(core): preserve reply bypasses in ambient triage (#25341)`** added a `runtime.getSetting("ALWAYS_RESPOND_CHANNELS")` read to `messageBypassesResponseEvaluation`, reached from `stage1ResponseStateProviderNames`. The file's stub runtimes are `{ providers: [] }` — no `getSetting`.

### Before
```
 × keeps RECENT_ERRORS on DM turns and unknown channel types (fail open)
TypeError: runtime.getSetting is not a function
 ❯ messageBypassesResponseEvaluation packages/core/src/services/message.ts:612:11
 × skips excluded providers at stage 1 and defers them to the planner recompose
AssertionError: expected 1 to be +0   // entities.calls()
      Tests  9 failed | 1 passed (10)
```

### After
```
      Tests  10 passed (10)
```

### Mutation check
Removed `"ENTITIES"` from `CORE_RESPONSE_STATE_PROVIDERS` in `message.ts`:
```
      Tests  3 failed | 7 passed (10)
```
Restored → `Tests  10 passed (10)`.

## 2. `packages/core/src/features/documents/action-context-gate.test.ts`

**Cause — 42edf0f5a2 `feat: add bounded progressive content access (#24305)`** moved the DOCUMENT `read` subaction from `service.getDocumentById` onto `service.readDocumentRange`. The test's stub service still only offered `getDocumentById`, so the handler threw, the J1 catch turned it into a failure result, and the "read-only subactions are admitted on knowledge-routed turns" assertions saw 0 calls.

### Before
```
 × allows the read-only read subaction when routed to knowledge
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 × allows the read-only read subaction when state is knowledge and message is general (app-path)
      Tests  2 failed | 16 passed (18)
```

### After
```
      Tests  18 passed (18)
```

### Mutation check
Removed `"read"` from `READ_ONLY_DOCUMENT_SUBACTIONS` in `actions.ts` (so a knowledge-routed read is gate-rejected):
```
      Tests  2 failed | 16 passed (18)
```
Restored → `Tests  18 passed (18)`.

## 3. `packages/core/src/services/message.deliver-then-persist.test.ts`

The simple path deliberately runs reply delivery and the response-memory write **concurrently** (`await Promise.allSettled([deliveryTask, persistTask])` in `message.ts`) — that is what the file's own header describes. The first test proved the ordering by `await`ing an adapter read *inside* the delivery callback and asserting zero rows were visible. That await yields, which hands the concurrent in-memory persist a scheduling window; **423aea34a0 (#24134)** removed enough pre-delivery awaits (`applyMessageHistoryCompactionHook`, the personality-verbosity lookup in `wrapSingleTurnVisibleCallback`) that the persist now wins the race.

Bisected over the eight commits touching `message.ts` in the sweep:
```
64408cbc9f ::  Tests  1 passed | 8 skipped (9)
231b7ea8e7 ::  Tests  1 passed | 8 skipped (9)
f0762367bb ::  Tests  1 passed | 8 skipped (9)
bfa465eb14 ::  Tests  1 passed | 8 skipped (9)
423aea34a0 ::  Tests  1 failed | 8 skipped (9)   <-- first bad
be546fd57f ::  Tests  1 failed | 8 skipped (9)
7b4ce922ee ::  Tests  1 failed | 8 skipped (9)
280c55eb66 ::  Tests  1 failed | 8 skipped (9)
```

The ordering invariant the production code actually guarantees is: **the persist task is constructed only after the delivery callback has been entered.** The test now reads the order log synchronously at callback entry instead of awaiting a DB round-trip. The existing `expect(h.order).toEqual(["stage1:1", "callback", "persist:reply"])` assertion is unchanged.

### Before
```
 × fires the delivery callback before the reply persist completes, then still persists it
AssertionError: expected 1 to be +0
 ❯ packages/core/src/services/message.deliver-then-persist.test.ts:271:36
      Tests  1 failed | 8 passed (9)
```
(order log at the time of failure: `["stage1:1","callback","persist:reply"]`, `repliesVisibleAtDelivery 1` — the callback *is* first, the row just landed during the await.)

### After
```
      Tests  9 passed (9)
```

### Mutation check
Deferred the delivery callback behind a 50 ms timer so the persist starts first:
```
AssertionError: expected [ 'stage1:1', 'persist:reply', …(1) ] to deeply equal [ 'stage1:1', 'callback' ]
      Tests  1 failed | 8 skipped (9)
```
Restored → `Tests  9 passed (9)`.

## Combined

```
$ ./node_modules/.bin/vitest run \
    packages/core/src/__tests__/stage1-provider-execution.test.ts \
    packages/core/src/services/message.deliver-then-persist.test.ts \
    packages/core/src/features/documents/action-context-gate.test.ts

 Test Files  3 passed (3)
      Tests  37 passed (37)
```
