### PR TITLE
test(app-core): cover database-recovery

### DIFF
--- a/packages/app-core/platforms/electrobun/src/database/database-recovery.test.ts
+++ b/packages/app-core/platforms/electrobun/src/database/database-recovery.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Verifies Electrobun PGlite backup and reset against the real filesystem.
+ * Injected `now` and `backupRoot` are the module's public options; fs stays real.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  backupPgliteDirectory,
+  databaseBackupRoot,
+  resetPgliteDirectory,
+} from "./database-recovery.ts";
+
+const FIXED_NOW = new Date("2026-05-17T12:34:56.789Z");
+const FIXED_STAMP = "2026-05-17T12-34-56-789Z";
+
+const tempDirs: string[] = [];
+
+function tempDir(name: string): string {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `eliza-db-recovery-${name}-`),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+function pgliteDir(name: string): string {
+  return path.join(tempDir(name), "database", "pglite");
+}
+
+function writeTree(root: string, files: Record<string, string>): void {
+  fs.mkdirSync(root, { recursive: true });
+  for (const [relative, body] of Object.entries(files)) {
+    const full = path.join(root, relative);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body, "utf8");
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("databaseBackupRoot", () => {
+  it("places pglite-backups next to the data directory", () => {
+    expect(databaseBackupRoot("/state/database/pglite")).toBe(
+      "/state/database/pglite-backups",
+    );
+    expect(databaseBackupRoot("/state/.elizadb")).toBe("/state/pglite-backups");
+    expect(databaseBackupRoot("pglite")).toBe("pglite-backups");
+  });
+});
+
+describe("backupPgliteDirectory", () => {
+  it("reports source-missing without creating a backup root", () => {
+    const sourceDir = pgliteDir("missing");
+    const result = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+
+    expect(result).toEqual({
+      sourceDir,
+      backupDir: null,
+      created: false,
+      reason: "source-missing",
+    });
+    expect(fs.existsSync(databaseBackupRoot(sourceDir))).toBe(false);
+  });
+
+  it("copies nested files into a timestamped sibling backup and leaves the source intact", () => {
+    const sourceDir = pgliteDir("copy");
+    writeTree(sourceDir, {
+      state: "ok",
+      "sub/nested.txt": "deep",
+    });
+
+    const result = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+    const expectedBackup = path.join(
+      databaseBackupRoot(sourceDir),
+      `pglite-${FIXED_STAMP}`,
+    );
+
+    expect(result).toEqual({
+      sourceDir,
+      backupDir: expectedBackup,
+      created: true,
+    });
+    expect(fs.readFileSync(path.join(expectedBackup, "state"), "utf8")).toBe(
+      "ok",
+    );
+    expect(
+      fs.readFileSync(path.join(expectedBackup, "sub", "nested.txt"), "utf8"),
+    ).toBe("deep");
+    expect(fs.readFileSync(path.join(sourceDir, "state"), "utf8")).toBe("ok");
+    expect(
+      fs.readFileSync(path.join(sourceDir, "sub", "nested.txt"), "utf8"),
+    ).toBe("deep");
+  });
+
+  it("backs up an empty pglite directory", () => {
+    const sourceDir = pgliteDir("empty");
+    fs.mkdirSync(sourceDir, { recursive: true });
+
+    const result = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+
+    expect(result.created).toBe(true);
+    expect(result.backupDir).toBe(
+      path.join(databaseBackupRoot(sourceDir), `pglite-${FIXED_STAMP}`),
+    );
+    expect(fs.readdirSync(result.backupDir as string)).toEqual([]);
+  });
+
+  it("honors a custom backupRoot", () => {
+    const sourceDir = pgliteDir("custom-root");
+    writeTree(sourceDir, { marker: "1" });
+    const backupRoot = path.join(tempDir("backups"), "custom");
+
+    const result = backupPgliteDirectory(sourceDir, {
+      now: () => FIXED_NOW,
+      backupRoot,
+    });
+
+    expect(result.backupDir).toBe(
+      path.join(backupRoot, `pglite-${FIXED_STAMP}`),
+    );
+    expect(fs.existsSync(databaseBackupRoot(sourceDir))).toBe(false);
+    expect(
+      fs.readFileSync(path.join(result.backupDir as string, "marker"), "utf8"),
+    ).toBe("1");
+  });
+
+  it("accepts a .elizadb basename", () => {
+    const sourceDir = path.join(tempDir("elizadb"), ".elizadb");
+    writeTree(sourceDir, { db: "yes" });
+
+    const result = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+
+    expect(result.created).toBe(true);
+    expect(result.backupDir).toBe(
+      path.join(databaseBackupRoot(sourceDir), `pglite-${FIXED_STAMP}`),
+    );
+    expect(
+      fs.readFileSync(path.join(result.backupDir as string, "db"), "utf8"),
+    ).toBe("yes");
+  });
+
+  it("uses the live clock when now is omitted", () => {
+    const sourceDir = pgliteDir("live-clock");
+    writeTree(sourceDir, { tick: "t" });
+
+    const result = backupPgliteDirectory(sourceDir);
+
+    expect(result.created).toBe(true);
+    expect(result.backupDir).toMatch(
+      new RegExp(
+        `^${databaseBackupRoot(sourceDir).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/pglite-\\d{4}-`,
+      ),
+    );
+    expect(
+      fs.readFileSync(path.join(result.backupDir as string, "tick"), "utf8"),
+    ).toBe("t");
+  });
+
+  it("merges into an existing timestamped backup without overwriting files", () => {
+    const sourceDir = pgliteDir("no-overwrite");
+    writeTree(sourceDir, { state: "first" });
+    const first = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+    expect(first.created).toBe(true);
+
+    fs.writeFileSync(path.join(sourceDir, "state"), "second", "utf8");
+    fs.writeFileSync(path.join(sourceDir, "extra"), "new", "utf8");
+    const second = backupPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+    expect(second.created).toBe(true);
+    expect(second.backupDir).toBe(first.backupDir);
+    expect(
+      fs.readFileSync(path.join(first.backupDir as string, "state"), "utf8"),
+    ).toBe("first");
+    expect(
+      fs.readFileSync(path.join(first.backupDir as string, "extra"), "utf8"),
+    ).toBe("new");
+  });
+
+  it("rejects memory://, filesystem root, wrong basename, and app-bundle paths", () => {
+    expect(() => backupPgliteDirectory("memory://")).toThrow(
+      "memory:// PGlite data cannot be backed up or reset.",
+    );
+    expect(() => backupPgliteDirectory("  memory://  ")).toThrow(
+      "memory:// PGlite data cannot be backed up or reset.",
+    );
+    expect(() => backupPgliteDirectory("/")).toThrow(
+      "PGlite reset target is too broad.",
+    );
+    expect(() => backupPgliteDirectory("/tmp/not-a-db")).toThrow(
+      /must end in pglite or \.elizadb/,
+    );
+    expect(() =>
+      backupPgliteDirectory("/Applications/Eliza.app/Contents/database/pglite"),
+    ).toThrow("PGlite reset target cannot be inside an app bundle.");
+  });
+});
+
+describe("resetPgliteDirectory", () => {
+  it("backs up, removes contents, and recreates an empty source directory", () => {
+    const sourceDir = pgliteDir("reset-existing");
+    writeTree(sourceDir, {
+      state: "ok",
+      "sub/nested.txt": "deep",
+    });
+
+    const result = resetPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+    const expectedBackup = path.join(
+      databaseBackupRoot(sourceDir),
+      `pglite-${FIXED_STAMP}`,
+    );
+
+    expect(result.sourceDir).toBe(sourceDir);
+    expect(result.removed).toBe(true);
+    expect(result.backup).toEqual({
+      sourceDir,
+      backupDir: expectedBackup,
+      created: true,
+    });
+    expect(fs.existsSync(sourceDir)).toBe(true);
+    expect(fs.readdirSync(sourceDir)).toEqual([]);
+    expect(fs.readFileSync(path.join(expectedBackup, "state"), "utf8")).toBe(
+      "ok",
+    );
+    expect(
+      fs.readFileSync(path.join(expectedBackup, "sub", "nested.txt"), "utf8"),
+    ).toBe("deep");
+  });
+
+  it("creates an empty source directory when the original is missing", () => {
+    const sourceDir = pgliteDir("reset-missing");
+
+    const result = resetPgliteDirectory(sourceDir, { now: () => FIXED_NOW });
+
+    expect(result.removed).toBe(false);
+    expect(result.backup).toEqual({
+      sourceDir,
+      backupDir: null,
+      created: false,
+      reason: "source-missing",
+    });
+    expect(fs.existsSync(sourceDir)).toBe(true);
+    expect(fs.readdirSync(sourceDir)).toEqual([]);
+    expect(fs.existsSync(databaseBackupRoot(sourceDir))).toBe(false);
+  });
+
+  it("forwards backupRoot to the backup step", () => {
+    const sourceDir = pgliteDir("reset-custom-root");
+    writeTree(sourceDir, { marker: "keep" });
+    const backupRoot = path.join(tempDir("reset-backups"), "custom");
+
+    const result = resetPgliteDirectory(sourceDir, {
+      now: () => FIXED_NOW,
+      backupRoot,
+    });
+
+    expect(result.removed).toBe(true);
+    expect(result.backup.backupDir).toBe(
+      path.join(backupRoot, `pglite-${FIXED_STAMP}`),
+    );
+    expect(
+      fs.readFileSync(
+        path.join(result.backup.backupDir as string, "marker"),
+        "utf8",
+      ),
+    ).toBe("keep");
+    expect(fs.readdirSync(sourceDir)).toEqual([]);
+  });
+
+  it("leaves the source tree in place when backup cannot create the backup root", () => {
+    const sourceDir = pgliteDir("reset-backup-fails");
+    writeTree(sourceDir, { state: "untouched" });
+    const backupRoot = path.join(tempDir("blocked"), "not-a-dir");
+    fs.writeFileSync(backupRoot, "file", "utf8");
+
+    expect(() =>
+      resetPgliteDirectory(sourceDir, {
+        now: () => FIXED_NOW,
+        backupRoot,
+      }),
+    ).toThrow();
+    expect(fs.readFileSync(path.join(sourceDir, "state"), "utf8")).toBe(
+      "untouched",
+    );
+  });
+
+  it("rejects unsafe reset targets before touching the filesystem", () => {
+    expect(() => resetPgliteDirectory("memory://")).toThrow(
+      "memory:// PGlite data cannot be backed up or reset.",
+    );
+    expect(() => resetPgliteDirectory("/")).toThrow(
+      "PGlite reset target is too broad.",
+    );
+    expect(() => resetPgliteDirectory("/tmp/other")).toThrow(
+      /must end in pglite or \.elizadb/,
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated vitest suite for `packages/app-core/platforms/electrobun/src/database/database-recovery.ts`, which had no same-named test file.

The suite drives the real module and the real filesystem. It does not mock `fs` or the recovery functions. Injected `now` and `backupRoot` are the module's public options.

Covered behaviour:

- `databaseBackupRoot` places `pglite-backups` next to the data directory, including `.elizadb` and relative names.
- `backupPgliteDirectory` reports `source-missing` with `backupDir: null` and does not create a backup root when the source is absent.
- Nested files are copied into `pglite-<sanitized-ISO-timestamp>` and the source tree is left intact.
- Empty directories are backed up as empty trees.
- A custom `backupRoot` is honored and the default sibling root is not created.
- `.elizadb` is an accepted basename.
- Omitting `now` uses the live clock and still produces a `pglite-` backup directory.
- A second backup at the same timestamp (`fs.cpSync` with `force: false`) merges new files and does not overwrite files already in the backup.
- Unsafe targets throw: `memory://` (including trimmed whitespace), filesystem root, wrong basename, and paths inside `.app/Contents`.
- `resetPgliteDirectory` on an existing tree backs up, removes contents, and recreates an empty source directory (`removed: true`).
- Reset of a missing source creates an empty directory (`removed: false`) without a backup.
- Reset forwards `backupRoot` to the backup step.
- When the backup root cannot be created (path exists as a file), reset throws and leaves the source tree in place.
- Unsafe reset targets throw before any filesystem mutation.

No production code is changed.

## Evidence

Test-only change. Hosted CI does not run on this fork contributor's pull requests. Counts below were observed locally against current `origin/develop` (`69967d93a0cfde0c1b266546793a13939a24c70b`) immediately before filing.

1. Vitest (electrobun-aware config; `packages/app-core/vitest.config.ts` excludes `platforms/electrobun/**`):

```
cd packages/app-core/platforms/electrobun && bunx vitest run --config vitest.electrobun.config.ts src/database/database-recovery.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

2. Biome (`biome.json` present; checkout is not sparse):

```
bunx biome check --write packages/app-core/platforms/electrobun/src/database/database-recovery.test.ts
Checked 1 file. No fixes applied.
```

3. Typecheck of the owning Electrobun package. The new file is absent from tsc output:

```
cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'database-recovery.test.ts' ; echo "EXIT:$?"
EXIT:1
```

Pre-existing errors elsewhere in the package are unrelated.

4. Diff touches only `packages/app-core/platforms/electrobun/src/database/database-recovery.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d4e30fb09c9570baa91c3e2c7d015f140fcadd3b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
