### PR TITLE
test(app-core): cover kiosk-canvas

### DIFF
--- a/packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.test.ts
+++ b/packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.test.ts
@@ -1,0 +1,234 @@
+/** Exercises kiosk canvas behavior with deterministic app-core test fixtures. */
+import type { JsonValue } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { SendToWebview } from "../types";
+import {
+  KIOSK_VIEW_EVENT_MESSAGE,
+  KioskCanvas,
+  type KioskViewEvent,
+} from "./kiosk-canvas";
+
+type SentCall = {
+  message: string;
+  payload: unknown;
+};
+
+function recordingSender(): {
+  send: SendToWebview;
+  sent: SentCall[];
+} {
+  const sent: SentCall[] = [];
+  return {
+    sent,
+    send: (message, payload) => {
+      sent.push({ message, payload });
+    },
+  };
+}
+
+function asViewEvent(payload: unknown): KioskViewEvent {
+  if (payload === null || typeof payload !== "object" || !("kind" in payload)) {
+    throw new Error("kiosk canvas sent a non-event payload");
+  }
+  return payload as KioskViewEvent;
+}
+
+describe("KioskCanvas", () => {
+  it("exports the renderer-bound kiosk view event channel name", () => {
+    expect(KIOSK_VIEW_EVENT_MESSAGE).toBe("kioskViewEvent");
+  });
+
+  it("mounts a window with empty-option defaults and a sequential kiosk-view id", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    const created = await canvas.createWindow({});
+
+    expect(created.id).toMatch(/^kiosk-view_\d+$/);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.message).toBe(KIOSK_VIEW_EVENT_MESSAGE);
+    expect(asViewEvent(sent[0]?.payload)).toEqual({
+      kind: "mount",
+      windowId: created.id,
+      url: "",
+      title: "View",
+      width: 760,
+      height: 520,
+      alwaysOnTop: false,
+    });
+  });
+
+  it("mounts a window with caller-supplied url, title, size, and alwaysOnTop", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    const created = await canvas.createWindow({
+      url: "https://example.invalid/view",
+      title: "Trace",
+      width: 1280,
+      height: 720,
+      alwaysOnTop: true,
+      x: 12,
+      y: 34,
+      transparent: true,
+    });
+
+    const event = asViewEvent(sent[0]?.payload);
+    expect(event).toEqual({
+      kind: "mount",
+      windowId: created.id,
+      url: "https://example.invalid/view",
+      title: "Trace",
+      width: 1280,
+      height: 720,
+      alwaysOnTop: true,
+    });
+    expect(event).not.toHaveProperty("x");
+    expect(event).not.toHaveProperty("y");
+    expect(event).not.toHaveProperty("transparent");
+  });
+
+  it("preserves empty title and zero size because nullish defaults do not replace them", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    await canvas.createWindow({
+      url: "",
+      title: "",
+      width: 0,
+      height: 0,
+      alwaysOnTop: false,
+    });
+
+    expect(asViewEvent(sent[0]?.payload)).toMatchObject({
+      kind: "mount",
+      url: "",
+      title: "",
+      width: 0,
+      height: 0,
+      alwaysOnTop: false,
+    });
+  });
+
+  it("assigns strictly increasing ids across consecutive creates on one canvas", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    const first = await canvas.createWindow({ title: "one" });
+    const second = await canvas.createWindow({ title: "two" });
+
+    const firstN = Number(first.id.slice("kiosk-view_".length));
+    const secondN = Number(second.id.slice("kiosk-view_".length));
+    expect(secondN).toBe(firstN + 1);
+    expect(first.id).not.toBe(second.id);
+    expect(sent).toHaveLength(2);
+    expect(asViewEvent(sent[0]?.payload).windowId).toBe(first.id);
+    expect(asViewEvent(sent[1]?.payload).windowId).toBe(second.id);
+  });
+
+  it("shares the module-level id counter across canvas instances", async () => {
+    const first = recordingSender();
+    const second = recordingSender();
+    const left = new KioskCanvas(first.send);
+    const right = new KioskCanvas(second.send);
+
+    const fromLeft = await left.createWindow({ title: "left" });
+    const fromRight = await right.createWindow({ title: "right" });
+
+    const leftN = Number(fromLeft.id.slice("kiosk-view_".length));
+    const rightN = Number(fromRight.id.slice("kiosk-view_".length));
+    expect(rightN).toBe(leftN + 1);
+    expect(first.sent).toHaveLength(1);
+    expect(second.sent).toHaveLength(1);
+    expect(asViewEvent(first.sent[0]?.payload).windowId).toBe(fromLeft.id);
+    expect(asViewEvent(second.sent[0]?.payload).windowId).toBe(fromRight.id);
+  });
+
+  it("unmounts an existing window by id without touching other mounted views", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+    const keep = await canvas.createWindow({ title: "keep" });
+    const drop = await canvas.createWindow({ title: "drop" });
+    sent.length = 0;
+
+    await canvas.destroyWindow({ id: drop.id });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.message).toBe(KIOSK_VIEW_EVENT_MESSAGE);
+    expect(asViewEvent(sent[0]?.payload)).toEqual({
+      kind: "unmount",
+      windowId: drop.id,
+    });
+    expect(asViewEvent(sent[0]?.payload).windowId).not.toBe(keep.id);
+  });
+
+  it("still emits unmount when the id was never mounted", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    await canvas.destroyWindow({ id: "kiosk-view_missing" });
+
+    expect(sent).toEqual([
+      {
+        message: KIOSK_VIEW_EVENT_MESSAGE,
+        payload: { kind: "unmount", windowId: "kiosk-view_missing" },
+      },
+    ]);
+  });
+
+  it("pushes an a2ui payload to the requested window id, including nested json", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+    const created = await canvas.createWindow({ title: "a2ui" });
+    sent.length = 0;
+    const payload: JsonValue = {
+      type: "dynamic-view.event",
+      nested: { ok: true, n: 3 },
+      list: ["a", 1, null],
+    };
+
+    await canvas.a2uiPush({ id: created.id, payload });
+
+    expect(asViewEvent(sent[0]?.payload)).toEqual({
+      kind: "a2ui",
+      windowId: created.id,
+      payload,
+    });
+  });
+
+  it("pushes a2ui to an unknown window id because membership is not checked", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    await canvas.a2uiPush({
+      id: "kiosk-view_never-created",
+      payload: "hello",
+    });
+
+    expect(asViewEvent(sent[0]?.payload)).toEqual({
+      kind: "a2ui",
+      windowId: "kiosk-view_never-created",
+      payload: "hello",
+    });
+  });
+
+  it("routes every canvas method through the same webview message name", async () => {
+    const { send, sent } = recordingSender();
+    const canvas = new KioskCanvas(send);
+
+    const created = await canvas.createWindow({ title: "channel" });
+    await canvas.a2uiPush({ id: created.id, payload: 1 });
+    await canvas.destroyWindow({ id: created.id });
+
+    expect(sent.map((call) => call.message)).toEqual([
+      KIOSK_VIEW_EVENT_MESSAGE,
+      KIOSK_VIEW_EVENT_MESSAGE,
+      KIOSK_VIEW_EVENT_MESSAGE,
+    ]);
+    expect(sent.map((call) => asViewEvent(call.payload).kind)).toEqual([
+      "mount",
+      "a2ui",
+      "unmount",
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.ts`, which previously had no sibling test file.

The suite drives the real `KioskCanvas` module with a recording `sendToWebview` collaborator (no mocked return-then-assert theatre). It records observed behaviour:

- `KIOSK_VIEW_EVENT_MESSAGE` is `"kioskViewEvent"`
- `createWindow({})` mounts with defaults `url=""`, `title="View"`, `width=760`, `height=520`, `alwaysOnTop=false`
- supplied url/title/size/`alwaysOnTop` are forwarded; `x`/`y`/`transparent` are accepted and omitted from the mount event
- empty title and zero size are preserved (`??` does not replace them)
- ids match `kiosk-view_<n>` and increase by one across consecutive creates
- the module-level counter is shared across canvas instances
- `destroyWindow` emits `unmount` for a mounted id and also for a never-mounted id
- `a2uiPush` forwards nested JSON and does not require the window to exist
- every method uses the same webview message name

This is a test-only change. No production behaviour is modified.

## Evidence

1. `bunx vitest run packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.test.ts` against current `origin/develop` (`69967d93a0cf`): **Test Files 1 passed (1), Tests 11 passed (11)**. Re-fetched `origin/develop` immediately before filing; `kiosk-canvas.ts` has no diff vs that tip.
2. `bunx biome check --write packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.test.ts` is clean (`Checked 1 file`, after one import-order fix). Config proven present: `biome.json` and `tsconfig.json` exist; sparse-checkout is not enabled.
3. `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'kiosk-canvas.test.ts'` is empty (`EXIT:1` from grep). The new test file introduced no TypeScript errors.
4. The diff touches only `packages/app-core/platforms/electrobun/src/dynamic-views/kiosk-canvas.test.ts` (234 insertions).

Hosted CI does not run on this fork contributor PR. Do not treat missing GitHub Actions checks as a pass.

## Test plan

- [x] Vitest collects the new file and all 11 tests pass
- [x] Biome check is clean on the new file
- [x] `tsc --noEmit` in `@elizaos/app-core` does not mention the new file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0a346c4103ea7632278f72240f48d975a190d751 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
