### PR TITLE
test(cloud): prove Billing survives cache outage

### DIFF
--- a/packages/cloud/e2e/tests/billing-cache-outage-adversarial.spec.ts
+++ b/packages/cloud/e2e/tests/billing-cache-outage-adversarial.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Proves a runtime-tier cache outage remains a field-level Billing observation:
+ * the real Worker still serves authoritative PGlite balance/compute data and
+ * the real UI renders those available fields. The browser transport is never
+ * intercepted, fulfilled, or replaced by a client-side mock.
+ */
+
+import { seedTestUser } from "../src/fixtures/seed";
+import {
+  createCloudAgent,
+  getPersistedAgentSummary,
+} from "../src/helpers/provisioning";
+import {
+  buildPlaywrightSessionToken,
+  expect,
+  test,
+} from "../src/helpers/test-fixtures";
+
+const BILLING_SNAPSHOT_PATH = "/api/v1/billing/limits";
+const BILLING_PAGE_PATH = "/cloud/billing";
+
+test.use({
+  stackOptions: {
+    backendFaults: true,
+    env: {
+      MOCK_REDIS: "0",
+      CACHE_ENABLED: "true",
+      CACHE_BACKEND: "redis",
+      // Port 1 is a privileged loopback port and therefore cannot be claimed by
+      // the unprivileged E2E stack. Connection refusal is immediate and keeps
+      // the outage hermetic: no packet can leave the local machine.
+      REDIS_URL: "redis://127.0.0.1:1",
+    },
+  },
+});
+
+test.describe("billing snapshot — runtime cache outage", () => {
+  test("keeps authoritative balance and empty compute available when Redis is unreachable", async ({
+    page,
+    stack,
+  }) => {
+    // SIWE nonce persistence correctly fails closed during a Redis outage, so
+    // this cache-focused spec seeds its authenticated authority directly in
+    // the real PGlite database. The browser still uses the stack's signed,
+    // server-validated Playwright session cookie; no client request is mocked.
+    const seededUser = await seedTestUser({
+      slug: `billing-cache-outage-${Date.now().toString(36)}`,
+    });
+    const frontendUrl = new URL(stack.urls.frontend);
+    await page.context().addCookies([
+      {
+        name: "eliza-test-auth",
+        value: "1",
+        domain: frontendUrl.hostname,
+        path: "/",
+      },
+      {
+        name: "eliza-test-session",
+        value: buildPlaywrightSessionToken(
+          seededUser.userId,
+          seededUser.organizationId,
+        ),
+        domain: frontendUrl.hostname,
+        path: "/",
+      },
+    ]);
+
+    const backendFaults = stack.mocks.backendFaults;
+    if (!backendFaults) throw new Error("backend fault controller unavailable");
+    backendFaults.clearFault();
+
+    // The combined app expects an agent API for its startup coordinator. Create
+    // a real, non-billable shared agent and route only those exact shell paths
+    // to its real Worker adapter; Cloud account APIs remain at the Worker root.
+    const agentId = await createCloudAgent(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      `billing-cache-outage-e2e-${Date.now().toString(36)}`,
+    );
+    const shellRuntime = await getPersistedAgentSummary(
+      agentId,
+      seededUser.organizationId,
+    );
+    expect(shellRuntime.executionTier).toBe("shared");
+    const sharedAdapterPrefix = `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`;
+    backendFaults.setPathRewrites(
+      [
+        "/api/health",
+        "/api/status",
+        "/api/auth/status",
+        "/api/auth/me",
+        "/api/conversations",
+        "/api/character",
+        "/api/first-run/status",
+        "/api/first-run",
+        "/api/views",
+        "/api/config",
+        "/api/runtime/mode",
+        "/api/commands",
+        "/api/custom-actions",
+        "/api/agent/events",
+        "/api/agent/start",
+        "/api/apps/overlay-presence",
+        "/api/lifeops/activity-signals",
+        "/api/stream/settings",
+      ].map((path) => ({
+        path,
+        targetPath: `${sharedAdapterPrefix}${path}`,
+      })),
+    );
+
+    await page.addInitScript(
+      ({ agentId, apiBase, apiKey }) => {
+        window.localStorage.setItem("eliza:first-run-complete", "1");
+        window.localStorage.setItem(
+          "elizaos:active-server",
+          JSON.stringify({
+            id: `cloud:${agentId}`,
+            kind: "cloud",
+            label: "Billing cache-outage E2E shared runtime",
+            apiBase,
+            accessToken: apiKey,
+            cloudRuntimeAgentId: agentId,
+            cloudRuntime: "shared",
+          }),
+        );
+      },
+      {
+        agentId,
+        apiBase: stack.urls.frontend,
+        apiKey: seededUser.apiKey,
+      },
+    );
+
+    const runtimeReady = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === "/api/status" &&
+        response.status() === 200,
+    );
+    await page.goto(stack.urls.frontend, { timeout: 60_000 });
+    await runtimeReady;
+    await expect(page.getByTestId("home-launcher-surface")).toBeVisible();
+
+    const response = await fetch(`${stack.urls.api}${BILLING_SNAPSHOT_PATH}`, {
+      headers: { Authorization: `Bearer ${seededUser.apiKey}` },
+    });
+    expect(
+      response.status,
+      `billing snapshot returned ${response.status}: ${await response.clone().text()}`,
+    ).toBe(200);
+
+    const body = (await response.json()) as {
+      success?: boolean;
+      data?: {
+        schemaVersion?: number;
+        v2?: {
+          balance?: unknown;
+          tier?: { runtimeCache?: unknown };
+          activeCompute?: { resources?: unknown };
+        };
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data?.schemaVersion).toBe(2);
+    expect(body.data?.v2?.tier?.runtimeCache).toMatchObject({
+      status: "unavailable",
+      source: "org-rate-limit-cache",
+      error: {
+        code: "runtime_tier_cache_unavailable",
+        retryable: true,
+      },
+    });
+    expect(body.data?.v2?.balance).toMatchObject({
+      status: "available",
+      source: "organizations",
+      value: {
+        balance: {
+          value: "1000.000000",
+          unit: "usd",
+          currency: "USD",
+        },
+      },
+    });
+    expect(body.data?.v2?.activeCompute?.resources).toMatchObject({
+      status: "available",
+      source: "active-billing-service",
+      value: [],
+    });
+
+    const uiSnapshotResponse = page.waitForResponse(
+      (candidate) =>
+        new URL(candidate.url()).pathname === BILLING_SNAPSHOT_PATH &&
+        candidate.status() === 200,
+    );
+    await page.goto(`${stack.urls.frontend}${BILLING_PAGE_PATH}`, {
+      timeout: 60_000,
+    });
+    await uiSnapshotResponse;
+
+    await expect(page.getByText("$1,000.00", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Active compute" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("No active billable compute", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Balance unavailable", { exact: true }),
+    ).toBeHidden();
+    await expect(
+      page.getByRole("heading", {
+        name: "Active compute unavailable",
+      }),
+    ).toBeHidden();
+    await expect(
+      page.getByText(
+        "Active resources cannot be shown from this observation. No empty state is inferred.",
+        { exact: true },
+      ),
+    ).toBeHidden();
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #22965. This is the bounded `billing-v3-cache-outage-e2e` tranche and does not close the broader Billing UI issue.

- [x] The branch was validated from `develop@c3f070a5ee1e45204df4a447d4592bc8d0bf416e`; while exact-head tests ran, `develop` advanced by one CI-only commit (`69967d93a0cfde0c1b266546793a13939a24c70b`) that changes no Cloud Billing/E2E path.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after the final content sync; the unrelated global verify blocker is recorded below.
- [x] The exact-head Playwright report will be attached before this draft is marked ready.

# Sync with develop

- [x] Commit parent / validation base: `c3f070a5ee1e45204df4a447d4592bc8d0bf416e`; zero rebase conflicts.
- [x] The only changed path is `packages/cloud/e2e/tests/billing-cache-outage-adversarial.spec.ts`.
- [x] The single intervening `develop` commit is CI-only and does not overlap the changed path.

# Risks

Low. This adds one Chromium E2E spec and changes no runtime, UI, schema, migration, cache implementation, or deployment code. The stack points Redis at a loopback-only closed port, so no packet can leave the local machine.

# Background

## What does this PR do?

It boots the real frontend, Cloud Worker, and PGlite database with the real Redis cache transport enabled and `MOCK_REDIS=0`, while the loopback Redis endpoint refuses connections. The test proves:

- Worker cache GET/SET operations fail through the real SocketRedis path and open the cache circuit breaker;
- `GET /api/v1/billing/limits` still returns 200;
- `tier.runtimeCache` is explicitly `unavailable` from `org-rate-limit-cache`, with a retryable `runtime_tier_cache_unavailable` observation;
- independent authoritative balance remains available from `organizations` at `1000.000000` USD;
- independent active-compute resources remain available from `active-billing-service` as `[]`;
- the shipped Billing UI renders `$1,000.00`, `Active compute`, and `No active billable compute` without poisoning those sections with page-wide unavailable states.

SIWE nonce storage correctly fails closed during a Redis outage. To keep the lane scoped to Billing degradation, the test seeds its synthetic identity directly in the real PGlite database and installs the existing HMAC-signed Playwright session cookie. The Worker validates that cookie and re-reads the user/organization authority from PGlite. No browser traffic is routed, fulfilled, or mocked.

## What kind of change is this?

Improvement: adversarial automated coverage for field-level Billing degradation under a real cache transport outage.

# Documentation changes needed?

No. This is additive test coverage for shipped behavior.

# Testing

## Where should a reviewer start?

`packages/cloud/e2e/tests/billing-cache-outage-adversarial.spec.ts`

## Detailed testing steps

Executed on exact head `a759f8e4936c6f4cc85301fba8725c3a9e31e279`:

```text
mise exec node@24.15.0 -- bun install --frozen-lockfile
PASS — 3724 installs checked, no changes

mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e test -- billing-cache-outage-adversarial.spec.ts --repeat-each=5
PASS — 5 passed (2.2m)

PLAYWRIGHT_JSON_OUTPUT_NAME=<temp-report> mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e test -- billing-cache-outage-adversarial.spec.ts --reporter=json
PASS — 1 passed (26.6s), scenario 12.187s; report SHA-256 `15132a815df2e3a11bb763bfcf71c0edde2a0b96e52f0ea408ef55e38e814ea5`

mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e typecheck
PASS — tsc --noEmit

mise exec node@24.15.0 -- bunx @biomejs/biome check packages/cloud/e2e/tests/billing-cache-outage-adversarial.spec.ts
PASS — Checked 1 file; no fixes applied

git diff --check c3f070a5ee1e45204df4a447d4592bc8d0bf416e...HEAD
PASS
```

An independent read-only exact-commit review found no P0–P3 issue. It confirmed SocketRedis failures/circuit breaker, real UI/Worker/PGlite, server-validated identity, exact shell-only rewrites, unchanged Billing transport, and absence of secrets or Playwright interception.

# Evidence Gate

Evidence matches the exact reviewed commit.
<!-- evidence-head:a759f8e4936c6f4cc85301fba8725c3a9e31e279 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - additive E2E test only; no rendered UI file or visual surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - additive E2E test only; no rendered UI file or visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changed; the exact-head browser execution is captured in the Playwright JSON report below.
<!-- evidence-row:backend-logs -->
- [x] Exact-head Worker transcript excerpt:

  ```text
  [wrangler:info] Ready on http://127.0.0.1:49255
  [Cache] GET failed ... error: 'jsg.Error: proxy request failed, cannot connect to the specified address'
  [Cache] SET failed ... error: 'jsg.Error: proxy request failed, cannot connect to the specified address'
  [Cache] Circuit breaker OPENED - degrading to cache-miss { failureCount: 5, cooldownMs: 60000 }
  [wrangler:info] GET /api/v1/billing/limits 200 OK (34ms)
  [wrangler:info] GET /api/v1/billing/limits 200 OK (47ms)
  [cloud-api] exited code=143 signal=null
  ```

  Exit 143 is the harness's expected teardown after the passing test.
<!-- evidence-row:frontend-logs -->
- [x] [25781-22965-cache-outage-a759f8e4.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25781-22965-cache-outage-a759f8e4.json)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, model, or LLM-provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the exact API/UI assertions are captured by the pending exact-head Playwright report; no external domain object is created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Backend + frontend logs

The attached Playwright report will identify the exact passing spec and source assertions. The Worker transcript above demonstrates the live cache transport failure, circuit breaker, and successful Billing snapshots. It contains no credential or Redis URL.

## Screenshots (before / after) + video walkthrough

N/A - the diff is one `.spec.ts` file and changes no rendered UI.

## Known gaps / failures

- `bun run verify` was executed on exact head `a759f8e4936c6f4cc85301fba8725c3a9e31e279`. It reached 142/146 turbo tasks and stopped in untouched upstream `@elizaos/cloud-api#lint:check`: import/format errors in `packages/cloud/api/v1/generate-video/route.ts` and `packages/cloud/api/v1/generate-video/route.surrogate.test.ts`. Their blobs are identical at the frozen base and HEAD (`31a917e6135339b80742a5ad8fdd54aa59f3c598` and `3ac96ca9ba92cadf9653500d8fa574d3f0fcab39`). This PR changes only the E2E spec, so the global gate is not claimed green.
- `127.0.0.1:1` is loopback-only and was refused in every exact-head repetition, but the E2E harness does not itself reserve that fixed port. A future dedicated failing-Redis fixture could make endpoint ownership absolute; this does not invalidate the observed SocketRedis outage proof.
- The lane deliberately does not prove SIWE availability during Redis failure; SIWE correctly fails closed. It proves Billing behavior for a server-validated existing session.
- The current Billing UI does not render `tier.runtimeCache` directly; the Worker JSON proves that field is unavailable, while the UI proves independent balance/compute sections remain usable.
- No production/staging state, real Redis, deploy, merge, or self-approval was performed.

## Maintainer CI exception record

N/A - no exception requested.

— [billing-v3-cache-outage-e2e]

