### PR TITLE
test(app-core): cover camera

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/camera.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/camera.test.ts
@@ -1,0 +1,214 @@
+/** Exercises camera behavior with deterministic app-core test fixtures. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CameraManager, getCameraManager } from "./camera";
+
+const nativePermissions = vi.hoisted(() => ({
+  checkPermission: vi.fn(),
+  requestPermission: vi.fn(),
+}));
+
+vi.mock("./permissions", () => ({
+  getPermissionManager: () => ({
+    checkPermission: nativePermissions.checkPermission,
+    requestPermission: nativePermissions.requestPermission,
+  }),
+}));
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+describe("CameraManager renderer-owned camera stubs", () => {
+  it("reports an empty device list and stays available", async () => {
+    await expect(new CameraManager().getDevices()).resolves.toEqual({
+      devices: [],
+      available: true,
+    });
+  });
+
+  it("ignores preview device options and reports available", async () => {
+    const manager = new CameraManager();
+
+    await expect(manager.startPreview()).resolves.toEqual({ available: true });
+    await expect(manager.startPreview({})).resolves.toEqual({
+      available: true,
+    });
+    await expect(manager.startPreview({ deviceId: "front" })).resolves.toEqual({
+      available: true,
+    });
+  });
+
+  it("resolves stopPreview without a payload", async () => {
+    await expect(new CameraManager().stopPreview()).resolves.toBeUndefined();
+  });
+
+  it("ignores switchCamera deviceId and reports available", async () => {
+    await expect(
+      new CameraManager().switchCamera({ deviceId: "rear" }),
+    ).resolves.toEqual({ available: true });
+  });
+
+  it("reports capture, startRecording, and stopRecording as available", async () => {
+    const manager = new CameraManager();
+
+    await expect(manager.capturePhoto()).resolves.toEqual({ available: true });
+    await expect(manager.startRecording()).resolves.toEqual({
+      available: true,
+    });
+    await expect(manager.stopRecording()).resolves.toEqual({
+      available: true,
+    });
+  });
+
+  it("stays idle after startRecording because native recording is not tracked", async () => {
+    const manager = new CameraManager();
+
+    await manager.startRecording();
+    await expect(manager.getRecordingState()).resolves.toEqual({
+      recording: false,
+      duration: 0,
+    });
+
+    await manager.stopRecording();
+    await expect(manager.getRecordingState()).resolves.toEqual({
+      recording: false,
+      duration: 0,
+    });
+  });
+
+  it("never invokes a registered webview callback from native camera operations", async () => {
+    const manager = new CameraManager();
+    const sendToWebview = vi.fn();
+    manager.setSendToWebview(sendToWebview);
+
+    await manager.getDevices();
+    await manager.startPreview({ deviceId: "cam-1" });
+    await manager.stopPreview();
+    await manager.switchCamera({ deviceId: "cam-2" });
+    await manager.capturePhoto();
+    await manager.startRecording();
+    await manager.stopRecording();
+    await manager.getRecordingState();
+    manager.dispose();
+
+    expect(sendToWebview).not.toHaveBeenCalled();
+  });
+});
+
+describe("getCameraManager", () => {
+  it("returns one CameraManager instance on repeated calls", () => {
+    const first = getCameraManager();
+    const second = getCameraManager();
+
+    expect(first).toBeInstanceOf(CameraManager);
+    expect(second).toBe(first);
+  });
+
+  it("does not alias a directly constructed manager onto the singleton", async () => {
+    const constructed = new CameraManager();
+    const singleton = getCameraManager();
+
+    expect(constructed).not.toBe(singleton);
+    await expect(constructed.getDevices()).resolves.toEqual({
+      devices: [],
+      available: true,
+    });
+    await expect(singleton.getDevices()).resolves.toEqual({
+      devices: [],
+      available: true,
+    });
+  });
+});
+
+describe("CameraManager permission-status mapping", () => {
+  beforeEach(() => {
+    nativePermissions.checkPermission.mockReset();
+    nativePermissions.requestPermission.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  it.each(["linux", "win32"] as const)(
+    "returns prompt on %s without consulting native permissions",
+    async (platform) => {
+      stubPlatform(platform);
+      const manager = new CameraManager();
+
+      await expect(manager.checkPermissions()).resolves.toEqual({
+        status: "prompt",
+      });
+      await expect(manager.requestPermissions()).resolves.toEqual({
+        status: "prompt",
+      });
+      expect(nativePermissions.checkPermission).not.toHaveBeenCalled();
+      expect(nativePermissions.requestPermission).not.toHaveBeenCalled();
+    },
+  );
+
+  it("on darwin maps only status from the native camera permission check", async () => {
+    stubPlatform("darwin");
+    nativePermissions.checkPermission.mockResolvedValue({
+      id: "camera",
+      status: "denied",
+      canRequest: true,
+      platform: "darwin",
+      extra: "must-not-leak",
+    });
+
+    const result = await new CameraManager().checkPermissions();
+
+    expect(result).toEqual({ status: "denied" });
+    expect(result).not.toHaveProperty("id");
+    expect(result).not.toHaveProperty("extra");
+    expect(nativePermissions.checkPermission).toHaveBeenCalledWith("camera");
+    expect(nativePermissions.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("on darwin maps only status from the native camera permission request", async () => {
+    stubPlatform("darwin");
+    nativePermissions.requestPermission.mockResolvedValue({
+      id: "camera",
+      status: "granted",
+      canRequest: false,
+      platform: "darwin",
+    });
+
+    await expect(new CameraManager().requestPermissions()).resolves.toEqual({
+      status: "granted",
+    });
+    expect(nativePermissions.requestPermission).toHaveBeenCalledWith("camera");
+    expect(nativePermissions.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it("propagates native permission check failures", async () => {
+    stubPlatform("darwin");
+    nativePermissions.checkPermission.mockRejectedValue(
+      new Error("camera probe failed"),
+    );
+
+    await expect(new CameraManager().checkPermissions()).rejects.toThrow(
+      "camera probe failed",
+    );
+  });
+
+  it("propagates native permission request failures", async () => {
+    stubPlatform("darwin");
+    nativePermissions.requestPermission.mockRejectedValue(
+      new Error("camera request failed"),
+    );
+
+    await expect(new CameraManager().requestPermissions()).rejects.toThrow(
+      "camera request failed",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/app-core/platforms/electrobun/src/native/camera.ts`, which previously had no colocated test file. The module exports `CameraManager` and `getCameraManager()`. Native methods are renderer-owned stubs; macOS permission checks forward to `getPermissionManager()` and return only `{ status }`. This PR drives that real class. No production source changes.

Covered behaviour (observed, not aspirational):

- `getDevices()` returns `{ devices: [], available: true }`
- `startPreview` / `switchCamera` ignore `deviceId` and report `{ available: true }`
- `stopPreview()` resolves `undefined`; capture and recording start/stop report `{ available: true }`
- `getRecordingState()` stays `{ recording: false, duration: 0 }` even after `startRecording()` / `stopRecording()`
- `setSendToWebview` is a no-op: native camera operations never invoke the callback; `dispose()` is a no-op
- `getCameraManager()` is a singleton; `new CameraManager()` is a distinct instance with the same stub returns
- non-macOS (`linux`, `win32`) `checkPermissions` / `requestPermissions` return `{ status: "prompt" }` without consulting native permissions
- on darwin, only `status` is mapped from the native camera permission check/request (`checkPermission("camera")` / `requestPermission("camera")`); extra fields are dropped
- native permission failures propagate (no catch in `camera.ts`)

## Verification

Exact head: `7b83d184f9fac416b425e758ae50b0a62f75f4ef` (parent `5c10466942360508e2bd903382974ea29a2f0fd8` is an ancestor of current `origin/develop` `1aedc2e579c7e3aa4c69f4c747cd5e275dbd1acd`; `camera.ts` is unchanged vs that tip, re-fetched immediately before filing)

1. Vitest (re-run against current `origin/develop` sources immediately before filing). Electrobun tests are collected by `vitest.electrobun.config.ts` (`packages/app-core/vitest.config.ts` excludes `platforms/electrobun/**`):

```text
cd packages/app-core/platforms/electrobun && bunx vitest run --config vitest.electrobun.config.ts src/native/camera.test.ts
 ✓ src/native/camera.test.ts (15 tests) 6ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  17:03:49
   Duration  171ms (transform 46ms, setup 0ms, import 61ms, tests 6ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/app-core/platforms/electrobun/src/native/camera.test.ts` — `Checked 1 file in 142ms. No fixes applied.` Config exists at repo-root `biome.json`; this checkout is not sparse.

3. Package typecheck: `cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'camera.test.ts'` produced no matches (grep EXIT:1). This file introduced zero TypeScript errors.

4. Diff touches only `packages/app-core/platforms/electrobun/src/native/camera.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are from local `bunx vitest` / `biome` / `tsc` on this head.

## Notes

Test-only change. No production behaviour is modified. Assertions record what the code does (renderer-owned stubs, idle recording state, prompt on non-macOS, status-only mapping on darwin), not a desired native camera implementation.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7b83d184f9fac416b425e758ae50b0a62f75f4ef -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
