### PR TITLE
test(app-core): cover desktop-session-prime

### DIFF
--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
@@ -1,0 +1,460 @@
+/** Exercises desktop session prime behavior with deterministic app-core test fixtures. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PACKAGED_WINDOWS_BOOTSTRAP_PARTITION } from "../main-window-session";
+import {
+  CSRF_COOKIE_NAME,
+  persistSession,
+  SESSION_COOKIE_NAME,
+} from "../native/auth-bridge";
+
+const authBridgeState = vi.hoisted(() => ({
+  loadOrCreateDesktopSession: vi.fn(),
+  actualLoad: undefined as
+    | undefined
+    | ((deps: { apiBase: string }) => Promise<{
+        sessionId: string;
+        csrfToken: string;
+        expiresAt: number;
+      } | null>),
+}));
+
+type StoredCookie = {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: "no_restriction" | "lax" | "strict";
+  expirationDate?: number;
+  url?: string;
+};
+
+const electrobunState = vi.hoisted(() => {
+  const defaultCookies: StoredCookie[] = [];
+  const partitions = new Map<string, StoredCookie[]>();
+
+  const defaultSet = vi.fn((cookie: StoredCookie): boolean => {
+    defaultCookies.push({ ...cookie });
+    return true;
+  });
+
+  const fromPartition = vi.fn((partition: string) => {
+    let bucket = partitions.get(partition);
+    if (!bucket) {
+      bucket = [];
+      partitions.set(partition, bucket);
+    }
+    const target = bucket;
+    return {
+      cookies: {
+        set: (cookie: StoredCookie): boolean => {
+          target.push({ ...cookie });
+          return true;
+        },
+      },
+    };
+  });
+
+  return {
+    defaultCookies,
+    partitions,
+    defaultSet,
+    fromPartition,
+    defaultSession: { cookies: { set: defaultSet } },
+  };
+});
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("electrobun/bun", () => ({
+  Session: {
+    defaultSession: electrobunState.defaultSession,
+    fromPartition: electrobunState.fromPartition,
+  },
+}));
+
+vi.mock("../native/auth-bridge", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../native/auth-bridge")>();
+  authBridgeState.actualLoad = actual.loadOrCreateDesktopSession;
+  authBridgeState.loadOrCreateDesktopSession.mockImplementation(
+    actual.loadOrCreateDesktopSession,
+  );
+  return {
+    ...actual,
+    loadOrCreateDesktopSession: authBridgeState.loadOrCreateDesktopSession,
+  };
+});
+
+import { logger } from "../logger";
+import {
+  markDesktopSessionStale,
+  primeDesktopSessionAuth,
+} from "./desktop-session-prime";
+
+const ENV_KEYS = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_DESKTOP_TEST_PARTITION",
+  "ELIZA_DESKTOP_TEST_API_BASE",
+  "ELIZA_DESKTOP_FORCE_CEF",
+] as const;
+
+const LOOPBACK_API = "http://127.0.0.1:31337";
+const RENDERER_ORIGIN = "http://127.0.0.1:5173";
+
+const originalEnv = new Map<string, string | undefined>();
+const tempRoots: string[] = [];
+
+function createStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "desktop-session-prime-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function seedPersistedSession(expiresAt = Date.now() + 86_400_000): {
+  sessionId: string;
+  csrfToken: string;
+  expiresAt: number;
+} {
+  const stateDir = createStateDir();
+  const session = {
+    sessionId: "desktop-session-id",
+    csrfToken: "desktop-csrf-token",
+    expiresAt,
+  };
+  persistSession(session, { ELIZA_STATE_DIR: stateDir });
+  process.env.ELIZA_STATE_DIR = stateDir;
+  return session;
+}
+
+function cookieNames(cookies: StoredCookie[]): string[] {
+  return cookies.map((cookie) => cookie.name);
+}
+
+describe("desktop-session-prime", () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    electrobunState.defaultCookies.length = 0;
+    electrobunState.partitions.clear();
+    electrobunState.defaultSet.mockReset();
+    electrobunState.defaultSet.mockImplementation((cookie: StoredCookie) => {
+      electrobunState.defaultCookies.push({ ...cookie });
+      return true;
+    });
+    electrobunState.fromPartition.mockReset();
+    electrobunState.fromPartition.mockImplementation((partition: string) => {
+      let bucket = electrobunState.partitions.get(partition);
+      if (!bucket) {
+        bucket = [];
+        electrobunState.partitions.set(partition, bucket);
+      }
+      const target = bucket;
+      return {
+        cookies: {
+          set: (cookie: StoredCookie): boolean => {
+            target.push({ ...cookie });
+            return true;
+          },
+        },
+      };
+    });
+    authBridgeState.loadOrCreateDesktopSession.mockReset();
+    authBridgeState.loadOrCreateDesktopSession.mockImplementation(
+      (deps: { apiBase: string }) => {
+        const actualLoad = authBridgeState.actualLoad;
+        if (!actualLoad) {
+          throw new Error("auth-bridge actual load was not captured");
+        }
+        return actualLoad(deps);
+      },
+    );
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.info).mockClear();
+    markDesktopSessionStale();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    originalEnv.clear();
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+    markDesktopSessionStale();
+  });
+
+  it("skips the bridge and cookie jar after a successful prime", async () => {
+    seedPersistedSession();
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(1);
+    expect(electrobunState.defaultCookies).toHaveLength(2);
+  });
+
+  it("re-runs the bridge after markDesktopSessionStale", async () => {
+    seedPersistedSession();
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+    markDesktopSessionStale();
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
+    expect(electrobunState.defaultCookies).toHaveLength(4);
+  });
+
+  it("leaves the jar empty and stays unprimed when the bridge produces no session", async () => {
+    process.env.ELIZA_STATE_DIR = createStateDir();
+
+    await primeDesktopSessionAuth("https://agent.example.com", RENDERER_ORIGIN);
+    await primeDesktopSessionAuth("https://agent.example.com", RENDERER_ORIGIN);
+
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledWith({
+      apiBase: "https://agent.example.com",
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "[Main] Desktop auth bridge produced no session; renderer will use the standard login flow.",
+    );
+    expect(electrobunState.defaultCookies).toEqual([]);
+    expect(electrobunState.fromPartition).not.toHaveBeenCalled();
+  });
+
+  it("warns with the Error message when the bridge throws and stays unprimed", async () => {
+    authBridgeState.loadOrCreateDesktopSession.mockRejectedValueOnce(
+      new Error("disk exploded"),
+    );
+
+    await primeDesktopSessionAuth(LOOPBACK_API, RENDERER_ORIGIN);
+    await primeDesktopSessionAuth(LOOPBACK_API, RENDERER_ORIGIN);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Main] Desktop auth bridge failed: disk exploded",
+    );
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
+    expect(electrobunState.defaultCookies).toEqual([]);
+  });
+
+  it("stringifies a non-Error bridge rejection", async () => {
+    authBridgeState.loadOrCreateDesktopSession.mockRejectedValueOnce(
+      "bridge down",
+    );
+
+    await primeDesktopSessionAuth(LOOPBACK_API, RENDERER_ORIGIN);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Main] Desktop auth bridge failed: bridge down",
+    );
+    expect(electrobunState.defaultCookies).toEqual([]);
+  });
+
+  it("installs session and csrf cookies on the default jar when no partition is set", async () => {
+    const session = seedPersistedSession(1_800_000_000_000);
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(electrobunState.fromPartition).not.toHaveBeenCalled();
+    expect(cookieNames(electrobunState.defaultCookies)).toEqual([
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+    ]);
+    expect(electrobunState.defaultCookies[0]).toEqual(
+      expect.objectContaining({
+        name: SESSION_COOKIE_NAME,
+        value: session.sessionId,
+        domain: "127.0.0.1",
+        path: "/",
+        secure: false,
+        httpOnly: true,
+        sameSite: "lax",
+        expirationDate: 1_800_000_000,
+      }),
+    );
+    expect(electrobunState.defaultCookies[1]).toEqual(
+      expect.objectContaining({
+        name: CSRF_COOKIE_NAME,
+        value: session.csrfToken,
+        domain: "127.0.0.1",
+        path: "/",
+        secure: false,
+        httpOnly: false,
+        sameSite: "lax",
+        expirationDate: 1_800_000_000,
+      }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      `[Main] Desktop loopback session primed on ${LOOPBACK_API}`,
+    );
+  });
+
+  it("installs cookies on Session.fromPartition when a test partition is set", async () => {
+    seedPersistedSession();
+    process.env.ELIZA_DESKTOP_TEST_PARTITION = "isolated";
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(electrobunState.fromPartition).toHaveBeenCalledWith(
+      "persist:isolated",
+    );
+    expect(electrobunState.defaultCookies).toEqual([]);
+    expect(
+      cookieNames(electrobunState.partitions.get("persist:isolated") ?? []),
+    ).toEqual([SESSION_COOKIE_NAME, CSRF_COOKIE_NAME]);
+  });
+
+  it("prefers ELIZA_DESKTOP_TEST_PARTITION over ELIZA_DESKTOP_TEST_API_BASE", async () => {
+    seedPersistedSession();
+    process.env.ELIZA_DESKTOP_TEST_PARTITION = "persist:winner";
+    process.env.ELIZA_DESKTOP_TEST_API_BASE = LOOPBACK_API;
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(electrobunState.fromPartition).toHaveBeenCalledWith(
+      "persist:winner",
+    );
+    expect(electrobunState.fromPartition).not.toHaveBeenCalledWith(
+      PACKAGED_WINDOWS_BOOTSTRAP_PARTITION,
+    );
+  });
+
+  it("uses the packaged bootstrap partition when only the test API base is set", async () => {
+    seedPersistedSession();
+    process.env.ELIZA_DESKTOP_TEST_API_BASE = LOOPBACK_API;
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(electrobunState.fromPartition).toHaveBeenCalledWith(
+      PACKAGED_WINDOWS_BOOTSTRAP_PARTITION,
+    );
+  });
+
+  it("installs both origins when the renderer is not the API origin", async () => {
+    seedPersistedSession();
+
+    await primeDesktopSessionAuth(LOOPBACK_API, RENDERER_ORIGIN);
+
+    expect(cookieNames(electrobunState.defaultCookies)).toEqual([
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+    ]);
+    expect(electrobunState.defaultCookies[0]?.domain).toBe("127.0.0.1");
+    expect(electrobunState.defaultCookies[2]?.domain).toBe("127.0.0.1");
+    expect(logger.info).toHaveBeenCalledWith(
+      `[Main] Desktop loopback session primed on ${LOOPBACK_API}, ${RENDERER_ORIGIN}`,
+    );
+  });
+
+  it("marks https origins secure and http origins not secure", async () => {
+    seedPersistedSession();
+
+    await primeDesktopSessionAuth(
+      "https://127.0.0.1:8443",
+      "http://127.0.0.1:5173",
+    );
+
+    const sessionCookies = electrobunState.defaultCookies.filter(
+      (cookie) => cookie.name === SESSION_COOKIE_NAME,
+    );
+    expect(sessionCookies[0]).toEqual(
+      expect.objectContaining({
+        secure: true,
+        domain: "127.0.0.1",
+      }),
+    );
+    expect(sessionCookies[1]).toEqual(
+      expect.objectContaining({
+        secure: false,
+        domain: "127.0.0.1",
+      }),
+    );
+  });
+
+  it("logs <no targets> for unparsable origins and still marks the process primed", async () => {
+    seedPersistedSession();
+
+    await primeDesktopSessionAuth("not a url", "");
+    await primeDesktopSessionAuth("not a url", "");
+
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(1);
+    expect(electrobunState.defaultCookies).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      "[Main] Desktop loopback session primed on <no targets>",
+    );
+  });
+
+  it("warns and stays unprimed when the cookie jar throws", async () => {
+    seedPersistedSession();
+    electrobunState.defaultSet.mockImplementation(() => {
+      throw new Error("jar locked");
+    });
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+    electrobunState.defaultSet.mockImplementation((cookie: StoredCookie) => {
+      electrobunState.defaultCookies.push({ ...cookie });
+      return true;
+    });
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Main] Desktop auth cookie install failed: jar locked",
+    );
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
+    expect(cookieNames(electrobunState.defaultCookies)).toEqual([
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+    ]);
+  });
+
+  it("stringifies a non-Error cookie-install throw", async () => {
+    seedPersistedSession();
+    electrobunState.defaultSet.mockImplementation(() => {
+      throw 42;
+    });
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Main] Desktop auth cookie install failed: 42",
+    );
+  });
+
+  it("warns and stays unprimed when Session.fromPartition throws", async () => {
+    seedPersistedSession();
+    process.env.ELIZA_DESKTOP_TEST_PARTITION = "broken";
+    electrobunState.fromPartition.mockImplementation(() => {
+      throw new Error("no such partition");
+    });
+
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+    await primeDesktopSessionAuth(LOOPBACK_API, LOOPBACK_API);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Main] Desktop auth cookie install failed: no such partition",
+    );
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
+    expect(electrobunState.defaultCookies).toEqual([]);
+  });
+});


### PR DESCRIPTION

# Relates to

Adds same-file unit coverage for `packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts`, which had no sibling test. Test-only; no production behavior change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

Hosted CI does **not** run on this fork PR. Local commands below are the proof.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

`bun run verify` was not run: this is a single new test file with no production
change. Focused vitest, biome, and package `tsc` are quoted below.

# Risks

Low. Adds tests only. No production code, exports, routes, or runtime behavior
change. Failure mode is a red unit suite, not a desktop session change.

# Background

## What does this PR do?

Covers `markDesktopSessionStale` and `primeDesktopSessionAuth` against the real
module:

- process-lifetime idempotency after a successful prime
- stale-flag re-entry after the embedded agent rebinds
- silent skip when `loadOrCreateDesktopSession` returns null (non-loopback API,
  no persisted session)
- warn-and-retry when the bridge throws an `Error` or a non-Error rejection
- real `installDesktopSessionCookies` onto `Session.defaultSession`
- `Session.fromPartition` when `ELIZA_DESKTOP_TEST_PARTITION` is set, including
  `persist:` normalization and preference over `ELIZA_DESKTOP_TEST_API_BASE`
- packaged bootstrap partition when only `ELIZA_DESKTOP_TEST_API_BASE` is set
- origin dedupe vs dual-origin install, https `secure` vs http
- `<no targets>` log for unparsable origins still marks the process primed
- cookie-jar and `fromPartition` throws leave the process unprimed so the next
  call retries

Native `electrobun/bun` is stubbed (the Vitest alias has no `Session`). The
auth-bridge loader is wrapped so unexpected throws can be injected; the default
implementation is the real `loadOrCreateDesktopSession` driven by a persisted
session file. Cookie install is the real function.

## What kind of change is this?

Improvements (test coverage for existing behavior).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts`

## Detailed testing steps

From `packages/app-core/platforms/electrobun`:

```bash
bunx vitest run src/lifecycle/desktop-session-prime.test.ts --config vitest.electrobun.config.ts
```

Observed on current `origin/develop` immediately before filing:

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

Biome (repo `biome.json` present; checkout is not sparse):

```
bunx biome check --write packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
Checked 1 file in 56ms. Fixed 1 file.
```

Re-ran the suite after the biome write: still **1 file, 15 passed**.

Package `tsc` from `packages/app-core/platforms/electrobun`:

```
bunx tsc --noEmit 2>&1 | grep 'desktop-session-prime.test.ts' ; echo "EXIT:$?"
```

Empty grep, `EXIT:1` (no matches). This test file introduced zero TypeScript
errors.

Diff touches only that test file.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:3dcfd6e0ab449be96dc1125e14f9eedbd68a2907 -->

- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface.
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface.
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only change; no user flow or UI.
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - no production path change; vitest output is the path proof.
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no frontend change.
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent, action, provider, prompt, or model change.
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - unit tests only; no domain artifact producer.
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; no production runtime path.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no UI.

### After

N/A - test-only change; no UI.

### Walkthrough video

N/A - test-only change; no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` not run. Scope is one new test file; focused vitest (15/15),
  biome, and package `tsc` (this file absent from errors) were run instead.
- Hosted GitHub Actions CI does not run on fork contributor PRs. Do not read a
  missing check as a failure of this change.
- No identity.slop.cash OAuth evidence trace: unattended session cannot finalize
  an interactive consent click.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
