### PR TITLE
test(agent): pin the inbox chat sort tie-break against regression

### DIFF
--- a/packages/agent/src/api/inbox-chat-sort.test.ts
+++ b/packages/agent/src/api/inbox-chat-sort.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for the `GET /api/inbox/chats` ordering tie-break.
+ *
+ * #25594 added a deterministic tie-break to the chat sort but read it from
+ * `a.roomId`, a field `InboxChat` does not have (the room id is `id`). The
+ * comparator therefore threw `Cannot read properties of undefined` for any two
+ * chats sharing a `lastMessageAt` — including the ordinary case of two rooms
+ * with no messages, whose timestamps both clamp to 0 — and the route turned
+ * that into a 500, so the whole inbox list failed to load.
+ */
+import type http from "node:http";
+import type { AgentRuntime, RouteHelpers, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleInboxRoute } from "./inbox-routes";
+
+vi.mock("@elizaos/plugin-discord", () => ({
+  cacheDiscordAvatarUrl: async (avatarUrl: string | undefined) => avatarUrl,
+}));
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const WORLD_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+// Deliberately out of lexical order so the tie-break has something to do.
+const ROOM_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+const ROOM_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const res = {} as http.ServerResponse;
+
+/** Two rooms of the same source, neither carrying a message or a createdAt. */
+function makeRuntime(): AgentRuntime {
+  const room = (id: UUID) => ({
+    id,
+    worldId: WORLD_ID,
+    source: "telegram",
+    name: `room-${id.slice(0, 4)}`,
+  });
+  return {
+    agentId: AGENT_ID,
+    getAllWorlds: async () => [
+      { id: WORLD_ID, name: "world", agentId: AGENT_ID },
+    ],
+    getRoomsByWorlds: async () => [room(ROOM_B), room(ROOM_A)],
+    getMemoriesByRoomIds: async () => [],
+    getMemories: async () => [],
+    getParticipantUserState: async () => null,
+    getRoom: async (id: UUID) => room(id),
+    getEntityById: async () => null,
+    getWorld: async () => ({ id: WORLD_ID, name: "world", agentId: AGENT_ID }),
+  } as unknown as AgentRuntime;
+}
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  return {
+    helpers: { json, error, readJsonBody: vi.fn() } as unknown as RouteHelpers,
+    json,
+    error,
+  };
+}
+
+describe("GET /api/inbox/chats ordering", () => {
+  it("sorts chats with identical timestamps instead of failing the request", async () => {
+    const { helpers, json, error } = makeHelpers();
+    const req = {
+      url: "/api/inbox/chats",
+      method: "GET",
+    } as http.IncomingMessage;
+
+    const handled = await handleInboxRoute(
+      req,
+      res,
+      "/api/inbox/chats",
+      "GET",
+      { runtime: makeRuntime() } as never,
+      helpers,
+    );
+
+    expect(handled).toBe(true);
+    // The pre-fix comparator threw, and the route reported it as a 500.
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledTimes(1);
+
+    const payload = json.mock.calls[0]?.[1] as {
+      chats: Array<{ id: string; lastMessageAt: number }>;
+    };
+    expect(payload.chats).toHaveLength(2);
+    // Every timestamp ties at 0, so the room id decides — ascending.
+    expect(payload.chats.map((chat) => chat.id)).toEqual([ROOM_A, ROOM_B]);
+    expect(payload.chats.every((chat) => chat.lastMessageAt === 0)).toBe(true);
+  });
+});

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -2596,11 +2596,6 @@ async function loadInboxChats(
       typeof a.lastMessageAt === "number" && Number.isFinite(a.lastMessageAt)
         ? a.lastMessageAt
         : 0;
-    // Tie-break on the room id so equal timestamps sort deterministically.
-    // InboxChat's room id is `id` (there is no `roomId` field): reading
-    // `a.roomId` here returned undefined and threw on `.localeCompare` for
-    // any two chats sharing a timestamp — including the common case of two
-    // chats whose `lastMessageAt` is absent or non-finite and both clamp to 0.
     return bLast - aLast || a.id.localeCompare(b.id);
   });
   return chats;

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -2596,6 +2596,11 @@ async function loadInboxChats(
       typeof a.lastMessageAt === "number" && Number.isFinite(a.lastMessageAt)
         ? a.lastMessageAt
         : 0;
+    // Tie-break on the room id so equal timestamps sort deterministically.
+    // InboxChat's room id is `id` (there is no `roomId` field): reading
+    // `a.roomId` here returned undefined and threw on `.localeCompare` for
+    // any two chats sharing a timestamp — including the common case of two
+    // chats whose `lastMessageAt` is absent or non-finite and both clamp to 0.
     return bLast - aLast || a.id.localeCompare(b.id);
   });
   return chats;


### PR DESCRIPTION
# Relates to

#25594 introduced the defect; #25700 corrected the comparator while this branch was in flight, but landed no test. This is the missing regression test plus the comment explaining why the tie is ordinary.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`27d58c07573`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None.** One new test file and a five-line comment. No behaviour change — the comparator on `develop` is already correct.

# Background

## What does this PR do?

`GET /api/inbox/chats` tie-broke its newest-first sort on `a.roomId`. `InboxChat` has no `roomId` — the room id is `id`, as the two sibling comparators in the same file already use. The tie-break therefore dereferenced `undefined` and threw, and because `loadInboxChats` runs inside the route's `try`, the throw became `helpers.error(res, "failed to load inbox chats: …", 500)`: **the entire inbox list failed to load**, not one row sorting oddly.

The tie is the ordinary case. A room with no messages takes `lastMessageAt: readRoomCreatedAt(room) ?? 0`, and the NaN clamp added by the same PR maps any non-finite timestamp to `0` — so two such rooms always tie and always throw.

#25700 has since fixed the comparator. It added no test, so the same one-word slip can return as easily as it arrived — and it arrived inside a PR whose stated purpose was making these comparators *safer*. This adds the guard.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`inbox-chat-sort.test.ts`; then the comment at the comparator, which records which field is the room id and why the tie is not a corner case.

## Detailed testing steps

- `cd packages/agent && bunx vitest run src/api/inbox-chat-sort.test.ts` → 1 pass. It drives `GET /api/inbox/chats` through `handleInboxRoute` with two rooms that both clamp to `lastMessageAt: 0`, asserts `helpers.error` was **not** called, and asserts a deterministic id-ascending order.
- **Mutation check**: restore `a.roomId.localeCompare(b.roomId)` → the test fails with the route reporting `failed to load inbox chats: Cannot read properties of undefined (reading 'localeCompare')`; restore the correct comparator → passes.
- Biome clean on both files.

# Evidence Gate

<!-- evidence-head:d89654cbcd8e4113683eafd54fc755fe36b13374 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The route's own error path: pre-fix it emitted `failed to load inbox chats: Cannot read properties of undefined (reading 'localeCompare')` with status 500; correct, it returns `{chats, count}` with 200. Both are asserted.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory sort only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The route's own error path: pre-fix it emitted `failed to load inbox chats: Cannot read properties of undefined (reading 'localeCompare')` with status 500; correct, it returns `{chats, count}` with 200. Both are asserted.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- The comparator fix itself is already on develop via #25700; this PR is the test that should have accompanied it.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

