### PR TITLE
fix(scenarios): stop granting OWNER to every scenario room

### DIFF
--- a/packages/scenario-runner/src/executor-room-identity-invariant.test.ts
+++ b/packages/scenario-runner/src/executor-room-identity-invariant.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Room-identity parity between what a scenario's seeds READ and what its turns
+ * are SENT AS, plus the scoping of the configured owner set. Both are executor
+ * invariants that no scenario file may restate.
+ *
+ * `rooms[].account` is hashed into an entity id by `resolveScenarioRooms`
+ * alone, and that recipe has already moved once (#24842 namespaced accounts per
+ * scenario: `scenario-account:<account>` became
+ * `scenario-account:<scenarioId>:<account>`). Scenarios that spelled the old
+ * recipe out a second time kept stamping roles and rows onto an entity nobody
+ * speaks as, so every scoped read missed and owner-only walls were never
+ * reached — the seed/runtime identity fork of #25009, one layer up. Seeds must
+ * therefore read `ctx.roomEntityIds` / `ctx.accountEntityIds` / `ctx.roomIds`,
+ * and those must equal the identity stamped on that room's turn messages.
+ *
+ * The owner set has the mirrored hazard: `ELIZA_OWNER_CONTACTS_JSON` feeds
+ * `roles.ts getConfiguredOwnerEntityIds`, which grants OWNER to every id it
+ * lists. Publishing every room there makes a scenario's deliberately non-owner
+ * room resolve as OWNER, and every owner-only refusal in the corpus passes
+ * vacuously. Only the owner's own linked accounts — rooms resolving to the
+ * primary room's canonical entity — belong in it.
+ *
+ * Real `runScenario` against the stubbed runtime the executor suite uses; the
+ * derivations under test are the executor's own.
+ */
+import type {
+  Action,
+  AgentRuntime,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import { stringToUuid } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ScenarioContext } from "../schema/index.d.ts";
+import { runScenario } from "./executor";
+
+type OwnerContactEntry = { entityId: string; source: string };
+
+function createIdentityRuntime(
+  onTurn: (roomKey: string, message: Memory) => void,
+  settings: Map<string, unknown>,
+): AgentRuntime {
+  const probe: Action = {
+    name: "IDENTITY_PROBE",
+    description: "Records the identity the executor stamps on a turn.",
+    validate: async () => true,
+    handler: async (
+      _runtime: IAgentRuntime,
+      message: Memory,
+      _state: unknown,
+      options: Record<string, unknown> | undefined,
+    ) => {
+      onTurn(String(options?.roomKey), message);
+      return { success: true, text: "recorded" };
+    },
+  } as Action;
+
+  return {
+    actions: [probe],
+    agentId: "00000000-0000-4000-8000-000000000001",
+    plugins: [],
+    routes: [],
+    ensureConnection: vi.fn(async () => undefined),
+    getEntityById: vi.fn(async () => null),
+    createEntity: vi.fn(async () => true),
+    getRelationships: vi.fn(async () => []),
+    createRelationship: vi.fn(async () => true),
+    getService: vi.fn(() => null),
+    reportError: vi.fn(),
+    setSetting: vi.fn((key: string, value: unknown) => {
+      settings.set(key, value);
+    }),
+    useModel: vi.fn() as AgentRuntime["useModel"],
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as AgentRuntime;
+}
+
+function ownerContacts(
+  settings: Map<string, unknown>,
+): Record<string, OwnerContactEntry> {
+  const raw = settings.get("ELIZA_OWNER_CONTACTS_JSON");
+  if (typeof raw !== "string") {
+    throw new Error("executor did not publish ELIZA_OWNER_CONTACTS_JSON");
+  }
+  return JSON.parse(raw) as Record<string, OwnerContactEntry>;
+}
+
+describe("scenario room identity invariant (seed scope == turn scope)", () => {
+  it("publishes the same entity a room's turns are sent as, for a prefixed account", async () => {
+    const scenarioId = "room-identity-invariant";
+    const turnMessages = new Map<string, Memory>();
+    const settings = new Map<string, unknown>();
+    const runtime = createIdentityRuntime(
+      (roomKey, message) => turnMessages.set(roomKey, message),
+      settings,
+    );
+    let seedContext: ScenarioContext | undefined;
+
+    const report = await runScenario(
+      {
+        id: scenarioId,
+        title: "Room identity invariant",
+        domain: "executor",
+        rooms: [
+          { id: "main", source: "client_chat", title: "Owner" },
+          {
+            id: "guest",
+            // The shape that forked: an authored account that already carries
+            // the scenario id, so a hand-rolled
+            // `scenario-account:<scenarioId>:guest` and the executor's
+            // `scenario-account:<scenarioId>:<account>` disagree.
+            account: `${scenarioId}:guest`,
+            source: "client_chat",
+            title: "Guest",
+          },
+          {
+            // A linked account: same canonical entity as `main`, different
+            // connector principal. Here `canonicalEntityId` and `userId`
+            // genuinely differ, so publishing the wrong one is observable —
+            // turns are sent as the connector principal, never the canonical
+            // alias.
+            id: "linked",
+            account: "linked-telegram",
+            entity: "owner",
+            source: "telegram",
+            title: "Owner on Telegram",
+          },
+        ],
+        seed: [
+          {
+            type: "custom",
+            name: "capture published topology",
+            apply(ctx) {
+              seedContext = ctx;
+            },
+          },
+        ],
+        turns: [
+          {
+            kind: "action",
+            name: "owner turn",
+            actionName: "IDENTITY_PROBE",
+            room: "main",
+            text: "owner speaks",
+            options: { roomKey: "main" },
+          },
+          {
+            kind: "action",
+            name: "guest turn",
+            actionName: "IDENTITY_PROBE",
+            room: "guest",
+            text: "guest speaks",
+            options: { roomKey: "guest" },
+          },
+          {
+            kind: "action",
+            name: "linked-account turn",
+            actionName: "IDENTITY_PROBE",
+            room: "linked",
+            text: "owner speaks on telegram",
+            options: { roomKey: "linked" },
+          },
+        ],
+      },
+      runtime,
+      { minJudgeScore: 0.8, providerName: "unit-test", turnTimeoutMs: 1_000 },
+    );
+
+    expect(report.status).toBe("passed");
+
+    for (const roomKey of ["main", "guest", "linked"]) {
+      const message = turnMessages.get(roomKey);
+      expect(message, `no turn recorded for room ${roomKey}`).toBeDefined();
+      // The invariant: what a seed reads IS what the turn is sent as.
+      expect(seedContext?.roomEntityIds?.[roomKey]).toBe(message?.entityId);
+      expect(seedContext?.roomIds?.[roomKey]).toBe(message?.roomId);
+    }
+
+    const guestEntityId = turnMessages.get("guest")?.entityId;
+    expect(seedContext?.accountEntityIds?.[`${scenarioId}:guest`]).toBe(
+      guestEntityId,
+    );
+    // The historical fork, pinned: re-deriving the account hash inside a
+    // scenario does NOT reproduce the executor's id. Any scenario that spells
+    // the recipe out itself is stamping a stranger.
+    expect(stringToUuid(`scenario-account:${scenarioId}:guest`)).not.toBe(
+      guestEntityId,
+    );
+    // The owner's own room stays reachable through the primary alias too.
+    expect(seedContext?.primaryUserId).toBe(turnMessages.get("main")?.entityId);
+    // `entityIds` is the canonical-alias map and is deliberately NOT the turn
+    // identity for a linked account — a seed that scopes rows by it instead of
+    // `roomEntityIds` writes where that room's turns can never read.
+    expect(seedContext?.entityIds?.owner).not.toBe(
+      turnMessages.get("linked")?.entityId,
+    );
+  });
+
+  it("configures only the owner's linked accounts as canonical owners", async () => {
+    const scenarioId = "owner-contact-scoping";
+    const turnMessages = new Map<string, Memory>();
+    const settings = new Map<string, unknown>();
+    const runtime = createIdentityRuntime(
+      (roomKey, message) => turnMessages.set(roomKey, message),
+      settings,
+    );
+    let seedContext: ScenarioContext | undefined;
+
+    const report = await runScenario(
+      {
+        id: scenarioId,
+        title: "Owner contact scoping",
+        domain: "executor",
+        rooms: [
+          {
+            id: "main",
+            account: "owner-chat",
+            entity: "owner",
+            source: "client_chat",
+            title: "Owner",
+          },
+          {
+            // A second connector account for the SAME canonical entity: a
+            // verified linked account of the owner (#24842's model), which must
+            // stay an owner contact.
+            id: "owner-telegram",
+            account: "owner-telegram",
+            entity: "owner",
+            source: "telegram",
+            title: "Owner on Telegram",
+          },
+          {
+            // A different principal entirely. Never an owner.
+            id: "guest",
+            account: `${scenarioId}:guest`,
+            entity: "guest",
+            source: "client_chat",
+            title: "Guest",
+          },
+        ],
+        seed: [
+          {
+            type: "custom",
+            name: "capture published topology",
+            apply(ctx) {
+              seedContext = ctx;
+            },
+          },
+        ],
+        turns: [
+          {
+            kind: "action",
+            name: "guest turn",
+            actionName: "IDENTITY_PROBE",
+            room: "guest",
+            text: "guest speaks",
+            options: { roomKey: "guest" },
+          },
+        ],
+      },
+      runtime,
+      { minJudgeScore: 0.8, providerName: "unit-test", turnTimeoutMs: 1_000 },
+    );
+
+    expect(report.status).toBe("passed");
+
+    const contacts = ownerContacts(settings);
+    expect(settings.get("ELIZA_ADMIN_ENTITY_ID")).toBe(
+      seedContext?.entityIds?.owner,
+    );
+
+    // The vacuous-wall regression: the guest must be absent from every id the
+    // roles system reads as a configured owner, or an owner-only refusal turn
+    // proves nothing.
+    const guestEntityId = turnMessages.get("guest")?.entityId;
+    const configuredOwnerIds = [
+      settings.get("ELIZA_ADMIN_ENTITY_ID"),
+      ...Object.values(contacts).map((contact) => contact.entityId),
+    ];
+    expect(guestEntityId).toBeDefined();
+    expect(configuredOwnerIds).not.toContain(guestEntityId);
+
+    // ...while the owner's verified linked account stays one, so #24842's
+    // cross-world continuity keeps working.
+    expect(Object.keys(contacts).sort()).toEqual([
+      "owner-chat",
+      "owner-telegram",
+    ]);
+    expect(contacts["owner-telegram"]?.entityId).toBe(
+      seedContext?.roomEntityIds?.["owner-telegram"],
+    );
+  });
+});

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -34,6 +34,7 @@ import {
   postDeliveryTaskQuarantineReason,
   revalidateOwnerExclusiveDisclosure,
   stringToUuid,
+  validateUuid,
 } from "@elizaos/core";
 import type { DeterministicModelDiagnostics } from "@elizaos/core/testing";
 import type { VoiceWorkbenchScenarioRun } from "@elizaos/plugin-local-inference/voice-workbench";
@@ -412,6 +413,22 @@ async function attestScenarioTurnAudience(
   await restoreScenarioConnectorTopology(runtime, room);
   await attestDeliveryAudienceFromCanonicalRoom(runtime, message);
   if (room.channelType !== ChannelType.DM) return;
+  // Owner-exclusive disclosure is an invariant of the OWNER's DM only. A room
+  // authored as a different principal — a guest, a second account, the
+  // counterparty of an owner-only wall — is *supposed* to be denied
+  // (`owner_mismatch`); that denial is the behaviour under test, not a harness
+  // fault, and raising on it would make a non-owner DM unmodellable. The owner
+  // identity is read back from the same setting the roles system resolves
+  // against, so this can never disagree with who the runtime calls the owner.
+  const configuredOwnerEntityId = validateUuid(
+    runtime.getSetting("ELIZA_ADMIN_ENTITY_ID"),
+  );
+  if (
+    configuredOwnerEntityId !== null &&
+    room.canonicalEntityId !== configuredOwnerEntityId
+  ) {
+    return;
+  }
   const decision = await revalidateOwnerExclusiveDisclosure(runtime, message);
   if (!decision.allowed) {
     throw new ElizaError("Scenario connector DM failed audience attestation", {
@@ -2835,14 +2852,28 @@ export async function runScenario(
       primaryRoom.canonicalEntityId,
       false,
     );
+    // Owner contacts are the owner's *linked* connector accounts — the
+    // per-platform principals that resolve back to the same canonical entity as
+    // the primary room (#24842's linked-identity model). Publishing every room
+    // here instead would make every configured entity a canonical owner
+    // (roles.ts `getConfiguredOwnerEntityIds` unions the contacts with
+    // ELIZA_ADMIN_ENTITY_ID and grants OWNER to the whole set), so a scenario's
+    // deliberately non-owner room — a guest, a second account, any owner-only
+    // wall's counterparty — would silently resolve as OWNER and every
+    // owner-only refusal in the corpus would pass vacuously.
     runtime.setSetting(
       "ELIZA_OWNER_CONTACTS_JSON",
       JSON.stringify(
         Object.fromEntries(
-          rooms.map((room) => [
-            room.accountId,
-            { entityId: room.userId, source: room.source },
-          ]),
+          rooms
+            .filter(
+              (room) =>
+                room.canonicalEntityId === primaryRoom.canonicalEntityId,
+            )
+            .map((room) => [
+              room.accountId,
+              { entityId: room.userId, source: room.source },
+            ]),
         ),
       ),
       false,

--- a/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-document-actions.scenario.ts
@@ -72,17 +72,41 @@ const ownerDeleteParams: JsonRecord = { action: "delete" };
 // processing (merged per source key); world-metadata role grants do not.
 const GUEST_STABLE_ID = `${SCENARIO_ID}-guest-admin`;
 
+/**
+ * The guest room's runtime identity, read from the executor-published topology
+ * instead of re-deriving it here. `rooms[].account` is hashed into the entity
+ * id by the executor alone (`scenario-account:<scenarioId>:<account>`), and
+ * that recipe has already changed once (#24842 namespaced accounts per
+ * scenario). A scenario that spells the recipe out a second time forks from the
+ * identity its own turns are sent under the moment the executor moves: seeds
+ * then stamp roles onto an entity nobody speaks as, and every owner-scoped read
+ * misses. Same class as #25009 — one derivation, one seam.
+ */
+function guestIdentity(
+  ctx: ScenarioContext,
+): { entityId: UUID; roomId: UUID } | string {
+  const entityId = ctx.roomEntityIds?.guest;
+  const roomId = ctx.roomIds?.guest;
+  if (!entityId || !roomId) {
+    return "executor did not publish the guest room identity (ctx.roomEntityIds/ctx.roomIds)";
+  }
+  return { entityId: entityId as UUID, roomId: roomId as UUID };
+}
+
 // Pins the tier the whitelist fixture actually resolves to (#16963). If the
 // connector stamp or whitelist silently stops applying, the guest degrades to
 // GUEST and the mutation-wall refusal would still pass — for the wrong reason
 // (any non-owner is refused). This probe runs the real roles.ts resolution the
 // DOCUMENT handler uses, so a degraded fixture is a hard failure instead.
 async function expectGuestResolvesAdmin(
-  runtime: ScenarioRuntime,
+  ctx: ScenarioContext,
 ): Promise<string | undefined> {
+  const runtime = ctx.runtime as ScenarioRuntime;
+  const guest = guestIdentity(ctx);
+  if (typeof guest === "string") return guest;
   const probe = {
-    entityId: stringToUuid(`scenario-account:${SCENARIO_ID}:guest`) as UUID,
-    roomId: stringToUuid(`scenario-room:${SCENARIO_ID}:guest`) as UUID,
+    entityId: guest.entityId,
+    roomId: guest.roomId,
     agentId: runtime.agentId,
     content: { text: "" },
   } as Memory;
@@ -215,11 +239,23 @@ export default scenario({
         if (!ctx.primaryRoomId || !ctx.primaryUserId) {
           return "primary room/user were not set by the executor";
         }
+        const guest = guestIdentity(ctx);
+        if (typeof guest === "string") return guest;
         const room = await runtime.getRoom(ctx.primaryRoomId as UUID);
         if (!room?.worldId) return "primary room world was not created";
         const stored = await service.addDocument({
           worldId: room.worldId,
-          roomId: ctx.primaryRoomId as UUID,
+          // ADMIN is intentionally room-limited for document reads
+          // (`documentReadConditions` in plugin-sql/src/base.ts requires the
+          // row's room to be one of the requester's, on top of the scope
+          // check). Seed the global record in the GUEST room so the non-owner
+          // can identify the target without widening that privacy boundary —
+          // otherwise the delete fails existence before the owner-only
+          // mutation wall is ever evaluated and this turn pins `not_found`,
+          // covering nothing. OWNER keeps global visibility, so the main-room
+          // list turns and the successful owner delete are unaffected. Same
+          // fixture shape as the live-document-delete sibling.
+          roomId: guest.roomId,
           entityId: ctx.primaryUserId as UUID,
           clientDocumentId: stringToUuid(`${SCENARIO_ID}:doc`) as UUID,
           contentType: "text/markdown",
@@ -245,18 +281,18 @@ export default scenario({
       // owner-only mutation wall, mirroring live-document-delete's fixture.
       apply: async (ctx) => {
         const runtime = ctx.runtime as ScenarioRuntime;
-        const guestId = stringToUuid(
-          `scenario-account:${SCENARIO_ID}:guest`,
-        ) as UUID;
+        const guest = guestIdentity(ctx);
+        if (typeof guest === "string") return guest;
         setConnectorAdminWhitelist(runtime, { telegram: [GUEST_STABLE_ID] });
-        const entity = (await runtime.getEntitiesByIds([guestId]))[0] ?? null;
+        const entity =
+          (await runtime.getEntitiesByIds([guest.entityId]))[0] ?? null;
         if (!entity) return "guest entity was not created by the executor";
         entity.metadata = {
           ...entity.metadata,
           telegram: { userId: GUEST_STABLE_ID },
         };
         await runtime.updateEntities([entity]);
-        return expectGuestResolvesAdmin(runtime);
+        return expectGuestResolvesAdmin(ctx);
       },
     },
   ],
@@ -375,8 +411,7 @@ export default scenario({
       // Runs before cleanup clears the whitelist, so it proves the ADMIN tier
       // held through the refusal turn — not just at seed time (#16963).
       name: "whitelisted guest still resolves as connector-admin (ADMIN)",
-      predicate: (ctx) =>
-        expectGuestResolvesAdmin(ctx.runtime as ScenarioRuntime),
+      predicate: (ctx) => expectGuestResolvesAdmin(ctx),
     },
     {
       type: "actionCalled",

--- a/packages/scenario-runner/test/scenarios/deterministic-todos-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-todos-actions.scenario.ts
@@ -364,7 +364,38 @@ export default scenario({
             pattern:
               "Add a todo to cover natural language routing(?![\\s\\S]*message:user:\\n)",
           },
+          // `toolNames` is set equality against the planner's ACTUAL tool
+          // surface, and retrieval ranks the catalog without ever narrowing it
+          // ("Retrieval ranks every parent; it never limits availability" —
+          // core/src/runtime/action-retrieval.ts). On this lane the runner
+          // registers the whole personal-assistant + goals roster, so the
+          // planner is offered every OWNER_* family, not just the todos one.
+          // Listing a subset matches nothing and the turn dies as an unmatched
+          // model call. Keep this list in sync with the plugins
+          // scenario-runner/src/runtime-factory.ts registers for the simulated
+          // profile.
           toolNames: [
+            "OWNER_REMINDERS",
+            "OWNER_REMINDERS_CREATE",
+            "OWNER_REMINDERS_UPDATE",
+            "OWNER_REMINDERS_DELETE",
+            "OWNER_REMINDERS_COMPLETE",
+            "OWNER_REMINDERS_SKIP",
+            "OWNER_REMINDERS_SNOOZE",
+            "OWNER_REMINDERS_REVIEW",
+            "OWNER_ALARMS",
+            "OWNER_ALARMS_CREATE",
+            "OWNER_ALARMS_UPDATE",
+            "OWNER_ALARMS_DELETE",
+            "OWNER_ALARMS_COMPLETE",
+            "OWNER_ALARMS_SKIP",
+            "OWNER_ALARMS_SNOOZE",
+            "OWNER_ALARMS_REVIEW",
+            "OWNER_GOALS",
+            "OWNER_GOALS_CREATE",
+            "OWNER_GOALS_UPDATE",
+            "OWNER_GOALS_DELETE",
+            "OWNER_GOALS_REVIEW",
             "OWNER_TODOS",
             "OWNER_TODOS_CREATE",
             "OWNER_TODOS_UPDATE",
@@ -373,6 +404,16 @@ export default scenario({
             "OWNER_TODOS_SKIP",
             "OWNER_TODOS_SNOOZE",
             "OWNER_TODOS_REVIEW",
+            "OWNER_ROUTINES",
+            "OWNER_ROUTINES_CREATE",
+            "OWNER_ROUTINES_UPDATE",
+            "OWNER_ROUTINES_DELETE",
+            "OWNER_ROUTINES_COMPLETE",
+            "OWNER_ROUTINES_SKIP",
+            "OWNER_ROUTINES_SNOOZE",
+            "OWNER_ROUTINES_REVIEW",
+            "OWNER_ROUTINES_SCHEDULE_SUMMARY",
+            "OWNER_ROUTINES_SCHEDULE_INSPECT",
             "TODO",
             "REPLY",
             "IGNORE",

--- a/packages/scenario-runner/test/scenarios/live-document-delete.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-document-delete.scenario.ts
@@ -68,9 +68,25 @@ let seededDocumentId: UUID | null = null;
 // processing (it is merged per source key), unlike world-metadata role grants
 // which each processed message clobbers.
 const GUEST_STABLE_ID = `${SCENARIO_ID}-guest-admin`;
-const GUEST_ROOM_ID = stringToUuid(
-  `scenario-room:${SCENARIO_ID}:guest`,
-) as UUID;
+
+/**
+ * The guest room's runtime identity, read from the executor-published topology
+ * rather than re-derived here. The executor alone owns the
+ * `scenario-account:<scenarioId>:<account>` recipe and has already changed it
+ * once (#24842 namespaced accounts per scenario); a scenario that spells it out
+ * a second time stamps its roles onto an entity nobody speaks as the moment the
+ * executor moves. One derivation, one seam.
+ */
+function guestIdentity(
+  ctx: ScenarioContext,
+): { entityId: UUID; roomId: UUID } | string {
+  const entityId = ctx.roomEntityIds?.guest;
+  const roomId = ctx.roomIds?.guest;
+  if (!entityId || !roomId) {
+    return "executor did not publish the guest room identity (ctx.roomEntityIds/ctx.roomIds)";
+  }
+  return { entityId: entityId as UUID, roomId: roomId as UUID };
+}
 
 function getDocumentService(ctx: ScenarioContext): DocumentService | null {
   const runtime = ctx.runtime as ScenarioRuntime;
@@ -250,6 +266,8 @@ export default scenario({
         if (!ctx.primaryRoomId || !ctx.primaryUserId) {
           return "primary room/user were not set by the executor";
         }
+        const guest = guestIdentity(ctx);
+        if (typeof guest === "string") return guest;
         const room = await runtime.getRoom(ctx.primaryRoomId as UUID);
         if (!room?.worldId) return "primary room world was not created";
         const stored = await service.addDocument({
@@ -258,7 +276,7 @@ export default scenario({
           // global record in the guest room so the non-owner can identify the
           // target without widening that privacy boundary; OWNER still has
           // global visibility and performs the successful delete later.
-          roomId: GUEST_ROOM_ID,
+          roomId: guest.roomId,
           entityId: ctx.primaryUserId as UUID,
           clientDocumentId: stringToUuid(`${SCENARIO_ID}:doc`) as UUID,
           contentType: "text/markdown",
@@ -279,11 +297,11 @@ export default scenario({
       name: "whitelist the guest entity as a connector admin",
       apply: async (ctx) => {
         const runtime = ctx.runtime as ScenarioRuntime;
-        const guestId = stringToUuid(
-          `scenario-account:${SCENARIO_ID}:guest`,
-        ) as UUID;
+        const guest = guestIdentity(ctx);
+        if (typeof guest === "string") return guest;
         setConnectorAdminWhitelist(runtime, { telegram: [GUEST_STABLE_ID] });
-        const entity = (await runtime.getEntitiesByIds([guestId]))[0] ?? null;
+        const entity =
+          (await runtime.getEntitiesByIds([guest.entityId]))[0] ?? null;
         if (!entity) return "guest entity was not created by the executor";
         entity.metadata = {
           ...entity.metadata,


### PR DESCRIPTION
# Relates to

Regressions from #24842 (`1c98cbde504`, linked-identity model) and a stale fixture in `deterministic-todos-actions` from #a0c6e7e6ccd. **The first finding below silently disabled owner-only authorization coverage across the entire scenario corpus and is the reason to review this promptly.**

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`7b2fc24fff4`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Test-harness only — no product code is changed — but the first fix *restores* coverage that has been silently absent, so expect scenarios asserting owner-only refusals to start actually asserting them.** If any of those scenarios were passing vacuously, they may now legitimately fail and reveal real product gaps. That is the point.

# Background

## What does this PR do?

### 1. Every scenario room was being granted OWNER (highest severity)

`packages/scenario-runner/src/executor.ts` published **every** room into `ELIZA_OWNER_CONTACTS_JSON`. `packages/core/src/roles.ts` `getConfiguredOwnerEntityIds` unions that set with `ELIZA_ADMIN_ENTITY_ID` and grants OWNER to all of it. So a scenario's deliberately non-owner room — a guest, a second account, the counterparty of any owner-only wall — **silently resolved as OWNER**, and every owner-only refusal in the corpus passed vacuously. This was not confined to the scenarios in this PR; it applies to any scenario that asserts a non-owner is refused.

Fix: owner contacts are now filtered to the owner's *linked* accounts — the rooms whose `canonicalEntityId` matches the primary room's, which is exactly #24842's linked-identity model — instead of every room.

### 2. Non-owner DMs were unmodellable

`attestScenarioTurnAudience` raised on any DM that failed owner-exclusive disclosure. For a guest room, `owner_mismatch` **is** the behaviour under test, so the attestation turned the assertion into a harness abort. It now applies to the owner's DM only, reading the owner identity back from the same setting the roles system resolves against so the two can never disagree.

### 3. Two scenarios still hand-rolled the pre-#24842 user id

#24842 changed the recipe from `scenario-account:${account}` to `scenario-account:${scenario.id}:${account}`. Both document scenarios still built the old form, so the seed stamped one entity while turns were sent as another, and the seed aborted with *"guest entity was not created by the executor."* They now read `ctx.roomEntityIds`/`ctx.roomIds` from the executor instead of recomputing the recipe — single-sourced, so this class of drift cannot recur.

### 4. `deterministic-todos-actions`' fixture listed a partial tool roster

`a0c6e7e6ccd` converted the planner fixture from `toolName` (contains) to manifest `toolNames`, which is **set equality**, but listed only the `OWNER_TODOS` family. Retrieval never narrows the catalog (`action-retrieval.ts`: *"Retrieval ranks every parent; it never limits availability"*), so the planner is offered all five `OWNER_*` families the lane registers, nothing matched, and turn 1 died. The list now reflects reality.

### The `forbidden` vs `not_found` question: the product is right, the fixture was wrong

The brief asked whether the document mutation wall answering `not_found` where the scenario expected `forbidden` is a defect. **It is not, and no product code was changed.** `deleteDocumentForRequester` resolves existence through the *requester-scoped* `adapter.getDocument` before evaluating permission, and `plugin-sql`'s base requires the row's room to be in the requester's rooms for any non-global-visibility role — ADMIN is deliberately room-limited. Three independent sources confirm the intent: a service test named *"does not expose foreign-agent or non-document rows through delete errors"*; an authorization test that explicitly pins membership revocation flipping the forbidden-class to `not_found`; and `live-document-delete.scenario.ts` stating it outright — *"ADMIN is intentionally room-limited for document reads. Seed the global record in the guest room so the non-owner can identify the target without widening that privacy boundary."* `not_found` is the safer, non-disclosing direction. The deterministic scenario seeded the document into the **owner's** room while its live sibling seeds into the **guest's**; the fixture was corrected to match its sibling.

## What kind of change is this?

Bug fixes (test harness; non-breaking to product).

# Documentation changes needed?

My changes do not require a change to the project documentation; each fix carries an in-code comment explaining the invariant it protects.

# Testing

## Where should a reviewer start?

The two hunks in `executor.ts` (owner-contacts filter and the DM attestation scope), then `executor-room-identity-invariant.test.ts`, which pins both seams.

## Detailed testing steps

- `cd packages/scenario-runner && bunx vitest run src/executor-room-identity-invariant.test.ts` → 2 pass.
- `deterministic-todos-actions` and `deterministic-document-actions`, each run individually with no competing runner: **1 passed / 0 failed each** (both failed on pristine `origin/develop` — todos on the fixture mismatch, documents on *"guest entity was not created by the executor"*).
- `test:unit` 506 passed / 1 failed; `test:mocks` 21 passed; the invariant suite plus five executor suites 60 passed.
- Mutation checks: removing the owner-contacts filter fails with `expected […] to not include '<guest>'`; publishing `canonicalEntityId` into `roomEntityIds` fails the seed-scope invariant; reverting the `userId` recipe fails the historical-fork pin; seeding the document into the owner's room as the *only* change reproduces `expected values.error="forbidden", saw "not_found"` exactly. One mutation initially survived, so the first test was extended with a linked-account room (where `canonicalEntityId ≠ userId`) to make the seam genuinely discriminating.
- Biome clean on all five touched files; typecheck 121 errors before and after (all pre-existing `TS2307` unbuilt-module cascade).

# Evidence Gate

<!-- evidence-head:7113c75630aa7422ca2f6ca4afe011155e40d2f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The scenario runner's own seed and turn output: pristine develop aborts the document seed with *guest entity was not created by the executor*; after the fix both scenarios complete and their assertions evaluate for real.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The published `ELIZA_OWNER_CONTACTS_JSON` set — previously every room, now only the owner's linked accounts; asserted directly in the invariant test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The scenario runner's own seed and turn output: pristine develop aborts the document seed with *guest entity was not created by the executor*; after the fix both scenarios complete and their assertions evaluate for real.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- `deterministic-todos-actions`' manifest `toolNames` is still **set equality** against the whole lane's plugin roster, so adding any plugin to `runtime-factory.ts` will break it again. The manifest schema offers no contains-matcher or predicate, unlike the runtime fixture API; adding one would remove the trap corpus-wide. Left out of scope deliberately.
- `live-document-delete.scenario.ts` receives the identical mechanical seam fix but is a live-lane scenario and could not be executed here.
- `src/echo-assertion-integrity.test.ts` fails on pristine `origin/develop` (about `packages/test/scenarios/conversation-quality/*`, untouched here).
- A pre-existing `bun.lock` drift surfaced during install (`@elizaos/synthetic-world` missing an `@elizaos/agent` entry); reverted and left alone, worth a separate look.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

