### PR TITLE
fix(app): reuse live dev:shared servers

### DIFF
--- a/packages/app/scripts/dev-server-registry.mjs
+++ b/packages/app/scripts/dev-server-registry.mjs
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+
+/**
+ * Coordinates deterministic development-server ports across worktrees through
+ * a lock-protected registry. Runtime liveness and reservation identities keep
+ * concurrent launchers from duplicating servers or overwriting newer owners.
+ */
+
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -8,6 +16,7 @@ export const DEFAULT_UI_PORT_BASE = 2100;
 export const DEFAULT_UI_PORT_SPAN = 900;
 export const DEFAULT_API_PORT_OFFSET = 10_000;
 export const REGISTRY_VERSION = 1;
+const STARTUP_RESERVATION_GRACE_MS = 120_000;
 
 export function defaultRegistryPath(env = process.env) {
   return (
@@ -111,6 +120,18 @@ export async function getEntryRuntime(entry) {
     portOpen,
     running: pidAlive || portOpen,
   };
+}
+
+function canReuseEntry(entry, runtime, now = Date.now()) {
+  if (!runtime.pidAlive) return false;
+  if (runtime.portOpen) return true;
+  if (typeof entry.reservationId !== "string" || !entry.reservationId) {
+    return false;
+  }
+  const startedAt = Date.parse(entry.startedAt);
+  if (!Number.isFinite(startedAt)) return false;
+  const reservationAge = now - startedAt;
+  return reservationAge >= 0 && reservationAge <= STARTUP_RESERVATION_GRACE_MS;
 }
 
 export async function listRegistryEntries({
@@ -229,20 +250,37 @@ export async function reservePortsForWorktree(
   worktreePath,
   { registryPath = defaultRegistryPath(), base, span } = {},
 ) {
+  const worktree = normalizeWorktreePath(worktreePath);
   return await withRegistryLock(
     async () => {
       const current = readRegistry(registryPath);
+      for (const existing of current.entries ?? []) {
+        if (existing.worktree !== worktree || existing.stoppedAt) continue;
+        const runtime = await getEntryRuntime(existing);
+        // A fresh launcher owns the reservation before Vite opens its port.
+        // After that bounded window, require both the owner PID and listener so
+        // one recycled PID or unrelated process on the port cannot mask Vite.
+        if (canReuseEntry(existing, runtime)) {
+          return { entry: existing, reused: true };
+        }
+      }
+
       const blockedUiPorts = new Set();
       while (true) {
-        const allocated = allocatePortsForWorktree(worktreePath, {
+        const allocated = allocatePortsForWorktree(worktree, {
           registry: current,
           base,
           span,
           blockedUiPorts,
         });
         if (!(await isPortOpen(allocated.entry.uiPort))) {
+          const startedAt = new Date().toISOString();
+          allocated.entry.pid = process.pid;
+          allocated.entry.reservationId = randomUUID();
+          allocated.entry.startedAt = startedAt;
+          allocated.entry.updatedAt = startedAt;
           writeRegistry(allocated.registry, registryPath);
-          return allocated.entry;
+          return { entry: allocated.entry, reused: false };
         }
         blockedUiPorts.add(allocated.entry.uiPort);
       }
@@ -254,7 +292,7 @@ export async function reservePortsForWorktree(
 export async function updateRegistryEntry(
   worktreePath,
   patch,
-  { registryPath = defaultRegistryPath() } = {},
+  { registryPath = defaultRegistryPath(), expectedReservationId } = {},
 ) {
   const worktree = normalizeWorktreePath(worktreePath);
   return await withRegistryLock(
@@ -263,6 +301,12 @@ export async function updateRegistryEntry(
       const entries = registry.entries ?? [];
       const index = entries.findIndex((entry) => entry.worktree === worktree);
       if (index === -1) return null;
+      if (
+        expectedReservationId !== undefined &&
+        entries[index].reservationId !== expectedReservationId
+      ) {
+        return null;
+      }
       const updated = {
         ...entries[index],
         ...patch,

--- a/packages/app/scripts/dev-server-registry.test.mjs
+++ b/packages/app/scripts/dev-server-registry.test.mjs
@@ -1,15 +1,157 @@
+/**
+ * Exercises deterministic port allocation and concurrent registry ownership
+ * with temporary files, real loopback sockets, and a poisoned-path subprocess
+ * that proves shared-server reuse without launching Vite.
+ */
+
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   allocatePortsForWorktree,
   createEmptyRegistry,
+  normalizeWorktreePath,
+  portsForUiPort,
   preferredUiPortForWorktree,
   readRegistry,
   reservePortsForWorktree,
+  updateRegistryEntry,
+  writeRegistry,
 } from "./dev-server-registry.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+const devSharedScript = path.join(here, "dev-shared.mjs");
+
+function makeRegistryPath(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-dev-registry-"));
+  t.after(() =>
+    fs.rmSync(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    }),
+  );
+  return path.join(dir, "registry.json");
+}
+
+async function listenOnLoopback(port = 0) {
+  const server = net.createServer();
+  server.listen(port, "127.0.0.1");
+  await once(server, "listening");
+  return server;
+}
+
+async function closeServer(server) {
+  if (!server.listening) return;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function findFreePort() {
+  const server = await listenOnLoopback();
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  await closeServer(server);
+  return address.port;
+}
+
+async function listenWithNextPortFree() {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const server = await listenOnLoopback();
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    if (address.port >= 65_535) {
+      await closeServer(server);
+      continue;
+    }
+    try {
+      const nextServer = await listenOnLoopback(address.port + 1);
+      await closeServer(nextServer);
+      return server;
+    } catch {
+      await closeServer(server);
+    }
+  }
+  throw new Error("Could not find adjacent loopback ports for the test");
+}
+
+function worktreePreferring(baseDir, targetPort, { base, span }) {
+  for (let index = 0; index < 100; index += 1) {
+    const candidate = path.join(baseDir, `worktree-${index}`);
+    if (preferredUiPortForWorktree(candidate, { base, span }) === targetPort) {
+      return candidate;
+    }
+  }
+  throw new Error(`Could not find a worktree preferring port ${targetPort}`);
+}
+
+function registryEntry(worktreePath, uiPort, patch = {}) {
+  const worktree = normalizeWorktreePath(worktreePath);
+  const ports = portsForUiPort(uiPort);
+  return {
+    worktree,
+    packageDir: path.join(worktree, "packages", "app"),
+    uiPort: ports.uiPort,
+    apiPort: ports.apiPort,
+    preferredUiPort: ports.uiPort,
+    pid: process.pid,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    lastRebuildAt: null,
+    ...patch,
+  };
+}
+
+async function runNode(scriptPath, { env, timeoutMs = 3_000 } = {}) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(() =>
+        reject(
+          new Error(
+            `Timed out waiting for ${path.basename(scriptPath)}\n${stdout}${stderr}`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => finish(() => reject(error)));
+    child.once("close", (code, signal) =>
+      finish(() => resolve({ code, signal, stdout, stderr })),
+    );
+  });
+}
 
 describe("shared dev server registry", () => {
   it("allocates stable deterministic ports for a worktree", () => {
@@ -58,9 +200,8 @@ describe("shared dev server registry", () => {
     );
   });
 
-  it("writes reservations through the lock-protected registry", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-dev-registry-"));
-    const registryPath = path.join(dir, "registry.json");
+  it("writes reservations through the lock-protected registry", async (t) => {
+    const registryPath = makeRegistryPath(t);
 
     const alpha = await reservePortsForWorktree("/tmp/eliza-workers/wt-alpha", {
       registryPath,
@@ -70,7 +211,254 @@ describe("shared dev server registry", () => {
     });
     const registry = readRegistry(registryPath);
 
+    assert.equal(alpha.reused, false);
+    assert.equal(beta.reused, false);
     assert.equal(registry.entries.length, 2);
-    assert.notEqual(alpha.uiPort, beta.uiPort);
+    assert.notEqual(alpha.entry.uiPort, beta.entry.uiPort);
+  });
+
+  it("reuses an established same-worktree server without rewriting it", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenOnLoopback();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+    const existing = registryEntry(worktree, address.port);
+    writeRegistry({ version: 1, entries: [existing] }, registryPath);
+    const before = fs.readFileSync(registryPath, "utf8");
+
+    const reservation = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base: address.port,
+      span: 1,
+    });
+
+    assert.equal(reservation.reused, true);
+    assert.deepEqual(reservation.entry, existing);
+    assert.equal(fs.readFileSync(registryPath, "utf8"), before);
+  });
+
+  it("does not reuse a stale reservation from its live PID alone", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const base = await findFreePort();
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+    const existing = registryEntry(worktree, base, {
+      reservationId: "stale-reservation",
+      startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    });
+    writeRegistry({ version: 1, entries: [existing] }, registryPath);
+
+    const reservation = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base,
+      span: 1,
+    });
+
+    assert.equal(reservation.reused, false);
+    assert.equal(reservation.entry.uiPort, base);
+    assert.notEqual(reservation.entry.reservationId, existing.reservationId);
+  });
+
+  it("does not reuse a stale reservation from its open port alone", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenWithNextPortFree();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const base = address.port;
+    const span = 2;
+    const worktree = worktreePreferring(
+      path.dirname(registryPath),
+      address.port,
+      { base, span },
+    );
+    const existing = registryEntry(worktree, address.port, {
+      pid: null,
+      reservationId: "stale-reservation",
+      startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    });
+    writeRegistry({ version: 1, entries: [existing] }, registryPath);
+
+    const reservation = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base,
+      span,
+    });
+
+    assert.equal(reservation.reused, false);
+    assert.equal(reservation.entry.uiPort, address.port + 1);
+    assert.notEqual(reservation.entry.reservationId, existing.reservationId);
+  });
+
+  it("gives concurrent same-worktree starters one fresh reservation", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const base = await findFreePort();
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+
+    const reservations = await Promise.all([
+      reservePortsForWorktree(worktree, { registryPath, base, span: 1 }),
+      reservePortsForWorktree(worktree, { registryPath, base, span: 1 }),
+    ]);
+
+    assert.deepEqual(reservations.map(({ reused }) => reused).sort(), [
+      false,
+      true,
+    ]);
+    assert.equal(reservations[0].entry.uiPort, reservations[1].entry.uiPort);
+    const registry = readRegistry(registryPath);
+    assert.equal(registry.entries.length, 1);
+    assert.equal(registry.entries[0].pid, process.pid);
+    assert.ok(registry.entries[0].reservationId);
+    assert.equal(
+      reservations[0].entry.reservationId,
+      reservations[1].entry.reservationId,
+    );
+    assert.ok(registry.entries[0].startedAt);
+  });
+
+  it("reclaims dead same-worktree reservations", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const base = await findFreePort();
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+    const child = spawn(process.execPath, ["-e", ""]);
+    const deadPid = child.pid;
+    assert.ok(deadPid);
+    await once(child, "exit");
+    writeRegistry(
+      {
+        version: 1,
+        entries: [registryEntry(worktree, base, { pid: deadPid })],
+      },
+      registryPath,
+    );
+
+    const reservation = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base,
+      span: 1,
+    });
+
+    assert.equal(reservation.reused, false);
+    assert.equal(reservation.entry.uiPort, base);
+    assert.equal(reservation.entry.pid, process.pid);
+  });
+
+  it("reclaims explicitly stopped same-worktree reservations", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const base = await findFreePort();
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+    writeRegistry(
+      {
+        version: 1,
+        entries: [
+          registryEntry(worktree, base, {
+            stoppedAt: "2026-01-01T00:01:00.000Z",
+          }),
+        ],
+      },
+      registryPath,
+    );
+
+    const reservation = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base,
+      span: 1,
+    });
+
+    assert.equal(reservation.reused, false);
+    assert.equal(reservation.entry.uiPort, base);
+    assert.equal(reservation.entry.stoppedAt, undefined);
+  });
+
+  it("linear-probes to the next port for a distinct worktree collision", () => {
+    const registry = createEmptyRegistry();
+    const base = 2400;
+    const span = 2;
+    const alpha = "/tmp/eliza-workers/alpha";
+    const preferred = preferredUiPortForWorktree(alpha, { base, span });
+    let beta;
+    for (let index = 0; index < 100; index += 1) {
+      const candidate = `/tmp/eliza-workers/beta-${index}`;
+      if (preferredUiPortForWorktree(candidate, { base, span }) === preferred) {
+        beta = candidate;
+        break;
+      }
+    }
+    assert.ok(beta);
+    const first = allocatePortsForWorktree(alpha, { registry, base, span });
+    first.entry.pid = process.pid;
+
+    const second = allocatePortsForWorktree(beta, {
+      registry: first.registry,
+      base,
+      span,
+    });
+
+    assert.equal(first.entry.uiPort, preferred);
+    assert.notEqual(second.entry.uiPort, preferred);
+    assert.equal(second.registry.entries.length, 2);
+  });
+
+  it("does not let a stale owner update a replacement reservation", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const base = await findFreePort();
+    const worktree = path.join(path.dirname(registryPath), "worktree");
+    const original = await reservePortsForWorktree(worktree, {
+      registryPath,
+      base,
+      span: 1,
+    });
+    assert.equal(original.reused, false);
+    assert.ok(original.entry.reservationId);
+    const replacement = registryEntry(worktree, base, {
+      reservationId: "replacement-reservation",
+    });
+    writeRegistry({ version: 1, entries: [replacement] }, registryPath);
+
+    const updated = await updateRegistryEntry(
+      worktree,
+      { pid: null, stoppedAt: "2026-01-01T00:02:00.000Z" },
+      {
+        registryPath,
+        expectedReservationId: original.entry.reservationId,
+      },
+    );
+
+    assert.equal(updated, null);
+    assert.deepEqual(readRegistry(registryPath).entries, [replacement]);
+  });
+
+  it("dev:shared exits without resolving Vite when it reuses a server", async (t) => {
+    const registryPath = makeRegistryPath(t);
+    const server = await listenOnLoopback();
+    t.after(() => closeServer(server));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const existing = registryEntry(repoRoot, address.port);
+    writeRegistry({ version: 1, entries: [existing] }, registryPath);
+    const before = fs.readFileSync(registryPath, "utf8");
+
+    const result = await runNode(devSharedScript, {
+      env: {
+        ELIZA_DEV_SERVER_REGISTRY: registryPath,
+        ELIZA_NODE_PATH: path.join(
+          path.dirname(registryPath),
+          "must-not-exist",
+        ),
+      },
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.signal, null);
+    assert.match(
+      result.stdout,
+      /reusing existing server; Vite was not started/,
+    );
+    assert.match(
+      result.stdout,
+      new RegExp(`ui=http://127\\.0\\.0\\.1:${address.port}`),
+    );
+    assert.equal(fs.readFileSync(registryPath, "utf8"), before);
   });
 });

--- a/packages/app/scripts/dev-shared.mjs
+++ b/packages/app/scripts/dev-shared.mjs
@@ -21,7 +21,9 @@ const appDir = path.resolve(here, "..");
 const worktree = normalizeWorktreePath(path.resolve(appDir, "../.."));
 const registryPath = defaultRegistryPath();
 
-const entry = await reservePortsForWorktree(worktree, { registryPath });
+const { entry, reused } = await reservePortsForWorktree(worktree, {
+  registryPath,
+});
 const env = {
   ...process.env,
   ELIZA_UI_PORT: String(entry.uiPort),
@@ -35,40 +37,48 @@ console.log(
     `[dev:shared] registry=${registryPath}`,
 );
 
-const viteCommand = resolveViteCommand({ appDir });
-const child = spawn(viteCommand.command, viteCommand.args, {
-  cwd: appDir,
-  env,
-  stdio: "inherit",
-});
+if (reused) {
+  console.log("[dev:shared] reusing existing server; Vite was not started");
+} else {
+  const viteCommand = resolveViteCommand({ appDir });
+  const child = spawn(viteCommand.command, viteCommand.args, {
+    cwd: appDir,
+    env,
+    stdio: "inherit",
+  });
 
-await updateRegistryEntry(
-  worktree,
-  {
-    pid: child.pid,
-    startedAt: new Date().toISOString(),
-    uiPort: entry.uiPort,
-    apiPort: entry.apiPort,
-    packageDir: appDir,
-  },
-  { registryPath },
-);
-
-function forward(signal) {
-  if (!child.killed) child.kill(signal);
-}
-process.once("SIGINT", () => forward("SIGINT"));
-process.once("SIGTERM", () => forward("SIGTERM"));
-
-child.on("exit", async (code, signal) => {
-  await updateRegistryEntry(
+  const registered = await updateRegistryEntry(
     worktree,
-    { pid: null, stoppedAt: new Date().toISOString() },
-    { registryPath },
+    {
+      pid: child.pid,
+      startedAt: new Date().toISOString(),
+      uiPort: entry.uiPort,
+      apiPort: entry.apiPort,
+      packageDir: appDir,
+    },
+    { registryPath, expectedReservationId: entry.reservationId },
   );
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+  if (!registered) {
+    child.kill();
+    throw new Error("Lost the dev server reservation before Vite launched");
   }
-  process.exit(code ?? 0);
-});
+
+  function forward(signal) {
+    if (!child.killed) child.kill(signal);
+  }
+  process.once("SIGINT", () => forward("SIGINT"));
+  process.once("SIGTERM", () => forward("SIGTERM"));
+
+  child.on("exit", async (code, signal) => {
+    await updateRegistryEntry(
+      worktree,
+      { pid: null, stoppedAt: new Date().toISOString() },
+      { registryPath, expectedReservationId: entry.reservationId },
+    );
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+}


### PR DESCRIPTION
# Relates to

Closes #25626

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest fetched `origin/develop` with zero conflicts.
- [x] `bun install --backend=copyfile --frozen-lockfile` and `bun run verify` were run after sync; the exact unrelated `verify` blocker is recorded below.
- [x] The exact-head evidence below demonstrates the behavior without requiring code inspection.

# Sync with develop

- [x] Rebased onto fetched `origin/develop` (`27d58c0757`); zero conflicts.
- [x] `bun run verify` was run at the PR head; its untouched Windows-formatting baseline blocker is documented under **Known gaps / failures**.

# Risks

Low. This affects only the private local `dev:shared` orchestration path. Established servers must have both a live owner PID and an open UI port; a UUID reservation permits PID-only reuse for a bounded 120-second startup window. Dead, stopped, PID-only-stale, and unrelated-port entries remain reclaimable. Reservation-ID compare-and-swap updates prevent an older launcher from modifying a successor reservation.

# Background

## What does this PR do?

- Reuses a live same-worktree server while holding the registry lock instead of launching a second Vite process.
- Records provisional launcher ownership atomically before releasing the lock.
- Uses reservation IDs for compare-and-swap child registration and teardown.
- Adds deterministic allocation, concurrency, stale-owner, stale-liveness, real-loopback, and real-`dev-shared.mjs` subprocess regression coverage.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. This restores the existing documented `dev:shared` start-or-reuse contract without changing its command or port-allocation policy.

# Testing

## Where should a reviewer start?

`packages/app/scripts/dev-server-registry.test.mjs`, especially the concurrent starter, stale PID/port, stale-owner, live-loopback reuse, and real `dev-shared.mjs` subprocess cases.

## Detailed testing steps

```text
bun install --backend=copyfile --frozen-lockfile
node --test packages/app/scripts/dev-server-registry.test.mjs
bun test packages/app/scripts/dev-server-registry.test.mjs
bunx @biomejs/biome check packages/app/scripts/dev-server-registry.mjs packages/app/scripts/dev-shared.mjs packages/app/scripts/dev-server-registry.test.mjs
node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app... --concurrency=8 --cache=local:rw --output-logs=errors-only --env-mode=loose
bun run --cwd packages/app typecheck
bun run --cwd packages/app audit:app
bun run verify
```

The subprocess regression seeds a live same-worktree loopback listener and supplies a deliberately nonexistent `ELIZA_NODE_PATH`. Exiting successfully with `Vite was not started` proves the reuse branch did not resolve or spawn Vite.

# Evidence Gate

<!-- evidence-head:15b813c4a2afd30eb520beb38a035ee7bc7cd7bd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - command-line development tooling only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - command-line development tooling only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - there is no rendered or interactive UI flow; the real process path is captured below.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused and real-process transcript:

<details>
<summary>Backend test and build output</summary>

```text
PR head 15b813c4a2afd30eb520beb38a035ee7bc7cd7bd
node --test packages/app/scripts/dev-server-registry.test.mjs
tests 13; pass 13; fail 0
PASS established same-worktree server reused without registry rewrite
PASS stale live-PID-only reservation rejected
PASS unrelated open-port-only reservation rejected
PASS concurrent starters yield one fresh and one reused reservation
PASS stale owner cannot update its replacement
PASS dev:shared exits without resolving or spawning Vite on reuse
bun test: 13 pass; 0 fail
Biome: 3 changed files checked; no fixes applied
Production build: 98 successful tasks; 98 total
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser request, frontend state, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Sanitized exact-head registry result:

```json
{
  "head": "15b813c4a2afd30eb520beb38a035ee7bc7cd7bd",
  "precondition": {
    "sameWorktree": true,
    "existingPidAlive": true,
    "existingUiPortOpen": true
  },
  "observed": {
    "reused": true,
    "registryBytesUnchanged": true,
    "viteResolutionAttempted": false,
    "secondViteProcessStarted": false
  },
  "stalePidOnlyReused": false,
  "openPortOnlyReused": false,
  "staleOwnerMutationAccepted": false
}
```
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

Exact PR head: `15b813c4a2afd30eb520beb38a035ee7bc7cd7bd`

```text
$ node --test packages/app/scripts/dev-server-registry.test.mjs
tests 13; pass 13; fail 0
✔ reuses an established same-worktree server without rewriting it
✔ does not reuse a stale reservation from its live PID alone
✔ does not reuse a stale reservation from its open port alone
✔ gives concurrent same-worktree starters one fresh reservation
✔ does not let a stale owner update a replacement reservation
✔ dev:shared exits without resolving Vite when it reuses a server

$ bun test packages/app/scripts/dev-server-registry.test.mjs
13 pass; 0 fail

$ biome check <three changed files>
Checked 3 files. No fixes applied.
```

Sanitized real-loopback registry result:

```json
{
  "head": "15b813c4a2afd30eb520beb38a035ee7bc7cd7bd",
  "sameWorktree": true,
  "existingPidAlive": true,
  "existingUiPortOpen": true,
  "observed": { "reused": true },
  "expected": "reuse the existing running reservation"
}
```

Frontend logs are N/A because this is local process orchestration with no browser path.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun run verify` at the exact PR head exits in the monorepo lint phase on untouched Windows checkout/generated files under `packages/app-core/platforms/electrobun` (including `src/preload.js`, `.generated/brand-config.json`, and existing test formatting). The three changed files pass Biome, and the production app dependency build passes 98/98 tasks.
- `bun run --cwd packages/app typecheck` reaches TypeScript and exits on the upstream `packages/agent/src/api/inbox-routes.ts:2599` use of missing `InboxChat.roomId` (introduced by `60837d953f`). This PR changes only three `.mjs` launcher/test files.
- `bun run --cwd packages/app audit:app` completes 226/227 Playwright tests with zero broken views, then the strict aggregate gate rejects two untouched Settings captures (`mobile-portrait`, `ipad-portrait`) as `needs-work`; OCR does not run after that capture failure. This PR has no rendered UI changes.

## Maintainer CI exception record

N/A - no exception requested.
