### PR TITLE
test(scenarios): assert lifeops concurrent-day deliveries on the real notifier

### DIFF
--- a/packages/scenario-runner/src/lifeops-concurrent-day-delivery-ledger.test.ts
+++ b/packages/scenario-runner/src/lifeops-concurrent-day-delivery-ledger.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Pins the delivery ledger of the `deterministic-lifeops-concurrent-day`
+ * scenario to the NOTIFICATION service its production dispatcher writes to.
+ *
+ * The scenario runtime always owns that service slot (core's
+ * `NotificationService`, registered by the `eliza` plugin), so a scenario
+ * cannot observe scheduled-task delivery through a capture service of its own:
+ * the ledger has to be the production inbox. These tests run the scenario's
+ * real seed and real delivery final check against a structural runtime whose
+ * NOTIFICATION service is a readable inbox of that shape, and prove the check
+ * counts one delivery per fired taskId, none for the gate-denied task, and
+ * fails honestly on a missing, duplicated, or mis-rendered delivery.
+ */
+
+import type {
+  ScenarioContext,
+  ScenarioDefinition,
+} from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+import concurrentDayScenario from "../test/scenarios/deterministic-lifeops-concurrent-day.scenario.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const DELIVERY_CHECK_NAME =
+  "every fired task delivered exactly one real notification; the gate-denied task delivered none";
+
+interface SeededTask {
+  taskId: string;
+  kind: string;
+  promptInstructions: string;
+  priority: string;
+  state: { status: string };
+  metadata?: JsonRecord;
+}
+
+/** Minimal readable inbox with the same surface core's NotificationService has. */
+class FakeNotificationInbox {
+  readonly delivered: Array<{ body?: string; data?: JsonRecord }> = [];
+
+  async notify(input: {
+    body?: string;
+    data?: JsonRecord;
+  }): Promise<{ ok: true }> {
+    this.delivered.push({ body: input.body, data: input.data });
+    return { ok: true };
+  }
+
+  listIncludingExpired(): Array<{ body?: string; data?: JsonRecord }> {
+    return [...this.delivered];
+  }
+}
+
+/** Stand-in for ScheduledTaskRunnerService's per-agent runner handle. */
+class FakeRunner {
+  readonly tasks: SeededTask[] = [];
+  private nextId = 0;
+
+  async schedule(input: JsonRecord): Promise<SeededTask> {
+    this.nextId += 1;
+    const task: SeededTask = {
+      taskId: `task-${String(this.nextId).padStart(2, "0")}`,
+      kind: String(input.kind),
+      promptInstructions: String(input.promptInstructions),
+      priority: String(input.priority),
+      state: { status: "scheduled" },
+      metadata: input.metadata as JsonRecord | undefined,
+    };
+    this.tasks.push(task);
+    return task;
+  }
+
+  async list(): Promise<SeededTask[]> {
+    return [...this.tasks];
+  }
+
+  async apply(taskId: string, verb: string): Promise<SeededTask> {
+    const task = this.tasks.find((entry) => entry.taskId === taskId);
+    if (!task) throw new Error(`unknown task ${taskId}`);
+    if (verb === "dismiss") task.state.status = "dismissed";
+    return task;
+  }
+}
+
+function buildContext(inbox: FakeNotificationInbox | null): {
+  ctx: ScenarioContext;
+  runner: FakeRunner;
+} {
+  const runner = new FakeRunner();
+  const runtime = {
+    agentId: "agent-under-test",
+    getService(serviceType: string): unknown {
+      if (serviceType === "lifeops_scheduled_task_runner") {
+        return { getRunner: () => runner };
+      }
+      if (serviceType === "notification") return inbox;
+      return null;
+    },
+  };
+  return {
+    ctx: { runtime, actionsCalled: [] } as unknown as ScenarioContext,
+    runner,
+  };
+}
+
+function definition(): ScenarioDefinition {
+  return concurrentDayScenario as ScenarioDefinition;
+}
+
+async function runSeed(ctx: ScenarioContext): Promise<string | undefined> {
+  const seed = definition().seed?.[0];
+  if (seed?.type !== "custom" || typeof seed.apply !== "function") {
+    throw new Error("scenario seed[0] is not a custom apply seed");
+  }
+  return (await seed.apply(ctx)) as string | undefined;
+}
+
+function runDeliveryCheck(ctx: ScenarioContext): string | undefined {
+  const check = definition().finalChecks?.find(
+    (candidate) => candidate.name === DELIVERY_CHECK_NAME,
+  );
+  if (check?.type !== "custom") {
+    throw new Error(`final check "${DELIVERY_CHECK_NAME}" is missing`);
+  }
+  return check.predicate(ctx) as string | undefined;
+}
+
+/** Deliver into the inbox exactly what the production dispatcher delivers. */
+async function deliverFiredTasks(
+  inbox: FakeNotificationInbox,
+  runner: FakeRunner,
+  options: { skipIndexes?: number[]; duplicateIndexes?: number[] } = {},
+): Promise<void> {
+  const skip = new Set(options.skipIndexes ?? []);
+  const duplicate = new Set(options.duplicateIndexes ?? []);
+  for (const [index, task] of runner.tasks.entries()) {
+    if (skip.has(index)) continue;
+    const copies = duplicate.has(index) ? 2 : 1;
+    for (let copy = 0; copy < copies; copy += 1) {
+      await inbox.notify({
+        body: `Heads up: ${task.promptInstructions}`,
+        data: { taskId: task.taskId, channelKey: "in_app" },
+      });
+    }
+  }
+}
+
+/** The gate-denied task is the only seeded plan that must deliver nothing. */
+function gateDeniedIndex(runner: FakeRunner): number {
+  const index = runner.tasks.findIndex((task) =>
+    task.promptInstructions.startsWith("Water the garden"),
+  );
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+describe("deterministic-lifeops-concurrent-day delivery ledger", () => {
+  it("reads the registered NOTIFICATION service inbox, not a scenario-owned sink", async () => {
+    const inbox = new FakeNotificationInbox();
+    const { ctx, runner } = buildContext(inbox);
+
+    expect(await runSeed(ctx)).toBeUndefined();
+    expect(runner.tasks).toHaveLength(26);
+
+    await deliverFiredTasks(inbox, runner, {
+      skipIndexes: [gateDeniedIndex(runner)],
+    });
+
+    expect(runDeliveryCheck(ctx)).toBeUndefined();
+  });
+
+  it("fails when a fired task delivered nothing", async () => {
+    const inbox = new FakeNotificationInbox();
+    const { ctx, runner } = buildContext(inbox);
+    expect(await runSeed(ctx)).toBeUndefined();
+
+    await deliverFiredTasks(inbox, runner, {
+      skipIndexes: [gateDeniedIndex(runner), 0],
+    });
+
+    expect(runDeliveryCheck(ctx)).toContain(
+      "approval-wire: expected 1 delivered notification(s), saw 0",
+    );
+  });
+
+  it("fails when the gate-denied task reached the surface", async () => {
+    const inbox = new FakeNotificationInbox();
+    const { ctx, runner } = buildContext(inbox);
+    expect(await runSeed(ctx)).toBeUndefined();
+
+    await deliverFiredTasks(inbox, runner);
+
+    expect(runDeliveryCheck(ctx)).toContain(
+      "sunday-only: expected 0 delivered notification(s), saw 1",
+    );
+  });
+
+  it("fails when one task delivered twice", async () => {
+    const inbox = new FakeNotificationInbox();
+    const { ctx, runner } = buildContext(inbox);
+    expect(await runSeed(ctx)).toBeUndefined();
+
+    await deliverFiredTasks(inbox, runner, {
+      skipIndexes: [gateDeniedIndex(runner)],
+      duplicateIndexes: [2],
+    });
+
+    expect(runDeliveryCheck(ctx)).toContain(
+      "medication: expected 1 delivered notification(s), saw 2",
+    );
+  });
+
+  it("fails when the delivered body is not the rendered owner-facing copy", async () => {
+    const inbox = new FakeNotificationInbox();
+    const { ctx, runner } = buildContext(inbox);
+    expect(await runSeed(ctx)).toBeUndefined();
+
+    const denied = gateDeniedIndex(runner);
+    for (const [index, task] of runner.tasks.entries()) {
+      if (index === denied) continue;
+      await inbox.notify({
+        body:
+          index === 1
+            ? task.promptInstructions
+            : `Heads up: ${task.promptInstructions}`,
+        data: { taskId: task.taskId },
+      });
+    }
+
+    expect(runDeliveryCheck(ctx)).toContain(
+      "midday-checkin: expected delivered body",
+    );
+  });
+
+  it("refuses to seed when no readable notification inbox is registered", async () => {
+    const { ctx } = buildContext(null);
+    expect(await runSeed(ctx)).toContain(
+      "no readable NOTIFICATION service is registered",
+    );
+  });
+});

--- a/packages/scenario-runner/test/scenarios/deterministic-lifeops-concurrent-day.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-lifeops-concurrent-day.scenario.ts
@@ -24,13 +24,11 @@
  * Runs keylessly: no message turns, no LLM calls — the strict proxy is never
  * consulted. The seed schedules through the production
  * `ScheduledTaskRunnerService` (PA's DB-backed deps), the same path the
- * SCHEDULED_TASKS action uses, and registers a real NOTIFICATION service so
- * in_app dispatch has a live delivery surface (the dispatcher honestly
- * reports `disconnected` when no surface accepts the payload) — which also
- * yields a per-task delivery ledger this scenario asserts.
+ * SCHEDULED_TASKS action uses, and the per-task delivery ledger is read back
+ * from the production notification inbox the dispatcher actually writes to.
  */
 
-import { type IAgentRuntime, Service, ServiceType } from "@elizaos/core";
+import { ServiceType } from "@elizaos/core";
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 
@@ -173,64 +171,46 @@ interface RunnerServiceLike {
 interface RuntimeLike {
   agentId: string;
   getService?: (serviceType: string) => unknown;
-  registerService?: (serviceDef: unknown) => Promise<void>;
-  getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
 }
 
 // ---------------------------------------------------------------------------
-// Real NOTIFICATION delivery surface. The production in_app dispatcher only
-// reports `ok` when a real surface (assistant event bus or notification
-// service) accepts the payload; a bare scenario runtime has neither, so
-// every fire would honestly defer as `dispatch_deferred(disconnected)`.
-// Registering this sink makes delivery real AND gives the scenario a
-// checkable ledger of what actually reached the owner surface.
+// Real delivery ledger. The production in_app dispatcher only reports `ok`
+// when a live surface accepts the payload, and it resolves that surface
+// through `getService(ServiceType.NOTIFICATION)`. The scenario runtime boots
+// the production `eliza` plugin, which owns that slot with core's
+// `NotificationService` (packages/agent/src/runtime/eliza-plugin.ts): a
+// scenario cannot substitute its own capture service there, so the ledger is
+// the durable inbox itself, keyed by the `data.taskId` every scheduled
+// dispatch stamps.
 // ---------------------------------------------------------------------------
 
-interface CapturedNotification {
-  title?: string;
-  body?: string;
-  category?: string;
-  priority?: string;
+interface DeliveredNotification {
+  body?: unknown;
   data?: JsonRecord;
 }
 
-const deliveredNotifications: CapturedNotification[] = [];
-
-class ScenarioNotificationSink extends Service {
-  static override serviceType = ServiceType.NOTIFICATION;
-  override capabilityDescription =
-    "Scenario-owned NOTIFICATION service: captures every delivered payload so the scenario can assert real deliveries.";
-
-  static override async start(
-    runtime: IAgentRuntime,
-  ): Promise<ScenarioNotificationSink> {
-    return new ScenarioNotificationSink(runtime);
-  }
-
-  override async stop(): Promise<void> {}
-
-  async notify(input: CapturedNotification): Promise<{ ok: true }> {
-    deliveredNotifications.push(input);
-    return { ok: true };
-  }
+interface NotificationInboxLike {
+  notify: (input: JsonRecord) => Promise<unknown>;
+  listIncludingExpired: () => DeliveredNotification[];
 }
 
-async function ensureNotificationSink(
+let notificationInbox: NotificationInboxLike | null = null;
+
+function resolveNotificationInbox(
   runtime: RuntimeLike,
-): Promise<string | undefined> {
-  const existing = runtime.getService?.(ServiceType.NOTIFICATION);
-  if (existing) return undefined;
-  if (typeof runtime.registerService !== "function") {
-    return "runtime.registerService unavailable; cannot register the notification sink";
+): NotificationInboxLike | null {
+  const service = runtime.getService?.(ServiceType.NOTIFICATION) as
+    | Partial<NotificationInboxLike>
+    | null
+    | undefined;
+  if (
+    !service ||
+    typeof service.notify !== "function" ||
+    typeof service.listIncludingExpired !== "function"
+  ) {
+    return null;
   }
-  await runtime.registerService(ScenarioNotificationSink);
-  // Registration is lazy — force the instance to start so the dispatcher's
-  // synchronous getService(NOTIFICATION) sees a live surface on tick 1.
-  await runtime.getServiceLoadPromise?.(ServiceType.NOTIFICATION);
-  if (!runtime.getService?.(ServiceType.NOTIFICATION)) {
-    return "notification sink did not start; in_app dispatch would honestly report disconnected";
-  }
-  return undefined;
+  return service as NotificationInboxLike;
 }
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -253,7 +233,7 @@ async function seedConcurrentDayTasks(
   ctx: ScenarioContext,
 ): Promise<string | undefined> {
   seededTaskIds.length = 0;
-  deliveredNotifications.length = 0;
+  notificationInbox = null;
   const runtime = ctx.runtime as RuntimeLike | undefined;
   const service = runtime?.getService?.("lifeops_scheduled_task_runner") as
     | RunnerServiceLike
@@ -262,8 +242,10 @@ async function seedConcurrentDayTasks(
   if (!runtime || !service || typeof service.getRunner !== "function") {
     return "ScheduledTaskRunnerService is not registered on the scenario runtime";
   }
-  const sinkFailure = await ensureNotificationSink(runtime);
-  if (sinkFailure) return sinkFailure;
+  notificationInbox = resolveNotificationInbox(runtime);
+  if (!notificationInbox) {
+    return "no readable NOTIFICATION service is registered; in_app dispatch would honestly report disconnected and no delivery ledger exists";
+  }
   const runner = service.getRunner({ agentId: runtime.agentId });
   seededRunner = runner;
 
@@ -499,26 +481,38 @@ function assertFullLedgerAccounting(): string | undefined {
 }
 
 function assertRealDeliveries(): string | undefined {
-  // Every FIRED task delivered exactly one real notification (body = the
+  // Every FIRED task delivered exactly one real notification into the
+  // production inbox, carrying its own taskId and the owner-facing body (the
   // deterministic render stand-in's "Heads up: " prefix + promptInstructions);
   // the gate-denied task never reached the surface.
-  const bodyCounts = new Map<string, number>();
-  for (const notification of deliveredNotifications) {
-    if (typeof notification.body === "string") {
-      bodyCounts.set(
-        notification.body,
-        (bodyCounts.get(notification.body) ?? 0) + 1,
-      );
-    }
+  if (!notificationInbox) {
+    return "notification inbox was never resolved; the seed did not run";
+  }
+  const bodiesByTaskId = new Map<string, string[]>();
+  for (const notification of notificationInbox.listIncludingExpired()) {
+    const taskId = notification.data?.taskId;
+    if (typeof taskId !== "string") continue;
+    const bodies = bodiesByTaskId.get(taskId) ?? [];
+    bodies.push(
+      typeof notification.body === "string" ? notification.body : "<no body>",
+    );
+    bodiesByTaskId.set(taskId, bodies);
   }
   const problems: string[] = [];
   for (const [index, plan] of TASK_PLAN.entries()) {
-    const delivered =
-      bodyCounts.get(`Heads up: ${plan.promptInstructions}`) ?? 0;
+    const taskId = seededTaskIds[index] ?? "";
+    const delivered = bodiesByTaskId.get(taskId) ?? [];
     const expected = index === GATE_DENIED_INDEX ? 0 : 1;
-    if (delivered !== expected) {
+    if (delivered.length !== expected) {
       problems.push(
-        `${plan.key}: expected ${expected} delivered notification(s), saw ${delivered}`,
+        `${plan.key}: expected ${expected} delivered notification(s), saw ${delivered.length}`,
+      );
+      continue;
+    }
+    const expectedBody = `Heads up: ${plan.promptInstructions}`;
+    if (expected === 1 && delivered[0] !== expectedBody) {
+      problems.push(
+        `${plan.key}: expected delivered body ${JSON.stringify(expectedBody)}, saw ${JSON.stringify(delivered[0])}`,
       );
     }
   }


### PR DESCRIPTION
# Relates to

`deterministic-lifeops-concurrent-day` has been failing its delivery assertion. The investigation's verdict is that the **product is correct and the scenario was watching a surface that could never receive anything** — no product code is changed here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`dc04ae2af86`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** One scenario file and one new unit test in the scenario-runner package.

# Background

## What does this PR do?

The scenario asserted that each of 25 fired scheduled tasks delivered exactly one notification, and saw zero for all 25 — a signature that reads like a broken delivery path.

Delivery was never broken. The report's own `modelFixtureDiagnostics.calls` shows **50 TEXT_SMALL calls = 25 fired tasks × (body render + title render)**, and the title render happens immediately before `notifier.notify(...)`, so notify was reached for every task. A temporary probe on `getNotifier` printed core's real `NotificationService` 25 times — never the scenario's capture sink.

The cause is in the scenario's own seed:

```ts
const existing = runtime.getService?.(ServiceType.NOTIFICATION);
if (existing) return undefined;   // sink registered only if the slot is free
```

The slot is never free. `packages/agent/src/runtime/eliza-plugin.ts` registers core's `NotificationService` in the `eliza` plugin's services, and the scenario runtime boots that plugin. So the capture array was dead by construction, while the real path delivered all 25 into the durable inbox with `data.taskId` stamped.

The ledger now reads `NotificationService.listIncludingExpired()` keyed by `data.taskId` and asserts one delivery per fired task, zero for the gate-denied task, and the exact owner-facing body — i.e. it asserts the real effect instead of a sink that could never fill.

This is explicitly **not** a repeat of #25009's owner-entity fork: the scan stage was fine on pristine develop (both tick assertions passed), only the delivery check failed.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The removed `if (existing) return undefined;` sink registration and the new ledger assertion that replaces it.

## Detailed testing steps

- Scenario, run individually with no competing runner: pristine `origin/develop` → `failed 1083ms | approval-wire: expected 1 delivered notification(s), saw 0; … overflow-low: … saw 0`; this branch → **`passed 914ms`**.
- `bunx vitest run src/lifeops-concurrent-day-delivery-ledger.test.ts` → 6 pass. Mutation check: revert the scenario → **5 of 6 fail**; restore → 6 pass.
- `test:unit` 514 passed / 1 failed (`src/echo-assertion-integrity.test.ts`, reproduced identically on pristine develop with these files removed); `test:mocks` 21 passed.
- Biome clean; `packages/scenario-runner` typecheck 121 errors before and after (pre-existing unresolved-workspace-module cascade). An earlier draft that statically imported the scenario dragged `test/scenarios/**` into the program and surfaced 7 pre-existing errors in that file; switching to a runtime import keeps the gate delta at zero.

# Evidence Gate

<!-- evidence-head:d51418965b9efbebef8e35250a558694f10c8948 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] `modelFixtureDiagnostics.calls` = 50 for 25 fired tasks (body + title render per task), the title render immediately preceding `notifier.notify`, and a probe showing core's `NotificationService` receiving all 25 — the deliveries were always happening.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The durable inbox rows themselves: 25 notifications stamped with `data.taskId`, now read back through `NotificationService.listIncludingExpired()` and asserted per task.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
`modelFixtureDiagnostics.calls` = 50 for 25 fired tasks (body + title render per task), the title render immediately preceding `notifier.notify`, and a probe showing core's `NotificationService` receiving all 25 — the deliveries were always happening.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Every decisive number was taken with `pgrep -f "cli.ts run test/scenarios"` empty immediately before and after the run; one run was aborted and retaken to get an exclusive window, because concurrent scenario runners on the same host can interfere (see #25758).
- Neither scenario in this PR touches the filesystem, so it is immune to that race.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

