### PR TITLE
test(scenarios): wait for companion readiness instead of sleeping

### DIFF
--- a/packages/scenario-runner/src/companion-device-readiness.test.ts
+++ b/packages/scenario-runner/src/companion-device-readiness.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pins the readiness barrier of the `deterministic-companion-device` scenario.
+ *
+ * Its seed registers the companion plugin, but `registerPlugin` is not a
+ * readiness barrier: core registers plugin services lazily and starts them
+ * fire-and-forget (packages/core/src/runtime.ts). Both companion actions
+ * validate on nothing but "is the COMPANION service live?", so a duration-based
+ * handshake wait turns a slow host into a validation rejection. These tests run
+ * the scenario's real `until` predicate against a structural runtime and prove
+ * it is a state barrier: false while the service is absent, false while it is
+ * present but pre-handshake, true only once it reports ready.
+ *
+ * The scenario is loaded at runtime rather than statically imported: it runs on
+ * Bun globals and an unmapped workspace specifier, neither of which this
+ * package's tsconfig program (`include: src/**`) covers.
+ */
+
+import type {
+  ScenarioContext,
+  ScenarioDefinition,
+} from "@elizaos/scenario-runner/schema";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const READINESS_TURN_NAME =
+  "companion service is live and the device handshake completed";
+
+let companionScenario: ScenarioDefinition;
+
+beforeAll(async () => {
+  const specifier = new URL(
+    "../test/scenarios/deterministic-companion-device.scenario.ts",
+    import.meta.url,
+  ).href;
+  const loaded = (await import(/* @vite-ignore */ specifier)) as {
+    default: ScenarioDefinition;
+  };
+  companionScenario = loaded.default;
+});
+
+function readinessPredicate(): (
+  ctx: ScenarioContext,
+) => boolean | Promise<boolean> {
+  const definition = companionScenario;
+  const turn = definition.turns.find(
+    (candidate) => candidate.name === READINESS_TURN_NAME,
+  );
+  if (!turn) {
+    throw new Error(`readiness turn "${READINESS_TURN_NAME}" is missing`);
+  }
+  if (turn.kind !== "wait") {
+    throw new Error("the companion readiness turn must be a wait turn");
+  }
+  if (typeof turn.until !== "function") {
+    throw new Error(
+      "the companion readiness turn must poll an `until` state predicate, not sleep for a fixed duration",
+    );
+  }
+  return turn.until;
+}
+
+function contextWithService(service: unknown): ScenarioContext {
+  return {
+    runtime: {
+      getService(serviceType: string): unknown {
+        return serviceType === "COMPANION" ? service : null;
+      },
+    },
+    actionsCalled: [],
+  } as unknown as ScenarioContext;
+}
+
+describe("deterministic-companion-device readiness barrier", () => {
+  it("is a bounded state predicate, not a fixed sleep", () => {
+    const definition = companionScenario;
+    const turn = definition.turns.find(
+      (candidate) => candidate.name === READINESS_TURN_NAME,
+    );
+    expect(turn?.kind).toBe("wait");
+    expect(typeof turn?.until).toBe("function");
+    expect(turn?.durationMs).toBeUndefined();
+    expect(turn?.timeoutMs).toBeGreaterThan(0);
+  });
+
+  it("stays false while the lazily-started COMPANION service is absent", async () => {
+    expect(await readinessPredicate()(contextWithService(null))).toBe(false);
+  });
+
+  it("stays false while the service exists but the device handshake has not completed", async () => {
+    const predicate = readinessPredicate();
+    expect(await predicate(contextWithService({ isReady: () => false }))).toBe(
+      false,
+    );
+  });
+
+  it("turns true only once the service reports a completed handshake", async () => {
+    const predicate = readinessPredicate();
+    let ready = false;
+    const ctx = contextWithService({ isReady: () => ready });
+    expect(await predicate(ctx)).toBe(false);
+    ready = true;
+    expect(await predicate(ctx)).toBe(true);
+  });
+});

--- a/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
@@ -158,9 +158,23 @@ export default scenario({
 
   turns: [
     {
+      // Readiness is a state barrier, not a duration. `registerPlugin` in the
+      // seed returns BEFORE the plugin's services are live: core registers
+      // services lazily and starts them fire-and-forget
+      // (packages/core/src/runtime.ts). Both actions below validate on nothing
+      // but "is the COMPANION service live?", so a host slow enough to lose
+      // that race fails the turn as a validation rejection. Poll the service
+      // itself: registered AND past the welcome→register handshake.
       kind: "wait",
-      name: "device handshake settles",
-      durationMs: 250,
+      name: "companion service is live and the device handshake completed",
+      timeoutMs: 15_000,
+      until: (ctx) => {
+        const runtime = ctx.runtime as AgentRuntime;
+        const service = runtime.getService<CompanionService>(
+          CompanionService.serviceType,
+        );
+        return service?.isReady() === true;
+      },
     },
     {
       kind: "action",

--- a/plugins/plugin-companion/src/companion.test.ts
+++ b/plugins/plugin-companion/src/companion.test.ts
@@ -429,6 +429,81 @@ describe("commands (UC1/UC2)", () => {
   });
 });
 
+describe("planner validation gate", () => {
+  /**
+   * `validate` answers exactly one question: is the COMPANION service live on
+   * this runtime? It reads neither the device connection state nor the planner
+   * payload, so a rejected validation means "service not started" and nothing
+   * else. Callers that drive these actions right after `registerPlugin` must
+   * wait on the service itself, because core registers plugin services lazily
+   * and starts them fire-and-forget (packages/core/src/runtime.ts).
+   */
+  it("validates only while the COMPANION service is registered", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+
+    stub.services.delete(CompanionService.serviceType);
+    expect(
+      await setCompanionMoodAction.validate(stub.runtime, NO_MESSAGE),
+    ).toBe(false);
+    expect(
+      await getCompanionStatusAction.validate(stub.runtime, NO_MESSAGE),
+    ).toBe(false);
+
+    stub.services.set(CompanionService.serviceType, service);
+    expect(
+      await setCompanionMoodAction.validate(stub.runtime, NO_MESSAGE),
+    ).toBe(true);
+    expect(
+      await getCompanionStatusAction.validate(stub.runtime, NO_MESSAGE),
+    ).toBe(true);
+  });
+
+  it("does not gate on device readiness: a registered-but-unconnected service still validates", async () => {
+    const device = await startMockDevice({ autoRegister: false });
+    const { service, stub } = await startService(device.url);
+    expect(service.isReady()).toBe(false);
+
+    expect(
+      await setCompanionMoodAction.validate(stub.runtime, NO_MESSAGE),
+    ).toBe(true);
+    const result = await setCompanionMoodAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+      undefined,
+      { parameters: { mood: "curious" } },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain("COMPANION_NOT_CONNECTED");
+  });
+
+  it("does not gate on the payload: an empty parameter envelope validates and fails in the handler", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+
+    expect(
+      await setCompanionMoodAction.validate(
+        stub.runtime,
+        NO_MESSAGE,
+        undefined,
+        {
+          parameters: {},
+        },
+      ),
+    ).toBe(true);
+    const result = await setCompanionMoodAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+      undefined,
+      { parameters: {} },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain("requires a `mood` parameter");
+  });
+});
+
 describe("touch events (UC3)", () => {
   it("stores the device touch event and surfaces it through the provider", async () => {
     const device = await startMockDevice();


### PR DESCRIPTION
# Relates to

A flake in `deterministic-companion-device`. Worth stating plainly: the failure this was originally chased for **does not reproduce on current develop** — #24117 already fixed it. What remains is a genuine readiness race with a deterministic reproduction.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`dc04ae2af86`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** One scenario file, one new scenario-runner test, and three added cases in the existing plugin suite. No product code.

# Background

## What does this PR do?

`deterministic-companion-device` passes 7/7 standalone on pristine develop, and `SET_COMPANION_MOOD.validate` never inspects the payload — it is `async (runtime) => companionService(runtime) !== null`. Both sides of the action envelope were migrated together in #24117 and the plugin suite already pins them, so the reported "validator vs fixture drift" is not present.

What *does* emit the reported string is a readiness race. `registerPlugin` is not a barrier: core registers services lazily and starts them fire-and-forget. The scenario bridged that gap with a fixed `durationMs: 250` sleep, which is a bet on service start-up latency rather than a wait for the thing it needs. Injecting a 400 ms delay into `CompanionService.start` reproduces the failure verbatim — `[executor] action turn 'set the companion mood' failed validation for 'SET_COMPANION_MOOD'`.

The sleep is replaced with the runner's bounded `until` predicate (service registered **and** past the welcome → register handshake). With the fix in place the scenario passes under an injected 400 ms delay and again at 3000 ms. The change also consumes the `CompanionService` import that #24708 added to this scenario and never used.

This is on its own branch precisely so it can be dropped independently if you would rather take zero change here.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The replaced `durationMs: 250` wait and the `until` predicate that supersedes it.

## Detailed testing steps

- Reproduction: inject a 400 ms delay into `CompanionService.start` → pristine scenario fails with the exact reported string; with this branch → passes. At 3000 ms → still passes.
- `bunx vitest run src/companion-device-readiness.test.ts` → 4 pass. Mutation: revert the scenario → **4 of 4 fail**.
- `plugins/plugin-companion` suite 18 → 21 pass. Mutation: `validate: async () => true` → 1 fails.
- Scenario standalone on pristine develop: 7/7 passed (i.e. the reported bug is absent); also passed inside the full 42-scenario lane.
- Biome clean; `plugin-companion` typecheck exit 0; `scenario-runner` typecheck 121 errors before and after.

# Evidence Gate

<!-- evidence-head:c2e8dc8fe8ab89b5820dc2798e41b65cf672ebd7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The executor's own line — `[executor] action turn 'set the companion mood' failed validation for 'SET_COMPANION_MOOD'` — reproduced on demand by delaying `CompanionService.start`, and absent once the wait is a predicate rather than a sleep.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted state.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The executor's own line — `[executor] action turn 'set the companion mood' failed validation for 'SET_COMPANION_MOOD'` — reproduced on demand by delaying `CompanionService.start`, and absent once the wait is a predicate rather than a sleep.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- **The originally reported defect does not exist on develop.** This PR fixes a real but different problem (a timing bet in the scenario). If you would rather not carry it, dropping this branch costs nothing else.
- Decisive runs were taken with no competing scenario runner (`pgrep` checked before and after).

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

