### PR TITLE
test(app-core): cover loopback-port

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/loopback-port.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/loopback-port.test.ts
@@ -1,0 +1,203 @@
+/** Exercises findFirstAvailableLoopbackPort against real loopback TCP binds. */
+import { type AddressInfo, createServer, type Server } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { findFirstAvailableLoopbackPort } from "./loopback-port";
+
+const LOOPBACK = "127.0.0.1";
+const held: Server[] = [];
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+function listenOn(host: string, port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    const fail = (error: Error) => {
+      server.close();
+      reject(error);
+    };
+    server.once("error", fail);
+    server.listen({ port, host, exclusive: true }, () => {
+      server.off("error", fail);
+      resolve(server);
+    });
+  });
+}
+
+async function occupy(host: string, port: number): Promise<Server> {
+  const server = await listenOn(host, port);
+  held.push(server);
+  return server;
+}
+
+async function occupyConsecutive(
+  host: string,
+  count: number,
+): Promise<{ start: number; servers: Server[] }> {
+  for (let attempt = 0; attempt < 32; attempt++) {
+    const probe = await listenOn(host, 0);
+    const address = probe.address();
+    if (!address || typeof address === "string") {
+      await closeServer(probe);
+      throw new Error("expected a TCP address from the probe listener");
+    }
+    const start = address.port;
+    await closeServer(probe);
+    if (start + count - 1 > 65535) {
+      continue;
+    }
+    const servers: Server[] = [];
+    try {
+      for (let offset = 0; offset < count; offset++) {
+        servers.push(await listenOn(host, start + offset));
+      }
+      held.push(...servers);
+      return { start, servers };
+    } catch {
+      // error-policy:J3 consecutive occupancy probe collided; try another start
+      await Promise.all(servers.map(closeServer));
+    }
+  }
+  throw new Error(`could not occupy ${count} consecutive ports on ${host}`);
+}
+
+afterEach(async () => {
+  const servers = held.splice(0);
+  await Promise.all(servers.map(closeServer));
+});
+
+describe("findFirstAvailableLoopbackPort", () => {
+  it.each([
+    [0],
+    [-1],
+    [0.9],
+    [65536],
+    [65535.1],
+    [Number.NaN],
+    [Number.POSITIVE_INFINITY],
+    [Number.NEGATIVE_INFINITY],
+  ] as const)("rejects invalid preferred port %s", async (preferred) => {
+    await expect(findFirstAvailableLoopbackPort(preferred)).rejects.toThrow(
+      `Invalid preferred port: ${preferred}`,
+    );
+  });
+
+  it("returns the preferred port when it is free", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+    const [server] = held.splice(0);
+    await closeServer(server);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK, maxHops: 1 }),
+    ).resolves.toBe(start);
+  });
+
+  it("returns the preferred port when options are omitted", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+    const [server] = held.splice(0);
+    await closeServer(server);
+
+    await expect(findFirstAvailableLoopbackPort(start)).resolves.toBe(start);
+  });
+
+  it("skips an occupied preferred port and returns the next hop", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK, maxHops: 4 }),
+    ).resolves.toBe(start + 1);
+  });
+
+  it("skips a contiguous occupied prefix and returns the first free hop", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 3);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK, maxHops: 8 }),
+    ).resolves.toBe(start + 3);
+  });
+
+  it("uses default maxHops of 64 when options omit it", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 2);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK }),
+    ).resolves.toBe(start + 2);
+  });
+
+  it("throws when every hop in maxHops is occupied", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 3);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK, maxHops: 3 }),
+    ).rejects.toThrow(
+      `No free TCP port on ${LOOPBACK} in range ${start}–${start + 2}`,
+    );
+  });
+
+  it("throws when maxHops is 0 without probing", async () => {
+    await expect(
+      findFirstAvailableLoopbackPort(43210, { host: LOOPBACK, maxHops: 0 }),
+    ).rejects.toThrow(`No free TCP port on ${LOOPBACK} in range 43210–43209`);
+  });
+
+  it("names the default host in the exhaustion error", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { maxHops: 1 }),
+    ).rejects.toThrow(
+      `No free TCP port on ${LOOPBACK} in range ${start}–${start}`,
+    );
+  });
+
+  it("honors an explicit host when probing", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+
+    await expect(
+      findFirstAvailableLoopbackPort(start, { host: LOOPBACK, maxHops: 1 }),
+    ).rejects.toThrow(
+      `No free TCP port on ${LOOPBACK} in range ${start}–${start}`,
+    );
+  });
+
+  it("releases a successful probe so the returned port can be bound", async () => {
+    const { start } = await occupyConsecutive(LOOPBACK, 1);
+    const [server] = held.splice(0);
+    await closeServer(server);
+
+    const port = await findFirstAvailableLoopbackPort(start, {
+      host: LOOPBACK,
+      maxHops: 1,
+    });
+    expect(port).toBe(start);
+
+    const rebound = await occupy(LOOPBACK, port);
+    const address = rebound.address() as AddressInfo;
+    expect(address.port).toBe(port);
+  });
+
+  it("stops at 65535 instead of wrapping and reports the requested hop window", async () => {
+    await occupy(LOOPBACK, 65535);
+
+    await expect(
+      findFirstAvailableLoopbackPort(65535, { host: LOOPBACK, maxHops: 4 }),
+    ).rejects.toThrow(`No free TCP port on ${LOOPBACK} in range 65535–65538`);
+  });
+
+  it("returns 65535 when that port is the preferred free hop", async () => {
+    const occupant = await occupy(LOOPBACK, 65535);
+    held.splice(held.indexOf(occupant), 1);
+    await closeServer(occupant);
+
+    await expect(
+      findFirstAvailableLoopbackPort(65535, { host: LOOPBACK, maxHops: 1 }),
+    ).resolves.toBe(65535);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/app-core/platforms/electrobun/src/native/loopback-port.ts`, which previously had no colocated test file. The module exports `findFirstAvailableLoopbackPort`. This PR drives that real export against real `node:net` loopback binds. No production source changes.

Covered behaviour (observed, not aspirational):

- Invalid `preferred` values (`0`, `-1`, `0.9`, `65536`, `65535.1`, `NaN`, `±Infinity`) throw `Invalid preferred port: …` before any bind
- A free preferred port is returned, including when `options` is omitted (default host `127.0.0.1`, default `maxHops` 64)
- An occupied preferred port is skipped; a contiguous occupied prefix is skipped until the first free hop
- Exhausting `maxHops` throws `No free TCP port on <host> in range <preferred>–<preferred+maxHops-1>` (en-dash), including `maxHops: 0` which throws without probing
- The default host appears in the exhaustion message when `host` is omitted
- A successful probe releases the port so a subsequent exclusive bind on the returned port succeeds
- Preferred `65535` is in range: a free `65535` is returned; an occupied `65535` does not wrap past 65535 and still reports the requested hop window

# Relates to

No linked issue. Test-only coverage for an untested colocated module.

Definition of Done: full standard in [`CONTRIBUTING.md`](CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`3dde1a3bf40bc8cc31d4205330544e3cca4f2dce`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change; focused vitest, biome, and package `tsc` results are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the vitest/biome/tsc counts below.

# Sync with develop

- [x] Branch parent is current `origin/develop` `3dde1a3bf40bc8cc31d4205330544e3cca4f2dce`, re-fetched immediately before filing; zero conflicts.
- [ ] `bun run verify` not re-run (test-only, no production change). Focused gates below.

# Risks

Low. Adds tests only; no production behaviour change. Failure mode is a false assertion of observed bind/hop behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Colocated unit coverage for `packages/app-core/platforms/electrobun/src/native/loopback-port.ts`.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/native/loopback-port.test.ts`, then the commands in **Verification**.

## Detailed testing steps

None: automated tests are acceptable.

# Evidence Gate

<!-- evidence-head:0647436388add4a8c3a4268eae357d9023103bbe -->

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model behaviour changed.

## Backend + frontend logs

N/A - test-only change; no server or UI path exercised.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface; the diff is one Vitest file.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Hosted CI does not run on this fork contributor PR. Local vitest, biome, and package `tsc` are the proof.

`bun run verify` was not run; this PR changes no production code.

The Electrobun package owns this file. `packages/app-core/vitest.config.ts` excludes `platforms/electrobun/**`, so the suite is collected with the Electrobun vitest config (the same config `bun run --cwd packages/app-core/platforms/electrobun test` uses).

## Maintainer CI exception record

N/A - no exception requested

## Verification

Exact head: `0647436388add4a8c3a4268eae357d9023103bbe` (parent is current `origin/develop` `3dde1a3bf40bc8cc31d4205330544e3cca4f2dce`, re-fetched immediately before filing)

1. Vitest (re-run against current `origin/develop` sources immediately before filing):

```text
cd packages/app-core/platforms/electrobun && bunx vitest run --config vitest.electrobun.config.ts src/native/loopback-port.test.ts
 ✓ src/native/loopback-port.test.ts (20 tests) 12ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  17:13:50
   Duration  391ms (transform 46ms, setup 0ms, import 57ms, tests 12ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/app-core/platforms/electrobun/src/native/loopback-port.test.ts` — `Checked 1 file in 32ms. Fixed 1 file.` The committed file is that formatted result. Config exists at repo-root `biome.json`; this checkout is not sparse.

3. Package typecheck: `cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'loopback-port.test.ts'` produced no matches (grep EXIT:1). This file introduced zero TypeScript errors.

4. Diff touches only `packages/app-core/platforms/electrobun/src/native/loopback-port.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are from local `bunx vitest` / `biome` / `tsc` on this head.

## Notes

Test-only change. No production behaviour is modified. Assertions record what the code does (including the `maxHops: 0` inverted range and the 65535 no-wrap window in the error text), not a desired redesign.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
