### PR TITLE
test(app-core): cover trace-dynamic-view

### DIFF
--- a/packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.test.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.test.ts
@@ -1,0 +1,151 @@
+/** Exercises trace dynamic view behavior with deterministic app-core test fixtures. */
+import * as fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fsHarness = vi.hoisted(() => {
+  const existsSync = vi.fn();
+  return {
+    existsSync,
+    realExistsSync: undefined as
+      | ((candidate: string | Buffer | URL) => boolean)
+      | undefined,
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  fsHarness.realExistsSync = actual.existsSync;
+  fsHarness.existsSync.mockImplementation(actual.existsSync);
+  return { ...actual, existsSync: fsHarness.existsSync };
+});
+
+import {
+  createTraceDynamicViewManifest,
+  TRACE_DYNAMIC_VIEW_ID,
+} from "./trace-dynamic-view";
+
+const baseDir = path.dirname(fileURLToPath(import.meta.url));
+const VIEW_FILE = "agent-run-trace.html";
+const firstCandidate = path.join(baseDir, "views", VIEW_FILE);
+const secondCandidate = path.join(baseDir, "trace", "views", VIEW_FILE);
+
+afterEach(() => {
+  fsHarness.existsSync.mockReset();
+  fsHarness.existsSync.mockImplementation((candidate) =>
+    Boolean(fsHarness.realExistsSync?.(String(candidate))),
+  );
+});
+
+describe("TRACE_DYNAMIC_VIEW_ID", () => {
+  it("identifies the system agent run trace view", () => {
+    expect(TRACE_DYNAMIC_VIEW_ID).toBe("agent.run.trace");
+  });
+});
+
+describe("createTraceDynamicViewManifest", () => {
+  it("returns the system floating manifest pointing at the on-disk trace HTML", () => {
+    const manifest = createTraceDynamicViewManifest();
+    const entrypointPath = fileURLToPath(manifest.entrypoint);
+
+    expect(manifest).toEqual({
+      id: TRACE_DYNAMIC_VIEW_ID,
+      title: "Agent Run Trace",
+      description: "Contextual trace view for agent runs and capability calls.",
+      source: "system",
+      entrypoint: pathToFileURL(firstCandidate).href,
+      placement: "floating",
+      metadata: {
+        trace: true,
+        productionPanel: false,
+      },
+    });
+    expect(entrypointPath).toBe(firstCandidate);
+    expect(fs.existsSync(entrypointPath)).toBe(true);
+    expect(path.basename(entrypointPath)).toBe(VIEW_FILE);
+    expect(fs.existsSync(secondCandidate)).toBe(false);
+  });
+
+  it("emits a file URL rather than a raw filesystem path", () => {
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.entrypoint.startsWith("file:")).toBe(true);
+    expect(manifest.entrypoint).not.toBe(firstCandidate);
+    expect(new URL(manifest.entrypoint).protocol).toBe("file:");
+  });
+
+  it("returns a fresh object on each call without mutating prior results", () => {
+    const first = createTraceDynamicViewManifest();
+    const second = createTraceDynamicViewManifest();
+
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+
+    first.title = "mutated";
+    first.metadata = { trace: false };
+    expect(second.title).toBe("Agent Run Trace");
+    expect(second.metadata).toEqual({
+      trace: true,
+      productionPanel: false,
+    });
+  });
+
+  it("stops at the first existing candidate and does not probe the nested path", () => {
+    fsHarness.existsSync.mockImplementation(
+      (candidate) =>
+        path.resolve(String(candidate)) === path.resolve(firstCandidate),
+    );
+
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.entrypoint).toBe(pathToFileURL(firstCandidate).href);
+    expect(fsHarness.existsSync).toHaveBeenCalledTimes(1);
+    expect(fsHarness.existsSync).toHaveBeenCalledWith(firstCandidate);
+    expect(fsHarness.existsSync).not.toHaveBeenCalledWith(secondCandidate);
+  });
+
+  it("prefers the sibling views path when both candidate HTML files exist", () => {
+    fsHarness.existsSync.mockReturnValue(true);
+
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.entrypoint).toBe(pathToFileURL(firstCandidate).href);
+    expect(manifest.entrypoint).not.toBe(pathToFileURL(secondCandidate).href);
+  });
+
+  it("falls through to the nested trace/views candidate when the sibling views file is missing", () => {
+    fsHarness.existsSync.mockImplementation(
+      (candidate) =>
+        path.resolve(String(candidate)) === path.resolve(secondCandidate),
+    );
+
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.entrypoint).toBe(pathToFileURL(secondCandidate).href);
+    expect(
+      fsHarness.existsSync.mock.calls.map((call) =>
+        path.resolve(String(call[0])),
+      ),
+    ).toEqual([path.resolve(firstCandidate), path.resolve(secondCandidate)]);
+  });
+
+  it("falls back to the first candidate when neither HTML path exists", () => {
+    fsHarness.existsSync.mockReturnValue(false);
+
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.entrypoint).toBe(pathToFileURL(firstCandidate).href);
+    expect(fileURLToPath(manifest.entrypoint)).toBe(firstCandidate);
+  });
+
+  it("does not invent permissions or extra metadata fields", () => {
+    const manifest = createTraceDynamicViewManifest();
+
+    expect(manifest.permissions).toBeUndefined();
+    expect(Object.keys(manifest.metadata ?? {})).toEqual([
+      "trace",
+      "productionPanel",
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.ts`, which previously had no dedicated test file. The production module is unchanged.

The module exports `TRACE_DYNAMIC_VIEW_ID` (`"agent.run.trace"`) and `createTraceDynamicViewManifest()`. Resolution walks two on-disk candidates in order (`views/agent-run-trace.html`, then nested `trace/views/agent-run-trace.html`) and falls back to the first candidate as a `file:` URL when neither path exists.

The suite drives the real module (sibling layout matches `launch-dynamic-view.test.ts`) and records observed behaviour:

- constant identity
- full manifest shape (system source, floating placement, trace metadata)
- on-disk HTML entrypoint as a `file:` URL, not a raw filesystem path
- fresh objects per call (mutation of one result does not affect the next)
- first existing candidate wins; the nested path is not probed when the sibling file exists
- sibling path wins a tie when both candidates exist
- nested candidate is used when only it exists
- first-candidate fallback when the queue is empty
- no invented `permissions` or extra metadata keys

## Evidence

1. **Vitest (re-run against current `origin/develop` immediately before filing):**
   `bunx vitest run packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.test.ts`
   Test Files  1 passed (1)
   Tests  9 passed (9)

2. **Biome:** `bunx biome check --write packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.test.ts`
   Checked 1 file. No fixes applied.

3. **Typecheck:** `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'trace-dynamic-view.test.ts'`
   Empty grep (exit 1). The new file appears nowhere in `tsc` output.

4. **Diff scope:** this pull request touches only `packages/app-core/platforms/electrobun/src/trace/trace-dynamic-view.test.ts`.

Hosted CI does not run on this fork contributor's pull requests. The counts above are from local `bunx vitest` / `biome` / `tsc` on the shared checkout.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e56bea3a825d49916f8a8e9e1c15aa4d9458929e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
