### PR TITLE
test(app-core): cover talkmode

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/talkmode.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/talkmode.test.ts
@@ -1,0 +1,704 @@
+/**
+ * Exercises TalkModeManager lifecycle, renderer forwarding, system TTS
+ * process selection, and ElevenLabs request construction. Bun.spawn and
+ * fetch are stubbed at the I/O boundary so tests never speak or hit the
+ * network; the manager itself is the real module.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./agent", () => ({
+  diagnosticLog: () => undefined,
+}));
+
+import type { SendToWebview } from "../types.js";
+import { getTalkModeManager, TalkModeManager } from "./talkmode";
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+const originalFetch = globalThis.fetch;
+const POWERSHELL_SPEAK_COMMAND =
+  "Add-Type -AssemblyName System.Speech; $s = New-Object System.Speech.Synthesis.SpeechSynthesizer; $s.Speak($env:ELIZA_TTS_TEXT)";
+const DEFAULT_ELEVENLABS_VOICE = "21m00Tcm4TlvDq8ikWAM";
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatform) {
+    Object.defineProperty(process, "platform", originalPlatform);
+  }
+}
+
+function setApiKey(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.ELEVEN_LABS_API_KEY;
+    return;
+  }
+  process.env.ELEVEN_LABS_API_KEY = value;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function immediateSpawn(): {
+  kill: ReturnType<typeof vi.fn>;
+  proc: ReturnType<typeof Bun.spawn>;
+} {
+  const kill = vi.fn();
+  return {
+    kill,
+    proc: {
+      exited: Promise.resolve(0),
+      kill,
+    } as unknown as ReturnType<typeof Bun.spawn>,
+  };
+}
+
+function hangingSpawn(): {
+  kill: ReturnType<typeof vi.fn>;
+  finish: (code?: number) => void;
+  proc: ReturnType<typeof Bun.spawn>;
+} {
+  const exited = deferred<number>();
+  const kill = vi.fn(() => {
+    exited.resolve(1);
+  });
+  return {
+    kill,
+    finish: (code = 0) => {
+      exited.resolve(code);
+    },
+    proc: {
+      exited: exited.promise,
+      kill,
+    } as unknown as ReturnType<typeof Bun.spawn>,
+  };
+}
+
+function streamChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("TalkModeManager", () => {
+  const previousApiKey = process.env.ELEVEN_LABS_API_KEY;
+  let sendToWebview: ReturnType<typeof vi.fn<SendToWebview>>;
+  let manager: TalkModeManager;
+
+  beforeEach(() => {
+    sendToWebview = vi.fn<SendToWebview>();
+    manager = new TalkModeManager();
+    manager.setSendToWebview(sendToWebview);
+    setApiKey(undefined);
+    vi.stubGlobal("Bun", { spawn: vi.fn() });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    setApiKey(previousApiKey);
+    globalThis.fetch = originalFetch;
+    restorePlatform();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("starts idle, reports enabled, and is not speaking", async () => {
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isEnabled()).resolves.toEqual({ enabled: true });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+    expect(sendToWebview).not.toHaveBeenCalled();
+  });
+
+  it("start reports Web Speech availability and moves to listening", async () => {
+    await expect(manager.start()).resolves.toEqual({
+      available: true,
+      reason: "Using Web Speech API for STT (native whisper pipeline removed)",
+    });
+    await expect(manager.getState()).resolves.toEqual({ state: "listening" });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "listening",
+    });
+  });
+
+  it("stop returns to idle and clears the speaking flag", async () => {
+    await manager.start();
+    await manager.stop();
+
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "idle",
+    });
+  });
+
+  it("isEnabled stays true across listening, speaking, error, and idle", async () => {
+    await expect(manager.isEnabled()).resolves.toEqual({ enabled: true });
+    await manager.start();
+    await expect(manager.isEnabled()).resolves.toEqual({ enabled: true });
+
+    vi.spyOn(Bun, "spawn").mockImplementation(() => {
+      throw new Error("say missing");
+    });
+    await manager.speak({ text: "hi" });
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+    await expect(manager.isEnabled()).resolves.toEqual({ enabled: true });
+
+    await manager.stop();
+    await expect(manager.isEnabled()).resolves.toEqual({ enabled: true });
+  });
+
+  it("forwards audio chunks only while listening", async () => {
+    await manager.audioChunk({ data: "idle-bytes" });
+    expect(sendToWebview).not.toHaveBeenCalled();
+
+    await manager.start();
+    sendToWebview.mockClear();
+    await manager.audioChunk({ data: "listen-bytes" });
+    expect(sendToWebview).toHaveBeenCalledTimes(1);
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeAudioChunkPush", {
+      data: "listen-bytes",
+    });
+
+    await manager.stop();
+    sendToWebview.mockClear();
+    await manager.audioChunk({ data: "after-stop" });
+    expect(sendToWebview).not.toHaveBeenCalled();
+  });
+
+  it("forwards empty audio data while listening and ignores it while idle", async () => {
+    await manager.audioChunk({ data: "" });
+    expect(sendToWebview).not.toHaveBeenCalled();
+
+    await manager.start();
+    sendToWebview.mockClear();
+    await manager.audioChunk({ data: "" });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeAudioChunkPush", {
+      data: "",
+    });
+  });
+
+  it("does not forward audio while system TTS is in flight", async () => {
+    const hanging = hangingSpawn();
+    vi.spyOn(Bun, "spawn").mockReturnValue(hanging.proc);
+
+    const speaking = manager.speak({ text: "hold" });
+    await vi.waitFor(async () => {
+      await expect(manager.getState()).resolves.toEqual({ state: "speaking" });
+    });
+
+    sendToWebview.mockClear();
+    await manager.audioChunk({ data: "during-speak" });
+    expect(sendToWebview).not.toHaveBeenCalled();
+
+    hanging.finish();
+    await speaking;
+  });
+
+  it("does not throw when no webview callback is registered", async () => {
+    const isolated = new TalkModeManager();
+    await expect(isolated.start()).resolves.toMatchObject({ available: true });
+    await expect(
+      isolated.audioChunk({ data: "orphan" }),
+    ).resolves.toBeUndefined();
+    await expect(isolated.stop()).resolves.toBeUndefined();
+    isolated.dispose();
+  });
+
+  it("merges updateConfig onto the existing config without wiping fields", async () => {
+    setApiKey("sk-test");
+    await manager.updateConfig({
+      language: "fr",
+      voiceId: "voice-from-config",
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "bonjour" });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://api.elevenlabs.io/v1/text-to-speech/voice-from-config/stream",
+    );
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      text: "bonjour",
+      model_id: "eleven_v3",
+    });
+  });
+
+  it("lets a later updateConfig replace voiceId used by the next speak", async () => {
+    setApiKey("sk-test");
+    await manager.updateConfig({ voiceId: "first-voice" });
+    await manager.updateConfig({ voiceId: "second-voice" });
+
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "next" });
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0] as [string];
+    expect(url).toContain("/second-voice/stream");
+  });
+
+  it.each([
+    ["darwin", ["say", "hello there"]],
+    ["linux", ["espeak", "hello there"]],
+  ] as const)(
+    "speaks through the %s system voice when no API key is set",
+    async (platform, argv) => {
+      stubPlatform(platform);
+      const spawned = immediateSpawn();
+      const spawn = vi.spyOn(Bun, "spawn").mockReturnValue(spawned.proc);
+
+      await manager.speak({ text: "hello there" });
+
+      expect(spawn).toHaveBeenCalledWith(argv, { stderr: "pipe" });
+      expect(globalThis.fetch).toBe(originalFetch);
+      expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+        state: "speaking",
+      });
+      expect(sendToWebview).toHaveBeenCalledWith("talkmodeSpeakComplete");
+      expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+        state: "idle",
+      });
+      await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+      await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+    },
+  );
+
+  it("speaks through PowerShell on win32 and passes text via env, not -Command", async () => {
+    stubPlatform("win32");
+    const spawned = immediateSpawn();
+    const spawn = vi.spyOn(Bun, "spawn").mockReturnValue(spawned.proc);
+
+    await manager.speak({ text: "rm -rf / ; hello" });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [argv, options] = spawn.mock.calls[0] as [
+      string[],
+      { stderr: string; env: NodeJS.ProcessEnv },
+    ];
+    expect(argv).toEqual([
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      POWERSHELL_SPEAK_COMMAND,
+    ]);
+    expect(argv[3]).not.toContain("rm -rf");
+    expect(argv[3]).not.toContain("hello");
+    expect(options.stderr).toBe("pipe");
+    expect(options.env.ELIZA_TTS_TEXT).toBe("rm -rf / ; hello");
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeSpeakComplete");
+  });
+
+  it("treats a whitespace-only ElevenLabs key as missing and uses system TTS", async () => {
+    stubPlatform("darwin");
+    setApiKey("   \t  ");
+    const spawned = immediateSpawn();
+    const spawn = vi.spyOn(Bun, "spawn").mockReturnValue(spawned.proc);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await manager.speak({ text: "fallback" });
+
+    expect(spawn).toHaveBeenCalledWith(["say", "fallback"], { stderr: "pipe" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sets error and skips speakComplete when system TTS spawn throws", async () => {
+    vi.spyOn(Bun, "spawn").mockImplementation(() => {
+      throw new Error("spawn failed");
+    });
+
+    await manager.speak({ text: "nope" });
+
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "speaking",
+    });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "error",
+    });
+    expect(sendToWebview).not.toHaveBeenCalledWith("talkmodeSpeakComplete");
+    expect(sendToWebview).not.toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "idle",
+    });
+  });
+
+  it("start after a system TTS error returns to listening", async () => {
+    vi.spyOn(Bun, "spawn").mockImplementation(() => {
+      throw new Error("spawn failed");
+    });
+    await manager.speak({ text: "nope" });
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+
+    await manager.start();
+    await expect(manager.getState()).resolves.toEqual({ state: "listening" });
+  });
+
+  it("stopSpeaking kills an in-flight system TTS process and returns to idle", async () => {
+    const hanging = hangingSpawn();
+    vi.spyOn(Bun, "spawn").mockReturnValue(hanging.proc);
+
+    const speaking = manager.speak({ text: "long" });
+    await vi.waitFor(async () => {
+      await expect(manager.isSpeaking()).resolves.toEqual({ speaking: true });
+    });
+
+    await manager.stopSpeaking();
+    expect(hanging.kill).toHaveBeenCalledTimes(1);
+    await speaking;
+
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+  });
+
+  it("stopSpeaking swallows kill failures from an already-exited process", async () => {
+    const hanging = hangingSpawn();
+    hanging.kill.mockImplementation(() => {
+      throw new Error("already exited");
+    });
+    vi.spyOn(Bun, "spawn").mockReturnValue(hanging.proc);
+
+    const speaking = manager.speak({ text: "long" });
+    await vi.waitFor(async () => {
+      await expect(manager.isSpeaking()).resolves.toEqual({ speaking: true });
+    });
+
+    await expect(manager.stopSpeaking()).resolves.toBeUndefined();
+    hanging.finish();
+    await speaking;
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+  });
+
+  it("stopSpeaking with nothing in flight still returns idle and not speaking", async () => {
+    await manager.start();
+    await manager.stopSpeaking();
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeStateChanged", {
+      state: "idle",
+    });
+  });
+
+  it("uses the default ElevenLabs voice, model, and voice settings", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: streamChunks([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "stream me" });
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      `https://api.elevenlabs.io/v1/text-to-speech/${DEFAULT_ELEVENLABS_VOICE}/stream`,
+    );
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "xi-api-key": "sk-live",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      text: "stream me",
+      model_id: "eleven_v3",
+      voice_settings: {
+        stability: 0.5,
+        similarity_boost: 0.75,
+      },
+    });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeAudioChunkPush", {
+      data: Buffer.from([1, 2, 3]).toString("base64"),
+    });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeAudioChunkPush", {
+      data: Buffer.from([4, 5]).toString("base64"),
+    });
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeSpeakComplete");
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+  });
+
+  it("trims the API key before sending it as xi-api-key", async () => {
+    setApiKey("  sk-padded  ");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "hi" });
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect((init.headers as Record<string, string>)["xi-api-key"]).toBe(
+      "sk-padded",
+    );
+  });
+
+  it("prefers directive voice, model, and settings over config and defaults", async () => {
+    setApiKey("sk-live");
+    await manager.updateConfig({ voiceId: "config-voice" });
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({
+      text: "override",
+      directive: {
+        voiceId: "directive-voice",
+        modelId: "eleven_turbo_v2",
+        stability: 0.1,
+        similarity: 0.9,
+      },
+    });
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://api.elevenlabs.io/v1/text-to-speech/directive-voice/stream",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      text: "override",
+      model_id: "eleven_turbo_v2",
+      voice_settings: {
+        stability: 0.1,
+        similarity_boost: 0.9,
+      },
+    });
+  });
+
+  it("keeps an empty directive voiceId instead of falling back to the default", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({
+      text: "empty-voice",
+      directive: { voiceId: "" },
+    });
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0] as [string];
+    expect(url).toBe("https://api.elevenlabs.io/v1/text-to-speech//stream");
+  });
+
+  it("completes ElevenLabs speech when the response body is missing", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "nobody" });
+    expect(sendToWebview).not.toHaveBeenCalledWith(
+      "talkmodeAudioChunkPush",
+      expect.anything(),
+    );
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeSpeakComplete");
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+  });
+
+  it("reports an ElevenLabs HTTP error and stays in error without speakComplete", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        body: streamChunks([new Uint8Array([9])]),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "secret" });
+
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeError", {
+      source: "elevenlabs",
+      message: "ElevenLabs API error: 401 Unauthorized",
+    });
+    expect(sendToWebview).not.toHaveBeenCalledWith(
+      "talkmodeAudioChunkPush",
+      expect.anything(),
+    );
+    expect(sendToWebview).not.toHaveBeenCalledWith("talkmodeSpeakComplete");
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+  });
+
+  it("reports a thrown ElevenLabs fetch error and stays in error", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "down" });
+
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeError", {
+      source: "elevenlabs",
+      message: "ECONNRESET",
+    });
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+  });
+
+  it("stringifies a non-Error ElevenLabs throw as the error message", async () => {
+    setApiKey("sk-live");
+    globalThis.fetch = vi.fn(async () => {
+      throw "upstream-down";
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "down" });
+
+    expect(sendToWebview).toHaveBeenCalledWith("talkmodeError", {
+      source: "elevenlabs",
+      message: "upstream-down",
+    });
+    await expect(manager.getState()).resolves.toEqual({ state: "error" });
+  });
+
+  it("treats AbortError from stopSpeaking as a quiet cancel, not an error", async () => {
+    setApiKey("sk-live");
+    const started = deferred<void>();
+    globalThis.fetch = vi.fn((_url, init) => {
+      started.resolve();
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        signal?.addEventListener("abort", () => {
+          const err = new Error("This operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const speaking = manager.speak({ text: "cancel me" });
+    await started.promise;
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: true });
+
+    await manager.stopSpeaking();
+    await speaking;
+
+    expect(sendToWebview).not.toHaveBeenCalledWith(
+      "talkmodeError",
+      expect.anything(),
+    );
+    expect(sendToWebview).not.toHaveBeenCalledWith("talkmodeSpeakComplete");
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+  });
+
+  it("does not call Bun.spawn when an ElevenLabs key is configured", async () => {
+    setApiKey("sk-live");
+    const spawn = vi.spyOn(Bun, "spawn");
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: null,
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await manager.speak({ text: "cloud" });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("dispose clears speaking and the webview callback without emitting", async () => {
+    await manager.start();
+    sendToWebview.mockClear();
+    manager.dispose();
+
+    expect(sendToWebview).not.toHaveBeenCalled();
+    await expect(manager.getState()).resolves.toEqual({ state: "idle" });
+    await expect(manager.isSpeaking()).resolves.toEqual({ speaking: false });
+
+    await manager.start();
+    expect(sendToWebview).not.toHaveBeenCalled();
+    await expect(manager.getState()).resolves.toEqual({ state: "listening" });
+  });
+});
+
+describe("getTalkModeManager", () => {
+  it("returns one TalkModeManager instance on repeated calls", () => {
+    const first = getTalkModeManager();
+    const second = getTalkModeManager();
+
+    expect(first).toBeInstanceOf(TalkModeManager);
+    expect(second).toBe(first);
+  });
+
+  it("does not alias a directly constructed manager onto the singleton", async () => {
+    const constructed = new TalkModeManager();
+    const singleton = getTalkModeManager();
+
+    expect(constructed).not.toBe(singleton);
+    await constructed.start();
+    await expect(constructed.getState()).resolves.toEqual({
+      state: "listening",
+    });
+    await expect(singleton.getState()).resolves.toEqual({ state: "idle" });
+    constructed.dispose();
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/platforms/electrobun/src/native/talkmode.ts`, which had no same-named test file. No production issue; this PR records observed native TalkModeManager behaviour.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6` with a single additive test file (no conflicts).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Branch parent is current `origin/develop` `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`; diff vs that parent is one test file.
- [ ] `bun run verify` was not run. This is a test-only PR; the owning-package focused checks below are the evidence.

# Risks

Low. The diff adds unit tests only and does not change production behaviour, exports, or native I/O. False expectations in the suite would be the only merge risk; assertions match observed manager behaviour (including empty `directive.voiceId` kept as-is, dispose without emitting, and AbortError treated as a quiet cancel).

# Background

## What does this PR do?

Adds `packages/app-core/platforms/electrobun/src/native/talkmode.test.ts` covering `TalkModeManager` and `getTalkModeManager`.

The suite drives the real manager. `Bun.spawn` and `fetch` are stubbed only at the I/O boundary so tests never invoke `say`/`espeak`/PowerShell or hit ElevenLabs. It covers:

- default idle / enabled / not-speaking
- `start` → listening and the Web Speech availability payload
- `stop` → idle, speaking cleared
- audio-chunk forwarding only while listening (including empty data); no forward while idle or while system TTS is in flight
- `updateConfig` merge (language/voice kept; later voiceId replaces earlier)
- system TTS argv on darwin (`say`) and linux (`espeak`)
- win32 PowerShell path: text in `ELIZA_TTS_TEXT`, never interpolated into `-Command`
- whitespace-only `ELEVEN_LABS_API_KEY` falls through to system TTS
- system TTS spawn throw → `error`, no `talkmodeSpeakComplete`, no idle
- `start` after error returns to listening
- `stopSpeaking` kills in-flight spawn, swallows kill failures, and is a no-op when idle
- ElevenLabs default voice `21m00Tcm4TlvDq8ikWAM`, model `eleven_v3`, stability 0.5 / similarity 0.75
- trimmed API key in `xi-api-key`
- directive overrides for voice/model/settings; empty directive voiceId is kept (not coalesced to the default)
- missing response body still completes; HTTP and thrown errors stay in `error`
- non-Error throw stringified
- `AbortError` from `stopSpeaking` is a quiet cancel (idle, no `talkmodeError`)
- ElevenLabs path does not spawn a system process
- `dispose` clears callback without emitting
- `getTalkModeManager` singleton vs a directly constructed instance

## What kind of change is this?

Improvements (tests for existing native TalkMode behaviour). No production code change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/native/talkmode.test.ts` and the vitest output below.

## Detailed testing steps

From `packages/app-core/platforms/electrobun` on this PR head, against current `origin/develop` (parent `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`; `talkmode.ts` has zero diff vs that develop):

```bash
bunx vitest run --config vitest.electrobun.config.ts src/native/talkmode.test.ts
```

Observed:

```
Test Files  1 passed (1)
     Tests  32 passed (32)
```

Vitest v4.1.5. Duration ~274ms.

```bash
bunx biome check --write packages/app-core/platforms/electrobun/src/native/talkmode.test.ts
```

Observed: `Checked 1 file in 105ms. No fixes applied.` Root `biome.json` is present; this worktree is not sparse.

```bash
cd packages/app-core/platforms/electrobun && bunx tsc --noEmit 2>&1 | grep 'talkmode.test.ts' ; echo "EXIT:$?"
```

Observed: no lines mentioning `talkmode.test.ts` (`grep` exit 1). Pre-existing package errors elsewhere are unrelated.

Diff touches only `packages/app-core/platforms/electrobun/src/native/talkmode.test.ts`.

We are a fork contributor: hosted CI does **not** run on our PRs. Do not infer CI green from this body.

# Evidence Gate

Evidence matches head `178055e26aa89f504a20f0826cdde1e7154459dc`.
<!-- evidence-head:178055e26aa89f504a20f0826cdde1e7154459dc -->

This PR adds tests and changes no production behaviour and no rendered UI.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only; no user flow or UI change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - test-only unit coverage; no production path change. Vitest output is the execution record.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain state change; spawn/fetch are stubbed so tests do not speak or call ElevenLabs.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only. Focused vitest run on this head: **1 file, 32 tests passed**.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only; no UI.

### After

N/A - test-only; no UI.

### Walkthrough video

N/A - test-only; no UI.

## Audio / voice walkthrough

N/A - this PR does not change TalkMode production TTS/STT. Tests stub `Bun.spawn` and `fetch` so they never play audio or call ElevenLabs.

## Known gaps / failures

- `bun run verify` was not run. Test-only PR; evidence is the focused vitest / biome / tsc results above.
- Hosted GitHub Actions CI does not run on fork PRs from `ss251/eliza`.
- Owning-package `tsc --noEmit` reports pre-existing errors in unrelated files; `talkmode.test.ts` is absent from that output.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
