### PR TITLE
test(app-core): cover voice-playback-adapter

### DIFF
--- a/packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.test.ts
@@ -1,0 +1,113 @@
+/** Exercises voice playback adapter behavior with deterministic app-core test fixtures. */
+import { describe, expect, it } from "vitest";
+import { VoiceError } from "./errors";
+import type { VoicePlayAudioParams } from "./types";
+import {
+  UnavailableVoicePlaybackAdapter,
+  type VoicePlaybackAdapter,
+} from "./voice-playback-adapter";
+
+const PLAYBACK_UNAVAILABLE_REASON =
+  "Host playback acknowledgement is not wired.";
+
+const audioParams: VoicePlayAudioParams = {
+  audioBase64: "Zg==",
+  mimeType: "audio/wav",
+};
+
+function adapter(): VoicePlaybackAdapter {
+  return new UnavailableVoicePlaybackAdapter();
+}
+
+describe("UnavailableVoicePlaybackAdapter", () => {
+  it("reports playback acknowledgement as unsupported", async () => {
+    expect(await adapter().status()).toEqual({
+      playbackAckSupported: false,
+      reason: PLAYBACK_UNAVAILABLE_REASON,
+    });
+  });
+
+  it("returns the same unavailable status on every call", async () => {
+    const playback = adapter();
+
+    expect(await playback.status()).toEqual(await playback.status());
+    expect(await playback.status()).toEqual(await adapter().status());
+  });
+
+  it("rejects playAudio with VOICE_AUDIO_OUTPUT_UNAVAILABLE", async () => {
+    const playback = adapter();
+
+    await expect(playback.playAudio(audioParams)).rejects.toBeInstanceOf(
+      VoiceError,
+    );
+
+    try {
+      await playback.playAudio(audioParams);
+      throw new Error("playAudio must reject");
+    } catch (error) {
+      if (!(error instanceof VoiceError)) {
+        throw error;
+      }
+      expect(error.code).toBe("VOICE_AUDIO_OUTPUT_UNAVAILABLE");
+      expect(error.message).toBe(PLAYBACK_UNAVAILABLE_REASON);
+      expect(error.name).toBe("VoiceError");
+      expect(error.details).toBeUndefined();
+    }
+  });
+
+  it("rejects playAudio for empty bytes, extra metadata, and concurrent calls", async () => {
+    const playback = adapter();
+    const variants: VoicePlayAudioParams[] = [
+      { audioBase64: "", mimeType: "" },
+      {
+        audioBase64: audioParams.audioBase64,
+        mimeType: "audio/mpeg",
+        trace: true,
+        metadata: { source: "test" },
+      },
+    ];
+
+    for (const params of variants) {
+      await expect(playback.playAudio(params)).rejects.toMatchObject({
+        name: "VoiceError",
+        code: "VOICE_AUDIO_OUTPUT_UNAVAILABLE",
+        message: PLAYBACK_UNAVAILABLE_REASON,
+      });
+    }
+
+    const settled = await Promise.allSettled([
+      playback.playAudio(audioParams),
+      playback.playAudio(audioParams),
+    ]);
+    expect(settled.every((result) => result.status === "rejected")).toBe(true);
+    for (const result of settled) {
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(result.reason).toBeInstanceOf(VoiceError);
+      }
+    }
+  });
+
+  it("interrupt is a no-op whether or not a reason is supplied", async () => {
+    const playback = adapter();
+
+    await expect(playback.interrupt()).resolves.toBeUndefined();
+    await expect(playback.interrupt({})).resolves.toBeUndefined();
+    await expect(
+      playback.interrupt({ reason: "barge-in" }),
+    ).resolves.toBeUndefined();
+    expect(await playback.status()).toEqual({
+      playbackAckSupported: false,
+      reason: PLAYBACK_UNAVAILABLE_REASON,
+    });
+  });
+
+  it("interrupt does not make playAudio succeed", async () => {
+    const playback = adapter();
+
+    await playback.interrupt({ reason: "barge-in" });
+    await expect(playback.playAudio(audioParams)).rejects.toBeInstanceOf(
+      VoiceError,
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

No existing issue. `packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.ts` had no same-named test file anywhere in the repo. This PR adds that suite only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the current `origin/develop` (`27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only diff. Focused vitest, biome, and package `tsc` were run on the exact head (quoted below). This is a fork contributor PR; hosted CI does **not** run on our PRs.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc output below without reading production code.

# Sync with develop

- [x] Branch parent is current `origin/develop` `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`; the production adapter file is unchanged versus develop.
- [ ] `bun run verify` was not run; this is a test-only addition. See **Known gaps / failures**.

# Risks

Low. Test-only. No production file is modified. The suite drives the real `UnavailableVoicePlaybackAdapter` and records the behavior that module actually has: status always reports acknowledgement unsupported, `playAudio` always throws `VOICE_AUDIO_OUTPUT_UNAVAILABLE`, and `interrupt` is a no-op.

# Background

## What does this PR do?

Adds `packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.test.ts` next to the source, matching sibling voice suites (`voice-latency-budget.test.ts`, `voice-tts-chunker.test.ts`).

Covered behavior (observed, not wished):

- `status()` returns `{ playbackAckSupported: false, reason: "Host playback acknowledgement is not wired." }` on every call, including across instances.
- `playAudio(params)` rejects with a `VoiceError` whose `code` is `VOICE_AUDIO_OUTPUT_UNAVAILABLE`, `message` matches the status reason, `name` is `VoiceError`, and `details` is undefined. The implementation does not inspect params, so empty bytes, extra metadata/`trace`, and concurrent calls all reject the same way.
- `interrupt()` resolves to `undefined` with no args, `{}`, or `{ reason: "barge-in" }` and does not change `status()` or make `playAudio` succeed.

There is no queue, comparator, or capacity in this module, so those branches do not exist to cover.

## What kind of change is this?

Improvements — tests for existing behavior. No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation. The adapter contract is unchanged.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.test.ts` (the only file in the diff).

## Detailed testing steps

From `packages/app-core/platforms/electrobun` (this package's vitest config; the app-core config excludes `platforms/electrobun/**`):

```bash
bunx vitest run --config vitest.electrobun.config.ts src/voice/voice-playback-adapter.test.ts
```

Re-run against current `origin/develop` immediately before filing:

```
Test Files  1 passed (1)
     Tests  6 passed (6)
  Duration  242ms
```

Biome (repo-root `biome.json` present; this checkout is not sparse):

```bash
bunx biome check --write packages/app-core/platforms/electrobun/src/voice/voice-playback-adapter.test.ts
# Checked 1 file in 145ms. No fixes applied.
```

Package `tsc` from `packages/app-core/platforms/electrobun`:

```bash
bunx tsc --noEmit 2>&1 | grep 'voice-playback-adapter.test' ; echo "GREP_EXIT:$?"
# empty grep (GREP_EXIT:1) — this test file introduced zero type errors.
```

# Evidence Gate

Evidence matches head `0032f01c24963fd18eb3de3950eb6c911fe1930c`.

This PR adds tests and changes no production behavior. Hosted CI does **not** run on this fork PR; do not read the checks panel as a pass.

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`.
- [x] After full-page screenshots: `N/A - test-only, no UI surface`.
- [x] Walkthrough video: `N/A - test-only, no UI surface`.
- [x] Backend logs: `N/A - unit tests of a stub adapter that never reaches a host; vitest output quoted above`.
- [x] Frontend logs: `N/A - no frontend change`.
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`.
- [x] Domain artifacts: `N/A - no DB/memory/schedule/wallet/audio output; the adapter under test always throws VOICE_AUDIO_OUTPUT_UNAVAILABLE`.
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change`.

## Backend + frontend logs

`N/A - test-only unit coverage; vitest counts quoted in Testing`.

## Screenshots (before / after) + video walkthrough

`N/A - test-only, no UI surface`.

## Audio / voice walkthrough

`N/A - test-only coverage of the unavailable stub adapter; production playback is not wired and this PR does not change that`.

## Known gaps / failures

- Did not run `bun run verify`. Scope is one new test file; focused vitest, biome, and package `tsc` are the complete evidence set for this test-only PR.
- Hosted GitHub Actions CI does not run on fork contributor PRs. Local vitest/biome/tsc quoted above are the reviewable proof.
- No identity.slop.cash OAuth trace: unattended session cannot finalize an interactive consent click.

## Maintainer CI exception record

`N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0032f01c24963fd18eb3de3950eb6c911fe1930c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
