### PR TITLE
fix(app): enforce liveness diagnostic closed schema

### DIFF
--- a/packages/app/test/privacy-safe-liveness-diagnostic-artifact.mjs
+++ b/packages/app/test/privacy-safe-liveness-diagnostic-artifact.mjs
@@ -9,6 +9,36 @@ import { dirname } from "node:path";
 
 export const LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA =
   "elizaos.cloud.liveness-failure-diagnostics/v1";
+export const LIVENESS_DIAGNOSTIC_ARTIFACT_FIELDS = Object.freeze([
+  "originalErrorName",
+  "chatSendAttemptDelta",
+  "logicalChatSendDelta",
+  "unidentifiedChatSendDelta",
+  "namedWarmingResponseDelta",
+  "successfulChatResponseDelta",
+  "clientErrorChatResponseDelta",
+  "serverErrorChatResponseDelta",
+  "otherChatResponseDelta",
+  "retryObservationAvailable",
+  "retryChipEverObserved",
+  "domSnapshotAvailable",
+  "draftCleared",
+  "newUserRowCount",
+  "newAssistantRowCount",
+  "failureRowPresent",
+  "retryRowPresent",
+  "interruptedRowPresent",
+  "widgetOnlyReplyRowPresent",
+  "threadLinesAvailable",
+  "anchorUserPresent",
+  "assistantRowPresent",
+  "assistantFailurePresent",
+  "assistantRetryPresent",
+  "assistantInterrupted",
+  "assistantHasMessageText",
+  "assistantPhase",
+  "assistantHasText",
+]);
 export const LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION = Object.freeze({
   type: "privacy-safe-liveness-diagnostic-artifact",
   description: "write-failed",
@@ -32,6 +62,18 @@ export async function writePrivacySafeLivenessDiagnostic({
   writeFileFn = writeFile,
 }) {
   try {
+    const privacySafeRecord = {};
+    for (const field of LIVENESS_DIAGNOSTIC_ARTIFACT_FIELDS) {
+      const value = diagnosticRecord[field];
+      if (
+        value === null ||
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
+        privacySafeRecord[field] = value;
+      }
+    }
     await mkdirFn(dirname(diagnosticPath), {
       recursive: true,
       mode: 0o700,
@@ -40,7 +82,7 @@ export async function writePrivacySafeLivenessDiagnostic({
       diagnosticPath,
       `${JSON.stringify(
         {
-          ...diagnosticRecord,
+          ...privacySafeRecord,
           schema: LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
         },
         null,

--- a/packages/app/test/privacy-safe-liveness-diagnostic-artifact.test.ts
+++ b/packages/app/test/privacy-safe-liveness-diagnostic-artifact.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  LIVENESS_DIAGNOSTIC_ARTIFACT_FIELDS,
   LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
   LIVENESS_DIAGNOSTIC_WRITE_FAILURE_ANNOTATION,
   writePrivacySafeLivenessDiagnostic,
@@ -14,14 +15,54 @@ import {
 describe("privacy-safe liveness diagnostic artifact", () => {
   it("writes the exact closed schema with private file permissions", async () => {
     const mkdirFn = vi.fn(async () => undefined);
-    const writeFileFn = vi.fn(async () => undefined);
+    let writtenPath: string | undefined;
+    let writtenData = "";
+    let writtenOptions:
+      | { encoding: string; flag: string; mode: number }
+      | undefined;
+    const writeFileFn = vi.fn(
+      async (
+        path: string,
+        data: string,
+        options: { encoding: string; flag: string; mode: number },
+      ) => {
+        writtenPath = path;
+        writtenData = data;
+        writtenOptions = options;
+      },
+    );
     const annotations: Array<{ type: string; description: string }> = [];
-    const diagnosticRecord = {
-      schema: "caller-must-not-override-the-closed-schema",
-      historyGetDelta: 1,
-      retryObservationAvailable: true,
-      phase: "terminal",
-    };
+    const allowedRecord = Object.fromEntries(
+      LIVENESS_DIAGNOSTIC_ARTIFACT_FIELDS.map((field, index) => [
+        field,
+        field === "originalErrorName"
+          ? "AssertionError"
+          : field === "assistantPhase"
+            ? "reply"
+            : field.endsWith("Delta") || field.endsWith("Count")
+              ? index
+              : index % 2 === 0,
+      ]),
+    );
+    const privateMarker = "private-transcript-must-not-escape";
+    const diagnosticRecord = Object.defineProperties(
+      {
+        ...allowedRecord,
+        schema: "caller-must-not-override-the-closed-schema",
+        assistantHasText: { privateMarker },
+        provider: "private-provider",
+        path: "/private/path",
+        token: "private-token",
+      },
+      {
+        transcript: {
+          enumerable: true,
+          get: () => {
+            throw new Error(privateMarker);
+          },
+        },
+      },
+    ) as unknown as Record<string, string | number | boolean | null>;
 
     await expect(
       writePrivacySafeLivenessDiagnostic({
@@ -37,18 +78,23 @@ describe("privacy-safe liveness diagnostic artifact", () => {
       recursive: true,
       mode: 0o700,
     });
-    expect(writeFileFn).toHaveBeenCalledWith(
-      "/tmp/eliza-run/diagnostic.json",
-      `${JSON.stringify(
-        {
-          ...diagnosticRecord,
-          schema: LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
-        },
-        null,
-        2,
-      )}\n`,
-      { encoding: "utf8", flag: "wx", mode: 0o600 },
-    );
+    expect(writeFileFn).toHaveBeenCalledOnce();
+    expect(writtenPath).toBe("/tmp/eliza-run/diagnostic.json");
+    expect(writtenOptions).toEqual({
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    const expectedRecord = { ...allowedRecord };
+    delete expectedRecord.assistantHasText;
+    expect(JSON.parse(writtenData)).toEqual({
+      ...expectedRecord,
+      schema: LIVENESS_DIAGNOSTIC_ARTIFACT_SCHEMA,
+    });
+    expect(writtenData).not.toContain(privateMarker);
+    expect(writtenData).not.toContain("private-provider");
+    expect(writtenData).not.toContain("/private/path");
+    expect(writtenData).not.toContain("private-token");
     expect(annotations).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

- Follow-up to merged #25700: enforce its documented closed schema inside the persistence helper.
- Project only the 28 approved scalar diagnostic fields; unknown or non-scalar caller values are omitted.
- Preserve fixed schema ownership, 0700/0600 filesystem modes, exclusive creation, and J4 ancillary failure semantics.
- Add adversarial coverage for hostile transcript getters plus provider, path, token, schema override, and non-scalar values.

## Exact source

- Base: `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`
- Head: `d2e3980ca3a1cb7e05e634138697eacb21c599a1`
- Local rollback tag: `fix-liveness-closed-schema-v2-current-20260823`

## Verification

- Focused Vitest: 4/4 pass under pinned 4.1.10.
- Exact two-file Biome 2.5.8: clean.
- Node syntax, `git diff --check`, and changed-patch gitleaks: clean.
- Sparse worktree had no borrowed or symlinked dependencies; full installed-workspace proof is delegated to required CI because the host volume is storage constrained.

## Release boundary

- Draft only; do not merge until required CI and maintainer review are green.
- No Cloudflare/Railway mutation or provider traffic is part of this PR.

@lalalune please review the persistence-boundary allowlist and adversarial fixture.
