### PR TITLE
test(app-core): cover voice-pipeline

### DIFF
--- a/packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts
@@ -1,0 +1,389 @@
+/** Exercises voice pipeline behavior with deterministic app-core test fixtures. */
+import { MODEL_CATALOG, VOICE_MODEL_VERSIONS } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import type { VoiceLatencyMark, VoiceStage, VoiceTurn } from "./types";
+import {
+  cloneVoiceTurn,
+  discoverStaticVoiceComponents,
+  summarizeVoiceLatency,
+} from "./voice-pipeline";
+
+function firstVersionById() {
+  const first = new Map<string, (typeof VOICE_MODEL_VERSIONS)[number]>();
+  for (const version of VOICE_MODEL_VERSIONS) {
+    if (!first.has(version.id)) first.set(version.id, version);
+  }
+  return first;
+}
+
+function mark(
+  stage: VoiceStage,
+  name: string,
+  offsetMs?: number,
+): VoiceLatencyMark {
+  const next: VoiceLatencyMark = {
+    stage,
+    name,
+    timestamp: "2026-05-17T12:00:00.000Z",
+  };
+  if (offsetMs !== undefined) next.offsetMs = offsetMs;
+  return next;
+}
+
+function makeTurn(
+  marks: VoiceLatencyMark[],
+  extra?: {
+    metadata?: VoiceTurn["metadata"];
+    transcriptFinal?: string;
+    error?: string;
+  },
+): VoiceTurn {
+  const turn: VoiceTurn = {
+    id: "voice-turn-1",
+    pipelineId: "voice-pipeline-1",
+    status: "started",
+    marks,
+    createdAt: "2026-05-17T12:00:00.000Z",
+    updatedAt: "2026-05-17T12:00:00.000Z",
+  };
+  if (extra?.metadata) turn.metadata = extra.metadata;
+  if (extra?.transcriptFinal !== undefined) {
+    turn.transcriptFinal = extra.transcriptFinal;
+  }
+  if (extra?.error !== undefined) turn.error = extra.error;
+  return turn;
+}
+
+describe("discoverStaticVoiceComponents", () => {
+  it("returns unique ids sorted by localeCompare", () => {
+    const components = discoverStaticVoiceComponents();
+    const ids = components.map((component) => component.id);
+
+    expect(ids).toEqual([...ids].sort((a, b) => a.localeCompare(b)));
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([
+      "asr",
+      "audio-input",
+      "audio-playback",
+      "diarizer",
+      "embedding",
+      "kokoro",
+      "speaker-encoder",
+      "turn-detector",
+      "turn-detector-intl",
+      "vad",
+      "voice-emotion",
+      "wakeword",
+    ]);
+  });
+
+  it("seeds every first-listed VOICE_MODEL_VERSIONS id plus host audio endpoints", () => {
+    const components = discoverStaticVoiceComponents();
+    const first = firstVersionById();
+
+    for (const [id, version] of first) {
+      const component = components.find((entry) => entry.id === id);
+      expect(component).toBeDefined();
+      expect(component?.status).toBe("available");
+      expect(component?.modelId).toBe(`${id}@${version.version}`);
+      expect(component?.path).toBe(
+        version.ggufAssets[0]?.filename ?? version.missingAssets?.[0]?.filename,
+      );
+    }
+
+    expect(components.find((entry) => entry.id === "audio-input")).toEqual(
+      expect.objectContaining({
+        name: "Audio Input",
+        role: "unknown",
+        provider: "electrobun",
+        status: "available",
+        raw: { source: "host" },
+      }),
+    );
+    expect(components.find((entry) => entry.id === "audio-playback")).toEqual(
+      expect.objectContaining({
+        name: "Audio Playback",
+        role: "playback",
+        provider: "electrobun",
+        status: "available",
+        raw: { source: "host" },
+      }),
+    );
+    expect(
+      components.find((entry) => entry.id === "audio-input")?.modelId,
+    ).toBeUndefined();
+    expect(
+      components.find((entry) => entry.id === "audio-playback")?.path,
+    ).toBeUndefined();
+  });
+
+  it("maps providers and roles from the first configured owner, not a later duplicate", () => {
+    const byId = Object.fromEntries(
+      discoverStaticVoiceComponents().map((component) => [
+        component.id,
+        component,
+      ]),
+    );
+    const asrDuplicates = VOICE_MODEL_VERSIONS.filter(
+      (version) => version.id === "asr",
+    );
+
+    expect(asrDuplicates.length).toBeGreaterThan(1);
+    expect(byId.asr.modelId).toBe("asr@0.3.0");
+    expect(byId.asr.modelId).not.toBe(`asr@${asrDuplicates[1]?.version}`);
+    expect(byId.asr.provider).toBe("eliza-1");
+    expect(byId.asr.role).toBe("asr");
+    expect(byId.vad.provider).toBe("eliza-1");
+    expect(byId.vad.role).toBe("vad");
+    expect(byId.kokoro.provider).toBe("kokoro");
+    expect(byId.kokoro.role).toBe("tts");
+    expect(byId.wakeword.provider).toBe("local-inference");
+    expect(byId.wakeword.role).toBe("unknown");
+    expect(byId["turn-detector"].role).toBe("turn-detection");
+    expect(byId["voice-emotion"].role).toBe("emotion");
+    expect(byId.diarizer.role).toBe("voice");
+  });
+
+  it("does not let MODEL_CATALOG replace an already-seeded component", () => {
+    const asr = discoverStaticVoiceComponents().find(
+      (component) => component.id === "asr",
+    );
+    const catalogAsr = MODEL_CATALOG.find(
+      (model) => model.sourceModel?.components.asr,
+    )?.sourceModel?.components.asr;
+
+    expect(catalogAsr?.file).toBe("bundles/e2b/asr/mmproj-audio-e2b-bf16.gguf");
+    expect(asr?.path).toBe("voice/asr/eliza-1-gemma-asr-q4_0.gguf");
+    expect(asr?.path).not.toBe(catalogAsr?.file);
+    expect(asr?.raw).toEqual(
+      expect.objectContaining({
+        source: "VOICE_MODEL_VERSIONS",
+        version: "0.3.0",
+        backend: null,
+      }),
+    );
+  });
+
+  it("prefers the first gguf asset over a missing-asset fallback", () => {
+    const kokoro = discoverStaticVoiceComponents().find(
+      (component) => component.id === "kokoro",
+    );
+    const firstKokoro = VOICE_MODEL_VERSIONS.find(
+      (version) => version.id === "kokoro",
+    );
+
+    expect(firstKokoro?.ggufAssets[0]?.filename).toBe(
+      "voice/kokoro/voices/af_sam.bin",
+    );
+    expect(firstKokoro?.missingAssets?.[0]?.filename).toBe(
+      "voice/kokoro/kokoro-v1.0-q4_k_m.gguf",
+    );
+    expect(kokoro?.path).toBe("voice/kokoro/voices/af_sam.bin");
+  });
+
+  it("falls back to the first missing asset when ggufAssets is empty", () => {
+    const asr = discoverStaticVoiceComponents().find(
+      (component) => component.id === "asr",
+    );
+    const firstAsr = VOICE_MODEL_VERSIONS.find(
+      (version) => version.id === "asr",
+    );
+
+    expect(firstAsr?.ggufAssets).toEqual([]);
+    expect(asr?.path).toBe(firstAsr?.missingAssets?.[0]?.filename);
+  });
+
+  it("is deterministic across calls", () => {
+    expect(discoverStaticVoiceComponents()).toEqual(
+      discoverStaticVoiceComponents(),
+    );
+  });
+});
+
+describe("summarizeVoiceLatency", () => {
+  it("returns undefined for a missing turn", () => {
+    expect(summarizeVoiceLatency(undefined)).toBeUndefined();
+  });
+
+  it("leaves every span undefined on an empty mark queue", () => {
+    expect(summarizeVoiceLatency(makeTurn([]))).toEqual({
+      inputToVadMs: undefined,
+      vadToAsrPartialMs: undefined,
+      asrPartialToRuntimePrepareMs: undefined,
+      asrFinalToRuntimeMs: undefined,
+      asrFinalToRuntimeCommitMs: undefined,
+      runtimeToFirstTokenMs: undefined,
+      firstTokenToTtsRequestMs: undefined,
+      ttsRequestToFirstAudioMs: undefined,
+      firstTokenToTtsFirstAudioMs: undefined,
+      ttsFirstAudioToPlaybackMs: undefined,
+      totalToFirstTokenMs: undefined,
+      totalToFirstAudioMs: undefined,
+      totalToPlaybackMs: undefined,
+    });
+  });
+
+  it("leaves a span undefined when only one endpoint exists", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([mark("input", "audio.input", 10)]),
+    );
+
+    expect(summary?.inputToVadMs).toBeUndefined();
+    expect(summary?.totalToFirstTokenMs).toBeUndefined();
+    expect(summary?.totalToPlaybackMs).toBeUndefined();
+  });
+
+  it("computes each named span from matching stage/name offsets", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([
+        mark("input", "audio.input", 0),
+        mark("vad", "speech.detected", 40),
+        mark("asr", "partial", 90),
+        mark("asr", "final", 140),
+        mark("runtime", "prepare.started", 160),
+        mark("runtime", "runtime.started", 200),
+        mark("model", "first_token", 350),
+        mark("tts", "started", 400),
+        mark("tts", "first_audio", 520),
+        mark("playback", "started", 610),
+      ]),
+    );
+
+    expect(summary).toEqual({
+      inputToVadMs: 40,
+      vadToAsrPartialMs: 50,
+      asrPartialToRuntimePrepareMs: 70,
+      asrFinalToRuntimeMs: 60,
+      asrFinalToRuntimeCommitMs: 60,
+      runtimeToFirstTokenMs: 150,
+      firstTokenToTtsRequestMs: 50,
+      ttsRequestToFirstAudioMs: 120,
+      firstTokenToTtsFirstAudioMs: 170,
+      ttsFirstAudioToPlaybackMs: 90,
+      totalToFirstTokenMs: 350,
+      totalToFirstAudioMs: 520,
+      totalToPlaybackMs: 610,
+    });
+  });
+
+  it("treats a zero offset as present rather than missing", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([
+        mark("input", "audio.input", 0),
+        mark("vad", "speech.detected", 0),
+      ]),
+    );
+
+    expect(summary?.inputToVadMs).toBe(0);
+  });
+
+  it("clamps a reversed pair to zero instead of emitting a negative span", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([
+        mark("input", "audio.input", 80),
+        mark("vad", "speech.detected", 20),
+      ]),
+    );
+
+    expect(summary?.inputToVadMs).toBe(0);
+  });
+
+  it("uses the first matching mark when the same stage/name is recorded twice", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([
+        mark("input", "audio.input", 10),
+        mark("input", "audio.input", 200),
+        mark("vad", "speech.detected", 40),
+      ]),
+    );
+
+    expect(summary?.inputToVadMs).toBe(30);
+  });
+
+  it("ignores unmatched names, unmatched stages, and marks without offsetMs", () => {
+    const summary = summarizeVoiceLatency(
+      makeTurn([
+        mark("input", "audio.input", 5),
+        mark("input", "other", 99),
+        mark("vad", "audio.input", 88),
+        mark("vad", "speech.detected"),
+        mark("turn", "speech.detected", 70),
+      ]),
+    );
+
+    expect(summary?.inputToVadMs).toBeUndefined();
+    expect(summary?.vadToAsrPartialMs).toBeUndefined();
+  });
+
+  it("does not mutate the turn while summarizing", () => {
+    const turn = makeTurn([
+      mark("input", "audio.input", 1),
+      mark("vad", "speech.detected", 4),
+    ]);
+    const before = structuredClone(turn);
+
+    summarizeVoiceLatency(turn);
+
+    expect(turn).toEqual(before);
+  });
+});
+
+describe("cloneVoiceTurn", () => {
+  it("returns a distinct turn whose mark and metadata records can be mutated independently", () => {
+    const original = makeTurn(
+      [
+        {
+          stage: "asr",
+          name: "final",
+          timestamp: "2026-05-17T12:00:00.000Z",
+          offsetMs: 12,
+          metadata: { token: "hello" },
+        },
+      ],
+      {
+        metadata: { owner: "pipeline" },
+        transcriptFinal: "hello",
+        error: "none",
+      },
+    );
+
+    const cloned = cloneVoiceTurn(original);
+    cloned.status = "completed";
+    cloned.transcriptFinal = "changed";
+    cloned.marks[0].name = "partial";
+    cloned.marks[0].offsetMs = 99;
+    cloned.marks[0].metadata = { token: "mutated" };
+    cloned.metadata = { owner: "clone" };
+    cloned.marks.push(mark("tts", "started", 20));
+
+    expect(cloned).not.toBe(original);
+    expect(cloned.marks).not.toBe(original.marks);
+    expect(original.status).toBe("started");
+    expect(original.transcriptFinal).toBe("hello");
+    expect(original.error).toBe("none");
+    expect(original.marks).toHaveLength(1);
+    expect(original.marks[0].name).toBe("final");
+    expect(original.marks[0].offsetMs).toBe(12);
+    expect(original.marks[0].metadata).toEqual({ token: "hello" });
+    expect(original.metadata).toEqual({ owner: "pipeline" });
+  });
+
+  it("clones a single-mark turn without metadata as undefined metadata", () => {
+    const original = makeTurn([mark("input", "audio.input", 3)]);
+    const cloned = cloneVoiceTurn(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned.metadata).toBeUndefined();
+    expect(cloned.marks[0].metadata).toBeUndefined();
+    cloned.marks[0].offsetMs = 0;
+    expect(original.marks[0].offsetMs).toBe(3);
+  });
+
+  it("clones an empty mark list to a distinct empty array", () => {
+    const original = makeTurn([]);
+    const cloned = cloneVoiceTurn(original);
+
+    expect(cloned.marks).toEqual([]);
+    expect(cloned.marks).not.toBe(original.marks);
+  });
+});


### PR DESCRIPTION
# Relates to

Test-only coverage for `packages/app-core/platforms/electrobun/src/voice/voice-pipeline.ts`, which had no same-named test file. No production issue; this PR records observed discovery, latency-summary, and clone behaviour.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6` with a single additive test file (no conflicts).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Branch parent is current `origin/develop` `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`; diff vs that parent is one test file.
- [ ] `bun run verify` was not run. This is a test-only PR; the owning-package focused checks below are the evidence.

# Risks

Low. The diff adds unit tests only and does not change production behaviour or exports. False expectations in the suite would be the only merge risk; assertions match observed module behaviour (first `VOICE_MODEL_VERSIONS` owner wins over later duplicates and over `MODEL_CATALOG`, reversed latency marks clamp to zero, first matching mark wins a tie).

# Background

## What does this PR do?

Adds `packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts` covering the three exports:

- `discoverStaticVoiceComponents`
- `summarizeVoiceLatency`
- `cloneVoiceTurn`

The suite drives the real module (live `@elizaos/shared` catalogs, no mocked discovery). It covers:

- unique ids sorted by `localeCompare`, including host `audio-input` / `audio-playback`
- first-listed `VOICE_MODEL_VERSIONS` entry per id (`asr@0.3.0`), not a later duplicate
- provider/role mapping (`eliza-1` for asr/vad, `kokoro` for tts, `local-inference` otherwise)
- `MODEL_CATALOG` does not replace an already-seeded component (`asr` path stays the versions missing-asset, not `bundles/e2b/asr/...`)
- first gguf asset wins over a missing-asset fallback (kokoro)
- empty `ggufAssets` falls back to `missingAssets[0]` (asr)
- deterministic repeated discovery
- `summarizeVoiceLatency(undefined)` is undefined; empty marks leave every span undefined
- single-endpoint marks leave the span undefined
- named stage/name spans, including `asrFinalToRuntimeMs` === `asrFinalToRuntimeCommitMs`
- offset `0` is present, not missing
- reversed offsets clamp to `0` rather than a negative span
- first matching mark wins when the same stage/name is recorded twice
- unmatched names/stages and marks without `offsetMs` are ignored
- summarize does not mutate the turn
- clone is a distinct object; mark/metadata records can be mutated independently
- empty mark list clones to a distinct empty array

## What kind of change is this?

Improvements (tests for existing Electrobun voice-pipeline behaviour). No production code change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts` and the vitest output below.

## Detailed testing steps

From the repository root on this PR head, against current `origin/develop` (parent `27d58c07573ad4b2f3b6b88211fcc66aa1b128f6`; `voice-pipeline.ts` has zero diff vs that develop):

```bash
bunx vitest run packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts
```

Observed on a re-run immediately before filing:

```
 ✓ packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts (19 tests) 20ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  17:22:31
   Duration  8.04s (transform 6.37s, setup 0ms, import 7.80s, tests 20ms, environment 0ms)
```

Vitest v4.1.10.

```bash
bunx biome check --write packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts
```

Observed: `Checked 1 file in 256ms. No fixes applied.` Root `biome.json` is present; this checkout is not sparse.

```bash
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'voice-pipeline.test.ts' ; echo "EXIT:$?"
```

Observed: no lines mentioning `voice-pipeline.test.ts` (`grep` exit 1). Pre-existing package errors elsewhere are unrelated.

Diff touches only `packages/app-core/platforms/electrobun/src/voice/voice-pipeline.test.ts`.

We are a fork contributor: hosted CI does **not** run on our PRs. Do not infer CI green from this body.

# Evidence Gate

Evidence matches head `21c530560543b49dfccb30a55e1fa2a9c366f8f1`.
<!-- evidence-head:21c530560543b49dfccb30a55e1fa2a9c366f8f1 -->

This PR adds tests and changes no production behaviour and no rendered UI.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only; no user flow or UI change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - test-only unit coverage; no production path change. Vitest output is the execution record.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain state change; the suite drives the real in-process module.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only. Focused vitest run immediately before filing: **1 file, 19 tests passed**.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only; no UI.

### After

N/A - test-only; no UI.

### Walkthrough video

N/A - test-only; no UI.

## Audio / voice walkthrough

N/A - this PR does not change voice-pipeline production behaviour. Tests call the real discovery/summary/clone functions in-process and do not capture or play audio.

## Known gaps / failures

- `bun run verify` was not run. Test-only PR; evidence is the focused vitest / biome / tsc results above.
- Hosted GitHub Actions CI does not run on fork PRs from `ss251/eliza`.
- Owning-package `tsc --noEmit` reports pre-existing errors in unrelated files; `voice-pipeline.test.ts` is absent from that output.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
