### PR TITLE
chore: restore the workspace lint closure

### DIFF
--- a/packages/agent/src/api/views-search-index.test.ts
+++ b/packages/agent/src/api/views-search-index.test.ts
@@ -132,11 +132,7 @@ describe("ViewSearchIndex ranking determinism", () => {
     }
 
     const ranked = await viewSearchIndex.search("query", rankingRuntime, 10);
-    expect(ranked.map((entry) => entry.viewId)).toEqual([
-      "a",
-      "z",
-      "corrupt",
-    ]);
+    expect(ranked.map((entry) => entry.viewId)).toEqual(["a", "z", "corrupt"]);
     expect(Number.isNaN(ranked[2].score)).toBe(true);
   });
 });

--- a/packages/agent/src/providers/skill-provider.test.ts
+++ b/packages/agent/src/providers/skill-provider.test.ts
@@ -146,7 +146,6 @@ describe("createDynamicSkillProvider instructions well-formed Unicode", () => {
     expect(isWellFormed(result.text)).toBe(true);
     expect(result.text).toContain(longBody);
   });
-
 });
 
 describe("dynamic skill ranking determinism", () => {
@@ -155,7 +154,11 @@ describe("dynamic skill ranking determinism", () => {
   // first, which is the order a comparator returning 0 for a tie preserves.
   const sharedDescription = "Use when converting spreadsheets into charts.";
   const tiedSkills = [
-    { slug: "zeta-runner", name: "Zeta Runner", description: sharedDescription },
+    {
+      slug: "zeta-runner",
+      name: "Zeta Runner",
+      description: sharedDescription,
+    },
     {
       slug: "alpha-runner",
       name: "Alpha Runner",

--- a/packages/agent/src/services/registry-client-queries.score-order.test.ts
+++ b/packages/agent/src/services/registry-client-queries.score-order.test.ts
@@ -5,8 +5,8 @@
  * unusable star count treated as none, then package name. Pure function, no I/O.
  */
 import { describe, expect, it } from "vitest";
-import type { RegistryPluginInfo } from "./registry-client-types.ts";
 import { scoreEntries } from "./registry-client-queries.ts";
+import type { RegistryPluginInfo } from "./registry-client-types.ts";
 
 function entry(name: string, stars: number): RegistryPluginInfo {
   return {

--- a/packages/cloud/shared/src/lib/services/discord.ts
+++ b/packages/cloud/shared/src/lib/services/discord.ts
@@ -1,5 +1,5 @@
 // Coordinates cloud service discord behavior behind route handlers.
-import { truncateWellFormed, toWellFormedUnicode } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "../utils/logger";
 
 const DISCORD_API = "https://discord.com/api/v10";

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -166,10 +166,7 @@ export interface HeadscaleUser {
 // Client
 // ---------------------------------------------------------------------------
 
-export function compareHeadscaleIds(
-  a: { id: string },
-  b: { id: string },
-): number {
+export function compareHeadscaleIds(a: { id: string }, b: { id: string }): number {
   const bNum = Number((b as any).id);
   const aNum = Number((a as any).id);
   const bVal = Number.isFinite(bNum) ? bNum : 0;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -6,11 +6,11 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { logger } from "../../utils/logger";
 import {
+  compareSharedRuntimeHistoryMessages,
   encodeSharedPublicWebGrounding,
   insertSharedRuntimeGroundingMessages,
   MAX_PUBLIC_WEB_GROUNDING_AGE_MS,
   MAX_PUBLIC_WEB_GROUNDING_FUTURE_SKEW_MS,
-  compareSharedRuntimeHistoryMessages,
   mergeSharedRuntimeHistoryMessages,
   parseSharedPublicWebGrounding,
   type SharedRuntimeHistoryMessageLike,
@@ -1047,4 +1047,3 @@ describe("headscale safe sort", () => {
     expect(arr[1].id).toBe("5");
   });
 });
-

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -551,9 +551,13 @@ export function compareSharedRuntimeHistoryMessages(
   b: { createdAt?: unknown; id?: unknown },
 ): number {
   const aCreated =
-    typeof (a as any).createdAt === "number" && Number.isFinite((a as any).createdAt) ? (a as any).createdAt : 0;
+    typeof (a as any).createdAt === "number" && Number.isFinite((a as any).createdAt)
+      ? (a as any).createdAt
+      : 0;
   const bCreated =
-    typeof (b as any).createdAt === "number" && Number.isFinite((b as any).createdAt) ? (b as any).createdAt : 0;
+    typeof (b as any).createdAt === "number" && Number.isFinite((b as any).createdAt)
+      ? (b as any).createdAt
+      : 0;
   return (
     aCreated - bCreated || String((a as any).id ?? "").localeCompare(String((b as any).id ?? ""))
   );

--- a/packages/core/src/__tests__/streaming-context-browser.test.ts
+++ b/packages/core/src/__tests__/streaming-context-browser.test.ts
@@ -4,11 +4,11 @@
  * `run`/`active` surface — no mocks, no AsyncLocalStorage, no I/O.
  */
 import { describe, expect, it } from "vitest";
-import type { StreamingContext } from "../streaming-context.ts";
 import {
 	createBrowserStreamingContextManager,
 	StackContextManager,
 } from "../streaming-context.browser.ts";
+import type { StreamingContext } from "../streaming-context.ts";
 
 const ctx = (messageId: string): StreamingContext => ({ messageId });
 

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -1596,12 +1596,14 @@ export class RelationshipsService extends Service {
 		for (const i of [...primary.interactions, ...secondary.interactions]) {
 			interactionMap.set(i.id, i);
 		}
-		const mergedInteractions = Array.from(interactionMap.values()).sort((a, b) => {
-			const aSafe = safeSortNumber(new Date(a.occurredAt).getTime());
-			const bSafe = safeSortNumber(new Date(b.occurredAt).getTime());
-			if (aSafe !== bSafe) return aSafe < bSafe ? -1 : 1;
-			return String(a.id ?? "").localeCompare(String(b.id ?? ""));
-		});
+		const mergedInteractions = Array.from(interactionMap.values()).sort(
+			(a, b) => {
+				const aSafe = safeSortNumber(new Date(a.occurredAt).getTime());
+				const bSafe = safeSortNumber(new Date(b.occurredAt).getTime());
+				if (aSafe !== bSafe) return aSafe < bSafe ? -1 : 1;
+				return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+			},
+		);
 		const mergedCategories = Array.from(
 			new Set([...primary.categories, ...secondary.categories]),
 		);
@@ -1762,7 +1764,9 @@ export class RelationshipsService extends Service {
 			const aSafe = safeSortNumber(a.daysSinceInteraction);
 			const bSafe = safeSortNumber(b.daysSinceInteraction);
 			if (aSafe !== bSafe) return bSafe > aSafe ? 1 : -1;
-			return String(a.contact.entityId).localeCompare(String(b.contact.entityId));
+			return String(a.contact.entityId).localeCompare(
+				String(b.contact.entityId),
+			);
 		});
 		return results;
 	}

--- a/packages/ui/knip.json
+++ b/packages/ui/knip.json
@@ -66,9 +66,6 @@
     "*.config.{ts,mts,mjs}",
     "scripts/**/*.{ts,mts,mjs}"
   ],
-  "ignoreDependencies": [
-    "@metamask/connect-evm",
-    "pixelmatch"
-  ],
+  "ignoreDependencies": ["@metamask/connect-evm", "pixelmatch"],
   "vitest": false
 }

--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
@@ -19,6 +19,7 @@
  * rAF, which would fabricate a slow frame for the watchdog on resume.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type * as React from "react";
 import { useEffect, useRef } from "react";
 import * as THREE from "three";
@@ -33,7 +34,6 @@ import {
   type ShaderUniformValues,
   uniformsEqual,
 } from "./shader-schema";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 /** Present cap while the home↔launcher rail is mid-gesture (#15282): the
  * compositor is already translating the promoted rail layer (plus, on one half,

--- a/packages/ui/src/cloud/lib/api-client.surrogate.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.surrogate.test.ts
@@ -1,6 +1,7 @@
 /** Surrogate-safe truncateWellFormed in api-client. */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("api-client surrogate-safe", () => {
   it("does not split surrogate pair at 500", () => {

--- a/packages/ui/stories/src/eliza-core-browser-shim.ts
+++ b/packages/ui/stories/src/eliza-core-browser-shim.ts
@@ -244,7 +244,6 @@ export function isConnectorConfigured(): boolean {
   return false;
 }
 
-
 export function isWechatConfigured(): boolean {
   return false;
 }

--- a/packages/ui/stories/src/lab/surfaces/ChatLab.tsx
+++ b/packages/ui/stories/src/lab/surfaces/ChatLab.tsx
@@ -183,10 +183,7 @@ export function ChatLab({
         </div>
       </div>
       <GlassStyles />
-      <ChatOverlay
-        controller={chat.controller}
-        firstRunOpen={firstRun}
-      />
+      <ChatOverlay controller={chat.controller} firstRunOpen={firstRun} />
       {controlsEl ? createPortal(controls, controlsEl) : null}
     </>
   );

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -26,9 +26,9 @@ import {
 	type Service,
 	ServiceType,
 	stringToUuid,
+	TurnAbortedError,
 	toWellFormedUnicode,
 	truncateWellFormed,
-	TurnAbortedError,
 	type UUID,
 } from "@elizaos/core";
 import {

--- a/plugins/plugin-google-workspace/src/gmail-thread-sort.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-thread-sort.test.ts
@@ -6,14 +6,10 @@
  */
 import { describe, expect, it } from "vitest";
 import { compareUnrespondedThreads, sortGmailMessages } from "./gmail.js";
-import type {
-  GoogleGmailMessageSummary,
-  GoogleGmailUnrespondedThread,
-} from "./types.js";
+import type { GoogleGmailMessageSummary, GoogleGmailUnrespondedThread } from "./types.js";
 
 function makeMessage(
-  overrides: Partial<GoogleGmailMessageSummary> &
-    Pick<GoogleGmailMessageSummary, "externalId">,
+  overrides: Partial<GoogleGmailMessageSummary> & Pick<GoogleGmailMessageSummary, "externalId">
 ): GoogleGmailMessageSummary {
   return {
     threadId: "thread-1",
@@ -37,10 +33,7 @@ function makeMessage(
   };
 }
 
-function makeThread(
-  threadId: string,
-  daysWaiting: number,
-): GoogleGmailUnrespondedThread {
+function makeThread(threadId: string, daysWaiting: number): GoogleGmailUnrespondedThread {
   return {
     threadId,
     externalMessageId: `${threadId}-message`,
@@ -78,10 +71,7 @@ describe("compareUnrespondedThreads", () => {
 
     threads.sort(compareUnrespondedThreads);
 
-    expect(threads.map((thread) => thread.threadId)).toEqual([
-      "a-thread",
-      "z-thread",
-    ]);
+    expect(threads.map((thread) => thread.threadId)).toEqual(["a-thread", "z-thread"]);
   });
 
   it("does not throw when threads tie, which is the common whole-day case", () => {
@@ -127,9 +117,6 @@ describe("sortGmailMessages", () => {
       }),
     ]);
 
-    expect(sorted.map((message) => message.externalId)).toEqual([
-      "msg-a",
-      "msg-z",
-    ]);
+    expect(sorted.map((message) => message.externalId)).toEqual(["msg-a", "msg-z"]);
   });
 });

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -1198,7 +1198,7 @@ async function mapWithConcurrency<T, TResult>(
 
 export function compareUnrespondedThreads(
   a: GoogleGmailUnrespondedThread,
-  b: GoogleGmailUnrespondedThread,
+  b: GoogleGmailUnrespondedThread
 ): number {
   const rightWaiting =
     typeof b.daysWaiting === "number" && Number.isFinite(b.daysWaiting) ? b.daysWaiting : 0;
@@ -1207,7 +1207,9 @@ export function compareUnrespondedThreads(
   return rightWaiting - leftWaiting || a.threadId.localeCompare(b.threadId);
 }
 
-export function sortGmailMessages(messages: GoogleGmailMessageSummary[]): GoogleGmailMessageSummary[] {
+export function sortGmailMessages(
+  messages: GoogleGmailMessageSummary[]
+): GoogleGmailMessageSummary[] {
   return [...messages].sort((left, right) => {
     if (left.isImportant !== right.isImportant) {
       return right.isImportant ? 1 : -1;

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -349,7 +349,9 @@ export function compareInboxItemsByReceivedAt(
   return bTime - aTime || a.id.localeCompare(b.id);
 }
 
-export function dedupeAndOrder(items: readonly InboxItem[]): readonly InboxItem[] {
+export function dedupeAndOrder(
+  items: readonly InboxItem[],
+): readonly InboxItem[] {
   const seen = new Map<string, InboxItem>();
   for (const item of items) {
     const key = dedupeKey(item);

--- a/plugins/plugin-inbox/test/inbox-curation.test.ts
+++ b/plugins/plugin-inbox/test/inbox-curation.test.ts
@@ -16,6 +16,10 @@
 
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import {
+  compareInboxItemsByReceivedAt,
+  dedupeAndOrder,
+} from "../src/actions/inbox.ts";
 import type {
   EmailCurationIdentityHook,
   EmailCurationPolicyHook,
@@ -24,10 +28,6 @@ import {
   compareCurationDecisions,
   curateEmailCandidates,
 } from "../src/inbox/email-curation.ts";
-import {
-  compareInboxItemsByReceivedAt,
-  dedupeAndOrder,
-} from "../src/actions/inbox.ts";
 import { InboxService } from "../src/inbox/service.ts";
 import type { InboundMessage } from "../src/inbox/types.ts";
 
@@ -233,7 +233,14 @@ describe("email curation safe sort (NaN + tiebreak)", () => {
     ];
     const policyHook = (ctx: { candidate: { id: string } }) => {
       if (ctx.candidate.id === "c-nan") {
-        return [{ kind: "lower_confidence" as const, amount: Number.NaN, code: "test_nan", message: "force NaN" }];
+        return [
+          {
+            kind: "lower_confidence" as const,
+            amount: Number.NaN,
+            code: "test_nan",
+            message: "force NaN",
+          },
+        ];
       }
       return [];
     };
@@ -263,7 +270,11 @@ describe("email curation safe sort (NaN + tiebreak)", () => {
   });
 
   it("handles NaN in compareCurationDecisions as 0", () => {
-    const a: any = { candidateId: "c-nan", action: "save", confidence: Number.NaN };
+    const a: any = {
+      candidateId: "c-nan",
+      action: "save",
+      confidence: Number.NaN,
+    };
     const b: any = { candidateId: "c-1", action: "save", confidence: 0.8 };
     // save weight 4 -> score 40+confidence, NaN -> 0 after guard, so c-1 wins
     const arr = [a, b];
@@ -275,9 +286,27 @@ describe("email curation safe sort (NaN + tiebreak)", () => {
 describe("dedupeAndOrder safe sort", () => {
   it("orders unparsable receivedAt via id tiebreak and NaN handling", () => {
     const items: any[] = [
-      { id: "b", platform: "gmail", channel: "inbox", receivedAt: "not-a-date", threadTopic: "" },
-      { id: "a", platform: "gmail", channel: "inbox", receivedAt: "not-a-date", threadTopic: "" },
-      { id: "c", platform: "gmail", channel: "inbox", receivedAt: "2026-08-23T10:00:00.000Z", threadTopic: "" },
+      {
+        id: "b",
+        platform: "gmail",
+        channel: "inbox",
+        receivedAt: "not-a-date",
+        threadTopic: "",
+      },
+      {
+        id: "a",
+        platform: "gmail",
+        channel: "inbox",
+        receivedAt: "not-a-date",
+        threadTopic: "",
+      },
+      {
+        id: "c",
+        platform: "gmail",
+        channel: "inbox",
+        receivedAt: "2026-08-23T10:00:00.000Z",
+        threadTopic: "",
+      },
     ];
     const ordered = dedupeAndOrder(items);
     // c has valid date, should be first; a,b tie on NaN with id tiebreak
@@ -301,4 +330,3 @@ describe("dedupeAndOrder safe sort", () => {
     expect(arr[1].id).toBe("nan");
   });
 });
-

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -1062,7 +1062,10 @@ describe("MeetingService — roster, transcripts, listing", () => {
       const listed = service.listSessions();
       // Both sessions really do tie, so only the id tiebreak can order them.
       expect(listed.map((s) => s.requestedAt)).toEqual([fixedNow, fixedNow]);
-      expect(listed.map((s) => s.id)).toEqual([LOW_SESSION_ID, HIGH_SESSION_ID]);
+      expect(listed.map((s) => s.id)).toEqual([
+        LOW_SESSION_ID,
+        HIGH_SESSION_ID,
+      ]);
     } finally {
       restore();
     }
@@ -1088,9 +1091,7 @@ describe("MeetingService — roster, transcripts, listing", () => {
       });
 
       const listed = service.listSessions();
-      expect(
-        listed.find((s) => s.id === broken.id)?.requestedAt,
-      ).toBeNaN();
+      expect(listed.find((s) => s.id === broken.id)?.requestedAt).toBeNaN();
       // The NaN timestamp must not poison the comparator: the session with a
       // real timestamp still sorts ahead of it.
       expect(listed.map((s) => s.id)).toEqual([healthy.id, broken.id]);

--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -5,7 +5,6 @@
  * no resolvable target. Runtime and Telegraf are mocked.
  */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { compareMessageConnectorTargets } from "./service.js";
 import { describe, expect, it, vi } from "vitest";
 import {
   claimTelegramPollerToken,
@@ -14,6 +13,7 @@ import {
   releaseTelegramPollerToken,
 } from "./poller-lock";
 import { TelegramService } from "./service";
+import { compareMessageConnectorTargets } from "./service.js";
 
 function createRuntime() {
   const runtime = {


### PR DESCRIPTION
# Relates to

Same class as #25333 and #25700. The lint closure has drifted again across ten packages, which reds the `Lint affected workspace closure` lane for unrelated PRs — observed tonight on #25789, #25796 and #25804, none of which touch the offending packages.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`24070f99bf2`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None.** `biome check --write` (safe fixes only): formatting and import order. `git diff -w` contains only line-wrap and import-sort changes; nothing semantic.

# Background

## What does this PR do?

`lint:check` fails on `origin/develop` in ten packages:

`agent`, `cloud-shared`, `core`, `plugin-discord`, `plugin-github`, `plugin-google-workspace`, `plugin-inbox`, `plugin-meetings`, `plugin-telegram`, `ui`

Because the lane runs the affected *closure*, a PR that touches none of them still fails if its closure reaches one — which is what has been happening. This sweeps all of them.

**plugin-github is deliberately not fixed here.** Its lint error is `lint/suspicious/noRedeclare` on a genuinely duplicated function (`compareTriagedNotifications` declared twice in the same file, which also fails that package's typecheck). That needs a real edit, not a formatter pass, and is #25820.

## What kind of change is this?

Chore (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`git diff -w` — if it shows only wrapped lines and re-sorted imports, the diff is doing exactly what it claims.

## Detailed testing steps

Full sweep on pristine develop first, to enumerate the failures rather than guess: `node packages/scripts/run-turbo.mjs run lint:check --concurrency=4 --continue` → the ten packages above. After the sweep, each one's own `bun run lint:check` reports clean (`No fixes applied`). Nine packages are fixed by this PR; plugin-github is left to #25820.

# Evidence Gate

<!-- evidence-head:ef846d308ec4741af6c92f1f0be894c52356ad73 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - formatting only.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - formatting only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
N/A - formatting only.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Warnings are untouched — only errors, which are what fail the lane.
- This is janitorial and will drift again; the durable fix is making the lane's failure mode visible on the PR that introduces the unformatted file rather than on the next unrelated PR. Out of scope here.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

