### PR TITLE
fix(github): drop the duplicated triage comparator

### DIFF
--- a/plugins/plugin-github/src/actions/notification-triage.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.ts
@@ -143,17 +143,6 @@ function formatTriageSummary(
     : `Triaged ${triagedCount} unread notification(s)`;
 }
 
-export function compareTriagedNotifications(
-  a: TriagedNotification,
-  b: TriagedNotification,
-): number {
-  const bScore =
-    typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-  const aScore =
-    typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-  return bScore - aScore || a.id.localeCompare(b.id);
-}
-
 export { formatTriageSummary, scoreNotification };
 
 export const notificationTriageAction: Action = {


### PR DESCRIPTION
# Relates to

#25317 introduced the comparator; #25620's sort-comparator sweep added the same function to the same file a second time. `plugin-github`'s typecheck fails on `develop` as a result, which reds the typecheck lane for any PR whose affected closure includes this package (observed on #25794).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`24070f99bf2`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None at runtime.** A duplicate function declaration means the later one already wins, and the two bodies are semantically identical — only the order of the two score consts differs. Removing the dead copy changes no behaviour and restores a passing typecheck.

# Background

## What does this PR do?

`compareTriagedNotifications` is declared twice in `plugins/plugin-github/src/actions/notification-triage.ts` (lines 76 and 146), so the package's typecheck fails with four errors:

```
TS2323: Cannot redeclare exported variable 'compareTriagedNotifications'.
TS2393: Duplicate function implementation.
```

This removes the second, undocumented copy and keeps the first, which carries the JSDoc explaining why a non-finite score is clamped to `0` and why equal scores tie-break on the notification id — the reasoning the NaN-safety work was for in the first place.

## What kind of change is this?

Bug fix (non-breaking; typecheck-only in effect).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The deleted block — compare it against the retained declaration a few dozen lines above to confirm the bodies match.

## Detailed testing steps

- `cd plugins/plugin-github && bun run typecheck` → `TS2323`/`TS2393` count goes from 4 to **0**. The remaining errors in that file are the pre-existing `TS2307 Cannot find module '@elizaos/core'` unbuilt-dist cascade, unchanged.
- `bunx vitest run src/actions/notification-triage.test.ts` → **11 pass** (the suite already exercises the comparator directly, including the NaN and tie-break cases).
- Biome clean on the file.

# Evidence Gate

<!-- evidence-head:ba99c109fd702c248e9600ad737eea2a3ae39101 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime change; a duplicate declaration was already shadowed by the later one.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted state.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
N/A - no runtime change; a duplicate declaration was already shadowed by the later one.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- No new test: the guard here is the typecheck itself, which now passes; the comparator's behaviour was and remains covered by the existing suite.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

