### PR TITLE
fix(video): use surrogate-safe truncateWellFormed on ffmpeg-static install failure reason

### DIFF
--- a/plugins/plugin-video/src/services/binaries.test.ts
+++ b/plugins/plugin-video/src/services/binaries.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   BinaryResolver,
   ffmpegStaticExecutableName,
+  formatInstallErrorReason,
   resolveFfmpegStaticCandidatePath,
   resolveNodeInstallRunner,
   ytDlpAssetName,
@@ -508,5 +509,16 @@ describe("resolveFfmpegStaticCandidatePath", () => {
 
   it("returns null when ffmpeg-static is not installed", () => {
     expect(resolveFfmpegStaticCandidatePath({ packageRoot: null })).toBeNull();
+  });
+
+  it("formats install error reasons with surrogate-safe truncation", () => {
+    const longMessage = "a".repeat(159) + "😀" + "b".repeat(20);
+    const err = new Error(longMessage);
+    const formatted = formatInstallErrorReason(err);
+    expect(formatted.startsWith("ffmpeg-static install failed: ")).toBe(true);
+    expect(formatted.length).toBeLessThanOrEqual(
+      "ffmpeg-static install failed: ".length + 160,
+    );
+    expect(formatted.includes("😀")).toBe(false);
   });
 });

--- a/plugins/plugin-video/src/services/binaries.ts
+++ b/plugins/plugin-video/src/services/binaries.ts
@@ -17,7 +17,12 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
-import { elizaLogger, resolveStateDir } from "@elizaos/core";
+import {
+  elizaLogger,
+  resolveStateDir,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import type { Flags as YtDlpFlags } from "youtube-dl-exec";
 import youtubeDl from "youtube-dl-exec";
 
@@ -663,7 +668,7 @@ async function installFfmpegStaticOnce(): Promise<
       // error-policy:J3 optional packaged binary — caller reports unavailable tool.
       return {
         installed: false,
-        reason: `ffmpeg-static install failed: ${describeError(err).slice(0, 160)}`,
+        reason: formatInstallErrorReason(err),
       };
     }
   })();
@@ -794,4 +799,8 @@ function errorMessage(err: unknown): string {
 
 function describeError(err: unknown): string {
   return errorMessage(err) || "(no message)";
+}
+
+export function formatInstallErrorReason(err: unknown): string {
+  return `ffmpeg-static install failed: ${truncateWellFormed(toWellFormedUnicode(describeError(err)), 160)}`;
 }


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` when constructing the failure reason for `ffmpeg-static` installation errors in `plugins/plugin-video/src/services/binaries.ts:666` to prevent raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when subprocess error outputs exceed length boundaries.

## Changes

- In `plugins/plugin-video/src/services/binaries.ts`, use `truncateWellFormed(toWellFormedUnicode(describeError(err)), 160)` when formatting install failure reasons.
- In `plugins/plugin-video/src/services/binaries.test.ts`, add unit test verifying that long error messages containing emoji/astral unicode characters at the 160-character boundary are truncated without splitting surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`294d8825fc`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-video test src/services/binaries.test.ts` | 19 pass (19 tests) | 20 pass (20 tests) |
| `bunx @biomejs/biome check plugins/plugin-video/src/services/binaries.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-video/src/services/binaries.ts:660-675`
- `plugins/plugin-video/src/services/binaries.test.ts:510-525`

## Risks

Low. Preserves complete unicode code points up to the specified boundary.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Video binary install error handling)
- [x] `audit:browser` — N/A (Subprocess install reason formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 20/20 pass in `binaries.test.ts`
- [x] `lint` — Biome clean
