### PR TITLE
test(app-core): cover automation-node-contributors

### DIFF
--- a/packages/app-core/src/api/automation-node-contributors.test.ts
+++ b/packages/app-core/src/api/automation-node-contributors.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Drives the app-core `automation-node-contributors` re-export against the real
+ * shared singleton. Covers contributor registration (empty/whitespace ids,
+ * trim, overwrite, insertion order, list copy, clear) and
+ * `buildRuntimeCapabilityNodes` gating (empty specs, missing actions/plugins,
+ * action name + simile + plugin matches, case/whitespace normalization, and
+ * `enabledWithoutRuntimeCapability`). No mocks.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import {
+  buildRuntimeCapabilityNodes as sharedBuild,
+  clearAutomationNodeContributorsForTests as sharedClear,
+  listAutomationNodeContributors as sharedList,
+  registerAutomationNodeContributor as sharedRegister,
+} from "@elizaos/shared/automation-node-contributors";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AutomationNodeContributor,
+  buildRuntimeCapabilityNodes,
+  clearAutomationNodeContributorsForTests,
+  listAutomationNodeContributors,
+  type RuntimeCapabilityNodeSpec,
+  registerAutomationNodeContributor,
+} from "./automation-node-contributors.ts";
+
+const REQUIRED_ID_ERROR = "Automation node contributor id is required";
+
+function spec(
+  overrides: {
+    id?: string;
+    label?: string;
+    description?: string;
+    class?: RuntimeCapabilityNodeSpec["class"];
+    backingCapability?: string;
+    actionNames?: string[];
+    pluginNames?: string[];
+    ownerScoped?: boolean;
+    enabledWithoutRuntimeCapability?: boolean;
+    disabledReason?: string;
+  } = {},
+): RuntimeCapabilityNodeSpec {
+  return {
+    id: overrides.id ?? "node.one",
+    label: overrides.label ?? "Node One",
+    description: overrides.description ?? "A catalog node",
+    class: overrides.class ?? "action",
+    backingCapability: overrides.backingCapability ?? "cap.one",
+    actionNames: overrides.actionNames ?? [],
+    pluginNames: overrides.pluginNames ?? [],
+    ownerScoped: overrides.ownerScoped ?? false,
+    enabledWithoutRuntimeCapability:
+      overrides.enabledWithoutRuntimeCapability ?? false,
+    disabledReason: overrides.disabledReason ?? "capability missing",
+  };
+}
+
+function runtime(
+  overrides: {
+    actions?: Array<{ name: string; similes?: string[] }>;
+    plugins?: Array<{ name: string }>;
+  } = {},
+): AgentRuntime {
+  return overrides as AgentRuntime;
+}
+
+const emptyContributor: AutomationNodeContributor = () => [];
+const otherContributor: AutomationNodeContributor = () => [];
+const thirdContributor: AutomationNodeContributor = () => [];
+
+describe("app-core automation-node-contributors re-export", () => {
+  beforeEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  afterEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  it("re-exports the same function identities as @elizaos/shared", () => {
+    expect(buildRuntimeCapabilityNodes).toBe(sharedBuild);
+    expect(registerAutomationNodeContributor).toBe(sharedRegister);
+    expect(listAutomationNodeContributors).toBe(sharedList);
+    expect(clearAutomationNodeContributorsForTests).toBe(sharedClear);
+  });
+
+  it("shares the contributor Map across the app-core and shared import paths", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    expect(sharedList()).toEqual([emptyContributor]);
+
+    sharedRegister("lifeops", otherContributor);
+    expect(listAutomationNodeContributors()).toEqual([
+      emptyContributor,
+      otherContributor,
+    ]);
+  });
+});
+
+describe("registerAutomationNodeContributor / listAutomationNodeContributors", () => {
+  beforeEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  afterEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  it("lists an empty queue after a clear, including a clear of an already empty map", () => {
+    expect(listAutomationNodeContributors()).toEqual([]);
+    clearAutomationNodeContributorsForTests();
+    expect(listAutomationNodeContributors()).toEqual([]);
+  });
+
+  it("lists a single registered contributor", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    expect(listAutomationNodeContributors()).toEqual([emptyContributor]);
+  });
+
+  it("lists contributors in Map insertion order", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    registerAutomationNodeContributor("lifeops", otherContributor);
+    registerAutomationNodeContributor("coding", thirdContributor);
+    expect(listAutomationNodeContributors()).toEqual([
+      emptyContributor,
+      otherContributor,
+      thirdContributor,
+    ]);
+  });
+
+  it("rejects an empty id", () => {
+    expect(() =>
+      registerAutomationNodeContributor("", emptyContributor),
+    ).toThrow(REQUIRED_ID_ERROR);
+    expect(listAutomationNodeContributors()).toEqual([]);
+  });
+
+  it("rejects a whitespace-only id after trim", () => {
+    expect(() =>
+      registerAutomationNodeContributor(" \t\n ", emptyContributor),
+    ).toThrow(REQUIRED_ID_ERROR);
+    expect(listAutomationNodeContributors()).toEqual([]);
+  });
+
+  it("trims contributor ids so padded and bare ids collide as one Map key", () => {
+    registerAutomationNodeContributor("  wallet  ", emptyContributor);
+    registerAutomationNodeContributor("wallet", otherContributor);
+    expect(listAutomationNodeContributors()).toEqual([otherContributor]);
+  });
+
+  it("overwrites the contributor for an existing id without changing insertion position", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    registerAutomationNodeContributor("lifeops", otherContributor);
+    registerAutomationNodeContributor("wallet", thirdContributor);
+    expect(listAutomationNodeContributors()).toEqual([
+      thirdContributor,
+      otherContributor,
+    ]);
+  });
+
+  it("returns a shallow copy so mutating the listed array does not change the registry", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    const listed = listAutomationNodeContributors();
+    listed.pop();
+    listed.push(otherContributor);
+    expect(listAutomationNodeContributors()).toEqual([emptyContributor]);
+  });
+
+  it("does not surface an unregistered id", () => {
+    registerAutomationNodeContributor("wallet", emptyContributor);
+    expect(listAutomationNodeContributors()).not.toContain(otherContributor);
+    expect(listAutomationNodeContributors()).toHaveLength(1);
+  });
+});
+
+describe("buildRuntimeCapabilityNodes", () => {
+  it("returns an empty array for an empty spec list", () => {
+    expect(buildRuntimeCapabilityNodes([], runtime())).toEqual([]);
+  });
+
+  it("disables a gated spec when the runtime has no actions or plugins", () => {
+    expect(
+      buildRuntimeCapabilityNodes(
+        [
+          spec({
+            actionNames: ["SWAP_EVM"],
+            pluginNames: ["wallet"],
+            disabledReason: "Load the wallet plugin.",
+          }),
+        ],
+        runtime(),
+      ),
+    ).toEqual([
+      {
+        id: "node.one",
+        label: "Node One",
+        description: "A catalog node",
+        class: "action",
+        source: "static_catalog",
+        backingCapability: "cap.one",
+        ownerScoped: false,
+        requiresSetup: true,
+        availability: "disabled",
+        disabledReason: "Load the wallet plugin.",
+      },
+    ]);
+  });
+
+  it("treats missing runtime.actions and runtime.plugins as empty lists", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["SWAP"], pluginNames: ["wallet"] })],
+      {} as AgentRuntime,
+    );
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.availability).toBe("disabled");
+    expect(nodes[0]?.requiresSetup).toBe(true);
+  });
+
+  it("enables a spec whose action name matches, case-insensitively, and omits disabledReason", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["swap_evm"], pluginNames: ["wallet"] })],
+      runtime({ actions: [{ name: "SWAP_EVM" }] }),
+    );
+    expect(nodes).toEqual([
+      {
+        id: "node.one",
+        label: "Node One",
+        description: "A catalog node",
+        class: "action",
+        source: "static_catalog",
+        backingCapability: "cap.one",
+        ownerScoped: false,
+        requiresSetup: false,
+        availability: "enabled",
+      },
+    ]);
+    expect(nodes[0]?.disabledReason).toBeUndefined();
+  });
+
+  it("enables a spec when a simile matches after trim and lowercase", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["  Swap_Evm  "] })],
+      runtime({
+        actions: [{ name: "OTHER", similes: [" SWAP_EVM "] }],
+      }),
+    );
+    expect(nodes[0]?.availability).toBe("enabled");
+    expect(nodes[0]?.requiresSetup).toBe(false);
+  });
+
+  it("enables a spec when a plugin name matches after trim and lowercase", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ pluginNames: [" Wallet "] })],
+      runtime({ plugins: [{ name: "WALLET" }] }),
+    );
+    expect(nodes[0]?.availability).toBe("enabled");
+  });
+
+  it("enables when either the action list or the plugin list matches", () => {
+    const byAction = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["SWAP"], pluginNames: ["wallet"] })],
+      runtime({ actions: [{ name: "swap" }] }),
+    );
+    const byPlugin = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["SWAP"], pluginNames: ["wallet"] })],
+      runtime({ plugins: [{ name: "wallet" }] }),
+    );
+    expect(byAction[0]?.availability).toBe("enabled");
+    expect(byPlugin[0]?.availability).toBe("enabled");
+  });
+
+  it("does not match an empty normalized plugin name because those names are dropped", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ pluginNames: ["   "] })],
+      runtime({ plugins: [{ name: "   " }, { name: "" }] }),
+    );
+    expect(nodes[0]?.availability).toBe("disabled");
+  });
+
+  it("does match an empty normalized action name because action names are not filtered", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [spec({ actionNames: ["  "] })],
+      runtime({ actions: [{ name: "   " }] }),
+    );
+    expect(nodes[0]?.availability).toBe("enabled");
+  });
+
+  it("enables every spec that sets enabledWithoutRuntimeCapability even with empty queues", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [
+        spec({
+          id: "always.on",
+          enabledWithoutRuntimeCapability: true,
+          actionNames: ["MISSING"],
+          pluginNames: ["missing"],
+        }),
+      ],
+      runtime(),
+    );
+    expect(nodes[0]?.availability).toBe("enabled");
+    expect(nodes[0]?.requiresSetup).toBe(false);
+    expect(nodes[0]?.disabledReason).toBeUndefined();
+  });
+
+  it("preserves spec order and mixed availability across several nodes", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [
+        spec({
+          id: "disabled.one",
+          label: "Disabled",
+          class: "trigger",
+          ownerScoped: true,
+          actionNames: ["MISSING"],
+        }),
+        spec({
+          id: "enabled.one",
+          label: "Enabled",
+          class: "agent",
+          actionNames: ["TASKS"],
+        }),
+      ],
+      runtime({ actions: [{ name: "tasks" }] }),
+    );
+    expect(nodes.map((node) => node.id)).toEqual([
+      "disabled.one",
+      "enabled.one",
+    ]);
+    expect(nodes[0]?.availability).toBe("disabled");
+    expect(nodes[0]?.ownerScoped).toBe(true);
+    expect(nodes[0]?.class).toBe("trigger");
+    expect(nodes[1]?.availability).toBe("enabled");
+    expect(nodes[1]?.class).toBe("agent");
+  });
+
+  it("copies label, description, backingCapability, and source through unchanged", () => {
+    const nodes = buildRuntimeCapabilityNodes(
+      [
+        spec({
+          id: "crypto:evm.swap",
+          label: "EVM Swap",
+          description: "Swap on EVM",
+          backingCapability: "wallet.evm.swap",
+          class: "integration",
+        }),
+      ],
+      runtime(),
+    );
+    expect(nodes[0]).toMatchObject({
+      id: "crypto:evm.swap",
+      label: "EVM Swap",
+      description: "Swap on EVM",
+      class: "integration",
+      source: "static_catalog",
+      backingCapability: "wallet.evm.swap",
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

Operator-directed test-coverage contribution. `packages/app-core/src/api/automation-node-contributors.ts` had no same-named vitest suite. This PR adds `automation-node-contributors.test.ts` next to the module. It does not close a GitHub issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Head is `f4ad5deda294cc996943b12a00e0a3ae37b67f99` (one commit on `origin/develop` at `24070f99bf211d3498c12da4ae4109066723d9fd`). Production `automation-node-contributors.ts` is byte-identical to current `origin/develop`; GitHub three-dot file list is the new test file only.
- [ ] `bun run verify` was not run. This is a test-only one-file change; focused vitest, biome, and tsc evidence is below.
- [x] A reviewer can confirm the change from the quoted commands without reading the production module.

# Sync with develop

- [x] Branch parent is `origin/develop` as of the push.
- [ ] `bun run verify` not run; see focused checks below.

# Risks

Low. No production code changes. The suite imports the app-core re-export and drives the real shared singleton (`registerAutomationNodeContributor`, `listAutomationNodeContributors`, `clearAutomationNodeContributorsForTests`, `buildRuntimeCapabilityNodes`). A wrong assertion would fail the new tests only.

# Background

## What does this PR do?

Adds unit coverage for the app-core compatibility re-export of `@elizaos/shared/automation-node-contributors`.

Covered behaviour (observed, not aspirational):

- Re-export identity: app-core functions are the same function objects as the shared module, and they share the contributor Map.
- Empty queue after clear, including clear of an already empty map.
- Single-element list; insertion-order list of several contributors.
- Empty id and whitespace-only id throw `Automation node contributor id is required` and do not insert.
- Trim: padded and bare ids collide as one Map key.
- Overwrite of an existing id replaces the contributor without moving its insertion position.
- `listAutomationNodeContributors` returns a shallow copy; mutating it does not change the registry.
- Unregistered contributor identity is not listed.
- `buildRuntimeCapabilityNodes([])` is `[]`.
- Gated spec with no runtime actions/plugins is `disabled`, `requiresSetup: true`, and includes `disabledReason`.
- Missing `runtime.actions` / `runtime.plugins` are treated as empty lists.
- Action-name match is case-insensitive; enabled nodes omit `disabledReason`.
- Simile match after trim + lowercase.
- Plugin-name match after trim + lowercase.
- Action list OR plugin list is sufficient to enable.
- Empty normalized plugin names are dropped from the runtime set (no match); empty normalized action names are not filtered (they match).
- `enabledWithoutRuntimeCapability: true` enables even with empty queues.
- Spec order and mixed availability are preserved; `source` is always `static_catalog`.

## What kind of change is this?

Improvements (tests for existing behavior). No production behavior change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/automation-node-contributors.test.ts`

## Detailed testing steps

Hosted CI does **not** run on this fork contributor PR. Local commands, re-run against current `origin/develop` immediately before filing:

```text
bunx vitest run packages/app-core/src/api/automation-node-contributors.test.ts
```

Observed (v4.1.10):

```text
Test Files  1 passed (1)
     Tests  23 passed (23)
```

```text
bunx biome check --write packages/app-core/src/api/automation-node-contributors.test.ts
# Checked 1 file in 37ms. Fixed 1 file.
# Committed bytes are the formatted result.
```

```text
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'automation-node-contributors.test.ts' ; echo "EXIT:$?"
# empty grep, EXIT:1 — automation-node-contributors.test.ts appears nowhere in tsc output
```

Diff touches only `packages/app-core/src/api/automation-node-contributors.test.ts`.

# Evidence Gate

Evidence head: `f4ad5deda294cc996943b12a00e0a3ae37b67f99`

<!-- evidence-head:f4ad5deda294cc996943b12a00e0a3ae37b67f99 -->

- [x] Before full-page screenshots: N/A - test-only change; no UI surface.
- [x] After full-page screenshots: N/A - test-only change; no UI surface.
- [x] Walkthrough video: N/A - test-only change; no UI flow.
- [x] Backend logs: N/A - no production path change; vitest output is the proof.
- [x] Frontend console/network logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - no DB, wallet, or scheduled-item change.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; focused vitest/biome/tsc output is quoted in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run; this PR adds one test file and changes no production behavior.
- Hosted GitHub Actions CI does not run on PRs from this fork. Reviewers should re-run the vitest command above on current `develop`.
- Receipt/trace minting skipped: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
