### PR TITLE
fix(inbox): use surrogate-safe truncateWellFormed on unparseable reflection reasoning

### DIFF
--- a/plugins/plugin-inbox/src/inbox/reflection.test.ts
+++ b/plugins/plugin-inbox/src/inbox/reflection.test.ts
@@ -24,5 +24,15 @@ describe("reflectOnAutoReply", () => {
     expect(result.reasoning.length).toBeLessThanOrEqual(
       "Could not parse reflection: ".length + 100,
     );
+    // The invariant the fix is actually about: the old raw.slice(0, 100) cut
+    // between the two code units of the astral char and left an unpaired high
+    // surrogate. Length and emoji-absence alone hold for the old code too, so
+    // assert well-formedness explicitly or this test cannot fail on develop.
+    expect(result.reasoning).toBe(result.reasoning.toWellFormed());
+    expect(
+      /[\uD800-\uDFFF]/.test(
+        result.reasoning.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ""),
+      ),
+    ).toBe(false);
   });
 });

--- a/plugins/plugin-inbox/src/inbox/reflection.test.ts
+++ b/plugins/plugin-inbox/src/inbox/reflection.test.ts
@@ -1,0 +1,28 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { reflectOnAutoReply } from "./reflection.ts";
+
+describe("reflectOnAutoReply", () => {
+  it("truncates unparseable reflection text with surrogate safety", async () => {
+    const rawUnparseable = `${"a".repeat(99)}😀${"b".repeat(20)}`;
+    const runtime = {
+      useModel: vi.fn().mockResolvedValue(rawUnparseable),
+    } as unknown as IAgentRuntime;
+
+    const result = await reflectOnAutoReply(runtime, {
+      senderName: "Alice",
+      source: "email",
+      inboundText: "Hello there",
+      replyText: "Hi Alice",
+    });
+
+    expect(result.approved).toBe(false);
+    expect(result.reasoning.startsWith("Could not parse reflection: ")).toBe(
+      true,
+    );
+    expect(result.reasoning.includes("😀")).toBe(false);
+    expect(result.reasoning.length).toBeLessThanOrEqual(
+      "Could not parse reflection: ".length + 100,
+    );
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/reflection.ts
+++ b/plugins/plugin-inbox/src/inbox/reflection.ts
@@ -12,6 +12,8 @@ import {
   ModelType,
   parseJsonModelRecord,
   runWithTrajectoryPurpose,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 function parseReflectionObject(raw: string): Record<string, unknown> | null {
@@ -100,7 +102,7 @@ export async function reflectOnSendConfirmation(
     }
     return {
       confirmed: false,
-      reasoning: `Could not parse reflection: ${raw.slice(0, 100)}`,
+      reasoning: `Could not parse reflection: ${truncateWellFormed(toWellFormedUnicode(raw), 100)}`,
     };
   } catch (error) {
     logger.warn(
@@ -185,7 +187,7 @@ export async function reflectOnAutoReply(
 
     return {
       approved: false,
-      reasoning: `Could not parse reflection: ${raw.slice(0, 100)}`,
+      reasoning: `Could not parse reflection: ${truncateWellFormed(toWellFormedUnicode(raw), 100)}`,
     };
   } catch (error) {
     logger.warn(


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` when surfacing unparseable raw model output in `reflectOnAutoReply` reasoning (`plugins/plugin-inbox/src/inbox/reflection.ts:188`) to prevent raw character slicing from splitting UTF-16 surrogate pairs into malformed lone surrogates when unparseable model completions exceed length limits.

## Changes

- In `plugins/plugin-inbox/src/inbox/reflection.ts:188`, replace `raw.slice(0, 100)` with `truncateWellFormed(toWellFormedUnicode(raw), 100)`.
- In `plugins/plugin-inbox/src/inbox/reflection.test.ts`, add unit test verifying that unparseable model completions containing emoji/astral unicode characters at the 100-character boundary are safely truncated without splitting surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`7867d8587a`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-inbox test src/inbox/reflection.test.ts` | N/A (new test file) | 1 pass (1 test) |
| `bunx @biomejs/biome check plugins/plugin-inbox/src/inbox/reflection.ts plugins/plugin-inbox/src/inbox/reflection.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-inbox/src/inbox/reflection.ts:180-195`
- `plugins/plugin-inbox/src/inbox/reflection.test.ts:1-30`

## Risks

Low. Preserves complete unicode code points up to the specified boundary.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Inbox reflection model validation)
- [x] `audit:browser` — N/A (Internal model output reasoning formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 1/1 pass in `reflection.test.ts`
- [x] `lint` — Biome clean
