### PR TITLE
test(app-core): cover tokens

### DIFF
--- a/packages/app-core/src/api/auth/tokens.test.ts
+++ b/packages/app-core/src/api/auth/tokens.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests the API-auth token helpers in `tokens.ts`: constant-time `tokenMatches`,
+ * multi-valued header normalisation in `extractHeaderValue`, and
+ * `getProvidedApiToken` source order (Bearer, then x-eliza-token,
+ * x-elizaos-token, x-api-key, x-api-token) including the 1024-char
+ * Authorization cap. Drives the real module — no crypto or header mocks.
+ */
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  extractHeaderValue,
+  getProvidedApiToken,
+  tokenMatches,
+} from "./tokens";
+
+/**
+ * Node types `IncomingHttpHeaders.authorization` as `string`, but duplicate
+ * headers arrive as `string[]` at runtime. The helpers under test accept that
+ * runtime bag; this wrapper is the test-side boundary.
+ */
+function incoming(
+  headers: Record<string, string | string[] | undefined>,
+): Pick<http.IncomingMessage, "headers"> {
+  return { headers: headers as http.IncomingHttpHeaders };
+}
+
+describe("tokenMatches", () => {
+  it("accepts identical strings, including empty and multi-byte UTF-8", () => {
+    expect(tokenMatches("secret-token", "secret-token")).toBe(true);
+    expect(tokenMatches("", "")).toBe(true);
+    expect(tokenMatches("🔐 café", "🔐 café")).toBe(true);
+  });
+
+  it("rejects same-length mismatches, including case", () => {
+    expect(tokenMatches("secret-token", "secret-t0ken")).toBe(false);
+    expect(tokenMatches("Token", "token")).toBe(false);
+  });
+
+  it("rejects length mismatches even when one string prefixes the other", () => {
+    expect(tokenMatches("secret", "secret1")).toBe(false);
+    expect(tokenMatches("secret1", "secret")).toBe(false);
+    expect(tokenMatches("", "x")).toBe(false);
+    expect(tokenMatches("x", "")).toBe(false);
+    expect(tokenMatches("ab", "ab\0")).toBe(false);
+  });
+
+  it("compares UTF-8 bytes, so NFC and NFD encodings of the same glyph differ", () => {
+    expect(tokenMatches("é", "\u00e9")).toBe(true);
+    expect(tokenMatches("é", "e\u0301")).toBe(false);
+  });
+});
+
+describe("extractHeaderValue", () => {
+  it("returns a present string as-is, including empty", () => {
+    expect(extractHeaderValue("Bearer abc")).toBe("Bearer abc");
+    expect(extractHeaderValue("")).toBe("");
+  });
+
+  it("returns the first string of a multi-valued header and ignores the rest", () => {
+    expect(extractHeaderValue(["first", "second"])).toBe("first");
+    expect(extractHeaderValue([""])).toBe("");
+  });
+
+  it("returns null when the header is absent, not an array of strings, or an empty array", () => {
+    expect(extractHeaderValue(undefined)).toBeNull();
+    expect(extractHeaderValue([])).toBeNull();
+    expect(extractHeaderValue([undefined as unknown as string])).toBeNull();
+  });
+});
+
+describe("getProvidedApiToken", () => {
+  it("reads a Bearer token from Authorization, case-insensitively, and trims it", () => {
+    expect(
+      getProvidedApiToken(incoming({ authorization: "Bearer   tok-value  " })),
+    ).toBe("tok-value");
+    expect(
+      getProvidedApiToken(incoming({ authorization: "bearer tok-value" })),
+    ).toBe("tok-value");
+    expect(
+      getProvidedApiToken(incoming({ authorization: "BEARER tok-value" })),
+    ).toBe("tok-value");
+  });
+
+  it("accepts one to eight separator whitespace chars after Bearer, including extras that trim off", () => {
+    expect(getProvidedApiToken(incoming({ authorization: "Bearer tok" }))).toBe(
+      "tok",
+    );
+    expect(
+      getProvidedApiToken(
+        incoming({ authorization: `Bearer${" ".repeat(8)}tok` }),
+      ),
+    ).toBe("tok");
+    // Observed: \s{1,8} consumes eight spaces; leftover spaces are captured and trimmed.
+    expect(
+      getProvidedApiToken(
+        incoming({ authorization: `Bearer${" ".repeat(9)}tok` }),
+      ),
+    ).toBe("tok");
+  });
+
+  it("does not treat a scheme without a token, or a non-Bearer scheme, as a provided token", () => {
+    expect(
+      getProvidedApiToken(incoming({ authorization: "Bearer" })),
+    ).toBeNull();
+    expect(
+      getProvidedApiToken(incoming({ authorization: "Basic abc" })),
+    ).toBeNull();
+    expect(
+      getProvidedApiToken(incoming({ authorization: "Bearertok" })),
+    ).toBeNull();
+  });
+
+  it("caps Authorization at 1024 characters before parsing Bearer", () => {
+    const token = "a".repeat(2000);
+    const authorization = `Bearer ${token}`;
+    const truncated = authorization.slice(0, 1024);
+    expect(getProvidedApiToken(incoming({ authorization }))).toBe(
+      truncated.slice("Bearer ".length),
+    );
+    expect(getProvidedApiToken(incoming({ authorization }))?.length).toBe(
+      1024 - "Bearer ".length,
+    );
+  });
+
+  it("prefers a valid Bearer token over the x-eliza-* / x-api-* headers", () => {
+    expect(
+      getProvidedApiToken(
+        incoming({
+          authorization: "Bearer from-bearer",
+          "x-eliza-token": "from-eliza",
+          "x-elizaos-token": "from-elizaos",
+          "x-api-key": "from-key",
+          "x-api-token": "from-api-token",
+        }),
+      ),
+    ).toBe("from-bearer");
+  });
+
+  it("walks x-eliza-token, then x-elizaos-token, then x-api-key, then x-api-token", () => {
+    expect(
+      getProvidedApiToken(
+        incoming({
+          "x-eliza-token": "from-eliza",
+          "x-elizaos-token": "from-elizaos",
+          "x-api-key": "from-key",
+          "x-api-token": "from-api-token",
+        }),
+      ),
+    ).toBe("from-eliza");
+    expect(
+      getProvidedApiToken(
+        incoming({
+          "x-elizaos-token": "from-elizaos",
+          "x-api-key": "from-key",
+          "x-api-token": "from-api-token",
+        }),
+      ),
+    ).toBe("from-elizaos");
+    expect(
+      getProvidedApiToken(
+        incoming({
+          "x-api-key": "from-key",
+          "x-api-token": "from-api-token",
+        }),
+      ),
+    ).toBe("from-key");
+    expect(
+      getProvidedApiToken(incoming({ "x-api-token": "from-api-token" })),
+    ).toBe("from-api-token");
+  });
+
+  it("falls through to later headers when Bearer is present but not a usable token", () => {
+    expect(
+      getProvidedApiToken(
+        incoming({
+          authorization: "Basic abc",
+          "x-eliza-token": "from-eliza",
+        }),
+      ),
+    ).toBe("from-eliza");
+  });
+
+  it("trims fallback header tokens; a present empty/whitespace value does not fall through", () => {
+    expect(
+      getProvidedApiToken(incoming({ "x-eliza-token": "  padded  " })),
+    ).toBe("padded");
+    // Observed: ?? only skips null/undefined. A present blank string wins, then trim → null.
+    expect(
+      getProvidedApiToken(
+        incoming({
+          "x-eliza-token": "   ",
+          "x-api-key": "from-key",
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      getProvidedApiToken(
+        incoming({ "x-eliza-token": "", "x-api-key": "from-key" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("continues the fallback chain when an earlier header is absent or an empty array", () => {
+    expect(
+      getProvidedApiToken(
+        incoming({
+          "x-eliza-token": [],
+          "x-api-key": "from-key",
+        }),
+      ),
+    ).toBe("from-key");
+  });
+
+  it("reads the first value when Authorization or fallback headers are arrays", () => {
+    expect(
+      getProvidedApiToken(
+        incoming({
+          authorization: ["Bearer array-bearer", "Bearer other"],
+        }),
+      ),
+    ).toBe("array-bearer");
+    expect(
+      getProvidedApiToken(
+        incoming({ "x-api-key": ["array-key", "other-key"] }),
+      ),
+    ).toBe("array-key");
+  });
+
+  it("returns null when no recognized header supplies a token", () => {
+    expect(getProvidedApiToken(incoming({}))).toBeNull();
+    expect(
+      getProvidedApiToken(incoming({ "x-other-token": "ignored" })),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION

# Relates to

No existing issue. `packages/app-core/src/api/auth/tokens.ts` had no same-named test file; this PR adds one colocated vitest suite.

- [x] This PR targets `develop` and is based on current `origin/develop` (`24070f99bf211d3498c12da4ae4109066723d9fd`) with a single test-only commit.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only PR (scoped vitest + biome + package tsc grep instead). Hosted CI does **not** run on this fork contributor PR; do not treat missing checks as a pass.
- [x] A reviewer can confirm the change from the commands and counts below without reading production code: this diff adds tests only.

# Sync with develop

- [x] Branch parent is `origin/develop` `24070f99bf211d3498c12da4ae4109066723d9fd`; `git diff --stat origin/develop...HEAD` is one file.
- [ ] `bun run verify` not run; see Known gaps.

# Risks

Low. Test-only addition. No production source, exports, or auth behaviour change. The suite records observed helper behaviour (including that a present blank `x-eliza-token` does **not** fall through `??` to later headers).

# Background

## What does this PR do?

Adds `packages/app-core/src/api/auth/tokens.test.ts`, a real vitest suite that imports `tokenMatches`, `extractHeaderValue`, and `getProvidedApiToken` from `./tokens` and drives those functions directly (Node `crypto.timingSafeEqual` included — no mocks).

Covered behaviour:

- `tokenMatches`: equal strings (empty and multi-byte UTF-8), same-length mismatch and case, length mismatch including prefix/`\0` pad, NFC vs NFD byte inequality
- `extractHeaderValue`: present string (including empty), first element of a multi-valued header, absent / empty-array / non-string first element → `null`
- `getProvidedApiToken`: Bearer (case, trim, 1–8 whitespace, leftover spaces after `{1,8}` trimmed), non-Bearer / missing token, 1024-character Authorization cap, source order Bearer → `x-eliza-token` → `x-elizaos-token` → `x-api-key` → `x-api-token`, fall-through only when Bearer is unusable, present blank fallback does not `??`-skip, empty-array earlier header does skip, array headers take the first value, unknown headers → `null`

## What kind of change is this?

Improvements (tests for existing auth token helpers). No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/auth/tokens.test.ts` next to `tokens.ts`.

## Detailed testing steps

From repo root, against the parent `origin/develop` (tokens.ts unchanged on that SHA):

```bash
bunx vitest run packages/app-core/src/api/auth/tokens.test.ts --config packages/app-core/vitest.config.ts
```

Observed (re-run after fetch of current `origin/develop` `24070f99bf211d3498c12da4ae4109066723d9fd`):

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  2.18s
```

```bash
bunx biome check packages/app-core/src/api/auth/tokens.test.ts
```

Observed: `Checked 1 file in 15ms. No fixes applied.` (`biome.json` is present; this checkout is not sparse.)

```bash
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'tokens.test.ts' ; echo "GREP_EXIT:$?"
```

Observed: no output from grep; `GREP_EXIT:1` (this file introduces no tsc diagnostic). Pre-existing errors elsewhere in the package are unchanged and not part of this diff.

Diff touches only `packages/app-core/src/api/auth/tokens.test.ts`.

# Evidence Gate

evidence-head: b462b92c136bda3ecf681ec732c8b260e18a13d2

Test-only, no UI, no backend route, no agent/prompt change. Hosted CI does not run on this fork PR.

- [x] Before screenshots: N/A - test-only, no rendered UI surface
- [x] After screenshots: N/A - test-only, no rendered UI surface
- [x] Walkthrough video: N/A - test-only, no user flow
- [x] Backend logs: N/A - no production path change; vitest output quoted above
- [x] Frontend logs: N/A - no frontend change
- [x] LLM trajectory: N/A - no agent/action/provider/prompt/model change
- [x] Domain artifacts: N/A - pure unit tests of token helpers
- [x] OCR review: N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only. Vitest: 1 file passed, 18 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Did not run full `bun run verify` (test-only scoped gates: vitest, biome, tsc grep).
- Hosted GitHub Actions CI does not run on this fork contributor PR; missing checks are not a pass.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b462b92c136bda3ecf681ec732c8b260e18a13d2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
