### PR TITLE
fix(app-core): use surrogate-safe truncateWellFormed on SIWE verify error message

### DIFF
--- a/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
@@ -155,11 +155,23 @@ describe("auth dev-login (SIWE wallet)", () => {
       fetchImpl: mock,
     });
     expect(result.ok).toBe(false);
-    expect(result.message).toContain("SIWE verify failed (400): ");
-    expect(result.message?.includes("😀")).toBe(false);
-    expect(result.message?.length).toBeLessThanOrEqual(
-      "SIWE verify failed (400): ".length + 160,
-    );
+    const message = result.message ?? "";
+    // The raw body cuts mid-surrogate-pair at unit 160: units 0-158 are "a",
+    // unit 159 is the high surrogate of 😀 and unit 160 its low surrogate, so a
+    // plain slice(0, 160) ends in an unpaired high surrogate.
+    expect(message).toBe(message.toWellFormed());
+    for (let i = 0; i < message.length; i += 1) {
+      const unit = message.charCodeAt(i);
+      if (unit >= 0xd800 && unit <= 0xdbff) {
+        const next = i + 1 < message.length ? message.charCodeAt(i + 1) : -1;
+        expect(next).toBeGreaterThanOrEqual(0xdc00);
+        expect(next).toBeLessThanOrEqual(0xdfff);
+        i += 1;
+        continue;
+      }
+      expect(unit >= 0xdc00 && unit <= 0xdfff).toBe(false);
+    }
+    expect(message).toBe(`SIWE verify failed (400): ${"a".repeat(159)}`);
   });
 
   it("a failed key persist is LOUD: warns, returns saveError, and prints manual-save instructions", async () => {

--- a/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
@@ -128,6 +128,40 @@ describe("auth dev-login (SIWE wallet)", () => {
     expect(result.message).toContain("verify failed (401)");
   });
 
+  it("truncates verify failure message with surrogate safety", async () => {
+    const longErr = `${"a".repeat(159)}😀${"b".repeat(20)}`;
+    const mock = (async (url: string | URL, _init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/nonce")) {
+        return new Response(
+          JSON.stringify({
+            nonce: "abc123nonce",
+            domain: "www.elizacloud.ai",
+            uri: "https://www.elizacloud.ai",
+            chainId: 1,
+            version: "1",
+            statement: "Sign in to Eliza Cloud",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(longErr, { status: 400 });
+    }) as unknown as typeof fetch;
+
+    const result = await runDevWalletLogin({
+      privateKey: FIXED_PK,
+      save: false,
+      log: () => {},
+      fetchImpl: mock,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("SIWE verify failed (400): ");
+    expect(result.message?.includes("😀")).toBe(false);
+    expect(result.message?.length).toBeLessThanOrEqual(
+      "SIWE verify failed (400): ".length + 160,
+    );
+  });
+
   it("a failed key persist is LOUD: warns, returns saveError, and prints manual-save instructions", async () => {
     const lines: string[] = [];
     const result = await runDevWalletLogin({

--- a/packages/app-core/src/cli/program/register.auth.ts
+++ b/packages/app-core/src/cli/program/register.auth.ts
@@ -21,6 +21,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   isLoopbackBindHost,
   readAliasedEnv,
@@ -458,7 +459,7 @@ export async function runDevWalletLogin(
     const txt = await verifyRes.text().catch(() => "");
     return {
       ok: false,
-      message: `SIWE verify failed (${verifyRes.status}): ${txt.slice(0, 160)}`,
+      message: `SIWE verify failed (${verifyRes.status}): ${truncateWellFormed(toWellFormedUnicode(txt), 160)}`,
     };
   }
   const verified = (await verifyRes.json()) as {


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` when surfacing failed Sign-In with Ethereum (SIWE) verification responses in `runDevWalletLogin` (`packages/app-core/src/cli/program/register.auth.ts:461`) to avoid raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when verification endpoint error texts exceed length limits.

## Changes

- In `packages/app-core/src/cli/program/register.auth.ts:461`, replace `txt.slice(0, 160)` with `truncateWellFormed(toWellFormedUnicode(txt), 160)`.
- In `packages/app-core/src/cli/program/register.auth.dev-login.test.ts`, add unit test verifying that error responses containing emoji/astral unicode characters at the 160-character cutoff boundary are safely truncated without producing lone surrogates.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`3365b2e2ed`) |
| --- | --- | --- |
| `bunx vitest run src/cli/program/register.auth.dev-login.test.ts` (in `packages/app-core`) | 4 pass (4 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check packages/app-core/src/cli/program/register.auth.ts packages/app-core/src/cli/program/register.auth.dev-login.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/cli/program/register.auth.ts:455-465`
- `packages/app-core/src/cli/program/register.auth.dev-login.test.ts:130-160`

## Risks

Low. Preserves complete unicode code points up to the specified boundary.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (App-core CLI auth error handling)
- [x] `audit:browser` — N/A (SIWE verification error response formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `register.auth.dev-login.test.ts`
- [x] `lint` — Biome clean
