### PR TITLE
test(app-core): cover automation-action-classifier

### DIFF
--- a/packages/app-core/src/api/automation-action-classifier.test.ts
+++ b/packages/app-core/src/api/automation-action-classifier.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests `classifyRuntimeActionNode`: a runtime action becomes an `"agent"`
+ * automation node only when it declares both `domain:agent-orchestration` and
+ * `capability:delegate`. Everything else, including missing or partial tags,
+ * stays in the `"action"` class. Drives the real helper through real
+ * `@elizaos/core` `hasActionTags` matching — no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { classifyRuntimeActionNode } from "./automation-action-classifier.ts";
+
+describe("classifyRuntimeActionNode", () => {
+  it("classifies an action that declares both required tags as agent", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["domain:agent-orchestration", "capability:delegate"],
+      }),
+    ).toBe("agent");
+  });
+
+  it("classifies the orchestrator TASKS tag set as agent", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: [
+          "domain:coding",
+          "domain:agent-orchestration",
+          "resource:agent-task",
+          "capability:delegate",
+        ],
+      }),
+    ).toBe("agent");
+  });
+
+  it("does not depend on required-tag order", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["capability:delegate", "domain:agent-orchestration"],
+      }),
+    ).toBe("agent");
+  });
+
+  it("matches required tags case-insensitively", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["Domain:Agent-Orchestration", "Capability:Delegate"],
+      }),
+    ).toBe("agent");
+  });
+
+  it("still classifies as agent when required tags are duplicated", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: [
+          "domain:agent-orchestration",
+          "domain:agent-orchestration",
+          "capability:delegate",
+          "capability:delegate",
+        ],
+      }),
+    ).toBe("agent");
+  });
+
+  it("keeps an action with only the orchestration domain tag in the action class", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["domain:agent-orchestration"],
+      }),
+    ).toBe("action");
+  });
+
+  it("keeps an action with only the delegate capability tag in the action class", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["capability:delegate"],
+      }),
+    ).toBe("action");
+  });
+
+  it("keeps an empty tag list in the action class", () => {
+    expect(classifyRuntimeActionNode({ tags: [] })).toBe("action");
+  });
+
+  it("treats a missing tags field as an empty list and returns action", () => {
+    expect(classifyRuntimeActionNode({})).toBe("action");
+  });
+
+  it("keeps unrelated tags in the action class", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["domain:settings", "capability:write"],
+      }),
+    ).toBe("action");
+  });
+
+  it("does not treat prefix or substring lookalikes as the required tags", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["domain:agent-orchestration-extra", "capability:delegate-extra"],
+      }),
+    ).toBe("action");
+    expect(
+      classifyRuntimeActionNode({
+        tags: ["domain:agent-orchestrator", "capability:delegated"],
+      }),
+    ).toBe("action");
+  });
+
+  it("does not match required tags padded with whitespace", () => {
+    expect(
+      classifyRuntimeActionNode({
+        tags: [" domain:agent-orchestration", "capability:delegate "],
+      }),
+    ).toBe("action");
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated Vitest suite for `classifyRuntimeActionNode` at
`packages/app-core/src/api/automation-action-classifier.test.ts`.

The helper has one exported function and a two-way tag match: both
`domain:agent-orchestration` and `capability:delegate` map to `"agent"`;
everything else maps to `"action"`. The suite drives the real module
through real `@elizaos/core` `hasActionTags` matching (no mocks) and pins:

- both required tags, including the live TASKS tag set
- required-tag order independence
- case-insensitive matching
- duplicated required tags
- orchestration-only and delegate-only tags
- empty tags, a missing `tags` field, and unrelated tags
- prefix/substring lookalikes and whitespace-padded tags

This is a test-only change. No production behaviour is modified.

Hosted CI does not run on this fork's pull requests. Local vitest, biome,
and tsc are the evidence.

## Evidence

1. `bunx vitest run packages/app-core/src/api/automation-action-classifier.test.ts`
   - Test Files  1 passed (1)
   - Tests  12 passed (12)
   Re-run against current `origin/develop` immediately before filing.

2. `bunx biome check --write packages/app-core/src/api/automation-action-classifier.test.ts`
   - Checked 1 file in 421ms. Fixed 1 file (one wrap). File left biome-clean.

3. `cd packages/app-core && bunx tsc --noEmit`
   - The new colocated test file does not appear in the output.

4. The diff touches only
   `packages/app-core/src/api/automation-action-classifier.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1bc05140ca5fdd38a07725e12bc351f07f4c2968 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
