### PR TITLE
fix(agent): use surrogate-safe truncateWellFormed on health routes debug preview

### DIFF
--- a/packages/agent/src/api/health-routes.debug-surrogate.test.ts
+++ b/packages/agent/src/api/health-routes.debug-surrogate.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { serializeForRuntimeDebug } from "./health-routes.ts";
+
+describe("serializeForRuntimeDebug surrogate safety", () => {
+  it("truncates long strings at unicode code point boundaries without lone surrogates", () => {
+    const longString = `${"a".repeat(17)}😀${"b".repeat(10)}`;
+    const result = serializeForRuntimeDebug(longString, {
+      maxDepth: 4,
+      maxArrayLength: 20,
+      maxObjectKeys: 20,
+      maxStringLength: 20,
+    }) as {
+      __type: string;
+      length: number;
+      preview: string;
+      truncated: boolean;
+    };
+
+    expect(result.__type).toBe("string");
+    expect(result.truncated).toBe(true);
+    expect(result.preview.endsWith("...")).toBe(true);
+    expect(result.preview.includes("😀")).toBe(false);
+  });
+});

--- a/packages/agent/src/api/health-routes.debug-surrogate.test.ts
+++ b/packages/agent/src/api/health-routes.debug-surrogate.test.ts
@@ -3,7 +3,11 @@ import { serializeForRuntimeDebug } from "./health-routes.ts";
 
 describe("serializeForRuntimeDebug surrogate safety", () => {
   it("truncates long strings at unicode code point boundaries without lone surrogates", () => {
-    const longString = `${"a".repeat(17)}😀${"b".repeat(10)}`;
+    // 16 leading "a" puts the old slice(0, maxStringLength - 3) boundary at index
+    // 17, i.e. between the two code units of the astral char. With 17 the cut
+    // landed cleanly before it, so the old code produced no lone surrogate and
+    // this test passed against unfixed code.
+    const longString = `${"a".repeat(16)}😀${"b".repeat(10)}`;
     const result = serializeForRuntimeDebug(longString, {
       maxDepth: 4,
       maxArrayLength: 20,
@@ -20,5 +24,8 @@ describe("serializeForRuntimeDebug surrogate safety", () => {
     expect(result.truncated).toBe(true);
     expect(result.preview.endsWith("...")).toBe(true);
     expect(result.preview.includes("😀")).toBe(false);
+    // The real invariant: truncation must not leave an unpaired surrogate.
+    expect(result.preview).toBe(result.preview.toWellFormed());
+    expect(/[\uD800-\uDFFF]/.test(result.preview.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ""))).toBe(false);
   });
 });

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -18,6 +18,8 @@ import type { AgentRuntime } from "@elizaos/core";
 import {
   getSwarmCoordinatorService,
   hasTextGenerationHandler,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 // Pure env detector lives in shared so status can report managed hosting mode
 // without loading the full cloud plugin graph (which may fail in lean test
@@ -226,7 +228,7 @@ function describeRuntimeServiceOrder(
   );
 }
 
-function serializeForRuntimeDebug(
+export function serializeForRuntimeDebug(
   value: unknown,
   options: RuntimeDebugSerializeOptions,
 ): unknown {
@@ -242,7 +244,7 @@ function serializeForRuntimeDebug(
       return {
         __type: "string",
         length: (current as string).length,
-        preview: `${(current as string).slice(0, options.maxStringLength - 3)}...`,
+        preview: `${truncateWellFormed(toWellFormedUnicode(current as string), Math.max(0, options.maxStringLength - 3))}...`,
         truncated: true,
       };
     }


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` when generating string debug previews in `serializeForRuntimeDebug` (`packages/agent/src/api/health-routes.ts:245`) to prevent raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when inspecting runtime values exceeding `options.maxStringLength`.

## Changes

- In `packages/agent/src/api/health-routes.ts:245`, replace `(current as string).slice(0, options.maxStringLength - 3)` with `truncateWellFormed(toWellFormedUnicode(current as string), Math.max(0, options.maxStringLength - 3))`.
- In `packages/agent/src/api/health-routes.debug-surrogate.test.ts`, add unit test verifying that string debug values containing astral/surrogate characters at the length cutoff boundary are safely truncated without lone surrogate corruption.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`47ff473b8d`) |
| --- | --- | --- |
| `bunx vitest run src/api/health-routes.debug-surrogate.test.ts` (in `packages/agent`) | N/A (new test file) | 1 pass (1 test) |
| `bunx @biomejs/biome check packages/agent/src/api/health-routes.ts packages/agent/src/api/health-routes.debug-surrogate.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/api/health-routes.ts:240-250`
- `packages/agent/src/api/health-routes.debug-surrogate.test.ts:1-25`

## Risks

Low. Preserves complete unicode code points up to the specified boundary.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent health routes debug serialization)
- [x] `audit:browser` — N/A (Runtime debug serialization preview formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 1/1 pass in `health-routes.debug-surrogate.test.ts`
- [x] `lint` — Biome clean
