### PR TITLE
fix(agent): safe NaN handling in registry-client listApps and listNonAppPlugins stars sort comparators

### DIFF
--- a/packages/agent/src/services/registry-client.test.ts
+++ b/packages/agent/src/services/registry-client.test.ts
@@ -727,4 +727,38 @@ describe("listNonAppPlugins and searchNonAppPlugins", () => {
     );
     expect(await searchNonAppPlugins("search", 0)).toEqual([]);
   });
+
+  it("sorts apps and non-app plugins deterministically when stars contains NaN or non-finite numbers", async () => {
+    const app1 = appPlugin("app-nan", NaN as unknown as number, {
+      displayName: "App NaN",
+    });
+    const app2 = appPlugin("app-high", 50, { displayName: "App High" });
+    const app3 = appPlugin("app-low", 10, { displayName: "App Low" });
+
+    const plug1 = plugin({ name: "plug-nan", stars: NaN });
+    const plug2 = plugin({ name: "plug-high", stars: 100 });
+    const plug3 = plugin({ name: "plug-low", stars: 5 });
+
+    fetchImpl = async () =>
+      new Map([
+        [app1.name, app1],
+        [app2.name, app2],
+        [app3.name, app3],
+        [plug1.name, plug1],
+        [plug2.name, plug2],
+        [plug3.name, plug3],
+      ]);
+
+    const { listApps, listNonAppPlugins } = await loadModule();
+
+    const apps = await listApps();
+    expect(apps.map((a) => a.name)).toEqual(["app-high", "app-low", "app-nan"]);
+
+    const plugins = await listNonAppPlugins();
+    expect(plugins.map((p) => p.name)).toEqual([
+      "plug-high",
+      "plug-low",
+      "plug-nan",
+    ]);
+  });
 });

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -443,7 +443,13 @@ export async function listApps(): Promise<RegistryAppInfo[]> {
     apps.push(toAppInfo(appEntry, sanitizeSandbox, LOCAL_APP_DEFAULT_SANDBOX));
   }
 
-  apps.sort((a, b) => b.stars - a.stars);
+  apps.sort((a, b) => {
+    const bStars =
+      typeof b.stars === "number" && Number.isFinite(b.stars) ? b.stars : 0;
+    const aStars =
+      typeof a.stars === "number" && Number.isFinite(a.stars) ? a.stars : 0;
+    return bStars - aStars;
+  });
   return apps;
 }
 
@@ -494,7 +500,13 @@ export async function listNonAppPlugins(): Promise<RegistryPluginListItem[]> {
     }
   }
 
-  plugins.sort((a, b) => b.stars - a.stars);
+  plugins.sort((a, b) => {
+    const bStars =
+      typeof b.stars === "number" && Number.isFinite(b.stars) ? b.stars : 0;
+    const aStars =
+      typeof a.stars === "number" && Number.isFinite(a.stars) ? a.stars : 0;
+    return bStars - aStars;
+  });
   return plugins;
 }
 


### PR DESCRIPTION
## Summary

Guards numerical star comparisons in `listApps` and `listNonAppPlugins` (`packages/agent/src/services/registry-client.ts:446, 497`) with `Number.isFinite(...)` and fallback to `0` to prevent `NaN` star counts from breaking sort transitivity and producing non-deterministic registry app and plugin listings.

## Changes

- In `packages/agent/src/services/registry-client.ts:446` and `497`, replace `b.stars - a.stars` with `Number.isFinite(...)` guarded comparisons defaulting non-finite values to `0`.
- In `packages/agent/src/services/registry-client.test.ts`, add unit test verifying that `listApps` and `listNonAppPlugins` deterministically sort items even when entries carry `NaN` or non-finite `stars`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`10b5d6c7da`) |
| --- | --- | --- |
| `bunx vitest run src/services/registry-client.test.ts` (in `packages/agent`) | 37 pass (37 tests) | 38 pass (38 tests) |
| `bunx @biomejs/biome check packages/agent/src/services/registry-client.ts packages/agent/src/services/registry-client.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/services/registry-client.ts:440-505`
- `packages/agent/src/services/registry-client.test.ts:725-760`

## Risks

Low. Ensures finite numerical comparisons and stable sort order.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent registry service star sorting)
- [x] `audit:browser` — N/A (Registry API listing order)
- [x] `build` — Clean build across workspace
- [x] `test` — 38/38 pass in `registry-client.test.ts`
- [x] `lint` — Biome clean
