### PR TITLE
test(cloud): cover post-settlement webhook replay

### DIFF
--- a/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
+++ b/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
@@ -152,37 +152,56 @@ test("lost provider response and duplicate webhook settle exactly once", async (
     status: "complete",
   });
   expect(completedSession.payment_intent).toBeTruthy();
-  const timestamp = Math.floor(Date.now() / 1_000);
   const eventId = "evt_cloud_e2e_checkout_completed_0001";
-  const rawEvent = JSON.stringify({
-    id: eventId,
-    object: "event",
-    api_version: "2024-11-20.acacia",
-    created: timestamp,
-    data: { object: completedSession },
-    livemode: false,
-    pending_webhooks: 1,
-    request: { id: null, idempotency_key: null },
-    type: "checkout.session.completed",
-  });
-  const signature = createHmac("sha256", WEBHOOK_SECRET)
-    .update(`${timestamp}.${rawEvent}`)
-    .digest("hex");
-  const deliverWebhook = () =>
+  const signWebhook = (signedEventId: string) => {
+    const timestamp = Math.floor(Date.now() / 1_000);
+    const rawEvent = JSON.stringify({
+      id: signedEventId,
+      object: "event",
+      api_version: "2024-11-20.acacia",
+      created: timestamp,
+      data: { object: completedSession },
+      livemode: false,
+      pending_webhooks: 1,
+      request: { id: null, idempotency_key: null },
+      type: "checkout.session.completed",
+    });
+    return {
+      eventId: signedEventId,
+      rawEvent,
+      signature: createHmac("sha256", WEBHOOK_SECRET)
+        .update(`${timestamp}.${rawEvent}`)
+        .digest("hex"),
+      timestamp,
+    };
+  };
+  const deliverWebhook = (signedEvent: ReturnType<typeof signWebhook>) =>
     fetch(`${stack.urls.api}${WEBHOOK_PATH}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "Stripe-Signature": `t=${timestamp},v1=${signature}`,
+        "Stripe-Signature": `t=${signedEvent.timestamp},v1=${signedEvent.signature}`,
       },
-      body: rawEvent,
+      body: signedEvent.rawEvent,
     });
+  const drainStripeQueue = async () => {
+    const response = await fetch(
+      `${stack.urls.api}/api/cron/process-stripe-queue`,
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer test-cron-secret" },
+      },
+    );
+    expect(response.status).toBe(200);
+    return (await response.json()) as Record<string, unknown>;
+  };
 
-  const firstWebhook = await deliverWebhook();
+  const originalSignedEvent = signWebhook(eventId);
+  const firstWebhook = await deliverWebhook(originalSignedEvent);
   expect(firstWebhook.status).toBe(200);
   expect(await firstWebhook.json()).toEqual({ received: true, queued: true });
 
-  const duplicateWebhook = await deliverWebhook();
+  const duplicateWebhook = await deliverWebhook(originalSignedEvent);
   expect(duplicateWebhook.status).toBe(200);
   expect(await duplicateWebhook.json()).toEqual({
     received: true,
@@ -194,15 +213,7 @@ test("lost provider response and duplicate webhook settle exactly once", async (
     event_type: "checkout.session.completed",
   });
 
-  const drainResponse = await fetch(
-    `${stack.urls.api}/api/cron/process-stripe-queue`,
-    {
-      method: "POST",
-      headers: { Authorization: "Bearer test-cron-secret" },
-    },
-  );
-  expect(drainResponse.status).toBe(200);
-  const drain = (await drainResponse.json()) as Record<string, unknown>;
+  const drain = await drainStripeQueue();
   expect(drain).toMatchObject({
     success: true,
     queue: "stripe-events",
@@ -216,14 +227,19 @@ test("lost provider response and duplicate webhook settle exactly once", async (
   });
 
   const settledOrder = await stripeCheckoutOrdersService.get(checkoutOrderId);
+  expect(
+    settledOrder,
+    "Checkout order must exist after settlement",
+  ).toBeDefined();
+  if (!settledOrder) throw new Error("settled Checkout order was not found");
   expect(settledOrder).toMatchObject({
     status: "settled",
     stripe_customer_id: session.customer,
     stripe_checkout_session_id: session.id,
     stripe_payment_intent_id: completedSession.payment_intent,
   });
-  expect(settledOrder?.credit_transaction_id).toBeTruthy();
-  expect(settledOrder?.settled_at).toBeInstanceOf(Date);
+  expect(settledOrder.credit_transaction_id).toBeTruthy();
+  expect(settledOrder.settled_at).toBeInstanceOf(Date);
 
   const matchingTransactions = (
     await creditsService.listTransactionsByOrganization(
@@ -236,7 +252,7 @@ test("lost provider response and duplicate webhook settle exactly once", async (
   );
   expect(matchingTransactions).toHaveLength(1);
   expect(matchingTransactions[0]).toMatchObject({
-    id: settledOrder?.credit_transaction_id,
+    id: settledOrder.credit_transaction_id,
     organization_id: seededUser.organizationId,
     amount: "5.000000",
     type: "credit",
@@ -257,4 +273,109 @@ test("lost provider response and duplicate webhook settle exactly once", async (
   expect(
     await creditsService.getOrganizationBalanceUsd(seededUser.organizationId),
   ).toBe(startingBalance + 5);
+
+  const settlementIdentity = {
+    orderId: settledOrder.id,
+    checkoutSessionId: settledOrder.stripe_checkout_session_id,
+    paymentIntentId: settledOrder.stripe_payment_intent_id,
+    creditTransactionId: settledOrder.credit_transaction_id,
+    settledAt: settledOrder.settled_at?.toISOString(),
+    transactionId: matchingTransactions[0]?.id,
+    invoiceId: matchingInvoices[0]?.id,
+  };
+  expect(settlementIdentity).toMatchObject({
+    orderId: checkoutOrderId,
+    checkoutSessionId: session.id,
+    paymentIntentId: completedSession.payment_intent,
+    creditTransactionId: expect.any(String),
+    settledAt: expect.any(String),
+    transactionId: expect.any(String),
+    invoiceId: expect.any(String),
+  });
+
+  // Stripe retries the exact already-settled event: durable event-id dedupe
+  // acknowledges it without enqueueing any second consumer delivery.
+  const postSettlementExactReplay = await deliverWebhook(originalSignedEvent);
+  expect(postSettlementExactReplay.status).toBe(200);
+  expect(await postSettlementExactReplay.json()).toEqual({
+    received: true,
+    duplicate: true,
+  });
+  expect(await drainStripeQueue()).toEqual({
+    success: true,
+    queue: "stripe-events",
+    before: 0,
+    after: 0,
+    attempted: 0,
+    acked: 0,
+    retried: 0,
+    dlqed: 0,
+    failed: 0,
+  });
+
+  // A distinct Stripe event id can legitimately carry the same Session and
+  // PaymentIntent. It must enter the queue, then hit settlement-level dedupe.
+  const replayEventId = "evt_cloud_e2e_checkout_completed_0002";
+  const newSignedEvent = signWebhook(replayEventId);
+  expect(newSignedEvent.signature).not.toBe(originalSignedEvent.signature);
+  const newEventReplay = await deliverWebhook(newSignedEvent);
+  expect(newEventReplay.status).toBe(200);
+  expect(await newEventReplay.json()).toEqual({ received: true, queued: true });
+  expect(
+    await webhookEventsRepository.findByEventId(replayEventId),
+  ).toMatchObject({
+    event_id: replayEventId,
+    provider: "stripe",
+    event_type: "checkout.session.completed",
+  });
+  expect(await drainStripeQueue()).toEqual({
+    success: true,
+    queue: "stripe-events",
+    before: 1,
+    after: 0,
+    attempted: 1,
+    acked: 1,
+    retried: 0,
+    dlqed: 0,
+    failed: 0,
+  });
+
+  const replayedOrder = await stripeCheckoutOrdersService.get(checkoutOrderId);
+  expect(replayedOrder).toMatchObject({
+    id: settlementIdentity.orderId,
+    status: "settled",
+    stripe_checkout_session_id: settlementIdentity.checkoutSessionId,
+    stripe_payment_intent_id: settlementIdentity.paymentIntentId,
+    credit_transaction_id: settlementIdentity.creditTransactionId,
+  });
+  expect(replayedOrder?.settled_at).toBeInstanceOf(Date);
+  expect(replayedOrder?.settled_at?.toISOString()).toBe(
+    settlementIdentity.settledAt,
+  );
+
+  const transactionsAfterReplay = (
+    await creditsService.listTransactionsByOrganization(
+      seededUser.organizationId,
+      100,
+    )
+  ).filter(
+    (transaction) =>
+      transaction.stripe_payment_intent_id === completedSession.payment_intent,
+  );
+  expect(transactionsAfterReplay).toHaveLength(1);
+  expect(transactionsAfterReplay[0]?.id).toBe(settlementIdentity.transactionId);
+
+  const invoicesAfterReplay = (
+    await invoicesService.listByOrganization(seededUser.organizationId)
+  ).filter((invoice) => invoice.stripe_invoice_id === `cs_${session.id}`);
+  expect(invoicesAfterReplay).toHaveLength(1);
+  expect(invoicesAfterReplay[0]?.id).toBe(settlementIdentity.invoiceId);
+
+  expect(
+    await creditsService.getOrganizationBalanceUsd(seededUser.organizationId),
+  ).toBe(startingBalance + 5);
+  expect(fakeStripe.state.sessions.size).toBe(1);
+  expect(fakeStripe.state.sessions.get(session.id)?.id).toBe(session.id);
+  expect(fakeStripe.state.effects).toHaveLength(1);
+  expect(fakeStripe.state.counters.checkoutSessionsCreated).toBe(1);
 });


### PR DESCRIPTION
## Summary

- extend the real Cloud E2E payment replay path through the Worker webhook route, Stripe queue drain, and PGlite ledger
- prove an exact post-settlement event replay is acknowledged as a duplicate without a second queue delivery
- prove a new Stripe event id for the same Checkout Session and PaymentIntent is queued and acknowledged without duplicating the order, credit transaction, invoice, balance mutation, provider session, or provider effect

Relates to #22965. This does not close the umbrella issue.

## Scope and risk

- test-only change: `packages/cloud/e2e/tests/billing-payment-replay.spec.ts`
- base: `7ec2bd190bbffd5d10db0733fa0927a72b3e0833`
- head: `9b6c542dec68945ac7544c96b0720a79d6b2d964`
- risk: low; no runtime or production configuration changes

## Validation

- `mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e test -- billing-payment-replay.spec.ts --repeat-each=5` — PASS (5/5)
- `mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e typecheck` — PASS
- `mise exec node@24.15.0 -- bunx biome check packages/cloud/e2e/tests/billing-payment-replay.spec.ts` — PASS
- `git diff --check 7ec2bd190bbffd5d10db0733fa0927a72b3e0833...HEAD` — PASS
- exact-head JSON reporter run — PASS (1/1); SHA-256 `6122dde650bbd340e20638726d3d69fcf42b4acee740f6175cfa295928db5918`
- independent review — no P0–P3 findings

`mise exec node@24.15.0 -- bun run verify` reaches the monorepo lint/typecheck fan-out, then fails on pre-existing Biome formatting in `packages/core/src/services/relationships-graph-builder.safe-sort.test.ts`. The entire `packages/core` tree is identical at base and head (`38ccff82e472e231c4bde2b7ec6cd7705f717b62`). The upstream `plugin-github` build that failed before the rebase now passes.

## Evidence notes

- backend flow: real local Worker endpoint, durable queue repository, cron drain endpoint, and PGlite-backed services; no browser request interception or direct settlement shortcut
- Stripe dependency: deterministic local fake Stripe server, not live Stripe
- concurrency boundary: sequential provider retries are covered; this test does not claim simultaneous-delivery race coverage
- screenshots / OCR / visual walkthrough: N/A (backend E2E test-only change)
- LLM evidence: N/A

<!-- evidence-head:9b6c542dec68945ac7544c96b0720a79d6b2d964 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only backend E2E change; no visual surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only backend E2E change; no visual surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - automated backend flow has no interactive UI walkthrough

<!-- evidence-row:backend-logs -->
- [x] [25833-22965-post-settlement-replay-9b6c542d.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25833-22965-post-settlement-replay-9b6c542d.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser-visible UI is changed by this backend E2E test

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM behavior or prompt path changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - assertions are contained in the unique Playwright backend report; no separate domain artifact is produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text changed


