### PR TITLE
fix(calendar): use setUTCFullYear for Date.UTC 0-99

### DIFF
--- a/plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts
+++ b/plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Behavioral regression for Date.UTC 0-99 — must use setUTCFullYear
+ * Calls real calendar primitives that previously used Date.UTC(y,m,d) directly.
+ */
+import { describe, it, expect } from "vitest";
+import { addDaysToLocalDate, getWeekdayForLocalDate } from "../internal/time";
+
+function createUTCDateViaSet(y: number, m: number, d: number): Date {
+  const dt = new Date(0);
+  dt.setUTCFullYear(y, m, d);
+  dt.setUTCHours(12, 0, 0, 0);
+  return dt;
+}
+
+describe("calendar Date.UTC 0-99 regression - real functions", () => {
+  it("addDaysToLocalDate year 0 stays 0 not 1900", () => {
+    const out = addDaysToLocalDate({ year: 0, month: 1, day: 1 }, 0);
+    expect(out.year).toBe(0);
+    expect(out.month).toBe(1);
+    expect(out.day).toBe(1);
+    // prove buggy Date.UTC would be 1900
+    expect(new Date(Date.UTC(0, 0, 1, 12, 0, 0)).getUTCFullYear()).not.toBe(0);
+    expect(createUTCDateViaSet(0, 0, 1).getUTCFullYear()).toBe(0);
+  });
+  it("addDaysToLocalDate year 99 stays 99 not 1999", () => {
+    const out = addDaysToLocalDate({ year: 99, month: 1, day: 1 }, 0);
+    expect(out.year).toBe(99);
+  });
+  it("addDaysToLocalDate year 5 delta 1 rolls correctly", () => {
+    const out = addDaysToLocalDate({ year: 5, month: 1, day: 1 }, 1);
+    expect(out.year).toBe(5);
+    expect(out.month).toBe(1);
+    expect(out.day).toBe(2);
+  });
+  it("getWeekdayForLocalDate year 99 matches setUTCFullYear weekday", () => {
+    const w = getWeekdayForLocalDate({ year: 99, month: 1, day: 1 });
+    const expected = createUTCDateViaSet(99, 0, 1).getUTCDay();
+    expect(w).toBe(expected);
+    // buggy Date.UTC would give 1999's weekday
+    const buggy = new Date(Date.UTC(99, 0, 1, 12, 0, 0)).getUTCDay();
+    expect(buggy).not.toBe(expected); // prove divergence, unless same weekday by coincidence (check year 5)
+  });
+  it("year 5 weekday divergence", () => {
+    const w = getWeekdayForLocalDate({ year: 5, month: 6, day: 15 });
+    const expected = createUTCDateViaSet(5, 5, 15).getUTCDay();
+    expect(w).toBe(expected);
+    const buggy = new Date(Date.UTC(5, 5, 15, 12, 0, 0)).getUTCDay();
+    // For year 5 vs 1905, weekdays differ (1905-06-15 Thursday vs 0005-06-15 ...)
+    // At least year is different, so we assert year fix, not just weekday coincidence
+    expect(createUTCDateViaSet(5, 5, 15).getUTCFullYear()).toBe(5);
+  });
+  it("Date.UTC bug proof: 5 -> 1905 vs setUTCFullYear -> 5", () => {
+    expect(new Date(Date.UTC(5, 0, 1)).getUTCFullYear()).toBe(1905);
+    expect(createUTCDateViaSet(5, 0, 1).getUTCFullYear()).toBe(5);
+  });
+});

--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -92,14 +92,10 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
 }
 
 function localPartsToEpochMs(parts: ZonedDateParts): number {
-  return Date.UTC(
-    parts.year,
-    parts.month - 1,
-    parts.day,
-    parts.hour,
-    parts.minute,
-    parts.second,
-  );
+  const d = new Date(0);
+  d.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  d.setUTCHours(parts.hour, parts.minute, parts.second, 0);
+  return d.getTime();
 }
 
 function sameZonedParts(left: ZonedDateParts, right: ZonedDateParts): boolean {
@@ -184,16 +180,9 @@ export function addDaysToLocalDate(
   dateOnly: Pick<ZonedDateParts, "year" | "month" | "day">,
   dayDelta: number,
 ): Pick<ZonedDateParts, "year" | "month" | "day"> {
-  const utcDate = new Date(
-    Date.UTC(
-      dateOnly.year,
-      dateOnly.month - 1,
-      dateOnly.day + dayDelta,
-      12,
-      0,
-      0,
-    ),
-  );
+  const utcDate = new Date(0);
+  utcDate.setUTCFullYear(dateOnly.year, dateOnly.month - 1, dateOnly.day + dayDelta);
+  utcDate.setUTCHours(12, 0, 0, 0);
   return {
     year: utcDate.getUTCFullYear(),
     month: utcDate.getUTCMonth() + 1,
@@ -204,9 +193,10 @@ export function addDaysToLocalDate(
 export function getWeekdayForLocalDate(
   dateOnly: Pick<ZonedDateParts, "year" | "month" | "day">,
 ): number {
-  return new Date(
-    Date.UTC(dateOnly.year, dateOnly.month - 1, dateOnly.day, 12, 0, 0),
-  ).getUTCDay();
+  const d = new Date(0);
+  d.setUTCFullYear(dateOnly.year, dateOnly.month - 1, dateOnly.day);
+  d.setUTCHours(12, 0, 0, 0);
+  return d.getUTCDay();
 }
 
 export function addMinutes(date: Date, minutes: number): Date {


### PR DESCRIPTION
Closes #25834

## Summary
Fix `Date.UTC` 0-99 bug in `plugins/plugin-calendar/src/internal/time.ts`. `Date.UTC(y,m,d)` re-maps years 0-99 to 1900-1999. Replace 3 sites (`localPartsToEpochMs`, `addDaysToLocalDate`, `getWeekdayForLocalDate`) with `setUTCFullYear` + `setUTCHours` pattern so year 0 stays 0, 5 stays 5, 99 stays 99. Adds behavioral regression `src/__tests__/regression-dateutc.test.ts` calling real functions.

## Exact-head evidence
Head: 40c075aacf9186395a50b6352f9cf3dea1e16ebd
Base: origin/develop@dde9e644a3a3fbae9df3941e141853c9904bb2ea
- `bun test plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts` — 6 pass (year 0/99/5, weekday divergence, Date.UTC bug proof)
- `bun test plugins/plugin-calendar/src/internal/time.test.ts` — 11 pass
- Before fix: 5 fail (1900,1999,1905)

## Definition of Done
- [x] Tests call real functions (`addDaysToLocalDate`, `getWeekdayForLocalDate`), not source-grep
- [x] `result.year` / weekday assertions, not `fs.readFileSync.toContain`
- [x] High-acceptance bug reproduced before fix (5 fail) and passes after
- [x] No duplicate PR (gh search prs --state open for same file/cause — none for calendar DateUTC)
- [x] Branch from origin/develop, not main

## Contribution provenance
AI provider/model: internal / verification
Client / agent tooling: Muse Code
Contribution skill revision: elizaOS/eliza@dde9e644a3a3fbae9df3941e141853c9904bb2ea:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [calendar-dateutc]
<!-- eliza-computer-attribution:v1 {"provider":"internal","model":"verification","client":"muse","skill_revision":"elizaOS/eliza@dde9e644a3a3fbae9df3941e141853c9904bb2ea:packages/skills/skills/contribute-to-eliza"} -->

Co-authored-by: internal-model <internal@example.com>
