### PR TITLE
fix(inmemorydb): safe NaN handling in adapter createdAt sort

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.safe-sort.test.ts
+++ b/plugins/plugin-inmemorydb/adapter.safe-sort.test.ts
@@ -1,26 +1,110 @@
-/** Safe NaN handling in inmemorydb adapter. */
-import { describe, expect, it } from "vitest";
-function sortByCreatedAt<T extends { createdAt?: number; id?: string }>(items: T[]): T[] {
-  return [...items].sort((a, b) => {
-    const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
-    const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
-    if (bSafe !== aSafe) return bSafe - aSafe;
-    return String(a.id ?? "").localeCompare(String(b.id ?? ""));
-  });
+/**
+ * Newest-first ordering of the ephemeral adapter's non-paginated memory reads
+ * when a stored row carries a non-finite `createdAt`.
+ *
+ * Drives the real `InMemoryDatabaseAdapter` over real `MemoryStorage`:
+ * `getMemoriesByRoomIds` and `getMemoriesByWorldId` must keep their
+ * `(createdAt DESC, id DESC)` contract instead of letting a `NaN` comparator
+ * result leave neighbouring rows in an engine-defined order.
+ */
+
+import type { Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const agentId = "10000000-0000-4000-8000-000000000001" as UUID;
+const entityId = "20000000-0000-4000-8000-000000000001" as UUID;
+const roomId = "30000000-0000-4000-8000-000000000001" as UUID;
+const worldId = "40000000-0000-4000-8000-000000000001" as UUID;
+
+const EARLY = "a1000000-0000-4000-8000-000000000001" as UUID;
+const BROKEN = "a2000000-0000-4000-8000-000000000002" as UUID;
+const LATE = "a3000000-0000-4000-8000-000000000003" as UUID;
+
+let adapter: InMemoryDatabaseAdapter;
+
+function memory(id: UUID, createdAt: number, text: string): Memory {
+  return {
+    id,
+    agentId,
+    entityId,
+    roomId,
+    worldId,
+    createdAt,
+    content: { text },
+  };
 }
-describe("inmemorydb safe sort", () => {
-  it("NaN as 0", () => {
-    const items = [{ id: "b", createdAt: NaN }, { id: "a", createdAt: NaN }, { id: "c", createdAt: 100 }];
-    const s = sortByCreatedAt(items);
-    expect(s[0].id).toBe("c");
-    expect(s[1].id).toBe("a");
+
+/**
+ * Insertion order is the order `getWhere` hands back, and it is chosen so the
+ * pre-fix comparator misorders the two finite rows: the `NaN` row sits between
+ * them, every comparison against it yields `NaN`, and the engine leaves the
+ * ascending run untouched instead of reversing it.
+ */
+async function seed(): Promise<void> {
+  await adapter.createMemories([
+    { memory: memory(EARLY, 100, "early"), tableName: "messages" },
+    {
+      memory: memory(BROKEN, Number.NaN as unknown as number, "broken"),
+      tableName: "messages",
+    },
+    { memory: memory(LATE, 200, "late"), tableName: "messages" },
+  ]);
+}
+
+beforeEach(async () => {
+  const storage = new MemoryStorage();
+  await storage.init();
+  adapter = new InMemoryDatabaseAdapter(storage, agentId);
+  await adapter.init();
+});
+
+describe("InMemoryDatabaseAdapter newest-first memory reads", () => {
+  it("getMemoriesByRoomIds keeps finite rows newest-first around a NaN createdAt", async () => {
+    await seed();
+    const results = await adapter.getMemoriesByRoomIds({
+      roomIds: [roomId],
+      tableName: "messages",
+    });
+    expect(results.map((m) => m.id)).toEqual([LATE, EARLY, BROKEN]);
   });
-  it("tiebreak", () => {
-    const items = [{ id: "z", createdAt: 1 }, { id: "a", createdAt: 1 }];
-    expect(sortByCreatedAt(items)[0].id).toBe("a");
+
+  it("getMemoriesByWorldId keeps finite rows newest-first around a NaN createdAt", async () => {
+    await seed();
+    const results = await adapter.getMemoriesByWorldId({
+      worldIds: [worldId],
+      tableName: "messages",
+    });
+    expect(results.map((m) => m.id)).toEqual([LATE, EARLY, BROKEN]);
   });
-  it("desc", () => {
-    const items = [{ id: "a", createdAt: 1 }, { id: "b", createdAt: 2 }];
-    expect(sortByCreatedAt(items)[0].id).toBe("b");
+
+  it("getMemoriesByRoomIds applies limit to the ordered result, not the raw insertion order", async () => {
+    await seed();
+    const results = await adapter.getMemoriesByRoomIds({
+      roomIds: [roomId],
+      tableName: "messages",
+      limit: 1,
+    });
+    expect(results.map((m) => m.id)).toEqual([LATE]);
+  });
+
+  it("breaks equal timestamps by descending id in both reads", async () => {
+    const lowId = "b1000000-0000-4000-8000-000000000001" as UUID;
+    const highId = "b2000000-0000-4000-8000-000000000002" as UUID;
+    await adapter.createMemories([
+      { memory: memory(lowId, 500, "low"), tableName: "messages" },
+      { memory: memory(highId, 500, "high"), tableName: "messages" },
+    ]);
+    const byRoom = await adapter.getMemoriesByRoomIds({
+      roomIds: [roomId],
+      tableName: "messages",
+    });
+    expect(byRoom.map((m) => m.id)).toEqual([highId, lowId]);
+    const byWorld = await adapter.getMemoriesByWorldId({
+      worldIds: [worldId],
+      tableName: "messages",
+    });
+    expect(byWorld.map((m) => m.id)).toEqual([highId, lowId]);
   });
 });

--- a/plugins/plugin-inmemorydb/adapter.safe-sort.test.ts
+++ b/plugins/plugin-inmemorydb/adapter.safe-sort.test.ts
@@ -1,0 +1,26 @@
+/** Safe NaN handling in inmemorydb adapter. */
+import { describe, expect, it } from "vitest";
+function sortByCreatedAt<T extends { createdAt?: number; id?: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
+    const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
+    if (bSafe !== aSafe) return bSafe - aSafe;
+    return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+  });
+}
+describe("inmemorydb safe sort", () => {
+  it("NaN as 0", () => {
+    const items = [{ id: "b", createdAt: NaN }, { id: "a", createdAt: NaN }, { id: "c", createdAt: 100 }];
+    const s = sortByCreatedAt(items);
+    expect(s[0].id).toBe("c");
+    expect(s[1].id).toBe("a");
+  });
+  it("tiebreak", () => {
+    const items = [{ id: "z", createdAt: 1 }, { id: "a", createdAt: 1 }];
+    expect(sortByCreatedAt(items)[0].id).toBe("a");
+  });
+  it("desc", () => {
+    const items = [{ id: "a", createdAt: 1 }, { id: "b", createdAt: 2 }];
+    expect(sortByCreatedAt(items)[0].id).toBe("b");
+  });
+});

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1126,7 +1126,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       }
       return true;
     });
-    memories.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    memories.sort((a, b) => {
+      const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
+      const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
+      if (bSafe !== aSafe) return bSafe - aSafe;
+      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+    });
     const offset = typeof params.offset === "number" ? params.offset : 0;
     let sliced = offset > 0 ? memories.slice(offset) : memories;
     if (params.limit !== undefined) sliced = sliced.slice(0, params.limit);
@@ -1397,7 +1402,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         (!worldSet || (m.worldId ? worldSet.has(m.worldId as UUID) : false)) &&
         (params.tableName ? storedMemoryTableName(m) === params.tableName : true)
     );
-    memories.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    memories.sort((a, b) => {
+      const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
+      const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
+      if (bSafe !== aSafe) return bSafe - aSafe;
+      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+    });
     const sliced = params.limit ? memories.slice(0, params.limit) : memories;
     return sliced.map(toMemory);
   }

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -365,6 +365,24 @@ function levenshtein(a: string, b: string): number {
 // Adapter
 // ────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Newest-first `(createdAt DESC, id DESC)` ordering, matching what the SQL
+ * adapters return for the unpaginated memory reads. A non-finite `createdAt`
+ * is normalised to `0` so the comparator never returns `NaN` — a `NaN` result
+ * makes `Array#sort` treat the pair as equal and leave surrounding runs in an
+ * engine-defined order, so one corrupted row silently reorders its neighbours.
+ * Ids break timestamp ties through the same case-insensitive comparison
+ * PostgreSQL applies.
+ */
+function compareStoredMemoriesNewestFirst(a: StoredMemory, b: StoredMemory): number {
+  const ta = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0;
+  const tb = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : 0;
+  if (ta !== tb) return tb - ta;
+  const aId = typeof a.id === "string" ? a.id : "";
+  const bId = typeof b.id === "string" ? b.id : "";
+  return compareMemoryIds(bId, aId);
+}
+
 export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
   private storage: IStorage;
@@ -1126,12 +1144,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       }
       return true;
     });
-    memories.sort((a, b) => {
-      const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
-      const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
-      if (bSafe !== aSafe) return bSafe - aSafe;
-      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
-    });
+    memories.sort(compareStoredMemoriesNewestFirst);
     const offset = typeof params.offset === "number" ? params.offset : 0;
     let sliced = offset > 0 ? memories.slice(offset) : memories;
     if (params.limit !== undefined) sliced = sliced.slice(0, params.limit);
@@ -1402,12 +1415,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         (!worldSet || (m.worldId ? worldSet.has(m.worldId as UUID) : false)) &&
         (params.tableName ? storedMemoryTableName(m) === params.tableName : true)
     );
-    memories.sort((a, b) => {
-      const aSafe = Number.isFinite(a.createdAt ?? 0) ? (a.createdAt ?? 0) : 0;
-      const bSafe = Number.isFinite(b.createdAt ?? 0) ? (b.createdAt ?? 0) : 0;
-      if (bSafe !== aSafe) return bSafe - aSafe;
-      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
-    });
+    memories.sort(compareStoredMemoriesNewestFirst);
     const sliced = params.limit ? memories.slice(0, params.limit) : memories;
     return sliced.map(toMemory);
   }


### PR DESCRIPTION
## Summary

`plugins/plugin-inmemorydb/adapter.ts:1129,1400` sorted memories by `(b.createdAt??0)-(a.createdAt??0)` without `isFinite`. `NaN` → `NaN` comparator → nondeterministic memory ordering in test/inmemory adapter (used in e2e). Other `ab.*` sorts in this file already guarded.

## Changes

- `plugins/plugin-inmemorydb/adapter.ts:1129,1400` both sorts → `isFinite` + `id` tiebreak (2 locations)
- `plugins/plugin-inmemorydb/adapter.safe-sort.test.ts` 3 tests

## Exact-head verification

| Check | Base (`origin/develop@dde9e64`) | Head (`d738aedb`) |
| --- | --- | --- |
| `bunx vitest run adapter.safe-sort.test.ts` | N/A | 3 pass |

## Risks

Low.

## Attribution

Authored by @byt61.
