### PR TITLE
fix(notes): use surrogate-safe truncateWellFormed on note title parsing

### DIFF
--- a/plugins/plugin-notes/src/__tests__/validation.test.ts
+++ b/plugins/plugin-notes/src/__tests__/validation.test.ts
@@ -58,6 +58,14 @@ describe("Notes boundary validation", () => {
       expect(() => parseNoteContent(123)).toThrow();
       expect(() => parseNoteContent("   ")).toThrow();
     });
+
+    it("splits long single-line content with surrogate safety at max title length", () => {
+      const longTitle = `${"a".repeat(239)}😀${"b".repeat(20)}`;
+      const result = parseNoteContent(longTitle);
+      expect(result.title.length).toBe(239);
+      expect(result.title.endsWith("😀")).toBe(false);
+      expect(result.body.startsWith("😀")).toBe(true);
+    });
   });
 
   describe("parseEntityId", () => {

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -5,7 +5,11 @@
  * by an apparently healthy empty state.
  */
 
-import { ElizaError } from "@elizaos/core";
+import {
+  ElizaError,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   type CreateNoteInput,
   NOTES_SCHEMA_VERSION,
@@ -111,9 +115,9 @@ export function parseNoteContent(
     maxLength: MAX_NOTE_CONTENT_LENGTH,
   });
   const [firstLine = "", ...remainingLines] = content.split(/\r?\n/);
-  const trimmedFirstLine = firstLine.trim();
-  const title = trimmedFirstLine.slice(0, MAX_TITLE_LENGTH).trim();
-  const overflow = trimmedFirstLine.slice(MAX_TITLE_LENGTH).trim();
+  const safeFirstLine = toWellFormedUnicode(firstLine.trim());
+  const title = truncateWellFormed(safeFirstLine, MAX_TITLE_LENGTH).trim();
+  const overflow = safeFirstLine.slice(title.length).trim();
   const body = [overflow, ...remainingLines].join("\n").trim();
   return {
     title: parseRequiredTitle(title, `${field}.firstLine`),


### PR DESCRIPTION
## Summary

Uses `truncateWellFormed` and `toWellFormedUnicode` from `@elizaos/core` in `parseNoteContent` (`plugins/plugin-notes/src/validation.ts:114-117`) to prevent splitting UTF-16 surrogate pairs into malformed lone surrogates when user note first-lines exceed `MAX_TITLE_LENGTH`.

## Changes

- In `plugins/plugin-notes/src/validation.ts`, safely extract the note title using `truncateWellFormed(safeFirstLine, MAX_TITLE_LENGTH)` and slice overflow starting from the safe title boundary.
- In `plugins/plugin-notes/src/__tests__/validation.test.ts`, add unit test verifying that note content containing an emoji/surrogate pair at the title cutoff boundary is partitioned into title and body without producing lone surrogates.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`bc1648e7e3`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-notes test src/__tests__/validation.test.ts` | 16 pass (16 tests) | 17 pass (17 tests) |
| `bunx @biomejs/biome check plugins/plugin-notes/src/validation.ts plugins/plugin-notes/src/__tests__/validation.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-notes/src/validation.ts:110-120`
- `plugins/plugin-notes/src/__tests__/validation.test.ts:55-70`

## Risks

Low. Preserves complete unicode code points and guarantees well-formed note titles and overflow bodies.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Notes input parsing validation)
- [x] `audit:browser` — N/A (Note title extraction)
- [x] `build` — Clean build across workspace
- [x] `test` — 17/17 pass in `validation.test.ts`
- [x] `lint` — Biome clean
