### PR TITLE
test(app-core): cover plugin-registry-load-deadline

### DIFF
--- a/packages/app-core/src/api/plugin-registry-load-deadline.test.ts
+++ b/packages/app-core/src/api/plugin-registry-load-deadline.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Colocated coverage for the /api/plugins cold-load deadline helper. Drives the
+ * real module: the wait constant the route uses, and resolveWithinDeadline
+ * racing a promise against that timer (settled value, timeout null, rejection
+ * unmasked, concurrent independent calls).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  PLUGIN_REGISTRY_LOAD_DEADLINE_MS,
+  resolveWithinDeadline,
+} from "./plugin-registry-load-deadline";
+
+describe("PLUGIN_REGISTRY_LOAD_DEADLINE_MS", () => {
+  it("is 2000 milliseconds", () => {
+    expect(PLUGIN_REGISTRY_LOAD_DEADLINE_MS).toBe(2_000);
+  });
+});
+
+describe("resolveWithinDeadline", () => {
+  it("returns the value when the promise is already settled", async () => {
+    await expect(
+      resolveWithinDeadline(Promise.resolve("warm"), 1_000),
+    ).resolves.toBe("warm");
+  });
+
+  it("returns a delayed value that settles inside the deadline", async () => {
+    const warm = new Promise<string>((resolve) => {
+      setTimeout(() => resolve("warm"), 5);
+    });
+    await expect(resolveWithinDeadline(warm, 80)).resolves.toBe("warm");
+  });
+
+  it("returns null when the promise is still pending at the deadline", async () => {
+    const never = new Promise<string>(() => {});
+    await expect(resolveWithinDeadline(never, 20)).resolves.toBeNull();
+  });
+
+  it("returns null when a late resolve happens after the deadline", async () => {
+    let resolveLate: (value: string) => void = () => {
+      throw new Error("late resolver was not captured");
+    };
+    const late = new Promise<string>((resolve) => {
+      resolveLate = resolve;
+    });
+    await expect(resolveWithinDeadline(late, 15)).resolves.toBeNull();
+    resolveLate("warm-after-deadline");
+    await expect(late).resolves.toBe("warm-after-deadline");
+  });
+
+  it("propagates rejection instead of converting it into a timeout null", async () => {
+    const boom = Promise.reject(new Error("registry import failed"));
+    await expect(resolveWithinDeadline(boom, 1_000)).rejects.toThrow(
+      "registry import failed",
+    );
+  });
+
+  it("does not rewrite an already-returned timeout null when the promise later rejects", async () => {
+    let rejectLate: (error: Error) => void = () => {
+      throw new Error("late rejector was not captured");
+    };
+    const late = new Promise<string>((_, reject) => {
+      rejectLate = reject;
+    });
+    const absorbed = late.then(
+      () => undefined,
+      () => undefined,
+    );
+    await expect(resolveWithinDeadline(late, 15)).resolves.toBeNull();
+    rejectLate(new Error("registry import failed after deadline"));
+    await absorbed;
+  });
+
+  it("passes through falsy settled values instead of treating them as a timeout", async () => {
+    await expect(
+      resolveWithinDeadline(Promise.resolve(0), 1_000),
+    ).resolves.toBe(0);
+    await expect(
+      resolveWithinDeadline(Promise.resolve(""), 1_000),
+    ).resolves.toBe("");
+    await expect(
+      resolveWithinDeadline(Promise.resolve(false), 1_000),
+    ).resolves.toBe(false);
+    await expect(
+      resolveWithinDeadline(Promise.resolve(undefined), 1_000),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns null when the promise itself settles to null", async () => {
+    await expect(
+      resolveWithinDeadline(Promise.resolve(null), 1_000),
+    ).resolves.toBeNull();
+  });
+
+  it("lets an already-settled promise win a 0ms deadline (microtask before timer)", async () => {
+    await expect(
+      resolveWithinDeadline(Promise.resolve("warm"), 0),
+    ).resolves.toBe("warm");
+  });
+
+  it("returns null for a pending promise at a 0ms deadline", async () => {
+    const never = new Promise<string>(() => {});
+    await expect(resolveWithinDeadline(never, 0)).resolves.toBeNull();
+  });
+
+  it("runs independent races without sharing a winner", async () => {
+    const never = new Promise<string>(() => {});
+    const [timedOut, settled] = await Promise.all([
+      resolveWithinDeadline(never, 15),
+      resolveWithinDeadline(Promise.resolve("warm"), 1_000),
+    ]);
+    expect(timedOut).toBeNull();
+    expect(settled).toBe("warm");
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/app-core/src/api/plugin-registry-load-deadline.ts`, which had no colocated `plugin-registry-load-deadline.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`dde9e644a3a3fbae9df3941e141853c9904bb2ea`) with a single-file commit (`packages/app-core/src/api/plugin-registry-load-deadline.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is `origin/develop` `dde9e644a3a3fbae9df3941e141853c9904bb2ea`, re-fetched immediately before filing; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. Failure mode is a false assertion of observed race/timeout behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/app-core/src/api/plugin-registry-load-deadline.test.ts` driving the real helper used by `GET /api/plugins` while the lazy `@elizaos/plugin-registry` import is still cold (`PLUGIN_REGISTRY_LOAD_DEADLINE_MS` + `resolveWithinDeadline`). No mocks of the system under test.

Covered behaviour, as observed in the live module:

- `PLUGIN_REGISTRY_LOAD_DEADLINE_MS` is `2000`
- An already-settled promise returns its value
- A delayed resolve inside the deadline returns that value
- A still-pending promise returns `null` at the deadline
- A resolve after the deadline does not rewrite the already-returned `null`
- Rejection of the input promise propagates (not converted to timeout `null`)
- A rejection after the deadline does not rewrite the already-returned `null`
- Falsy settled values (`0`, `""`, `false`, `undefined`) pass through
- A promise that settles to `null` yields `null` (same observable as a timeout)
- An already-settled promise wins a `0ms` deadline (microtask before timer)
- A pending promise at a `0ms` deadline returns `null`
- Independent concurrent races do not share a winner

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/plugin-registry-load-deadline.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (the production helper is unchanged vs this PR's parent):

```bash
bunx vitest run packages/app-core/src/api/plugin-registry-load-deadline.test.ts
bunx biome check --write packages/app-core/src/api/plugin-registry-load-deadline.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'plugin-registry-load-deadline.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop`):

1. Vitest: **Test Files 1 passed (1), Tests 12 passed (12)** (`bunx vitest run packages/app-core/src/api/plugin-registry-load-deadline.test.ts`).

```text
 ✓ packages/app-core/src/api/plugin-registry-load-deadline.test.ts (12 tests) 85ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  17:34:43
   Duration  218ms (transform 29ms, setup 0ms, import 37ms, tests 85ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/app-core/src/api/plugin-registry-load-deadline.test.ts` — `Checked 1 file in 412ms. Fixed 1 file.` The committed file is that formatted result. Config exists at repo-root `biome.json`; this checkout is not sparse.
3. `tsc --noEmit` in `packages/app-core`: **`plugin-registry-load-deadline.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors in other files are unrelated.
4. Diff touches **only** `packages/app-core/src/api/plugin-registry-load-deadline.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Evidence head (40-character SHA of this PR): `0517c5a2a75b4004e3470c64c403e8af20f6b3b5`

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 12 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Hosted CI does not run on this fork contributor PR. Local vitest, biome, and package `tsc` are the proof.

`bun run verify` was not run; this PR changes no production code.

`tsc --noEmit` for `packages/app-core` still reports pre-existing errors in other files; none mention `plugin-registry-load-deadline.test.ts`.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0517c5a2a75b4004e3470c64c403e8af20f6b3b5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
