### PR TITLE
fix(ui): handle max<=0 and max==1 in truncateMessageForDisplay

### DIFF
--- a/packages/ui/src/__tests__/regression-truncation.test.ts
+++ b/packages/ui/src/__tests__/regression-truncation.test.ts
@@ -16,12 +16,13 @@ describe("truncateMessageForDisplay — behavioral maxLen & surrogate (real)", (
     expect(truncateMessageForDisplay("a".repeat(6100), 0)).toBe("");
     expect(truncateMessageForDisplay("👋hello", 0)).toBe("");
   });
-  it("max 1 survives astral boundary well-formed", () => {
+  it("max 1 survives astral boundary as a single well-formed ellipsis", () => {
     const emoji = String.fromCharCode(0xD83D, 0xDE00);
     const out = truncateMessageForDisplay(`${emoji}${"a".repeat(10)}`, 1);
     expect(isWellFormed(out)).toBe(true);
     expect((out as any).isWellFormed()).toBe(true);
-    expect(out.startsWith("…")).toBe(true);
+    expect(out).toBe("…");
+    expect(out.length).toBe(1);
   });
   it("short input under max returns well-formed unchanged", () => {
     const text = "short message";

--- a/packages/ui/src/__tests__/regression-truncation.test.ts
+++ b/packages/ui/src/__tests__/regression-truncation.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Behavioral regression for truncation maxLen — calls real truncateMessageForDisplay
+ * Contract: surrogate-safe, well-formed, max<=0 → "", max handling, never split surrogate
+ */
+import { describe, it, expect } from "vitest";
+import { truncateMessageForDisplay } from "../components/pages/browser-wallet-consent-format";
+import { toWellFormedUnicode } from "@elizaos/core";
+
+function isWellFormed(value: string): boolean {
+  return typeof (value as any).isWellFormed === "function" ? (value as any).isWellFormed() : !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(value);
+}
+
+describe("truncateMessageForDisplay — behavioral maxLen & surrogate (real)", () => {
+  it("max 0 → '' (not '… (5 more chars)')", () => {
+    expect(truncateMessageForDisplay("hello", 0)).toBe("");
+    expect(truncateMessageForDisplay("a".repeat(6100), 0)).toBe("");
+    expect(truncateMessageForDisplay("👋hello", 0)).toBe("");
+  });
+  it("max 1 survives astral boundary well-formed", () => {
+    const emoji = String.fromCharCode(0xD83D, 0xDE00);
+    const out = truncateMessageForDisplay(`${emoji}${"a".repeat(10)}`, 1);
+    expect(isWellFormed(out)).toBe(true);
+    expect((out as any).isWellFormed()).toBe(true);
+    expect(out.startsWith("…")).toBe(true);
+  });
+  it("short input under max returns well-formed unchanged", () => {
+    const text = "short message";
+    expect(truncateMessageForDisplay(text, 240)).toBe(toWellFormedUnicode(text));
+    expect(isWellFormed(truncateMessageForDisplay(text, 240))).toBe(true);
+  });
+  it("keeps surrogate pairs intact at 240 boundary with suffix", () => {
+    const emoji = String.fromCharCode(0xD83D, 0xDE00);
+    const text = `${"a".repeat(239)}${emoji}${"b".repeat(20)}`;
+    const out = truncateMessageForDisplay(text, 240);
+    expect(isWellFormed(out)).toBe(true);
+    expect((out as any).isWellFormed()).toBe(true);
+    expect(out).toContain("… (");
+  });
+  it("large 6100 with default max 240 is truncated and well-formed", () => {
+    const out = truncateMessageForDisplay("a".repeat(6100), 240);
+    expect(out.length).toBeGreaterThan(240);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toContain("more chars");
+  });
+  it("never emits lone surrogates at every boundary around 240", () => {
+    const emoji = String.fromCharCode(0xD83E, 0xDD8A);
+    for (let n = 0; n <= 245; n++) {
+      const text = `${"x".repeat(n)}${emoji}${"y".repeat(20)}`;
+      const out = truncateMessageForDisplay(text, 240);
+      expect(isWellFormed(out)).toBe(true);
+      expect((out as any).isWellFormed()).toBe(true);
+    }
+  });
+  it("sanitizes lone surrogates before truncation", () => {
+    const lone = `msg ${String.fromCharCode(0xD800)} ${"x".repeat(300)}`;
+    const out = truncateMessageForDisplay(lone, 240);
+    expect(out).toContain("�");
+    expect(isWellFormed(out)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/pages/browser-wallet-consent-format.test.ts
+++ b/packages/ui/src/components/pages/browser-wallet-consent-format.test.ts
@@ -66,13 +66,20 @@ describe("truncateMessageForDisplay well-formed", () => {
     expect(isWellFormed(truncateMessageForDisplay(text, 240))).toBe(true);
   });
 
-  it("handles max=1 astral boundary to empty well-formed prefix", () => {
+  it("handles max=1 astral boundary as a single well-formed ellipsis", () => {
     const emoji = String.fromCharCode(0xd83d, 0xde00);
     const text = `${emoji}${"a".repeat(10)}`;
     const out = truncateMessageForDisplay(text, 1);
     expect(isWellFormed(out)).toBe(true);
     expect(out.isWellFormed()).toBe(true);
-    expect(out.startsWith("… (")).toBe(true);
+    // max===1 cannot hold the "… (N more chars)" suffix; cap is a hard "…".
+    expect(out).toBe("…");
+    expect(out.length).toBe(1);
+  });
+
+  it("max<=0 returns empty rather than a suffix-only preview", () => {
+    expect(truncateMessageForDisplay("hello", 0)).toBe("");
+    expect(truncateMessageForDisplay("a".repeat(100), 0)).toBe("");
   });
 
   it("never emits lone surrogates at every boundary around 240", () => {

--- a/packages/ui/src/components/pages/browser-wallet-consent-format.ts
+++ b/packages/ui/src/components/pages/browser-wallet-consent-format.ts
@@ -72,6 +72,8 @@ export function decodeBase64ForPreview(base64: string): string {
 
 export function truncateMessageForDisplay(message: string, max = 240): string {
   const wellFormed = toWellFormedUnicode(message);
+  if (max <= 0) return "";
   if (wellFormed.length <= max) return wellFormed;
+  if (max === 1) return "…";
   return `${truncateWellFormed(wellFormed, Math.max(0, max))}… (${wellFormed.length - max} more chars)`;
 }


### PR DESCRIPTION
Closes #25844

## Summary
Fix `truncateMessageForDisplay` maxLen handling in `packages/ui/src/components/pages/browser-wallet-consent-format.ts`: `max<=0` now returns `""` (was `"… (5 more chars)"`), `max==1` truncated returns `"…"` per high-acceptance contract, before surrogate-safe `truncateWellFormed`. Adds behavioral regression `src/__tests__/regression-truncation.test.ts` calling real function.

## Exact-head evidence
Head: d14ef370616f7c094fe3b02023c53d3e968440e8
Base: origin/develop@dde9e644a3a3fbae9df3941e141853c9904bb2ea
- `bun test packages/ui/src/__tests__/regression-truncation.test.ts` — 7 pass (max0→"", max1 astral, 240 surrogate, 6100, lone)
- `bun test packages/ui/src/components/pages/browser-wallet-consent-format.test.ts` — 8 pass (existing well-formed)

## Definition of Done
- [x] Calls real function, not stub
- [x] Max edge cases proven (max0 fail before → pass after)
- [x] Surrogate-safe preserved

## Contribution provenance
AI provider/model: internal / verification
Client / agent tooling: Muse Code
Contribution skill revision: elizaOS/eliza@dde9e644a3a3fbae9df3941e141853c9904bb2ea:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ui-truncation]
<!-- eliza-computer-attribution:v1 {"provider":"internal","model":"verification","client":"muse","skill_revision":"elizaOS/eliza@dde9e644a3a3fbae9df3941e141853c9904bb2ea:packages/skills/skills/contribute-to-eliza"} -->

Co-authored-by: internal-model <internal@example.com>
