### PR TITLE
fix(agent): safe NaN handling in boot-timer slowest laps sort comparator

### DIFF
--- a/packages/agent/src/runtime/boot-timer.test.ts
+++ b/packages/agent/src/runtime/boot-timer.test.ts
@@ -41,4 +41,41 @@ describe("BootTimer", () => {
       "[test-boot] deferred:vault: 35ms (t+2055ms)",
     );
   });
+
+  it("sorts slowest laps first in summary even when lap timings contain non-finite numbers", () => {
+    const timer = new BootTimer("[test-boot]");
+    vi.advanceTimersByTime(10);
+    timer.lap("fast");
+    vi.advanceTimersByTime(100);
+    timer.lap("slow");
+    vi.advanceTimersByTime(50);
+    timer.lap("medium");
+
+    // Inject non-finite lap to assert safe sort ordering without NaN perturbation
+    (
+      timer as unknown as {
+        laps: Array<{ name: string; ms: number; cumulativeMs: number }>;
+      }
+    ).laps.push({
+      name: "corrupted-nan",
+      ms: Number.NaN,
+      cumulativeMs: Number.NaN,
+    });
+
+    timer.summary();
+    const summaryLog = loggerMocks.info.mock.calls.find((call) =>
+      call[0].includes("boot phase summary"),
+    );
+    expect(summaryLog).toBeDefined();
+    expect(summaryLog[0]).toContain("slow");
+    expect(summaryLog[0].indexOf("slow")).toBeLessThan(
+      summaryLog[0].indexOf("medium"),
+    );
+    expect(summaryLog[0].indexOf("medium")).toBeLessThan(
+      summaryLog[0].indexOf("fast"),
+    );
+    expect(summaryLog[0].indexOf("fast")).toBeLessThan(
+      summaryLog[0].indexOf("corrupted-nan"),
+    );
+  });
 });

--- a/packages/agent/src/runtime/boot-timer.ts
+++ b/packages/agent/src/runtime/boot-timer.ts
@@ -73,7 +73,19 @@ export class BootTimer {
 
   summary(): void {
     const { totalMs, laps } = this.getSummary();
-    const slowest = [...laps].sort((a, b) => b.ms - a.ms);
+    const slowest = [...laps].sort((a, b) => {
+      const bMs = typeof b.ms === "number" && Number.isFinite(b.ms) ? b.ms : 0;
+      const aMs = typeof a.ms === "number" && Number.isFinite(a.ms) ? a.ms : 0;
+      const bCum =
+        typeof b.cumulativeMs === "number" && Number.isFinite(b.cumulativeMs)
+          ? b.cumulativeMs
+          : 0;
+      const aCum =
+        typeof a.cumulativeMs === "number" && Number.isFinite(a.cumulativeMs)
+          ? a.cumulativeMs
+          : 0;
+      return bMs - aMs || bCum - aCum || a.name.localeCompare(b.name);
+    });
     const lines = slowest.map(
       (p) => `    ${String(p.ms).padStart(7)}ms  ${p.name}`,
     );


### PR DESCRIPTION
## Summary

Guards numerical lap timings in `BootTimer.summary()` (`packages/agent/src/runtime/boot-timer.ts:76`) with `Number.isFinite(...)` and fallback to `0` with `cumulativeMs` tiebreaking to prevent non-finite/NaN lap timings from breaking sort transitivity when producing boot phase diagnostic summaries.

## Changes

- In `packages/agent/src/runtime/boot-timer.ts:76`, replace `b.ms - a.ms` with a safe comparator that guards both `b.ms` and `a.ms` with `Number.isFinite(...)` and breaks ties using `b.cumulativeMs - a.cumulativeMs`.
- In `packages/agent/src/runtime/boot-timer.test.ts`, add unit test verifying that `timer.summary()` sorts slowest laps first in descending duration order.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`8ec334fdf4`) |
| --- | --- | --- |
| `bunx vitest run src/runtime/boot-timer.test.ts` (in `packages/agent`) | 1 pass (1 test) | 2 pass (2 tests) |
| `bunx @biomejs/biome check packages/agent/src/runtime/boot-timer.ts packages/agent/src/runtime/boot-timer.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/runtime/boot-timer.ts:70-84`
- `packages/agent/src/runtime/boot-timer.test.ts:35-55`

## Risks

Low. Preserves stable, well-ordered boot phase summaries.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent boot telemetry sorting)
- [x] `audit:browser` — N/A (Boot timer phase summary formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 2/2 pass in `boot-timer.test.ts`
- [x] `lint` — Biome clean
