### PR TITLE
fix(agent): safe NaN handling in pendant-session saveSegment ordinal sort comparator

### DIFF
--- a/packages/agent/src/services/pendant-session/repository.test.ts
+++ b/packages/agent/src/services/pendant-session/repository.test.ts
@@ -2,6 +2,7 @@ import type { PendantSegment } from "@elizaos/shared/contracts/pendant-session-s
 import { getTableConfig } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  InMemoryPendantSessionRepository,
   SqlPendantSessionRepository,
   type StoredPendantSessionDocument,
 } from "./repository.ts";
@@ -244,5 +245,66 @@ describe("pendant session relational persistence", () => {
     expect(queryText(tx.execute.mock.calls[2]?.[0])).toContain(
       "INSERT INTO app_lifeops.pendant_session_insight_refs",
     );
+  });
+});
+
+describe("InMemoryPendantSessionRepository", () => {
+  it("sorts saved segments deterministically with safe NaN handling", async () => {
+    const repo = new InMemoryPendantSessionRepository();
+    const doc = stored();
+    await repo.create(doc);
+
+    const seg1: PendantSegment = {
+      ...segment(),
+      id: "seg-1",
+      ordinal: 2,
+    };
+    const seg0: PendantSegment = {
+      ...segment(),
+      id: "seg-0",
+      ordinal: 0,
+    };
+    const segNaN: PendantSegment = {
+      ...segment(),
+      id: "seg-nan",
+      ordinal: NaN as unknown as number,
+    };
+
+    let current = await repo.load({
+      ownerId: "owner-1",
+      agentId: "agent-1",
+      sessionId: "session-1",
+    });
+    if (!current) throw new Error("session not found");
+    await repo.saveSegment(current, seg1);
+
+    current = await repo.load({
+      ownerId: "owner-1",
+      agentId: "agent-1",
+      sessionId: "session-1",
+    });
+    if (!current) throw new Error("session not found");
+    await repo.saveSegment(current, seg0);
+
+    current = await repo.load({
+      ownerId: "owner-1",
+      agentId: "agent-1",
+      sessionId: "session-1",
+    });
+    if (!current) throw new Error("session not found");
+    await repo.saveSegment(current, segNaN);
+
+    const fetched = await repo.load({
+      ownerId: "owner-1",
+      agentId: "agent-1",
+      sessionId: "session-1",
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched?.segments.length).toBe(3);
+    expect(fetched?.segments.map((s) => s.id)).toEqual([
+      "seg-0",
+      "seg-nan",
+      "seg-1",
+    ]);
   });
 });

--- a/packages/agent/src/services/pendant-session/repository.ts
+++ b/packages/agent/src/services/pendant-session/repository.ts
@@ -634,7 +634,17 @@ export class InMemoryPendantSessionRepository
     } else {
       next.segments.push({ ...segment, words: [...segment.words] });
     }
-    next.segments.sort((a, b) => a.ordinal - b.ordinal);
+    next.segments.sort((a, b) => {
+      const aOrdinal =
+        typeof a.ordinal === "number" && Number.isFinite(a.ordinal)
+          ? a.ordinal
+          : 0;
+      const bOrdinal =
+        typeof b.ordinal === "number" && Number.isFinite(b.ordinal)
+          ? b.ordinal
+          : 0;
+      return aOrdinal - bOrdinal || a.id.localeCompare(b.id);
+    });
     this.rows.set(key, next);
   }
 


### PR DESCRIPTION
## Summary

Guards numerical `ordinal` comparisons in `InMemoryPendantSessionRepository.saveSegment` (`packages/agent/src/services/pendant-session/repository.ts:637`) with `Number.isFinite(...)` and fallback to `0` with segment ID tiebreaking to prevent non-finite/NaN segment ordinals from breaking sort transitivity and ordering.

## Changes

- In `packages/agent/src/services/pendant-session/repository.ts:637`, guard `a.ordinal` and `b.ordinal` with `Number.isFinite(...)` and fallback to `0`, breaking ties with `a.id.localeCompare(b.id)`.
- In `packages/agent/src/services/pendant-session/repository.test.ts`, add unit test verifying that `saveSegment` orders saved segments deterministically when segment ordinals include `NaN`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`286ba9e12d`) |
| --- | --- | --- |
| `bunx vitest run src/services/pendant-session/repository.test.ts` (in `packages/agent`) | 7 pass (7 tests) | 8 pass (8 tests) |
| `bunx @biomejs/biome check packages/agent/src/services/pendant-session/repository.ts packages/agent/src/services/pendant-session/repository.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/services/pendant-session/repository.ts:635-645`
- `packages/agent/src/services/pendant-session/repository.test.ts:240-300`

## Risks

Low. Ensures finite numerical comparisons and deterministic segment ordering.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Pendant session repository sorting)
- [x] `audit:browser` — N/A (Segment ordinal ordering)
- [x] `build` — Clean build across workspace
- [x] `test` — 8/8 pass in `repository.test.ts`
- [x] `lint` — Biome clean
