### PR TITLE
fix(cloud): type deferred replacement signal

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts
@@ -302,7 +302,7 @@ function callerConflict(
 }
 
 function deferredSignal(): { promise: Promise<void>; resolve: () => void } {
-  let resolvePromise = () => {
+  let resolvePromise: () => void = () => {
     throw new Error("Deferred signal was resolved before initialization");
   };
   const promise = new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- explicitly type the replacement-attempt deferred resolver as `() => void`
- restore the Cloud API deploy verifier/typecheck introduced by #25721

## Verification
- `bun test --config=/dev/null packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts` (13 pass)
- `bun run --cwd packages/cloud/api typecheck`
- `bunx biome check packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts`
- `git diff --check`

## Staging context
Cloud CF staging run 32638110639 stopped before any Cloudflare mutation at API Worker Verify Worker with TS2322 on this resolver. Pages artifact build and DB migration verification passed; no Worker/Pages deploy, routing, session exchange, or version receipt occurred.