### PR TITLE
fix(cloud): sort canonical digest keys by code unit, not locale

### DIFF
--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -310,7 +310,9 @@ function canonicalJson(value: unknown): string {
   }
   if (value !== null && typeof value === "object") {
     return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent, so
+      // the admission recovery contract must not serialize differently per host.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
       .join(",")}}`;
   }

--- a/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.locale-order.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.locale-order.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pins `stableSerialize` to UTF-16 code-unit key ordering. Its output feeds the
+ * sha1 runtime settings signature, so the same settings object must serialize
+ * identically on every host. The existing suite only compares two insertion
+ * orders through the same sorter, which passes under ICU collation too; these
+ * cases assert the exact serialized order and cover keys that ICU ranks equal.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { stableSerialize } from "./stable-serialize";
+
+const NFC_KEY = "caf\u00e9"; // precomposed U+00E9
+const NFD_KEY = "cafe\u0301"; // decomposed "e" + U+0301
+
+describe("stableSerialize canonical key order", () => {
+  test("orders mixed-case keys by code unit, not by locale collation", () => {
+    // ICU puts "a" before "B"; code unit puts "B" (0x42) before "a" (0x61).
+    expect(stableSerialize({ a: 1, B: 2 })).toBe('{"B":2,"a":1}');
+  });
+
+  test("orders non-ASCII keys by code unit, not by locale collation", () => {
+    expect(stableSerialize({ "\u00e4": 1, z: 2 })).toBe('{"z":2,"\u00e4":1}');
+  });
+
+  test("applies code-unit ordering to nested objects", () => {
+    expect(stableSerialize({ nested: { a: 1, B: 2 }, A: 3 })).toBe(
+      '{"A":3,"nested":{"B":2,"a":1}}',
+    );
+  });
+
+  test("gives canonically equivalent distinct keys a total, insertion-independent order", () => {
+    expect(stableSerialize({ [NFC_KEY]: 1, [NFD_KEY]: 2 })).toBe(
+      stableSerialize({ [NFD_KEY]: 2, [NFC_KEY]: 1 }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts
@@ -32,7 +32,10 @@ function serializeStableValue(value: unknown, seen: WeakSet<object>): string {
     seen.add(value);
     const entries = Object.entries(value as Record<string, unknown>)
       .filter(([, entryValue]) => entryValue !== undefined)
-      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent and
+      // ranks canonically equivalent distinct keys as equal, so the sha1 settings
+      // signature derived from this output must not vary with the host locale.
+      .sort(([leftKey], [rightKey]) => (leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0));
     const serialized = `{${entries
       .map(
         ([key, entryValue]) => `${JSON.stringify(key)}:${serializeStableValue(entryValue, seen)}`,

--- a/packages/cloud/shared/src/lib/services/affiliate-payout-outbox.ts
+++ b/packages/cloud/shared/src/lib/services/affiliate-payout-outbox.ts
@@ -105,7 +105,10 @@ function canonicalJson(value: unknown): unknown {
   if (typeof value !== "object" || value === null) return value;
   return Object.fromEntries(
     Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent and
+      // ranks canonically equivalent distinct keys as equal, so identical payout
+      // metadata could compare unequal across hosts and key insertion order.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, nested]) => [key, canonicalJson(nested)]),
   );
 }

--- a/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.locale-order.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.locale-order.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Pins pricing dimension normalization to UTF-16 code-unit key ordering.
+ * `buildDimensionKey` is the lookup/cache key for a resolved price, so the same
+ * dimension set must produce one key on every host. ICU collation orders
+ * mixed-case and non-ASCII dimension names by locale, which splits one logical
+ * price into several cache entries and can miss an exact-match override.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { buildDimensionKey, normalizePricingDimensions } from "./dimensions";
+
+describe("pricing dimension canonical key order", () => {
+  test("orders mixed-case dimension names by code unit, not by locale collation", () => {
+    // ICU puts "audio" before "Bitrate"; code unit puts "Bitrate" (0x42) first.
+    expect(Object.keys(normalizePricingDimensions({ audio: "wav", Bitrate: 128 }))).toEqual([
+      "Bitrate",
+      "audio",
+    ]);
+  });
+
+  test("orders non-ASCII dimension names by code unit", () => {
+    expect(Object.keys(normalizePricingDimensions({ "\u00e4type": "a", zone: "b" }))).toEqual([
+      "zone",
+      "\u00e4type",
+    ]);
+  });
+
+  test("builds one identical lookup key regardless of insertion order", () => {
+    const left = buildDimensionKey({ audio: "wav", Bitrate: 128, zone: "eu", "\u00e4type": "x" });
+    const right = buildDimensionKey({ "\u00e4type": "x", zone: "eu", Bitrate: 128, audio: "wav" });
+    expect(left).toBe(right);
+    expect(left).toBe('{"Bitrate":128,"audio":"wav","zone":"eu","\u00e4type":"x"}');
+  });
+
+  test("still collapses an empty dimension set to the wildcard key", () => {
+    expect(buildDimensionKey()).toBe("*");
+    expect(buildDimensionKey({})).toBe("*");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/dimensions.ts
@@ -59,7 +59,10 @@ export function normalizePricingDimensions(
   return Object.fromEntries(
     Object.entries(dimensions)
       .filter(([, value]) => value !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent, so
+      // the same dimension set would build different lookup keys per host and
+      // split one resolved price across several cache entries.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, value]) => [key, normalizeDimensionValue(value)]),
   );
 }

--- a/packages/cloud/shared/src/lib/services/container-jobs-writer.ts
+++ b/packages/cloud/shared/src/lib/services/container-jobs-writer.ts
@@ -31,7 +31,9 @@ function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value && typeof value === "object") {
     const entries = Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent, so
+      // the job readback equality check must not depend on the host locale.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, next]) => `${JSON.stringify(key)}:${canonicalJson(next)}`);
     return `{${entries.join(",")}}`;
   }

--- a/packages/cloud/shared/src/lib/services/doordash-checkout-binding.locale-order.test.ts
+++ b/packages/cloud/shared/src/lib/services/doordash-checkout-binding.locale-order.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pins the managed DoorDash checkout binding digest to UTF-16 code-unit key
+ * ordering. `assertManagedCheckoutBinding` is the guard that stops a cart or
+ * price preview from changing between user confirmation and order placement, so
+ * the digest must be a pure function of cart content. ICU collation makes it a
+ * function of the host locale and of property insertion order as well, which
+ * lets an unchanged cart fail the binding check after any JSON round-trip that
+ * reorders keys.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+import {
+  assertManagedCheckoutBinding,
+  managedCheckoutBindingDigest,
+} from "./doordash-checkout-binding";
+
+const NFC_KEY = "caf\u00e9"; // precomposed U+00E9
+const NFD_KEY = "cafe\u0301"; // decomposed "e" + U+0301
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+describe("managed checkout binding canonical key order", () => {
+  test("digests mixed-case cart keys in code-unit order, not locale order", () => {
+    // ICU collation would serialize {"a":1,"B":2}; code-unit order is "B" (0x42)
+    // before "a" (0x61). The expected wire string is pinned literally here rather
+    // than recomputed, so the assertion fails if the sorter regresses.
+    expect(managedCheckoutBindingDigest({ a: 1, B: 2 }, null)).toBe(
+      sha256('{"cart":{"B":2,"a":1},"checkout":null}'),
+    );
+  });
+
+  test("digests non-ASCII cart keys in code-unit order", () => {
+    expect(managedCheckoutBindingDigest({ "\u00e4": 1, z: 2 }, null)).toBe(
+      sha256('{"cart":{"z":2,"\u00e4":1},"checkout":null}'),
+    );
+  });
+
+  test("an unchanged cart still binds after a key-reordering round-trip", () => {
+    const digest = managedCheckoutBindingDigest(
+      { items: [{ Qty: 2, name: "fries" }], storeId: "s-1", Tip: "1.00" },
+      { Total: "9.99", subtotal: "8.99" },
+    );
+    expect(() =>
+      assertManagedCheckoutBinding(
+        digest,
+        { Tip: "1.00", storeId: "s-1", items: [{ name: "fries", Qty: 2 }] },
+        { subtotal: "8.99", Total: "9.99" },
+      ),
+    ).not.toThrow();
+  });
+
+  test("canonically equivalent distinct keys bind independent of insertion order", () => {
+    expect(managedCheckoutBindingDigest({ [NFC_KEY]: 1, [NFD_KEY]: 2 }, null)).toBe(
+      managedCheckoutBindingDigest({ [NFD_KEY]: 2, [NFC_KEY]: 1 }, null),
+    );
+  });
+
+  test("a genuinely changed cart still fails the binding", () => {
+    const digest = managedCheckoutBindingDigest({ storeId: "s-1", Tip: "1.00" }, null);
+    expect(() =>
+      assertManagedCheckoutBinding(digest, { storeId: "s-1", Tip: "5.00" }, null),
+    ).toThrow("DoorDash cart or checkout changed after confirmation");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/doordash-checkout-binding.ts
+++ b/packages/cloud/shared/src/lib/services/doordash-checkout-binding.ts
@@ -11,7 +11,10 @@ function stableValue(value: unknown): unknown {
   if (!isRecord(value)) return value;
   return Object.fromEntries(
     Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent and
+      // ranks canonically equivalent distinct keys as equal, so a confirmed cart
+      // would rebind differently across hosts and across key insertion order.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, entry]) => [key, stableValue(entry)]),
   );
 }

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -150,7 +150,10 @@ function canonicalJson(value: unknown): unknown {
   if (typeof value !== "object" || value === null) return value;
   return Object.fromEntries(
     Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent and
+      // ranks canonically equivalent distinct keys as equal, so identical ledger
+      // metadata could compare unequal across hosts and key insertion order.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, nested]) => [key, canonicalJson(nested)]),
   );
 }

--- a/packages/cloud/shared/src/lib/services/settlement-digest.locale-order.test.ts
+++ b/packages/cloud/shared/src/lib/services/settlement-digest.locale-order.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Pins the settlement replay digest to UTF-16 code-unit key ordering. The digest
+ * is the idempotency key for invoice creation, app-charge callback outbox
+ * delivery, and direct wallet payment replay, so "same settlement contract =>
+ * same digest" must hold on every host. ICU collation breaks that twice: it
+ * orders mixed-case and non-ASCII keys by locale, and it ranks canonically
+ * equivalent-but-distinct keys as equal, which leaves their relative order
+ * decided by object insertion order rather than by content.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { canonicalSettlementJson, settlementDigest } from "./settlement-digest";
+
+// Precomposed U+00E9 vs decomposed "e" + U+0301. Distinct JavaScript property
+// keys that `localeCompare` reports as equal (returns 0).
+const NFC_KEY = "caf\u00e9"; // precomposed U+00E9
+const NFD_KEY = "cafe\u0301"; // decomposed "e" + U+0301
+
+describe("settlement digest canonical key order", () => {
+  test("orders mixed-case keys by code unit, not by locale collation", () => {
+    // Code unit: "B" (0x42) < "a" (0x61). ICU collation puts "a" before "B".
+    expect(canonicalSettlementJson({ a: 1, B: 2 })).toBe('{"B":2,"a":1}');
+  });
+
+  test("orders non-ASCII keys by code unit, not by locale collation", () => {
+    // Code unit: "z" (0x7a) < "\u00e4" (0xe4). ICU collation puts "\u00e4" before "z".
+    expect(canonicalSettlementJson({ "\u00e4": 1, z: 2 })).toBe('{"z":2,"\u00e4":1}');
+  });
+
+  test("nested settlement metadata uses the same code-unit ordering", () => {
+    expect(canonicalSettlementJson({ meta: { a: 1, B: 2 }, A: 3 })).toBe(
+      '{"A":3,"meta":{"B":2,"a":1}}',
+    );
+  });
+
+  test("canonically equivalent distinct keys get a total order independent of insertion order", () => {
+    // Under ICU collation these two keys compare equal, so the sort is stable on
+    // insertion order and the same contract digests two different ways.
+    const inserted = { [NFC_KEY]: 1, [NFD_KEY]: 2 };
+    const reversed = { [NFD_KEY]: 2, [NFC_KEY]: 1 };
+    expect(Object.keys(inserted)).toHaveLength(2);
+    expect(settlementDigest(inserted)).toBe(settlementDigest(reversed));
+    expect(canonicalSettlementJson(inserted)).toBe(canonicalSettlementJson(reversed));
+  });
+
+  test("zero-width-joined metadata keys also stay insertion-order independent", () => {
+    const plain = "sku";
+    const zeroWidth = "sk\u200bu";
+    expect(settlementDigest({ [plain]: 1, [zeroWidth]: 2 })).toBe(
+      settlementDigest({ [zeroWidth]: 2, [plain]: 1 }),
+    );
+  });
+
+  test("digest stays a pure function of content for a realistic settlement contract", () => {
+    const contract = {
+      amount_due: "10.00",
+      Currency: "usd",
+      metadata: { Plan: "pro", plan_id: "p-1" },
+      stripe_invoice_id: "in_123",
+    };
+    const reordered = {
+      stripe_invoice_id: "in_123",
+      metadata: { plan_id: "p-1", Plan: "pro" },
+      Currency: "usd",
+      amount_due: "10.00",
+    };
+    expect(settlementDigest(contract)).toBe(settlementDigest(reordered));
+    expect(canonicalSettlementJson(contract)).toBe(
+      '{"Currency":"usd","amount_due":"10.00","metadata":{"Plan":"pro","plan_id":"p-1"},"stripe_invoice_id":"in_123"}',
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/settlement-digest.ts
+++ b/packages/cloud/shared/src/lib/services/settlement-digest.ts
@@ -8,7 +8,10 @@ function canonicalJson(value: unknown): unknown {
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>)
       .filter(([, nested]) => nested !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right))
+      // Code-unit order, not localeCompare: ICU collation is locale-dependent and
+      // ranks canonically equivalent distinct keys as equal, so the replay digest
+      // would vary with the host locale and with key insertion order.
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([key, nested]) => [key, canonicalJson(nested)]),
   );
 }


### PR DESCRIPTION
# Relates to

Sibling-site follow-up to the `localeCompare` determinism fix landed in core by #23736. The #23751 review closed with: *"If you find more of these, the sibling-site check is the valuable half: a determinism helper that got copied usually got its bug copied too."* This is that sweep for `packages/cloud`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package gates run and recorded below (see **Known gaps / failures** for two pre-existing unrelated typecheck errors).
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `7d17ef3d5d267056f5aa0b149b601f9155681668`; zero conflicts. `git diff --check origin/develop...HEAD` clean.
- [x] Package gates pass post-sync; the only failures are pre-existing on unmodified `develop` and documented below.

# Risks

**Low.** Eight one-line comparator replacements, no signature or control-flow change. The new comparator is a total order on distinct strings, so it is strictly more deterministic than the one it replaces — it can only remove ambiguity, never add it.

The one behavioral consequence worth naming: for keys that ICU ordered differently from code units (mixed-case, non-ASCII), the serialized byte order changes, so **digests computed before this change differ from digests computed after** for those key shapes. That is the point of the fix — the old value was locale-dependent and not reproducible — but it means any digest already persisted from a mixed-case/non-ASCII key set will not re-verify. Pure-lowercase-ASCII key sets, which is the overwhelming majority of stored contracts, are byte-identical before and after.

This PR deliberately excludes the two remaining `localeCompare` sites in `packages/cloud` that compute **protocol** signatures (X/Twitter OAuth 1.0a in `advertising/providers/x-twitter.ts`, Twilio webhook HMAC in `api/eliza-app/webhook/_forward.ts`). Those are spec-conformance rather than internal determinism and carry live-integration risk, so they are a separate PR.

# Background

## What does this PR do?

Eight cloud canonical-serialization helpers sorted object keys with `localeCompare`. ICU collation breaks a canonical contract in two independent ways:

1. **Locale-dependent.** The default collator follows the host locale. The same key set orders differently under `sv-SE` than `en-US`:

   ```
   en-US    ["_x","a","Å","ä","B","o","ö","z"]
   sv-SE    ["_x","a","B","o","z","Å","ä","ö"]
   codeUnit ["B","_x","a","o","z","Å","ä","ö"]
   ```

2. **Not a total order.** `localeCompare` returns `0` for *distinct* JavaScript property keys — NFC vs NFD (`"caf\u00e9"` vs `"cafe\u0301"`), and keys separated only by ignorable characters such as U+200B or U+00AD. When the comparator reports equal, `Array.prototype.sort` is stable and falls back to **property insertion order**, so the same logical object canonicalizes two different ways.

Reproduced against the real `settlementDigest` before the fix:

```
canonical(a) = {"café":1,"café":2}      digest = e719669797...
canonical(b) = {"café":2,"café":1}      digest = a2d1540821...
STABLE? false
```

These outputs are idempotency and integrity keys, so "same content ⇒ same bytes" must hold on every host:

| Site | Contract it backs |
|---|---|
| `services/settlement-digest.ts` | sha256 replay digest for invoice creation, app-charge callback outbox, direct wallet payment replay |
| `services/doordash-checkout-binding.ts` | sha256 guard that a confirmed cart/price preview did not change before the order is placed |
| `eliza/runtime/stable-serialize.ts` | feeds the sha1 runtime settings signature |
| `services/affiliate-payout-outbox.ts` | payout metadata equality |
| `services/redeemable-earnings.ts` | earnings ledger metadata equality |
| `services/container-jobs-writer.ts` | container job readback equality |
| `services/ai-pricing/dimensions.ts` | resolved-price lookup and cache key |
| `api/src/inference-admission-gate.ts` | admission recovery contract |

Each is replaced with UTF-16 code-unit ordering — the same comparator #23736 already landed in `core/src/utils/deterministic.ts` and `core/src/runtime/context-hash.ts`:

```ts
.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
```

Concretely, this is what breaks today: `invoicesService.create` digests the contract before insert and re-digests the row read back from Postgres. `jsonb` does not preserve key order, so if the metadata carries a canonically-equivalent or ignorable-character key pair, the two digests disagree and the call throws `"Invoice idempotency replay does not match the original settlement"` on a settlement that actually committed. `assertManagedCheckoutBinding` fails the same way for an unchanged cart.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The rationale is captured as a comment at each call site, matching the wording style of the core fix.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/settlement-digest.locale-order.test.ts` — it asserts the exact serialized key order and the insertion-order independence that the old comparator could not provide.

The #23751 review noted that the obvious test shape is vacuous: comparing two insertion orders through the same sorter passes under `localeCompare` too. These suites therefore pin **exact serialized output** and use key pairs ICU ranks as equal, so they cannot pass without the fix.

## Detailed testing steps

```bash
cd packages/cloud/shared
bun test src/lib/services/settlement-digest.locale-order.test.ts \
         src/lib/services/doordash-checkout-binding.locale-order.test.ts \
         src/lib/services/ai-pricing/dimensions.locale-order.test.ts \
         src/lib/eliza/runtime/stable-serialize.locale-order.test.ts
```

To confirm the suites are not vacuous, revert only the eight production files (keep the tests) and re-run — 16 of 19 fail. The 3 that pass in both states are deliberate controls (a genuinely changed cart still fails its binding; an empty dimension set still collapses to `"*"`), proving the change does not weaken existing behavior.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9d112c0bc37247611c620f92223ca300a1480bbe -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this PR changes key-sort comparators in cloud serialization helpers only.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; behavior is byte-level serialization order, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the changed helpers are pure functions with no logging; the red/green suite output below is the direct execution record of the real code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts attached — the digest/canonical-JSON values produced by the real helpers before and after, plus the cross-locale ordering table, are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.` The authoritative execution record is the red/green run below.

### Red — production fix reverted, test files unchanged

<details><summary>16 of 19 assertions fail against the current comparator</summary>

```
(fail) managed checkout binding canonical key order > digests mixed-case cart keys in code-unit order, not locale order
(fail) managed checkout binding canonical key order > digests non-ASCII cart keys in code-unit order
(fail) managed checkout binding canonical key order > canonically equivalent distinct keys bind independent of insertion order
(fail) settlement digest canonical key order > orders mixed-case keys by code unit, not by locale collation
(fail) settlement digest canonical key order > orders non-ASCII keys by code unit, not by locale collation
(fail) settlement digest canonical key order > nested settlement metadata uses the same code-unit ordering
(fail) settlement digest canonical key order > canonically equivalent distinct keys get a total order independent of insertion order
(fail) settlement digest canonical key order > zero-width-joined metadata keys also stay insertion-order independent
(fail) settlement digest canonical key order > digest stays a pure function of content for a realistic settlement contract
(fail) stableSerialize canonical key order > orders mixed-case keys by code unit, not by locale collation
(fail) stableSerialize canonical key order > orders non-ASCII keys by code unit, not by locale collation
(fail) stableSerialize canonical key order > applies code-unit ordering to nested objects
(fail) stableSerialize canonical key order > gives canonically equivalent distinct keys a total, insertion-independent order
(fail) pricing dimension canonical key order > orders mixed-case dimension names by code unit, not by locale collation
(fail) pricing dimension canonical key order > orders non-ASCII dimension names by code unit
(fail) pricing dimension canonical key order > builds one identical lookup key regardless of insertion order

 3 pass
 16 fail
Ran 19 tests across 4 files.
```

Example failure showing the defect directly:

```
error: expect(received).toBe(expected)
Expected: "a2d154082182d12d601088ebd807c6aa696cd07ae4d8614ef552e6be956f9bef"
Received: "e71966979f73d0ef15a1e01ef50733f0919cc853e4f85fe405c4dc1b65b19c8e"
  at settlement-digest.locale-order.test.ts:42
  (same settlement contract, two key insertion orders, two different digests)
```

</details>

### Green — with the fix, at this exact head

```
bun test v1.3.11 (af24e281)
 19 pass
 0 fail
 24 expect() calls
Ran 19 tests across 4 files. [37.00ms]
```

### Existing suite still green (no behavior regression)

```
$ bun test src/lib/eliza/runtime/stable-serialize.test.ts
 6 pass
 0 fail
 10 expect() calls
```

### Affected-suite A/B (52 existing suites touching the changed modules)

Same suites, same host, unpatched `develop` production files vs this branch:

| batch | baseline (`develop`) | this branch |
|---|---|---|
| 1 | 15 pass / 10 fail | **19 pass / 6 fail** |
| 2 | 13 pass / 7 fail | 13 pass / 7 fail |
| 3 | 11 pass / 8 fail | 11 pass / 8 fail |
| 4 | 9 pass / 8 fail | **12 pass / 5 fail** |
| 5 | 0 pass / 12 fail | 0 pass / 12 fail |
| 6 | 8 pass / 13 fail | **11 pass / 10 fail** |
| 7 | 14 pass / 8 fail | **20 pass / 2 fail** |

Strictly better in every batch, worse in none. The delta is exactly the 16 new assertions. The residual failures are identical on unmodified `develop` — see **Known gaps**.

## Domain artifacts

Cross-locale ordering of one key set, showing the host dependence being removed:

```
en-US    ["_x","a","Å","ä","B","o","ö","z"]
sv-SE    ["_x","a","B","o","z","Å","ä","ö"]
de-DE    ["_x","a","Å","ä","B","o","ö","z"]
codeUnit ["B","_x","a","o","z","Å","ä","ö"]   <- deterministic, now used
```

Distinct keys that `localeCompare` reports as equal (`=== 0`), which is what makes the sort insertion-order dependent:

```
"ab"  vs "a\u00ADb"   -> 0   (soft hyphen, ignorable)
"ab"  vs "a\u200Bb"   -> 0   (zero-width space, ignorable)
"caf\u00e9" vs "cafe\u0301" -> 0   (NFC vs NFD, canonically equivalent)
```

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **`packages/cloud/shared` typecheck: PASS** (exit 0).
- **`packages/cloud/api` typecheck: exit 1, pre-existing and unrelated.** Both errors are in files this PR does not touch, and reproduce identically with this branch's only `cloud/api` change reverted:
  - `../shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts(309,5): error TS2322`
  - `../shared/src/lib/eliza/runtime/initializer.ts(14,32): error TS2307: Cannot find module '@elizaos/plugin-doordash'` — a missing workspace build declaration.
- **Residual failures in the 52-suite A/B** are environment-dependent (PGlite schema bootstrap, live provider-catalog fetches, absent credential env) and are present in identical numbers on unmodified `develop`. None are introduced by this PR; the A/B table above is the control.
- **Biome:** clean on all 12 changed files.
- Full-repo `bun run verify` was not run to completion for this PR; the affected-package gates (Biome, both typechecks, the four new suites, and the 52-suite A/B) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
