### PR TITLE
test(app-core): cover server-html

### DIFF
--- a/packages/app-core/src/api/server-html.test.ts
+++ b/packages/app-core/src/api/server-html.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Colocated coverage for the app-core HTML API-base injector. Drives the real
+ * `injectApiBaseIntoHtml` re-export: early returns, first `</head>` placement,
+ * trim, boot-config merge, token sinks, and inline-script serialization.
+ */
+import { describe, expect, it } from "vitest";
+import { injectApiBaseIntoHtml } from "./server-html";
+
+const HTML = "<!doctype html><html><head></head><body></body></html>";
+const TOKEN = "secret-full-capability-token";
+const VAPID = "BExamplePublicKeyBase64Url";
+const API_BASE = "https://agent.example.test/api";
+
+function extractInlineScript(html: string): string {
+  const open = html.indexOf("<script>");
+  const close = html.indexOf("</script>");
+  if (open < 0 || close < 0 || close <= open) {
+    throw new Error("injected HTML has no inline <script>");
+  }
+  return html.slice(open + "<script>".length, close);
+}
+
+function runInjectedScript(
+  html: string,
+  stored?: unknown,
+): {
+  window: Record<PropertyKey, unknown>;
+  store: Map<string, string>;
+} {
+  const script = extractInlineScript(html);
+  const store = new Map<string, string>();
+  if (stored !== undefined) {
+    store.set("elizaos:active-server", JSON.stringify(stored));
+  }
+  const localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+  const window: Record<PropertyKey, unknown> = {};
+  new Function("window", "localStorage", script)(window, localStorage);
+  return { window, store };
+}
+
+describe("injectApiBaseIntoHtml", () => {
+  it("returns the same Buffer when base, token, and VAPID are all absent", () => {
+    const html = Buffer.from(HTML);
+    expect(injectApiBaseIntoHtml(html)).toBe(html);
+    expect(injectApiBaseIntoHtml(html, undefined, undefined)).toBe(html);
+    expect(injectApiBaseIntoHtml(html, null, {})).toBe(html);
+  });
+
+  it("treats whitespace-only base, token, and VAPID as absent", () => {
+    const html = Buffer.from(HTML);
+    expect(
+      injectApiBaseIntoHtml(html, "   ", {
+        apiToken: "\t",
+        webPushVapidPublicKey: "\n",
+      }),
+    ).toBe(html);
+  });
+
+  it("returns the same Buffer when </head> is missing even with values to inject", () => {
+    const html = Buffer.from("<html><body>no head</body></html>");
+    expect(
+      injectApiBaseIntoHtml(html, API_BASE, {
+        apiToken: TOKEN,
+        webPushVapidPublicKey: VAPID,
+      }),
+    ).toBe(html);
+  });
+
+  it("does not treat a case-shifted </HEAD> as the insertion point", () => {
+    const html = Buffer.from("<html><HEAD></HEAD><body></body></html>");
+    expect(injectApiBaseIntoHtml(html, API_BASE).toString("utf-8")).toBe(
+      html.toString("utf-8"),
+    );
+  });
+
+  it("inserts one script immediately before the first </head>", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), API_BASE).toString(
+      "utf-8",
+    );
+    expect(out.match(/<script>/g)).toHaveLength(1);
+    expect(out.match(/<\/script>/g)).toHaveLength(1);
+    expect(out).toContain("</script></head>");
+    expect(out.indexOf("<script>")).toBeLessThan(out.indexOf("</head>"));
+  });
+
+  it("uses the first </head> when the document contains more than one", () => {
+    const html =
+      "<html><head></head><body><template></head></template></body></html>";
+    const out = injectApiBaseIntoHtml(Buffer.from(html), API_BASE).toString(
+      "utf-8",
+    );
+    const firstClose = out.indexOf("</head>");
+    const secondClose = out.indexOf("</head>", firstClose + 1);
+    expect(out.slice(0, firstClose)).toContain("<script>");
+    expect(out.slice(firstClose, secondClose)).not.toContain("<script>");
+    expect(out.slice(secondClose)).toBe("</head></template></body></html>");
+  });
+
+  it("does not mutate the input Buffer when it injects", () => {
+    const html = Buffer.from(HTML);
+    const before = Buffer.from(html);
+    injectApiBaseIntoHtml(html, API_BASE);
+    expect(html.equals(before)).toBe(true);
+  });
+
+  it("trims externalBase and seeds it as apiBase in a single boot-config write", () => {
+    const out = injectApiBaseIntoHtml(
+      Buffer.from(HTML),
+      `  ${API_BASE}  `,
+    ).toString("utf-8");
+    const { window } = runInjectedScript(out);
+    const boot = window.__ELIZAOS_APP_BOOT_CONFIG__ as {
+      apiBase?: string;
+      apiToken?: string;
+      webPushVapidPublicKey?: string;
+    };
+    expect(boot.apiBase).toBe(API_BASE);
+    expect(boot.apiToken).toBeUndefined();
+    expect(boot.webPushVapidPublicKey).toBeUndefined();
+    expect(window.__ELIZA_API_TOKEN__).toBeUndefined();
+    expect(out.split("__ELIZAOS_APP_BOOT_CONFIG__=next").length - 1).toBe(1);
+  });
+
+  it("does not emit token sinks when only an API base is provided", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), API_BASE).toString(
+      "utf-8",
+    );
+    expect(out).not.toContain("apiToken");
+    expect(out).not.toContain("__ELIZA_API_TOKEN__");
+    expect(out).not.toContain("elizaos:active-server");
+  });
+
+  it("seeds every token sink when only an API token is provided", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), undefined, {
+      apiToken: `  ${TOKEN}  `,
+    }).toString("utf-8");
+    const { window, store } = runInjectedScript(out);
+    const bootKey = Symbol.for("elizaos.app.boot-config");
+    expect(
+      (window.__ELIZAOS_APP_BOOT_CONFIG__ as { apiToken?: string }).apiToken,
+    ).toBe(TOKEN);
+    expect(
+      (window[bootKey] as { current: { apiToken?: string } }).current.apiToken,
+    ).toBe(TOKEN);
+    expect(window.__ELIZA_API_TOKEN__).toBe(TOKEN);
+    expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: TOKEN,
+    });
+    expect(store.get("eliza:first-run-complete")).toBeUndefined();
+    expect(out).not.toContain("apiBase");
+    expect(out).not.toContain("webPushVapidPublicKey");
+  });
+
+  it("refreshes accessToken on an existing local record and leaves remote/cloud records untouched", () => {
+    const localHtml = injectApiBaseIntoHtml(Buffer.from(HTML), undefined, {
+      apiToken: TOKEN,
+    }).toString("utf-8");
+    const local = runInjectedScript(localHtml, {
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: "stale-token",
+    });
+    expect(
+      JSON.parse(local.store.get("elizaos:active-server") ?? "{}"),
+    ).toEqual({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: TOKEN,
+    });
+
+    const remote = {
+      id: "remote:https://box.lan",
+      kind: "remote",
+      label: "box.lan",
+      apiBase: "https://box.lan",
+    };
+    const remoteResult = runInjectedScript(localHtml, remote);
+    expect(
+      JSON.parse(remoteResult.store.get("elizaos:active-server") ?? "{}"),
+    ).toEqual(remote);
+
+    const cloud = {
+      id: "cloud:https://elizacloud.ai",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://elizacloud.ai",
+    };
+    const cloudResult = runInjectedScript(localHtml, cloud);
+    expect(
+      JSON.parse(cloudResult.store.get("elizaos:active-server") ?? "{}"),
+    ).toEqual(cloud);
+  });
+
+  it("seeds a local record when stored JSON is corrupt", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), undefined, {
+      apiToken: TOKEN,
+    }).toString("utf-8");
+    const script = extractInlineScript(out);
+    const store = new Map<string, string>([
+      ["elizaos:active-server", "{not json"],
+    ]);
+    const localStorage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+    };
+    new Function("window", "localStorage", script)({}, localStorage);
+    expect(JSON.parse(store.get("elizaos:active-server") ?? "{}")).toEqual({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+      accessToken: TOKEN,
+    });
+  });
+
+  it("still seeds in-memory token sinks when localStorage throws", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), undefined, {
+      apiToken: TOKEN,
+    }).toString("utf-8");
+    const script = extractInlineScript(out);
+    const hostile = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+    const window: Record<PropertyKey, unknown> = {};
+    expect(() =>
+      new Function("window", "localStorage", script)(window, hostile),
+    ).not.toThrow();
+    expect(
+      (window.__ELIZAOS_APP_BOOT_CONFIG__ as { apiToken?: string }).apiToken,
+    ).toBe(TOKEN);
+    expect(window.__ELIZA_API_TOKEN__).toBe(TOKEN);
+  });
+
+  it("seeds the VAPID public key into the boot-config store", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), undefined, {
+      webPushVapidPublicKey: ` ${VAPID} `,
+    }).toString("utf-8");
+    const { window } = runInjectedScript(out);
+    expect(
+      (window.__ELIZAOS_APP_BOOT_CONFIG__ as { webPushVapidPublicKey?: string })
+        .webPushVapidPublicKey,
+    ).toBe(VAPID);
+    expect(out).not.toContain("apiToken");
+    expect(out).not.toContain("__ELIZA_API_TOKEN__");
+  });
+
+  it("merges apiBase and VAPID into one boot-config write", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), API_BASE, {
+      webPushVapidPublicKey: VAPID,
+    }).toString("utf-8");
+    const { window } = runInjectedScript(out);
+    expect(window.__ELIZAOS_APP_BOOT_CONFIG__).toEqual({
+      apiBase: API_BASE,
+      webPushVapidPublicKey: VAPID,
+    });
+    expect(out.split("__ELIZAOS_APP_BOOT_CONFIG__=next").length - 1).toBe(1);
+  });
+
+  it("keeps boot-config overrides and token sinks as separate sequential writes", () => {
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), API_BASE, {
+      apiToken: TOKEN,
+      webPushVapidPublicKey: VAPID,
+    }).toString("utf-8");
+    expect(out.split("__ELIZAOS_APP_BOOT_CONFIG__=next").length - 1).toBe(2);
+    const { window } = runInjectedScript(out);
+    expect(window.__ELIZAOS_APP_BOOT_CONFIG__).toEqual({
+      apiBase: API_BASE,
+      webPushVapidPublicKey: VAPID,
+      apiToken: TOKEN,
+    });
+    expect(window.__ELIZA_API_TOKEN__).toBe(TOKEN);
+  });
+
+  it("keeps script-shaped values inside the generated JavaScript literal", () => {
+    const externalBase =
+      'https://agent.example.test/</script><script data-owned="no">alert(1)</script>?x=&';
+    const token =
+      'token</script><script data-owned="no">alert(2)</script>&A\u2028\u2029B';
+    const vapid = 'vapid</script><img src=x onerror="alert(3)">&';
+    const out = injectApiBaseIntoHtml(Buffer.from(HTML), externalBase, {
+      apiToken: token,
+      webPushVapidPublicKey: vapid,
+    }).toString("utf-8");
+
+    expect(out.match(/<script>/g)).toHaveLength(1);
+    expect(out.match(/<\/script>/g)).toHaveLength(1);
+    expect(out).not.toContain('</script><script data-owned="no">');
+    expect(out).toContain("\\u003c/script\\u003e");
+    expect(out).toContain("\\u0026");
+    expect(out).toContain("\\u2028\\u2029");
+
+    const { window } = runInjectedScript(out);
+    const boot = window.__ELIZAOS_APP_BOOT_CONFIG__ as {
+      apiBase: string;
+      apiToken: string;
+      webPushVapidPublicKey: string;
+    };
+    expect(boot.apiBase).toBe(externalBase);
+    expect(boot.apiToken).toBe(token);
+    expect(boot.webPushVapidPublicKey).toBe(vapid);
+    expect(window.__ELIZA_API_TOKEN__).toBe(token);
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/app-core/src/api/server-html.ts`, which had no colocated `server-html.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`) with a single-file commit (`packages/app-core/src/api/server-html.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is `origin/develop` `5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`, re-fetched immediately before filing; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. Failure mode is a false assertion of observed HTML injection behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/app-core/src/api/server-html.test.ts` driving the real `injectApiBaseIntoHtml` re-export in `server-html.ts` (the app-core wrapper around `@elizaos/agent`). No mocks of the system under test.

Covered behaviour, as observed in the live module:

- Same Buffer identity when base, token, and VAPID are all absent (`undefined` / `null` / empty opts)
- Whitespace-only base, token, and VAPID are treated as absent
- Missing `</head>` returns the original Buffer even when values are present
- Case-shifted `</HEAD>` is not an insertion point (`indexOf` is case-sensitive)
- One `<script>` is inserted immediately before the first `</head>`
- A later `</head>` in the body is left as a second close tag
- The input Buffer is not mutated when injection happens
- Trimmed `externalBase` is seeded as `apiBase` in a single boot-config write, without token sinks
- Token-only injection seeds boot-config `apiToken`, `window.__ELIZA_API_TOKEN__`, and `elizaos:active-server` (fresh `local:embedded` record); does not write `eliza:first-run-complete`
- Existing `kind: "local"` records get `accessToken` refreshed; `remote` and `cloud` records are left untouched
- Corrupt stored JSON is replaced with a fresh local record
- In-memory token sinks still land when `localStorage` throws
- Trimmed VAPID public key is seeded into boot-config without token sinks
- `apiBase` and VAPID merge into one boot-config write; adding a token is a second sequential write
- Script-breaking characters in base/token/VAPID stay inside the generated JavaScript literal (`\\u003c`, `\\u0026`, `\\u2028\\u2029`)

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/server-html.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (`server-html.ts` unchanged vs this PR's parent). The suite must be collected with the app-core vitest config so `@elizaos/agent` aliases resolve:

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/server-html.test.ts
bunx biome check --write packages/app-core/src/api/server-html.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'server-html.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop` `5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`):

1. Vitest: **Test Files 1 passed (1), Tests 17 passed (17)** (`bunx vitest run --config vitest.config.ts src/api/server-html.test.ts` from `packages/app-core`).

```text
 ✓ src/api/server-html.test.ts (17 tests) 7ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  17:44:13
   Duration  16.77s (transform 13.22s, setup 0ms, import 16.68s, tests 7ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/app-core/src/api/server-html.test.ts` — `Checked 1 file in 33ms. Fixed 1 file.` The committed file is that formatted result. Config exists at repo-root `biome.json`; this checkout is not sparse.
3. `tsc --noEmit` in `packages/app-core`: **`server-html.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors in other files are unrelated.
4. Diff touches **only** `packages/app-core/src/api/server-html.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Evidence head (40-character SHA of this PR): `38b9b3a7f220bbc289eb4311c3a8f93ec77d8703`

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 17 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Hosted CI does not run on this fork contributor PR. Local vitest, biome, and package `tsc` are the proof.

`bun run verify` was not run; this PR changes no production code.

`tsc --noEmit` for `packages/app-core` still reports pre-existing errors in other files; none mention `server-html.test.ts`.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:38b9b3a7f220bbc289eb4311c3a8f93ec77d8703 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
