### PR TITLE
feat(registry): list @deskcrew/plugin-bounty-board

### DIFF
--- a/packages/registry/entries/third-party/deskcrew__plugin-bounty-board.json
+++ b/packages/registry/entries/third-party/deskcrew__plugin-bounty-board.json
@@ -1,0 +1,9 @@
+{
+  "package": "@deskcrew/plugin-bounty-board",
+  "repository": "github:webmilmind1/plugin-bounty-board",
+  "kind": "plugin",
+  "description": "Earn USDC answering real support bounties, or run your own bounty board, over x402 pay-per-call. No account or API key: the wallet is the identity, a human approves the winning answer, and the submitting wallet is paid 85% automatically on Base or Solana.",
+  "homepage": "https://deskcrew.io/agents",
+  "version": "1.0.0",
+  "tags": ["x402", "usdc", "bounties", "payments", "micropayments", "solana", "base", "earn", "support", "agent-economy"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -184,6 +184,56 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@deskcrew/plugin-bounty-board": {
+      "git": {
+        "repo": "webmilmind1/plugin-bounty-board",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@deskcrew/plugin-bounty-board",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Earn USDC answering real support bounties, or run your own bounty board, over x402 pay-per-call. No account or API key: the wallet is the identity, a human approves the winning answer, and the submitting wallet is paid 85% automatically on Base or Solana.",
+      "homepage": "https://deskcrew.io/agents",
+      "topics": [
+        "x402",
+        "usdc",
+        "bounties",
+        "payments",
+        "micropayments",
+        "solana",
+        "base",
+        "earn",
+        "support",
+        "agent-economy"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@human.tech/plugin-waap": {
       "git": {
         "repo": "holonym-foundation/eliza-plugin-waap",


### PR DESCRIPTION
## Summary

Lists `@deskcrew/plugin-bounty-board` in the community plugin registry, per the submission in #25547. The submitter cannot fork the repository (GitHub UI error) and the released CLI (1.7.2) lacks the documented `plugins submit` command, so the issue is the submission path; this PR lands it exactly as documented in `packages/registry/README.md` → "Adding a third-party plugin".

Two-file data-only change:

- `packages/registry/entries/third-party/deskcrew__plugin-bounty-board.json` — the submitted JSON **verbatim** (all 7 fields, tag order, pinned `version: 1.0.0`).
- `packages/registry/generated-registry.json` — regenerated with the committed generator (`bun run generate`), never hand-edited: one 50-line insertion sorted between `@davyjones0x/plugin-peer-cash` and `@human.tech/plugin-waap`, registry grows 48 → 49 entries.

## Verification

External claims verified live before implementation:

- npm: `GET registry.npmjs.org/@deskcrew%2fplugin-bounty-board` → 200. `versions` includes `1.0.0` (MIT; `repository` matches `github.com/webmilmind1/plugin-bounty-board`; description matches). `dist-tags.latest` is `1.0.1`, but `version` records "the published npm version this entry was registered against" and the submission pins `1.0.0` — honored verbatim.
- GitHub repo `github.com/webmilmind1/plugin-bounty-board` → HTTP 200; homepage `https://deskcrew.io/agents` → HTTP 200.

Local gates (all executed at the pushed head after rebase onto develop tip `5cdd5f2d7df`):

| Gate | Result |
|---|---|
| `bun run --cwd packages/registry validate` | `[registry] 49 third-party entries validated` (was 48) |
| `bun run --cwd packages/registry generate` | regenerated; diff inspected — exactly one insertion, zero drift on the other 48 entries |
| `bun run --cwd packages/registry test` | 7 files / 41 tests passed — includes the on-disk suite (`registry.test.ts` → "keeps generated-registry.json in sync with source entries") which loads the real `entries/third-party/` directory including the new entry and asserts wire-format equality |
| `bun run --cwd packages/registry typecheck` | clean |
| `bun run --cwd packages/registry lint:check` / `format:check` | clean |
| RED CONTROL (fail-closed proof) | adding a second file claiming the same `@deskcrew/plugin-bounty-board` package → `validate` exits 1: `Duplicate registry entry for @deskcrew/plugin-bounty-board` |
| Byte-comparison probe | written entry == submitted JSON field-for-field (parsed comparison, incl. tag order); wire mapping asserted: `git.repo webmilmind1/plugin-bounty-board`, `git.v2.branch main`, `npm.v2 1.0.0`, `topics` == submitted tags, `thirdParty true`, `supports v2 only` — matches the runtime consumer mapping in `packages/agent/src/services/registry-client-network.ts` (`npm.v2` → `v2Version`) |
| Independent review | RepoPrompt CE review agent (Codex `gpt-5.6-sol`, embedded exact-bytes diff + entry + generator mapping): verdict **APPROVE, no must-fix items** |

`generate:first-party:check` currently exits 1 on develop with a Zod `subtype` enum error inside `collectPluginOwnedEntries` — proven **pre-existing** via a stash control on pristine develop (identical failure without this change); unrelated to the third-party lane.

Curation note: the plugin is financially sensitive (x402 pay-per-call bounties, wallet-as-identity, 85% payout split), but the registry already lists comparable financial entries (offramp, x402, yieldsignal), and no schema, mapping, or policy violation was found by either reviewer.

Closes #25547.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - data-only registry entry change; no UI surface exists to photograph.

<!-- evidence-row:after-screenshots -->
N/A - data-only registry entry change; no UI surface exists to photograph.

<!-- evidence-row:walkthrough-video -->
N/A - no user-visible flow; the change is one JSON entry plus its machine-generated wire output.

<!-- evidence-row:backend-logs -->
Executed at the pushed head `6eba63443aa12e8b3b3740d1f2737d10aa93ca10` (worktree, pinned bun 1.3.14):

```
$ bun run --cwd packages/registry validate
[registry] 49 third-party entries validated
$ bun run --cwd packages/registry test
 Test Files  7 passed (7)
      Tests  41 passed (41)
$ bun run --cwd packages/registry typecheck
$ tsc --noEmit -p tsconfig.json
(clean exit 0)
$ bun run --cwd packages/registry lint:check
Checked 56 files in 72ms. No fixes applied.
$ bun run --cwd packages/registry format:check
Checked 56 files in 29ms. No fixes applied.
```

RED CONTROL (fail-closed proof): adding a duplicate `zz-red-control.json` claiming the same package name makes `validate` exit 1 with `Duplicate registry entry for @deskcrew/plugin-bounty-board (zz-red-control.json)`.

Byte-compare probe: written entry == issue-submitted JSON field-for-field; wire mapping asserted against `src/generate.ts` and the runtime consumer `packages/agent/src/services/registry-client-network.ts`.

<!-- evidence-row:frontend-logs -->
N/A - data-only registry entry change; no frontend surface touched.

<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt, or inference-path change.

<!-- evidence-row:domain-artifacts -->
N/A - no domain/UI artifacts; the added entry file and regenerated wire JSON are inline in the diff.

<!-- evidence-head:6eba63443aa12e8b3b3740d1f2737d10aa93ca10 -->

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza"} -->

