### PR TITLE
fix(agent): sort chat fingerprint keys by code unit, not locale

### DIFF
--- a/packages/agent/src/api/conversation-chat-fingerprint.locale-order.test.ts
+++ b/packages/agent/src/api/conversation-chat-fingerprint.locale-order.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pins the conversation chat fingerprint to UTF-16 code-unit key ordering.
+ * The fingerprint is the idempotency identity for a chat turn, and its input
+ * includes caller-supplied `metadata`, so a client controls the property names
+ * that reach the canonicalizer. ICU collation orders those names by host locale
+ * and ranks canonically equivalent distinct names as equal, which lets two
+ * agent replicas derive different fingerprints for the same request and admit a
+ * duplicate turn that idempotency was supposed to collapse.
+ */
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { buildConversationChatFingerprint } from "./conversation-routes.ts";
+
+const NFC_KEY = "caf\u00e9"; // precomposed U+00E9
+const NFD_KEY = "cafe\u0301"; // decomposed "e" + U+0301
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+const BASE = {
+  prompt: "hello",
+  images: [],
+  source: "api",
+  channelType: "dm",
+  preferredLanguage: "en",
+};
+
+describe("conversation chat fingerprint canonical key order", () => {
+  it("orders caller metadata keys by code unit, not by locale collation", () => {
+    // ICU collation would emit {"a":1,"B":2}; code-unit order is "B" (0x42)
+    // before "a" (0x61). The expected wire string is pinned literally rather
+    // than recomputed, so the assertion fails if the sorter regresses.
+    expect(
+      buildConversationChatFingerprint({ ...BASE, metadata: { a: 1, B: 2 } }),
+    ).toBe(
+      sha256(
+        '{"channelType":"dm","images":[],"metadata":{"B":2,"a":1},"preferredLanguage":"en","prompt":"hello","source":"api"}',
+      ),
+    );
+  });
+
+  it("orders non-ASCII metadata keys by code unit", () => {
+    expect(
+      buildConversationChatFingerprint({
+        ...BASE,
+        metadata: { "\u00e4": 1, z: 2 },
+      }),
+    ).toBe(
+      sha256(
+        '{"channelType":"dm","images":[],"metadata":{"z":2,"\u00e4":1},"preferredLanguage":"en","prompt":"hello","source":"api"}',
+      ),
+    );
+  });
+
+  it("gives canonically equivalent distinct metadata keys an insertion-independent order", () => {
+    // ICU ranks these two distinct property names equal, so the sort falls back
+    // to insertion order and the same turn fingerprints two different ways.
+    expect(
+      buildConversationChatFingerprint({
+        ...BASE,
+        metadata: { [NFC_KEY]: 1, [NFD_KEY]: 2 },
+      }),
+    ).toBe(
+      buildConversationChatFingerprint({
+        ...BASE,
+        metadata: { [NFD_KEY]: 2, [NFC_KEY]: 1 },
+      }),
+    );
+  });
+
+  it("still separates turns that genuinely differ", () => {
+    expect(
+      buildConversationChatFingerprint({ ...BASE, metadata: { a: 1 } }),
+    ).not.toBe(
+      buildConversationChatFingerprint({ ...BASE, metadata: { a: 2 } }),
+    );
+  });
+});

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -483,14 +483,21 @@ function canonicalChatFingerprintValue(value: unknown): unknown {
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
+        // Code-unit order, not localeCompare: ICU collation is locale-dependent
+        // and ranks canonically equivalent distinct keys as equal, so two
+        // replicas would fingerprint one turn differently and admit a duplicate.
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
         .map(([key, entry]) => [key, canonicalChatFingerprintValue(entry)]),
     );
   }
   return value;
 }
 
-function buildConversationChatFingerprint(input: {
+/**
+ * Idempotency identity for one chat turn. Exported so the canonical key
+ * ordering it depends on can be pinned by test.
+ */
+export function buildConversationChatFingerprint(input: {
   prompt: string;
   images: unknown;
   source: unknown;


### PR DESCRIPTION
# Relates to

Sibling-site follow-up to the `localeCompare` determinism fix landed in core by #23736, whose #23751 review asked for exactly this sweep: *"a determinism helper that got copied usually got its bug copied too."* Companion to #25854, which covers the `packages/cloud` sites. This one is `packages/agent`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package gates run and recorded below (one pre-existing unrelated typecheck error documented).
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`; zero conflicts.
- [x] Package gates pass post-sync; the single typecheck failure is pre-existing on unmodified `develop` and documented below.

# Risks

**Low.** One comparator replacement plus one additive `export`. No signature, parameter, or control-flow change.

The fingerprint is **process-local reservation state** — it feeds the in-memory chat idempotency scope (`buildConversationChatIdempotencyScope` / `setChatMessageIdOutcome`) and is never persisted or exchanged with another service. There is therefore no stored-value or wire-compatibility surface: the only effect of the changed byte order is that in-flight reservations from a process started before the change would not match, which is already true across any restart.

**Deliberately excluded from this PR:** `packages/agent/src/services/remote-plugin-adapter.ts:1402` carries the identical `localeCompare` canonicalizer, and it is *not* fixed here. That one feeds `hashRemotePluginModuleForProvenance`, which is compared against `provenance.digestSha256` produced by the external `eliza-cloud-build` signer. No code in this repository computes that digest, so changing the verifier alone would silently reject already-signed manifests, and `remote-plugin-adapter.walk-bound.test.ts` explicitly enshrines the current canonicalization as a backward-compatibility oracle ("a module whose provenance digest is computed this way must still be trusted"). Its exposure is also narrower: every `RemotePluginModuleManifest` key is lowercase-initial ASCII, where ICU and code-unit ordering agree; only arbitrary nested `config`/`schema`/`metadata` keys can diverge. Fixing it needs a coordinated signer change, so it is reported here rather than changed blind.

# Background

## What does this PR do?

`buildConversationChatFingerprint` sha256s a canonicalized turn descriptor and uses it as the idempotency identity for a chat turn. Its input includes caller-supplied `metadata`, so **a client controls the property names that reach the canonicalizer**.

Those names were sorted with `localeCompare`, which breaks a canonical contract two ways:

1. **Locale-dependent.** The default collator follows the host locale, so the same key set orders differently per host:

   ```
   en-US    ["_x","a","Å","ä","B","o","ö","z"]
   sv-SE    ["_x","a","B","o","z","Å","ä","ö"]
   codeUnit ["B","_x","a","o","z","Å","ä","ö"]
   ```

2. **Not a total order.** `localeCompare` returns `0` for *distinct* property names — NFC vs NFD (`"caf\u00e9"` vs `"cafe\u0301"`), and names separated only by ignorable characters such as U+200B or U+00AD. When the comparator reports equal, `Array.prototype.sort` is stable and falls back to **insertion order**, so one logical turn fingerprints two different ways.

The consequence: two agent replicas behind a load balancer, or one replica whose metadata object was rebuilt in a different key order, derive different fingerprints for the same request — and admit a **duplicate chat turn** that idempotency was supposed to collapse.

Replaced with UTF-16 code-unit ordering, the same comparator #23736 landed in `core/src/utils/deterministic.ts` and `core/src/runtime/context-hash.ts`:

```ts
.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
```

`buildConversationChatFingerprint` is additionally `export`ed so the regression can pin the exact canonical bytes rather than mirroring the sorter. `conversation-routes.ts` already exports several route helpers (`normalizeActionCallbackHistory`, `formatConversationMessageText`, `serializeMessageAttachments`, …) for the same reason.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The rationale is captured as a comment at the call site, matching the wording of the core fix.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/conversation-chat-fingerprint.locale-order.test.ts`.

The #23751 review flagged that the obvious test shape is vacuous — comparing two insertion orders through the same sorter passes under `localeCompare` too. This suite instead pins the **exact canonical wire string** and hashes it independently, and uses key pairs ICU ranks as equal, so it cannot pass without the fix.

## Detailed testing steps

```bash
cd packages/agent
npx vitest run src/api/conversation-chat-fingerprint.locale-order.test.ts
```

To confirm the suite is not vacuous, revert only `conversation-routes.ts`'s comparator (keep the `export` and the test) and re-run — 3 of 4 fail. The 4th is a deliberate control (turns that genuinely differ must still fingerprint differently) which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:00f29a891de929759ebe2b694213c2b398c22c54 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a key-sort comparator in an HTTP route helper.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is byte-level canonicalization order, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - the changed helper is a pure function with no logging; the red/green suite output below is the direct execution record of the real code path, including the conversation idempotency suite that consumes the fingerprint.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed; this is turn-identity hashing only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts attached — the fingerprint values produced by the real helper before and after, plus the cross-locale ordering table, are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — comparator reverted, test unchanged

```
FAIL src/api/conversation-chat-fingerprint.locale-order.test.ts
  > orders caller metadata keys by code unit, not by locale collation
  > orders non-ASCII metadata keys by code unit
  > gives canonically equivalent distinct metadata keys an insertion-independent order

AssertionError: expected '2080cd6f7f51ec8d038e7c8c2c6716b4e3cff…' to be '00e237f8f1ae258aba5f2b815d7a2b00e86eb…'
Expected: "00e237f8f1ae258aba5f2b815d7a2b00e86ebee717e02b998abfae377d8580cf"
Received: "2080cd6f7f51ec8d038e7c8c2c6716b4e3cff2e046f49b1cbd0782ed0ce09f8e"
  (same turn, two metadata key insertion orders, two different fingerprints)

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

### Green — with the fix, at this exact head

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Consumers still green (no behavior regression)

```
$ npx vitest run src/api/__tests__/conversation-idempotency.test.ts \
                 src/api/chat-attachments.test.ts \
                 src/api/conversation-sort.test.ts \
                 src/api/conversation-metadata.test.ts \
                 src/api/conversation-restore.test.ts \
                 src/api/conversation-chat-fingerprint.locale-order.test.ts

 Test Files  6 passed (6)
      Tests  94 passed (94)
```

The conversation idempotency suite is the direct consumer of this fingerprint and passes unchanged.

## Domain artifacts

Distinct property names that `localeCompare` reports as equal (`=== 0`), which is what makes the sort fall back to insertion order:

```
"ab"  vs "a\u00ADb"   -> 0   (soft hyphen, ignorable)
"ab"  vs "a\u200Bb"   -> 0   (zero-width space, ignorable)
"caf\u00e9" vs "cafe\u0301" -> 0   (NFC vs NFD, canonically equivalent)
```

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **`packages/agent` typecheck: exit 1, pre-existing and unrelated.** The single error is in a file this PR does not touch and reproduces with this branch's production change reverted:
  `src/runtime/__tests__/owner-entity.test.ts(12,57): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.`
  It arrived with the recently merged #25704.
- **`remote-plugin-adapter.ts:1402` is knowingly left unfixed** — see **Risks**. It needs a coordinated change to the external `eliza-cloud-build` signer, which is not in this repository, so it is reported rather than changed blind. Happy to open a follow-up if maintainers can confirm the signer's canonicalization.
- Full-repo `bun run verify` was not run to completion for this PR; the affected-package gates (Biome, typecheck, the new suite, and the five consumer suites) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
