### PR TITLE
test(app-core): cover setup-contract

### DIFF
--- a/packages/app-core/src/api/setup-contract.test.ts
+++ b/packages/app-core/src/api/setup-contract.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Colocated coverage for the app-core connector-setup HTTP-route contract
+ * re-export. Drives the real module: identity with `@elizaos/core`, the closed
+ * SETUP_ERROR_CODES set, buildSetupError envelope shape (including empty and
+ * connector-specific codes), and setupPath composition for every action,
+ * empty/single connectors, and unencoded interpolations. No mocks.
+ */
+import {
+  SETUP_ERROR_CODES as CORE_SETUP_ERROR_CODES,
+  buildSetupError as coreBuildSetupError,
+  setupPath as coreSetupPath,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import * as setupContract from "./setup-contract";
+import {
+  buildSetupError,
+  SETUP_ERROR_CODES,
+  type SetupErrorCode,
+  type SetupErrorResponse,
+  type SetupState,
+  type SetupStatusResponse,
+  setupPath,
+} from "./setup-contract";
+
+describe("app-core setup-contract re-export", () => {
+  it("re-exports the same runtime values as @elizaos/core", () => {
+    expect(buildSetupError).toBe(coreBuildSetupError);
+    expect(SETUP_ERROR_CODES).toBe(CORE_SETUP_ERROR_CODES);
+    expect(setupPath).toBe(coreSetupPath);
+  });
+
+  it("exposes only the three runtime contract symbols", () => {
+    expect(Object.keys(setupContract).sort()).toEqual([
+      "SETUP_ERROR_CODES",
+      "buildSetupError",
+      "setupPath",
+    ]);
+  });
+});
+
+describe("SETUP_ERROR_CODES", () => {
+  it("is the closed four-code map in declaration order", () => {
+    expect(Object.keys(SETUP_ERROR_CODES)).toEqual([
+      "BAD_REQUEST",
+      "SERVICE_UNAVAILABLE",
+      "INTERNAL_ERROR",
+      "TOO_MANY_SESSIONS",
+    ]);
+    expect(SETUP_ERROR_CODES).toEqual({
+      BAD_REQUEST: "bad_request",
+      SERVICE_UNAVAILABLE: "service_unavailable",
+      INTERNAL_ERROR: "internal_error",
+      TOO_MANY_SESSIONS: "too_many_sessions",
+    });
+  });
+
+  it("values are the SetupErrorCode union members", () => {
+    const codes: SetupErrorCode[] = Object.values(SETUP_ERROR_CODES);
+    expect(codes).toEqual([
+      "bad_request",
+      "service_unavailable",
+      "internal_error",
+      "too_many_sessions",
+    ]);
+  });
+
+  it("is a mutable object at runtime (as const is compile-time only)", () => {
+    expect(Object.isFrozen(SETUP_ERROR_CODES)).toBe(false);
+    expect(Object.isSealed(SETUP_ERROR_CODES)).toBe(false);
+  });
+});
+
+describe("buildSetupError", () => {
+  it("wraps each catalogued code and a message in { error: { code, message } }", () => {
+    for (const code of Object.values(SETUP_ERROR_CODES)) {
+      const err: SetupErrorResponse = buildSetupError(code, `failed: ${code}`);
+      expect(err).toEqual({
+        error: { code, message: `failed: ${code}` },
+      });
+      expect(Object.keys(err)).toEqual(["error"]);
+      expect(Object.keys(err.error)).toEqual(["code", "message"]);
+    }
+  });
+
+  it("accepts a connector-specific code string that is not in the catalog", () => {
+    expect(buildSetupError("unauthorized", "pairing token expired")).toEqual({
+      error: { code: "unauthorized", message: "pairing token expired" },
+    });
+  });
+
+  it("preserves empty code and empty message instead of substituting defaults", () => {
+    expect(buildSetupError("", "")).toEqual({
+      error: { code: "", message: "" },
+    });
+  });
+
+  it("returns a new envelope each call and does not alias the inputs", () => {
+    const first = buildSetupError("bad_request", "one");
+    const second = buildSetupError("bad_request", "one");
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(first.error).not.toBe(second.error);
+  });
+
+  it("keeps unicode, whitespace, and JSON-special characters in the message", () => {
+    const message = 'line\n\t"quoted" \\ 你好';
+    expect(buildSetupError("internal_error", message)).toEqual({
+      error: { code: "internal_error", message },
+    });
+  });
+});
+
+describe("setupPath", () => {
+  it("composes /api/setup/<connector>/<action> for every documented action", () => {
+    expect(setupPath("telegram", "status")).toBe("/api/setup/telegram/status");
+    expect(setupPath("telegram", "start")).toBe("/api/setup/telegram/start");
+    expect(setupPath("telegram", "cancel")).toBe("/api/setup/telegram/cancel");
+  });
+
+  it("interpolates an empty connector as a double slash rather than omitting the segment", () => {
+    expect(setupPath("", "status")).toBe("/api/setup//status");
+  });
+
+  it("interpolates a single-character connector without padding", () => {
+    expect(setupPath("x", "start")).toBe("/api/setup/x/start");
+  });
+
+  it("does not URI-encode, strip slashes, or reject extra path segments in the connector", () => {
+    expect(setupPath("blue bubbles", "status")).toBe(
+      "/api/setup/blue bubbles/status",
+    );
+    expect(setupPath("a/b", "start")).toBe("/api/setup/a/b/start");
+    expect(setupPath("tg?x=1", "cancel")).toBe("/api/setup/tg?x=1/cancel");
+  });
+
+  it("does not validate action at runtime — an out-of-union string is interpolated as-is", () => {
+    expect(setupPath("telegram", "delete" as "status")).toBe(
+      "/api/setup/telegram/delete",
+    );
+  });
+});
+
+describe("SetupState and SetupStatusResponse", () => {
+  it("SetupState is the closed four-state lifecycle union", () => {
+    const states: SetupState[] = ["idle", "configuring", "paired", "error"];
+    expect([...states].sort()).toEqual([
+      "configuring",
+      "error",
+      "idle",
+      "paired",
+    ]);
+  });
+
+  it("SetupStatusResponse carries connector, state, and optional typed detail", () => {
+    const withDetail: SetupStatusResponse<{ qr: string }> = {
+      connector: "telegram",
+      state: "configuring",
+      detail: { qr: "otpauth://totp/eliza" },
+    };
+    const withoutDetail: SetupStatusResponse = {
+      connector: "imessage",
+      state: "idle",
+    };
+    expect(withDetail.detail?.qr).toBe("otpauth://totp/eliza");
+    expect(withoutDetail.detail).toBeUndefined();
+    expect(withoutDetail).toEqual({ connector: "imessage", state: "idle" });
+  });
+});


### PR DESCRIPTION
# Relates to

Operator-selected coverage gap: `packages/app-core/src/api/setup-contract.ts` is
the long-standing `@elizaos/app-core` re-export of the connector-setup HTTP-route
contract (`buildSetupError`, `SETUP_ERROR_CODES`, `setupPath`, and the
`SetupState` / `SetupStatusResponse` / `SetupErrorResponse` types) and had no
same-named test file. Production still imports this path (`@elizaos/app-core`
barrel and `@elizaos/app-core/api/setup-contract` comments on connector plugins).
This PR adds one colocated test file and does not change runtime behavior.

Definition of Done: focused behavioral tests for the public app-core re-export,
recorded at the exact pushed head.

- [x] Targets `develop` and was branched from the latest fetched `origin/develop`
      (`5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`) before the final proof.
- [x] Reviewers can confirm the changed behavior from the committed focused test
      and inline red/green output.
- [ ] Full-repo `bun run verify` was not re-run. This is a test-only addition;
      focused vitest, biome, and `tsc --noEmit` (grep of the new file) are quoted
      below. Hosted GitHub Actions CI does **not** run on this fork-authored PR.

# Sync with develop

- [x] Branched from `origin/develop` at `5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`;
      the diff is a single new test file, so there are no merge conflicts.
- [ ] `bun run verify` was not run post-sync. Focused gates are in **Testing**.
      See **Known gaps / failures**.

# Risks

Low. Tests only. No production source, export, route, or scheduler change. The
canonical implementation in `packages/core/src/types/connector-setup.ts` is
untouched; this suite pins that app-core still re-exports the same runtime
values and that calling them through the app-core path preserves observed
behavior.

# Background

## What does this PR do?

Adds `packages/app-core/src/api/setup-contract.test.ts`, which imports through
the app-core module (`./setup-contract`, the same path the package barrel
re-exports) and drives the real `SETUP_ERROR_CODES`, `buildSetupError`, and
`setupPath`.

The module under test is a re-export. The suite therefore:

1. Asserts runtime identity with `@elizaos/core` (same function and object
   references) and that the app-core module exposes only those three runtime
   symbols.
2. Pins `SETUP_ERROR_CODES` as the closed four-code map in declaration order,
   the `SetupErrorCode` value set, and that `as const` does not freeze or seal
   the object at runtime.
3. Exercises `buildSetupError` for every catalogued code, a connector-specific
   code that is not in the catalog, empty code/message (no default
   substitution), fresh envelopes per call (no aliasing), and unicode /
   whitespace / JSON-special characters in the message.
4. Exercises `setupPath` for every documented action (`status` / `start` /
   `cancel`), empty connector (double slash, segment not omitted), single-
   character connector, unencoded spaces / extra slashes / query characters,
   and the observed lack of runtime action validation.
5. Documents the closed `SetupState` union and `SetupStatusResponse` with and
   without optional typed `detail`.

No mocks. The system under test is never replaced.

## What kind of change is this?

Test-only, non-breaking.

# Documentation changes needed?

No. The public API is unchanged.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/setup-contract.test.ts`.

## Detailed testing steps

Focused proof at the pushed head (`5ae866038d5fc54ae48c7a7589f5ebe76a10e461`),
re-run against current `origin/develop` (`5cdd5f2d7dfa40b137adb57fb4cae3cf27ddf949`;
`packages/app-core/src/api/setup-contract.ts` blob identical to that develop):

```bash
cd packages/app-core && bunx vitest run src/api/setup-contract.test.ts --config vitest.config.ts
bunx biome check --write packages/app-core/src/api/setup-contract.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep setup-contract.test.ts ; echo "GREP_EXIT:$?"
```

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app-core/src/api/setup-contract.test.ts (17 tests) 3ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  17:46:38
   Duration  4.13s (transform 3.21s, setup 0ms, import 4.01s, tests 3ms, environment 0ms)
```

`bunx biome check --write packages/app-core/src/api/setup-contract.test.ts` —
checked 1 file; import order was organized once and the committed file is that
result. `biome.json` is present in this checkout (not sparse).

`cd packages/app-core && bunx tsc --noEmit 2>&1 | grep setup-contract.test.ts`
printed no lines (`GREP_EXIT:1`). The new test file introduced zero type
diagnostics.

The diff touches only `packages/app-core/src/api/setup-contract.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork-authored PR. This body
does not imply CI passed.

# Evidence Gate

<!-- evidence-head:5ae866038d5fc54ae48c7a7589f5ebe76a10e461 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes. Test-only file; no production behavior change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes. Test-only file; no production behavior change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow. Unit-test coverage of a re-export contract.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server path change. Vitest output is quoted in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response. No UI or client change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, schedule, wallet, or generated-file change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only. Focused vitest output is quoted under Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI changes.

### After

N/A - no rendered UI changes.

### Walkthrough video

N/A - unit-test coverage of a re-export contract; no UI flow.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- Full-repo `bun run verify` was not run. Factory instruction for this test-only
  PR is focused vitest + biome + package `tsc --noEmit` (new file grepped out of
  the output). Those three gates are quoted above.
- Hosted GitHub Actions CI does not run on fork-authored PRs.
- No signed identity.slop.cash OAuth trace: unattended session cannot finalize
  an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
