### PR TITLE
test(app-core): cover server-security

### DIFF
--- a/packages/app-core/src/api/server-security.test.ts
+++ b/packages/app-core/src/api/server-security.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Colocated coverage for the app-core server-security wrappers. Drives the
+ * real re-exported bind-host token mint and the four auth helpers through
+ * live `@elizaos/agent` implementations plus the compat header mirror —
+ * no mocks of the module under test.
+ */
+import type http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureApiTokenForBindHost,
+  resolveMcpTerminalAuthorizationRejection,
+  resolveTerminalRunClientId,
+  resolveTerminalRunRejection,
+  resolveWebSocketUpgradeRejection,
+} from "./server-security";
+
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_API_BIND",
+  "ELIZA_DISABLE_AUTO_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "STEWARD_AGENT_TOKEN",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZA_TERMINAL_RUN_TOKEN",
+  "ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP",
+  "ELIZA_ALLOW_WS_QUERY_TOKEN",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+  "ELIZA_ALLOWED_ORIGINS",
+  "CORS_ORIGINS",
+  "ELIZA_ALLOWED_HOSTS",
+  "WAIFU_CHAT_ACCESS_JWT_SECRET",
+] as const;
+
+const STDIO_SERVERS = {
+  local: { type: "stdio", command: "echo", args: [] },
+};
+const HTTP_SERVERS = {
+  remote: { type: "http", url: "https://example.test/mcp" },
+};
+const TERMINAL_SECRET = "terminal-run-secret";
+const API_SECRET = "configured-api-token";
+
+let savedEnv: Record<string, string | undefined>;
+
+function asReq(
+  headers: http.IncomingHttpHeaders = {},
+  remoteAddress: string | undefined = "127.0.0.1",
+): http.IncomingMessage {
+  return {
+    headers,
+    socket: { remoteAddress },
+  } as unknown as http.IncomingMessage;
+}
+
+function wsUrl(pathname = "/ws", search = ""): URL {
+  return new URL(`http://127.0.0.1${pathname}${search}`);
+}
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("resolveTerminalRunClientId", () => {
+  it("returns null for an empty request and empty body (empty queue)", () => {
+    expect(resolveTerminalRunClientId(asReq(), {})).toBeNull();
+    expect(resolveTerminalRunClientId(asReq(), null)).toBeNull();
+    expect(resolveTerminalRunClientId(asReq(), undefined)).toBeNull();
+  });
+
+  it("accepts a single valid x-eliza-client-id header", () => {
+    expect(
+      resolveTerminalRunClientId(
+        asReq({ "x-eliza-client-id": "desktop.session-1" }),
+        {},
+      ),
+    ).toBe("desktop.session-1");
+  });
+
+  it("mirrors x-elizaos-client-id onto the upstream x-eliza-client-id header", () => {
+    const req = asReq({ "x-elizaos-client-id": "app-shell" });
+    expect(resolveTerminalRunClientId(req, { clientId: "body-id" })).toBe(
+      "app-shell",
+    );
+    expect(req.headers["x-eliza-client-id"]).toBe("app-shell");
+  });
+
+  it("does not overwrite an existing x-eliza-client-id when both aliases are set (tie)", () => {
+    const req = asReq({
+      "x-eliza-client-id": "canonical-id",
+      "x-elizaos-client-id": "brand-id",
+    });
+    expect(resolveTerminalRunClientId(req, { clientId: "body-id" })).toBe(
+      "canonical-id",
+    );
+    expect(req.headers["x-eliza-client-id"]).toBe("canonical-id");
+    expect(req.headers["x-elizaos-client-id"]).toBe("brand-id");
+  });
+
+  it("prefers a valid header over a valid body clientId", () => {
+    expect(
+      resolveTerminalRunClientId(asReq({ "x-eliza-client-id": "header-id" }), {
+        clientId: "body-id",
+      }),
+    ).toBe("header-id");
+  });
+
+  it("falls through to body when the header is missing, blank, or invalid", () => {
+    expect(resolveTerminalRunClientId(asReq(), { clientId: "from-body" })).toBe(
+      "from-body",
+    );
+    expect(
+      resolveTerminalRunClientId(asReq({ "x-eliza-client-id": "   " }), {
+        clientId: "from-body",
+      }),
+    ).toBe("from-body");
+    expect(
+      resolveTerminalRunClientId(asReq({ "x-eliza-client-id": "bad id" }), {
+        clientId: "from-body",
+      }),
+    ).toBe("from-body");
+  });
+
+  it("uses the first value of a multi-value client-id header", () => {
+    expect(
+      resolveTerminalRunClientId(
+        asReq({ "x-eliza-client-id": ["first-id", "second-id"] }),
+        { clientId: "body-id" },
+      ),
+    ).toBe("first-id");
+  });
+
+  it("rejects non-string body clientId and characters outside the safe alphabet", () => {
+    expect(
+      resolveTerminalRunClientId(asReq(), {
+        clientId: 42 as unknown as string,
+      }),
+    ).toBeNull();
+    expect(
+      resolveTerminalRunClientId(asReq(), { clientId: "has/slash" }),
+    ).toBeNull();
+    expect(
+      resolveTerminalRunClientId(asReq(), { clientId: "plus+sign" }),
+    ).toBeNull();
+  });
+
+  it("accepts a 128-character id and rejects a 129-character overflow", () => {
+    const atCapacity = `${"a".repeat(127)}_`;
+    const overflow = `${"a".repeat(129)}`;
+    expect(resolveTerminalRunClientId(asReq(), { clientId: atCapacity })).toBe(
+      atCapacity,
+    );
+    expect(
+      resolveTerminalRunClientId(asReq(), { clientId: overflow }),
+    ).toBeNull();
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(
+      resolveTerminalRunClientId(
+        asReq({ "x-eliza-client-id": "  trimmed.id  " }),
+        {},
+      ),
+    ).toBe("trimmed.id");
+  });
+});
+
+describe("resolveTerminalRunRejection", () => {
+  it("allows the run when neither a terminal token nor an API token is configured", () => {
+    expect(resolveTerminalRunRejection(asReq(), {})).toBeNull();
+  });
+
+  it("disables terminal run for token-authenticated sessions that have no terminal token", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(resolveTerminalRunRejection(asReq(), {})).toEqual({
+      status: 403,
+      reason:
+        "Terminal run is disabled for token-authenticated API sessions. Set ELIZA_TERMINAL_RUN_TOKEN to enable command execution.",
+    });
+  });
+
+  it("returns 401 when the terminal token is configured but not provided", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(resolveTerminalRunRejection(asReq(), {})).toEqual({
+      status: 401,
+      reason:
+        "Missing terminal token. Provide X-Eliza-Terminal-Token header or terminalToken in request body.",
+    });
+  });
+
+  it("accepts a matching body terminalToken", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveTerminalRunRejection(asReq(), { terminalToken: TERMINAL_SECRET }),
+    ).toBeNull();
+  });
+
+  it("mirrors x-elizaos-terminal-token so the upstream header path authorizes", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    const req = asReq({ "x-elizaos-terminal-token": TERMINAL_SECRET });
+    expect(resolveTerminalRunRejection(req, {})).toBeNull();
+    expect(req.headers["x-eliza-terminal-token"]).toBe(TERMINAL_SECRET);
+  });
+
+  it("lets the canonical x-eliza-terminal-token win a dual-alias tie", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    const req = asReq({
+      "x-eliza-terminal-token": TERMINAL_SECRET,
+      "x-elizaos-terminal-token": "wrong-brand-token",
+    });
+    expect(resolveTerminalRunRejection(req, {})).toBeNull();
+    expect(req.headers["x-eliza-terminal-token"]).toBe(TERMINAL_SECRET);
+  });
+
+  it("prefers a present header token over the body, even when the body matches", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveTerminalRunRejection(
+        asReq({ "x-eliza-terminal-token": "wrong-header" }),
+        { terminalToken: TERMINAL_SECRET },
+      ),
+    ).toEqual({ status: 401, reason: "Invalid terminal token." });
+  });
+
+  it("falls through to the body when the header is blank or a non-string array", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveTerminalRunRejection(asReq({ "x-eliza-terminal-token": "  " }), {
+        terminalToken: TERMINAL_SECRET,
+      }),
+    ).toBeNull();
+    expect(
+      resolveTerminalRunRejection(
+        asReq({ "x-eliza-terminal-token": [TERMINAL_SECRET] }),
+        { terminalToken: TERMINAL_SECRET },
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a mismatched token and ignores a non-string body token", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveTerminalRunRejection(asReq(), { terminalToken: "nope" }),
+    ).toEqual({ status: 401, reason: "Invalid terminal token." });
+    expect(
+      resolveTerminalRunRejection(asReq(), {
+        terminalToken: 1 as unknown as string,
+      }),
+    ).toEqual({
+      status: 401,
+      reason:
+        "Missing terminal token. Provide X-Eliza-Terminal-Token header or terminalToken in request body.",
+    });
+  });
+
+  it("trims the provided header and body tokens before comparing", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveTerminalRunRejection(
+        asReq({ "x-eliza-terminal-token": `  ${TERMINAL_SECRET}  ` }),
+        {},
+      ),
+    ).toBeNull();
+    expect(
+      resolveTerminalRunRejection(asReq(), {
+        terminalToken: `  ${TERMINAL_SECRET}  `,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveMcpTerminalAuthorizationRejection", () => {
+  it("returns null when the server map is empty or has no stdio entries", () => {
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), {}, {}),
+    ).toBeNull();
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), HTTP_SERVERS, {}),
+    ).toBeNull();
+    expect(
+      resolveMcpTerminalAuthorizationRejection(
+        asReq(),
+        {
+          missing: { url: "https://example.test" },
+          array: ["stdio"],
+          nothing: null,
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it("requires ELIZA_TERMINAL_RUN_TOKEN when any server is stdio", () => {
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), STDIO_SERVERS, {}),
+    ).toEqual({
+      status: 403,
+      reason:
+        "Stdio MCP server configuration requires ELIZA_TERMINAL_RUN_TOKEN. Set ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP=1 only for intentional local development.",
+    });
+  });
+
+  it("detects a stdio server mixed into a larger map (single matching element)", () => {
+    expect(
+      resolveMcpTerminalAuthorizationRejection(
+        asReq(),
+        { ...HTTP_SERVERS, ...STDIO_SERVERS },
+        {},
+      ),
+    ).toMatchObject({ status: 403 });
+  });
+
+  it("delegates to the terminal-run gate once the terminal token is configured", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_SECRET;
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), STDIO_SERVERS, {}),
+    ).toEqual({
+      status: 401,
+      reason:
+        "Missing terminal token. Provide X-Eliza-Terminal-Token header or terminalToken in request body.",
+    });
+    const req = asReq({ "x-elizaos-terminal-token": TERMINAL_SECRET });
+    expect(
+      resolveMcpTerminalAuthorizationRejection(req, STDIO_SERVERS, {}),
+    ).toBeNull();
+  });
+
+  it("allows the unauthenticated-stdio compat flag to skip the unconfigured 403", () => {
+    process.env.ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP = "1";
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), STDIO_SERVERS, {}),
+    ).toBeNull();
+  });
+
+  it("still 403s stdio MCP under the compat flag when an API token is configured without a terminal token", () => {
+    process.env.ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP = "1";
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), STDIO_SERVERS, {}),
+    ).toEqual({
+      status: 403,
+      reason:
+        "Terminal run is disabled for token-authenticated API sessions. Set ELIZA_TERMINAL_RUN_TOKEN to enable command execution.",
+    });
+  });
+
+  it("does not treat a non-1 compat flag as a passthrough", () => {
+    process.env.ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP = "0";
+    expect(
+      resolveMcpTerminalAuthorizationRejection(asReq(), STDIO_SERVERS, {}),
+    ).toMatchObject({ status: 403 });
+  });
+});
+
+describe("resolveWebSocketUpgradeRejection", () => {
+  it("returns 404 for any pathname other than /ws, before origin or auth checks", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({
+          origin: "https://evil.example",
+          authorization: `Bearer ${API_SECRET}`,
+        }),
+        wsUrl("/ws/"),
+      ),
+    ).toEqual({ status: 404, reason: "Not found" });
+    expect(resolveWebSocketUpgradeRejection(asReq(), wsUrl("/api/ws"))).toEqual(
+      { status: 404, reason: "Not found" },
+    );
+  });
+
+  it("returns 403 when a non-local origin is present and not allowlisted", () => {
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ origin: "https://evil.example" }),
+        wsUrl(),
+      ),
+    ).toEqual({ status: 403, reason: "Origin not allowed" });
+  });
+
+  it("treats a whitespace-only Origin as not allowed", () => {
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({ origin: "   " }), wsUrl()),
+    ).toEqual({ status: 403, reason: "Origin not allowed" });
+  });
+
+  it("allows a missing origin, and a local origin only when Host matches", () => {
+    expect(resolveWebSocketUpgradeRejection(asReq(), wsUrl())).toBeNull();
+    // Origin is CORS-allowed, but loopback trust requires a matching Host.
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ origin: "http://localhost:5173" }),
+        wsUrl(),
+      ),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({
+          origin: "http://localhost:5173",
+          host: "localhost:5173",
+        }),
+        wsUrl(),
+      ),
+    ).toBeNull();
+  });
+
+  it("lets an allowlisted remote origin past CORS, then still requires auth", () => {
+    process.env.ELIZA_ALLOWED_ORIGINS = "https://dashboard.example";
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ origin: "https://dashboard.example" }),
+        wsUrl(),
+      ),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({
+          origin: "https://dashboard.example",
+          authorization: `Bearer ${API_SECRET}`,
+        }),
+        wsUrl(),
+      ),
+    ).toBeNull();
+  });
+
+  it("allows a tokenless upgrade from a trusted loopback peer", () => {
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({}, "127.0.0.1"), wsUrl()),
+    ).toBeNull();
+  });
+
+  it("returns 401 for a tokenless upgrade from a non-loopback peer", () => {
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({}, "8.8.8.8"), wsUrl()),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("returns 401 when local-auth is required even on loopback", () => {
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({}, "127.0.0.1"), wsUrl()),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("returns 401 for a mismatched handshake bearer token", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ authorization: "Bearer wrong-token" }),
+        wsUrl(),
+      ),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("accepts a matching x-elizaos-token after the compat header mirror", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    const req = asReq({ "x-elizaos-token": API_SECRET });
+    expect(resolveWebSocketUpgradeRejection(req, wsUrl())).toBeNull();
+    expect(req.headers["x-eliza-token"]).toBe(API_SECRET);
+  });
+
+  it("accepts a matching Authorization bearer without requiring a query token", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ authorization: `Bearer ${API_SECRET}` }),
+        wsUrl(),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not reject a query token when the query-token flag is off (post-open auth)", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({}, "127.0.0.1"),
+        wsUrl("/ws", `?token=${API_SECRET}`),
+      ),
+    ).toBeNull();
+  });
+
+  it("authorizes a query token when ELIZA_ALLOW_WS_QUERY_TOKEN=1", () => {
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({}, "8.8.8.8"),
+        wsUrl("/ws", `?token=${API_SECRET}`),
+      ),
+    ).toBeNull();
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({}, "8.8.8.8"),
+        wsUrl("/ws", "?apiKey=wrong"),
+      ),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({}, "8.8.8.8"),
+        wsUrl("/ws", `?api_key=${API_SECRET}`),
+      ),
+    ).toBeNull();
+  });
+
+  it("requires a handshake token for a cloud-provisioned container", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    process.env.ELIZA_API_TOKEN = API_SECRET;
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({}, "127.0.0.1"), wsUrl()),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(
+      resolveWebSocketUpgradeRejection(
+        asReq({ authorization: `Bearer ${API_SECRET}` }, "127.0.0.1"),
+        wsUrl(),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns 401 for a cloud-provisioned container that has no API token", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    expect(
+      resolveWebSocketUpgradeRejection(asReq({}, "127.0.0.1"), wsUrl()),
+    ).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+});
+
+describe("ensureApiTokenForBindHost", () => {
+  it("leaves an already-configured token in place on every bind", () => {
+    process.env.ELIZA_API_TOKEN = "operator-supplied-token";
+    ensureApiTokenForBindHost("0.0.0.0");
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.ELIZA_API_TOKEN).toBe("operator-supplied-token");
+  });
+
+  it("does not mint a token for a loopback bind when none is configured", () => {
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("treats an empty bind host as loopback and does not mint", () => {
+    ensureApiTokenForBindHost("");
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("honors ELIZA_DISABLE_AUTO_API_TOKEN on loopback and specific non-loopback binds", () => {
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+    ensureApiTokenForBindHost("192.168.1.5");
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("mints a 64-hex token for a wildcard bind even when auto-token is disabled", () => {
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("mints a token for the IPv6 wildcard bind", () => {
+    ensureApiTokenForBindHost("::");
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("mints a token for a specific non-loopback bind when auto-token is enabled", () => {
+    ensureApiTokenForBindHost("192.168.1.5");
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("mints a token for a cloud-provisioned container even when auto-token is disabled", () => {
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION

# Relates to

No issue. `packages/app-core/src/api/server-security.ts` had no colocated vitest file; this PR adds one. The existing `__tests__/server-security.test.ts` mocks `@elizaos/agent` and the compat helpers; this suite drives the real wrappers.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` (`b612c28a8367abb2320257025a2c720322bdb18e`) with a single-file commit (`4d6d53c4e68ec3975a0df01cc018af30c3f6d5b4`).
- [ ] `bun run verify` was not run. This is a test-only addition. Hosted CI does **not** run on fork contributor PRs; do not read a missing Actions run as a pass.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc results below.

# Sync with develop

- [x] Branch created from `origin/develop` at `b612c28a8367abb2320257025a2c720322bdb18e`; zero conflicts; diff is one new test file.
- [ ] `bun run verify` not run (test-only PR). Focused package checks are quoted below.

# Risks

Low. Adds tests only. No production behaviour change.

# Background

## What does this PR do?

Adds colocated vitest coverage for `packages/app-core/src/api/server-security.ts`. The module re-exports `ensureApiTokenForBindHost` and wraps four agent auth helpers in `runWithCompatAuthContext` (mirroring `x-elizaos-*` ↔ `x-eliza-*` headers) plus `normalizeCompatRejection` on the two rejection helpers.

The suite drives the real module — no mocks of the wrappers or of `@elizaos/agent`. It pins observed behaviour:

- `resolveTerminalRunClientId`: empty request, header vs body precedence, dual-alias tie (canonical `x-eliza-client-id` wins), invalid/blank header fall-through, multi-value first-element, 128-char capacity vs 129 overflow, alphabet rejection, trim.
- `resolveTerminalRunRejection`: tokenless allow, API-token-without-terminal-token 403, missing 401, matching body/header, `x-elizaos-terminal-token` mirror, dual-alias tie, header-over-body even when body matches, blank/array header fall-through, mismatch, trim.
- `resolveMcpTerminalAuthorizationRejection`: empty / non-stdio maps, stdio 403, mixed map, configured-token 401 then mirrored-header allow, unauthenticated-stdio compat flag, compat flag still 403 when an API token is set, non-`1` flag is not a passthrough.
- `resolveWebSocketUpgradeRejection`: 404 before origin/auth, 403 for disallowed and whitespace origin, missing origin vs Host-matched local origin (tokenless local origin without Host is 401 — that is what the live trust check does), allowlisted remote origin still 401 until a matching bearer is presented, loopback vs non-loopback vs `ELIZA_REQUIRE_LOCAL_AUTH`, bearer mismatch, `x-elizaos-token` mirror, query-token flag off does not reject a `?token=` URL, query `token`/`apiKey`/`api_key` when the flag is on, cloud-provisioned handshake requirement.
- `ensureApiTokenForBindHost`: existing token never overwritten, loopback and empty host do not mint, disable flag honoured on loopback and specific IPs, wildcard IPv4/IPv6 mint 64-hex even when disabled, non-loopback mint when enabled, cloud container mints even when disabled.

Expectations match what the live helpers actually return. The Host-matched local-origin case was rewritten after the first run showed 401, not 200/null.

## What kind of change is this?

Tests (non-breaking). No production code change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/server-security.test.ts`, then the quoted commands below.

## Detailed testing steps

Re-run against current `origin/develop` immediately before filing (head `4d6d53c4e68ec3975a0df01cc018af30c3f6d5b4`, parent `b612c28a8367abb2320257025a2c720322bdb18e`; `server-security.ts` unchanged vs later develop `b7fe8b08b0d631cb8180d798c4a812064692dc54`):

```bash
cd packages/app-core && bunx vitest run src/api/server-security.test.ts
```

Result: **Test Files 1 passed (1), Tests 50 passed (50)** (vitest 4.1.5, duration ~14s).

```bash
bunx biome check --write packages/app-core/src/api/server-security.test.ts
```

Result: **Checked 1 file in 123ms. Fixed 1 file.** Config at repo-root `biome.json` (checkout is not sparse). Clean after that write; the committed file is the biome-formatted one.

```bash
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'src/api/server-security.test.ts' ; echo "EXIT:$?"
```

Result: the colocated file **does not appear**. Grep for the basename also hits a pre-existing TS2307 in `src/api/__tests__/server-security.test.ts` (`Cannot find module './server-security.ts'`) — that file is not in this diff.

The diff touches **only** `packages/app-core/src/api/server-security.test.ts`.

We are a fork contributor (`ss251/eliza`). Hosted CI does not run on this PR.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:4d6d53c4e68ec3975a0df01cc018af30c3f6d5b4 -->

Test-only PR; no production behaviour change. UI / video / trajectory rows are N/A.

- [x] Before full-page screenshots — `N/A - test-only, no UI surface`
- [x] After full-page screenshots — `N/A - test-only, no UI surface`
- [x] Walkthrough video — `N/A - test-only, no UI surface`
- [x] Backend logs — `N/A - unit tests of pure request helpers, no server boot`
- [x] Frontend console/network logs — `N/A - no frontend change`
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts — `N/A - no DB/memory/schedule/wallet output`
- [x] OCR visual-text review — `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - unit tests of request helpers; vitest counts quoted above.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI surface.

## Audio / voice walkthrough

N/A - not a voice change.

## Known gaps / failures

- `bun run verify` was not run; this PR adds tests and changes no production behaviour.
- Hosted GitHub Actions does not run on fork contributor PRs. The quoted vitest/biome/tsc results are local against current `origin/develop`.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
