### PR TITLE
test(app-core): cover cli-utils

### DIFF
--- a/packages/app-core/src/cli/cli-utils.test.ts
+++ b/packages/app-core/src/cli/cli-utils.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Direct unit coverage for `runCommandWithRuntime`: success, default
+ * error-and-exit reporting, throwable stringification, and the optional
+ * `onError` callback branch.
+ *
+ * The harness drives the real helper with in-memory runtime recorders. It
+ * does not mock the module under test.
+ */
+import { describe, expect, it } from "vitest";
+import { runCommandWithRuntime } from "./cli-utils";
+
+function createRuntime() {
+  const errors: string[] = [];
+  const exits: number[] = [];
+  return {
+    errors,
+    exits,
+    runtime: {
+      error: (message: string) => {
+        errors.push(message);
+      },
+      exit: (code: number) => {
+        exits.push(code);
+      },
+    },
+  };
+}
+
+describe("runCommandWithRuntime", () => {
+  it("awaits a successful action and does not report or exit", async () => {
+    const { errors, exits, runtime } = createRuntime();
+    const order: string[] = [];
+
+    await runCommandWithRuntime(runtime, async () => {
+      order.push("start");
+      await Promise.resolve();
+      order.push("done");
+    });
+
+    expect(order).toEqual(["start", "done"]);
+    expect(errors).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+
+  it("does not invoke onError when the action resolves", async () => {
+    const { errors, exits, runtime } = createRuntime();
+    const onErrorCalls: unknown[] = [];
+
+    await runCommandWithRuntime(
+      runtime,
+      async () => undefined,
+      (err) => {
+        onErrorCalls.push(err);
+      },
+    );
+
+    expect(onErrorCalls).toEqual([]);
+    expect(errors).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+
+  it("stringifies a thrown Error and exits with code 1 when onError is omitted", async () => {
+    const { errors, exits, runtime } = createRuntime();
+
+    await runCommandWithRuntime(runtime, async () => {
+      throw new Error("boom");
+    });
+
+    expect(errors).toEqual(["Error: boom"]);
+    expect(exits).toEqual([1]);
+  });
+
+  it("reports then exits, in that order, on the default failure path", async () => {
+    const events: string[] = [];
+    const runtime = {
+      error: (message: string) => {
+        events.push(`error:${message}`);
+      },
+      exit: (code: number) => {
+        events.push(`exit:${code}`);
+      },
+    };
+
+    await runCommandWithRuntime(runtime, async () => {
+      throw new Error("ordered");
+    });
+
+    expect(events).toEqual(["error:Error: ordered", "exit:1"]);
+  });
+
+  it("stringifies a thrown string the same way String(err) does", async () => {
+    const { errors, exits, runtime } = createRuntime();
+
+    await runCommandWithRuntime(runtime, async () => {
+      throw "plain failure";
+    });
+
+    expect(errors).toEqual(["plain failure"]);
+    expect(exits).toEqual([1]);
+  });
+
+  it("stringifies non-Error throwables including numbers and objects", async () => {
+    const numberCase = createRuntime();
+    await runCommandWithRuntime(numberCase.runtime, async () => {
+      throw 42;
+    });
+    expect(numberCase.errors).toEqual(["42"]);
+    expect(numberCase.exits).toEqual([1]);
+
+    const objectCase = createRuntime();
+    await runCommandWithRuntime(objectCase.runtime, async () => {
+      throw { reason: "nope" };
+    });
+    expect(objectCase.errors).toEqual(["[object Object]"]);
+    expect(objectCase.exits).toEqual([1]);
+  });
+
+  it("delegates to onError with the original throwable and does not report or exit", async () => {
+    const { errors, exits, runtime } = createRuntime();
+    const received: unknown[] = [];
+    const failure = new Error("delegated");
+
+    await runCommandWithRuntime(
+      runtime,
+      async () => {
+        throw failure;
+      },
+      (err) => {
+        received.push(err);
+      },
+    );
+
+    expect(received).toEqual([failure]);
+    expect(errors).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+
+  it("returns after onError without rethrowing the original failure", async () => {
+    const { runtime } = createRuntime();
+
+    await expect(
+      runCommandWithRuntime(
+        runtime,
+        async () => {
+          throw new Error("swallowed");
+        },
+        () => {},
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not catch throws from onError, and never reaches runtime.error/exit", async () => {
+    const { errors, exits, runtime } = createRuntime();
+    const callbackError = new Error("onError failed");
+
+    await expect(
+      runCommandWithRuntime(
+        runtime,
+        async () => {
+          throw new Error("original");
+        },
+        () => {
+          throw callbackError;
+        },
+      ),
+    ).rejects.toBe(callbackError);
+
+    expect(errors).toEqual([]);
+    expect(exits).toEqual([]);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/cli-utils.ts`, which had no
same-named test file in the repository. No production behaviour change.

- [x] This PR targets `develop` and is based on current `origin/develop`
      (`b7fe8b08b0d631cb8180d798c4a812064692dc54`) with one commit on top.
- [ ] `bun install` and `bun run verify` were not run. This is a test-only
      addition of one colocated Vitest file. Scoped evidence is vitest, biome,
      and `tsc --noEmit` as quoted below.
- [x] A reviewer can confirm the suite without reading production code: the
      quoted vitest run exercises `runCommandWithRuntime` directly.

# Sync with develop

- [x] Branch `test/app-core-cli-utils-coverage` is `origin/develop` plus one
      test-file commit. Zero conflicts. Re-fetched immediately before filing.
- [ ] `bun run verify` was not run (test-only; scoped checks quoted below).

# Risks

Low. Adds a colocated unit test next to a 21-line helper. No production file
is modified.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/cli-utils.test.ts` covering the only export,
`runCommandWithRuntime`:

- successful async action: no `error` / `exit`
- `onError` is not invoked on success
- thrown `Error` / string / number / object: `runtime.error(String(err))` then
  `runtime.exit(1)` in that order
- optional `onError` receives the original throwable and suppresses report/exit
- `onError` swallows the original failure (the helper resolves)
- throws from `onError` propagate; default report/exit is not reached

The suite drives the real helper with in-memory runtime recorders. It does not
mock the module under test.

## What kind of change is this?

Testing (behavior-preserving coverage; no production change).

## Why are we doing this? Any context or related work?

`packages/app-core/src/cli/cli-utils.ts` is used by `start`, `setup`, `doctor`,
`db`, and `auth` command registration. It had no colocated test. This records
the behaviour the helper actually implements.

# Documentation changes needed?

No. Test-only change; production API and docs are unchanged.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/cli-utils.test.ts` and the helper it imports.

## Detailed testing steps

From the repository root, after this head:

```bash
bunx vitest run packages/app-core/src/cli/cli-utils.test.ts
```

Observed on re-fetch of current `origin/develop` immediately before filing:

```
 ✓ packages/app-core/src/cli/cli-utils.test.ts (9 tests) 3ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  17:51:01
   Duration  125ms (transform 31ms, setup 0ms, import 39ms, tests 3ms, environment 0ms)
```

`bunx biome check --write packages/app-core/src/cli/cli-utils.test.ts`:
`Checked 1 file in 76ms. Fixed 1 file.` (initial format wrap of an `onError`
callback). The committed file is that formatted result.

`cd packages/app-core && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep 'cli-utils.test.ts'`:
empty (exit 1 from grep). The new file appears nowhere in the typecheck output.

We are a **fork contributor**. Hosted CI does **not** run on this pull request.
Do not infer that GitHub Actions passed.

# Evidence Gate

Evidence head: `083f296d9995ce53e94ecc7ae5b17c53ceef4370`

- [x] Before full-page screenshots: N/A - test-only, no UI surface.
- [x] After full-page screenshots: N/A - test-only, no UI surface.
- [x] Walkthrough video: N/A - test-only, no UI surface.
- [x] Backend logs: N/A - no production runtime path changed; vitest output is
      the execution evidence.
- [x] Frontend console/network logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - no DB, memory, schedule, wallet, or generated
      product artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only coverage of a CLI error-wrapper helper; no model call.

## Backend + frontend logs

N/A - no production server or UI path changed. The vitest transcript above is
the run of the new suite against the live helper.

## Screenshots (before / after) + video walkthrough

N/A - no UI change. Diff is one test file.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds tests and changes no production
  behaviour. Scoped evidence is the vitest / biome / tsc quotes above.
- Hosted GitHub Actions CI does not run on fork-contributor pull requests.
- Interactive `identity.slop.cash` OAuth evidence was not finalized (unattended
  session; nobody is present to complete the browser consent step).

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:083f296d9995ce53e94ecc7ae5b17c53ceef4370 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
