### PR TITLE
test(app-core): cover cli-name

### DIFF
--- a/packages/app-core/src/cli/cli-name.test.ts
+++ b/packages/app-core/src/cli/cli-name.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for CLI display-name resolution and command rewriting.
+ * Drives the real `cli-name` module: the module-load env snapshot, prefix
+ * matching, and every replace / leave-untouched branch. Does not mock the
+ * system under test.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CLI_PREFIX_RE, replaceCliName, resolveCliName } from "./cli-name";
+
+describe("resolveCliName", () => {
+  it("returns a stable snapshot across repeated calls", () => {
+    const first = resolveCliName();
+    const second = resolveCliName();
+    expect(first).toBe(second);
+    expect(typeof first).toBe("string");
+    expect(first.length).toBeGreaterThan(0);
+  });
+
+  it("does not observe APP_CLI_NAME mutations after the module has loaded", () => {
+    const snapshot = resolveCliName();
+    const previous = process.env.APP_CLI_NAME;
+    process.env.APP_CLI_NAME = `mutated-${snapshot}-later`;
+    try {
+      expect(resolveCliName()).toBe(snapshot);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.APP_CLI_NAME;
+      } else {
+        process.env.APP_CLI_NAME = previous;
+      }
+    }
+  });
+});
+
+describe("resolveCliName module-load snapshot", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("uses APP_CLI_NAME captured at import, trimmed", async () => {
+    vi.resetModules();
+    vi.stubEnv("APP_CLI_NAME", "  custom-bin  ");
+    const mod = await import("./cli-name");
+    expect(mod.resolveCliName()).toBe("custom-bin");
+    vi.stubEnv("APP_CLI_NAME", "ignored-later");
+    expect(mod.resolveCliName()).toBe("custom-bin");
+  });
+
+  it("defaults to eliza when APP_CLI_NAME is unset", async () => {
+    vi.resetModules();
+    vi.stubEnv("APP_CLI_NAME", "");
+    const mod = await import("./cli-name");
+    expect(mod.resolveCliName()).toBe("eliza");
+  });
+
+  it("defaults to eliza when APP_CLI_NAME is whitespace-only", async () => {
+    vi.resetModules();
+    vi.stubEnv("APP_CLI_NAME", "   \t  ");
+    const mod = await import("./cli-name");
+    expect(mod.resolveCliName()).toBe("eliza");
+  });
+});
+
+describe("CLI_PREFIX_RE", () => {
+  it.each([
+    "eliza",
+    "eliza start",
+    "elizaos",
+    "elizaos run",
+    "bun eliza start",
+    "npm elizaos dev",
+    "bunx eliza x",
+    "npx elizaos y",
+    "bun  eliza start",
+  ])("matches %j", (input) => {
+    expect(CLI_PREFIX_RE.test(input)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    " eliza start",
+    "Eliza start",
+    "ELIZA start",
+    "elizafoo",
+    "eliza_os",
+    "git commit",
+    "echo eliza",
+    "pnpm eliza start",
+    "yarn elizaos run",
+    "node eliza start",
+    "buneliza start",
+    "other eliza",
+  ])("does not match %j", (input) => {
+    expect(CLI_PREFIX_RE.test(input)).toBe(false);
+  });
+});
+
+describe("replaceCliName", () => {
+  it("returns empty and whitespace-only commands unchanged", () => {
+    expect(replaceCliName("", "mycli")).toBe("");
+    expect(replaceCliName("   ", "mycli")).toBe("   ");
+    expect(replaceCliName("\n\t", "mycli")).toBe("\n\t");
+  });
+
+  it("leaves commands that do not start with a CLI token unchanged", () => {
+    expect(replaceCliName("git commit", "mycli")).toBe("git commit");
+    expect(replaceCliName("echo eliza", "mycli")).toBe("echo eliza");
+    expect(replaceCliName(" eliza start", "mycli")).toBe(" eliza start");
+    expect(replaceCliName("Eliza start", "mycli")).toBe("Eliza start");
+    expect(replaceCliName("elizafoo", "mycli")).toBe("elizafoo");
+    expect(replaceCliName("pnpm eliza start", "mycli")).toBe(
+      "pnpm eliza start",
+    );
+  });
+
+  it("replaces a leading eliza token with the supplied name", () => {
+    expect(replaceCliName("eliza", "mycli")).toBe("mycli");
+    expect(replaceCliName("eliza start", "mycli")).toBe("mycli start");
+    expect(replaceCliName("eliza start --verbose", "mycli")).toBe(
+      "mycli start --verbose",
+    );
+  });
+
+  it("replaces a leading elizaos token, not the eliza prefix of that word", () => {
+    expect(replaceCliName("elizaos", "mycli")).toBe("mycli");
+    expect(replaceCliName("elizaos run", "mycli")).toBe("mycli run");
+  });
+
+  it("rewrites only the leading token when the command repeats the name", () => {
+    expect(replaceCliName("eliza start && eliza stop", "mycli")).toBe(
+      "mycli start && eliza stop",
+    );
+  });
+
+  it("treats a hyphen after eliza as a word boundary and rewrites the prefix", () => {
+    expect(replaceCliName("eliza-os run", "mycli")).toBe("mycli-os run");
+  });
+
+  it.each([
+    ["bun eliza start", "bun mycli start"],
+    ["npm elizaos dev", "npm mycli dev"],
+    ["bunx eliza x", "bunx mycli x"],
+    ["npx elizaos y", "npx mycli y"],
+    ["bun  eliza start", "bun  mycli start"],
+  ] as const)("preserves runner prefix in %j", (input, expected) => {
+    expect(replaceCliName(input, "mycli")).toBe(expected);
+  });
+
+  it("substitutes an empty display name when one is supplied", () => {
+    expect(replaceCliName("eliza start", "")).toBe(" start");
+    expect(replaceCliName("bun eliza start", "")).toBe("bun  start");
+  });
+
+  it("defaults the replacement name to resolveCliName()", () => {
+    const name = resolveCliName();
+    expect(replaceCliName("eliza start")).toBe(`${name} start`);
+    expect(replaceCliName("elizaos run")).toBe(`${name} run`);
+    expect(replaceCliName("bun eliza start")).toBe(`bun ${name} start`);
+  });
+});


### PR DESCRIPTION

## Relates to

No issue. Test-only coverage for `packages/app-core/src/cli/cli-name.ts`, which had no same-named test file on `origin/develop`.

- [x] This PR targets `develop` and is based on current `origin/develop` (`b7fe8b08b0d631cb8180d798c4a812064692dc54`).
- [x] Focused verification passed in isolation (vitest, biome, tsc).
- [x] A reviewer can confirm the change from the commands and counts below.

`#24984` is an unrelated multi-file PR whose title mentions cli-name; this PR is a single-file suite against current develop.

## Summary

Adds `packages/app-core/src/cli/cli-name.test.ts` driving the real module (no mocks of the system under test). Covers:

- `resolveCliName` stability and the module-load `APP_CLI_NAME` snapshot (trim, empty, whitespace-only, post-load mutation ignored)
- `CLI_PREFIX_RE` match and miss cases (runners, case, word-boundary, mid-string, unsupported runners)
- `replaceCliName` leave-untouched branches (empty, whitespace, leading space, wrong case, non-token) and rewrite branches (`eliza` vs `elizaos`, runner prefixes including extra spaces, empty display name, default name from `resolveCliName()`, only the leading token)

No production code changes.

## Evidence

Hosted CI does **not** run on this fork contributor PR. Do not infer that GitHub Actions passed. Local counts below were re-run against current `origin/develop` immediately before filing.

1. Vitest (re-run after refetch of `origin/develop`):

```
bunx vitest run packages/app-core/src/cli/cli-name.test.ts --config packages/app-core/vitest.config.ts

 Test Files  1 passed (1)
      Tests  41 passed (41)
```

2. Biome:

```
bunx biome check --write packages/app-core/src/cli/cli-name.test.ts
Checked 1 file in 25ms. Fixed 1 file.
```

(`biome.json` is present; this worktree is not sparse. The write pass applied one wrapping fix; the file as committed is that result.)

3. Typecheck of the owning package; this test file does not appear in `tsc` output:

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'cli-name.test.ts' ; echo "EXIT:$?"
GREP_EXIT:1
```

Empty grep (exit 1) means `cli-name.test.ts` introduced no TypeScript diagnostics.

4. Diff touches only the test file: `packages/app-core/src/cli/cli-name.test.ts` (+162).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:26f8dcbbe9b361576ec0c9efd0617f20f4b88a89 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
