### PR TITLE
chore(workflow): restore format closure

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/workflow-contract.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-contract.test.ts
@@ -1,11 +1,8 @@
 /** Exercises Smithers workflow normalization through the public persistence service contract. */
 import { describe, expect, test } from 'bun:test';
-import { compareWorkflowSearchCandidates } from '../../src/services/workflow-service.js';
 import { validateSmithersSource } from '../../src/services/smithers-runtime';
-import type {
-  WorkflowDefinition,
-  WorkflowDefinitionResponse,
-} from '../../src/types/index';
+import { compareWorkflowSearchCandidates } from '../../src/services/workflow-service.js';
+import type { WorkflowDefinition, WorkflowDefinitionResponse } from '../../src/types/index';
 
 function workflow(): WorkflowDefinition {
   return {
@@ -44,18 +41,10 @@ describe('workflow contract', () => {
       workflow: { id } as unknown as WorkflowDefinitionResponse,
       score,
     });
-    const candidates = [
-      candidate('z-wf', 5),
-      candidate('a-wf', 5),
-      candidate('m-wf', 9),
-    ];
+    const candidates = [candidate('z-wf', 5), candidate('a-wf', 5), candidate('m-wf', 9)];
 
     candidates.sort(compareWorkflowSearchCandidates);
 
-    expect(candidates.map(({ workflow }) => workflow.id)).toEqual([
-      'm-wf',
-      'a-wf',
-      'z-wf',
-    ]);
+    expect(candidates.map(({ workflow }) => workflow.id)).toEqual(['m-wf', 'a-wf', 'z-wf']);
   });
 });


### PR DESCRIPTION
## Summary

- formats the one `plugin-workflow` test that failed canonical Develop Full `32638475465`
- applies the same import ordering required by the package Biome check
- changes no runtime or assertion semantics

## Exact provenance

- base: `b7fe8b08b0d631cb8180d798c4a812064692dc54`
- head: `6551cb6e52c129cbaff55052e2b195811cb56475`
- failed canonical job: `quality / Format`, file `plugins/plugin-workflow/__tests__/unit/workflow-contract.test.ts`
- introducing source: merged #25394 / `4a666e278990b2212811ab5e95abdb70eb2d9e1b`

## Verification

- `bunx @biomejs/biome@2.5.8 format plugins/plugin-workflow/__tests__/unit/workflow-contract.test.ts` — pass
- `bunx @biomejs/biome@2.5.8 check plugins/plugin-workflow/__tests__/unit/workflow-contract.test.ts` — pass
- `git diff --check` — pass
- gitleaks exact one-commit range — pass, no leaks
- focused Bun test in the intentionally sparse isolated worktree could not resolve `@elizaos/core`; no dependency tree was borrowed or symlinked, so the required PR smoke is the installed-workspace proof

## Release boundary

This is a narrow baseline CI closure required before Shared Cloud/Railway serialization. Keep draft until normal review/CI; no workflow rerun, staging deploy, or provider action is part of this PR.