### PR TITLE
test(app-core): cover git-commit

### DIFF
--- a/packages/app-core/src/cli/git-commit.test.ts
+++ b/packages/app-core/src/cli/git-commit.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Direct unit coverage for `resolveCommitHash`. The helper memoizes the first
+ * hit for the process and probes GIT_COMMIT / GIT_SHA, then a git HEAD walk
+ * from `cwd` (directory `.git`, `gitdir:` worktree files, and ref indirection).
+ * Each case reloads the module so the memo cannot leak; fixtures are real temp
+ * trees, not mocked `fs` or env.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "app-core-git-commit-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function nestDirs(root: string, depth: number): string {
+  let current = root;
+  for (let i = 0; i < depth; i += 1) {
+    current = path.join(current, `level-${i}`);
+    fs.mkdirSync(current, { recursive: true });
+  }
+  return current;
+}
+
+function writeGitDir(
+  repoRoot: string,
+  headContents: string,
+  refs: Record<string, string> = {},
+): string {
+  const gitDir = path.join(repoRoot, ".git");
+  fs.mkdirSync(gitDir, { recursive: true });
+  fs.writeFileSync(path.join(gitDir, "HEAD"), headContents);
+  for (const [ref, value] of Object.entries(refs)) {
+    const refPath = path.join(gitDir, ref);
+    fs.mkdirSync(path.dirname(refPath), { recursive: true });
+    fs.writeFileSync(refPath, value);
+  }
+  return gitDir;
+}
+
+async function loadResolveCommitHash() {
+  const { resolveCommitHash } = await import("./git-commit");
+  return resolveCommitHash;
+}
+
+describe("resolveCommitHash", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers GIT_COMMIT, trims whitespace, and returns the first 7 characters", async () => {
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(
+      resolveCommitHash({
+        cwd: makeTempDir(),
+        env: {
+          GIT_COMMIT: "  abcdef1234567890  ",
+          GIT_SHA: "deadbeeignored",
+        },
+      }),
+    ).toBe("abcdef1");
+  });
+
+  it("falls through to GIT_SHA when GIT_COMMIT is empty or whitespace", async () => {
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(
+      resolveCommitHash({
+        cwd: makeTempDir(),
+        env: { GIT_COMMIT: "   ", GIT_SHA: "sha2567remainder" },
+      }),
+    ).toBe("sha2567");
+  });
+
+  it("keeps hashes shorter than 7 characters", async () => {
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(
+      resolveCommitHash({
+        cwd: makeTempDir(),
+        env: { GIT_COMMIT: "abc" },
+      }),
+    ).toBe("abc");
+  });
+
+  it("returns null when env is empty and no .git exists within the walk", async () => {
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(
+      resolveCommitHash({
+        cwd: makeTempDir(),
+        env: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("reads a detached hash from a directory .git/HEAD", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "cafebabeface0000111122223333444455556666\n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBe("cafebab");
+  });
+
+  it("follows a symbolic ref from HEAD to the ref file", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "ref: refs/heads/main\n", {
+      "refs/heads/main": "  0123456789abcdef  \n",
+    });
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBe("0123456");
+  });
+
+  it("returns null when HEAD points at a missing ref (ENOENT)", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "ref: refs/heads/does-not-exist\n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBeNull();
+  });
+
+  it("returns null for an empty HEAD file", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "   \n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBeNull();
+  });
+
+  it("follows a relative gitdir: worktree pointer", async () => {
+    const root = makeTempDir();
+    const work = path.join(root, "work");
+    const gitDir = path.join(root, "actual-git");
+    fs.mkdirSync(work);
+    fs.mkdirSync(path.join(gitDir, "refs", "heads"), { recursive: true });
+    fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/topic\n");
+    fs.writeFileSync(
+      path.join(gitDir, "refs", "heads", "topic"),
+      "feedfacecafebabe\n",
+    );
+    fs.writeFileSync(path.join(work, ".git"), "gitdir: ../actual-git\n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd: work, env: {} })).toBe("feedfac");
+  });
+
+  it("follows an absolute gitdir: pointer with extra whitespace", async () => {
+    const root = makeTempDir();
+    const work = path.join(root, "linked");
+    const gitDir = path.join(root, "store");
+    fs.mkdirSync(work);
+    fs.mkdirSync(gitDir);
+    fs.writeFileSync(
+      path.join(gitDir, "HEAD"),
+      "aaabbbcccdddeeefffaaabbbcccddd\n",
+    );
+    fs.writeFileSync(path.join(work, ".git"), `GITDIR:   ${gitDir}  \n`);
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd: work, env: {} })).toBe("aaabbbc");
+  });
+
+  it("walks up parent directories to find .git", async () => {
+    const repo = makeTempDir();
+    writeGitDir(repo, "bbbbbbbccccccccccccccccccccccccccccccc\n");
+    const cwd = nestDirs(repo, 3);
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBe("bbbbbbb");
+  });
+
+  it("stops the parent walk after 12 directories", async () => {
+    const repo = makeTempDir();
+    writeGitDir(repo, "dddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n");
+    const tooDeep = nestDirs(repo, 12);
+    const withinLimit = nestDirs(repo, 11);
+    const resolveDeep = await loadResolveCommitHash();
+    expect(resolveDeep({ cwd: tooDeep, env: {} })).toBeNull();
+    vi.resetModules();
+    const resolveNear = await loadResolveCommitHash();
+    expect(resolveNear({ cwd: withinLimit, env: {} })).toBe("ddddddd");
+  });
+
+  it("skips a .git file without gitdir: and continues the parent walk", async () => {
+    const repo = makeTempDir();
+    writeGitDir(repo, "eeeeeeefffffffffffffffffffffffffffffff\n");
+    const nested = nestDirs(repo, 1);
+    fs.writeFileSync(path.join(nested, ".git"), "not-a-gitdir-pointer\n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd: nested, env: {} })).toBe("eeeeeee");
+  });
+
+  it("treats a case-folded REF: HEAD as a detached value, not a symbolic ref", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "REF: refs/heads/main\n", {
+      "refs/heads/main": "ffffffffffff11111111111111111111111111\n",
+    });
+    const resolveCommitHash = await loadResolveCommitHash();
+    // startsWith("ref:") is case-sensitive; formatCommit then slices 7 chars.
+    expect(resolveCommitHash({ cwd, env: {} })).toBe("REF: re");
+  });
+
+  it("memoizes the first hit and ignores later env or cwd changes", async () => {
+    const first = makeTempDir();
+    const second = makeTempDir();
+    writeGitDir(second, "99999998888888888888888888888888888888\n");
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(
+      resolveCommitHash({
+        cwd: first,
+        env: { GIT_COMMIT: "1111111aaaa" },
+      }),
+    ).toBe("1111111");
+    expect(
+      resolveCommitHash({
+        cwd: second,
+        env: { GIT_COMMIT: "2222222bbbb", GIT_SHA: "3333333cccc" },
+      }),
+    ).toBe("1111111");
+  });
+
+  it("memoizes a null miss so a later GIT_COMMIT cannot override it", async () => {
+    const cwd = makeTempDir();
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: {} })).toBeNull();
+    expect(
+      resolveCommitHash({ cwd, env: { GIT_COMMIT: "shouldnot" } }),
+    ).toBeNull();
+  });
+
+  it("lets GIT_COMMIT win over a real git tree at cwd", async () => {
+    const cwd = makeTempDir();
+    writeGitDir(cwd, "ref: refs/heads/main\n", {
+      "refs/heads/main": "ababababababababababababababababababab\n",
+    });
+    const resolveCommitHash = await loadResolveCommitHash();
+    expect(resolveCommitHash({ cwd, env: { GIT_COMMIT: "envwinsxyz" } })).toBe(
+      "envwins",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

`packages/app-core/src/cli/git-commit.ts` had no same-named test file. This PR adds `packages/app-core/src/cli/git-commit.test.ts` and changes no production code.

`resolveCommitHash` is the CLI version-stamp helper: it memoizes the first hit for the process, then probes `GIT_COMMIT` / `GIT_SHA`, bundled `build-info.json` / `package.json` `gitHead` (both absent in this checkout, so those probes return null), then a walk up from `cwd` to `.git/HEAD` (directory `.git`, `gitdir:` worktree files, and `ref:` indirection). Unresolved hashes return `null`; they do not throw.

The suite drives the real module through a temp-index of real git trees. `vi.resetModules()` is used only to isolate the process memo between cases — `fs` and env are not mocked. Assertions record observed behaviour, including the case-sensitive `startsWith("ref:")` check: a `REF:` HEAD is formatted as a detached 7-character string (`REF: re`), not followed as a symbolic ref.

Covered branches:

- `GIT_COMMIT` wins over `GIT_SHA` and over a real git tree; whitespace is trimmed; values are sliced to 7 characters; shorter hashes are kept
- empty / whitespace `GIT_COMMIT` falls through to `GIT_SHA`
- empty env + no `.git` within the 12-directory walk → `null`
- detached `.git/HEAD`, symbolic `ref:` follow, missing ref (ENOENT) → `null`, empty HEAD → `null`
- relative and absolute `gitdir:` worktree pointers (absolute match is case-insensitive and trims path whitespace)
- parent walk, 12-directory cap (12-deep miss / 11-deep hit), and a non-`gitdir:` `.git` file that continues the parent walk
- process memo of both a hit and a `null` miss (later options cannot override)

## Evidence

1. **vitest** (re-run after `git fetch origin develop`; `origin/develop` and this PR's parent are both `b7fe8b08b0d631cb8180d798c4a812064692dc54`; `packages/app-core/src/cli/git-commit.ts` is unchanged on current develop):

```
bunx vitest run packages/app-core/src/cli/git-commit.test.ts

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

2. **biome** (config present at repo-root `biome.json`; worktree is not sparse):

```
bunx biome check --write packages/app-core/src/cli/git-commit.test.ts
Checked 1 file in 73ms. Fixed 1 file.
```

Re-check after that wrap is clean. The only biome edit was a line wrap on the last assertion.

3. **tsc** from `packages/app-core`:

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'git-commit.test.ts' ; echo "EXIT:$?"
EXIT:1
```

`git-commit.test.ts` does not appear in `tsc` output (grep exit 1 = no matches). Pre-existing package errors, if any, are not from this file.

4. **diff scope:** this pull request adds only `packages/app-core/src/cli/git-commit.test.ts`. No production behaviour changes.

Hosted CI does not run on this fork contributor PR. The counts above are from local `bunx vitest`, `bunx biome`, and `bunx tsc` on this checkout.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2759d41549a398b9cf7aed3b70e1343e639d3fc3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
