### PR TITLE
test(app-core): cover profile

### DIFF
--- a/packages/app-core/src/cli/profile.test.ts
+++ b/packages/app-core/src/cli/profile.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Direct unit coverage for CLI `--profile` / `--dev` argv extraction and
+ * env default wiring. Drives `parseCliProfileArgs` and `applyCliProfileEnv`
+ * without mocking the module under test.
+ */
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { applyCliProfileEnv, parseCliProfileArgs } from "./profile";
+
+const cli = (...args: string[]): string[] => ["node", "eliza", ...args];
+
+describe("parseCliProfileArgs", () => {
+  it("returns the original argv unchanged when it is shorter than node+script", () => {
+    expect(parseCliProfileArgs([])).toEqual({
+      ok: true,
+      profile: null,
+      argv: [],
+    });
+    expect(parseCliProfileArgs(["node"])).toEqual({
+      ok: true,
+      profile: null,
+      argv: ["node"],
+    });
+  });
+
+  it("leaves a node+script argv with no extra flags as a null profile", () => {
+    expect(parseCliProfileArgs(cli())).toEqual({
+      ok: true,
+      profile: null,
+      argv: ["node", "eliza"],
+    });
+  });
+
+  it("strips --dev and sets the reserved dev profile", () => {
+    expect(parseCliProfileArgs(cli("--dev", "start", "--verbose"))).toEqual({
+      ok: true,
+      profile: "dev",
+      argv: ["node", "eliza", "start", "--verbose"],
+    });
+  });
+
+  it("accepts a repeated --dev flag as still the dev profile", () => {
+    expect(parseCliProfileArgs(cli("--dev", "--dev", "start"))).toEqual({
+      ok: true,
+      profile: "dev",
+      argv: ["node", "eliza", "start"],
+    });
+  });
+
+  it("strips --profile <name> and --profile=<name>, including trimmed equals values", () => {
+    expect(parseCliProfileArgs(cli("--profile", "alice", "start"))).toEqual({
+      ok: true,
+      profile: "alice",
+      argv: ["node", "eliza", "start"],
+    });
+    expect(parseCliProfileArgs(cli("--profile=bob", "--verbose"))).toEqual({
+      ok: true,
+      profile: "bob",
+      argv: ["node", "eliza", "--verbose"],
+    });
+    expect(parseCliProfileArgs(cli("--profile=  carol  ", "start"))).toEqual({
+      ok: true,
+      profile: "carol",
+      argv: ["node", "eliza", "start"],
+    });
+  });
+
+  it("lets a later --profile overwrite an earlier one", () => {
+    expect(
+      parseCliProfileArgs(cli("--profile", "alice", "--profile=bob", "start")),
+    ).toEqual({
+      ok: true,
+      profile: "bob",
+      argv: ["node", "eliza", "start"],
+    });
+  });
+
+  it("preserves non-profile flags that appear before the command word", () => {
+    expect(
+      parseCliProfileArgs(
+        cli("--verbose", "--profile", "alice", "start", "-x"),
+      ),
+    ).toEqual({
+      ok: true,
+      profile: "alice",
+      argv: ["node", "eliza", "--verbose", "start", "-x"],
+    });
+  });
+
+  it("stops parsing profile flags once a non-flag command word is seen", () => {
+    expect(
+      parseCliProfileArgs(cli("start", "--dev", "--profile", "alice")),
+    ).toEqual({
+      ok: true,
+      profile: null,
+      argv: ["node", "eliza", "start", "--dev", "--profile", "alice"],
+    });
+  });
+
+  it("does not treat -- as a command word, so later --profile still applies", () => {
+    expect(
+      parseCliProfileArgs(cli("--", "--profile", "alice", "start")),
+    ).toEqual({
+      ok: true,
+      profile: "alice",
+      argv: ["node", "eliza", "--", "start"],
+    });
+  });
+
+  it("skips holes in the args array before the command word", () => {
+    const argv: string[] = ["node", "eliza"];
+    argv[3] = "--dev";
+    argv[4] = "start";
+    expect(parseCliProfileArgs(argv)).toEqual({
+      ok: true,
+      profile: "dev",
+      argv: ["node", "eliza", "start"],
+    });
+  });
+
+  it("rejects --profile without a usable value", () => {
+    expect(parseCliProfileArgs(cli("--profile"))).toEqual({
+      ok: false,
+      error: "--profile requires a value",
+    });
+    expect(parseCliProfileArgs(cli("--profile="))).toEqual({
+      ok: false,
+      error: "--profile requires a value",
+    });
+    expect(parseCliProfileArgs(cli("--profile=   "))).toEqual({
+      ok: false,
+      error: "--profile requires a value",
+    });
+    expect(parseCliProfileArgs(cli("--profile", ""))).toEqual({
+      ok: false,
+      error: "--profile requires a value",
+    });
+  });
+
+  it("rejects names that fail the path-safe profile charset or length cap", () => {
+    const invalid = 'Invalid --profile (use letters, numbers, "_", "-" only)';
+    expect(parseCliProfileArgs(cli("--profile", "has space"))).toEqual({
+      ok: false,
+      error: invalid,
+    });
+    expect(parseCliProfileArgs(cli("--profile", "a/b"))).toEqual({
+      ok: false,
+      error: invalid,
+    });
+    expect(parseCliProfileArgs(cli("--profile", "-leading"))).toEqual({
+      ok: false,
+      error: invalid,
+    });
+    expect(parseCliProfileArgs(cli("--profile", "foo=bar"))).toEqual({
+      ok: false,
+      error: invalid,
+    });
+    expect(parseCliProfileArgs(cli("--profile", "a".repeat(65)))).toEqual({
+      ok: false,
+      error: invalid,
+    });
+    expect(parseCliProfileArgs(cli("--profile", "a".repeat(64)))).toEqual({
+      ok: true,
+      profile: "a".repeat(64),
+      argv: ["node", "eliza"],
+    });
+  });
+
+  it("treats a following flag as the --profile value when no equals form is used", () => {
+    expect(parseCliProfileArgs(cli("--profile", "--dev"))).toEqual({
+      ok: false,
+      error: 'Invalid --profile (use letters, numbers, "_", "-" only)',
+    });
+  });
+
+  it("rejects combining --dev with a non-dev --profile, regardless of order", () => {
+    expect(parseCliProfileArgs(cli("--dev", "--profile", "alice"))).toEqual({
+      ok: false,
+      error: "Cannot combine --dev with --profile",
+    });
+    expect(parseCliProfileArgs(cli("--profile=alice", "--dev"))).toEqual({
+      ok: false,
+      error: "Cannot combine --dev with --profile",
+    });
+    expect(parseCliProfileArgs(cli("--dev", "--profile=dev"))).toEqual({
+      ok: false,
+      error: "Cannot combine --dev with --profile",
+    });
+  });
+
+  it("allows --dev after --profile dev because the names already match", () => {
+    expect(
+      parseCliProfileArgs(cli("--profile", "dev", "--dev", "start")),
+    ).toEqual({
+      ok: true,
+      profile: "dev",
+      argv: ["node", "eliza", "start"],
+    });
+  });
+});
+
+describe("applyCliProfileEnv", () => {
+  const homedir = (): string => "/home/eliza-profile-test";
+
+  it("is a no-op when the profile is empty after trim", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_PROFILE: "keep-me",
+    };
+    applyCliProfileEnv({ profile: "   ", env, homedir });
+    applyCliProfileEnv({ profile: "", env, homedir });
+    expect(env).toEqual({ ELIZA_PROFILE: "keep-me" });
+  });
+
+  it("always writes ELIZA_PROFILE and fills namespace, state dir, and config path", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_PROFILE: "already-set",
+    };
+    applyCliProfileEnv({ profile: "  alice  ", env, homedir });
+    expect(env.ELIZA_PROFILE).toBe("alice");
+    expect(env.ELIZA_NAMESPACE).toBe("eliza");
+    expect(env.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza-alice"),
+    );
+    expect(env.ELIZA_CONFIG_PATH).toBe(
+      path.join("/home/eliza-profile-test", ".eliza-alice", "eliza.json"),
+    );
+    expect(env.ELIZA_GATEWAY_PORT).toBeUndefined();
+  });
+
+  it("omits the state-dir suffix for default regardless of letter case", () => {
+    const lower: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "default", env: lower, homedir });
+    expect(lower.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza"),
+    );
+    expect(lower.ELIZA_CONFIG_PATH).toBe(
+      path.join("/home/eliza-profile-test", ".eliza", "eliza.json"),
+    );
+
+    const mixed: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "Default", env: mixed, homedir });
+    expect(mixed.ELIZA_PROFILE).toBe("Default");
+    expect(mixed.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza"),
+    );
+  });
+
+  it("keeps the original profile case in the non-default state-dir suffix", () => {
+    const env: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "Alice", env, homedir });
+    expect(env.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza-Alice"),
+    );
+  });
+
+  it("trims a provided namespace and uses it in both the state dir and config file", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_NAMESPACE: "  customNS  ",
+    };
+    applyCliProfileEnv({ profile: "alice", env, homedir });
+    expect(env.ELIZA_NAMESPACE).toBe("customNS");
+    expect(env.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".customNS-alice"),
+    );
+    expect(env.ELIZA_CONFIG_PATH).toBe(
+      path.join("/home/eliza-profile-test", ".customNS-alice", "customNS.json"),
+    );
+  });
+
+  it("treats a blank namespace as the eliza default", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_NAMESPACE: "   ",
+    };
+    applyCliProfileEnv({ profile: "alice", env, homedir });
+    expect(env.ELIZA_NAMESPACE).toBe("eliza");
+    expect(env.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza-alice"),
+    );
+  });
+
+  it("does not override a non-blank ELIZA_STATE_DIR or ELIZA_CONFIG_PATH", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_STATE_DIR: "/explicit/state",
+      ELIZA_CONFIG_PATH: "/explicit/config.json",
+    };
+    applyCliProfileEnv({ profile: "alice", env, homedir });
+    expect(env.ELIZA_STATE_DIR).toBe("/explicit/state");
+    expect(env.ELIZA_CONFIG_PATH).toBe("/explicit/config.json");
+  });
+
+  it("fills a whitespace state dir, then derives config path from the filled value", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_STATE_DIR: "  ",
+      ELIZA_CONFIG_PATH: "  ",
+    };
+    applyCliProfileEnv({ profile: "alice", env, homedir });
+    const stateDir = path.join("/home/eliza-profile-test", ".eliza-alice");
+    expect(env.ELIZA_STATE_DIR).toBe(stateDir);
+    expect(env.ELIZA_CONFIG_PATH).toBe(path.join(stateDir, "eliza.json"));
+  });
+
+  it("derives ELIZA_CONFIG_PATH from an explicit state dir when config path is blank", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_STATE_DIR: "/explicit/state",
+    };
+    applyCliProfileEnv({ profile: "alice", env, homedir });
+    expect(env.ELIZA_CONFIG_PATH).toBe(
+      path.join("/explicit/state", "eliza.json"),
+    );
+  });
+
+  it("defaults the gateway port only for the exact trimmed profile name dev", () => {
+    const dev: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "dev", env: dev, homedir });
+    expect(dev.ELIZA_GATEWAY_PORT).toBe("19001");
+
+    const already: Record<string, string | undefined> = {
+      ELIZA_GATEWAY_PORT: "18080",
+    };
+    applyCliProfileEnv({ profile: "dev", env: already, homedir });
+    expect(already.ELIZA_GATEWAY_PORT).toBe("18080");
+
+    const blankPort: Record<string, string | undefined> = {
+      ELIZA_GATEWAY_PORT: "  ",
+    };
+    applyCliProfileEnv({ profile: "dev", env: blankPort, homedir });
+    expect(blankPort.ELIZA_GATEWAY_PORT).toBe("19001");
+
+    const mixed: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "Dev", env: mixed, homedir });
+    expect(mixed.ELIZA_GATEWAY_PORT).toBeUndefined();
+    expect(mixed.ELIZA_STATE_DIR).toBe(
+      path.join("/home/eliza-profile-test", ".eliza-Dev"),
+    );
+  });
+
+  it("uses os.homedir when homedir is omitted", () => {
+    const env: Record<string, string | undefined> = {};
+    applyCliProfileEnv({ profile: "alice", env });
+    expect(env.ELIZA_STATE_DIR).toBe(path.join(os.homedir(), ".eliza-alice"));
+  });
+
+  it("writes defaults onto process.env when env is omitted", () => {
+    const keys = [
+      "ELIZA_PROFILE",
+      "ELIZA_NAMESPACE",
+      "ELIZA_STATE_DIR",
+      "ELIZA_CONFIG_PATH",
+      "ELIZA_GATEWAY_PORT",
+    ] as const;
+    const snapshot: Record<string, string | undefined> = {};
+    for (const key of keys) {
+      snapshot[key] = process.env[key];
+      delete process.env[key];
+    }
+    try {
+      applyCliProfileEnv({
+        profile: "alice",
+        homedir: () => "/tmp/eliza-profile-process-env",
+      });
+      expect(process.env.ELIZA_PROFILE).toBe("alice");
+      expect(process.env.ELIZA_NAMESPACE).toBe("eliza");
+      expect(process.env.ELIZA_STATE_DIR).toBe(
+        path.join("/tmp/eliza-profile-process-env", ".eliza-alice"),
+      );
+      expect(process.env.ELIZA_CONFIG_PATH).toBe(
+        path.join(
+          "/tmp/eliza-profile-process-env",
+          ".eliza-alice",
+          "eliza.json",
+        ),
+      );
+    } finally {
+      for (const key of keys) {
+        const value = snapshot[key];
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/app-core/src/cli/profile.ts`, which had no colocated `profile.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/app-core/src/cli/profile.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` (`b7fe8b08b0d631cb8180d798c4a812064692dc54`) at file time; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only. Does not change CLI argv parsing, profile validation, or env wiring. Failure mode is a red suite, not a behaviour change.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/profile.test.ts` driving the real `parseCliProfileArgs` and `applyCliProfileEnv` exports (no mocks of the system under test). Injected `env` and `homedir` are the module's own parameters.

Covered behaviour, as observed in the live module:

`parseCliProfileArgs`:
- argv shorter than node+script is returned unchanged with `profile: null`
- node+script only yields a null profile
- `--dev` is stripped and sets profile `"dev"`; a repeated `--dev` stays `"dev"`
- `--profile <name>` and `--profile=<name>` (including trimmed equals values) are stripped
- a later `--profile` overwrites an earlier one
- non-profile flags before the command word are preserved
- parsing stops at the first non-flag command word, so later `--dev` / `--profile` stay in argv
- `--` is not a command word, so a later `--profile` still applies
- holes in the args array are skipped
- missing / empty / whitespace `--profile` values error with `"--profile requires a value"`
- invalid charset, leading hyphen, embedded `=`, and 65-char names error with the path-safe message; 64-char names are accepted
- `--profile --dev` treats `--dev` as the value and rejects it as an invalid name (not the combine error)
- `--dev` combined with a non-dev `--profile` errors regardless of order, including `--dev --profile=dev`
- `--profile dev --dev` is allowed because the names already match

`applyCliProfileEnv`:
- blank / whitespace profile is a no-op
- `ELIZA_PROFILE` is always written (including when already set); namespace/state/config defaults fill
- `"default"` / `"Default"` omit the state-dir suffix; non-default names keep original case in the suffix
- a provided namespace is trimmed and used in both the state dir and config filename; blank namespace falls back to `"eliza"`
- non-blank `ELIZA_STATE_DIR` / `ELIZA_CONFIG_PATH` are not overridden
- whitespace state dir is filled, then config path is derived from the filled value
- explicit state dir still yields a derived config path when config path is blank
- gateway port `"19001"` is filled only for the exact trimmed name `"dev"`; `"Dev"` does not get a port; an existing non-blank port is kept; whitespace port is treated as empty
- omitted `homedir` uses `os.homedir()`
- omitted `env` writes defaults onto `process.env`

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/profile.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (`profile.ts` unchanged vs this PR's parent):

```bash
bunx vitest run packages/app-core/src/cli/profile.test.ts
bunx biome check --write packages/app-core/src/cli/profile.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'profile.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-fetched `origin/develop` `b7fe8b08b0d631cb8180d798c4a812064692dc54`; `profile.ts` SHA `7aad99a4e7be47349bc0a96cc0a1c0e1595b1dbe` matches the parent):

1. Vitest: **Test Files 1 passed (1), Tests 27 passed (27)** (`bunx vitest run packages/app-core/src/cli/profile.test.ts`). Duration 187ms.
2. Biome: `bunx biome check --write packages/app-core/src/cli/profile.test.ts` — **Checked 1 file in 23ms. Fixed 1 file.** The committed bytes are that post-write file. Config present (`biome.json`); worktree is not sparse.
3. `tsc --noEmit` in `packages/app-core`: **`profile.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors in other packages are unrelated.
4. Diff touches **only** `packages/app-core/src/cli/profile.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Evidence head (40-character SHA of this PR): `e9867f8ee73630be3f8f4189b6ce669f45345c6b`

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 27 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

# Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. `tsc --noEmit` for `packages/app-core` still reports pre-existing errors in other packages; none mention `profile.test.ts`.

# Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e9867f8ee73630be3f8f4189b6ce669f45345c6b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
