### PR TITLE
fix(ci): dispatch Platform Smoke from trusted develop

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,10 +58,17 @@ the previously compared base at the mutation boundary. An advanced develop tip
 is a neutral stale reconciliation; a behind or divergent main fails instead of
 creating an untested merge commit.
 The delegated `platform-smoke.yml` family preserves macOS and Windows core
-proof without a separate periodic authority. Its manual dispatch is the
-read-only route for exact-ref pre-merge platform evidence; it adds no automatic
-pull-request or push authority and does not replace PR Static Smoke or Develop
-Full.
+proof without a separate periodic authority. Its additional manual dispatch
+lets an authorized maintainer collect pre-merge watchdog/core evidence from
+both hosted platforms for an exact pull-request head SHA. Resolve that immutable
+SHA (for example, `gh pr view <number> --json headRefOid -q .headRefOid`), then
+run `gh workflow run platform-smoke.yml --ref develop -f source_sha=<40-hex-sha>`.
+The `--ref develop` argument is mandatory: it selects the trusted workflow
+definition, while `source_sha` selects only the candidate checkout. The job is
+read-only, references no repository or environment secrets, persists no
+checkout credential, and grants no deploy authority. This is supplemental
+evidence, not a replacement for PR Static Smoke or the automatic Develop Full
+validation of the merged tip.
 
 `.github/rulesets/required-branches.json` is the reviewed no-bypass ruleset
 manifest for `develop` and `main`. `scripts/security/apply-branch-protection.sh`

--- a/.github/workflows/develop-full.yml
+++ b/.github/workflows/develop-full.yml
@@ -219,7 +219,6 @@ jobs:
     needs: plan
     if: needs.plan.outputs.run_platform_smoke == 'true'
     uses: ./.github/workflows/platform-smoke.yml
-    secrets: inherit
 
   scenarios:
     needs: plan

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -1,10 +1,23 @@
 # This read-only workflow preserves deterministic macOS and Windows runtime
-# proof inside Develop Full and supports explicit exact-ref evidence runs.
+# proof. Develop Full remains the sole automatic authority; manual dispatches
+# use the trusted develop definition to test one exact candidate commit.
 name: Platform Smoke
+run-name: Platform Smoke (${{ inputs.source_sha || github.sha }})
 
 on:
   workflow_call:
-  workflow_dispatch: {}
+    inputs:
+      source_sha:
+        description: Optional exact commit SHA for a trusted caller
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact 40-character commit SHA to validate
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -19,9 +32,41 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
+      - name: Validate manual source request
+        if: inputs.source_sha != ''
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "::error::Manual Platform Smoke must be dispatched with --ref develop"
+            exit 1
+          fi
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ inputs.source_sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
           submodules: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.source_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::Checked out $actual_sha instead of requested $EXPECTED_SHA"
+            exit 1
+          fi
+          echo "Validated source: \`$actual_sha\`" >> "$GITHUB_STEP_SUMMARY"
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:

--- a/packages/scripts/__tests__/develop-full-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-full-workflow.test.ts
@@ -80,7 +80,11 @@ describe("Develop Full workflow authority", () => {
     for (const name of delegatedJobs) {
       const job = workflow.jobs?.[name];
       expect(job?.uses).toMatch(/^\.\/\.github\/workflows\/.+\.yml$/);
-      expect(job?.secrets).toBe("inherit");
+      if (name === "platform-smoke") {
+        expect(job?.secrets).toBeUndefined();
+      } else {
+        expect(job?.secrets).toBe("inherit");
+      }
       expect(job?.permissions).toBeUndefined();
       expect(job?.needs).toBe("plan");
       expect(job?.if).toContain("needs.plan.outputs.run_");

--- a/packages/scripts/__tests__/platform-smoke-workflow.test.ts
+++ b/packages/scripts/__tests__/platform-smoke-workflow.test.ts
@@ -1,38 +1,155 @@
-/** Verifies the platform smoke workflow remains callable and manually dispatchable without automatic authority. */
+/** Verifies the read-only platform smoke workflow remains callable, manually dispatchable, and cross-platform. */
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const workflow = Bun.YAML.parse(
-  readFileSync(
-    fileURLToPath(
-      new URL("../../../.github/workflows/platform-smoke.yml", import.meta.url),
-    ),
-    "utf8",
-  ),
-) as {
-  on?: Record<string, unknown>;
+const workflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/platform-smoke.yml", import.meta.url),
+);
+const workflowSource = readFileSync(workflowPath, "utf8");
+type SourceShaInput = {
+  description?: string;
+  required?: boolean;
+  type?: string;
+  default?: string;
+};
+const workflow = Bun.YAML.parse(workflowSource) as {
+  "run-name"?: string;
+  on?: {
+    workflow_call?: { inputs?: Record<string, SourceShaInput> };
+    workflow_dispatch?: {
+      inputs?: Record<string, SourceShaInput>;
+    };
+  };
   permissions?: Record<string, string>;
   jobs?: Record<
     string,
     {
+      environment?: unknown;
+      permissions?: Record<string, string>;
+      secrets?: unknown;
       strategy?: { matrix?: { os?: string[] } };
       "runs-on"?: string;
+      steps?: Array<{
+        name?: string;
+        uses?: string;
+        if?: string;
+        env?: Record<string, string>;
+        run?: string;
+        with?: Record<string, unknown>;
+      }>;
     }
   >;
 };
 
-test("platform smoke exposes only callable and explicit manual triggers", () => {
-  expect(Object.keys(workflow.on ?? {}).sort()).toEqual([
-    "workflow_call",
-    "workflow_dispatch",
-  ]);
-  expect(workflow.permissions).toEqual({ contents: "read" });
-});
+const platformJob = workflow.jobs?.["platform-smoke"];
+const steps = platformJob?.steps ?? [];
 
-test("manual evidence retains both hosted platform cells", () => {
-  const job = workflow.jobs?.["platform-smoke"];
-  expect(job?.strategy?.matrix?.os).toEqual(["macos-15", "windows-2025"]);
-  expect(job?.["runs-on"]).toBe("${{ matrix.os }}");
+describe("Platform Smoke workflow", () => {
+  test("exposes only reusable and manual entry points with read-only contents", () => {
+    expect(Object.keys(workflow.on ?? {}).sort()).toEqual([
+      "workflow_call",
+      "workflow_dispatch",
+    ]);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(Object.keys(workflow.on?.workflow_call?.inputs ?? {})).toEqual([
+      "source_sha",
+    ]);
+    expect(Object.keys(workflow.on?.workflow_dispatch?.inputs ?? {})).toEqual([
+      "source_sha",
+    ]);
+    expect(workflow.on?.workflow_call?.inputs?.source_sha).toEqual({
+      description: "Optional exact commit SHA for a trusted caller",
+      required: false,
+      type: "string",
+      default: "",
+    });
+    expect(workflow.on?.workflow_dispatch?.inputs?.source_sha).toEqual({
+      description: "Exact 40-character commit SHA to validate",
+      required: true,
+      type: "string",
+    });
+  });
+
+  test("keeps one secretless, deployment-free cross-platform job", () => {
+    expect(Object.keys(workflow.jobs ?? {})).toEqual(["platform-smoke"]);
+    expect(platformJob?.strategy?.matrix?.os).toEqual([
+      "macos-15",
+      "windows-2025",
+    ]);
+    expect(platformJob?.["runs-on"]).toBe("$" + "{{ matrix.os }}");
+    expect(platformJob?.permissions).toBeUndefined();
+    expect(platformJob?.environment).toBeUndefined();
+    expect(platformJob?.secrets).toBeUndefined();
+    expect(workflowSource).not.toMatch(/\bsecrets\s*(?:[:.]|\[)/);
+  });
+
+  test("dispatches the trusted definition and checks out only the exact SHA", () => {
+    const expectedRef = "$" + "{{ inputs.source_sha || github.sha }}";
+    expect(workflow["run-name"]).toBe(`Platform Smoke (${expectedRef})`);
+    const validation = steps.find(
+      (step) => step.name === "Validate manual source request",
+    );
+    expect(validation?.if).toBe("inputs.source_sha != ''");
+    expect(validation?.env).toEqual({
+      SOURCE_SHA: "$" + "{{ inputs.source_sha }}",
+    });
+    expect(validation?.run).toContain(
+      '[ "$GITHUB_REF" != "refs/heads/develop" ]',
+    );
+    expect(validation?.run).toContain("^[0-9a-f]{40}$");
+
+    const checkout = steps.find((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+    expect(checkout?.with).toEqual({
+      ref: expectedRef,
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      submodules: false,
+    });
+
+    const verification = steps.find(
+      (step) => step.name === "Verify exact source checkout",
+    );
+    expect(verification?.env).toEqual({ EXPECTED_SHA: expectedRef });
+    expect(verification?.run).toContain("git rev-parse HEAD");
+    expect(verification?.run).toContain('[ "$actual_sha" != "$EXPECTED_SHA" ]');
+    expect(verification?.run).toContain("$GITHUB_STEP_SUMMARY");
+  });
+
+  test("preserves the focused watchdog and core commands", () => {
+    expect(steps.map((step) => step.name ?? step.uses?.split("@")[0])).toEqual([
+      "Validate manual source request",
+      "actions/checkout",
+      "Verify exact source checkout",
+      "oven-sh/setup-bun",
+      "actions/setup-node",
+      "Run batch watchdog process-tree self-test",
+      "Install dependencies",
+      "Build core",
+      "Run core tests",
+    ]);
+    const namedCommands = Object.fromEntries(
+      steps
+        .filter((step) => step.name && step.run)
+        .map((step) => [step.name, step.run]),
+    );
+    expect(Object.keys(namedCommands)).toEqual([
+      "Validate manual source request",
+      "Verify exact source checkout",
+      "Run batch watchdog process-tree self-test",
+      "Install dependencies",
+      "Build core",
+      "Run core tests",
+    ]);
+    expect(namedCommands).toMatchObject({
+      "Run batch watchdog process-tree self-test":
+        "node packages/scripts/test-cloud-run-watchdog.self-test.mjs",
+      "Install dependencies": "bun install --frozen-lockfile --ignore-scripts",
+      "Build core": "bun run build:core",
+      "Run core tests": "bun run test:core",
+    });
+  });
 });


### PR DESCRIPTION
Closes #25860.

## Summary

- dispatches the reviewed `develop` Platform Smoke definition while treating
  the exact pull-request head SHA as validated input
- checks out and verifies that immutable SHA with no persisted Git credential,
  and exposes the candidate SHA in the run name and step summary
- removes `secrets: inherit` from the Develop Full caller and expands the static
  contracts around triggers, inputs, permissions, secrets, steps, commands, and
  the macOS/Windows matrix
- documents the safe `gh workflow run ... --ref develop -f source_sha=...`
  operator flow

## Security boundary

`workflow_dispatch --ref <candidate-branch>` selects the workflow definition
from that branch as well as its revision. The new flow always selects the
reviewed definition on `develop`; only the checkout SHA comes from the candidate.
Reusable callers continue to test their own `github.sha` unless the reviewed
caller explicitly supplies the optional exact-SHA input.

## Validation

- `bun install --frozen-lockfile` with Node `24.15.0` / Bun `1.3.14`: pass
- focused Platform Smoke + Develop Full contracts: 11 passed, 0 failed, 188
  assertions
- pinned external action contract: pass
- pinned `actionlint` over both changed workflows: pass
- workflow trigger policy: 61 workflows, exactly 1 develop-push authority
- Bun pin and Windows command-inventory contracts: pass
- changed-test Biome, Markdown links, and `git diff --check`: pass
- `bun run verify`: reaches the repository-wide Turbo lint/typecheck phase, then
  fails on pre-existing Biome formatting in
  `packages/evidence/src/visual-primitives.test.mjs`; that file is byte-identical
  to `origin/develop` (`git diff --quiet` exits 0) and is outside this diff

## Evidence

N/A for screenshots, video, model/provider output, or deployment evidence: this
is a read-only CI authority contract with no product UI, provider, environment,
or production effect. A real safe manual run is necessarily post-merge because
the trusted `develop` definition must first accept `source_sha`; use the exact
documented command after merge.
