### PR TITLE
test(app-core): cover build-program

### DIFF
--- a/packages/app-core/src/cli/program/build-program.test.ts
+++ b/packages/app-core/src/cli/program/build-program.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Direct unit coverage for `buildProgram`. Drives the real assembler and
+ * asserts the Commander program it returns: name/version stamp, global flags,
+ * registered commands (including argv-dependent lazy sub-CLIs), preAction hook
+ * installation, and root-only help text. Collaborators are not replaced.
+ */
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCliName } from "../cli-name";
+import { CLI_VERSION } from "../version";
+import { buildProgram } from "./build-program";
+
+const ORIGINAL_ARGV = process.argv.slice();
+const ORIGINAL_LAZY = process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+
+/** Top-level commands `registerProgramCommands` wires for a bare `eliza` argv. */
+const DEFAULT_COMMAND_NAMES = [
+  "start",
+  "run",
+  "benchmark",
+  "capability-router",
+  "setup",
+  "doctor:mtp",
+  "doctor",
+  "db",
+  "configure",
+  "config",
+  "dashboard",
+  "update",
+  "auth",
+  "plugins",
+  "models",
+] as const;
+
+function commandNames(program: Command): string[] {
+  return program.commands.map((command) => command.name());
+}
+
+function captureOutputHelp(program: Command): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  }) as typeof process.stdout.write);
+  try {
+    program.outputHelp();
+    return chunks.join("");
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("buildProgram", () => {
+  beforeEach(() => {
+    process.argv = ["node", "eliza"];
+    delete process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+  });
+
+  afterEach(() => {
+    process.argv = ORIGINAL_ARGV;
+    if (ORIGINAL_LAZY === undefined) {
+      delete process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+    } else {
+      process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS = ORIGINAL_LAZY;
+    }
+  });
+
+  it("returns a Commander program, not a singleton", () => {
+    const first = buildProgram();
+    const second = buildProgram();
+    expect(first).toBeInstanceOf(Command);
+    expect(second).toBeInstanceOf(Command);
+    expect(first).not.toBe(second);
+  });
+
+  it("stamps the resolved CLI name and CLI_VERSION", () => {
+    const program = buildProgram();
+    expect(program.name()).toBe(resolveCliName());
+    expect(program.version()).toBe(CLI_VERSION);
+    expect(typeof CLI_VERSION).toBe("string");
+    expect(CLI_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("registers the global flags configureProgramHelp defines", () => {
+    const program = buildProgram();
+    const flags = program.options.map((option) => option.flags);
+    expect(flags).toEqual(
+      expect.arrayContaining([
+        "-v, --version",
+        "--verbose",
+        "--debug",
+        "--dev",
+        "--profile <name>",
+        "--no-color",
+      ]),
+    );
+  });
+
+  it("registers every top-level command in registry order for a bare argv", () => {
+    const program = buildProgram();
+    expect(commandNames(program)).toEqual([...DEFAULT_COMMAND_NAMES]);
+  });
+
+  it("attaches adopt-codex under the existing auth command", () => {
+    const program = buildProgram();
+    const auth = program.commands.find((command) => command.name() === "auth");
+    expect(auth).toBeDefined();
+    expect(auth?.commands.map((command) => command.name())).toContain(
+      "adopt-codex",
+    );
+    expect(commandNames(program).filter((name) => name === "auth")).toEqual([
+      "auth",
+    ]);
+  });
+
+  it("installs a preAction hook on the assembled program", () => {
+    const program = buildProgram() as Command & {
+      _lifeCycleHooks?: { preAction?: unknown[] };
+    };
+    const hooks = program._lifeCycleHooks?.preAction ?? [];
+    expect(hooks.length).toBe(1);
+    expect(typeof hooks[0]).toBe("function");
+  });
+
+  it("includes the Examples block and CLI docs link only on root help", () => {
+    const program = buildProgram();
+    const rootHelp = captureOutputHelp(program);
+    expect(rootHelp).toMatch(/Examples:/);
+    expect(rootHelp).toContain("docs.eliza.ai/cli");
+    expect(rootHelp).toContain(CLI_VERSION);
+
+    const start = program.commands.find(
+      (command) => command.name() === "start",
+    );
+    expect(start).toBeDefined();
+    const startHelp = captureOutputHelp(start as Command);
+    expect(startHelp).not.toMatch(/Examples:/);
+    expect(startHelp).not.toContain("docs.eliza.ai/cli");
+  });
+
+  it("registers only the named lazy sub-CLI when argv selects one", () => {
+    process.argv = ["node", "eliza", "plugins"];
+    const program = buildProgram();
+    const names = commandNames(program);
+    expect(names).toContain("plugins");
+    expect(names).not.toContain("models");
+  });
+
+  it("still registers both lazy sub-CLIs when argv is --help", () => {
+    process.argv = ["node", "eliza", "--help"];
+    const program = buildProgram();
+    const names = commandNames(program);
+    expect(names).toContain("plugins");
+    expect(names).toContain("models");
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/program/build-program.ts`. No linked issue: the assembler had no colocated behavioral suite. `packages/app-core/src/cli/program/__tests__/build-program.test.ts` already exists on `develop` but replaces Commander and every collaborator with mocks; this PR adds a real-module suite next to the source, matching the colocated `*.test.ts` convention in the same directory.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

Focused vitest / biome / tsc are quoted in **Testing**. `bun run verify` was not re-run: this diff adds one test file and changes no production behaviour. Hosted GitHub Actions CI does **not** run on this fork PR.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Parent of this head is `1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only. No production code, no CLI flag, no command-registration order change. The suite asserts the assembler as it behaves today.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program/build-program.test.ts`. `buildProgram()` is the only export: it constructs a Commander `Command`, then calls `configureProgramHelp`, `registerPreActionHooks`, and `registerProgramCommands` in that order. The suite drives that real function and asserts the program it returns:

- a Commander instance that is not a singleton
- name stamped from `resolveCliName()` and version stamped from `CLI_VERSION`
- global flags `-v/--version`, `--verbose`, `--debug`, `--dev`, `--profile`, `--no-color`
- top-level commands in registry order for a bare `eliza` argv
- `auth adopt-codex` attached under the existing `auth` command (no second `auth`)
- one `preAction` hook installed
- root help includes `Examples:` and `docs.eliza.ai/cli`; `start` help does not
- argv `plugins` registers only that lazy sub-CLI (not `models`)
- argv `--help` still registers both lazy sub-CLIs

Expectations are what the live assembler actually returns, not a preferred inventory.

## What kind of change is this?

Improvements (tests for existing behavior). No production change.

## Why are we doing this? Any context or related work?

`build-program.ts` had no colocated real-module test. The mock-theatre file under `__tests__/` cannot catch a wiring regression (wrong version, dropped command, lost preAction hook, lazy-sub-CLI argv branch).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/program/build-program.test.ts`, then the quoted vitest run below.

## Detailed testing steps

None: automated tests. Command and counts from this exact tree (re-run after rebasing onto current `origin/develop`):

```text
$ cd packages/app-core && bunx vitest run src/cli/program/build-program.test.ts

 RUN  v4.1.5 /Volumes/thescoho_1TB/Developer/eliza/packages/app-core
 ✓ src/cli/program/build-program.test.ts (9 tests) 10ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  9.10s (transform 7.00s, setup 0ms, import 8.99s, tests 10ms, environment 0ms)
```

```text
$ bunx biome check --write packages/app-core/src/cli/program/build-program.test.ts
Checked 1 file in 191ms. Fixed 1 file.
```

`biome.json` is present in the checkout; sparse-checkout is not enabled. The committed file is the biome-written result.

```text
$ cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'src/cli/program/build-program.test.ts' ; echo "EXIT:$?"
EXIT:1
```

The new file appears nowhere in `tsc --noEmit` output (package `tsconfig.json` excludes `src/cli/**`; a targeted grep of `tsconfig.typecheck.json` output also does not name this colocated path).

Diff touches only `packages/app-core/src/cli/program/build-program.test.ts`.

This is a fork contributor PR. Hosted CI does not run on it; do not treat missing Actions checks as a failure of this change.

# Evidence Gate

Test-only, no production behaviour change, no UI, no agent/prompt path.

- Before screenshots: N/A - test-only, no rendered UI surface
- After screenshots: N/A - test-only, no rendered UI surface
- Walkthrough video: N/A - test-only, no user flow
- Backend logs: N/A - no server path; vitest output quoted above
- Frontend logs: N/A - no frontend change
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change
- Domain artifacts: N/A - no DB/memory/schedule/wallet/audio artifact
- OCR review: N/A - no rendered visual surface

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no runtime server or frontend path. Vitest counts are quoted in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI.

### Before

N/A - test-only, no UI.

### After

N/A - test-only, no UI.

### Walkthrough video

N/A - test-only, no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; the complete evidence set is the quoted vitest / biome / tsc results.
- No signed identity.slop.cash trace: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
- Hosted GitHub Actions CI does not run on fork contributor PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7c3d6cef2f434a65a6c5122729dc01a87a2b08aa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
