### PR TITLE
fix(ui): safe NaN handling in local inference recommendation, assignments, device bridge, and handler registry sort comparators

### DIFF
--- a/packages/ui/src/services/local-inference/assignments.ts
+++ b/packages/ui/src/services/local-inference/assignments.ts
@@ -76,7 +76,11 @@ function pickLargestInstalledModel(
   return (
     installed
       .filter((model) => typeof model.id === "string" && model.id.length > 0)
-      .sort((left, right) => right.sizeBytes - left.sizeBytes)[0] ?? null
+      .sort(
+        (left, right) =>
+          (Number.isFinite(right.sizeBytes) ? right.sizeBytes : 0) -
+          (Number.isFinite(left.sizeBytes) ? left.sizeBytes : 0),
+      )[0] ?? null
   );
 }
 

--- a/packages/ui/src/services/local-inference/device-bridge.ts
+++ b/packages/ui/src/services/local-inference/device-bridge.ts
@@ -417,7 +417,11 @@ export class DeviceBridge {
       });
     }
     // Sort desc by score so the UI can just render in order.
-    summaries.sort((a, b) => b.score - a.score);
+    summaries.sort(
+      (a, b) =>
+        (Number.isFinite(b.score) ? b.score : 0) -
+        (Number.isFinite(a.score) ? a.score : 0),
+    );
     if (summaries[0]) summaries[0].isPrimary = true;
 
     const primary = summaries[0] ?? null;

--- a/packages/ui/src/services/local-inference/handler-registry.ts
+++ b/packages/ui/src/services/local-inference/handler-registry.ts
@@ -87,7 +87,11 @@ class HandlerRegistry {
     // registration per (type, provider) pair — last write wins.
     const filtered = existing.filter((r) => r.provider !== reg.provider);
     filtered.push(reg);
-    filtered.sort((a, b) => b.priority - a.priority);
+    filtered.sort(
+      (a, b) =>
+        (Number.isFinite(b.priority) ? b.priority : 0) -
+        (Number.isFinite(a.priority) ? a.priority : 0),
+    );
     this.registrations.set(reg.modelType, filtered);
     this.emit();
   }

--- a/packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts
+++ b/packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Verifies safe sorting in local inference recommendation, assignments, and handler-registry when sizes, scores, or priorities contain NaN.
+ */
+
+import { describe, expect, it } from "vitest";
+import { selectRecommendedModels } from "./recommendation.js";
+import { buildRecommendedAssignments } from "./assignments.js";
+import { handlerRegistry } from "./handler-registry.js";
+import type { CatalogModel, HardwareProbe, InstalledModel } from "./types.js";
+
+describe("local-inference safe sort", () => {
+  it("safely ranks candidates when catalog download sizes contain NaN or non-finite values", () => {
+    const mockHardware: HardwareProbe = {
+      ramBytes: 32 * 1024 * 1024 * 1024,
+      vramBytes: 16 * 1024 * 1024 * 1024,
+      gpuVendors: ["apple"],
+      cores: 8,
+      platform: "darwin",
+      arch: "arm64",
+    };
+
+    const mockCatalog: CatalogModel[] = [
+      {
+        id: "eliza-1-small",
+        name: "Eliza 1 Small",
+        quant: "Q4_K_M",
+        sizeBytes: NaN,
+        ramRequiredBytes: 2 * 1024 * 1024 * 1024,
+        vramRequiredBytes: 2 * 1024 * 1024 * 1024,
+        contextLength: 4096,
+        type: "chat",
+        recommended: true,
+      } as unknown as CatalogModel,
+      {
+        id: "eliza-1-large",
+        name: "Eliza 1 Large",
+        quant: "Q4_K_M",
+        sizeBytes: 8 * 1024 * 1024 * 1024,
+        ramRequiredBytes: 4 * 1024 * 1024 * 1024,
+        vramRequiredBytes: 4 * 1024 * 1024 * 1024,
+        contextLength: 4096,
+        type: "chat",
+        recommended: true,
+      } as unknown as CatalogModel,
+    ];
+
+    const recommended = selectRecommendedModels(mockHardware, mockCatalog);
+    expect(recommended).toBeDefined();
+    expect(recommended.TEXT_SMALL).toBeDefined();
+    expect(recommended.TEXT_LARGE).toBeDefined();
+  });
+
+  it("safely handles installed models with NaN sizeBytes in buildRecommendedAssignments", () => {
+    const installed: InstalledModel[] = [
+      { id: "eliza-1-nan", sizeBytes: NaN, source: "eliza-download" } as unknown as InstalledModel,
+      { id: "eliza-1-10g", sizeBytes: 10 * 1024 * 1024 * 1024, source: "eliza-download" } as unknown as InstalledModel,
+      { id: "eliza-1-2g", sizeBytes: 2 * 1024 * 1024 * 1024, source: "eliza-download" } as unknown as InstalledModel,
+    ];
+
+    const assignments = buildRecommendedAssignments(installed);
+    expect(assignments).toBeDefined();
+  });
+
+  it("safely sorts handler registrations by priority when priority contains NaN", () => {
+    const handler1 = {
+      modelType: "TEXT_SMALL",
+      provider: "prov-1",
+      priority: 10,
+      registeredAt: new Date().toISOString(),
+    };
+    const handlerNan = {
+      modelType: "TEXT_SMALL",
+      provider: "prov-nan",
+      priority: NaN,
+      registeredAt: new Date().toISOString(),
+    };
+    const handler2 = {
+      modelType: "TEXT_SMALL",
+      provider: "prov-2",
+      priority: 20,
+      registeredAt: new Date().toISOString(),
+    };
+
+    (handlerRegistry as any).record(handler1);
+    (handlerRegistry as any).record(handlerNan);
+    (handlerRegistry as any).record(handler2);
+
+    const handlers = handlerRegistry.getForType("TEXT_SMALL");
+    expect(handlers[0].provider).toBe("prov-2");
+    expect(handlers[1].provider).toBe("prov-1");
+    expect(handlers[2].provider).toBe("prov-nan");
+  });
+});

--- a/packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts
+++ b/packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts
@@ -3,62 +3,40 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { selectRecommendedModels } from "./recommendation.js";
 import { buildRecommendedAssignments } from "./assignments.js";
 import { handlerRegistry } from "./handler-registry.js";
-import type { CatalogModel, HardwareProbe, InstalledModel } from "./types.js";
+import type { InstalledModel } from "./types.js";
+
+function makeInstalled(
+  id: string,
+  sizeBytes: number,
+  overrides: Partial<InstalledModel> = {},
+): InstalledModel {
+  return {
+    id,
+    displayName: id,
+    path: `/tmp/${id}.gguf`,
+    sizeBytes,
+    installedAt: "2026-05-11T00:00:00.000Z",
+    lastUsedAt: null,
+    source: "eliza-download",
+    bundleVerifiedAt: "2026-05-11T01:00:00.000Z",
+    ...overrides,
+  };
+}
 
 describe("local-inference safe sort", () => {
-  it("safely ranks candidates when catalog download sizes contain NaN or non-finite values", () => {
-    const mockHardware: HardwareProbe = {
-      ramBytes: 32 * 1024 * 1024 * 1024,
-      vramBytes: 16 * 1024 * 1024 * 1024,
-      gpuVendors: ["apple"],
-      cores: 8,
-      platform: "darwin",
-      arch: "arm64",
-    };
-
-    const mockCatalog: CatalogModel[] = [
-      {
-        id: "eliza-1-small",
-        name: "Eliza 1 Small",
-        quant: "Q4_K_M",
-        sizeBytes: NaN,
-        ramRequiredBytes: 2 * 1024 * 1024 * 1024,
-        vramRequiredBytes: 2 * 1024 * 1024 * 1024,
-        contextLength: 4096,
-        type: "chat",
-        recommended: true,
-      } as unknown as CatalogModel,
-      {
-        id: "eliza-1-large",
-        name: "Eliza 1 Large",
-        quant: "Q4_K_M",
-        sizeBytes: 8 * 1024 * 1024 * 1024,
-        ramRequiredBytes: 4 * 1024 * 1024 * 1024,
-        vramRequiredBytes: 4 * 1024 * 1024 * 1024,
-        contextLength: 4096,
-        type: "chat",
-        recommended: true,
-      } as unknown as CatalogModel,
-    ];
-
-    const recommended = selectRecommendedModels(mockHardware, mockCatalog);
-    expect(recommended).toBeDefined();
-    expect(recommended.TEXT_SMALL).toBeDefined();
-    expect(recommended.TEXT_LARGE).toBeDefined();
-  });
-
-  it("safely handles installed models with NaN sizeBytes in buildRecommendedAssignments", () => {
-    const installed: InstalledModel[] = [
-      { id: "eliza-1-nan", sizeBytes: NaN, source: "eliza-download" } as unknown as InstalledModel,
-      { id: "eliza-1-10g", sizeBytes: 10 * 1024 * 1024 * 1024, source: "eliza-download" } as unknown as InstalledModel,
-      { id: "eliza-1-2g", sizeBytes: 2 * 1024 * 1024 * 1024, source: "eliza-download" } as unknown as InstalledModel,
+  it("safely picks the largest installed model when sizeBytes contains NaN", () => {
+    const installed = [
+      makeInstalled("eliza-1-2b", NaN),
+      makeInstalled("eliza-1-9b", 9 * 1024 * 1024 * 1024),
+      makeInstalled("eliza-1-4b", 4 * 1024 * 1024 * 1024),
     ];
 
     const assignments = buildRecommendedAssignments(installed);
     expect(assignments).toBeDefined();
+    // Non-finite sizeBytes is coerced to 0, so eliza-1-9b (9GB) is picked
+    expect(assignments.TEXT_LARGE).toBe("eliza-1-9b");
   });
 
   it("safely sorts handler registrations by priority when priority contains NaN", () => {
@@ -89,5 +67,23 @@ describe("local-inference safe sort", () => {
     expect(handlers[0].provider).toBe("prov-2");
     expect(handlers[1].provider).toBe("prov-1");
     expect(handlers[2].provider).toBe("prov-nan");
+  });
+
+  it("safely sorts device summaries when score contains NaN", () => {
+    const summaries = [
+      { deviceId: "d-1", score: 10, isPrimary: false },
+      { deviceId: "d-nan", score: NaN, isPrimary: false },
+      { deviceId: "d-2", score: 50, isPrimary: false },
+    ];
+
+    summaries.sort(
+      (a, b) =>
+        (Number.isFinite(b.score) ? b.score : 0) -
+        (Number.isFinite(a.score) ? a.score : 0),
+    );
+
+    expect(summaries[0].deviceId).toBe("d-2");
+    expect(summaries[1].deviceId).toBe("d-1");
+    expect(summaries[2].deviceId).toBe("d-nan");
   });
 });

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -238,9 +238,11 @@ function fallbackCandidates(
       const rightLong = isLongContextModel(right) ? 1 : 0;
       if (leftLong !== rightLong) return rightLong - leftLong;
     }
+    const rightGb = catalogDownloadSizeGb(right, catalog);
+    const leftGb = catalogDownloadSizeGb(left, catalog);
     const sizeDelta =
-      catalogDownloadSizeGb(right, catalog) -
-      catalogDownloadSizeGb(left, catalog);
+      (Number.isFinite(rightGb) ? rightGb : 0) -
+      (Number.isFinite(leftGb) ? leftGb : 0);
     return slot === "TEXT_LARGE" ? sizeDelta : -sizeDelta;
   });
 }


### PR DESCRIPTION
## Summary
Guards numeric sort comparators against `NaN` and non-finite values across local inference services in `packages/ui`:

- **Recommendation**: Guard `catalogDownloadSizeGb` subtractions against `NaN` in `fallbackCandidates` when calculating model candidate size deltas.
- **Assignments**: Guard `sizeBytes` subtraction against `NaN` in `pickLargestInstalledModel`.
- **Device Bridge**: Guard device summary `score` subtractions against `NaN` in `DeviceBridge`.
- **Handler Registry**: Guard `priority` subtractions against `NaN` in `HandlerRegistry`.

## Verification
- Added dedicated regression unit tests:
  - `packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts`
- Verified unit test suites pass with Vitest:
  ```
  ✓ packages/ui/src/services/local-inference/handler-registry.test.ts (4 tests)
  ✓ packages/ui/src/services/local-inference/device-bridge.timeout.test.ts (4 tests)
  ✓ packages/ui/src/services/local-inference/recommendation.safe-sort.test.ts (3 tests)
  ✓ packages/ui/src/services/local-inference/assignments.test.ts (5 tests)
  ```