### PR TITLE
test(app-core): cover program

### DIFF
--- a/packages/app-core/src/cli/program.test.ts
+++ b/packages/app-core/src/cli/program.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Direct unit coverage for the CLI program barrel. Imports `buildProgram`
+ * from `./program` — the public re-export `runCli` loads — and drives the
+ * real Commander assembly: name/version, global flags, command registration
+ * order, nested subcommands, lazy plugins/models argv branches, unknown
+ * commands, and independent instances. Does not mock commander or the
+ * register modules.
+ */
+import { Command, CommanderError } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCliName } from "./cli-name";
+import { buildProgram } from "./program";
+import { buildProgram as buildProgramFromAssembly } from "./program/build-program";
+import { CLI_VERSION } from "./version";
+
+const FULL_TOP_LEVEL_COMMANDS = [
+  "start",
+  "run",
+  "benchmark",
+  "capability-router",
+  "setup",
+  "doctor:mtp",
+  "doctor",
+  "db",
+  "configure",
+  "config",
+  "dashboard",
+  "update",
+  "auth",
+  "plugins",
+  "models",
+] as const;
+
+function commandNames(program: Command): string[] {
+  return program.commands.map((command) => command.name());
+}
+
+function findCommand(program: Command, name: string): Command | undefined {
+  return program.commands.find((command) => command.name() === name);
+}
+
+function childNames(command: Command | undefined): string[] {
+  return command?.commands.map((child) => child.name()) ?? [];
+}
+
+function withArgv<T>(argv: string[], fn: () => T): T {
+  const previous = process.argv;
+  process.argv = argv;
+  try {
+    return fn();
+  } finally {
+    process.argv = previous;
+  }
+}
+
+function overrideExit(command: Command): void {
+  command.exitOverride();
+  for (const child of command.commands) {
+    overrideExit(child);
+  }
+}
+
+function parseUserArgs(program: Command, args: string[]): CommanderError {
+  overrideExit(program);
+  try {
+    program.parse(args, { from: "user" });
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error(`parse(${JSON.stringify(args)}) returned without exiting`);
+}
+
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  }) as typeof process.stdout.write);
+  try {
+    fn();
+    return chunks.join("");
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("buildProgram barrel", () => {
+  afterEach(() => {
+    delete process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+  });
+
+  it("re-exports the same buildProgram function as the assembly module", () => {
+    expect(buildProgram).toBe(buildProgramFromAssembly);
+    expect(typeof buildProgram).toBe("function");
+  });
+});
+
+describe("buildProgram assembly", () => {
+  afterEach(() => {
+    delete process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+  });
+
+  it("returns a Commander program named for the resolved CLI with CLI_VERSION", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    expect(program).toBeInstanceOf(Command);
+    expect(program.name()).toBe(resolveCliName());
+    expect(program.version()).toBe(CLI_VERSION);
+    expect(program.version()).toMatch(/\S/);
+  });
+
+  it("registers the global verbose/debug/dev/profile and --no-color flags", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    const flags = program.options.map((option) => option.flags);
+    expect(flags).toEqual(
+      expect.arrayContaining([
+        "--verbose",
+        "--debug",
+        "--dev",
+        "--profile <name>",
+        "--no-color",
+      ]),
+    );
+  });
+
+  it("registers top-level commands in registry order when the queue is empty", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    expect(commandNames(program)).toEqual([...FULL_TOP_LEVEL_COMMANDS]);
+  });
+
+  it("still registers both lazy sub-CLIs when the primary command is unrelated", () => {
+    const program = withArgv(["node", "eliza", "start"], () => buildProgram());
+    expect(commandNames(program)).toEqual([...FULL_TOP_LEVEL_COMMANDS]);
+  });
+
+  it("registers only the matching lazy sub-CLI when argv names plugins", () => {
+    const program = withArgv(["node", "eliza", "plugins", "list"], () =>
+      buildProgram(),
+    );
+    const names = commandNames(program);
+    expect(names).toContain("plugins");
+    expect(names).not.toContain("models");
+    expect(names).toEqual([
+      "start",
+      "run",
+      "benchmark",
+      "capability-router",
+      "setup",
+      "doctor:mtp",
+      "doctor",
+      "db",
+      "configure",
+      "config",
+      "dashboard",
+      "update",
+      "auth",
+      "plugins",
+    ]);
+  });
+
+  it("registers only the matching lazy sub-CLI when argv names models", () => {
+    const program = withArgv(["node", "eliza", "models"], () => buildProgram());
+    const names = commandNames(program);
+    expect(names).toContain("models");
+    expect(names).not.toContain("plugins");
+    expect(names.at(-1)).toBe("models");
+  });
+
+  it("registers both lazy sub-CLIs when argv is --help even if a sub-CLI is named", () => {
+    const program = withArgv(["node", "eliza", "plugins", "--help"], () =>
+      buildProgram(),
+    );
+    expect(commandNames(program)).toEqual([...FULL_TOP_LEVEL_COMMANDS]);
+  });
+
+  it("returns undefined for a command that was never registered", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    expect(findCommand(program, "completion")).toBeUndefined();
+    expect(findCommand(program, "not-a-command")).toBeUndefined();
+    expect(findCommand(program, "")).toBeUndefined();
+  });
+
+  it("wires nested subcommands onto config, db, auth, update, and capability-router", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    expect(childNames(findCommand(program, "config"))).toEqual([
+      "get",
+      "path",
+      "show",
+    ]);
+    expect(childNames(findCommand(program, "db"))).toEqual(["reset"]);
+    expect(childNames(findCommand(program, "auth"))).toEqual([
+      "reset",
+      "dev-login",
+      "adopt-codex",
+    ]);
+    expect(childNames(findCommand(program, "update"))).toEqual([
+      "status",
+      "channel",
+    ]);
+    expect(childNames(findCommand(program, "capability-router"))).toEqual([
+      "connect",
+      "conformance",
+    ]);
+    expect(childNames(findCommand(program, "start"))).toEqual([]);
+    expect(childNames(findCommand(program, "doctor"))).toEqual([]);
+  });
+
+  it("registers start and run as sibling commands, not aliases of one command", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    const start = findCommand(program, "start");
+    const run = findCommand(program, "run");
+    expect(start).toBeDefined();
+    expect(run).toBeDefined();
+    expect(start).not.toBe(run);
+    expect(start?.description()).toBe("Start the elizaOS agent runtime");
+    expect(run?.description()).toBe("Alias for start");
+    expect(start?.options.map((option) => option.long)).toEqual([
+      "--connection-key",
+    ]);
+    expect(run?.options.map((option) => option.long)).toEqual([
+      "--connection-key",
+    ]);
+  });
+
+  it("builds independent program instances that do not share the command list", () => {
+    const first = withArgv(["node", "eliza"], () => buildProgram());
+    const second = withArgv(["node", "eliza"], () => buildProgram());
+    expect(first).not.toBe(second);
+    expect(commandNames(first)).toEqual(commandNames(second));
+    first.command("only-on-first");
+    expect(findCommand(first, "only-on-first")).toBeDefined();
+    expect(findCommand(second, "only-on-first")).toBeUndefined();
+  });
+});
+
+describe("buildProgram parse", () => {
+  it("exits with the unknown-command error for a missing top-level name", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    const error = parseUserArgs(program, ["definitely-not-a-command"]);
+    expect(error.code).toBe("commander.unknownCommand");
+    expect(error.message).toMatch(/definitely-not-a-command/);
+  });
+
+  it("exits with the version error and writes CLI_VERSION for -v and --version", () => {
+    const dashV = withArgv(["node", "eliza"], () => buildProgram());
+    const long = withArgv(["node", "eliza"], () => buildProgram());
+    const fromShort = parseUserArgs(dashV, ["-v"]);
+    const fromLong = parseUserArgs(long, ["--version"]);
+    expect(fromShort.code).toBe("commander.version");
+    expect(fromLong.code).toBe("commander.version");
+    expect(fromShort.message).toBe(CLI_VERSION);
+    expect(fromLong.message).toBe(CLI_VERSION);
+  });
+
+  it("exits with helpDisplayed for --help and includes Examples only on the root", () => {
+    const program = withArgv(["node", "eliza"], () => buildProgram());
+    let error: CommanderError | undefined;
+    const rootHelp = captureStdout(() => {
+      error = parseUserArgs(program, ["--help"]);
+    });
+    expect(error?.code).toBe("commander.helpDisplayed");
+    expect(rootHelp).toMatch(/Examples:/);
+    expect(rootHelp).toMatch(/Docs:/);
+    expect(rootHelp).toContain("start");
+    expect(rootHelp).toContain("doctor");
+
+    const startProgram = withArgv(["node", "eliza"], () => buildProgram());
+    const startHelp = captureStdout(() => {
+      parseUserArgs(startProgram, ["start", "--help"]);
+    });
+    expect(startHelp).not.toMatch(/Examples:/);
+    expect(startHelp).toMatch(/Start the elizaOS agent runtime/);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/program.ts`, which had no same-named test file. No product issue: this records the live Commander assembly the CLI already ships.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Based on latest `origin/develop` (`1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`); zero conflicts.
- [ ] `bun run verify` is not claimed. This is a test-only add; the focused vitest / biome / tsc checks below were run at this head. Hosted CI does **not** run on fork contributor PRs.

# Risks

Low. Adds one vitest file. No production code, no exports, no CLI behavior change.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program.test.ts` next to the barrel `program.ts` that re-exports `buildProgram`. The suite imports from `./program` (the path `runCli` loads) and drives the **real** Commander assembly — no mocked `commander`, help, preaction, or command-registry.

Covered behavior, observed on the live module:

- The barrel re-exports the same `buildProgram` function as `program/build-program.ts`.
- Returned program is a `Command` named with `resolveCliName()` and versioned with `CLI_VERSION`.
- Global flags `--verbose`, `--debug`, `--dev`, `--profile <name>`, `--no-color`.
- Top-level command **order** when argv has no sub-CLI primary: `start`, `run`, `benchmark`, `capability-router`, `setup`, `doctor:mtp`, `doctor`, `db`, `configure`, `config`, `dashboard`, `update`, `auth`, `plugins`, `models`.
- Empty vs single lazy sub-CLI: argv `plugins` registers only `plugins` (not `models`); argv `models` registers only `models`; `--help` still registers both.
- Missing command lookup returns `undefined` (`completion`, empty name, unknown name).
- Nested subcommands on `config` / `db` / `auth` / `update` / `capability-router`; `start` and `run` are sibling commands, not aliases.
- Independent `buildProgram()` instances do not share the command list.
- Unknown top-level name → `commander.unknownCommand`.
- `-v` / `--version` → `commander.version` with message `CLI_VERSION`.
- Root `--help` includes Examples/Docs; `start --help` does not include the root Examples block.

## What kind of change is this?

Improvements (test coverage only; no production behavior change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Run the new file:

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/cli/program.test.ts
```

## Detailed testing steps

Automated tests only. From `packages/app-core` at head `3415278de4fa4e07fb24b21ee6ed5947008271bc`, re-run against current `origin/develop` immediately before filing:

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

Duration ~11s (import of the real command registry). Vitest also printed the live unknown-command and version lines (`2.0.3-beta.7`) while those cases ran.

```
bunx biome check --write packages/app-core/src/cli/program.test.ts
# Checked 1 file in 150ms. No fixes applied.
# biome.json and tsconfig.json are present; sparse-checkout is not enabled.
```

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'program.test.ts' ; echo "EXIT:$?"
# empty grep (exit 1 from grep); the new file appears nowhere in tsc output.
# (packages/app-core/tsconfig.json excludes src/cli/**; no new error was introduced.)
```

The diff touches **only** `packages/app-core/src/cli/program.test.ts`.

# Evidence Gate

Evidence head: `3415278de4fa4e07fb24b21ee6ed5947008271bc`

This PR adds tests and changes no production behavior, so UI/video/log/trajectory artifacts do not apply.

- [x] Before screenshots: N/A - test-only; no UI surface.
- [x] After screenshots: N/A - test-only; no UI surface.
- [x] Walkthrough video: N/A - test-only; no UI surface.
- [x] Backend logs: N/A - no production path change; vitest counts above are the proof.
- [x] Frontend logs: N/A - no frontend change.
- [x] LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - no DB/memory/schedule/wallet output.
- [x] OCR review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only; no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no production path change. Focused vitest run quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scoped proof is the 15/15 vitest pass, clean biome, and tsc grep with no hits on this file.
- Hosted GitHub Actions CI does **not** run on this fork contributor PR. Do not treat missing checks as a pass.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3415278de4fa4e07fb24b21ee6ed5947008271bc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
