### PR TITLE
test(app-core): cover command-registry

### DIFF
--- a/packages/app-core/src/cli/program/command-registry.test.ts
+++ b/packages/app-core/src/cli/program/command-registry.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Direct unit coverage for `registerProgramCommands`. Drives the real
+ * registrar against a live Commander program and asserts the observed
+ * registration order, the default `process.argv` hand-off, and the
+ * argv-dependent lazy sub-CLI branches without replacing the module
+ * under test or its per-command registrars.
+ */
+import { Command } from "commander";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerProgramCommands } from "./command-registry";
+
+const ROOT_ARGV = ["node", "eliza"] as const;
+
+/** Commands registered before the argv-dependent lazy sub-CLIs. */
+const CORE_COMMAND_NAMES = [
+  "start",
+  "run",
+  "benchmark",
+  "capability-router",
+  "setup",
+  "doctor:mtp",
+  "doctor",
+  "db",
+  "configure",
+  "config",
+  "dashboard",
+  "update",
+  "auth",
+] as const;
+
+function commandNames(program: Command): string[] {
+  return program.commands.map((command) => command.name());
+}
+
+function findCommand(program: Command, name: string): Command | undefined {
+  return program.commands.find((command) => command.name() === name);
+}
+
+describe("registerProgramCommands", () => {
+  const previousDisableLazy = process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+
+  afterEach(() => {
+    if (previousDisableLazy === undefined) {
+      delete process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS;
+    } else {
+      process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS = previousDisableLazy;
+    }
+  });
+
+  it("registers core commands in source order, then both lazy sub-CLIs", () => {
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+
+    expect(commandNames(program)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+      "models",
+    ]);
+  });
+
+  it("registers each top-level name exactly once on an empty program", () => {
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+
+    const names = commandNames(program);
+    for (const name of names) {
+      expect(names.filter((candidate) => candidate === name)).toHaveLength(1);
+    }
+  });
+
+  it("registers start and its run alias as sibling commands", () => {
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+
+    const start = findCommand(program, "start");
+    const run = findCommand(program, "run");
+    expect(start?.description()).toBe("Start the elizaOS agent runtime");
+    expect(run?.description()).toBe("Alias for start");
+  });
+
+  it("attaches adopt-codex under the single auth group created earlier", () => {
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+
+    const authCommands = program.commands.filter(
+      (command) => command.name() === "auth",
+    );
+    expect(authCommands).toHaveLength(1);
+
+    const subNames = authCommands[0]?.commands.map((command) => command.name());
+    expect(subNames).toEqual(["reset", "dev-login", "adopt-codex"]);
+  });
+
+  it("forwards an explicit argv so only the matching lazy sub-CLI is registered", () => {
+    const pluginsProgram = new Command();
+    registerProgramCommands(pluginsProgram, [...ROOT_ARGV, "plugins"]);
+    expect(commandNames(pluginsProgram)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+    ]);
+
+    const modelsProgram = new Command();
+    registerProgramCommands(modelsProgram, [...ROOT_ARGV, "models"]);
+    expect(commandNames(modelsProgram)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "models",
+    ]);
+  });
+
+  it("registers both lazy sub-CLIs when argv has no primary command", () => {
+    const emptyProgram = new Command();
+    registerProgramCommands(emptyProgram, []);
+    expect(commandNames(emptyProgram)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+      "models",
+    ]);
+
+    const shortProgram = new Command();
+    registerProgramCommands(shortProgram, ["node"]);
+    expect(commandNames(shortProgram)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+      "models",
+    ]);
+  });
+
+  it("registers both lazy sub-CLIs when the primary command is not a sub-CLI", () => {
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV, "start"]);
+    expect(commandNames(program)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+      "models",
+    ]);
+  });
+
+  it("registers both lazy sub-CLIs when argv contains help or version flags", () => {
+    for (const flag of ["--help", "-h", "--version", "-v", "-V"] as const) {
+      const program = new Command();
+      registerProgramCommands(program, [...ROOT_ARGV, "plugins", flag]);
+      expect(commandNames(program), flag).toEqual([
+        ...CORE_COMMAND_NAMES,
+        "plugins",
+        "models",
+      ]);
+    }
+  });
+
+  it("uses process.argv when the argv argument is omitted", () => {
+    const previousArgv = process.argv;
+    process.argv = [...ROOT_ARGV, "models"];
+    try {
+      const program = new Command();
+      registerProgramCommands(program);
+      expect(commandNames(program)).toEqual([...CORE_COMMAND_NAMES, "models"]);
+    } finally {
+      process.argv = previousArgv;
+    }
+  });
+
+  it("does not add lazy placeholders when ELIZA_DISABLE_LAZY_SUBCOMMANDS is set", () => {
+    process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS = "1";
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+    expect(commandNames(program)).toEqual([...CORE_COMMAND_NAMES]);
+  });
+
+  it("does not treat a falsey lazy-disable env as eager registration", () => {
+    process.env.ELIZA_DISABLE_LAZY_SUBCOMMANDS = "0";
+    const program = new Command();
+    registerProgramCommands(program, [...ROOT_ARGV]);
+    expect(commandNames(program)).toEqual([
+      ...CORE_COMMAND_NAMES,
+      "plugins",
+      "models",
+    ]);
+  });
+
+  it("mutates the provided program and returns undefined", () => {
+    const program = new Command();
+    const result = registerProgramCommands(program, [...ROOT_ARGV]);
+    expect(result).toBeUndefined();
+    expect(program.commands.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage-only addition for `packages/app-core/src/cli/program/command-registry.ts`, which had no same-named test file. No existing open PR already covers this file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only one-file change. Focused vitest, biome, and package `tsc --noEmit` are quoted below.
- [x] A reviewer can confirm the change from the vitest counts below without reading production code: the diff adds tests only.

# Sync with develop

- [x] Branch is `origin/develop` (`1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`) plus this single test-file commit. Zero conflicts.
- [ ] `bun run verify` was not re-run. Focused gates for this file passed as quoted under Testing. This is a fork contributor PR; hosted CI does not run on our PRs.

# Risks

Low. Test-only change. No production source, exports, CLI wiring, or docs are modified. Failure mode is a false assertion against current `registerProgramCommands` behaviour, which would fail the suite rather than change the CLI.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program/command-registry.test.ts`, a same-named vitest suite that drives the real `registerProgramCommands` against a live Commander program.

Covered behaviour, as observed from the source and the live registrars it calls:

- core command registration order (`start`, `run`, `benchmark`, `capability-router`, `setup`, `doctor:mtp`, `doctor`, `db`, `configure`, `config`, `dashboard`, `update`, `auth`)
- both lazy sub-CLIs (`plugins`, `models`) on an empty/short argv and on a non-sub-CLI primary
- exactly-once names on an empty program
- `start` / `run` sibling commands
- a single `auth` group with `reset`, `dev-login`, `adopt-codex` (auth registered before adopt-codex)
- argv forwarding that registers only the matching lazy sub-CLI (`plugins` or `models`)
- help/version flags (`--help`, `-h`, `--version`, `-v`, `-V`) skip the single-sub-CLI shortcut
- omitted argv uses `process.argv`
- `ELIZA_DISABLE_LAZY_SUBCOMMANDS=1` skips lazy placeholders; `=0` does not
- the helper mutates the provided program and returns `undefined`

## What kind of change is this?

Improvements (tests for existing CLI command registration; no production behaviour change).

## Why are we doing this? Any context or related work?

`command-registry.ts` is the ordered wiring for every top-level `eliza` command and the argv hand-off into lazy sub-CLIs. It had no same-named test file. This records the behaviour the code actually has.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/program/command-registry.test.ts`, then:

```bash
cd packages/app-core && bunx vitest run src/cli/program/command-registry.test.ts
```

## Detailed testing steps

Automated tests only. The suite imports `registerProgramCommands` from `./command-registry` and a real `Command` from `commander`. It does not mock the module under test or the per-command registrars.

Re-fetched `origin/develop` immediately before filing (`1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`) and re-ran the suite.

```
Test Files  1 passed (1)
     Tests  12 passed (12)
  Duration  8.58s
```

Biome (config present at repo-root `biome.json`; checkout is not sparse):

```
bunx biome check --write packages/app-core/src/cli/program/command-registry.test.ts
Checked 1 file in 13ms. Fixed 1 file.
```

The committed file is that formatted result.

Package `tsc --noEmit` from `packages/app-core`: `command-registry.test.ts` does not appear in the output (grep exit 1 / no matches). Pre-existing package errors, if any, are not from this file.

The diff touches only `packages/app-core/src/cli/program/command-registry.test.ts`.

Hosted CI does not run on this fork contributor PR; do not treat missing GitHub Actions as a pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

N/A for UI/backend/LLM artifacts: this PR adds unit tests and changes no production behaviour. Complete evidence set is the vitest / biome / tsc quotes above.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only change; no backend path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only change; no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; unit tests only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only change; no runtime path.

## Screenshots (before / after) + video walkthrough

N/A - test-only change; no UI surface.

### Before

N/A - test-only change; no UI surface.

### After

N/A - test-only change; no UI surface.

### Walkthrough video

N/A - test-only change; no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run; this is a one-file test-only PR. Focused vitest (12/12), biome, and package tsc grep are quoted above.
- Hosted CI does not run on fork contributor PRs.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e70e11d7afc6057105de72b124a5ea99d8984ea5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
