### PR TITLE
test(app-core): cover register.models

### DIFF
--- a/packages/app-core/src/cli/program/register.models.test.ts
+++ b/packages/app-core/src/cli/program/register.models.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Direct unit coverage for `registerModelsCli`. Drives the real registrar
+ * against a live Commander program and asserts command wiring plus the
+ * observed env-probe listing: every provider in source order, truthy vs
+ * falsy keys, empty string, value non-leakage, and that the action never
+ * writes env.
+ */
+import { getLogPrefix } from "@elizaos/shared";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerModelsCli } from "./register.models";
+
+/** Fixed probe table copied from the registrar; order is part of the contract. */
+const PROVIDERS = [
+  ["ANTHROPIC_API_KEY", "Anthropic (Claude)"],
+  ["OPENAI_API_KEY", "OpenAI (GPT)"],
+  ["GOOGLE_API_KEY", "Google (Gemini)"],
+  ["GOOGLE_CLOUD_API_KEY", "Google Antigravity (Vertex AI)"],
+  ["GROQ_API_KEY", "Groq"],
+  ["XAI_API_KEY", "xAI (Grok)"],
+  ["OPENROUTER_API_KEY", "OpenRouter"],
+  ["DEEPSEEK_API_KEY", "DeepSeek"],
+  ["TOGETHER_API_KEY", "Together AI"],
+  ["MISTRAL_API_KEY", "Mistral"],
+  ["COHERE_API_KEY", "Cohere"],
+  ["PERPLEXITY_API_KEY", "Perplexity"],
+  ["ZAI_API_KEY", "Zai"],
+  ["MOONSHOT_API_KEY", "Kimi / Moonshot"],
+  ["OLLAMA_BASE_URL", "Ollama (local)"],
+  ["ELIZAOS_CLOUD_API_KEY", "elizaOS Cloud"],
+] as const;
+
+type ProviderKey = (typeof PROVIDERS)[number][0];
+
+const savedEnv: Partial<Record<ProviderKey, string | undefined>> = {};
+
+function expectedListing(configured: ReadonlySet<string>): string[] {
+  return [
+    `${getLogPrefix()} Model providers:`,
+    ...PROVIDERS.map(
+      ([key, name]) =>
+        `  ${name}: ${configured.has(key) ? "configured" : "not set"}`,
+    ),
+  ];
+}
+
+async function runModelsCommand(): Promise<string[]> {
+  const lines: string[] = [];
+  const spy = vi
+    .spyOn(console, "log")
+    .mockImplementation((message?: unknown) => {
+      lines.push(String(message));
+    });
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerModelsCli(program);
+    await program.parseAsync(["models"], { from: "user" });
+    return lines;
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("registerModelsCli", () => {
+  beforeEach(() => {
+    for (const [key] of PROVIDERS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key] of PROVIDERS) {
+      const previous = savedEnv[key];
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  });
+
+  it("registers a models command that lists providers, with no extra options", () => {
+    const program = new Command();
+    registerModelsCli(program);
+
+    expect(program.commands.map((command) => command.name())).toEqual([
+      "models",
+    ]);
+    const models = program.commands[0];
+    expect(models?.description()).toBe("Show configured model providers");
+    expect(models?.options.map((option) => option.long)).toEqual([]);
+  });
+
+  it("does not print anything merely by registering the command", () => {
+    const spy = vi.spyOn(console, "log");
+    try {
+      registerModelsCli(new Command());
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("prints every provider as not set when none of the probed keys are present", async () => {
+    const lines = await runModelsCommand();
+    expect(lines).toEqual(expectedListing(new Set()));
+  });
+
+  it("prints every provider as configured, in source order, when every key is set", async () => {
+    for (const [key] of PROVIDERS) {
+      process.env[key] = `secret-for-${key}`;
+    }
+    const lines = await runModelsCommand();
+    expect(lines).toEqual(
+      expectedListing(new Set(PROVIDERS.map(([key]) => key))),
+    );
+  });
+
+  it("classifies a mixed queue per-key without reordering", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant";
+    process.env.GROQ_API_KEY = "gsk";
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_cloud";
+    const lines = await runModelsCommand();
+    expect(lines).toEqual(
+      expectedListing(
+        new Set(["ANTHROPIC_API_KEY", "GROQ_API_KEY", "ELIZAOS_CLOUD_API_KEY"]),
+      ),
+    );
+  });
+
+  it("treats an empty-string key as not set", async () => {
+    process.env.OPENAI_API_KEY = "";
+    const lines = await runModelsCommand();
+    expect(lines).toEqual(expectedListing(new Set()));
+    expect(lines).toContain("  OpenAI (GPT): not set");
+  });
+
+  it("treats a whitespace-only key as configured because the probe does not trim", async () => {
+    process.env.OPENAI_API_KEY = " ";
+    const lines = await runModelsCommand();
+    expect(lines).toEqual(expectedListing(new Set(["OPENAI_API_KEY"])));
+  });
+
+  it("treats the string 0 as configured (truthy, no numeric coerce)", async () => {
+    process.env.XAI_API_KEY = "0";
+    const lines = await runModelsCommand();
+    expect(lines).toContain("  xAI (Grok): configured");
+  });
+
+  it("never writes the env values or key names into the listing", async () => {
+    const secret = "sk-this-must-not-leak-into-stdout";
+    process.env.OPENAI_API_KEY = secret;
+    const output = (await runModelsCommand()).join("\n");
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain("OPENAI_API_KEY");
+    expect(output).toContain("  OpenAI (GPT): configured");
+  });
+
+  it("does not write or delete provider env keys", async () => {
+    process.env.XAI_API_KEY = "keep-me";
+    const snapshot = Object.fromEntries(
+      PROVIDERS.map(([key]) => [key, process.env[key]]),
+    );
+    await runModelsCommand();
+    expect(process.env.XAI_API_KEY).toBe("keep-me");
+    for (const [key] of PROVIDERS) {
+      expect(process.env[key]).toBe(snapshot[key]);
+    }
+  });
+
+  it("does not list env vars outside the fixed provider table", async () => {
+    const extraKey = "SOME_RANDOM_API_KEY";
+    const previous = process.env[extraKey];
+    process.env[extraKey] = "yes";
+    try {
+      const output = (await runModelsCommand()).join("\n");
+      expect(output).not.toContain("SOME_RANDOM");
+      expect(output.split("\n")).toHaveLength(PROVIDERS.length + 1);
+    } finally {
+      if (previous === undefined) delete process.env[extraKey];
+      else process.env[extraKey] = previous;
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/program/register.models.ts`. No linked issue: the registrar had no same-named test file anywhere in the repo.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

Focused vitest / biome / tsc are quoted in **Testing**. `bun run verify` was not re-run: this diff adds one test file and changes no production behaviour. Hosted GitHub Actions CI does **not** run on this fork PR.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Parent of this head is `1f45fe5eb2d3c2d023d0748b2376070e1a1ce91f`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only. No production code, no CLI flag, no command-registration order change. The suite asserts `registerModelsCli` as it behaves today.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program/register.models.test.ts`. `registerModelsCli` is the only export: it registers a Commander `models` command whose action probes a fixed table of 16 provider env keys and prints each as `configured` or `not set`. The suite drives that real function (no mocked registrar, no stubbed env table) and asserts:

- the command is named `models`, described `Show configured model providers`, and carries no extra options
- registration alone does not print
- an empty probe queue (no keys set) lists every provider as `not set`, in source order
- a full queue (every key set) lists every provider as `configured`, in the same order
- a mixed queue is classified per-key without reordering
- empty string is `not set`; whitespace-only and the string `0` are `configured` (JS truthiness; the probe does not trim or coerce)
- env values and key names never appear in the listing
- the action does not write or delete provider env keys
- env vars outside the fixed table are not listed; output is one header plus one line per provider

Expectations are what the live registrar actually prints, not a preferred inventory.

## What kind of change is this?

Improvements (tests for existing behavior). No production change.

## Why are we doing this? Any context or related work?

`register.models.ts` had no colocated test. A wiring or env-probe regression (dropped provider, reordered listing, leaked secret, empty-string treated as configured) would not be caught.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/program/register.models.test.ts`, then the quoted vitest run below.

## Detailed testing steps

None: automated tests. Command and counts from this exact tree (re-run after fetching current `origin/develop`; `register.models.ts` is unchanged vs that parent):

```text
$ bunx vitest run packages/app-core/src/cli/program/register.models.test.ts

 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app-core/src/cli/program/register.models.test.ts (11 tests) 6ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  4.29s (transform 3.36s, setup 0ms, import 4.20s, tests 6ms, environment 0ms)
```

```text
$ bunx biome check --write packages/app-core/src/cli/program/register.models.test.ts
Checked 1 file in 198ms. Fixed 1 file.
```

`biome.json` is present in the checkout; sparse-checkout is not enabled. The committed file is the biome-written result.

```text
$ cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'register.models.test.ts' ; echo "EXIT:$?"
EXIT:1
```

The new file appears nowhere in `tsc --noEmit` output (package `tsconfig.json` excludes `src/cli/**`; a targeted grep of `tsconfig.typecheck.json` output also does not name this colocated path).

Diff touches only `packages/app-core/src/cli/program/register.models.test.ts`.

This is a fork contributor PR. Hosted CI does not run on it; do not treat missing Actions checks as a failure of this change.

# Evidence Gate

Test-only, no production behaviour change, no UI, no agent/prompt path.

- Before screenshots: N/A - test-only, no rendered UI surface
- After screenshots: N/A - test-only, no rendered UI surface
- Walkthrough video: N/A - test-only, no user flow
- Backend logs: N/A - no server path; vitest output quoted above
- Frontend logs: N/A - no frontend change
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change
- Domain artifacts: N/A - no DB/memory/schedule/wallet/audio artifact
- OCR review: N/A - no rendered visual surface

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no runtime server or frontend path. Vitest counts are quoted in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI.

### Before

N/A - test-only, no UI.

### After

N/A - test-only, no UI.

### Walkthrough video

N/A - test-only, no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; the complete evidence set is the quoted vitest / biome / tsc results.
- No signed identity.slop.cash trace: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
- Hosted GitHub Actions CI does not run on fork contributor PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d0e5cdc64bcafd5a544be2de27538fc63d757307 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
