### PR TITLE
test(app-core): cover register.configure

### DIFF
--- a/packages/app-core/src/cli/program/register.configure.test.ts
+++ b/packages/app-core/src/cli/program/register.configure.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Direct unit coverage for `registerConfigureCommand`. Drives the real
+ * Commander program: empty registration, append-after-sibling order, the
+ * after-help docs link, and the configure action's printed guidance. Does
+ * not mock commander, theme, or formatDocsLink.
+ */
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { formatDocsLink, theme } from "@elizaos/shared";
+import { Command, CommanderError } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as configureModule from "./register.configure";
+import { registerConfigureCommand } from "./register.configure";
+
+const CONFIG_PATH = path.join(homedir(), ".local/state/eliza/eliza.json");
+
+function makeProgram(): {
+  program: Command;
+  out: string[];
+  err: string[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (chunk) => {
+      out.push(chunk);
+    },
+    writeErr: (chunk) => {
+      err.push(chunk);
+    },
+  });
+  return { program, out, err };
+}
+
+function parseUserArgs(program: Command, args: string[]): CommanderError {
+  try {
+    program.parse(args, { from: "user" });
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error(`parse(${JSON.stringify(args)}) returned without exiting`);
+}
+
+function findCommand(program: Command, name: string): Command | undefined {
+  return program.commands.find((command) => command.name() === name);
+}
+
+function captureConsoleLog(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = vi
+    .spyOn(console, "log")
+    .mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    });
+  return {
+    lines,
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
+function expectedActionLines(): string[] {
+  return [
+    `\n${theme.heading("Configuration")}\n`,
+    "Set values with:",
+    `  ${theme.command("eliza config get <key>")}     Read a config value`,
+    `  Edit ~/.local/state/eliza/eliza.json directly for full control.\n`,
+    "Common environment variables:",
+    `  ${theme.command("ANTHROPIC_API_KEY")}    Anthropic (Claude)`,
+    `  ${theme.command("OPENAI_API_KEY")}       OpenAI (GPT)`,
+    `  ${theme.command("GOOGLE_API_KEY")}       Google (Gemini)\n`,
+  ];
+}
+
+describe("registerConfigureCommand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports only registerConfigureCommand", () => {
+    expect(Object.keys(configureModule)).toEqual(["registerConfigureCommand"]);
+    expect(typeof registerConfigureCommand).toBe("function");
+  });
+
+  it("registers a single configure command on an empty program", () => {
+    const { program } = makeProgram();
+    expect(program.commands).toEqual([]);
+
+    registerConfigureCommand(program);
+
+    expect(program.commands.map((command) => command.name())).toEqual([
+      "configure",
+    ]);
+    const configure = findCommand(program, "configure");
+    expect(configure).toBeDefined();
+    expect(configure?.description()).toBe("Configuration guidance");
+    expect(configure?.alias()).toBeUndefined();
+    expect(configure?.aliases()).toEqual([]);
+    expect(configure?.options).toEqual([]);
+    expect(configure?.commands).toEqual([]);
+    expect(configure?.registeredArguments).toEqual([]);
+  });
+
+  it("does not register config or a missing sibling name", () => {
+    const { program } = makeProgram();
+    registerConfigureCommand(program);
+
+    expect(findCommand(program, "config")).toBeUndefined();
+    expect(findCommand(program, "configuration")).toBeUndefined();
+    expect(findCommand(program, "")).toBeUndefined();
+  });
+
+  it("appends configure after an already-registered sibling", () => {
+    const { program } = makeProgram();
+    program.command("db").description("Database helpers");
+
+    registerConfigureCommand(program);
+
+    expect(program.commands.map((command) => command.name())).toEqual([
+      "db",
+      "configure",
+    ]);
+    expect(findCommand(program, "db")?.description()).toBe("Database helpers");
+  });
+
+  it("prints static configuration guidance without writing the config file", () => {
+    const existed = existsSync(CONFIG_PATH);
+    const mtimeMs = existed ? statSync(CONFIG_PATH).mtimeMs : undefined;
+
+    const { program } = makeProgram();
+    registerConfigureCommand(program);
+    const capture = captureConsoleLog();
+
+    program.parse(["configure"], { from: "user" });
+
+    capture.restore();
+    expect(capture.lines).toEqual(expectedActionLines());
+    expect(existsSync(CONFIG_PATH)).toBe(existed);
+    if (existed) {
+      expect(statSync(CONFIG_PATH).mtimeMs).toBe(mtimeMs);
+    }
+  });
+
+  it("appends the configuration docs link after --help", () => {
+    const { program, out } = makeProgram();
+    registerConfigureCommand(program);
+
+    const error = parseUserArgs(program, ["configure", "--help"]);
+    expect(error.code).toBe("commander.helpDisplayed");
+
+    const help = out.join("");
+    expect(help).toContain("Usage:");
+    expect(help).toContain("Configuration guidance");
+    expect(help).toMatch(/-h, --help/);
+    // Commander strips SGR from after-help text, so "Docs:" is unstyled even
+    // though the thunk calls theme.muted. The docs URL is still the live
+    // formatDocsLink result (non-TTY fallback is the canonical URL).
+    expect(help).toContain(
+      `Docs: ${formatDocsLink("/configuration", "docs.eliza.ai/configuration")}`,
+    );
+  });
+
+  it("rejects an unknown option on configure", () => {
+    const { program } = makeProgram();
+    registerConfigureCommand(program);
+
+    const error = parseUserArgs(program, ["configure", "--task"]);
+    expect(error.code).toBe("commander.unknownOption");
+    expect(error.message).toMatch(/--task/);
+  });
+});


### PR DESCRIPTION

## Summary

Adds real unit coverage for `packages/app-core/src/cli/program/register.configure.ts`, which previously had no same-named test file. The suite drives the real Commander program, live `theme`, and live `formatDocsLink` — it does not mock the module under test.

`registerConfigureCommand` is guidance-only: it registers `eliza configure`, prints how to read/edit config values and the common provider API-key environment variables, and appends a docs link on `--help`. It does not mutate config.

## Tests

New file: `packages/app-core/src/cli/program/register.configure.test.ts`

Covers the exported surface and observed branches:

- export surface is only `registerConfigureCommand`
- empty program: a single `configure` command with description `Configuration guidance`, no alias, no options, no subcommands, no arguments
- missing names (`config`, `configuration`, `""`) are not registered
- append-after-sibling order is preserved (`db` then `configure`)
- action prints the eight live guidance lines (heading, `eliza config get <key>`, config path, `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`) and does not write `~/.local/state/eliza/eliza.json`
- `--help` includes the after-help docs link (Commander strips SGR from after-help text; the live `formatDocsLink` URL is still present)
- unknown option `--task` is rejected with `commander.unknownOption`

## Evidence

Re-fetched `origin/develop` (`f73af990a4dcdecccee9caf741d350a8f28d0a7b`) and re-ran immediately before filing. `register.configure.ts` is unchanged vs that tip.

1. `bunx vitest run packages/app-core/src/cli/program/register.configure.test.ts`

```
 ✓ packages/app-core/src/cli/program/register.configure.test.ts (7 tests) 6ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

2. `bunx biome check --write packages/app-core/src/cli/program/register.configure.test.ts`

Config present (`biome.json` at repo root; worktree is not sparse). Result: `Checked 1 file in 203ms. Fixed 1 file.` (spyOn wrapping). File is biome-clean after that write.

3. `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep register.configure.test ; echo "EXIT:$?"`

Empty grep. `GREP_EXIT:1` — this test file appears nowhere in `tsc` output (no new type errors in the added file). Pre-existing package errors, if any, are not from this file.

4. Diff touches only the new test file. No production behaviour change.

Hosted CI does not run on this fork contributor's pull requests. Local vitest / biome / tsc are the verification.

## Scope

Test-only. No production source, config, or docs changes.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f029155cf2e1d3e2704a59aa029bec6dac4023f0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
