### PR TITLE
test(app-core): cover register.auth

### DIFF
--- a/packages/app-core/src/cli/program/register.auth.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Unit coverage for `register.auth.ts`: loopback-gated `eliza auth reset`,
+ * commander wiring, cloud API host mapping, and SIWE dev-login. Drives the
+ * real module through its documented test hooks (injected store, proof
+ * reader, fetch, env) — the system under test is never replaced with a mock.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AuthStore } from "../../services/auth-store";
+import {
+  registerAuthCommand,
+  resolveCloudApiBase,
+  runDevWalletLogin,
+  runElizaAuthReset,
+} from "./register.auth";
+
+const CHALLENGE = "a".repeat(64);
+const FIXED_PK =
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+const savedEnv: Record<string, string | undefined> = {};
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(path.join(tmpdir(), "register-auth-"));
+  for (const key of ["ELIZA_STATE_DIR", "ELIZA_NAMESPACE", "HOME"]) {
+    savedEnv[key] = process.env[key];
+  }
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+function proofPath(): string {
+  return path.join(stateDir, "auth", "RESET_PROOF.txt");
+}
+
+function makeStore(opts?: {
+  owners?: { id: string }[];
+  machines?: { id: string }[];
+  revokeCounts?: Record<string, number>;
+}): {
+  store: AuthStore;
+  kinds: Array<"owner" | "machine">;
+  revokes: Array<{ id: string; now: number }>;
+  audits: Array<{
+    action: string;
+    outcome: string;
+    metadata: { revoked: number };
+  }>;
+} {
+  const kinds: Array<"owner" | "machine"> = [];
+  const revokes: Array<{ id: string; now: number }> = [];
+  const audits: Array<{
+    action: string;
+    outcome: string;
+    metadata: { revoked: number };
+  }> = [];
+  const store = {
+    async listIdentitiesByKind(kind: "owner" | "machine") {
+      kinds.push(kind);
+      return kind === "owner" ? (opts?.owners ?? []) : (opts?.machines ?? []);
+    },
+    async revokeAllSessionsForIdentity(id: string, now: number) {
+      revokes.push({ id, now });
+      return opts?.revokeCounts?.[id] ?? 0;
+    },
+    async appendAuditEvent(input: {
+      action: string;
+      outcome: string;
+      metadata: { revoked: number };
+    }) {
+      audits.push(input);
+      return input;
+    },
+  } as unknown as AuthStore;
+  return { store, kinds, revokes, audits };
+}
+
+const LOOPBACK_ENV = { ELIZA_API_BIND: "127.0.0.1" };
+
+describe("registerAuthCommand", () => {
+  it("registers reset and dev-login under auth with the documented options", () => {
+    const program = new Command();
+    registerAuthCommand(program);
+
+    const auth = program.commands.find((command) => command.name() === "auth");
+    expect(auth).toBeDefined();
+    expect(auth?.commands.map((command) => command.name()).sort()).toEqual([
+      "dev-login",
+      "reset",
+    ]);
+
+    const reset = auth?.commands.find((command) => command.name() === "reset");
+    expect(reset?.description()).toBe("Revoke all sessions (loopback only)");
+
+    const devLogin = auth?.commands.find(
+      (command) => command.name() === "dev-login",
+    );
+    expect(devLogin?.options.map((option) => option.long)).toEqual([
+      "--cloud",
+      "--no-save",
+      "--json",
+    ]);
+  });
+});
+
+describe("runElizaAuthReset", () => {
+  it("refuses a non-loopback bind before touching proof or store", async () => {
+    const { store, kinds } = makeStore();
+    let readerCalls = 0;
+    const result = await runElizaAuthReset({
+      env: { ELIZA_API_BIND: "192.168.1.1" },
+      store,
+      proofReader: async () => {
+        readerCalls += 1;
+        return CHALLENGE;
+      },
+      challenge: CHALLENGE,
+      log: () => {},
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "not_loopback",
+      message:
+        "refusing to run: ELIZA_API_BIND=192.168.1.1 is not a loopback address",
+    });
+    expect(readerCalls).toBe(0);
+    expect(kinds).toEqual([]);
+  });
+
+  it("refuses a wildcard bind and a public hostname the same way", async () => {
+    for (const bind of ["0.0.0.0", "example.com"]) {
+      const result = await runElizaAuthReset({
+        env: { ELIZA_API_BIND: bind },
+        store: makeStore().store,
+        proofReader: async () => CHALLENGE,
+        challenge: CHALLENGE,
+        log: () => {},
+      });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("not_loopback");
+      expect(result.message).toContain(`ELIZA_API_BIND=${bind}`);
+    }
+  });
+
+  it("treats an unset bind as the default loopback and proceeds past the gate", async () => {
+    const { store } = makeStore();
+    const result = await runElizaAuthReset({
+      env: {},
+      store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      proofPollIntervalMs: 10,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts localhost and ::1 as loopback binds", async () => {
+    for (const bind of ["localhost", "::1"]) {
+      const result = await runElizaAuthReset({
+        env: { ELIZA_API_BIND: bind },
+        store: makeStore().store,
+        proofReader: async () => CHALLENGE,
+        challenge: CHALLENGE,
+        proofTimeoutMs: 200,
+        proofPollIntervalMs: 10,
+        skipProofCleanup: true,
+        log: () => {},
+      });
+      expect(result).toEqual({ ok: true });
+    }
+  });
+
+  it("times out when the proof file is never written", async () => {
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      proofReader: async () => null,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 80,
+      proofPollIntervalMs: 20,
+      log: () => {},
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "proof_failed",
+      message: "filesystem proof was not written within the timeout",
+    });
+  });
+
+  it("keeps polling through a mismatched token and never resets on a miss", async () => {
+    const { store, kinds } = makeStore();
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store,
+      proofReader: async () => "not-the-challenge",
+      challenge: CHALLENGE,
+      proofTimeoutMs: 80,
+      proofPollIntervalMs: 20,
+      log: () => {},
+    });
+    expect(result.reason).toBe("proof_failed");
+    expect(kinds).toEqual([]);
+  });
+
+  it("trims surrounding whitespace on the proof token before matching", async () => {
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      proofReader: async () => `  \n${CHALLENGE}\t`,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      proofPollIntervalMs: 10,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("matches on a later poll after earlier empty and mismatched reads", async () => {
+    let n = 0;
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      proofReader: async () => {
+        n += 1;
+        if (n === 1) return null;
+        if (n === 2) return "wrong";
+        return CHALLENGE;
+      },
+      challenge: CHALLENGE,
+      proofTimeoutMs: 400,
+      proofPollIntervalMs: 10,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true });
+    expect(n).toBe(3);
+  });
+
+  it("revokes zero sessions when both owner and machine queues are empty", async () => {
+    const { store, kinds, revokes, audits } = makeStore();
+    const lines: string[] = [];
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: (line) => lines.push(line),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(kinds).toEqual(["owner", "machine"]);
+    expect(revokes).toEqual([]);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("auth.reset.cli");
+    expect(audits[0]?.outcome).toBe("success");
+    expect(audits[0]?.metadata.revoked).toBe(0);
+    expect(lines.join("\n")).toContain("revoked 0 session(s)");
+    expect(lines.join("\n")).toContain("Identities and password");
+  });
+
+  it("walks owners then machines in listed order and sums revoke counts", async () => {
+    const { store, kinds, revokes, audits } = makeStore({
+      owners: [{ id: "owner-a" }, { id: "owner-b" }],
+      machines: [{ id: "machine-1" }],
+      revokeCounts: { "owner-a": 2, "owner-b": 0, "machine-1": 3 },
+    });
+    const lines: string[] = [];
+    const before = Date.now();
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: (line) => lines.push(line),
+    });
+    const after = Date.now();
+
+    expect(result).toEqual({ ok: true });
+    expect(kinds).toEqual(["owner", "machine"]);
+    expect(revokes.map((entry) => entry.id)).toEqual([
+      "owner-a",
+      "owner-b",
+      "machine-1",
+    ]);
+    for (const entry of revokes) {
+      expect(entry.now).toBeGreaterThanOrEqual(before);
+      expect(entry.now).toBeLessThanOrEqual(after);
+    }
+    expect(audits[0]?.metadata.revoked).toBe(5);
+    expect(lines.join("\n")).toContain("revoked 5 session(s)");
+  });
+
+  it("revokes a single identity without inventing extra walks", async () => {
+    const { store, revokes } = makeStore({
+      owners: [{ id: "only-owner" }],
+      revokeCounts: { "only-owner": 1 },
+    });
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true });
+    expect(revokes.map((entry) => entry.id)).toEqual(["only-owner"]);
+  });
+
+  it("prints the challenge and proof path before waiting", async () => {
+    const lines: string[] = [];
+    await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: (line) => lines.push(line),
+    });
+    const output = lines.join("\n");
+    expect(output).toContain("Eliza auth reset");
+    expect(output).toContain(CHALLENGE);
+    expect(output).toContain(proofPath());
+  });
+
+  it("runs the injected cleanup hook after a successful reset", async () => {
+    let cleaned = 0;
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      cleanup: async () => {
+        cleaned += 1;
+      },
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true });
+    expect(cleaned).toBe(1);
+  });
+
+  it("does not run cleanup when proof times out", async () => {
+    let cleaned = 0;
+    await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      cleanup: async () => {
+        cleaned += 1;
+      },
+      proofReader: async () => null,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 50,
+      proofPollIntervalMs: 10,
+      log: () => {},
+    });
+    expect(cleaned).toBe(0);
+  });
+
+  it("reads the real proof file and deletes it on success", async () => {
+    mkdirSync(path.join(stateDir, "auth"), { recursive: true });
+    writeFileSync(proofPath(), CHALLENGE, "utf8");
+
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      proofPollIntervalMs: 10,
+      log: () => {},
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(() => readFileSync(proofPath())).toThrow();
+  });
+
+  it("leaves the proof file in place when skipProofCleanup is set", async () => {
+    mkdirSync(path.join(stateDir, "auth"), { recursive: true });
+    writeFileSync(proofPath(), CHALLENGE, "utf8");
+
+    const result = await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store: makeStore().store,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(readFileSync(proofPath(), "utf8")).toBe(CHALLENGE);
+  });
+
+  it("propagates a non-ENOENT proof-file read error instead of returning store_error", async () => {
+    mkdirSync(proofPath(), { recursive: true });
+
+    await expect(
+      runElizaAuthReset({
+        env: LOOPBACK_ENV,
+        store: makeStore().store,
+        challenge: CHALLENGE,
+        proofTimeoutMs: 200,
+        log: () => {},
+      }),
+    ).rejects.toMatchObject({ code: "EISDIR" });
+  });
+
+  it("lets a throwing store reject rather than mapping to reason store_error", async () => {
+    const store = {
+      async listIdentitiesByKind() {
+        throw new Error("db down");
+      },
+      async revokeAllSessionsForIdentity() {
+        return 0;
+      },
+      async appendAuditEvent() {
+        return {};
+      },
+    } as unknown as AuthStore;
+
+    await expect(
+      runElizaAuthReset({
+        env: LOOPBACK_ENV,
+        store,
+        proofReader: async () => CHALLENGE,
+        challenge: CHALLENGE,
+        proofTimeoutMs: 200,
+        skipProofCleanup: true,
+        log: () => {},
+      }),
+    ).rejects.toThrow("db down");
+  });
+
+  it("writes the CLI audit event to the JSONL log with the revoked count", async () => {
+    const { store } = makeStore({
+      owners: [{ id: "owner-1" }],
+      revokeCounts: { "owner-1": 4 },
+    });
+    await runElizaAuthReset({
+      env: LOOPBACK_ENV,
+      store,
+      proofReader: async () => CHALLENGE,
+      challenge: CHALLENGE,
+      proofTimeoutMs: 200,
+      skipProofCleanup: true,
+      log: () => {},
+    });
+
+    const auditPath = path.join(stateDir, "auth", "audit.log");
+    const line = JSON.parse(readFileSync(auditPath, "utf8").trim()) as {
+      action: string;
+      outcome: string;
+      userAgent: string;
+      actorIdentityId: null;
+      metadata: { revoked: number };
+    };
+    expect(line.action).toBe("auth.reset.cli");
+    expect(line.outcome).toBe("success");
+    expect(line.userAgent).toBe("eliza-cli auth reset");
+    expect(line.actorIdentityId).toBeNull();
+    expect(line.metadata.revoked).toBe(4);
+  });
+});
+
+describe("resolveCloudApiBase", () => {
+  it("folds hostname case so mixed-case production hosts stay on production", () => {
+    expect(resolveCloudApiBase("https://ELIZA.APP/api/v1")).toBe(
+      "https://api.eliza.app",
+    );
+    expect(resolveCloudApiBase("https://Staging.Eliza.App")).toBe(
+      "https://api-staging.eliza.app",
+    );
+  });
+
+  it("treats a whitespace-only input as unparseable rather than the production default", () => {
+    expect(resolveCloudApiBase("   ")).toBe("");
+  });
+});
+
+describe("runDevWalletLogin", () => {
+  it("fails closed when verify returns no apiKey", async () => {
+    const impl = (async (url: string | URL) => {
+      if (String(url).includes("/nonce")) {
+        return new Response(
+          JSON.stringify({
+            nonce: "n1",
+            domain: "www.elizacloud.ai",
+            uri: "https://www.elizacloud.ai",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ address: "0xabc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runDevWalletLogin({
+      privateKey: FIXED_PK,
+      save: false,
+      log: () => {},
+      fetchImpl: impl,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe("SIWE verify returned no apiKey");
+  });
+
+  it("takes organizationId from user.organization_id when organization is null", async () => {
+    let captured = "";
+    const impl = (async (url: string | URL, init?: RequestInit) => {
+      if (String(url).includes("/nonce")) {
+        return new Response(
+          JSON.stringify({
+            nonce: "n2",
+            domain: "www.elizacloud.ai",
+            uri: "https://www.elizacloud.ai",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      const payload = JSON.parse(String(init?.body ?? "{}")) as {
+        message: string;
+      };
+      captured = payload.message;
+      return new Response(
+        JSON.stringify({
+          apiKey: "eliza_devkey_UNIT",
+          user: { organization_id: "org-from-user" },
+          organization: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await runDevWalletLogin({
+      privateKey: FIXED_PK,
+      save: false,
+      log: () => {},
+      fetchImpl: impl,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.organizationId).toBe("org-from-user");
+    expect(result.savedTo).toBeNull();
+    // Observed SIWE shape when the nonce omits statement, version, and chainId:
+    // no statement paragraph, Version defaults to 1, Chain ID defaults to 1.
+    expect(captured).toContain(
+      "wants you to sign in with your Ethereum account:",
+    );
+    expect(captured).not.toContain("Sign in to Eliza Cloud");
+    expect(captured).toContain("Version: 1");
+    expect(captured).toContain("Chain ID: 1");
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/app-core/src/cli/program/register.auth.ts`, which had no colocated `register.auth.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/app-core/src/cli/program/register.auth.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` (`24bab55f58f0f66d31f9258b793c11fb236f5b7c`) at file time; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only. Does not change CLI auth reset, SIWE login, or cloud host mapping production code. Failure mode is a red suite, not a behaviour change.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program/register.auth.test.ts` driving the real `register.auth.ts` exports through the module's own test hooks (injected `AuthStore`, proof reader, env, fetch). The system under test is never replaced with a mock.

Covered behaviour, as observed in the live module:

`registerAuthCommand`:
- registers `auth` with `reset` and `dev-login` subcommands
- `reset` description is `Revoke all sessions (loopback only)`
- `dev-login` options are `--cloud`, `--no-save`, `--json` (Commander stores the negate flag as `--no-save`, not `--save`)

`runElizaAuthReset`:
- non-loopback bind (`192.168.1.1`) returns `{ ok: false, reason: "not_loopback" }` and never calls the proof reader or store
- wildcard `0.0.0.0` and `example.com` refuse the same way
- unset `ELIZA_API_BIND` uses the default loopback and proceeds
- `localhost` and `::1` are accepted as loopback
- a missing or mismatched proof token times out with `{ ok: false, reason: "proof_failed" }` and does not walk identities
- surrounding whitespace on the proof token is trimmed before matching
- empty then mismatched reads keep polling until a later match
- empty owner and machine queues revoke 0 sessions, still write `auth.reset.cli` success with `metadata.revoked: 0`
- owners are walked before machines, in listed order; revoke counts are summed (2+0+3 = 5)
- a single owner identity is the only revoke target
- the challenge and proof path are printed before waiting
- injected `cleanup` runs after success and is skipped on proof timeout
- the default filesystem reader accepts a real `RESET_PROOF.txt` and deletes it on success
- `skipProofCleanup: true` leaves the proof file in place
- a proof path that is a directory (`EISDIR`) rejects rather than returning `reason: "store_error"` (that reason is in the result type but is never assigned)
- a throwing store rejects with the thrown error rather than mapping to `store_error`
- the JSONL audit log records `auth.reset.cli` / `success` / `eliza-cli auth reset` / the revoked count

`resolveCloudApiBase`:
- mixed-case production and staging hosts still map within their own environment
- whitespace-only input is treated as unparseable and returns `""`, not the production default

`runDevWalletLogin` (save disabled, injected fetch):
- verify 200 with no `apiKey` returns `{ ok: false, message: "SIWE verify returned no apiKey" }`
- `organization: null` plus `user.organization_id` yields that org id
- omitted nonce `statement` / `version` / `chainId` produce a SIWE message with no statement paragraph and Version/Chain ID defaulting to 1

Sibling files already cover the full `resolveCloudApiBase` host table and the happy-path SIWE mint; this suite fills the colocated gap plus the reset path that had no tests.

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/program/register.auth.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (`register.auth.ts` unchanged vs this PR's parent):

```bash
bunx vitest run packages/app-core/src/cli/program/register.auth.test.ts
bunx biome check --write packages/app-core/src/cli/program/register.auth.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'register.auth.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (after refetch of `origin/develop`):

1. Vitest: **Test Files 1 passed (1), Tests 24 passed (24)** (`bunx vitest run packages/app-core/src/cli/program/register.auth.test.ts`). Duration 5.23s.
2. Biome: **Checked 1 file in 254ms. Fixed 1 file.** (one formatting apply on first write; the committed file is the formatted result).
3. `tsc --noEmit` in `packages/app-core`: **`register.auth.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors in other packages are unrelated.
4. Diff touches **only** `packages/app-core/src/cli/program/register.auth.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Evidence head (40-character SHA of this PR): `78eb4ca963b03eef23d854df9f0d4a4f1f0eab43`

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 24 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

# Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. `tsc --noEmit` for `packages/app-core` still reports pre-existing errors in other packages; none mention `register.auth.test.ts`.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:78eb4ca963b03eef23d854df9f0d4a4f1f0eab43 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
