### PR TITLE
fix(agent): fall back to the state-dir workspace over unreadable legacy registry state

### DIFF
--- a/packages/agent/src/shared/workspace-resolution.test.ts
+++ b/packages/agent/src/shared/workspace-resolution.test.ts
@@ -274,17 +274,16 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
     expect(resolved).toBe(path.join(stateDir, "workspace"));
   });
 
-  it("propagates an unreadable legacy folder config when no registry exists", () => {
+  it("falls back to the state-dir workspace when unreadable legacy state has no registry (#25884)", () => {
     const stateDir = makeTmp("ws-legacy-throw-");
     mkdirSync(path.join(stateDir, "workspace-folder.json"));
 
-    expect(() =>
-      resolveDefaultAgentWorkspaceDir(
-        isolatedEnv(stateDir),
-        () => stateDir,
-        () => "/",
-      ),
-    ).toThrow();
+    const resolved = resolveDefaultAgentWorkspaceDir(
+      isolatedEnv(stateDir),
+      () => stateDir,
+      () => "/",
+    );
+    expect(resolved).toBe(path.join(stateDir, "workspace"));
   });
 
   it("falls through malformed workspace-folder JSON to the state-dir default", () => {

--- a/packages/agent/src/shared/workspace-resolution.ts
+++ b/packages/agent/src/shared/workspace-resolution.ts
@@ -38,6 +38,26 @@ function hasExplicitStateDirOverride(env: NodeJS.ProcessEnv): boolean {
   return EXPLICIT_STATE_DIR_KEYS.some((key) => Boolean(env[key]?.trim()));
 }
 
+// Filesystem read failures on the legacy workspace-folder.json that the
+// documented fallback boundary treats as ignorable unreadable state. ENOENT
+// never reaches this list: the config module already degrades an absent file
+// to null (error-policy:J4), so these are the rethrown non-missing cases.
+const RECOVERABLE_LEGACY_STATE_ERRNO_CODES = new Set([
+  "EISDIR",
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+]);
+
+function isUnreadableLegacyStateError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    RECOVERABLE_LEGACY_STATE_ERRNO_CODES.has(
+      (error as NodeJS.ErrnoException).code ?? "",
+    )
+  );
+}
+
 function isLikelyPackagedRuntimeDir(dir: string): boolean {
   if (typeof dir !== "string") return false;
   const normalized = dir.replace(/\\/g, "/").toLowerCase();
@@ -86,7 +106,17 @@ export function resolveDefaultAgentWorkspaceDir(
   // absent the registry synthesizes an active project from the legacy
   // workspace-folder.json (see readProjectRegistry), so this step subsumes the
   // legacy read below without changing behavior for a lone picked folder.
-  const activeProject = getActiveProject(env);
+  // The synthesized read propagates the config module's deliberate non-ENOENT
+  // rethrows (EISDIR/EACCES when workspace-folder.json is a directory or
+  // unreadable), and unreadable legacy state is documented as ignorable in
+  // favor of the state-directory workspace — recover exactly those filesystem
+  // read failures (#25884) and keep every other failure strict (#25769).
+  let activeProject: ReturnType<typeof getActiveProject> = null;
+  try {
+    activeProject = getActiveProject(env);
+  } catch (error) {
+    if (!isUnreadableLegacyStateError(error)) throw error;
+  }
   if (activeProject?.localPath?.trim()) {
     return resolveUserPath(activeProject.localPath);
   }


### PR DESCRIPTION
# Relates to

Closes #25884

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (built directly on develop@24bab55 via the Git data API).
- [x] Focused tests pass after sync (exact command and output below).
- [x] A reviewer can confirm the change works from the inverted regression below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite passes post-sync (below); no unrelated blocker.

# Risks

Low. One boundary moves: filesystem read failures (EISDIR/EACCES/EPERM/ENOTDIR)
from the synthesized legacy read inside `getActiveProject` are now recovered at
the resolver and fall through to `<stateDir>/workspace`. Every other failure —
and every other `getActiveProject`/registry behavior — stays strict exactly as
#25769 left it.

# Background

## What does this PR do?

`resolveDefaultAgentWorkspaceDir` called `getActiveProject(env)` before the
documented fallback boundary. With `projects.json` absent, `readProjectRegistry`
synthesizes its active project from the legacy `workspace-folder.json`, and
that synthesized read propagates the config module's deliberate non-ENOENT
rethrows — EISDIR when the file is a directory, EACCES when unreadable. Because
`DEFAULT_AGENT_WORKSPACE_DIR` resolves at module import, unreadable first-run
legacy state escaped before the resolver's existing catch and prevented the
agent from booting (#25884).

The resolver now wraps the active-project read in the same recoverable class
as its existing legacy-config catch:

- exactly the filesystem read failures listed in
  `RECOVERABLE_LEGACY_STATE_ERRNO_CODES` are recovered (ENOENT never reaches
  the list — the config module already degrades an absent file to `null`
  under error-policy:J4);
- everything else rethrows, preserving strict failures for inputs that are not
  documented as recoverable (#25769's intent);
- resolution then falls through deterministically to `<stateDir>/workspace`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/shared/workspace-resolution.ts` — the guarded
`getActiveProject` call and the errno list — then the inverted regression in
`workspace-resolution.test.ts` (search `#25884`).

## Detailed testing steps

- `cd packages/agent && bunx vitest run src/shared/workspace-resolution.test.ts`
  - 33 pass / 0 fail (32 pre-existing + the inverted #25769 regression).
- The inverted test creates `workspace-folder.json` as a **directory** with no
  `projects.json` — the exact #25884 reproduction — and now asserts
  `<stateDir>/workspace` instead of a throw.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:cc95880fe7af742df56f6ea5ba852dbbb50e35a8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; this is agent boot-path filesystem
      resolution covered by deterministic unit tests.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed; the fallback result is asserted by
      the inverted regression.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - filesystem-state bug whose reproduction (a directory named
      workspace-folder.json, no projects.json) is encoded directly in the test.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no logging is added or changed; the failure mode is an exception
      at module import that the test previously expected and now asserts the
      recovered result for.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output; the
      artifacts are temp-dir fixture files created and asserted by the test.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
 ✓ src/shared/workspace-resolution.test.ts (33 tests) 41ms

 Test Files  1 passed (1)
      Tests  33 passed (33)
```

## Known gaps / failures

None for this change. Full-package `bun run verify` could not run in this
environment; the focused vitest suite above and the touched files' formatting
(existing tab/comment style) were checked locally.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->
