### PR TITLE
test(app-core): cover register.start

### DIFF
--- a/packages/app-core/src/cli/program/register.start.test.ts
+++ b/packages/app-core/src/cli/program/register.start.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Direct unit coverage for `registerStartCommand`. Drives a real Commander
+ * program: start/run registration order, `--connection-key` option branches,
+ * start-only docs help, loopback vs network auto-token, and the ready banner.
+ * `startEliza` is stubbed so the suite never boots a live server; token writes
+ * and console output come from the registrar itself.
+ */
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installServerOnlyProcessOwner } from "../../runtime/server-only-process";
+import { registerStartCommand } from "./register.start";
+
+const startEliza = vi.hoisted(() => vi.fn(async (_opts: unknown) => undefined));
+const pairing = vi.hoisted(() => ({
+  next: null as { code: string; expiresAt: number } | null,
+}));
+
+vi.mock("../../runtime/eliza", () => ({
+  startEliza,
+}));
+
+vi.mock("../../api/auth-pairing-routes", () => ({
+  ensureAuthPairingCodeForRemoteAccess: () => pairing.next,
+}));
+
+const ENV_KEYS = [
+  "ELIZA_API_TOKEN",
+  "ELIZA_API_BIND",
+  "ELIZA_DISABLE_AUTO_API_TOKEN",
+  "ELIZA_PORT",
+  "ELIZA_UI_PORT",
+  "ELIZA_PAIRING_DISABLED",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_BOOT_PROFILE",
+] as const;
+
+type SavedEnv = Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+let savedEnv: SavedEnv;
+const logs: string[] = [];
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => undefined,
+    writeErr: () => undefined,
+  });
+  registerStartCommand(program);
+  for (const command of program.commands) {
+    command.exitOverride();
+  }
+  return program;
+}
+
+function commandNames(program: Command): string[] {
+  return program.commands.map((command) => command.name());
+}
+
+function findCommand(program: Command, name: string): Command | undefined {
+  return program.commands.find((command) => command.name() === name);
+}
+
+function captureOutputHelp(command: Command): string {
+  const chunks: string[] = [];
+  command.configureOutput({
+    writeOut: (str) => {
+      chunks.push(str);
+    },
+    writeErr: () => undefined,
+  });
+  command.outputHelp();
+  return chunks.join("");
+}
+
+async function parseUser(
+  args: string[],
+  program: Command = createProgram(),
+): Promise<Command> {
+  await program.parseAsync(args, { from: "user" });
+  return program;
+}
+
+function startCall(): {
+  serverOnly?: boolean;
+  onServerOnlyHostReady?: unknown;
+  onEmbeddingProgress?: (phase: string, detail?: string) => void;
+} {
+  expect(startEliza).toHaveBeenCalledTimes(1);
+  return startEliza.mock.calls[0]?.[0] as {
+    serverOnly?: boolean;
+    onServerOnlyHostReady?: unknown;
+    onEmbeddingProgress?: (phase: string, detail?: string) => void;
+  };
+}
+
+beforeEach(() => {
+  savedEnv = {} as SavedEnv;
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.ELIZA_PAIRING_DISABLED = "1";
+  logs.length = 0;
+  pairing.next = null;
+  startEliza.mockClear();
+  startEliza.mockImplementation(async () => undefined);
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+describe("registerStartCommand", () => {
+  it("appends start then run onto an empty program, not a commander alias", () => {
+    const program = createProgram();
+    const start = findCommand(program, "start");
+    const run = findCommand(program, "run");
+
+    expect(commandNames(program)).toEqual(["start", "run"]);
+    expect(start?.description()).toBe("Start the elizaOS agent runtime");
+    expect(run?.description()).toBe("Alias for start");
+    expect(start?.aliases()).toEqual([]);
+    expect(run?.aliases()).toEqual([]);
+    expect(findCommand(program, "missing")).toBeUndefined();
+  });
+
+  it("preserves existing commands and appends start/run after them", () => {
+    const program = new Command();
+    program.command("seed");
+    registerStartCommand(program);
+    expect(commandNames(program)).toEqual(["seed", "start", "run"]);
+  });
+
+  it("wires --connection-key [key] on both start and run", () => {
+    const program = createProgram();
+    for (const name of ["start", "run"] as const) {
+      const command = findCommand(program, name);
+      expect(command?.options.map((option) => option.flags)).toEqual([
+        "--connection-key [key]",
+      ]);
+    }
+  });
+
+  it("attaches the getting-started docs block only to start help", () => {
+    const program = createProgram();
+    const startHelp = captureOutputHelp(
+      findCommand(program, "start") as Command,
+    );
+    const runHelp = captureOutputHelp(findCommand(program, "run") as Command);
+
+    expect(startHelp).toContain("Docs:");
+    expect(startHelp).toContain("docs.eliza.ai/getting-started");
+    expect(runHelp).not.toContain("Docs:");
+    expect(runHelp).not.toContain("docs.eliza.ai/getting-started");
+  });
+
+  it("stores an explicit --connection-key value as ELIZA_API_TOKEN", async () => {
+    await parseUser(["start", "--connection-key", "explicit-token-value"]);
+    expect(process.env.ELIZA_API_TOKEN).toBe("explicit-token-value");
+    expect(startCall().serverOnly).toBe(true);
+  });
+
+  it("treats --connection-key true as a literal token, not the bare flag", async () => {
+    await parseUser(["start", "--connection-key", "true"]);
+    expect(process.env.ELIZA_API_TOKEN).toBe("true");
+  });
+
+  it("generates a 32-char hex token when --connection-key is bare", async () => {
+    await parseUser(["start", "--connection-key"]);
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("generates a different token on each bare --connection-key invocation", async () => {
+    await parseUser(["start", "--connection-key"]);
+    const first = process.env.ELIZA_API_TOKEN;
+    delete process.env.ELIZA_API_TOKEN;
+    startEliza.mockClear();
+    await parseUser(["run", "--connection-key"]);
+    const second = process.env.ELIZA_API_TOKEN;
+    expect(first).toMatch(/^[0-9a-f]{32}$/);
+    expect(second).toMatch(/^[0-9a-f]{32}$/);
+    expect(second).not.toBe(first);
+  });
+
+  it("does not auto-generate a token on the default loopback bind", async () => {
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("does not auto-generate a token when binding localhost", async () => {
+    process.env.ELIZA_API_BIND = "localhost";
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("auto-generates a token when binding a network address with none configured", async () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("auto-generates a token for a non-loopback unicast bind", async () => {
+    process.env.ELIZA_API_BIND = "10.1.2.3";
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("keeps an already-configured token on a network bind", async () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    process.env.ELIZA_API_TOKEN = "already-configured-token";
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toBe("already-configured-token");
+  });
+
+  it("does not auto-generate when auto-token is disabled on a network bind", async () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    await parseUser(["start"]);
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+  });
+
+  it("still honors an explicit key when auto-token is disabled", async () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    await parseUser(["start", "--connection-key", "forced-key"]);
+    expect(process.env.ELIZA_API_TOKEN).toBe("forced-key");
+  });
+
+  it("boots server-only and hands the process owner to startEliza", async () => {
+    await parseUser(["start"]);
+    const opts = startCall();
+    expect(opts.serverOnly).toBe(true);
+    expect(opts.onServerOnlyHostReady).toBe(installServerOnlyProcessOwner);
+    expect(typeof opts.onEmbeddingProgress).toBe("function");
+  });
+
+  it("run invokes the same server-only boot path as start", async () => {
+    await parseUser(["run"]);
+    expect(startCall().serverOnly).toBe(true);
+  });
+
+  it("prints the default localhost URL with the default server-only port", async () => {
+    await parseUser(["start"]);
+    expect(logs.join("\n")).toContain(
+      "Connect at: http://localhost:2138         ",
+    );
+    expect(logs.join("\n")).toContain("Server is running.");
+  });
+
+  it("pads a custom ELIZA_PORT into the boxed URL line", async () => {
+    process.env.ELIZA_PORT = "9999";
+    await parseUser(["start"]);
+    expect(logs.join("\n")).toContain(
+      "Connect at: http://localhost:9999         ",
+    );
+  });
+
+  it("masks a connection key in the banner, leaving only the last four characters", async () => {
+    await parseUser(["start", "--connection-key", "abcdefghij"]);
+    const banner = logs.join("\n");
+    expect(banner).toContain("Connection key: ******ghij            ");
+    expect(banner).not.toContain("abcdefghij");
+  });
+
+  it("omits the connection-key banner line when no token is configured", async () => {
+    await parseUser(["start"]);
+    expect(logs.join("\n")).not.toContain("Connection key:");
+  });
+
+  it("pads a pairing code into the boxed banner when pairing is present", async () => {
+    pairing.next = { code: "WXYZ-ABCD-EFGH", expiresAt: 1 };
+    await parseUser(["start", "--connection-key", "pairing-token"]);
+    expect(logs.join("\n")).toContain("Pairing code: WXYZ-ABCD-EFGH          ");
+  });
+
+  it("omits the pairing code line when pairing is absent", async () => {
+    pairing.next = null;
+    await parseUser(["start", "--connection-key", "pairing-token"]);
+    expect(logs.join("\n")).not.toContain("Pairing code:");
+  });
+
+  it("logs embedding download and ready, and ignores other phases", async () => {
+    await parseUser(["start"]);
+    logs.length = 0;
+    const progress = startCall().onEmbeddingProgress;
+    expect(progress).toBeDefined();
+    progress?.("downloading", "model.bin 40%");
+    progress?.("downloading");
+    progress?.("ready");
+    progress?.("loading", "should-not-log");
+    expect(logs).toEqual([
+      "[eliza] Embedding: model.bin 40%",
+      "[eliza] Embedding: downloading...",
+      "[eliza] Embedding model ready",
+    ]);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/program/register.start.ts`, which had no same-named test file. No linked issue: this is a behavior-preserving unit-test addition, not a product change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`1f45fe5eb2d3` at fetch / `05115857287579678e15ebf5d6244f0ffcfafea6` head) with a single-file test commit and zero conflicts.
- [ ] `bun install` and `bun run verify` were not run. Focused vitest / biome / tsc on the new file are quoted below. Hosted CI does **not** run on this fork contributor's PRs; do not treat missing GitHub Actions as a pass.
- [x] A reviewer can confirm the change works without reading production code: run the quoted vitest command; 1 file / 24 tests passed.

# Sync with develop

- [x] Branch created from current `origin/develop` immediately before filing; zero conflicts.
- [ ] `bun run verify` was not run (test-only PR; focused suite quoted below). Not a production-behavior change.

# Risks

Low. The diff adds one vitest file and does not change production behavior. Failure mode is a false assertion about existing CLI wiring; the suite was written against observed `registerStartCommand` behavior (start/run as sibling commands, not a Commander alias; auto-token only on non-loopback bind).

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/program/register.start.test.ts` covering `registerStartCommand`:

- empty program → `start` then `run` in that order, with descriptions, and `run` is a second command rather than a Commander alias
- existing commands are preserved; start/run append
- `--connection-key [key]` on both commands
- getting-started docs help text on `start` only
- explicit `--connection-key <value>` writes `ELIZA_API_TOKEN`
- `--connection-key true` is a literal token string, not the bare-flag generator
- bare `--connection-key` generates a 32-char hex token; two invocations differ
- default loopback / `localhost` bind does not auto-generate
- `0.0.0.0` and `10.1.2.3` auto-generate when no token exists
- an existing token is kept on a network bind
- `ELIZA_DISABLE_AUTO_API_TOKEN=1` blocks auto-generation but still honors an explicit key
- server-only boot options (`serverOnly: true`, real `installServerOnlyProcessOwner`)
- `run` takes the same boot path
- boxed ready banner: default port 2138, custom `ELIZA_PORT`, masked connection key (last four visible), omitted key line when none, pairing line pad when present / omitted when absent
- embedding progress logs downloading/ready and ignores other phases

`startEliza` and the pairing helper are test doubles so the suite never boots a live server. Token writes and banner/progress `console.log` come from the real registrar.

## What kind of change is this?

Improvements (tests for existing CLI behavior). No production source change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
bunx vitest run packages/app-core/src/cli/program/register.start.test.ts
```

Re-run against current `origin/develop` immediately before filing.

## Detailed testing steps

None: automated tests are acceptable.

Observed immediately before filing, on current `origin/develop`:

```
✓ packages/app-core/src/cli/program/register.start.test.ts (24 tests) 16ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  18:03:20
   Duration  22.71s
```

`bunx biome check --write packages/app-core/src/cli/program/register.start.test.ts` — Checked 1 file. Fixed 1 file (format wrap); then clean.

`cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'register.start.test.ts'` — empty (GREP_EXIT:1). The new file introduced zero type errors.

The diff touches only `packages/app-core/src/cli/program/register.start.test.ts`.

Hosted CI does not run on this fork; these local counts are the evidence.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:05115857287579678e15ebf5d6244f0ffcfafea6 -->

This PR adds tests and changes no production behavior. The complete evidence set is the four items in Testing above.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only change; no production path to log.
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only change; no frontend request.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/memory/schedule/wallet/audio artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; no production request path.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI.

### Before

N/A - test-only; no UI.

### After

N/A - test-only; no UI.

### Walkthrough video

N/A - test-only; no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; focused vitest (24/24), biome, and tsc-grep are quoted above.
- Hosted GitHub Actions CI does not run on this fork contributor's PRs. Missing check runs are expected, not a pass.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
