### PR TITLE
fix(ui): storybook brand audit — broken stories, banned colors, contrast

### DIFF
--- a/packages/ui/src/cloud-ui/components/connection-card.tsx
+++ b/packages/ui/src/cloud-ui/components/connection-card.tsx
@@ -96,7 +96,13 @@ function ConnectionConnectedBadge({
   className?: string;
 }) {
   return (
-    <Badge variant="default" className={cn("bg-green-500", className)}>
+    <Badge
+      variant="outline"
+      className={cn(
+        "bg-status-success-bg text-status-success border-status-success/30",
+        className,
+      )}
+    >
       <CheckCircle className="h-3 w-3 mr-1" />
       {label}
     </Badge>

--- a/packages/ui/src/cloud-ui/components/monetization/earnings-simulator.tsx
+++ b/packages/ui/src/cloud-ui/components/monetization/earnings-simulator.tsx
@@ -66,7 +66,7 @@ export function EarningsSimulator({
     <div className={cn("bg-neutral-900 rounded-sm p-4", className)}>
       {/* Header */}
       <h3 className="text-sm font-medium text-white flex items-center gap-2 mb-4">
-        <Calculator className="h-4 w-4 text-purple-400" />
+        <Calculator className="h-4 w-4 text-accent" />
         Earnings Calculator
       </h3>
 
@@ -143,11 +143,11 @@ export function EarningsSimulator({
 
         {/* Inference earnings */}
         <div className="flex items-center justify-between text-sm">
-          <span className="text-purple-400 flex items-center gap-1.5">
+          <span className="text-accent flex items-center gap-1.5">
             <Zap className="h-3 w-3" />
             Inference ({markupPercentage}%)
           </span>
-          <span className="font-mono text-purple-400">
+          <span className="font-mono text-accent">
             +${calculations.inferenceEarnings.toFixed(2)}
           </span>
         </div>

--- a/packages/ui/src/cloud-ui/components/monetization/revenue-flow-diagram.tsx
+++ b/packages/ui/src/cloud-ui/components/monetization/revenue-flow-diagram.tsx
@@ -72,8 +72,8 @@ export function RevenueFlowDiagram({
             icon={<Wallet className="h-5 w-5" />}
             label="You"
             value={`Earn $${markup.toFixed(2)}`}
-            color="text-txt-strong"
-            bgColor="bg-muted"
+            color="text-accent"
+            bgColor="bg-accent-subtle"
             highlight
           />
         </div>
@@ -160,7 +160,7 @@ function FlowNode({
     <div
       className={cn(
         "flex flex-col items-center gap-2 p-3 rounded-sm border transition-colors w-[90px]",
-        highlight ? "border-border" : "border-white/10",
+        highlight ? "border-accent/40" : "border-white/10",
         bgColor,
       )}
     >
@@ -220,7 +220,9 @@ function FlowNodeMobile({
     <div
       className={cn(
         "flex items-center justify-between p-3 rounded-sm border",
-        highlight ? "border-border bg-muted" : "border-white/10 bg-black/30",
+        highlight
+          ? "border-accent/40 bg-accent-subtle"
+          : "border-white/10 bg-black/30",
       )}
     >
       <div className="flex items-center gap-2">

--- a/packages/ui/src/cloud-ui/components/timeline.tsx
+++ b/packages/ui/src/cloud-ui/components/timeline.tsx
@@ -54,7 +54,7 @@ export const Timeline = ({
       ref={containerRef}
     >
       <div className="max-w-7xl mx-auto py-20 px-4 md:px-8 lg:px-10">
-        <h2 className="text-lg md:text-4xl mb-4 text-white max-w-4xl">
+        <h2 className="text-lg md:text-5xl mb-4 text-white max-w-4xl">
           {title}
         </h2>
         <p className="text-neutral-300 text-sm md:text-base max-w-sm">
@@ -72,7 +72,7 @@ export const Timeline = ({
               <div className="h-10 absolute left-3 md:left-3 w-10 rounded-full bg-neutral-900 flex items-center justify-center">
                 <div className="h-4 w-4 rounded-full bg-neutral-700 border border-neutral-600 p-2" />
               </div>
-              <h3 className="hidden md:block text-xl md:pl-20 md:text-5xl font-bold text-neutral-400">
+              <h3 className="hidden md:block text-xl md:pl-20 md:text-4xl font-bold text-neutral-400">
                 {item.title}
               </h3>
             </div>
@@ -93,7 +93,7 @@ export const Timeline = ({
         >
           <motion.div
             style={progressStyle}
-            className="absolute inset-x-0 top-0  w-[2px] bg-gradient-to-t from-purple-500 via-blue-500 to-transparent from-[0%] via-[10%] rounded-full"
+            className="absolute inset-x-0 top-0  w-[2px] bg-gradient-to-t from-accent via-accent/60 to-transparent from-[0%] via-[10%] rounded-full"
           />
         </div>
       </div>

--- a/packages/ui/src/cloud/admin/RedemptionsPage.tsx
+++ b/packages/ui/src/cloud/admin/RedemptionsPage.tsx
@@ -109,7 +109,7 @@ interface SystemStatus {
 const STATUS_COLORS: Record<string, string> = {
   pending: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
   approved: "bg-white/10 text-white/80 border-white/20",
-  processing: "bg-purple-500/20 text-purple-400 border-purple-500/30",
+  processing: "bg-accent/20 text-accent border-accent/30",
   completed: "bg-green-500/20 text-green-400 border-green-500/30",
   failed: "bg-red-500/20 text-red-400 border-red-500/30",
   rejected: "bg-red-500/20 text-red-400 border-red-500/30",
@@ -395,7 +395,7 @@ export default function RedemptionsPage(): React.JSX.Element {
               </p>
             </div>
             <div className="text-center">
-              <p className="text-2xl font-bold text-purple-400">
+              <p className="text-2xl font-bold text-accent">
                 {stats?.processing || 0}
               </p>
               <p className="text-xs text-muted-foreground">

--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -72,7 +72,7 @@ export default function ApplicationsPage() {
                   defaultValue: "Total Requests",
                 })}
                 value={totalRequests.toLocaleString()}
-                icon={<TrendingUp className="h-5 w-5 text-purple-500" />}
+                icon={<TrendingUp className="h-5 w-5 text-accent" />}
               />
             </DashboardStatGrid>
             {isLoading ? (

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -437,7 +437,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <DashboardStatCard
                 label="Total Requests"
                 value={totalStats.totalRequests?.toLocaleString("en-US") || "0"}
-                icon={<Activity className="h-5 w-5 text-purple-400" />}
+                icon={<Activity className="h-5 w-5 text-accent" />}
               />
               <DashboardStatCard
                 label="Total Users"
@@ -716,7 +716,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                           ).toFixed(1)
                         : "0"
                     }
-                    icon={<Activity className="h-5 w-5 text-purple-400" />}
+                    icon={<Activity className="h-5 w-5 text-accent" />}
                   />
                 </div>
               )}

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -364,7 +364,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                 ${data.total.toFixed(2)}
               </p>
               <div className="flex gap-3 text-xs mt-2">
-                <span className="text-purple-400 flex items-center gap-1">
+                <span className="text-accent flex items-center gap-1">
                   <Zap className="h-3 w-3" />$
                   {data.inferenceEarnings.toFixed(2)}
                 </span>
@@ -419,7 +419,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
               <Legend />
               <Bar
                 dataKey="inferenceEarnings"
-                fill="#a855f7"
+                fill="var(--accent)"
                 name="Inference Markup"
                 stackId="a"
                 radius={[4, 4, 0, 0]}
@@ -512,7 +512,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
 function TransactionIcon({ type }: { type: string }) {
   switch (type) {
     case "inference_markup":
-      return <Zap className="h-4 w-4 text-purple-400" />;
+      return <Zap className="h-4 w-4 text-accent" />;
     case "purchase_share":
       return <Coins className="h-4 w-4 text-yellow-400" />;
     case "withdrawal":
@@ -526,7 +526,7 @@ function TransactionBadge({ type }: { type: string }) {
   switch (type) {
     case "inference_markup":
       return (
-        <Badge className="bg-purple-500/20 text-purple-400 border-purple-500/30 text-[10px]">
+        <Badge className="bg-accent/20 text-accent border-accent/30 text-[10px]">
           Inference
         </Badge>
       );

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -473,7 +473,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <span className="text-lg font-mono font-semibold text-purple-400">
+                <span className="text-lg font-mono font-semibold text-accent">
                   {settings.inferenceMarkupPercentage}%
                 </span>
               </div>
@@ -496,7 +496,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     className={cn(
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.inferenceMarkupPercentage === preset
-                        ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
+                        ? "bg-accent/20 text-accent border border-accent/30"
                         : "bg-surface text-neutral-400 hover:bg-bg-hover border border-transparent",
                     )}
                     onClick={() =>

--- a/packages/ui/src/cloud/mcps/McpEditorDialog.stories.tsx
+++ b/packages/ui/src/cloud/mcps/McpEditorDialog.stories.tsx
@@ -2,6 +2,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MockAppProvider } from "../../storybook/mock-providers";
+import { CloudI18nProvider } from "../shell/CloudI18nProvider";
 import type { UserMcpRecord } from "./lib/api-types";
 import { McpEditorDialog } from "./McpEditorDialog";
 
@@ -28,6 +30,17 @@ const meta = {
   title: "Cloud/MCPs/EditorDialog",
   component: McpEditorDialog,
   parameters: { layout: "fullscreen" },
+  decorators: [
+    // MockAppProvider seeds the useAppSelector store; CloudI18nProvider backs
+    // the dialog's useCloudT() (the cloud routes have their own i18n context).
+    (Story) => (
+      <MockAppProvider>
+        <CloudI18nProvider initialLang="en">
+          <Story />
+        </CloudI18nProvider>
+      </MockAppProvider>
+    ),
+  ],
 } satisfies Meta<typeof McpEditorDialog>;
 
 export default meta;

--- a/packages/ui/src/components/accounts/AccountCard.stories.tsx
+++ b/packages/ui/src/components/accounts/AccountCard.stories.tsx
@@ -1,28 +1,9 @@
-/** Storybook stories for AccountCard across provider/health/usage states, under a stub AppContext supplying `t`. */
+/** Storybook stories for AccountCard across provider/health/usage states, under the shared MockAppProvider. */
 
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AccountWithCredentialFlag } from "../../api/client-agent";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { AccountCard } from "./AccountCard";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    if (prop === "navigation") {
-      return {
-        scheduleAfterTabCommit: (fn: () => void) => {
-          queueMicrotask(fn);
-        },
-      };
-    }
-    return () => {};
-  },
-});
 
 const baseAccount: AccountWithCredentialFlag = {
   id: "acct_anthropic_primary",
@@ -49,11 +30,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="max-w-3xl p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   argTypes: {

--- a/packages/ui/src/components/accounts/ProviderAccountRow.stories.tsx
+++ b/packages/ui/src/components/accounts/ProviderAccountRow.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Storybook stories for ProviderAccountRow — the unified Accounts row across
  * connected/disconnected, healthy/attention, and rotation-selection states.
- * Renders under a stub AppContext supplying `t`.
+ * Renders under the shared MockAppProvider.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -9,8 +9,7 @@ import type {
   AccountsListProvider,
   AccountWithCredentialFlag,
 } from "../../api/client-agent";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import {
   type AccountProviderOption,
   getAccountProviderOption,
@@ -24,22 +23,6 @@ function option(
   if (!found) throw new Error(`missing provider option: ${id}`);
   return found;
 }
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    if (prop === "navigation") {
-      return {
-        scheduleAfterTabCommit: (fn: () => void) => queueMicrotask(fn),
-      };
-    }
-    return () => {};
-  },
-});
 
 function acct(
   over: Partial<AccountWithCredentialFlag> &
@@ -98,11 +81,11 @@ const meta = {
   component: ProviderAccountRow,
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="max-w-3xl bg-bg p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   args: {

--- a/packages/ui/src/components/accounts/ProviderPicker.stories.tsx
+++ b/packages/ui/src/components/accounts/ProviderPicker.stories.tsx
@@ -1,34 +1,22 @@
 /**
  * Storybook story for ProviderPicker — the command-palette provider chooser
- * in the Add Account dialog. Renders under a stub AppContext supplying `t`.
+ * in the Add Account dialog. Renders under the shared MockAppProvider.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { ProviderPicker } from "./ProviderPicker";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
 
 const meta = {
   title: "Accounts/ProviderPicker",
   component: ProviderPicker,
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="max-w-md bg-bg p-4">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   args: {

--- a/packages/ui/src/components/accounts/RotationStrategyPicker.stories.tsx
+++ b/packages/ui/src/components/accounts/RotationStrategyPicker.stories.tsx
@@ -1,27 +1,8 @@
-/** Storybook stories for RotationStrategyPicker across the account rotation strategies, under a stub AppContext supplying `t`. */
+/** Storybook stories for RotationStrategyPicker across the account rotation strategies, under the shared MockAppProvider. */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { RotationStrategyPicker } from "./RotationStrategyPicker";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    if (prop === "navigation") {
-      return {
-        scheduleAfterTabCommit: (fn: () => void) => {
-          queueMicrotask(fn);
-        },
-      };
-    }
-    return () => {};
-  },
-});
 
 const meta = {
   title: "Accounts/RotationStrategyPicker",
@@ -29,11 +10,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   argTypes: {

--- a/packages/ui/src/components/apps/AppsCatalogGrid.stories.tsx
+++ b/packages/ui/src/components/apps/AppsCatalogGrid.stories.tsx
@@ -1,13 +1,12 @@
 /**
- * Storybook stories for `AppsCatalogGrid`, wrapped in a stub `AppContext`, across
- * populated, loading, error, and search-filtered states.
+ * Storybook stories for `AppsCatalogGrid`, wrapped in the shared
+ * MockAppProvider, across populated, loading, error, and search-filtered
+ * states.
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { ReactNode } from "react";
 import type { RegistryAppInfo } from "../../api";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { AppsCatalogGrid } from "./AppsCatalogGrid";
 
 function makeApp(overrides: Partial<RegistryAppInfo>): RegistryAppInfo {
@@ -83,20 +82,6 @@ const sampleApps: RegistryAppInfo[] = [
   }),
 ];
 
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") return (k: string) => k;
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
-
-function AppContextDecorator({ children }: { children: ReactNode }) {
-  return (
-    <AppContext.Provider value={mockAppContext}>{children}</AppContext.Provider>
-  );
-}
-
 const meta = {
   title: "Apps/AppsCatalogGrid",
   component: AppsCatalogGrid,
@@ -104,11 +89,11 @@ const meta = {
   parameters: { layout: "padded" },
   decorators: [
     (Story) => (
-      <AppContextDecorator>
+      <MockAppProvider>
         <div style={{ minWidth: 960 }}>
           <Story />
         </div>
-      </AppContextDecorator>
+      </MockAppProvider>
     ),
   ],
   args: {

--- a/packages/ui/src/components/character/CharacterRoster.stories.tsx
+++ b/packages/ui/src/components/character/CharacterRoster.stories.tsx
@@ -1,20 +1,8 @@
 /** Storybook stories for the character roster preset picker. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { CharacterRoster, type CharacterRosterEntry } from "./CharacterRoster";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
 
 function makeEntry(
   id: string,
@@ -83,11 +71,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="bg-background flex min-h-[360px] w-full items-center justify-center p-8">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   argTypes: {

--- a/packages/ui/src/components/chat/widgets/chat-widget-shell.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/chat-widget-shell.stories.tsx
@@ -1,6 +1,7 @@
 /** Expanded work-in-progress and collapsed completed chat-widget states. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { CheckCircle2, Plug } from "lucide-react";
+import { MockAppProvider } from "../../../storybook/mock-providers";
 import { Input } from "../../ui/input";
 import { ChatWidgetShell } from "./chat-widget-shell";
 
@@ -8,6 +9,14 @@ const meta = {
   title: "Chat/Widgets/ChatWidgetShell",
   component: ChatWidgetShell,
   parameters: { layout: "padded" },
+  decorators: [
+    // MockAppProvider seeds the useAppSelector store the shell reads `t` from.
+    (Story) => (
+      <MockAppProvider>
+        <Story />
+      </MockAppProvider>
+    ),
+  ],
   args: {
     title: "Connect Discord",
     icon: <Plug className="size-4" aria-hidden />,

--- a/packages/ui/src/components/chat/widgets/connector-card.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-card.stories.tsx
@@ -6,12 +6,23 @@
  * and the full-app audit.
  */
 import type { Meta, StoryObj } from "@storybook/react";
+import { MockAppProvider } from "../../../storybook/mock-providers";
 import { ConnectorCardWidget } from "./connector-card";
 
 const meta = {
   title: "Chat/Widgets/ConnectorCard",
   component: ConnectorCardWidget,
   tags: ["autodocs"],
+  decorators: [
+    // MockAppProvider seeds the useAppSelector store the card reads
+    // `t` / `elizaCloudConnected` / `loadPlugins` from. `elizaCloudConnected`
+    // must be an explicit boolean — the mock Proxy's noop fallback is truthy.
+    (Story) => (
+      <MockAppProvider value={{ elizaCloudConnected: false }}>
+        <Story />
+      </MockAppProvider>
+    ),
+  ],
 } satisfies Meta<typeof ConnectorCardWidget>;
 
 export default meta;

--- a/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorChannelModeSwitch.stories.tsx
@@ -6,29 +6,17 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { ConnectorChannelModeSwitch } from "./ConnectorChannelModeSwitch";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
 
 const meta = {
   title: "Connectors/ConnectorChannelModeSwitch",
   component: ConnectorChannelModeSwitch,
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <Story />
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
 } satisfies Meta<typeof ConnectorChannelModeSwitch>;

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.stories.tsx
@@ -6,20 +6,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { ConnectorModeSelector } from "./ConnectorModeSelector";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
 
 function Wrapper(props: {
   connectorId: string;
@@ -43,11 +31,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="max-w-xl p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   argTypes: {

--- a/packages/ui/src/components/connectors/TelegramBotSetupPanel.stories.tsx
+++ b/packages/ui/src/components/connectors/TelegramBotSetupPanel.stories.tsx
@@ -3,20 +3,8 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { TelegramBotSetupPanel } from "./TelegramBotSetupPanel";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
 
 const meta = {
   title: "Connectors/TelegramBotSetupPanel",
@@ -24,11 +12,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="max-w-xl p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   parameters: {

--- a/packages/ui/src/components/custom-actions/CustomActionEditor.stories.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionEditor.stories.tsx
@@ -1,28 +1,9 @@
-/** Storybook stories for CustomActionEditor across handler types and create/edit modes, under a stub AppContext supplying `t`. */
+/** Storybook stories for CustomActionEditor across handler types and create/edit modes, under the shared MockAppProvider. */
 
 import type { CustomActionDef } from "@elizaos/shared";
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { CustomActionEditor } from "./CustomActionEditor";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "";
-    }
-    if (prop === "uiLanguage") return "en";
-    if (prop === "navigation") {
-      return {
-        scheduleAfterTabCommit: (fn: () => void) => {
-          queueMicrotask(fn);
-        },
-      };
-    }
-    return () => {};
-  },
-});
 
 const sampleHttpAction: CustomActionDef = {
   id: "act-http-1",
@@ -82,11 +63,11 @@ const meta = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <AppContext.Provider value={mockAppContext}>
+      <MockAppProvider>
         <div className="p-6">
           <Story />
         </div>
-      </AppContext.Provider>
+      </MockAppProvider>
     ),
   ],
   argTypes: {

--- a/packages/ui/src/components/local-inference/DeviceBridgeStatus.tsx
+++ b/packages/ui/src/components/local-inference/DeviceBridgeStatus.tsx
@@ -19,7 +19,7 @@ export function DeviceBridgeStatusBar({
   if (!status) return null;
 
   const dotClass = status.connected
-    ? "bg-emerald-500"
+    ? "bg-status-success"
     : status.pendingRequests > 0
       ? "bg-amber-500"
       : "bg-muted-foreground/40";

--- a/packages/ui/src/components/local-inference/DevicesPanel.tsx
+++ b/packages/ui/src/components/local-inference/DevicesPanel.tsx
@@ -45,7 +45,9 @@ export function DevicesPanel({
           >
             <span
               className={`inline-flex h-2 w-2 rounded-full ${
-                device.isPrimary ? "bg-emerald-500" : "bg-muted-foreground/60"
+                device.isPrimary
+                  ? "bg-status-success"
+                  : "bg-muted-foreground/60"
               }`}
               aria-hidden
             />

--- a/packages/ui/src/components/local-inference/ModelCard.tsx
+++ b/packages/ui/src/components/local-inference/ModelCard.tsx
@@ -47,7 +47,7 @@ interface ModelCardProps {
 }
 
 const FIT_STYLES: Record<FitLevel, string> = {
-  fits: "text-emerald-500 border-emerald-500/40 bg-emerald-500/10",
+  fits: "text-status-success border-status-success/40 bg-status-success-bg",
   tight: "text-amber-500 border-amber-500/40 bg-amber-500/10",
   wontfit: "text-rose-500 border-rose-500/40 bg-rose-500/10",
 };

--- a/packages/ui/src/components/local-inference/ProvidersList.tsx
+++ b/packages/ui/src/components/local-inference/ProvidersList.tsx
@@ -100,7 +100,7 @@ export function ProvidersList() {
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         {providers.map((p) => {
           const dot = p.enableState.enabled
-            ? "bg-emerald-500"
+            ? "bg-status-success"
             : "bg-muted-foreground/40";
           const { Icon, labelKey, label } = KIND_ICON[p.kind];
           return (

--- a/packages/ui/src/components/pages/WorkflowCanvas.tsx
+++ b/packages/ui/src/components/pages/WorkflowCanvas.tsx
@@ -78,7 +78,7 @@ function WorkflowStepNode({ data, selected }: NodeProps<WorkflowCanvasNode>) {
             state === "failed"
               ? "bg-destructive"
               : state === "finished"
-                ? "bg-emerald-500"
+                ? "bg-status-success"
                 : state === "waiting"
                   ? "bg-amber-500"
                   : "animate-pulse bg-primary"

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -90,7 +90,7 @@ function terminal(status: WorkflowExecution["status"]): boolean {
 }
 
 function statusDot(status: WorkflowExecution["status"]): string {
-  if (status === "finished") return "bg-emerald-500";
+  if (status === "finished") return "bg-status-success";
   if (status === "failed" || status === "cancelled") return "bg-destructive";
   if (status.startsWith("waiting")) return "bg-amber-500";
   return "bg-primary";
@@ -200,7 +200,7 @@ function WorkflowWidget({
         {widget.component === "status" ? (
           <div className="flex items-center gap-2 rounded-lg bg-muted/30 p-3">
             <span
-              className={`h-2.5 w-2.5 rounded-full ${value === false || value === "failed" || value === "error" ? "bg-destructive" : "bg-emerald-500"}`}
+              className={`h-2.5 w-2.5 rounded-full ${value === false || value === "failed" || value === "error" ? "bg-destructive" : "bg-status-success"}`}
             />
             <span className="font-medium">
               {typeof value === "string" || typeof value === "number"
@@ -536,7 +536,7 @@ export function WorkflowEditor({
             title={workflow.active ? "Enabled" : "Disabled"}
           >
             <span
-              className={`h-2.5 w-2.5 rounded-full ${workflow.active ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
+              className={`h-2.5 w-2.5 rounded-full ${workflow.active ? "bg-status-success" : "bg-muted-foreground/40"}`}
             />
           </button>
         ) : null}

--- a/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
+++ b/packages/ui/src/components/pages/WorkflowTriggerPanel.tsx
@@ -198,7 +198,7 @@ export function WorkflowTriggerPanel({
     <section aria-label="Workflow triggers" className="bg-card/40 px-3 py-2">
       <div className="flex min-w-0 items-center gap-2 overflow-x-auto">
         <span
-          className="h-2 w-2 shrink-0 rounded-full bg-emerald-500"
+          className="h-2 w-2 shrink-0 rounded-full bg-status-success"
           title="Manual"
         >
           <span className="sr-only">Manual</span>

--- a/packages/ui/src/components/release-center/sections.stories.tsx
+++ b/packages/ui/src/components/release-center/sections.stories.tsx
@@ -1,9 +1,8 @@
-/** Storybook stories for the Release Center sections (status, notes, build/runtime, session, WebGPU), under a stub AppContext supplying `t`. */
+/** Storybook stories for the Release Center sections (status, notes, build/runtime, session, WebGPU), under the shared MockAppProvider. */
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { useRef } from "react";
-import type { AppContextValue } from "../../state/internal";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import {
   BuildRuntimeSection,
   ReleaseNotesSection,
@@ -21,28 +20,12 @@ import type {
   WgpuTagElement,
 } from "./types";
 
-const mockApp = {
-  t: (
-    _key: string,
-    options?: { defaultValue?: string } & Record<string, unknown>,
-  ) => {
-    let out = options?.defaultValue ?? _key;
-    if (options) {
-      for (const [k, v] of Object.entries(options)) {
-        if (k === "defaultValue") continue;
-        out = out.replace(`{{${k}}}`, String(v));
-      }
-    }
-    return out;
-  },
-} as AppContextValue;
-
 const withAppContext = (Story: () => JSX.Element) => (
-  <AppContext.Provider value={mockApp}>
+  <MockAppProvider>
     <div className="max-w-3xl space-y-4 p-4">
       <Story />
     </div>
-  </AppContext.Provider>
+  </MockAppProvider>
 );
 
 const updateStatus: AppReleaseStatus = {

--- a/packages/ui/src/components/release-center/shared.stories.tsx
+++ b/packages/ui/src/components/release-center/shared.stories.tsx
@@ -1,27 +1,8 @@
-/** Storybook stories for the Release Center shared primitives (StatusPill tones, DefinitionRow), under a stub AppContext supplying `t`. */
+/** Storybook stories for the Release Center shared primitives (StatusPill tones, DefinitionRow), under the shared MockAppProvider. */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { DefinitionRow, StatusPill } from "./shared";
-
-const mockAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? "Unavailable";
-    }
-    if (prop === "uiLanguage") return "en";
-    if (prop === "navigation") {
-      return {
-        scheduleAfterTabCommit: (fn: () => void) => {
-          queueMicrotask(fn);
-        },
-      };
-    }
-    return () => {};
-  },
-});
 
 const meta = {
   title: "ReleaseCenter/Shared",
@@ -65,11 +46,11 @@ type DefinitionRowStory = StoryObj<typeof DefinitionRow>;
 
 export const DefinitionRowDefault: DefinitionRowStory = {
   render: (args) => (
-    <AppContext.Provider value={mockAppContext}>
+    <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
         <DefinitionRow {...args} />
       </div>
-    </AppContext.Provider>
+    </MockAppProvider>
   ),
   args: {
     label: "Version",
@@ -79,11 +60,11 @@ export const DefinitionRowDefault: DefinitionRowStory = {
 
 export const DefinitionRowNumeric: DefinitionRowStory = {
   render: (args) => (
-    <AppContext.Provider value={mockAppContext}>
+    <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
         <DefinitionRow {...args} />
       </div>
-    </AppContext.Provider>
+    </MockAppProvider>
   ),
   args: {
     label: "Downloads",
@@ -93,11 +74,11 @@ export const DefinitionRowNumeric: DefinitionRowStory = {
 
 export const DefinitionRowEmptyFallback: DefinitionRowStory = {
   render: (args) => (
-    <AppContext.Provider value={mockAppContext}>
+    <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
         <DefinitionRow {...args} />
       </div>
-    </AppContext.Provider>
+    </MockAppProvider>
   ),
   args: {
     label: "Release notes",
@@ -108,11 +89,11 @@ export const DefinitionRowEmptyFallback: DefinitionRowStory = {
 
 export const DefinitionRowUnavailable: DefinitionRowStory = {
   render: (args) => (
-    <AppContext.Provider value={mockAppContext}>
+    <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
         <DefinitionRow {...args} />
       </div>
-    </AppContext.Provider>
+    </MockAppProvider>
   ),
   args: {
     label: "Build hash",

--- a/packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx
@@ -87,7 +87,7 @@ function statusDotClass(status: string): string {
   switch (status.toLowerCase()) {
     case "running":
     case "ready":
-      return "text-emerald-500";
+      return "text-status-success";
     case "sleeping":
     case "suspended":
     case "suspending":

--- a/packages/ui/src/components/shared/confirm-delete-control.stories.tsx
+++ b/packages/ui/src/components/shared/confirm-delete-control.stories.tsx
@@ -1,28 +1,16 @@
-/** Storybook stories for ConfirmDeleteControl: default, custom labels, ghost/outline variants, disabled, and busy state, under a stub AppContext supplying `t`. */
+/** Storybook stories for ConfirmDeleteControl: default, custom labels, ghost/outline variants, disabled, and busy state, under the shared MockAppProvider. */
 
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
-import type { AppContextValue } from "../../state/types";
-import { AppContext } from "../../state/useApp";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { ConfirmDeleteControl } from "./confirm-delete-control";
 
-const stubAppContext = new Proxy({} as AppContextValue, {
-  get(_, prop) {
-    if (prop === "t") {
-      return (_key: string, opts?: { defaultValue?: string }) =>
-        opts?.defaultValue ?? String(_key);
-    }
-    if (prop === "uiLanguage") return "en";
-    return () => {};
-  },
-});
-
 const withAppContext = (Story: () => ReactNode) => (
-  <AppContext.Provider value={stubAppContext}>
+  <MockAppProvider>
     <div className="p-4 flex items-center gap-2 bg-background">
       <Story />
     </div>
-  </AppContext.Provider>
+  </MockAppProvider>
 );
 
 const meta = {

--- a/packages/ui/src/components/shell/ChatSurface.stories.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.stories.tsx
@@ -3,6 +3,7 @@
  * banner, and overlay contexts.
  */
 import type { Meta, StoryObj } from "@storybook/react";
+import { MockAppProvider } from "../../storybook/mock-providers";
 import { ChatSurface } from "./ChatSurface";
 import type { ShellMessage } from "./shell-state";
 
@@ -45,10 +46,14 @@ const meta = {
   component: ChatSurface,
   parameters: { layout: "fullscreen" },
   decorators: [
+    // MockAppProvider seeds the useAppSelector store for the message-row
+    // composites (InlineWidgetText / FormSubmitReceipt read selector state).
     (Story) => (
-      <div style={{ height: 420, width: 360, margin: "0 auto" }}>
-        <Story />
-      </div>
+      <MockAppProvider>
+        <div style={{ height: 420, width: 360, margin: "0 auto" }}>
+          <Story />
+        </div>
+      </MockAppProvider>
     ),
   ],
   args: {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -2602,7 +2602,7 @@ export function NotificationsHomeCenter({
           <button
             type="button"
             onClick={() => void retryNotificationHydration()}
-            className="flex h-11 shrink-0 items-center gap-1.5 rounded-xl bg-orange-500 px-3 text-xs font-semibold text-black transition-colors hover:bg-orange-600"
+            className="flex h-11 shrink-0 items-center gap-1.5 rounded-xl bg-accent px-3 text-xs font-semibold text-accent-foreground transition-colors hover:bg-accent-hover"
           >
             <RefreshCw aria-hidden className="h-3.5 w-3.5" />
             Retry

--- a/packages/ui/src/components/shell/VoiceCaptureHud.tsx
+++ b/packages/ui/src/components/shell/VoiceCaptureHud.tsx
@@ -263,7 +263,11 @@ export function VoiceCaptureHud() {
               className="flex items-baseline gap-1 whitespace-nowrap tabular-nums"
             >
               <span className="text-white/60">+{line.offsetMs}</span>
-              <span className={line.bad ? "text-red-400" : "text-emerald-300"}>
+              <span
+                className={
+                  line.bad ? "text-destructive" : "text-status-success"
+                }
+              >
                 {line.step}
               </span>
               {line.token ? (

--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -111,17 +111,23 @@ function Calendar({
           defaultClassNames.day,
         ),
         range_start: cn(
-          "rounded-l-md bg-accent",
+          "rounded-l-md bg-accent text-accent-foreground",
           defaultClassNames.range_start,
         ),
-        range_middle: cn("rounded-none", defaultClassNames.range_middle),
-        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        range_middle: cn(
+          "rounded-none text-accent-foreground",
+          defaultClassNames.range_middle,
+        ),
+        range_end: cn(
+          "rounded-r-md bg-accent text-accent-foreground",
+          defaultClassNames.range_end,
+        ),
         today: cn(
           "bg-accent text-accent-foreground rounded-sm data-[selected=true]:rounded-none",
           defaultClassNames.today,
         ),
         outside: cn(
-          "text-muted-foreground aria-selected:text-muted-foreground",
+          "text-muted-foreground aria-selected:text-accent-foreground/70",
           defaultClassNames.outside,
         ),
         disabled: cn(

--- a/packages/ui/src/styles/brand-gold.css
+++ b/packages/ui/src/styles/brand-gold.css
@@ -197,6 +197,22 @@
   --header-bar-fg: #e8e8ec;
   --section-bar-bg: var(--rich-black);
   --section-bar-fg: #e8e8ec;
+
+  /* First-run text tokens default to dark-on-light values; without these
+     overrides, first-run/auth screens render near-invisible dark text on the
+     dark background (WCAG ratio ~1.05 on the sign-in heading). */
+  --first-run-text-strong: rgba(250, 250, 252, 0.98);
+  --first-run-text-primary: rgba(240, 240, 244, 0.96);
+  --first-run-text-subtle: rgba(208, 208, 216, 0.88);
+  --first-run-text-muted: rgba(192, 192, 202, 0.84);
+  --first-run-text-faint: rgba(160, 160, 172, 0.76);
+  --first-run-text-stroke: rgba(0, 0, 0, 0.42);
+  --first-run-input-bg: rgba(255, 255, 255, 0.08);
+  --first-run-text-support-bg: rgba(255, 255, 255, 0.06);
+  --first-run-card-bg: rgba(255, 255, 255, 0.05);
+  --first-run-card-bg-hover: rgba(255, 255, 255, 0.09);
+  --first-run-panel-bg: rgba(255, 255, 255, 0.05);
+  --first-run-roster-bg: rgba(255, 255, 255, 0.07);
 }
 
 [data-testid="companion-header-chat-controls"] > button {


### PR DESCRIPTION
## Summary

A full static + dynamic audit of the `packages/ui` Storybook (355 components / 1,604 stories, crawled headlessly with computed-style extraction and pixel verification) surfaced brand-contract violations, WCAG contrast failures, and 62 stories that failed to render at all. This PR fixes them in five phases; items that need an explicit design ruling (user accent presets, syntax-highlight palette, third-party brand colors, decorative gradient palettes) are deliberately untouched and listed at the end.

## Phases

1. **First-run/auth dark-theme tokens** (`styles/brand-gold.css`) — the `--first-run-text-*` token set only had light-appearance values, so LoginView/setup headings rendered dark-on-dark at WCAG ratio ~1.05 (verified invisible by pixel sampling). Added dark-scope overrides.
2. **62 broken stories across 17 components** — story decorators mounted a raw `AppContext.Provider` with a local mock but never seeded the `useAppSelector` external store; every selector-based consumer threw. All migrated to the shared `MockAppProvider`. Re-crawl: 62 broken → 0 (AccountCard "empty" flag is a crawler race; probe shows full render, zero page errors).
3. **Green off-token sweep** — raw `green-*`/`emerald-*` classes → `--status-success` token utilities (local-inference, workflow pages, cloud panel, voice HUD).
4. **Banned purple/blue on cloud surfaces** — timeline `from-purple-500 via-blue-500` gradient, monetization/redemptions purple badges + icons, recharts `#a855f7` fill → accent tokens. Also: ConnectionCard "Connected" badge black-on-#121212 (ratio 1.1) → status-success tokens; RevenueFlowDiagram white-on-mid-gray → accent-subtle surfaces; Timeline h3-larger-than-h2 inversion fixed.
5. **Strays** — notifications retry button `bg-orange-500/hover:orange-600` → `bg-accent/hover:bg-accent-hover` (brand hover rule: darker orange, never black); calendar range/today cells pinned to `text-accent-foreground` (day numbers previously ~2.2–2.75:1 on the orange fill).

## Verification

- Dynamic re-crawl of all 112 affected stories on a Storybook built from this branch: **0 `useAppSelector` errors** (was 61), **broken stories 62 → 0**, **no rendered purple/blue** outside the deferred exemptions (the one remaining blue pixel-hit is Discord's `#5865f2` logo tile, a deliberate third-party brand color).
- Pixel verification: LoginView heading spread 1 → readable; calendar range day spread 209 (readable); ModelCard/ConfirmDelete/Cockpit buttons readable (earlier flags were an rgb-parser artifact on `oklab()` backgrounds).
- `bun run --cwd packages/ui typecheck` clean; Biome clean on all touched files.
- `bun run --cwd packages/ui test`: 17 failures / 4 lint errors — **byte-identical to clean `develop`** (verified by stash-baseline; none in touched files).

## Deferred for design ruling (not in this PR)

- User-selectable accent presets (`state/ui-preferences.ts`) render red/amber/rose swatches by design.
- VS Code syntax palette in `cloud-ui/components/code/code-display.tsx` (blues/purples).
- Discord/Telegram/LinkedIn brand colors in connection surfaces.
- Decorative tile/avatar gradient palettes (`ViewTileImage`, `app-identity`, wallpaper idioms) — two pairs breach no-blue/purple.
- Remaining raw red/amber status classes in cloud dashboard pages (pending ruling on whether red maps to orange `--destructive` everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before / after (inline)

Each image is a labeled side-by-side pair: **left = BEFORE** (develop @ `6a0afa8a21`), **right = AFTER** (this branch).

### LoginView — invisible heading fixed (desktop)
![LoginView before/after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-loginview-desktop.jpg)

### LoginView (mobile)
![LoginView before/after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-loginview-mobile.jpg)

### AccountCard — Storybook error screen → rendered card (1 of 62 fixed stories)
![AccountCard before/after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-accountcard-broken-fixed-desktop.jpg)

### Timeline — banned purple/blue gradient → accent
![Timeline before/after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-timeline-gradient-desktop.jpg)

### ConnectionCard — unreadable Connected badge → status-success tokens
![ConnectionCard before/after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-connectioncard-badge-desktop.jpg)

### RevenueFlowDiagram — white-on-gray → accent-subtle surfaces
![RevenueFlowDiagram before/after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-revenueflow-contrast-desktop.jpg)

### Calendar — range day numbers readable on the orange fill
![Calendar before/after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-calendar-range-desktop.jpg)

## Evidence

<!-- evidence-head:3ece40e90fd0f94df6c527dc3c379c899e27ba3d -->

All assets on the `pr-evidence-9` release. Every screenshot pair is a labeled side-by-side: left = **BEFORE** (develop @ `6a0afa8a21`, Storybook :6006), right = **AFTER** (this branch, Storybook :6007).

<!-- evidence-row:before-screenshots -->
- Before screenshots (left half of each labeled pair; all 22 affected stories, desktop + mobile): [25901-all-pairs-desktop.zip](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-all-pairs-desktop.zip) · [25901-all-pairs-mobile.zip](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-all-pairs-mobile.zip) · key singles: [25901-loginview-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-loginview-desktop.jpg) · [25901-accountcard-broken-fixed-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-accountcard-broken-fixed-desktop.jpg)

<!-- evidence-row:after-screenshots -->
- After screenshots (right half of the same pairs): [25901-loginview-mobile.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-loginview-mobile.jpg) · [25901-timeline-gradient-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-timeline-gradient-desktop.jpg) · [25901-connectioncard-badge-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-connectioncard-badge-desktop.jpg) · [25901-revenueflow-contrast-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-revenueflow-contrast-desktop.jpg) · [25901-calendar-range-desktop.jpg](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-calendar-range-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- Walkthrough video (12 fixed stories, each shown before then after with on-screen labels): https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-walkthrough-v2.mp4

<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - Storybook-only component catalog change; no server path fires (no backend process involved)`

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs (post-fix crawl of all 112 affected stories — 0 useAppSelector errors, was 61): [25901-frontend-console-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-frontend-console-logs.json)

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent, model, prompt, provider, or action behavior changed`

<!-- evidence-row:domain-artifacts -->
- Domain artifacts (the audit datasets this PR is built on — per-story computed-color/contrast crawls): [25901-audit-crawl-before.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-audit-crawl-before.jsonl) (develop, all 1604 stories: 62 broken, 61 useAppSelector errors, contrast failures) · [25901-audit-crawl-after.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-audit-crawl-after.jsonl) (this branch, 112 affected stories: 0 errors)

<!-- evidence-row:ocr-review -->
- OCR visual text review (tesseract readout, before vs after; LoginView heading unreadable → full copy, AccountCard error screen → real card text): [25901-ocr-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25901-ocr-review.md)
