### PR TITLE
fix(health): safe NaN handling in awake-probability, sleep cycle, and regularity sort comparators

### DIFF
--- a/plugins/plugin-health/src/sleep/awake-probability.compute.test.ts
+++ b/plugins/plugin-health/src/sleep/awake-probability.compute.test.ts
@@ -111,4 +111,31 @@ describe("computeAwakeProbability", () => {
     }
     expect(awake.computedAt).toBe(iso(nowDay));
   });
+
+  it("selects strongest evidence deterministically when evidence confidences contain non-finite numbers", () => {
+    const result = computeAwakeProbability(
+      args({
+        nowMs: now3am,
+        timezone: "UTC",
+        signals: [],
+        windows: [],
+        sleepCycle: {
+          isProbablySleeping: true,
+          sleepConfidence: 0.9,
+          currentSleepStartedAt: iso(now3am - 4 * 3_600_000),
+          lastSleepEndedAt: null,
+          sleepStatus: "sleeping_now",
+          evidence: [
+            { source: "device_gap", confidence: Number.NaN },
+            { source: "wearable_tracker", confidence: 0.85 },
+            { source: "ambient_sensor", confidence: 0.5 },
+          ],
+        },
+        regularity: insufficientRegularity,
+      }),
+    );
+    expect(result.contributingSources.map((c) => c.source)).toContain(
+      "wearable_tracker",
+    );
+  });
 });

--- a/plugins/plugin-health/src/sleep/awake-probability.ts
+++ b/plugins/plugin-health/src/sleep/awake-probability.ts
@@ -151,9 +151,19 @@ export function computeAwakeProbability(args: {
     args.nowMs >= currentSleepStartMs
   ) {
     const strongestEvidence =
-      [...args.sleepCycle.evidence].sort(
-        (left, right) => right.confidence - left.confidence,
-      )[0]?.source ?? "activity_gap";
+      [...args.sleepCycle.evidence].sort((left, right) => {
+        const rightConf =
+          typeof right.confidence === "number" &&
+          Number.isFinite(right.confidence)
+            ? right.confidence
+            : 0;
+        const leftConf =
+          typeof left.confidence === "number" &&
+          Number.isFinite(left.confidence)
+            ? left.confidence
+            : 0;
+        return rightConf - leftConf || left.source.localeCompare(right.source);
+      })[0]?.source ?? "activity_gap";
     const sleepWeight = -2.8 * clamp(args.sleepCycle.sleepConfidence, 0.3, 1);
     contributors.push({
       source: strongestEvidence,

--- a/plugins/plugin-health/src/sleep/sleep-cycle.ts
+++ b/plugins/plugin-health/src/sleep/sleep-cycle.ts
@@ -101,10 +101,13 @@ function normalizeSleepHour(hour: number): number {
 }
 
 function median(values: number[]): number | null {
-  if (values.length === 0) {
+  const finiteValues = values.filter(
+    (v) => typeof v === "number" && Number.isFinite(v),
+  );
+  if (finiteValues.length === 0) {
     return null;
   }
-  const sorted = [...values].sort((left, right) => left - right);
+  const sorted = [...finiteValues].sort((left, right) => left - right);
   const middle = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 1) {
     return sorted[middle] ?? null;

--- a/plugins/plugin-health/src/sleep/sleep-regularity.ts
+++ b/plugins/plugin-health/src/sleep/sleep-regularity.ts
@@ -242,8 +242,11 @@ function circularMeanHour(minuteValues: readonly number[]): number | null {
 }
 
 function medianNumber(values: readonly number[]): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((left, right) => left - right);
+  const finiteValues = values.filter(
+    (v) => typeof v === "number" && Number.isFinite(v),
+  );
+  if (finiteValues.length === 0) return null;
+  const sorted = [...finiteValues].sort((left, right) => left - right);
   const middle = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 1) {
     const value = sorted[middle];


### PR DESCRIPTION
## Summary

Guards numerical comparisons in `plugins/plugin-health/src/sleep/awake-probability.ts`, `sleep-cycle.ts`, and `sleep-regularity.ts` with `Number.isFinite(...)` and filters non-finite values before calculating median sleep metrics, preventing `NaN` confidence and non-finite timestamps from breaking sort transitivity or returning corrupted sleep analytics.

## Changes

- In `plugins/plugin-health/src/sleep/awake-probability.ts:153`, guard `confidence` comparison with `Number.isFinite(...)` and add deterministic source tiebreaker.
- In `plugins/plugin-health/src/sleep/sleep-cycle.ts:103`, filter non-finite numbers before computing median duration.
- In `plugins/plugin-health/src/sleep/sleep-regularity.ts:244`, filter non-finite numbers before computing median values in `medianNumber`.
- In `plugins/plugin-health/src/sleep/awake-probability.compute.test.ts`, add unit test verifying that `computeAwakeProbability` deterministically selects the strongest evidence when evidence confidences contain `NaN`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`dc5ea4fa9a`) |
| --- | --- | --- |
| `bun test src/sleep/awake-probability.compute.test.ts` (in `plugins/plugin-health`) | 5 pass (5 tests) | 6 pass (6 tests) |
| `bun test src/sleep/sleep-cycle.test.ts` (in `plugins/plugin-health`) | 8 pass (8 tests) | 8 pass (8 tests) |
| `bun test src/sleep/sleep-regularity.baseline.test.ts` (in `plugins/plugin-health`) | 3 pass (3 tests) | 3 pass (3 tests) |
| `bunx @biomejs/biome check plugins/plugin-health/src/sleep/awake-probability.ts plugins/plugin-health/src/sleep/sleep-cycle.ts plugins/plugin-health/src/sleep/sleep-regularity.ts plugins/plugin-health/src/sleep/awake-probability.compute.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-health/src/sleep/awake-probability.ts:150-165`
- `plugins/plugin-health/src/sleep/sleep-cycle.ts:100-115`
- `plugins/plugin-health/src/sleep/sleep-regularity.ts:240-255`
- `plugins/plugin-health/src/sleep/awake-probability.compute.test.ts:100-140`

## Risks

Low. Guarantees finite numerical comparisons and stable median calculations.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Health plugin sleep metrics sorting)
- [x] `audit:browser` — N/A (Awake probability and sleep cycle calculations)
- [x] `build` — Clean build across workspace
- [x] `test` — All tests pass in `plugin-health`
- [x] `lint` — Biome clean
