### PR TITLE
fix(evidence): buffer large release inventories

### DIFF
--- a/scripts/pr-evidence.mjs
+++ b/scripts/pr-evidence.mjs
@@ -36,6 +36,7 @@ import { pathToFileURL } from "node:url";
 
 const PRIMARY_RELEASE_TAG = "pr-evidence";
 const REPO = "elizaOS/eliza";
+const TOOL_OUTPUT_MAX_BYTES = 64 * 1024 * 1024;
 // GitHub caps a single release at 1000 assets. Keep headroom below that so a
 // normal multi-file batch never straddles the boundary; roll to the next
 // overflow release before the wall. The 422 fallback in `uploadAssets` covers
@@ -57,8 +58,21 @@ const ROW_IDS = [
   "ocr-review",
 ];
 
+/**
+ * Runs a tooling child with the repository-standard 64 MiB output ceiling.
+ * Release-family inventories exceed Node's default; callers can override the
+ * bound or other child-process options deliberately through `opts`.
+ */
+export function runBufferedUtf8(file, args, opts = {}) {
+  return execFileSync(file, args, {
+    encoding: "utf8",
+    maxBuffer: TOOL_OUTPUT_MAX_BYTES,
+    ...opts,
+  });
+}
+
 function gh(args, opts = {}) {
-  return execFileSync("gh", args, { encoding: "utf8", ...opts });
+  return runBufferedUtf8("gh", args, opts);
 }
 
 function fail(message) {

--- a/scripts/pr-evidence.test.mjs
+++ b/scripts/pr-evidence.test.mjs
@@ -1,8 +1,7 @@
 /**
- * Tests for the pr-evidence uploader's overflow logic: the pure release-
- * selection rule plus the upload/rollover pipeline (uploadAssets, attach,
- * createOverflowReleaseIfAbsent) driven through an injected `gh` runner.
- * Deterministic: no network or real `gh` process is touched.
+ * Exercises the PR-evidence CLI's bounded child runner and release rollover.
+ * The buffering regression uses a real local Node child; release operations
+ * use an injected `gh` runner, so the suite never touches GitHub.
  */
 
 import assert from "node:assert/strict";
@@ -24,6 +23,7 @@ import {
   prEvidenceReleaseIndex,
   prEvidenceTagForIndex,
   renderRow,
+  runBufferedUtf8,
   selectPrEvidenceTarget,
   uploadAssets,
 } from "./pr-evidence.mjs";
@@ -51,6 +51,20 @@ function attributionFooter({ separator = true } = {}) {
   ];
   return lines.join("\n");
 }
+
+describe("bounded child-process output", () => {
+  it("captures output above Node's default one-mebibyte ceiling", () => {
+    const payloadBytes = 1_100_000;
+    const sentinel = "<complete>";
+    const output = runBufferedUtf8(process.execPath, [
+      "-e",
+      `process.stdout.write("x".repeat(${payloadBytes})); process.stdout.write("${sentinel}");`,
+    ]);
+
+    assert.equal(output.length, payloadBytes + sentinel.length);
+    assert.ok(output.endsWith(sentinel));
+  });
+});
 
 describe("pr-evidence tag <-> sequence index", () => {
   it("maps the primary tag to index 1 and overflow tags to their number", () => {


### PR DESCRIPTION
# Relates to

Closes #25871.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; the exact unrelated Windows/Turbo blocker is recorded below.
- [x] A reviewer can confirm the change from the live before/after transcript and automated regression below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `fd3800f1700430b83115426d6a6146b55271bdda`; zero conflicts.
- [x] Post-sync focused checks pass; the exact unrelated full-verify blocker is documented in **Known gaps / failures**.

# Risks

Low. The change only raises the bounded UTF-8 output ceiling for `pr-evidence` tooling children to the repository-standard 64 MiB. Caller-supplied child-process options remain authoritative, so existing explicit limits and stdio behavior are preserved.

# Background

## What does this PR do?

The live `pr-evidence` release-family inventory is now 1,069,675 bytes across 7,067 assets. Node's default synchronous child-process buffer is 1 MiB, so the uploader terminates `gh` with `ENOBUFS` before it can parse the inventory.

This PR adds a small bounded UTF-8 child runner, routes the existing `gh` helper through it, and adds a real local child-process regression that emits more than 1 MiB plus a trailing sentinel.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. The affected helper and regression test document the buffer contract at the implementation boundary.

# Testing

## Where should a reviewer start?

Start with `runBufferedUtf8` in `scripts/pr-evidence.mjs`, then the `bounded child-process output` case in `scripts/pr-evidence.test.mjs`.

## Detailed testing steps

1. Run `node --test scripts/pr-evidence.test.mjs` and confirm 36/36 tests pass.
2. Run `bun test scripts/pr-evidence.test.mjs` and confirm 36/36 tests pass.
3. Run `biome check scripts/pr-evidence.mjs scripts/pr-evidence.test.mjs` and confirm both files are clean.
4. Invoke the release-family query with Node's default `execFileSync` buffer and observe `ENOBUFS` at 1,069,675 bytes.
5. Invoke the same query through `runBufferedUtf8` and confirm all 9 release records / 7,067 assets parse with the trailing newline intact.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:651a2569133fa007d465b873ea040ea85faeae62 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - command-line-only tooling changes; no rendered UI surface exists before the fix.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - command-line-only tooling changes; no rendered UI surface exists after the fix.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the change has no interactive UI or visual user flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: exact live inventory and focused-suite transcript.

<details><summary>Exact post-sync transcript</summary>

```text
$ node --test scripts/pr-evidence.test.mjs
tests 36; pass 36; fail 0; duration_ms 152.6794
$ bun test scripts/pr-evidence.test.mjs
36 pass; 0 fail; Ran 36 tests across 1 file.
$ biome check scripts/pr-evidence.mjs scripts/pr-evidence.test.mjs
Checked 2 files. No fixes applied.
$ default execFileSync against the live release-family query
{"ok":false,"code":"ENOBUFS","errno":-4060,"syscall":"spawnSync gh","stdoutBytes":1069675}
$ runBufferedUtf8 against the same live release-family query
{"bytes":1069675,"releases":9,"assets":7067,"complete":true}
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, browser request, or client state path changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the read-only release inventory produces no persistent domain artifact.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

The exact live backend/tooling transcript is embedded in the `backend-logs` evidence row above. Frontend logs are N/A because this PR has no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - command-line-only tooling change with no rendered surface.

### Before

N/A - no rendered surface.

### After

N/A - no rendered surface.

### Walkthrough video

N/A - no interactive visual flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

`bun install --frozen-lockfile` completed successfully with pinned Bun 1.3.14. On this Windows host, the repository's postinstall logged `EPERM` warnings for optional directory symlinks, then completed and built its private workspace package.

`bun run verify` passed the guide-pair, Biome-version, i18n, Bun-version, Turbo-cache, workspace-dependency, plugin-test-convention, alias-read, and tsconfig-resolution gates. It then stopped before package typecheck/lint execution because Turbo reported:

```text
x Unable to find package manager binary: cannot find binary path
error: script "verify" exited with code 1
```

The pinned `bun` executable remained directly resolvable and runnable from Node on the same `PATH`; this host/Turbo discovery failure is unrelated to the two changed `.mjs` files. The exact-file Biome check and both Node and Bun focused suites pass post-sync.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

