### PR TITLE
test(app-core): cover preaction

### DIFF
--- a/packages/app-core/src/cli/program/preaction.test.ts
+++ b/packages/app-core/src/cli/program/preaction.test.ts
@@ -1,147 +1,327 @@
 /**
- * Covers registerPreActionHooks in ./preaction.ts: the Commander `preAction`
- * hook it installs must set the process title from the top-level command, emit
- * the banner and schedule the update check for ordinary commands, and skip both
- * for `--help`/`--version`, the update/completion commands, and
- * `ELIZA_HIDE_BANNER`. The hook's collaborators (argv parsing, banner,
- * globals, update notifier) are mocked so the assertions are about the hook's
- * own branching; the hook itself is the real exported implementation.
+ * Direct unit coverage for Commander `preAction` hook wiring. Drives the real
+ * `registerPreActionHooks` export through a real Commander program: process-title
+ * derivation from the command parent chain, the help/version short-circuit,
+ * banner and update-notification skip branches, verbose/debug flag application,
+ * and `NODE_NO_WARNINGS` assignment. The hook module is not mocked.
  */
+import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as updateNotifier from "../../services/update-notifier";
+import { isVerbose, setVerbose } from "../../utils/globals";
+import * as banner from "../banner";
+import { resolveCliName } from "../cli-name";
+import { registerPreActionHooks } from "./preaction";
 
-const mocks = vi.hoisted(() => ({
-  isTruthyEnvValue: vi.fn(() => false),
-  setVerbose: vi.fn(),
-  getCommandPath: vi.fn((): string[] => []),
-  getVerboseFlag: vi.fn(() => false),
-  hasHelpOrVersion: vi.fn(() => false),
-  emitCliBanner: vi.fn(),
-  resolveCliName: vi.fn(() => "eliza"),
-  scheduleUpdateNotification: vi.fn(),
-}));
+const ORIGINAL_ARGV = process.argv.slice();
+const ORIGINAL_TITLE = process.title;
+const ORIGINAL_NODE_NO_WARNINGS = process.env.NODE_NO_WARNINGS;
+const ORIGINAL_HIDE_BANNER = process.env.ELIZA_HIDE_BANNER;
+const ORIGINAL_CI = process.env.CI;
+const PROGRAM_VERSION = "9.9.9-preaction-test";
 
-vi.mock("@elizaos/shared", () => ({
-  isTruthyEnvValue: (...a: unknown[]) => mocks.isTruthyEnvValue(...a),
-}));
-vi.mock("../../utils/globals", () => ({
-  setVerbose: (...a: unknown[]) => mocks.setVerbose(...a),
-}));
-vi.mock("../argv", () => ({
-  getCommandPath: (...a: unknown[]) => mocks.getCommandPath(...a),
-  getVerboseFlag: (...a: unknown[]) => mocks.getVerboseFlag(...a),
-  hasHelpOrVersion: (...a: unknown[]) => mocks.hasHelpOrVersion(...a),
-}));
-vi.mock("../banner", () => ({
-  emitCliBanner: (...a: unknown[]) => mocks.emitCliBanner(...a),
-}));
-vi.mock("../cli-name", () => ({
-  resolveCliName: (...a: unknown[]) => mocks.resolveCliName(...a),
-}));
-vi.mock("../../services/update-notifier", () => ({
-  scheduleUpdateNotification: (...a: unknown[]) =>
-    mocks.scheduleUpdateNotification(...a),
-}));
+type PreActionFn = (
+  thisCommand: Command,
+  actionCommand: Command,
+) => void | Promise<void>;
 
-type PreActionHook = (
-  thisCommand: unknown,
-  actionCommand: unknown,
-) => Promise<void>;
+function getPreAction(program: Command): PreActionFn {
+  const hooks = (
+    program as Command & {
+      _lifeCycleHooks?: { preAction?: PreActionFn[] };
+    }
+  )._lifeCycleHooks?.preAction;
+  const hook = hooks?.[0];
+  if (hooks?.length !== 1 || !hook) {
+    throw new Error(`expected 1 preAction hook, got ${hooks?.length ?? 0}`);
+  }
+  return hook;
+}
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut() {},
+    writeErr() {},
+  });
+  program.name(resolveCliName());
+  program.helpOption(false);
+  registerPreActionHooks(program, PROGRAM_VERSION);
+  return program;
+}
+
+async function runHook(
+  program: Command,
+  actionCommand: Command,
+): Promise<void> {
+  await getPreAction(program)(program, actionCommand);
+}
 
 describe("registerPreActionHooks", () => {
-  let hookFn: PreActionHook;
-  let originalTitle: string;
-
-  beforeEach(async () => {
-    vi.resetModules();
-    mocks.hasHelpOrVersion.mockReset().mockReturnValue(false);
-    mocks.getCommandPath.mockReset().mockReturnValue([]);
-    mocks.getVerboseFlag.mockReset().mockReturnValue(false);
-    mocks.isTruthyEnvValue.mockReset().mockReturnValue(false);
-    mocks.resolveCliName.mockReset().mockReturnValue("eliza");
-    mocks.scheduleUpdateNotification.mockReset();
-    mocks.emitCliBanner.mockReset();
-    mocks.setVerbose.mockReset();
-    originalTitle = process.title;
-
-    const mod = await import("./preaction.ts");
-    const program = {
-      hook: vi.fn((_name: string, fn: PreActionHook) => {
-        hookFn = fn;
-      }),
-    };
-    mod.registerPreActionHooks(program as never, "1.0.0");
-    expect(program.hook).toHaveBeenCalledWith(
-      "preAction",
-      expect.any(Function),
-    );
+  beforeEach(() => {
+    process.argv = ["node", "eliza", "start"];
+    process.title = "node";
+    delete process.env.ELIZA_HIDE_BANNER;
+    delete process.env.NODE_NO_WARNINGS;
+    process.env.CI = "1";
+    setVerbose(false);
+    vi.spyOn(banner, "emitCliBanner");
+    vi.spyOn(updateNotifier, "scheduleUpdateNotification");
   });
 
   afterEach(() => {
-    process.title = originalTitle;
-  });
-
-  function mockActionCommand(name = "chat") {
-    return { name: vi.fn(() => name), parent: { parent: null } };
-  }
-
-  it("emits the banner and schedules the update check for an ordinary command", async () => {
-    await hookFn({}, mockActionCommand());
-    expect(mocks.emitCliBanner).toHaveBeenCalledWith("1.0.0");
-    expect(mocks.scheduleUpdateNotification).toHaveBeenCalledTimes(1);
-  });
-
-  it("sets the process title from the top-level command name", async () => {
-    await hookFn({}, mockActionCommand("start"));
-    expect(process.title).toBe("eliza-start");
-  });
-
-  it("leaves the process title alone when the command is the CLI itself", async () => {
-    const before = process.title;
-    await hookFn({}, mockActionCommand("eliza"));
-    expect(process.title).toBe(before);
-  });
-
-  it("resolves the verbose flag and silences node warnings when not verbose", async () => {
-    const hadNoWarnings = process.env.NODE_NO_WARNINGS;
-    delete process.env.NODE_NO_WARNINGS;
-    try {
-      await hookFn({}, mockActionCommand());
-      expect(mocks.setVerbose).toHaveBeenCalledWith(false);
-      expect(process.env.NODE_NO_WARNINGS).toBe("1");
-    } finally {
-      if (hadNoWarnings === undefined) delete process.env.NODE_NO_WARNINGS;
-      else process.env.NODE_NO_WARNINGS = hadNoWarnings;
+    vi.restoreAllMocks();
+    process.argv = ORIGINAL_ARGV;
+    process.title = ORIGINAL_TITLE;
+    setVerbose(false);
+    if (ORIGINAL_NODE_NO_WARNINGS === undefined) {
+      delete process.env.NODE_NO_WARNINGS;
+    } else {
+      process.env.NODE_NO_WARNINGS = ORIGINAL_NODE_NO_WARNINGS;
+    }
+    if (ORIGINAL_HIDE_BANNER === undefined) {
+      delete process.env.ELIZA_HIDE_BANNER;
+    } else {
+      process.env.ELIZA_HIDE_BANNER = ORIGINAL_HIDE_BANNER;
+    }
+    if (ORIGINAL_CI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = ORIGINAL_CI;
     }
   });
 
-  it("skips everything when help/version is in argv", async () => {
-    mocks.hasHelpOrVersion.mockReturnValue(true);
-    await hookFn({}, mockActionCommand());
-    expect(mocks.emitCliBanner).not.toHaveBeenCalled();
-    expect(mocks.scheduleUpdateNotification).not.toHaveBeenCalled();
-    expect(mocks.setVerbose).not.toHaveBeenCalled();
+  it("installs a single preAction hook on the program", () => {
+    const program = makeProgram();
+    expect(typeof getPreAction(program)).toBe("function");
   });
 
+  it("runs before the command action when Commander parses", async () => {
+    const program = makeProgram();
+    const order: string[] = [];
+    program.command("start").action(() => {
+      order.push("action");
+    });
+
+    await program.parseAsync(["node", "eliza", "start"]);
+
+    expect(order).toEqual(["action"]);
+    expect(process.title).toBe(`${resolveCliName()}-start`);
+    expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+    expect(updateNotifier.scheduleUpdateNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets the process title from a top-level command name", async () => {
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+    expect(process.title).toBe(`${resolveCliName()}-start`);
+  });
+
+  it("walks nested commands up to the top-level command name", async () => {
+    const program = makeProgram();
+    const plugin = program.command("plugin");
+    const nested = plugin.command("nested");
+    const leaf = nested.command("leaf");
+
+    await runHook(program, leaf);
+
+    expect(process.title).toBe(`${resolveCliName()}-plugin`);
+  });
+
+  it("leaves the process title alone when the command is the CLI itself", async () => {
+    const program = makeProgram();
+    const before = process.title;
+    await runHook(program, program);
+    expect(process.title).toBe(before);
+  });
+
+  it("leaves the process title alone when the command name is empty", async () => {
+    const program = makeProgram();
+    const unnamed = new Command("");
+    const before = process.title;
+    await runHook(program, unnamed);
+    expect(unnamed.name()).toBe("");
+    expect(process.title).toBe(before);
+  });
+
+  it("sets the process title when a root command uses a different name", async () => {
+    const program = makeProgram();
+    program.name("other");
+    await runHook(program, program);
+    expect(process.title).toBe(`${resolveCliName()}-other`);
+  });
+
+  it("emits the banner and schedules the update check for an ordinary command", async () => {
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+    expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+    expect(updateNotifier.scheduleUpdateNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["-h", "--help", "-v", "-V", "--version"] as const)(
+    "skips banner, notifier, and verbose setup when argv contains %s",
+    async (flag) => {
+      process.argv = ["node", "eliza", "start", flag];
+      const program = makeProgram();
+      const start = program.command("start");
+      await runHook(program, start);
+
+      expect(process.title).toBe(`${resolveCliName()}-start`);
+      expect(banner.emitCliBanner).not.toHaveBeenCalled();
+      expect(updateNotifier.scheduleUpdateNotification).not.toHaveBeenCalled();
+      expect(isVerbose()).toBe(false);
+      expect(process.env.NODE_NO_WARNINGS).toBeUndefined();
+    },
+  );
+
+  it("still short-circuits when --help appears after the -- terminator", async () => {
+    process.argv = ["node", "eliza", "start", "--", "--help"];
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+
+    expect(banner.emitCliBanner).not.toHaveBeenCalled();
+    expect(updateNotifier.scheduleUpdateNotification).not.toHaveBeenCalled();
+    expect(isVerbose()).toBe(false);
+  });
+
+  it.each(["1", "true", "yes", "y", "on", "enabled"] as const)(
+    "skips the banner when ELIZA_HIDE_BANNER is %s",
+    async (value) => {
+      process.env.ELIZA_HIDE_BANNER = value;
+      const program = makeProgram();
+      const start = program.command("start");
+      await runHook(program, start);
+
+      expect(banner.emitCliBanner).not.toHaveBeenCalled();
+      expect(updateNotifier.scheduleUpdateNotification).not.toHaveBeenCalled();
+      expect(isVerbose()).toBe(false);
+      expect(process.env.NODE_NO_WARNINGS).toBe("1");
+    },
+  );
+
+  it.each(["0", "false", "no", "", "  "] as const)(
+    "does not treat ELIZA_HIDE_BANNER=%j as a hide request",
+    async (value) => {
+      process.env.ELIZA_HIDE_BANNER = value;
+      const program = makeProgram();
+      const start = program.command("start");
+      await runHook(program, start);
+
+      expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+      expect(updateNotifier.scheduleUpdateNotification).toHaveBeenCalledTimes(
+        1,
+      );
+    },
+  );
+
   it("skips the banner for the update command", async () => {
-    mocks.getCommandPath.mockReturnValue(["update"]);
-    await hookFn({}, mockActionCommand());
-    expect(mocks.emitCliBanner).not.toHaveBeenCalled();
-    expect(mocks.scheduleUpdateNotification).not.toHaveBeenCalled();
+    process.argv = ["node", "eliza", "update"];
+    const program = makeProgram();
+    const update = program.command("update");
+    await runHook(program, update);
+
+    expect(banner.emitCliBanner).not.toHaveBeenCalled();
+    expect(updateNotifier.scheduleUpdateNotification).not.toHaveBeenCalled();
+    expect(process.env.NODE_NO_WARNINGS).toBe("1");
   });
 
   it("skips the banner for the completion command", async () => {
-    mocks.getCommandPath.mockReturnValue(["completion"]);
-    await hookFn({}, mockActionCommand());
-    expect(mocks.emitCliBanner).not.toHaveBeenCalled();
-    expect(mocks.scheduleUpdateNotification).not.toHaveBeenCalled();
+    process.argv = ["node", "eliza", "completion"];
+    const program = makeProgram();
+    const completion = program.command("completion");
+    await runHook(program, completion);
+
+    expect(banner.emitCliBanner).not.toHaveBeenCalled();
+    expect(updateNotifier.scheduleUpdateNotification).not.toHaveBeenCalled();
   });
 
-  it("skips the banner when ELIZA_HIDE_BANNER is set", async () => {
-    mocks.isTruthyEnvValue.mockReturnValue(true);
-    await hookFn({}, mockActionCommand());
-    expect(mocks.emitCliBanner).not.toHaveBeenCalled();
-    expect(mocks.scheduleUpdateNotification).not.toHaveBeenCalled();
-    // The hook still resolves verbosity once the banner branch is skipped.
-    expect(mocks.setVerbose).toHaveBeenCalledWith(false);
+  it("does not hide the banner when update is not the first command path segment", async () => {
+    process.argv = ["node", "eliza", "plugins", "update"];
+    const program = makeProgram();
+    const plugins = program.command("plugins");
+    await runHook(program, plugins);
+
+    expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+    expect(updateNotifier.scheduleUpdateNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hide the banner for an empty command path", async () => {
+    process.argv = ["node", "eliza"];
+    const program = makeProgram();
+    await runHook(program, program);
+
+    expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+    expect(updateNotifier.scheduleUpdateNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("still calls emitCliBanner when argv includes --json (preaction does not skip it)", async () => {
+    process.argv = ["node", "eliza", "start", "--json"];
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+
+    expect(banner.emitCliBanner).toHaveBeenCalledWith(PROGRAM_VERSION);
+  });
+
+  it("sets verbose from --verbose and does not assign NODE_NO_WARNINGS", async () => {
+    process.argv = ["node", "eliza", "start", "--verbose"];
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+
+    expect(isVerbose()).toBe(true);
+    expect(process.env.NODE_NO_WARNINGS).toBeUndefined();
+  });
+
+  it("treats --debug as verbose because the hook passes includeDebug", async () => {
+    process.argv = ["node", "eliza", "start", "--debug"];
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+
+    expect(isVerbose()).toBe(true);
+    expect(process.env.NODE_NO_WARNINGS).toBeUndefined();
+  });
+
+  it("does not treat --verbose after -- as a verbose flag", async () => {
+    process.argv = ["node", "eliza", "start", "--", "--verbose"];
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+
+    expect(isVerbose()).toBe(false);
+    expect(process.env.NODE_NO_WARNINGS).toBe("1");
+  });
+
+  it("silences node warnings when not verbose and NODE_NO_WARNINGS is unset", async () => {
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+    expect(isVerbose()).toBe(false);
+    expect(process.env.NODE_NO_WARNINGS).toBe("1");
+  });
+
+  it("does not overwrite an existing NODE_NO_WARNINGS value", async () => {
+    process.env.NODE_NO_WARNINGS = "0";
+    const program = makeProgram();
+    const start = program.command("start");
+    await runHook(program, start);
+    expect(isVerbose()).toBe(false);
+    expect(process.env.NODE_NO_WARNINGS).toBe("0");
+  });
+
+  it("still applies verbose setup when the banner is hidden", async () => {
+    process.argv = ["node", "eliza", "update", "--verbose"];
+    const program = makeProgram();
+    const update = program.command("update");
+    await runHook(program, update);
+
+    expect(banner.emitCliBanner).not.toHaveBeenCalled();
+    expect(isVerbose()).toBe(true);
+    expect(process.env.NODE_NO_WARNINGS).toBeUndefined();
   });
 });


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/app-core/src/cli/program/preaction.ts`. Develop already had a colocated `preaction.test.ts`, but that suite mocked every collaborator (`argv`, banner, globals, `isTruthyEnvValue`, update notifier, and a fake Commander program). This PR replaces it with tests that drive the real hook.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is based on the latest fetched `origin/develop` (`fd3800f1700430b83115426d6a6146b55271bdda`) with a single test-file commit on top.
- [x] A reviewer can confirm the change from the focused Vitest output quoted below.

# Sync with develop

- [x] Branch tip is `origin/develop` plus this test-only commit; zero conflicts.
- [x] Hosted GitHub Actions CI does **not** run on this fork contributor PR. Focused vitest / biome / tsc proof is quoted below. Do not infer that Actions passed.

# Risks

Low. Production `registerPreActionHooks` is unchanged. The suite observes the real Commander `preAction` hook, real `process.argv`, real `ELIZA_HIDE_BANNER` truthiness, and real `setVerbose` / `NODE_NO_WARNINGS` assignment. `emitCliBanner` and `scheduleUpdateNotification` are spied only to record whether the hook called them.

# Background

## What does this PR do?

Rewrites `packages/app-core/src/cli/program/preaction.test.ts` so `registerPreActionHooks` is exercised through a real Commander program. Coverage includes:

- hook installation and Commander `parseAsync` firing the hook before the command action
- process-title derivation: top-level command, nested parent-chain walk, CLI-name match, empty name, differently named root
- `--help` / `--version` / `-h` / `-v` / `-V` short-circuit (title still set; banner, notifier, and verbose setup skipped), including `--help` after `--`
- banner hide: `ELIZA_HIDE_BANNER` truthy vs falsy values, `update` and `completion` first-path segments, empty path, `update` not in first segment, `--json` (preaction still calls `emitCliBanner`)
- `--verbose` and `--debug` (`includeDebug: true`), `--verbose` after `--`, `NODE_NO_WARNINGS ??= "1"` vs preserve-existing, verbose setup when the banner is hidden

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app-core/src/cli/program/preaction.test.ts` — colocated next to `preaction.ts`, same layout as `build-program.test.ts` and `register.benchmark.test.ts`. Import path is `./preaction`.

## Detailed testing steps

From the repository root, at the pushed head `188928504604e9eb6ac842ab2c32266b9336a259` (parent `origin/develop` `fd3800f1700430b83115426d6a6146b55271bdda`):

```bash
bunx vitest run packages/app-core/src/cli/program/preaction.test.ts --config packages/app-core/vitest.config.ts
bunx biome check --write packages/app-core/src/cli/program/preaction.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'preaction.test.ts' ; echo "EXIT:$?"
```

Focused Vitest (re-run after re-fetching current `origin/develop`; production `preaction.ts` is unchanged vs that tip):

```text
 ✓ packages/app-core/src/cli/program/preaction.test.ts (36 tests) 699ms

 Test Files  1 passed (1)
      Tests  36 passed (36)
   Start at  18:09:18
   Duration  9.59s (transform 6.87s, setup 0ms, import 8.80s, tests 699ms, environment 0ms)
```

`bunx biome check --write` on the test file: checked 1 file, no fixes applied.

`bunx tsc --noEmit` in `packages/app-core`: `preaction.test.ts` appears nowhere in the output (`grep` exit 1). The default package `tsconfig.json` excludes `src/cli/**`; the same grep against `tsc --noEmit -p tsconfig.typecheck.json` (which includes `src/cli`) is also empty, so this file adds zero TypeScript errors.

The diff touches only `packages/app-core/src/cli/program/preaction.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:188928504604e9eb6ac842ab2c32266b9336a259 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes; test-only CLI hook coverage.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes; test-only CLI hook coverage.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (36 passed / 36).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / schedule / wallet artifacts; unit tests of a CLI preAction hook.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR does not change agent, action, provider, prompt, or model code.

## Backend + frontend logs

N/A - no server or UI path changed. Focused Vitest output is quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI surfaces.

### Before

N/A - no UI surfaces.

### After

N/A - no UI surfaces.

### Walkthrough video

N/A - no UI surfaces.

## Audio / voice walkthrough

N/A - no voice / TTS / STT path changed.

## Known gaps / failures

Hosted GitHub Actions does not run on fork contributor PRs. Proof is the local vitest / biome / tsc commands quoted above.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
