### PR TITLE
chore(calendar): restore lint closure

### DIFF
--- a/plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts
+++ b/plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts
@@ -2,7 +2,7 @@
  * Behavioral regression for Date.UTC 0-99 — must use setUTCFullYear
  * Calls real calendar primitives that previously used Date.UTC(y,m,d) directly.
  */
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { addDaysToLocalDate, getWeekdayForLocalDate } from "../internal/time";
 
 function createUTCDateViaSet(y: number, m: number, d: number): Date {
@@ -44,7 +44,7 @@ describe("calendar Date.UTC 0-99 regression - real functions", () => {
     const w = getWeekdayForLocalDate({ year: 5, month: 6, day: 15 });
     const expected = createUTCDateViaSet(5, 5, 15).getUTCDay();
     expect(w).toBe(expected);
-    const buggy = new Date(Date.UTC(5, 5, 15, 12, 0, 0)).getUTCDay();
+    const _buggy = new Date(Date.UTC(5, 5, 15, 12, 0, 0)).getUTCDay();
     // For year 5 vs 1905, weekdays differ (1905-06-15 Thursday vs 0005-06-15 ...)
     // At least year is different, so we assert year fix, not just weekday coincidence
     expect(createUTCDateViaSet(5, 5, 15).getUTCFullYear()).toBe(5);

--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -181,7 +181,11 @@ export function addDaysToLocalDate(
   dayDelta: number,
 ): Pick<ZonedDateParts, "year" | "month" | "day"> {
   const utcDate = new Date(0);
-  utcDate.setUTCFullYear(dateOnly.year, dateOnly.month - 1, dateOnly.day + dayDelta);
+  utcDate.setUTCFullYear(
+    dateOnly.year,
+    dateOnly.month - 1,
+    dateOnly.day + dayDelta,
+  );
   utcDate.setUTCHours(12, 0, 0, 0);
   return {
     year: utcDate.getUTCFullYear(),


### PR DESCRIPTION
## Summary

- restore Biome import order in the Date.UTC regression test
- mark the intentionally unused buggy comparison as intentionally unused
- format the long setUTCFullYear call

This is a mechanical two-file closure for the plugin-calendar lint failure exposed by current Develop Full and PR Static Smoke. It does not change calendar behavior.

## Exact source

- base: fd3800f1700430b83115426d6a6146b55271bdda
- head: e85c96ce35cab0068bd6c53bcce0077eaeef6619
- local rollback tag: fix-plugin-calendar-format-closure-v1-20260823

## Proof

- Biome 2.5.8 format: clean
- Biome 2.5.8 check: clean
- bun test plugins/plugin-calendar/src/__tests__/regression-dateutc.test.ts: 6 pass, 0 fail, 15 assertions
- git diff --check: clean
- gitleaks exact one-commit range: no leaks

## Release boundary

No deployment or workflow dispatch. Cloudflare and Railway remain closed pending canonical green plus the separate Windows watchdog and Devices composition gates.