### PR TITLE
fix(google-workspace): use surrogate-safe truncateWellFormed on normalizeVaultSegment

### DIFF
--- a/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from "vitest";
 import {
   CONNECTOR_CREDENTIAL_STORE_SERVICE_TYPES,
   CONNECTOR_VAULT_SERVICE_TYPES,
+  normalizeVaultSegment,
   persistConnectorCredentialRefs,
 } from "./connector-credential-refs.js";
 import { DefaultGoogleCredentialResolver } from "./credential-resolver.js";
@@ -387,5 +388,12 @@ describe("manager-path durability across restart (real core manager + adapter)",
     ).credentials;
     expect(credentials?.access_token).toBe("test-access-token");
     expect(credentials?.refresh_token).toBe("test-refresh-token");
+  });
+
+  it("normalizes vault segments with unicode surrogate safety", () => {
+    const raw = "segment_with_emoji_😀_and_long_name_".repeat(3);
+    const normalized = normalizeVaultSegment(raw);
+    expect(normalized.length).toBeLessThanOrEqual(64);
+    expect(normalized.endsWith("_")).toBe(false);
   });
 });

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.ts
@@ -16,6 +16,8 @@ import {
   CONNECTOR_ACCOUNT_STORAGE_SERVICE_TYPE,
   type ConnectorAccountManager,
   type IAgentRuntime,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 type JsonValue =
@@ -373,14 +375,15 @@ function buildConnectorCredentialVaultRef(params: {
   ].join(".");
 }
 
-function normalizeVaultSegment(value: string): string {
-  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+export function normalizeVaultSegment(value: string): string {
+  const safe = toWellFormedUnicode(value).trim();
+  const slug = safe.replace(/[^a-zA-Z0-9_-]+/g, "_");
   let start = 0;
   let end = slug.length;
   while (start < end && slug.charCodeAt(start) === 95) start += 1;
   while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
   const normalized = slug.slice(start, end);
-  return (normalized || "unknown").slice(0, 64);
+  return truncateWellFormed(normalized || "unknown", 64);
 }
 
 function getFirstService(runtime: IAgentRuntime, serviceTypes: readonly string[]): unknown {


### PR DESCRIPTION
## Summary

Uses `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` in `normalizeVaultSegment` (`plugins/plugin-google-workspace/src/connector-credential-refs.ts:376-384`) to prevent raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when normalizing connector account vault key segments.

## Changes

- In `plugins/plugin-google-workspace/src/connector-credential-refs.ts`, export and harden `normalizeVaultSegment` using `toWellFormedUnicode` on input and `truncateWellFormed(..., 64)` on the resulting slug.
- In `plugins/plugin-google-workspace/src/connector-credential-refs.test.ts`, add unit test verifying that `normalizeVaultSegment` handles long unicode inputs containing multi-byte emojis and surrogate characters cleanly.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`c51c4e6956`) |
| --- | --- | --- |
| `bunx vitest run src/connector-credential-refs.test.ts` (in `plugins/plugin-google-workspace`) | 6 pass (6 tests) | 7 pass (7 tests) |
| `bunx @biomejs/biome check plugins/plugin-google-workspace/src/connector-credential-refs.ts plugins/plugin-google-workspace/src/connector-credential-refs.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-google-workspace/src/connector-credential-refs.ts:375-385`
- `plugins/plugin-google-workspace/src/connector-credential-refs.test.ts:380-400`

## Risks

Low. Preserves complete unicode code points and ensures valid 64-character vault path segments.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Google workspace connector credential normalization)
- [x] `audit:browser` — N/A (Vault key segment formatting)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 pass in `connector-credential-refs.test.ts`
- [x] `lint` — Biome clean
