### PR TITLE
test(app-core): cover version

### DIFF
--- a/packages/app-core/src/cli/version.test.ts
+++ b/packages/app-core/src/cli/version.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Direct unit coverage for the CLI_VERSION load-time constant. Drives the
+ * real `version` module: import-time resolution from this file's location,
+ * app-core package.json match when no bundle override is set, env preference
+ * on a fresh load, empty and whitespace overrides, and the 0.0.0 fallback
+ * when require() cannot see the package. Does not mock the module under test.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveElizaVersion } from "@elizaos/agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CLI_VERSION } from "./version";
+
+const VERSION_MODULE_URL = new URL("./version.ts", import.meta.url).href;
+const APP_CORE_PACKAGE_JSON = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+);
+const appCorePackage = JSON.parse(
+  readFileSync(APP_CORE_PACKAGE_JSON, "utf8"),
+) as {
+  name: string;
+  version: string;
+};
+const originalBundledVersion = process.env.ELIZA_BUNDLED_VERSION;
+
+afterEach(() => {
+  if (originalBundledVersion === undefined) {
+    delete process.env.ELIZA_BUNDLED_VERSION;
+  } else {
+    process.env.ELIZA_BUNDLED_VERSION = originalBundledVersion;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("CLI_VERSION", () => {
+  it("exports a non-empty string resolved at import time", () => {
+    expect(typeof CLI_VERSION).toBe("string");
+    expect(CLI_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("is the module's only named export", async () => {
+    const versionModule = await import("./version");
+    expect(Object.keys(versionModule).sort()).toEqual(["CLI_VERSION"]);
+  });
+
+  it("matches the app-core package.json version when no bundle override is set", () => {
+    expect(process.env.ELIZA_BUNDLED_VERSION).toBeUndefined();
+    expect(appCorePackage.name).toBe("@elizaos/app-core");
+    expect(appCorePackage.version.length).toBeGreaterThan(0);
+    expect(CLI_VERSION).toBe(appCorePackage.version);
+  });
+
+  it("equals resolveElizaVersion for this module's import.meta.url", () => {
+    expect(CLI_VERSION).toBe(resolveElizaVersion(VERSION_MODULE_URL));
+  });
+
+  it("is the same constant across a re-import of the cached module", async () => {
+    const again = await import("./version");
+    expect(again.CLI_VERSION).toBe(CLI_VERSION);
+  });
+
+  it("is not the stripped-bundle 0.0.0 fallback while package.json is visible", () => {
+    expect(CLI_VERSION).not.toBe("0.0.0");
+  });
+
+  it("anchors require() at version.ts so a foreign URL cannot see app-core package.json", () => {
+    expect(resolveElizaVersion("file:///tmp/not-an-app-core-module.ts")).toBe(
+      "0.0.0",
+    );
+    expect(CLI_VERSION).toBe(appCorePackage.version);
+  });
+
+  it("does not observe ELIZA_BUNDLED_VERSION mutations after the module has loaded", () => {
+    const snapshot = CLI_VERSION;
+    process.env.ELIZA_BUNDLED_VERSION = "mutated-after-load";
+    expect(CLI_VERSION).toBe(snapshot);
+    expect(resolveElizaVersion(VERSION_MODULE_URL)).toBe("mutated-after-load");
+  });
+
+  it("prefers ELIZA_BUNDLED_VERSION when the module is loaded under that env", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "9.9.9-bundled";
+    vi.resetModules();
+    const { CLI_VERSION: bundledVersion } = await import("./version");
+    expect(bundledVersion).toBe("9.9.9-bundled");
+  });
+
+  it("falls through an empty ELIZA_BUNDLED_VERSION to package.json", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "";
+    vi.resetModules();
+    const { CLI_VERSION: resolved } = await import("./version");
+    expect(resolved).toBe(appCorePackage.version);
+  });
+
+  it("uses a whitespace-only ELIZA_BUNDLED_VERSION as a truthy override", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = " ";
+    vi.resetModules();
+    const { CLI_VERSION: resolved } = await import("./version");
+    expect(resolved).toBe(" ");
+  });
+
+  it("treats ELIZA_BUNDLED_VERSION 0.0.0 as an override, not the missing-package fallback", async () => {
+    process.env.ELIZA_BUNDLED_VERSION = "0.0.0";
+    vi.resetModules();
+    const { CLI_VERSION: resolved } = await import("./version");
+    expect(resolved).toBe("0.0.0");
+    expect(appCorePackage.version).not.toBe("0.0.0");
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/cli/version.ts`, which had no same-named test file. No product issue: this records the live `CLI_VERSION` load-time resolution the CLI already ships.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`fd3800f1700430b83115426d6a6146b55271bdda`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Based on latest `origin/develop` (`fd3800f1700430b83115426d6a6146b55271bdda`); zero conflicts.
- [ ] `bun run verify` is not claimed. This is a test-only add; the focused vitest / biome / tsc checks below were run at this head. Hosted CI does **not** run on fork contributor PRs.

# Risks

Low. Adds one vitest file. No production code, no exports, no CLI behavior change.

# Background

## What does this PR do?

Adds `packages/app-core/src/cli/version.test.ts` next to `version.ts`, which exports the load-time constant `CLI_VERSION = resolveElizaVersion(import.meta.url)`. The suite drives the **real** module — no mocked resolver and no mock of the system under test.

Covered behavior, observed on the live module:

- `CLI_VERSION` is a non-empty string, and the module's only named export.
- With `ELIZA_BUNDLED_VERSION` unset, it matches `@elizaos/app-core` `package.json` (`2.0.3-beta.7`), which is the `../../package.json` `createRequire` lands on from `src/cli/version.ts`.
- It equals `resolveElizaVersion` for this module's `import.meta.url`.
- Re-importing the cached module returns the same constant.
- It is not the stripped-bundle `"0.0.0"` fallback while package.json is visible.
- A foreign `file://` URL that cannot see app-core `package.json` resolves to `"0.0.0"`; `CLI_VERSION` still matches the package version (the `import.meta.url` anchor).
- After load, mutating `ELIZA_BUNDLED_VERSION` does not change `CLI_VERSION`, while a fresh `resolveElizaVersion` call re-reads env.
- Fresh load with `ELIZA_BUNDLED_VERSION=9.9.9-bundled` prefers that override.
- Empty `ELIZA_BUNDLED_VERSION` falls through to package.json (falsy `||`).
- Whitespace-only `ELIZA_BUNDLED_VERSION` (`" "`) is a truthy override.
- `ELIZA_BUNDLED_VERSION=0.0.0` is an override, not the missing-package fallback (package.json is not `"0.0.0"`).

## What kind of change is this?

Improvements (test coverage only; no production behavior change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Run the new file:

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/cli/version.test.ts
```

## Detailed testing steps

Automated tests only. From `packages/app-core` at head `3addd9ea8c012690c3aa19c515c5517d963a937c`, re-run against current `origin/develop` immediately before filing:

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Duration ~22s (import of `@elizaos/agent` through the real `version` module). biome.json and tsconfig.json are present; sparse-checkout is not enabled.

```
bunx biome check --write packages/app-core/src/cli/version.test.ts
# Checked 1 file in 70ms. No fixes applied.
```

```
cd packages/app-core && bunx tsc --noEmit -p tsconfig.typecheck.json 2>&1 | grep 'version.test.ts' ; echo "EXIT:$?"
# empty grep (exit 1 from grep); the new file appears nowhere in tsc output.
# Default packages/app-core/tsconfig.json excludes src/cli/**, so typecheck.json
# is the config that actually compiles this file. Pre-existing errors elsewhere
# in the package are unchanged and do not mention version.test.ts.
```

The diff touches **only** `packages/app-core/src/cli/version.test.ts`.

# Evidence Gate

Evidence head: `3addd9ea8c012690c3aa19c515c5517d963a937c`

This PR adds tests and changes no production behavior, so UI/video/log/trajectory artifacts do not apply.

- [x] Before screenshots: N/A - test-only; no UI surface.
- [x] After screenshots: N/A - test-only; no UI surface.
- [x] Walkthrough video: N/A - test-only; no UI surface.
- [x] Backend logs: N/A - no production path change; vitest counts above are the proof.
- [x] Frontend logs: N/A - no frontend change.
- [x] LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - no DB/memory/schedule/wallet output.
- [x] OCR review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only; no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no production path change. Focused vitest run quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scoped proof is the 12/12 vitest pass, clean biome, and tsc grep with no hits on this file.
- Hosted GitHub Actions CI does **not** run on this fork contributor PR. Do not treat missing checks as a pass.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3addd9ea8c012690c3aa19c515c5517d963a937c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
