### PR TITLE
fix(capacitor-bridge): use surrogate-safe truncateWellFormed on model-grind sample and android diagnostics

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -62,7 +62,11 @@ process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING ||= "1";
 
 import * as nodeFs from "node:fs";
 import nodePath from "node:path";
-import type { IAgentRuntime } from "@elizaos/core";
+import {
+	type IAgentRuntime,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "@elizaos/core";
 import { androidAliasSibling, installMobileFsShim } from "../shared/fs-shim.ts";
 import {
 	createStdioBridge,
@@ -393,7 +397,7 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		_logToFile(`[android-bridge] unhandledRejection: ${msg}`);
 		_appendDiagnostics("agent-fatal", {
 			kind: "unhandledRejection",
-			message: msg.slice(0, 2000),
+			message: truncateWellFormed(toWellFormedUnicode(msg), 2000),
 		});
 		console.error("[android-bridge] unhandled rejection:", msg);
 	});
@@ -403,7 +407,10 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		);
 		_appendDiagnostics("agent-fatal", {
 			kind: "uncaughtException",
-			message: (error.stack || error.message).slice(0, 2000),
+			message: truncateWellFormed(
+				toWellFormedUnicode(error.stack || error.message),
+				2000,
+			),
 		});
 		console.error(
 			"[android-bridge] uncaught exception:",
@@ -455,7 +462,7 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		_logToFile(`[android-bridge] startEliza THREW: ${msg}`);
 		_appendDiagnostics("agent-fatal", {
 			kind: "startEliza-threw",
-			message: msg.slice(0, 2000),
+			message: truncateWellFormed(toWellFormedUnicode(msg), 2000),
 		});
 		throw err;
 	} finally {

--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
@@ -13,6 +13,8 @@
  * there), keeping this orchestration testable and free of native coupling.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 export interface ModelGrindDeps {
 	callIosHost: (
 		method: string,
@@ -258,7 +260,7 @@ export async function runModelGrind(
 			};
 			r.detail = {
 				outputTokens: outTokens,
-				sample: text.slice(0, 120),
+				sample: truncateWellFormed(toWellFormedUnicode(text), 120),
 				mtp: res.specAccepted ?? res.mtpAccepted ?? null,
 			};
 			r.ok = outTokens > 0 && text.trim().length > 0;


### PR DESCRIPTION
## Summary

Uses `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` in `plugins/plugin-capacitor-bridge/src/ios/model-grind.ts:261` and `plugins/plugin-capacitor-bridge/src/android/bridge.ts:396, 406, 458` to prevent raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when recording diagnostic error snippets and model output telemetry samples.

## Changes

- In `plugins/plugin-capacitor-bridge/src/ios/model-grind.ts:261`, sanitize and truncate the generated model text sample using `truncateWellFormed(toWellFormedUnicode(text), 120)`.
- In `plugins/plugin-capacitor-bridge/src/android/bridge.ts:396, 406, 458`, sanitize and truncate unhandled rejection, uncaught exception, and startup error messages using `truncateWellFormed(toWellFormedUnicode(...), 2000)`.
- In `plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts`, add unit test verifying that `runModelGrind` cleanly truncates sample text at unicode surrogate boundaries without bisecting multi-byte characters.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`84725ab7df`) |
| --- | --- | --- |
| `bunx vitest run src/ios/model-grind.test.ts` (in `plugins/plugin-capacitor-bridge`) | 12 pass (12 tests) | 13 pass (13 tests) |
| `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/ios/model-grind.ts plugins/plugin-capacitor-bridge/src/android/bridge.ts plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-capacitor-bridge/src/ios/model-grind.ts:255-265`
- `plugins/plugin-capacitor-bridge/src/android/bridge.ts:390-410`
- `plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts:130-155`

## Risks

Low. Ensures valid UTF-16 encoding and prevents lone surrogate exceptions during telemetry serialization.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Mobile native capacitor bridge diagnostics and telemetry)
- [x] `audit:browser` — N/A (Native model grind testing)
- [x] `build` — Clean build across workspace
- [x] `test` — 13/13 pass in `model-grind.test.ts`
- [x] `lint` — Biome clean
