### PR TITLE
test(app-core): cover capacitor-quickjs

### DIFF
--- a/packages/app-core/src/connectors/capacitor-quickjs.test.ts
+++ b/packages/app-core/src/connectors/capacitor-quickjs.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Colocated coverage for the CapacitorQuickJs connector. Drives the real
+ * module: import-time factory registration, the native-platform / platform /
+ * plugin-availability gate (including short-circuit and host-precedence
+ * branches), and the bridge's evaluate / importModule / dispose forwarding.
+ * The Kotlin/Swift plugin is not present in Node, so registerPlugin is
+ * substituted with a recording double; assertions check unwrapping and
+ * argument forwarding, not the double echoing its own return value.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { JsValue } from "./capacitor-quickjs.ts";
+
+type EvaluateOpts = {
+  code: string;
+  sourceUrl?: string;
+  timeoutMs?: number;
+};
+
+type ImportOpts = {
+  absolutePath: string;
+  specifier?: string;
+};
+
+type CapturedBridge = {
+  kind: string;
+  evaluate: (opts: EvaluateOpts) => Promise<JsValue>;
+  importModule: (opts: ImportOpts) => Promise<{ exports: JsValue }>;
+  dispose: () => Promise<void>;
+};
+
+type CapturedFactory = {
+  kind: string;
+  create: () => Promise<CapturedBridge | null>;
+};
+
+type CapacitorHost = {
+  isNativePlatform?: () => boolean;
+  getPlatform?: () => string;
+  isPluginAvailable?: (name: string) => boolean;
+};
+
+const harness = vi.hoisted(() => {
+  const factories: CapturedFactory[] = [];
+  const plugin = {
+    evaluate: vi.fn(),
+    importModule: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const importedCapacitor: CapacitorHost = {
+    isNativePlatform: () => false,
+    getPlatform: () => "web",
+    isPluginAvailable: () => false,
+  };
+  const registerPluginNames: string[] = [];
+  return {
+    factories,
+    plugin,
+    importedCapacitor,
+    registerPluginNames,
+  };
+});
+
+vi.mock("@elizaos/agent", () => ({
+  registerJsRuntimeFactory: (factory: CapturedFactory) => {
+    harness.factories.push(factory);
+  },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: harness.importedCapacitor,
+  registerPlugin: (name: string) => {
+    harness.registerPluginNames.push(name);
+    return harness.plugin;
+  },
+}));
+
+const { CapacitorQuickJs } = await import("./capacitor-quickjs.ts");
+
+function factory(kind: string): CapturedFactory {
+  const found = harness.factories.find((entry) => entry.kind === kind);
+  if (!found) {
+    throw new Error(`expected factory ${kind} to be registered`);
+  }
+  return found;
+}
+
+function setImportedCapacitor(host: CapacitorHost): void {
+  harness.importedCapacitor.isNativePlatform = host.isNativePlatform;
+  harness.importedCapacitor.getPlatform = host.getPlatform;
+  harness.importedCapacitor.isPluginAvailable = host.isPluginAvailable;
+}
+
+function setGlobalCapacitor(host: CapacitorHost | undefined): void {
+  if (host === undefined) {
+    Reflect.deleteProperty(globalThis, "Capacitor");
+    return;
+  }
+  (globalThis as typeof globalThis & { Capacitor?: CapacitorHost }).Capacitor =
+    host;
+}
+
+const nativeAndroid: CapacitorHost = {
+  isNativePlatform: () => true,
+  getPlatform: () => "android",
+  isPluginAvailable: (name) => name === "CapacitorQuickJs",
+};
+
+const nativeIos: CapacitorHost = {
+  isNativePlatform: () => true,
+  getPlatform: () => "ios",
+  isPluginAvailable: (name) => name === "CapacitorQuickJs",
+};
+
+afterEach(() => {
+  setGlobalCapacitor(undefined);
+  setImportedCapacitor({
+    isNativePlatform: () => false,
+    getPlatform: () => "web",
+    isPluginAvailable: () => false,
+  });
+  harness.plugin.evaluate.mockReset();
+  harness.plugin.importModule.mockReset();
+  harness.plugin.dispose.mockReset();
+});
+
+describe("CapacitorQuickJs plugin registration", () => {
+  it("registers the native plugin under the CapacitorQuickJs name and exports that handle", () => {
+    expect(harness.registerPluginNames).toEqual(["CapacitorQuickJs"]);
+    expect(CapacitorQuickJs).toBe(harness.plugin);
+  });
+
+  it("registers the android factory then the ios fallback, in that order", () => {
+    expect(harness.factories.map((entry) => entry.kind)).toEqual([
+      "quickjs-android",
+      "quickjs-ios-fallback",
+    ]);
+  });
+});
+
+describe("quickjs-android factory create()", () => {
+  it("returns null when the imported Capacitor host is not native", async () => {
+    setGlobalCapacitor(undefined);
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null when isNativePlatform is missing", async () => {
+    setGlobalCapacitor({
+      getPlatform: () => "android",
+      isPluginAvailable: () => true,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null when isNativePlatform is truthy but not strictly true", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => "yes" as unknown as boolean,
+      getPlatform: () => "android",
+      isPluginAvailable: () => true,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("does not probe the plugin when isNativePlatform is false", async () => {
+    const isPluginAvailable = vi.fn(() => true);
+    const getPlatform = vi.fn(() => "android");
+    setGlobalCapacitor({
+      isNativePlatform: () => false,
+      getPlatform,
+      isPluginAvailable,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+    expect(getPlatform).not.toHaveBeenCalled();
+    expect(isPluginAvailable).not.toHaveBeenCalled();
+  });
+
+  it("returns null on ios even when the plugin is available", async () => {
+    setGlobalCapacitor(nativeIos);
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null on web", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "web",
+      isPluginAvailable: () => true,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null when getPlatform is missing", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      isPluginAvailable: () => true,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("does not probe the plugin when the platform does not match", async () => {
+    const isPluginAvailable = vi.fn(() => true);
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "ios",
+      isPluginAvailable,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+    expect(isPluginAvailable).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the plugin is unavailable", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      isPluginAvailable: () => false,
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null when isPluginAvailable is missing", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("returns null when isPluginAvailable is true only for a different plugin name", async () => {
+    const names: string[] = [];
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      isPluginAvailable: (name) => {
+        names.push(name);
+        return name === "CapacitorJsc";
+      },
+    });
+    expect(await factory("quickjs-android").create()).toBeNull();
+    expect(names).toEqual(["CapacitorQuickJs"]);
+  });
+
+  it("returns a quickjs-android bridge when native android has the plugin", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    const bridge = await factory("quickjs-android").create();
+    expect(bridge).not.toBeNull();
+    expect(bridge?.kind).toBe("quickjs-android");
+  });
+
+  it("prefers globalThis.Capacitor over the imported Capacitor host", async () => {
+    setImportedCapacitor(nativeAndroid);
+    setGlobalCapacitor(nativeIos);
+    expect(await factory("quickjs-android").create()).toBeNull();
+  });
+
+  it("falls back to the imported Capacitor host when globalThis.Capacitor is absent", async () => {
+    setGlobalCapacitor(undefined);
+    setImportedCapacitor(nativeAndroid);
+    const bridge = await factory("quickjs-android").create();
+    expect(bridge?.kind).toBe("quickjs-android");
+  });
+});
+
+describe("quickjs-ios-fallback factory create()", () => {
+  it("returns null on android even when the plugin is available", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    expect(await factory("quickjs-ios-fallback").create()).toBeNull();
+  });
+
+  it("returns null when the platform string is the wrong case", async () => {
+    setGlobalCapacitor({
+      isNativePlatform: () => true,
+      getPlatform: () => "iOS",
+      isPluginAvailable: () => true,
+    });
+    expect(await factory("quickjs-ios-fallback").create()).toBeNull();
+  });
+
+  it("returns a quickjs-ios-fallback bridge when native ios has the plugin", async () => {
+    setGlobalCapacitor(nativeIos);
+    const bridge = await factory("quickjs-ios-fallback").create();
+    expect(bridge).not.toBeNull();
+    expect(bridge?.kind).toBe("quickjs-ios-fallback");
+  });
+
+  it("falls back to the imported Capacitor host for ios", async () => {
+    setGlobalCapacitor(undefined);
+    setImportedCapacitor(nativeIos);
+    const bridge = await factory("quickjs-ios-fallback").create();
+    expect(bridge?.kind).toBe("quickjs-ios-fallback");
+  });
+});
+
+describe("CapacitorQuickJsBridge", () => {
+  it("unwraps evaluate's { value } and forwards code, sourceUrl, and timeoutMs", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    const returned: JsValue = { kind: "number", value: 7 };
+    harness.plugin.evaluate.mockResolvedValue({ value: returned });
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    const result = await bridge.evaluate({
+      code: "1+6",
+      sourceUrl: "eval.ts",
+      timeoutMs: 250,
+    });
+
+    expect(harness.plugin.evaluate).toHaveBeenCalledOnce();
+    expect(harness.plugin.evaluate).toHaveBeenCalledWith({
+      code: "1+6",
+      sourceUrl: "eval.ts",
+      timeoutMs: 250,
+    });
+    expect(result).toBe(returned);
+    expect(result).toEqual({ kind: "number", value: 7 });
+  });
+
+  it("forwards evaluate options that omit sourceUrl and timeoutMs", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.evaluate.mockResolvedValue({
+      value: { kind: "undefined" },
+    });
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    await bridge.evaluate({ code: "void 0" });
+    expect(harness.plugin.evaluate).toHaveBeenCalledWith({ code: "void 0" });
+  });
+
+  it("propagates evaluate rejection from the native plugin", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.evaluate.mockRejectedValue(new Error("timeout"));
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    await expect(
+      bridge.evaluate({ code: "while(true){}", timeoutMs: 1 }),
+    ).rejects.toThrow("timeout");
+  });
+
+  it("unwraps importModule's { exports } and forwards absolutePath plus specifier", async () => {
+    setGlobalCapacitor(nativeIos);
+    const exports: JsValue = {
+      kind: "object",
+      entries: [["ok", { kind: "boolean", value: true }]],
+    };
+    harness.plugin.importModule.mockResolvedValue({ exports });
+    const bridge = await factory("quickjs-ios-fallback").create();
+    if (!bridge) throw new Error("expected ios bridge");
+
+    const result = await bridge.importModule({
+      absolutePath: "/data/mod.js",
+      specifier: "file:///data/mod.js",
+    });
+
+    expect(harness.plugin.importModule).toHaveBeenCalledWith({
+      absolutePath: "/data/mod.js",
+      specifier: "file:///data/mod.js",
+    });
+    expect(result).toEqual({ exports });
+    expect(result.exports).toBe(exports);
+  });
+
+  it("forwards importModule options that omit specifier", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.importModule.mockResolvedValue({
+      exports: { kind: "null" },
+    });
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    const result = await bridge.importModule({
+      absolutePath: "/data/only.js",
+    });
+    expect(harness.plugin.importModule).toHaveBeenCalledWith({
+      absolutePath: "/data/only.js",
+    });
+    expect(result.exports).toEqual({ kind: "null" });
+  });
+
+  it("propagates importModule rejection from the native plugin", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.importModule.mockRejectedValue(
+      new Error("module not found"),
+    );
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    await expect(
+      bridge.importModule({ absolutePath: "/missing.js" }),
+    ).rejects.toThrow("module not found");
+  });
+
+  it("forwards dispose to the native plugin", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.dispose.mockResolvedValue(undefined);
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    await bridge.dispose();
+    expect(harness.plugin.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("propagates dispose rejection from the native plugin", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    harness.plugin.dispose.mockRejectedValue(new Error("already disposed"));
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    await expect(bridge.dispose()).rejects.toThrow("already disposed");
+  });
+
+  it("passes every JsValue kind through evaluate unchanged", async () => {
+    setGlobalCapacitor(nativeAndroid);
+    const bridge = await factory("quickjs-android").create();
+    if (!bridge) throw new Error("expected android bridge");
+
+    const values: JsValue[] = [
+      { kind: "undefined" },
+      { kind: "null" },
+      { kind: "boolean", value: false },
+      { kind: "number", value: 0 },
+      { kind: "string", value: "" },
+      { kind: "array", items: [] },
+      {
+        kind: "object",
+        entries: [],
+      },
+      { kind: "function", functionId: "fn:0" },
+    ];
+
+    for (const value of values) {
+      harness.plugin.evaluate.mockResolvedValueOnce({ value });
+      const result = await bridge.evaluate({ code: "expr" });
+      expect(result).toBe(value);
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/connectors/capacitor-quickjs.ts`, which had no same-named test file. No production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds a colocated Vitest file only. No production source, exports, or
runtime behaviour change.

# Background

## What does this PR do?

Adds `packages/app-core/src/connectors/capacitor-quickjs.test.ts` covering the
real connector:

- `registerPlugin("CapacitorQuickJs")` and the exported plugin handle
- import-time factory order: `quickjs-android` then `quickjs-ios-fallback`
- `create()` returns null for missing/`false`/non-strict-true native, missing
  platform, web/wrong-case platform, missing or false plugin probe, and a
  probe that is true only for a different plugin name
- short-circuit: `getPlatform` / `isPluginAvailable` are not called when the
  native or platform check already failed
- `create()` returns a bridge with the matching `kind` on native android / ios
  when `isPluginAvailable("CapacitorQuickJs")` is true
- `globalThis.Capacitor` takes precedence over the imported Capacitor host;
  imported Capacitor is used when `globalThis.Capacitor` is absent
- bridge `evaluate` unwraps `{ value }` and forwards `code` / `sourceUrl` /
  `timeoutMs` (including omitted optionals)
- bridge `importModule` unwraps `{ exports }` and forwards `absolutePath` /
  `specifier` (including omitted specifier)
- evaluate / importModule / dispose rejections from the native plugin
  propagate
- every `JsValue` kind passes through `evaluate` by identity

The Kotlin/Swift plugin is not present in Node, so `registerPlugin` is a
recording double. Assertions check unwrapping and argument forwarding against
that double — not that a mock returned X and the test echoed X.

## What kind of change is this?

Improvements (test coverage only; no production change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/connectors/capacitor-quickjs.test.ts`

## Detailed testing steps

None: automated tests are the proof.

Re-fetched `origin/develop` immediately before filing and re-ran Vitest against
the current tree. `capacitor-quickjs.ts` is unchanged vs `origin/develop`.
Diff is exactly this one test file.

```
bunx vitest run packages/app-core/src/connectors/capacitor-quickjs.test.ts

 Test Files  1 passed (1)
      Tests  29 passed (29)
   Start at  18:14:52
   Duration  502ms (transform 173ms, setup 0ms, import 241ms, tests 8ms, environment 0ms)
```

```
bunx biome check --write packages/app-core/src/connectors/capacitor-quickjs.test.ts
Checked 1 file in 210ms. Fixed 1 file.
```

(The committed file is the Biome-written result.)

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'capacitor-quickjs.test' ; echo "EXIT:$?"
EXIT:1
```

Empty grep: this test file introduced zero TypeScript errors. Pre-existing
package errors, if any, are not from this file.

Hosted CI does **not** run on this PR (fork contributor). Do not treat missing
GitHub Actions as a pass.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:4984a682cdfebcf98e4562198fd14e1d34b82613 -->

- [x] Before full-page screenshots: N/A - test-only change; no UI surface.
- [x] After full-page screenshots: N/A - test-only change; no UI surface.
- [x] Walkthrough video: N/A - test-only change; no user flow.
- [x] Backend logs: N/A - no production code path changed; Vitest output is the
      executed proof.
- [x] Frontend console/network logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - no DB/memory/schedule/wallet/on-chain/audio
      artefact is produced by this unit suite.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only unit suite; quoted Vitest / Biome / tsc output is in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- `bun run verify` was not run. This is a single colocated test file with no
  production change; the required proof is the focused Vitest / Biome / tsc
  counts quoted above. Hosted CI does not run on fork PRs.
- Private identity.slop.cash OAuth trace was not finalized: unattended session
  cannot complete the interactive GitHub consent step.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
