### PR TITLE
test(app-core): cover chat-failure-strings.generated

### DIFF
--- a/packages/app-core/src/platform/chat-failure-strings.generated.test.ts
+++ b/packages/app-core/src/platform/chat-failure-strings.generated.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit coverage for the generated mobile chat-reply failure vocabulary
+ * (`chat-failure-strings.generated`): ordered fragment lists, derived
+ * case-insensitive regexes, shared vs platform-specific classifiers, think-tag
+ * leakage, and the anti-false-green contract that genuine smoke replies do not
+ * match. Drives the real generated module with no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ANDROID_FAILURE_FRAGMENTS,
+  ANDROID_FULL_TURN_FAILURE_RE,
+  IOS_FAILURE_FRAGMENTS,
+  IOS_FULL_BUN_SMOKE_FAILURE_RE,
+} from "./chat-failure-strings.generated";
+
+const THINK_TAG_FAILURE_FRAGMENTS = [
+  "<think\\b",
+  "<\\/think>",
+  "\\/?\\bno_think\\b",
+] as const;
+
+const EXPECTED_IOS_FAILURE_FRAGMENTS = [
+  "something went wrong",
+  "backend is not running",
+  "local backend is not running",
+  "no local backend",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "waiting for the model download",
+  "timed out",
+  ...THINK_TAG_FAILURE_FRAGMENTS,
+] as const;
+
+const EXPECTED_ANDROID_FAILURE_FRAGMENTS = [
+  "something went wrong",
+  "no local gguf",
+  "no local model",
+  "no model registered",
+  "no provider",
+  "connect a provider",
+  "device_disconnected",
+  "device_timeout",
+  "timed out",
+  "chat generation failed",
+  "waiting for the model download",
+  "set chat routing",
+  "progress:\\s*0%",
+  ...THINK_TAG_FAILURE_FRAGMENTS,
+] as const;
+
+const IOS_ONLY_PHRASES = [
+  "backend is not running",
+  "local backend is not running",
+  "no local backend",
+] as const;
+
+const ANDROID_ONLY_PHRASES = [
+  "no local gguf",
+  "device_disconnected",
+  "device_timeout",
+  "chat generation failed",
+  "set chat routing",
+  "progress: 0%",
+] as const;
+
+describe("IOS_FAILURE_FRAGMENTS", () => {
+  it("pins the historical iOS alternation order, including trailing think-tag fragments", () => {
+    expect([...IOS_FAILURE_FRAGMENTS]).toEqual([
+      ...EXPECTED_IOS_FAILURE_FRAGMENTS,
+    ]);
+    expect(IOS_FAILURE_FRAGMENTS).toHaveLength(13);
+    expect(IOS_FAILURE_FRAGMENTS.slice(-3)).toEqual([
+      ...THINK_TAG_FAILURE_FRAGMENTS,
+    ]);
+  });
+
+  it("exposes a readable tuple; missing indexes are undefined, not a thrown removal", () => {
+    const fragments: readonly string[] = IOS_FAILURE_FRAGMENTS;
+    expect(fragments[0]).toBe("something went wrong");
+    expect(fragments[12]).toBe("\\/?\\bno_think\\b");
+    expect(fragments[13]).toBeUndefined();
+    expect(fragments[-1]).toBeUndefined();
+  });
+});
+
+describe("ANDROID_FAILURE_FRAGMENTS", () => {
+  it("pins the historical Android alternation order, including trailing think-tag fragments", () => {
+    expect([...ANDROID_FAILURE_FRAGMENTS]).toEqual([
+      ...EXPECTED_ANDROID_FAILURE_FRAGMENTS,
+    ]);
+    expect(ANDROID_FAILURE_FRAGMENTS).toHaveLength(16);
+    expect(ANDROID_FAILURE_FRAGMENTS.slice(-3)).toEqual([
+      ...THINK_TAG_FAILURE_FRAGMENTS,
+    ]);
+  });
+
+  it("shares the think-tag group and the overlapping readiness phrases with iOS", () => {
+    for (const fragment of THINK_TAG_FAILURE_FRAGMENTS) {
+      expect(IOS_FAILURE_FRAGMENTS).toContain(fragment);
+      expect(ANDROID_FAILURE_FRAGMENTS).toContain(fragment);
+    }
+    for (const fragment of [
+      "something went wrong",
+      "no local model",
+      "no model registered",
+      "no provider",
+      "connect a provider",
+      "waiting for the model download",
+      "timed out",
+    ] as const) {
+      expect(IOS_FAILURE_FRAGMENTS).toContain(fragment);
+      expect(ANDROID_FAILURE_FRAGMENTS).toContain(fragment);
+    }
+  });
+
+  it("keeps platform-only fragments off the other list", () => {
+    for (const fragment of [
+      "backend is not running",
+      "local backend is not running",
+      "no local backend",
+    ] as const) {
+      expect(IOS_FAILURE_FRAGMENTS).toContain(fragment);
+      expect(ANDROID_FAILURE_FRAGMENTS).not.toContain(fragment);
+    }
+    for (const fragment of [
+      "no local gguf",
+      "device_disconnected",
+      "device_timeout",
+      "chat generation failed",
+      "set chat routing",
+      "progress:\\s*0%",
+    ] as const) {
+      expect(ANDROID_FAILURE_FRAGMENTS).toContain(fragment);
+      expect(IOS_FAILURE_FRAGMENTS).not.toContain(fragment);
+    }
+  });
+});
+
+describe("derived failure regexes", () => {
+  it("builds each regex by joining fragments with | and the i flag only", () => {
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.source).toBe(
+      IOS_FAILURE_FRAGMENTS.join("|"),
+    );
+    expect(ANDROID_FULL_TURN_FAILURE_RE.source).toBe(
+      ANDROID_FAILURE_FRAGMENTS.join("|"),
+    );
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.flags).toBe("i");
+    expect(ANDROID_FULL_TURN_FAILURE_RE.flags).toBe("i");
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.global).toBe(false);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.global).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.sticky).toBe(false);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.sticky).toBe(false);
+  });
+
+  it("does not advance lastIndex across repeated .test calls (no /g)", () => {
+    const haystack = "Something went wrong";
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test(haystack)).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.lastIndex).toBe(0);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test(haystack)).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test(haystack)).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.lastIndex).toBe(0);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test(haystack)).toBe(true);
+  });
+});
+
+describe("IOS_FULL_BUN_SMOKE_FAILURE_RE", () => {
+  it("classifies every iOS fragment as a failure, including wrapped haystacks", () => {
+    const haystacks: Record<(typeof IOS_FAILURE_FRAGMENTS)[number], string> = {
+      "something went wrong": "Error: something went wrong while starting",
+      "backend is not running": "The backend is not running on :3000",
+      "local backend is not running": "Local backend is not running",
+      "no local backend": "no local backend configured",
+      "no local model": "no local model is loaded",
+      "no model registered": "no model registered yet",
+      "no provider": "no provider available",
+      "connect a provider": "Please connect a provider first",
+      "waiting for the model download": "waiting for the model download (1/3)",
+      "timed out": "request timed out after 30s",
+      "<think\\b": "<think>chain of thought</think>",
+      "<\\/think>": "hidden </think> leak",
+      "\\/?\\bno_think\\b": "leaked no_think marker",
+    };
+    for (const fragment of IOS_FAILURE_FRAGMENTS) {
+      expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test(haystacks[fragment])).toBe(
+        true,
+      );
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("SOMETHING WENT WRONG")).toBe(
+      true,
+    );
+    expect(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.test("LOCAL BACKEND IS NOT RUNNING"),
+    ).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("</THINK>")).toBe(true);
+  });
+
+  it("does not classify an empty string or a genuine smoke reply as a failure", () => {
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("")).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("ios smoke model works")).toBe(
+      false,
+    );
+    expect(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.test("hello in one short sentence"),
+    ).toBe(false);
+  });
+
+  it("does not treat Android-only failure renders as iOS failures", () => {
+    for (const phrase of ANDROID_ONLY_PHRASES) {
+      expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test(phrase)).toBe(false);
+    }
+  });
+
+  it("honors think-tag word boundaries and does not match timeout as timed out", () => {
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("<think>")).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("<think foo>")).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("<thinking>")).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("no_think")).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("/no_think")).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("xno_think")).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("no_thinks")).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("timed out")).toBe(true);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("timeout")).toBe(false);
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.test("device_timeout")).toBe(false);
+  });
+
+  it("lets the earliest matching alternative win when phrases overlap", () => {
+    expect(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.exec("backend is not running")?.[0],
+    ).toBe("backend is not running");
+    expect(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.exec("local backend is not running")?.[0],
+    ).toBe("local backend is not running");
+    expect(
+      IOS_FULL_BUN_SMOKE_FAILURE_RE.exec("The backend is not running now")?.[0],
+    ).toBe("backend is not running");
+    expect(IOS_FULL_BUN_SMOKE_FAILURE_RE.exec("no local backend")?.[0]).toBe(
+      "no local backend",
+    );
+  });
+});
+
+describe("ANDROID_FULL_TURN_FAILURE_RE", () => {
+  it("classifies every Android fragment as a failure", () => {
+    const haystacks: Record<
+      (typeof ANDROID_FAILURE_FRAGMENTS)[number],
+      string
+    > = {
+      "something went wrong": "Something went wrong",
+      "no local gguf": "no local gguf on disk",
+      "no local model": "no local model",
+      "no model registered": "no model registered",
+      "no provider": "no provider",
+      "connect a provider": "connect a provider",
+      device_disconnected: "device_disconnected",
+      device_timeout: "device_timeout",
+      "timed out": "timed out",
+      "chat generation failed": "chat generation failed",
+      "waiting for the model download": "waiting for the model download",
+      "set chat routing": "set chat routing",
+      "progress:\\s*0%": "progress: 0%",
+      "<think\\b": "<think>leak</think>",
+      "<\\/think>": "</think>",
+      "\\/?\\bno_think\\b": "/no_think",
+    };
+    for (const fragment of ANDROID_FAILURE_FRAGMENTS) {
+      expect(ANDROID_FULL_TURN_FAILURE_RE.test(haystacks[fragment])).toBe(true);
+    }
+  });
+
+  it("matches progress:\\s*0% on zero-or-more whitespace and rejects nearby percents", () => {
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress:0%")).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress: 0%")).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress:\t0%")).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress:  0%")).toBe(true);
+    expect(
+      ANDROID_FULL_TURN_FAILURE_RE.exec("progress: 0% remaining")?.[0],
+    ).toBe("progress: 0%");
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress: 10%")).toBe(false);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress:00%")).toBe(false);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("progress: 0")).toBe(false);
+  });
+
+  it("does not classify an empty string or a genuine smoke reply as a failure", () => {
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("")).toBe(false);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("android smoke model works")).toBe(
+      false,
+    );
+  });
+
+  it("does not treat iOS-only backend-down renders as Android failures", () => {
+    for (const phrase of IOS_ONLY_PHRASES) {
+      expect(ANDROID_FULL_TURN_FAILURE_RE.test(phrase)).toBe(false);
+    }
+  });
+
+  it("classifies device disconnect and chat-generation-failed as failures", () => {
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("device_disconnected")).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("DEVICE_DISCONNECTED")).toBe(true);
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("chat generation failed")).toBe(
+      true,
+    );
+    expect(ANDROID_FULL_TURN_FAILURE_RE.test("timeout")).toBe(false);
+  });
+});


### PR DESCRIPTION

# Relates to

Operator-selected coverage gap: `packages/app-core/src/platform/chat-failure-strings.generated.ts` had no same-named test file anywhere in the repo. That generated module is the runtime TypeScript copy of the mobile chat-reply FAILURE vocabulary consumed by iOS full-Bun smoke (`IOS_FULL_BUN_SMOKE_FAILURE_RE`) and Android full-turn smoke (`ANDROID_FULL_TURN_FAILURE_RE`). A silent classifier regression here is the #13687 false-green: an error-boundary heading or think-tag leak counted as a genuine model reply.

This PR adds one colocated test file and does not change production behavior.

Definition of Done: focused behavioral tests for every exported symbol, recorded at the exact pushed head.

- [x] Targets `develop` and was rebased onto the latest fetched `origin/develop` before the final proof (`19ceae5901e73dd51a935a2a3ed3c5b71a4885f2`).
- [x] Reviewers can confirm the changed behavior from the committed focused test and inline red/green output.

# Sync with develop

- [x] Branch parent is current `origin/develop` (`19ceae5901e73dd51a935a2a3ed3c5b71a4885f2`); zero conflicts; diff is one test file.
- [x] `bun run verify` was not re-run for this test-only change. Focused vitest, biome, and package `tsc` are quoted below. Hosted GitHub Actions CI does **not** run on this fork-authored PR.

# Risks

Low. Tests only. No production source, export, generated artifact, or classifier change.

# Background

## What does this PR do?

Adds `packages/app-core/src/platform/chat-failure-strings.generated.test.ts`, which imports the four exports from `./chat-failure-strings.generated` (the same relative path `ios-runtime-bridge.ts` uses) and drives the real generated module. No mocks.

Covered behavior, observed from the live generated file (not from the `.mjs` generator, which *does* throw on an empty fragment list — the generated TypeScript `buildFailureRegExp` is not exported and does not implement that guard):

1. `IOS_FAILURE_FRAGMENTS` is the 13-entry historical iOS alternation, trailing think-tag group last. Out-of-range indexes are `undefined`; nothing throws.
2. `ANDROID_FAILURE_FRAGMENTS` is the 16-entry historical Android alternation, same trailing think-tag group. Shared readiness phrases stay on both lists; iOS-only backend-down phrases stay off Android and vice versa.
3. Each derived regex is `fragments.join("|")` with the `i` flag only (not `/g`, not sticky). Repeated `.test()` does not flip via `lastIndex`.
4. Every iOS fragment classifies a wrapped haystack as a failure; case-insensitive; empty string and `ios smoke model works` do **not** match.
5. Android-only renders (`no local gguf`, `device_disconnected`, `device_timeout`, `chat generation failed`, `set chat routing`, `progress: 0%`) do **not** match the iOS regex.
6. Think-tag word boundaries: `<think>` / `<think foo>` / `no_think` / `/no_think` match; `<thinking>`, `xno_think`, `no_thinks` do not. `timed out` matches; `timeout` and `device_timeout` do not on iOS.
7. Overlapping iOS alternatives: earliest match wins (`backend is not running` vs `local backend is not running` vs wrapped haystack).
8. Every Android fragment classifies as a failure. `progress:\s*0%` matches zero-or-more whitespace (`progress:0%`, `progress: 0%`, tab, two spaces) and rejects `progress: 10%`, `progress:00%`, `progress: 0`.
9. iOS-only backend-down renders do **not** match the Android regex. Genuine `android smoke model works` does not match.

## What kind of change is this?

Test-only, non-breaking.

# Documentation changes needed?

No. The public API is unchanged.

# Testing

## Where should a reviewer start?

`packages/app-core/src/platform/chat-failure-strings.generated.test.ts`.

## Detailed testing steps

Focused proof re-run against current `origin/develop` immediately before filing, at the pushed head (`7938831017a861907e205055047e32cf599f635c`):

```bash
bunx vitest run packages/app-core/src/platform/chat-failure-strings.generated.test.ts
bunx biome check --write packages/app-core/src/platform/chat-failure-strings.generated.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'chat-failure-strings.generated.test' ; echo "EXIT:$?"
```

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app-core/src/platform/chat-failure-strings.generated.test.ts (18 tests) 5ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  18:14:11
   Duration  123ms (transform 31ms, setup 0ms, import 39ms, tests 5ms, environment 0ms)
```

`bunx biome check --write packages/app-core/src/platform/chat-failure-strings.generated.test.ts` — `Checked 1 file in 15ms. No fixes applied.` Config `biome.json` is present in the checkout; `git sparse-checkout list` reports this worktree is not sparse.

`packages/app-core` `tsc --noEmit` grep for `chat-failure-strings.generated.test` printed nothing (`EXIT:1` from grep). The test file introduced zero new type errors. Pre-existing diagnostics in unrelated files are not this change.

The diff touches only `packages/app-core/src/platform/chat-failure-strings.generated.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork-authored PR. This body does not imply CI passed.

# Evidence Gate

<!-- evidence-head:7938831017a861907e205055047e32cf599f635c -->

- [x] Before full-page screenshots: N/A - test-only change; no rendered UI surface.
- [x] After full-page screenshots: N/A - test-only change; no rendered UI surface.
- [x] Walkthrough video: N/A - test-only change; no user flow.
- [x] Backend logs: N/A - no production runtime path changed; vitest output is the proof.
- [x] Frontend console/network logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - classifier unit tests; no DB/wallet/media artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only coverage of a generated regex vocabulary; no model call.

## Backend + frontend logs

N/A - no production path changed. Focused vitest output is quoted above.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not re-run. This PR adds one test file and changes no production behavior; the required evidence for that scope is the focused vitest / biome / tsc grep quoted above.

Hosted GitHub Actions CI does not run on fork-authored PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
