### PR TITLE
test(app-core): cover channel-plugin-map

### DIFF
--- a/packages/app-core/src/runtime/channel-plugin-map.test.ts
+++ b/packages/app-core/src/runtime/channel-plugin-map.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for CHANNEL_PLUGIN_MAP, the generated channel-name → plugin
+ * package lookup app-core re-exports from the first-party registry artifact.
+ * The module has no mutators, queues, or comparators — these cases lock the
+ * live mapping, missing-key lookup, alias sharing, and identity with the JSON
+ * artifact. Drives the real module; no mocks.
+ */
+
+import generatedChannelPluginMap from "@elizaos/registry/first-party/channel-plugin-map.json" with {
+  type: "json",
+};
+import { describe, expect, it } from "vitest";
+import * as channelPluginMapModule from "./channel-plugin-map";
+import { CHANNEL_PLUGIN_MAP } from "./channel-plugin-map";
+
+const expectedChannelPluginMap: Record<string, string> = {
+  blooio: "@elizaos/plugin-blooio",
+  discord: "@elizaos/plugin-discord",
+  discordLocal: "@elizaos/plugin-discord",
+  googlechat: "@elizaos/plugin-google-workspace",
+  imessage: "@elizaos/plugin-imessage",
+  matrix: "@elizaos/plugin-matrix",
+  mattermost: "@elizaos/plugin-mattermost",
+  msteams: "@elizaos/plugin-msteams",
+  slack: "@elizaos/plugin-slack",
+  telegram: "@elizaos/plugin-telegram",
+  twitter: "@elizaos/plugin-x",
+  wechat: "@elizaos/plugin-wechat",
+  whatsapp: "@elizaos/plugin-whatsapp",
+  x: "@elizaos/plugin-x",
+};
+
+describe("CHANNEL_PLUGIN_MAP", () => {
+  it("is the only export and re-exports the generated JSON artifact by identity", () => {
+    expect(Object.keys(channelPluginMapModule)).toEqual(["CHANNEL_PLUGIN_MAP"]);
+    expect(CHANNEL_PLUGIN_MAP).toBe(generatedChannelPluginMap);
+    expect(CHANNEL_PLUGIN_MAP).toEqual(expectedChannelPluginMap);
+  });
+
+  it("resolves every shipped channel name to its owning plugin package", () => {
+    expect(CHANNEL_PLUGIN_MAP.blooio).toBe("@elizaos/plugin-blooio");
+    expect(CHANNEL_PLUGIN_MAP.discord).toBe("@elizaos/plugin-discord");
+    expect(CHANNEL_PLUGIN_MAP.discordLocal).toBe("@elizaos/plugin-discord");
+    expect(CHANNEL_PLUGIN_MAP.googlechat).toBe(
+      "@elizaos/plugin-google-workspace",
+    );
+    expect(CHANNEL_PLUGIN_MAP.imessage).toBe("@elizaos/plugin-imessage");
+    expect(CHANNEL_PLUGIN_MAP.matrix).toBe("@elizaos/plugin-matrix");
+    expect(CHANNEL_PLUGIN_MAP.mattermost).toBe("@elizaos/plugin-mattermost");
+    expect(CHANNEL_PLUGIN_MAP.msteams).toBe("@elizaos/plugin-msteams");
+    expect(CHANNEL_PLUGIN_MAP.slack).toBe("@elizaos/plugin-slack");
+    expect(CHANNEL_PLUGIN_MAP.telegram).toBe("@elizaos/plugin-telegram");
+    expect(CHANNEL_PLUGIN_MAP.twitter).toBe("@elizaos/plugin-x");
+    expect(CHANNEL_PLUGIN_MAP.wechat).toBe("@elizaos/plugin-wechat");
+    expect(CHANNEL_PLUGIN_MAP.whatsapp).toBe("@elizaos/plugin-whatsapp");
+    expect(CHANNEL_PLUGIN_MAP.x).toBe("@elizaos/plugin-x");
+  });
+
+  it("shares one plugin across alias keys rather than picking a winner", () => {
+    expect(CHANNEL_PLUGIN_MAP.twitter).toBe(CHANNEL_PLUGIN_MAP.x);
+    expect(CHANNEL_PLUGIN_MAP.discord).toBe(CHANNEL_PLUGIN_MAP.discordLocal);
+  });
+
+  it("returns undefined for missing, empty, whitespace, and case-mismatched names", () => {
+    expect(CHANNEL_PLUGIN_MAP["not-a-channel"]).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP[""]).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP[" "]).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP.Discord).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP.TELEGRAM).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP.bluebubbles).toBeUndefined();
+    expect(CHANNEL_PLUGIN_MAP.signal).toBeUndefined();
+  });
+
+  it("exposes a non-empty map whose keys are sorted and whose values are plugin packages", () => {
+    const keys = Object.keys(CHANNEL_PLUGIN_MAP);
+    expect(keys.length).toBe(Object.keys(expectedChannelPluginMap).length);
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys).toEqual([...keys].sort());
+    for (const key of keys) {
+      expect(key.trim()).toBe(key);
+      expect(key.length).toBeGreaterThan(0);
+      expect(CHANNEL_PLUGIN_MAP[key]).toMatch(/^@elizaos\/plugin-[a-z0-9-]+$/);
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/app-core/src/runtime/channel-plugin-map.ts`, which had no same-named test file in the tree.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is based on the latest fetched `origin/develop` (`19ceae5901e73dd51a935a2a3ed3c5b71a4885f2`) with zero conflicts.
- [x] Focused vitest, biome, and tsc checks were run on the added file. Full `bun run verify` was not run for this test-only change.
- [x] A reviewer can confirm the mapping from the committed suite without reading production code.

# Sync with develop

- [x] Branch parent is current `origin/develop` `19ceae5901e73dd51a935a2a3ed3c5b71a4885f2`; zero conflicts.
- [x] `bun run verify` was not re-run for this test-only PR. Focused vitest / biome / tsc results are quoted below.

# Risks

Low. Production `CHANNEL_PLUGIN_MAP` is unchanged. The suite drives the real re-export (identity with the generated JSON artifact, every shipped channel → plugin mapping, alias sharing for `twitter`/`x` and `discord`/`discordLocal`, missing/empty/case-mismatched lookups returning `undefined`, and sorted non-empty keys whose values are `@elizaos/plugin-*` packages). The module has no mutators, queues, capacity, or comparators.

# Background

## What does this PR do?

Adds a colocated Vitest suite for app-core's `CHANNEL_PLUGIN_MAP`, the channel-name → plugin-package lookup re-exported from `@elizaos/registry/first-party/channel-plugin-map.json`. Coverage is behavior, not mocks: import the real module and assert the live generated map.

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed. Diff is one new test file.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app-core/src/runtime/channel-plugin-map.test.ts` — same colocated layout as `autonomy-policy.test.ts` and `skip-plugins-env.test.ts`. Import path is `./channel-plugin-map`.

## Detailed testing steps

```bash
bunx vitest run packages/app-core/src/runtime/channel-plugin-map.test.ts --config packages/app-core/vitest.config.ts
bunx biome check --write packages/app-core/src/runtime/channel-plugin-map.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'channel-plugin-map.test' ; echo "EXIT:$?"
```

Focused proof at the pushed head `2dc684608c8aa9c979be4794a5e2ee80536ba9a9` against current `origin/develop`:

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app-core/src/runtime/channel-plugin-map.test.ts (5 tests) 3ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  18:14:02
   Duration  114ms (transform 28ms, setup 0ms, import 36ms, tests 3ms, environment 0ms)
```

`bunx biome check --write` on the new file: Checked 1 file in 23ms. Fixed 1 file (import order). The committed file is that formatted result.

`bunx tsc --noEmit` in `packages/app-core`, grepped for `channel-plugin-map.test`: no lines (EXIT:1 from grep). This file adds zero TypeScript errors versus an untouched control.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:2dc684608c8aa9c979be4794a5e2ee80536ba9a9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (5 passed / 5).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only; no DB, memory, schedule, wallet, or generated production artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change. Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Backend + frontend logs

N/A - no backend or frontend runtime path changed. Focused Vitest output is quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI.

### Before

N/A - test-only; no UI.

### After

N/A - test-only; no UI.

### Walkthrough video

N/A - test-only; no UI.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT change.

## Known gaps / failures

- Full `bun run verify` was not run. This PR adds one test file and changes no production behavior; the complete evidence set is the focused vitest (5 passed / 5), biome check, and tsc grep showing the new file nowhere.
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- No private contribution receipt: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
