### PR TITLE
fix(computeruse): use surrogate-safe truncateWellFormed on terminal queued text and iOS keyboard typing preview

### DIFF
--- a/plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts
+++ b/plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts
@@ -32,7 +32,7 @@
  * cleanly so callers don't have to reach into the raw Capacitor bridge.
  */
 
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   ComputerInterface,
   CursorPosition,
@@ -186,7 +186,10 @@ export class IosComputerInterface implements ComputerInterface {
   }
 
   async typeText(args: { text: string }): Promise<void> {
-    this.refuseKeyboard("typeText", args.text.slice(0, 16));
+    this.refuseKeyboard(
+      "typeText",
+      truncateWellFormed(toWellFormedUnicode(args.text), 16),
+    );
   }
 
   async pressKey(args: { key: string }): Promise<void> {

--- a/plugins/plugin-computeruse/src/platform/terminal.surrogate.test.ts
+++ b/plugins/plugin-computeruse/src/platform/terminal.surrogate.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { normalizeOutput } from "./terminal.js";
+import { normalizeOutput, typeTerminal } from "./terminal.js";
 
 function isWellFormed(v: string): boolean {
   if (!v) return true;
@@ -53,5 +53,12 @@ describe("computeruse terminal output well-formed", () => {
     const out = normalizeOutput(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out).toBe("term \uFFFD ok");
+  });
+
+  it("safely truncates queued text in typeTerminal at surrogate boundary", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `${"a".repeat(49)}${fox}more`;
+    const res = typeTerminal(input);
+    expect(res.message).toBe(`queued terminal text: ${"a".repeat(49)}`);
   });
 });

--- a/plugins/plugin-computeruse/src/platform/terminal.ts
+++ b/plugins/plugin-computeruse/src/platform/terminal.ts
@@ -5,7 +5,7 @@
  */
 import { execFile } from "node:child_process";
 import os from "node:os";
-import { toWellFormedUnicode } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { TerminalActionResult } from "../types.js";
 import { checkDangerousCommand, sanitizeChildEnv } from "./security.js";
 
@@ -203,7 +203,7 @@ export function typeTerminal(
     success: true,
     sessionId,
     session_id: sessionId,
-    message: `queued terminal text: ${text.slice(0, 50)}`,
+    message: `queued terminal text: ${truncateWellFormed(toWellFormedUnicode(text), 50)}`,
   };
 }
 


### PR DESCRIPTION
## Summary

Uses `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` in `plugins/plugin-computeruse/src/platform/terminal.ts:206` and `plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts:189` to prevent raw character slicing from bisecting UTF-16 surrogate pairs into malformed lone surrogates when producing queued terminal text action messages and iOS keyboard typing refusal previews.

## Changes

- In `plugins/plugin-computeruse/src/platform/terminal.ts:206`, sanitize and truncate queued terminal text using `truncateWellFormed(toWellFormedUnicode(text), 50)`.
- In `plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts:189`, sanitize and truncate the typing refusal preview string using `truncateWellFormed(toWellFormedUnicode(args.text), 16)`.
- In `plugins/plugin-computeruse/src/platform/terminal.surrogate.test.ts`, add unit test verifying that `typeTerminal` safely truncates text containing multi-byte surrogate characters at the 50-character limit boundary.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`bbcbc75c98`) |
| --- | --- | --- |
| `bunx vitest run src/platform/terminal.surrogate.test.ts src/__tests__/ios-computer-interface.test.ts` (in `plugins/plugin-computeruse`) | 25 pass (25 tests) | 26 pass (26 tests) |
| `bunx @biomejs/biome check plugins/plugin-computeruse/src/platform/terminal.ts plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts plugins/plugin-computeruse/src/platform/terminal.surrogate.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-computeruse/src/platform/terminal.ts:200-210`
- `plugins/plugin-computeruse/src/mobile/ios-computer-interface.ts:185-195`
- `plugins/plugin-computeruse/src/platform/terminal.surrogate.test.ts:50-65`

## Risks

Low. Preserves complete unicode code points and prevents lone surrogate corruption.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Computer use plugin platform terminal and iOS input interfaces)
- [x] `audit:browser` — N/A (Terminal message generation and keyboard refusal previews)
- [x] `build` — Clean build across workspace
- [x] `test` — 26/26 pass in `terminal.surrogate.test.ts` & `ios-computer-interface.test.ts`
- [x] `lint` — Biome clean
