### PR TITLE
test(app-core): cover dev-settings-figlet-heading

### DIFF
--- a/packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts
+++ b/packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Direct unit coverage for the Node-only figlet heading printed above each
+ * dev-settings table. Drives the real module (figlet is a package dependency);
+ * expectations are the strings this checkout produced, including the boxed
+ * marker emitted when the requested font is missing.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type DevSubsystemBannerKind,
+  prependDevSubsystemFigletHeading,
+  renderDevSubsystemFigletHeading,
+} from "./dev-settings-figlet-heading";
+
+const STANDARD_HEADINGS: Record<DevSubsystemBannerKind, string[]> = {
+  orchestrator: [
+    "   ___  ____   ____ _   _ _____ ____ _____ ____      _  _____ ___  ____  ",
+    "  / _ \\|  _ \\ / ___| | | | ____/ ___|_   _|  _ \\    / \\|_   _/ _ \\|  _ \\ ",
+    " | | | | |_) | |   | |_| |  _| \\___ \\ | | | |_) |  / _ \\ | || | | | |_) |",
+    " | |_| |  _ <| |___|  _  | |___ ___) || | |  _ <  / ___ \\| || |_| |  _ < ",
+    "  \\___/|_| \\_\\\\____|_| |_|_____|____/ |_| |_| \\_\\/_/   \\_\\_| \\___/|_| \\_\\",
+  ],
+  vite: [
+    " __     _____ _____ _____ ",
+    " \\ \\   / /_ _|_   _| ____|",
+    "  \\ \\ / / | |  | | |  _|  ",
+    "   \\ V /  | |  | | | |___ ",
+    "    \\_/  |___| |_| |_____|",
+  ],
+  api: [
+    "     _    ____ ___ ",
+    "    / \\  |  _ \\_ _|",
+    "   / _ \\ | |_) | | ",
+    "  / ___ \\|  __/| | ",
+    " /_/   \\_\\_|  |___|",
+  ],
+  electrobun: [
+    "  _____ _     _____ ____ _____ ____   ___  ____  _   _ _   _ ",
+    " | ____| |   | ____/ ___|_   _|  _ \\ / _ \\| __ )| | | | \\ | |",
+    " |  _| | |   |  _|| |     | | | |_) | | | |  _ \\| | | |  \\| |",
+    " | |___| |___| |__| |___  | | |  _ <| |_| | |_) | |_| | |\\  |",
+    " |_____|_____|_____\\____| |_| |_| \\_\\\\___/|____/ \\___/|_| \\_|",
+  ],
+};
+
+const BOXED_FALLBACK: Record<DevSubsystemBannerKind, string> = {
+  orchestrator: " ______________ \n| ORCHESTRATOR |\n|______________|",
+  vite: " ______ \n| VITE |\n|______|",
+  api: " _____ \n| API |\n|_____|",
+  electrobun: " ____________ \n| ELECTROBUN |\n|____________|",
+};
+
+const KINDS = Object.keys(STANDARD_HEADINGS) as DevSubsystemBannerKind[];
+
+const MISSING_FONT = "ThisFontDoesNotExistXYZ";
+
+describe("renderDevSubsystemFigletHeading", () => {
+  it.each(KINDS)("renders the Standard-font figlet block for %s", (kind) => {
+    expect(renderDevSubsystemFigletHeading(kind).split("\n")).toEqual(
+      STANDARD_HEADINGS[kind],
+    );
+  });
+
+  it("strips only trailing whitespace from the finished block", () => {
+    for (const kind of KINDS) {
+      const out = renderDevSubsystemFigletHeading(kind);
+      expect(out).toBe(STANDARD_HEADINGS[kind].join("\n"));
+      expect(out).not.toMatch(/\s$/u);
+    }
+  });
+
+  it("treats omitted options, an empty object, and the documented defaults as the same", () => {
+    const omitted = renderDevSubsystemFigletHeading("api");
+    expect(renderDevSubsystemFigletHeading("api", {})).toBe(omitted);
+    expect(renderDevSubsystemFigletHeading("api", { maxWidth: 80 })).toBe(
+      omitted,
+    );
+    expect(renderDevSubsystemFigletHeading("api", { font: "Standard" })).toBe(
+      omitted,
+    );
+    expect(
+      renderDevSubsystemFigletHeading("api", {
+        maxWidth: 80,
+        font: "Standard",
+      }),
+    ).toBe(omitted);
+  });
+
+  it("accepts the Small font as a distinct shorter block", () => {
+    const small = renderDevSubsystemFigletHeading("api", { font: "Small" });
+    expect(small.split("\n")).toEqual([
+      "    _   ___ ___ ",
+      "   /_\\ | _ \\_ _|",
+      "  / _ \\|  _/| | ",
+      " /_/ \\_\\_| |___|",
+    ]);
+    expect(small).not.toBe(renderDevSubsystemFigletHeading("api"));
+  });
+
+  it("wraps the figlet block when maxWidth is narrower than the Standard line", () => {
+    const wrapped = renderDevSubsystemFigletHeading("api", { maxWidth: 10 });
+    expect(wrapped.split("\n")).toEqual([
+      "     _    ",
+      "    / \\   ",
+      "   / _ \\  ",
+      "  / ___ \\ ",
+      " /_/__ \\_\\",
+      " |  _ \\   ",
+      " | |_) |  ",
+      " |  __/   ",
+      " |_|_     ",
+      " |_ _|    ",
+      "  | |     ",
+      "  | |     ",
+      " |___|",
+    ]);
+    expect(wrapped.split("\n").length).toBeGreaterThan(
+      STANDARD_HEADINGS.api.length,
+    );
+  });
+
+  it("leaves wrapping unchanged for non-positive maxWidth (figlet treats them as default)", () => {
+    const omitted = renderDevSubsystemFigletHeading("api");
+    expect(renderDevSubsystemFigletHeading("api", { maxWidth: 0 })).toBe(
+      omitted,
+    );
+    expect(renderDevSubsystemFigletHeading("api", { maxWidth: -1 })).toBe(
+      omitted,
+    );
+  });
+
+  it("treats an empty font name as the Standard default rather than the boxed fallback", () => {
+    expect(renderDevSubsystemFigletHeading("api", { font: "" })).toBe(
+      renderDevSubsystemFigletHeading("api"),
+    );
+  });
+
+  it.each(KINDS)(
+    "falls back to the boxed marker when the requested font is missing for %s",
+    (kind) => {
+      const out = renderDevSubsystemFigletHeading(kind, {
+        font: MISSING_FONT,
+      });
+      expect(out).toBe(BOXED_FALLBACK[kind]);
+      expect(out.split("\n")).toHaveLength(3);
+    },
+  );
+});
+
+describe("prependDevSubsystemFigletHeading", () => {
+  it("joins the heading and table with a single blank line", () => {
+    const head = renderDevSubsystemFigletHeading("api");
+    expect(prependDevSubsystemFigletHeading("api", "| table |")).toBe(
+      `${head}\n\n| table |`,
+    );
+  });
+
+  it("keeps an empty table as a trailing blank line after the heading", () => {
+    const head = renderDevSubsystemFigletHeading("vite");
+    expect(prependDevSubsystemFigletHeading("vite", "")).toBe(`${head}\n\n`);
+  });
+
+  it("preserves table newlines rather than flattening them", () => {
+    const head = renderDevSubsystemFigletHeading("api");
+    expect(prependDevSubsystemFigletHeading("api", "row1\nrow2")).toBe(
+      `${head}\n\nrow1\nrow2`,
+    );
+    expect(prependDevSubsystemFigletHeading("api", "\nfooter")).toBe(
+      `${head}\n\n\nfooter`,
+    );
+  });
+
+  it("forwards font and maxWidth into the heading used above the table", () => {
+    const head = renderDevSubsystemFigletHeading("electrobun", {
+      font: MISSING_FONT,
+      maxWidth: 40,
+    });
+    expect(
+      prependDevSubsystemFigletHeading("electrobun", "T", {
+        font: MISSING_FONT,
+        maxWidth: 40,
+      }),
+    ).toBe(`${head}\n\nT`);
+    expect(head).toBe(BOXED_FALLBACK.electrobun);
+  });
+});


### PR DESCRIPTION

## Summary

Test-only coverage for `packages/app-core/src/runtime/dev-settings-figlet-heading.ts`, the Node-only figlet heading printed above each dev-settings table. There was no same-named test file. Production code is unchanged.

The suite drives the real module (figlet is already an `@elizaos/app-core` dependency). It does not mock `textSync` and then assert the mock. Expectations are the strings this checkout produced:

- Standard-font figlet blocks for `orchestrator`, `vite`, `api`, and `electrobun`
- omitted options, `{}`, `{ maxWidth: 80 }`, and `{ font: "Standard" }` are the same output
- Small font is a distinct shorter block; `maxWidth: 10` wraps to 13 lines
- non-positive `maxWidth` and an empty font name keep the Standard default (figlet's observed behaviour, not a throw)
- a missing font falls back to the boxed marker (`| API |` / `| VITE |` / …)
- `prependDevSubsystemFigletHeading` inserts one blank line, preserves an empty or multiline table, and forwards `font` / `maxWidth`

Hosted CI does not run on this fork contributor's pull requests. Local verification is quoted below; do not read this as a GitHub Actions pass.

## Evidence

1. `bunx vitest run packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts`

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Re-run against current `origin/develop` immediately before filing (production blob `packages/app-core/src/runtime/dev-settings-figlet-heading.ts` is unchanged at this head).

2. `bunx biome check --write packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts`

```
Checked 1 file in 118ms. Fixed 1 file.
```

Biome rewrote wrapping on first pass; the quoted vitest counts are from the post-biome file. Config was present (`biome.json`, not sparse-checkout).

3. `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'dev-settings-figlet-heading.test.ts' ; echo "EXIT:$?"`

```
EXIT:1
```

The new test file appears nowhere in `tsc` output (grep exit 1 = no matches). Pre-existing package errors, if any, are not from this file.

4. The diff touches only `packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6322292533538e893e6c3ee9298f2fb8e7f39450 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
