### PR TITLE
test(app-core): cover native-plugin-entrypoints

### DIFF
--- a/packages/app-core/src/platform/native-plugin-entrypoints.test.ts
+++ b/packages/app-core/src/platform/native-plugin-entrypoints.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit coverage for the mobile-boot side-effect barrel
+ * `native-plugin-entrypoints`: the ordered Capacitor plugin import list, the
+ * empty export surface, plugin registration on `@capacitor/core`, and the
+ * import-time JS-runtime factories so `resolveJsRuntimeBridge()` can find
+ * `jsc-ios` / `quickjs-*` on a Capacitor host. Drives the real module; no
+ * mocks of the barrel.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Capacitor } from "@capacitor/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SOURCE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "native-plugin-entrypoints.ts",
+);
+
+const EXPECTED_IMPORTS = [
+  "@elizaos/capacitor-camera",
+  "@elizaos/capacitor-canvas",
+  "@elizaos/capacitor-contacts",
+  "@elizaos/capacitor-gateway",
+  "@elizaos/capacitor-location",
+  "@elizaos/capacitor-messages",
+  "@elizaos/capacitor-mobile-agent-bridge",
+  "@elizaos/capacitor-mobile-signals",
+  "@elizaos/capacitor-appblocker",
+  "@elizaos/capacitor-bun-runtime",
+  "@elizaos/capacitor-phone",
+  "@elizaos/capacitor-screencapture",
+  "@elizaos/capacitor-swabble",
+  "@elizaos/capacitor-system",
+  "@elizaos/capacitor-talkmode",
+  "@elizaos/capacitor-websiteblocker",
+  "../connectors/capacitor-jsc.ts",
+  "../connectors/capacitor-quickjs.ts",
+] as const;
+
+const WEB_PLUGIN_NAMES = [
+  "ElizaCamera",
+  "ElizaCanvas",
+  "ElizaContacts",
+  "Gateway",
+  "ElizaLocation",
+  "ElizaMessages",
+  "MobileAgentBridge",
+  "MobileSignals",
+  "ElizaAppBlocker",
+  "ElizaBunRuntime",
+  "ElizaPhone",
+  "ScreenCapture",
+  "Swabble",
+  "ElizaSystem",
+  "TalkMode",
+  "ElizaWebsiteBlocker",
+] as const;
+
+interface CapacitorHost {
+  isNativePlatform?: () => boolean;
+  getPlatform?: () => string;
+  isPluginAvailable?: (name: string) => boolean;
+}
+
+function sourceImports(source: string): string[] {
+  const matches = source.matchAll(/^import\s+"([^"]+)";$/gm);
+  return [...matches].map((match) => match[1]);
+}
+
+function hideNodeVersion(): () => void {
+  const original = process.versions.node;
+  Object.defineProperty(process.versions, "node", {
+    configurable: true,
+    enumerable: true,
+    value: undefined,
+  });
+  return () => {
+    Object.defineProperty(process.versions, "node", {
+      configurable: true,
+      enumerable: true,
+      value: original,
+    });
+  };
+}
+
+function installCapacitorHost(host: CapacitorHost): () => void {
+  const globalCapacitor = globalThis as { Capacitor?: unknown };
+  const previous = globalCapacitor.Capacitor;
+  globalCapacitor.Capacitor = host;
+  return () => {
+    if (previous === undefined) {
+      delete globalCapacitor.Capacitor;
+    } else {
+      globalCapacitor.Capacitor = previous;
+    }
+  };
+}
+
+describe("native-plugin-entrypoints source contract", () => {
+  const source = readFileSync(SOURCE_PATH, "utf8");
+
+  it("imports every native plugin and JS-runtime connector in boot order", () => {
+    expect(sourceImports(source)).toEqual([...EXPECTED_IMPORTS]);
+  });
+
+  it("exports nothing — it is a side-effect barrel", () => {
+    expect(source).not.toMatch(/^export\b/m);
+  });
+});
+
+describe("native-plugin-entrypoints boot side effects", () => {
+  it("evaluates to an empty module namespace", async () => {
+    const loaded = await import("./native-plugin-entrypoints");
+    expect(Object.keys(loaded)).toEqual([]);
+  });
+
+  it("returns the same module object on a second import", async () => {
+    const first = await import("./native-plugin-entrypoints");
+    const second = await import("./native-plugin-entrypoints");
+    expect(second).toBe(first);
+  });
+
+  it("registers each Capacitor plugin that ships a web implementation", async () => {
+    await import("./native-plugin-entrypoints");
+    for (const name of WEB_PLUGIN_NAMES) {
+      expect(Capacitor.isPluginAvailable(name), name).toBe(true);
+    }
+  });
+
+  it("does not report a missing plugin as available", async () => {
+    await import("./native-plugin-entrypoints");
+    expect(Capacitor.isPluginAvailable("DefinitelyNotARegisteredPlugin")).toBe(
+      false,
+    );
+  });
+
+  it("leaves native-only JS-runtime plugins unavailable on the web platform", async () => {
+    await import("./native-plugin-entrypoints");
+    expect(Capacitor.getPlatform()).toBe("web");
+    expect(Capacitor.isPluginAvailable("CapacitorJsc")).toBe(false);
+    expect(Capacitor.isPluginAvailable("CapacitorQuickJs")).toBe(false);
+  });
+
+  it("still resolves the host-node bridge on Node after the barrel loads", async () => {
+    await import("./native-plugin-entrypoints");
+    const { resolveJsRuntimeBridge } = await import("@elizaos/agent");
+    const bridge = await resolveJsRuntimeBridge();
+    expect(bridge.kind).toBe("host-node");
+    await bridge.dispose();
+  });
+});
+
+describe("native-plugin-entrypoints JS-runtime factory registration", () => {
+  const restorers: Array<() => void> = [];
+
+  beforeEach(() => {
+    vi.resetModules();
+    const warn = console.warn.bind(console);
+    vi.spyOn(console, "warn").mockImplementation((message, ...rest) => {
+      if (
+        typeof message === "string" &&
+        message.includes("already registered. Cannot register plugins twice.")
+      ) {
+        return;
+      }
+      warn(message, ...rest);
+    });
+  });
+
+  afterEach(() => {
+    while (restorers.length > 0) {
+      restorers.pop()?.();
+    }
+    vi.restoreAllMocks();
+  });
+
+  async function resolveOnCapacitorHost(host: CapacitorHost) {
+    restorers.push(hideNodeVersion());
+    restorers.push(installCapacitorHost(host));
+    await import("./native-plugin-entrypoints");
+    const { resolveJsRuntimeBridge } = await import("@elizaos/agent");
+    return resolveJsRuntimeBridge();
+  }
+
+  it("selects jsc-ios on iOS when the JSC plugin is present", async () => {
+    const bridge = await resolveOnCapacitorHost({
+      isNativePlatform: () => true,
+      getPlatform: () => "ios",
+      isPluginAvailable: (name) => name === "CapacitorJsc",
+    });
+    expect(bridge.kind).toBe("jsc-ios");
+  });
+
+  it("prefers jsc-ios over the QuickJS fallback when both iOS plugins exist", async () => {
+    const bridge = await resolveOnCapacitorHost({
+      isNativePlatform: () => true,
+      getPlatform: () => "ios",
+      isPluginAvailable: (name) =>
+        name === "CapacitorJsc" || name === "CapacitorQuickJs",
+    });
+    expect(bridge.kind).toBe("jsc-ios");
+  });
+
+  it("falls back to quickjs-ios-fallback when JSC is missing on iOS", async () => {
+    const bridge = await resolveOnCapacitorHost({
+      isNativePlatform: () => true,
+      getPlatform: () => "ios",
+      isPluginAvailable: (name) => name === "CapacitorQuickJs",
+    });
+    expect(bridge.kind).toBe("quickjs-ios-fallback");
+  });
+
+  it("selects quickjs-android on Android when the QuickJS plugin is present", async () => {
+    const bridge = await resolveOnCapacitorHost({
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      isPluginAvailable: (name) => name === "CapacitorQuickJs",
+    });
+    expect(bridge.kind).toBe("quickjs-android");
+  });
+
+  it("does not select an iOS factory on Android even if JSC claims to be present", async () => {
+    const bridge = await resolveOnCapacitorHost({
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      isPluginAvailable: (name) =>
+        name === "CapacitorJsc" || name === "CapacitorQuickJs",
+    });
+    expect(bridge.kind).toBe("quickjs-android");
+  });
+
+  it("throws when no Capacitor JS-runtime plugin is available", async () => {
+    await expect(
+      resolveOnCapacitorHost({
+        isNativePlatform: () => true,
+        getPlatform: () => "ios",
+        isPluginAvailable: () => false,
+      }),
+    ).rejects.toThrow(
+      "[js-runtime-bridge] no JS runtime available (platform=ios)",
+    );
+  });
+
+  it("throws on an unknown platform when every factory returns null", async () => {
+    await expect(
+      resolveOnCapacitorHost({
+        isNativePlatform: () => false,
+        getPlatform: () => "web",
+        isPluginAvailable: () => false,
+      }),
+    ).rejects.toThrow(
+      "[js-runtime-bridge] no JS runtime available (platform=web)",
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/app-core/src/platform/native-plugin-entrypoints.ts`, which had no same-named test file anywhere in the repository.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the fetched `origin/develop` with a single test-only commit.
- [x] Focused Vitest, Biome, and `tsc --noEmit` (this file absent from tsc output) were run after that sync.
- [x] A reviewer can confirm the barrel's behavior from the committed suite without reading production code.

# Sync with develop

- [x] Branch parent is the fetched `origin/develop` (`8b4fff7ecc5db1b5549072aaf28aa9911b29eb74`); zero conflicts; diff is one new test file.
- [x] `bun run verify` was not run for this test-only change. Focused package proof is quoted below. Hosted GitHub Actions CI does **not** run on this fork contributor PR.

# Risks

Low. Production `native-plugin-entrypoints.ts` is unchanged. The suite drives the real side-effect barrel (ordered Capacitor plugin imports, empty export surface, plugin registration on `@capacitor/core`, and the import-time JS-runtime factories that `resolveJsRuntimeBridge()` uses on a Capacitor host).

# Background

## What does this PR do?

Adds a colocated Vitest suite for the mobile-boot side-effect barrel. The module exports nothing; its behavior is the import list and the registrations those imports perform. Coverage is behavior, not mocks: the real barrel is imported, Capacitor plugin availability is queried on the live `@capacitor/core` registry, and `resolveJsRuntimeBridge()` is driven on Node and on a substituted Capacitor host so `jsc-ios`, `quickjs-ios-fallback`, and `quickjs-android` factories actually resolve.

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app-core/src/platform/native-plugin-entrypoints.test.ts` — same layout as `native-library-policy.test.ts` and `ios-runtime-backends.test.ts` in that directory. Import path is `./native-plugin-entrypoints`.

## Detailed testing steps

From `packages/app-core`:

```bash
bunx vitest run src/platform/native-plugin-entrypoints.test.ts
bunx biome check --write src/platform/native-plugin-entrypoints.test.ts
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'native-plugin-entrypoints.test' ; echo "GREP_EXIT:$?"
```

Focused proof at the pushed head `4808348a60b9306a78ca45347886201d31da4e20` (re-run against current `origin/develop` immediately before filing; the production barrel is byte-identical to that develop SHA):

```text
RUN  v4.1.5 /Volumes/thescoho_1TB/Developer/eliza/packages/app-core
 ✓ src/platform/native-plugin-entrypoints.test.ts (15 tests) 14120ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  18:20:26
   Duration  14.27s (transform 8.98s, setup 0ms, import 46ms, tests 14.12s, environment 0ms)
```

`bunx biome check --write` on the new file: checked 1 file, no fixes applied.

`bunx tsc --noEmit` in `packages/app-core`: this file appears nowhere in the output (`GREP_EXIT:1`). Pre-existing errors in other packages are unchanged; this test file adds zero TypeScript errors.

The diff touches only `packages/app-core/src/platform/native-plugin-entrypoints.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:4808348a60b9306a78ca45347886201d31da4e20 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (15 passed / 15).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-only change; no DB, wallet, or scheduled-item artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR does not change agent/action/provider/prompt/model behavior.

## Backend + frontend logs

N/A - no server or UI path changed. Focused Vitest output is quoted in Testing.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no rendered UI.

### Before

N/A - no rendered UI changes.

### After

N/A - no rendered UI changes.

### Walkthrough video

N/A - deterministic unit tests; no interactive UI flow.

## Audio / voice walkthrough

N/A - no voice/TTS/STT surface.

## Known gaps / failures

- Hosted GitHub Actions CI does not run on fork contributor PRs. Local Vitest/Biome/tsc proof is quoted above.
- Package `tsc --noEmit` reports pre-existing errors in other files; `native-plugin-entrypoints.test.ts` does not appear in that output.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
