### PR TITLE
fix(scenario-runner): isolate each scenario's action surface in a shared runtime

### DIFF
--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -819,6 +819,7 @@ export async function runCli(
         // a peer's actions and keep this scenario's tool surface identical to a
         // solo run.
         batchPluginPackages: requiredPlugins,
+        scenarioDeclaredActionNames: runtimeResult.scenarioDeclaredActionNames,
       });
       const report =
         executionProfile === "provider-qualified"

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -814,6 +814,11 @@ export async function runCli(
         abortSignal: runAbortController.signal,
         executionProfile,
         runDir: effectiveRunDir,
+        // Every scenario in this batch shares one runtime carrying the union of
+        // their declared plugins. Hand that union to the executor so it can hide
+        // a peer's actions and keep this scenario's tool surface identical to a
+        // solo run.
+        batchPluginPackages: requiredPlugins,
       });
       const report =
         executionProfile === "provider-qualified"

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -125,6 +125,13 @@ export interface ExecutorOptions {
    * independent of batch composition. Omit it for a single-scenario runtime.
    */
   batchPluginPackages?: readonly string[];
+  /**
+   * Action names present only because a scenario declared the contributing
+   * package, from `createScenarioRuntime`. Without it every peer-declared
+   * package's actions are hidden, including baseline ones an undeclaring
+   * scenario legitimately drives.
+   */
+  scenarioDeclaredActionNames?: readonly string[];
 }
 
 /**
@@ -1982,6 +1989,7 @@ async function executeActionTurn(
   room: ScenarioRoomDefinition,
   currentNow: Date,
   turnTimeoutMs: number,
+  hiddenActionNames: readonly string[] = [],
 ): Promise<{
   validation: NonNullable<ScenarioTurnExecution["validation"]>;
   responseText: string;
@@ -2006,6 +2014,15 @@ async function executeActionTurn(
     (candidate: Action) => candidate.name === actionName,
   );
   if (!action) {
+    // Distinguish "this action does not exist" from "per-scenario action
+    // scoping hid it because only a batch peer declared the owning package".
+    // The second reads as a missing action but is a declaration gap, and
+    // saying so is the difference between a one-line fix and an afternoon.
+    if (hiddenActionNames.includes(actionName)) {
+      throw new Error(
+        `[executor] action turn '${turn.name}' requested '${actionName}', which is hidden from this scenario because only another scenario in this run declared the plugin that provides it; add that package to this scenario's requires.plugins`,
+      );
+    }
     throw new Error(
       `[executor] action turn '${turn.name}' requested unknown action '${actionName}'`,
     );
@@ -2853,6 +2870,7 @@ export async function runScenario(
     runtime,
     scenario,
     opts.batchPluginPackages ?? [],
+    opts.scenarioDeclaredActionNames,
   );
   if (actionScope.hiddenActionNames.length > 0) {
     logger.info(
@@ -3052,6 +3070,7 @@ export async function runScenario(
                       resolveTurnRoom(turn, rooms),
                       logicalNow,
                       opts.turnTimeoutMs || DEFAULT_TURN_TIMEOUT_MS,
+                      actionScope.hiddenActionNames,
                     )),
                   }
                 : kind === "wait"

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -74,6 +74,7 @@ import {
   resolveRequiredPluginPackages,
 } from "./required-plugins.ts";
 import { waitForScenarioRequiredServices } from "./required-services.ts";
+import { enterScenarioActionScope } from "./scenario-action-scope.ts";
 import { applyScenarioSeedStep } from "./seeds.ts";
 import type {
   FinalCheckReport,
@@ -117,6 +118,13 @@ export interface ExecutorOptions {
   worldId?: string;
   /** Maximum time to reach post-delivery quiescence before quarantining the runtime. */
   postDeliveryTimeoutMs?: number;
+  /**
+   * Every plugin package declared by *any* scenario sharing this runtime. The
+   * CLI registers that union before the first scenario runs, so the executor
+   * needs it to hide a peer's actions and keep each scenario's tool surface
+   * independent of batch composition. Omit it for a single-scenario runtime.
+   */
+  batchPluginPackages?: readonly string[];
 }
 
 /**
@@ -2838,6 +2846,19 @@ export async function runScenario(
   const originalGetService = runtime.getService.bind(runtime);
   const scenarioComputerUseService = createScenarioComputerUseService();
   let apiServer: ScenarioApiServer | null = null;
+  // Scope the shared runtime's action list to this scenario before anything can
+  // observe it. Restoring in `finally` also drops actions the seed registers, so
+  // neither a peer's plugin nor this scenario's own leaks across the batch.
+  const actionScope = enterScenarioActionScope(
+    runtime,
+    scenario,
+    opts.batchPluginPackages ?? [],
+  );
+  if (actionScope.hiddenActionNames.length > 0) {
+    logger.info(
+      `[scenario-runner] ${scenario.id}: hiding ${actionScope.hiddenActionNames.length} action(s) declared only by batch peers: ${actionScope.hiddenActionNames.join(", ")}`,
+    );
+  }
   try {
     beginScenarioModelFixtureAttempt(
       runtime,
@@ -3234,6 +3255,7 @@ export async function runScenario(
     if (apiServer) {
       await apiServer.close();
     }
+    actionScope.restore();
     report.durationMs = Date.now() - startedAt;
   }
 

--- a/packages/scenario-runner/src/required-plugins.ts
+++ b/packages/scenario-runner/src/required-plugins.ts
@@ -152,14 +152,26 @@ function pluginNameAliases(packageName: string): Set<string> {
   ]);
 }
 
+/**
+ * Whether one registered plugin is the one a scenario declared as
+ * `packageName`. A plugin's internal `name` routinely differs from its package
+ * specifier, so this alias comparison is the only correct identity test and
+ * every caller must share it.
+ */
+export function pluginMatchesScenarioPackage(
+  plugin: Pick<Plugin, "name">,
+  packageName: string,
+): boolean {
+  if (typeof plugin.name !== "string") return false;
+  return pluginNameAliases(packageName).has(plugin.name.trim());
+}
+
 export function pluginPackageIsRegistered(
   runtime: Pick<AgentRuntime, "plugins">,
   packageName: string,
 ): boolean {
-  const aliases = pluginNameAliases(packageName);
-  return runtime.plugins.some(
-    (plugin) =>
-      typeof plugin.name === "string" && aliases.has(plugin.name.trim()),
+  return runtime.plugins.some((plugin) =>
+    pluginMatchesScenarioPackage(plugin, packageName),
   );
 }
 

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -126,6 +126,13 @@ export interface RuntimeFactoryResult {
   pgliteDir: string;
   executionProfile: ScenarioExecutionProfile;
   registeredPluginPackages: readonly string[];
+  /**
+   * Action names this runtime carries *only* because some scenario declared the
+   * contributing package. Actions the runtime registers regardless are absent,
+   * so per-scenario scoping can hide a batch peer's plugin without ever hiding
+   * a baseline capability an undeclaring scenario legitimately uses.
+   */
+  scenarioDeclaredActionNames: readonly string[];
   providerName: LiveProviderName | typeof DETERMINISTIC_MODEL_PROVIDER_NAME;
   providerConfig:
     | LiveProviderConfig
@@ -1016,11 +1023,20 @@ export async function createScenarioRuntime(
     }
   }
 
+  // Anything already on the runtime at this point is baseline capability that
+  // exists no matter which scenarios are batched; only the delta below belongs
+  // to a scenario's own `requires.plugins` declaration.
+  const baselineActionNames = new Set(
+    runtime.actions.map((action) => action.name),
+  );
   const requiredPluginPackages = await registerScenarioRequiredPlugins(
     runtime,
     options?.requiredPlugins ?? [],
     executionProfile,
   );
+  const scenarioDeclaredActionNames = runtime.actions
+    .map((action) => action.name)
+    .filter((name) => !baselineActionNames.has(name));
   for (const packageName of requiredPluginPackages) {
     registeredPluginPackages.add(packageName);
   }
@@ -1173,6 +1189,9 @@ export async function createScenarioRuntime(
     pgliteDir,
     executionProfile,
     registeredPluginPackages: [...registeredPluginPackages].sort(),
+    scenarioDeclaredActionNames: [
+      ...new Set(scenarioDeclaredActionNames),
+    ].sort(),
     providerName: providerConfig.name,
     providerConfig,
     cleanup,

--- a/packages/scenario-runner/src/scenario-action-scope.test.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Covers per-scenario action scoping on the shared scenario runtime: the unit
+ * contract of `scenario-action-scope.ts`, and an end-to-end regression that
+ * drives two scenarios through the real `runScenario` in one process against
+ * one runtime — the exact shape that used to let a batch peer's plugin change
+ * the second scenario's planner tool surface and starve its model fixtures.
+ * The runtime is a lightweight fake; the fixture registry is the real one from
+ * `@elizaos/core/testing`.
+ */
+
+import type { Action, AgentRuntime, Plugin } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { createDeterministicModelPlugin } from "@elizaos/core/testing";
+import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
+import { describe, expect, it, vi } from "vitest";
+import { runScenario } from "./executor.ts";
+import {
+  enterScenarioActionScope,
+  foreignScenarioActionNames,
+} from "./scenario-action-scope.ts";
+
+function action(name: string): Action {
+  return {
+    name,
+    description: name,
+    examples: [],
+    validate: async () => true,
+    handler: async () => undefined,
+  } as unknown as Action;
+}
+
+function plugin(name: string, actionNames: string[]): Plugin {
+  return {
+    name,
+    description: name,
+    actions: actionNames.map(action),
+  } as unknown as Plugin;
+}
+
+function scenarioDeclaring(id: string, packages: string[]): ScenarioDefinition {
+  return {
+    id,
+    title: id,
+    domain: "scenario-runner",
+    requires: { plugins: packages },
+    turns: [],
+  } as unknown as ScenarioDefinition;
+}
+
+describe("foreignScenarioActionNames", () => {
+  const runtime = {
+    actions: [],
+    plugins: [
+      plugin("coding-tools", ["FILE", "SHELL", "WORKTREE"]),
+      plugin("app-control", ["APP", "VIEWS"]),
+      plugin("bootstrap", ["REPLY", "IGNORE"]),
+    ],
+  } as unknown as Parameters<typeof foreignScenarioActionNames>[0];
+
+  it("names only the actions a batch peer's declared plugin contributed", () => {
+    const hidden = foreignScenarioActionNames(
+      runtime,
+      scenarioDeclaring("coding", ["@elizaos/plugin-coding-tools"]),
+      ["@elizaos/plugin-coding-tools", "@elizaos/plugin-app-control"],
+    );
+    expect([...hidden].sort()).toEqual(["APP", "VIEWS"]);
+  });
+
+  it("never hides an action the scenario's own declared plugin provides", () => {
+    const shared = {
+      actions: [],
+      plugins: [
+        plugin("coding-tools", ["FILE"]),
+        plugin("app-control", ["FILE", "APP"]),
+      ],
+    } as unknown as Parameters<typeof foreignScenarioActionNames>[0];
+    const hidden = foreignScenarioActionNames(
+      shared,
+      scenarioDeclaring("coding", ["@elizaos/plugin-coding-tools"]),
+      ["@elizaos/plugin-coding-tools", "@elizaos/plugin-app-control"],
+    );
+    expect([...hidden].sort()).toEqual(["APP"]);
+  });
+
+  it("hides nothing when the runtime carries no peer declarations", () => {
+    const hidden = foreignScenarioActionNames(
+      runtime,
+      scenarioDeclaring("coding", ["@elizaos/plugin-coding-tools"]),
+      ["@elizaos/plugin-coding-tools"],
+    );
+    expect([...hidden]).toEqual([]);
+  });
+});
+
+describe("enterScenarioActionScope", () => {
+  it("hides peer actions for the scope and restores the exact prior list", () => {
+    const runtime = {
+      actions: [action("FILE"), action("APP"), action("REPLY")],
+      plugins: [
+        plugin("coding-tools", ["FILE"]),
+        plugin("app-control", ["APP"]),
+      ],
+    } as unknown as Parameters<typeof enterScenarioActionScope>[0];
+
+    const scope = enterScenarioActionScope(
+      runtime,
+      scenarioDeclaring("coding", ["@elizaos/plugin-coding-tools"]),
+      ["@elizaos/plugin-coding-tools", "@elizaos/plugin-app-control"],
+    );
+    expect(runtime.actions.map((entry) => entry.name)).toEqual([
+      "FILE",
+      "REPLY",
+    ]);
+    expect(scope.hiddenActionNames).toEqual(["APP"]);
+
+    scope.restore();
+    expect(runtime.actions.map((entry) => entry.name)).toEqual([
+      "FILE",
+      "APP",
+      "REPLY",
+    ]);
+  });
+
+  it("drops actions registered inside the scope so they cannot leak forward", () => {
+    const runtime = {
+      actions: [action("REPLY")],
+      plugins: [],
+    } as unknown as Parameters<typeof enterScenarioActionScope>[0];
+
+    const scope = enterScenarioActionScope(
+      runtime,
+      scenarioDeclaring("seeded", []),
+      [],
+    );
+    runtime.actions.push(action("SEED_ONLY"));
+    scope.restore();
+    expect(runtime.actions.map((entry) => entry.name)).toEqual(["REPLY"]);
+  });
+});
+
+/**
+ * The regression that matters: two scenarios, one process, one runtime. The
+ * runtime carries both scenarios' plugins because the CLI registers the batch
+ * union before the first scenario starts. The second scenario must observe the
+ * same action surface it would observe alone, and its own model fixtures must
+ * be consumed.
+ */
+describe("two scenarios sharing one runtime", () => {
+  function createSharedRuntime(): {
+    runtime: AgentRuntime;
+    callPlanner: (prompt: string, toolNames: string[]) => Promise<unknown>;
+  } {
+    const codingTools = plugin("coding-tools", ["FILE"]);
+    const appControl = plugin("app-control", ["APP"]);
+    const deterministic = createDeterministicModelPlugin();
+    const runtime = {
+      actions: [...(codingTools.actions ?? []), ...(appControl.actions ?? [])],
+      plugins: [codingTools, appControl],
+      routes: [],
+      ensureConnection: vi.fn(async () => undefined),
+      getService: vi.fn(() => null),
+      setSetting: vi.fn(),
+      scenarioModelFixtures: deterministic.fixtures,
+      assertScenarioModelFixturesConsumed: deterministic.assertFixturesConsumed,
+      getScenarioModelFixtureDiagnostics: deterministic.getFixtureDiagnostics,
+      setScenarioModelFixtureMode: vi.fn(),
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    } as unknown as AgentRuntime;
+    const handler = deterministic.models?.[ModelType.ACTION_PLANNER] as (
+      runtime: unknown,
+      params: unknown,
+    ) => Promise<unknown>;
+    return {
+      runtime,
+      callPlanner: (prompt, toolNames) =>
+        handler(runtime, {
+          prompt,
+          tools: toolNames.map((name) => ({ name, parameters: {} })),
+        }),
+    };
+  }
+
+  /**
+   * A scenario whose seed records the action surface it can see and consumes
+   * one strict fixture that matches on the exact tool-name set — the same
+   * `toolNames` match the real deterministic corpus uses.
+   */
+  function observingScenario(
+    id: string,
+    declaredPackages: string[],
+    observedToolNames: string[],
+    seen: string[][],
+    callPlanner: (prompt: string, toolNames: string[]) => Promise<unknown>,
+  ): ScenarioDefinition {
+    return {
+      id,
+      title: id,
+      domain: "scenario-runner",
+      lane: "pr-deterministic",
+      requires: { plugins: declaredPackages },
+      modelFixtures: {
+        mode: "fixtures",
+        fixtures: [
+          {
+            name: `${id}-planner`,
+            match: {
+              modelType: "ACTION_PLANNER",
+              toolNames: observedToolNames,
+            },
+            response: { text: "ok" },
+          },
+        ],
+      },
+      seed: [
+        {
+          type: "custom",
+          name: "observe the visible action surface",
+          apply: async (ctx: { runtime?: unknown }) => {
+            const visible = (
+              ctx.runtime as { actions: Array<{ name: string }> }
+            ).actions.map((entry) => entry.name);
+            seen.push(visible);
+            await callPlanner(id, visible);
+            return undefined;
+          },
+        },
+      ],
+      turns: [],
+    } as unknown as ScenarioDefinition;
+  }
+
+  it("gives the second scenario a solo action surface and consumes its fixtures", async () => {
+    const { runtime, callPlanner } = createSharedRuntime();
+    const seen: string[][] = [];
+    const batch = [
+      "@elizaos/plugin-app-control",
+      "@elizaos/plugin-coding-tools",
+    ];
+    const options = {
+      providerName: "deterministic-model-provider",
+      minJudgeScore: 0,
+      turnTimeoutMs: 5_000,
+      batchPluginPackages: batch,
+    };
+
+    const first = await runScenario(
+      observingScenario(
+        "peer-app-control",
+        ["@elizaos/plugin-app-control"],
+        ["APP"],
+        seen,
+        callPlanner,
+      ),
+      runtime,
+      options,
+    );
+    const second = await runScenario(
+      observingScenario(
+        "coding-tools-under-test",
+        ["@elizaos/plugin-coding-tools"],
+        ["FILE"],
+        seen,
+        callPlanner,
+      ),
+      runtime,
+      options,
+    );
+
+    // Neither scenario may see the other's action.
+    expect(seen[0]).toEqual(["APP"]);
+    expect(seen[1]).toEqual(["FILE"]);
+
+    // The second scenario's own fixtures were consumed — the failure this
+    // guards reported `consumed: 0` for every fixture it declared.
+    const fixtures = second.modelFixtureDiagnostics?.fixtures ?? [];
+    expect(fixtures.map((entry) => entry.name)).toEqual([
+      "coding-tools-under-test-planner",
+    ]);
+    expect(fixtures.every((entry) => entry.consumed >= entry.min)).toBe(true);
+    expect(second.modelFixtureDiagnostics?.unexpectedCalls ?? []).toEqual([]);
+
+    expect(first.failedAssertions).toEqual([]);
+    expect(second.failedAssertions).toEqual([]);
+
+    // The runtime is handed back intact for whatever runs next.
+    expect(runtime.actions.map((entry) => entry.name).sort()).toEqual([
+      "APP",
+      "FILE",
+    ]);
+  });
+});

--- a/packages/scenario-runner/src/scenario-action-scope.test.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.test.ts
@@ -82,6 +82,22 @@ describe("foreignScenarioActionNames", () => {
     expect([...hidden].sort()).toEqual(["APP"]);
   });
 
+  it("never hides a baseline action, even when a peer declared its package", () => {
+    // plugin-browser is both a runtime baseline capability and something some
+    // scenarios declare. A scenario that drives BROWSER without declaring the
+    // package must keep it; only actions that exist *because* of a declaration
+    // may be hidden.
+    const hidden = foreignScenarioActionNames(
+      runtime,
+      scenarioDeclaring("coding", ["@elizaos/plugin-coding-tools"]),
+      ["@elizaos/plugin-coding-tools", "@elizaos/plugin-app-control"],
+      // Only APP exists because a scenario declared app-control; VIEWS is a
+      // baseline action the runtime carries either way.
+      ["APP"],
+    );
+    expect([...hidden]).toEqual(["APP"]);
+  });
+
   it("hides nothing when the runtime carries no peer declarations", () => {
     const hidden = foreignScenarioActionNames(
       runtime,

--- a/packages/scenario-runner/src/scenario-action-scope.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-scenario action scoping for the shared scenario runtime.
+ *
+ * PGLite cannot be torn down and rebuilt between scenarios, so one CLI
+ * invocation runs every scenario against one `AgentRuntime`. The CLI registers
+ * the union of every loaded scenario's `requires.plugins` into that runtime
+ * before the first scenario starts, and a scenario's own seed may register
+ * more. Both accumulate: without scoping, the action planner is offered the
+ * union of every batched scenario's actions, so the tool surface a scenario
+ * observes depends on which *other* scenarios happen to share the process.
+ *
+ * That is not a cosmetic difference. Strict deterministic model fixtures match
+ * on the exact tool-name set (`DeterministicModelFixtureMatch.toolNames`), so a
+ * peer's action silently turns a passing scenario red — the scenario stops
+ * routing, replies instead of acting, and its own fixtures report zero
+ * consumption. This module restores batch independence by hiding, for the
+ * lifetime of one scenario, every action contributed by a batch peer's declared
+ * plugin that this scenario did not declare, and by restoring the runtime's
+ * action list afterwards so a scenario's seed-registered actions do not leak
+ * forward either.
+ */
+
+import type { Action, AgentRuntime } from "@elizaos/core";
+import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
+import {
+  pluginMatchesScenarioPackage,
+  resolveRequiredPluginPackages,
+} from "./required-plugins.ts";
+
+/** The narrow runtime surface this scoping needs. */
+export type ActionScopedRuntime = Pick<AgentRuntime, "actions" | "plugins">;
+
+function actionNamesForPackages(
+  runtime: ActionScopedRuntime,
+  packageNames: readonly string[],
+): Set<string> {
+  const names = new Set<string>();
+  if (packageNames.length === 0) return names;
+  for (const plugin of runtime.plugins) {
+    if (
+      !packageNames.some((packageName) =>
+        pluginMatchesScenarioPackage(plugin, packageName),
+      )
+    ) {
+      continue;
+    }
+    for (const action of (plugin.actions ?? []) as Action[]) {
+      if (typeof action?.name === "string") names.add(action.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Action names contributed only by plugins that a *peer* scenario in this batch
+ * declared. An action that this scenario's own declared plugins also provide is
+ * never hidden, so overlapping declarations stay visible.
+ */
+export function foreignScenarioActionNames(
+  runtime: ActionScopedRuntime,
+  scenario: ScenarioDefinition,
+  batchPluginPackages: readonly string[],
+): Set<string> {
+  const declared = resolveRequiredPluginPackages(scenario);
+  const declaredSet = new Set(declared);
+  const foreignPackages = batchPluginPackages.filter(
+    (packageName) => !declaredSet.has(packageName),
+  );
+  const foreign = actionNamesForPackages(runtime, foreignPackages);
+  for (const name of actionNamesForPackages(runtime, declared)) {
+    foreign.delete(name);
+  }
+  return foreign;
+}
+
+/**
+ * Scope the runtime's action list to this scenario and return the restore
+ * callback. The restore reinstates the exact pre-scenario action list, which
+ * both re-exposes hidden peer actions and drops actions registered by this
+ * scenario's seed.
+ */
+export function enterScenarioActionScope(
+  runtime: ActionScopedRuntime,
+  scenario: ScenarioDefinition,
+  batchPluginPackages: readonly string[],
+): { hiddenActionNames: string[]; restore: () => void } {
+  const snapshot = [...runtime.actions];
+  const hidden = foreignScenarioActionNames(
+    runtime,
+    scenario,
+    batchPluginPackages,
+  );
+  if (hidden.size > 0) {
+    const kept = snapshot.filter((action) => !hidden.has(action.name));
+    runtime.actions.splice(0, runtime.actions.length, ...kept);
+  }
+  return {
+    hiddenActionNames: [...hidden].sort(),
+    restore: () => {
+      runtime.actions.splice(0, runtime.actions.length, ...snapshot);
+    },
+  };
+}

--- a/packages/scenario-runner/src/scenario-action-scope.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.ts
@@ -60,6 +60,7 @@ export function foreignScenarioActionNames(
   runtime: ActionScopedRuntime,
   scenario: ScenarioDefinition,
   batchPluginPackages: readonly string[],
+  scenarioDeclaredActionNames?: readonly string[],
 ): Set<string> {
   const declared = resolveRequiredPluginPackages(scenario);
   const declaredSet = new Set(declared);
@@ -69,6 +70,17 @@ export function foreignScenarioActionNames(
   const foreign = actionNamesForPackages(runtime, foreignPackages);
   for (const name of actionNamesForPackages(runtime, declared)) {
     foreign.delete(name);
+  }
+  // A package a peer declared may also be part of the runtime's baseline, and
+  // a scenario is entitled to every baseline action whether or not it declared
+  // the owning package. Hiding those broke scenarios that legitimately drive a
+  // baseline action without a `requires.plugins` entry, so restrict the hidden
+  // set to the actions that exist solely because of a scenario declaration.
+  if (scenarioDeclaredActionNames) {
+    const scenarioOnly = new Set(scenarioDeclaredActionNames);
+    for (const name of [...foreign]) {
+      if (!scenarioOnly.has(name)) foreign.delete(name);
+    }
   }
   return foreign;
 }
@@ -83,12 +95,14 @@ export function enterScenarioActionScope(
   runtime: ActionScopedRuntime,
   scenario: ScenarioDefinition,
   batchPluginPackages: readonly string[],
+  scenarioDeclaredActionNames?: readonly string[],
 ): { hiddenActionNames: string[]; restore: () => void } {
   const snapshot = [...runtime.actions];
   const hidden = foreignScenarioActionNames(
     runtime,
     scenario,
     batchPluginPackages,
+    scenarioDeclaredActionNames,
   );
   if (hidden.size > 0) {
     const kept = snapshot.filter((action) => !hidden.has(action.name));

--- a/packages/scenario-runner/test/scenarios/deterministic-browser-computeruse-progress.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-browser-computeruse-progress.scenario.ts
@@ -308,6 +308,14 @@ export default scenario({
     "progress",
   ],
   isolation: "shared-runtime",
+  // The seed registers `browserPlugin` directly, which silently no-ops when a
+  // batch peer already registered the same package — leaving this scenario
+  // dependent on batch composition for its own actions. Declaring the package
+  // states the dependency the seed only implies, so per-scenario action
+  // scoping keeps BROWSER visible here whoever else is in the run.
+  requires: {
+    plugins: ["@elizaos/plugin-browser"],
+  },
   seed: [
     {
       type: "custom",

--- a/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
@@ -7,7 +7,6 @@ import { promises as fs, realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { stringToUuid } from "@elizaos/core";
 import type {
   CapturedAction,
   ScenarioContext,
@@ -19,7 +18,6 @@ import codingToolsPlugin from "../../../../plugins/plugin-coding-tools/src/index
 
 const execFileAsync = promisify(execFile);
 
-const scenarioId = "deterministic-coding-tools-actions";
 const tmpRoot = path.join(
   realpathSync(os.tmpdir()),
   "eliza-scenario-coding-tools",
@@ -33,11 +31,7 @@ const worktreePath = path.join(
   "scenario-coding-worktree",
 );
 const worktreeBranch = "scenario-coding-tools-branch";
-const roomId = stringToUuid(`scenario-room:${scenarioId}:main`);
-const worldId = stringToUuid(`scenario-runner-world:${scenarioId}`);
-const userId = stringToUuid(
-  `scenario-account:scenario-user:${scenarioId}:main`,
-);
+const ROOM = "main";
 
 const writeParameters = {
   action: "write",
@@ -70,6 +64,33 @@ const exitWorktreeParameters = {
   cleanup: true,
 };
 
+/**
+ * The exact tool set the action planner is offered on every turn of this
+ * scenario: core's always-available REPLY/IGNORE/STOP plus the actions
+ * `@elizaos/plugin-coding-tools` contributes. It is one constant, not a
+ * per-route list, because the runtime offers the same validated action surface
+ * on every turn — a per-route copy only invited the two to drift apart.
+ *
+ * The fixtures below match this set exactly, so it doubles as an assertion that
+ * no other plugin's action reaches this scenario's planner. That is the
+ * property `enterScenarioActionScope` restores: before it, a batch peer's
+ * plugin (app-control's APP/VIEWS/SETTINGS/BACKGROUND) joined this list and
+ * every route fixture stopped matching.
+ */
+const codingToolsPlannerToolNames = [
+  "FILE",
+  "READ",
+  "WRITE",
+  "EDIT",
+  "SHELL",
+  "WORKTREE",
+  "WEB_FETCH",
+  "WEB_SEARCH",
+  "REPLY",
+  "IGNORE",
+  "STOP",
+];
+
 const strictCodingToolRoutes = [
   {
     actionName: "FILE",
@@ -77,14 +98,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Write the deterministic coding tools note file",
     messageToUser: `Wrote ${notePath}`,
-    plannerToolNames: [
-      "FILE",
-      "WEB_FETCH",
-      "START_CODING_TASK",
-      "REPLY",
-      "IGNORE",
-      "STOP",
-    ],
+    plannerToolNames: codingToolsPlannerToolNames,
   },
   {
     actionName: "FILE",
@@ -92,7 +106,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Read the deterministic coding tools note file",
     messageToUser: "alpha coding-tools scenario",
-    plannerToolNames: ["FILE", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
+    plannerToolNames: codingToolsPlannerToolNames,
   },
   {
     actionName: "SHELL",
@@ -101,7 +115,7 @@ const strictCodingToolRoutes = [
     input:
       "Run a shell command to count the deterministic coding tools note lines",
     messageToUser: "shell-ok:2",
-    plannerToolNames: ["SHELL", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
+    plannerToolNames: codingToolsPlannerToolNames,
   },
   {
     actionName: "WORKTREE",
@@ -109,7 +123,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Enter an isolated repo worktree",
     messageToUser: `Entered worktree ${worktreeBranch}`,
-    plannerToolNames: ["SHELL", "WORKTREE", "REPLY", "IGNORE", "STOP"],
+    plannerToolNames: codingToolsPlannerToolNames,
   },
   {
     actionName: "WORKTREE",
@@ -117,7 +131,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Exit and clean up the isolated repo worktree",
     messageToUser: "Exited and removed worktree",
-    plannerToolNames: ["SHELL", "WORKTREE", "REPLY", "IGNORE", "STOP"],
+    plannerToolNames: codingToolsPlannerToolNames,
   },
 ];
 
@@ -601,6 +615,18 @@ export default scenario({
         if (typeof sandbox?.addRoot !== "function") {
           return "coding-tools sandbox service unavailable";
         }
+        // The runner owns room/world/principal id derivation and publishes the
+        // resolved ids on the context before seeds run. Re-deriving them here
+        // would fork that contract: when the executor renamed the connector
+        // account namespace, this scenario's local copy silently addressed a
+        // *different* principal and joined a third participant to a two-party
+        // DM, which fails the executor's own audience attestation at turn 1.
+        const roomId = ctx.roomIds?.[ROOM];
+        const worldId = ctx.roomWorldIds?.[ROOM];
+        const userId = ctx.roomEntityIds?.[ROOM];
+        if (!roomId || !worldId || !userId) {
+          return `scenario context is missing runner-resolved ids for room "${ROOM}"`;
+        }
         sandbox.addRoot(roomId, tmpRoot);
         session.setCwd(roomId, repoRoot);
         await runtime.ensureConnection?.({
@@ -647,7 +673,7 @@ export default scenario({
   ],
   rooms: [
     {
-      id: "main",
+      id: ROOM,
       source: "telegram",
       title: "Deterministic Coding Tools",
     },


### PR DESCRIPTION
# Relates to

`deterministic-coding-tools-actions` passes alone and fails when another scenario runs before it in the same CLI invocation, which makes the batch lanes (`test:corpus:pr:e2e`, `test:orchestrator:pr:e2e`) untrustworthy. Also fixes a second regression from #24842 (`1c98cbde504`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`dd4eae58a3b`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Medium — it changes what actions a scenario's runtime exposes.** Each scenario now sees only the actions it declares plus the baseline set, instead of the union of every loaded scenario's declarations. That is the intended contract, but it can surface scenarios that were silently relying on a peer's plugin being registered. One such case appeared during development and is fixed here (see below); the full lane was run to find the rest.

# Background

## What does this PR do?

### The real cause was not the fixture registry

The obvious suspect — a deterministic-model fixture registry not reset between scenarios — is **not** it. The registry *is* reset per scenario. The actual cause is in `cli.ts`: it registers the **union of every loaded scenario's `requires.plugins`** into the one shared runtime before any scenario runs. Strict planner fixtures match on the *exact* tool-name set, so a peer scenario's action unmatches every route fixture in the victim.

Proof, and it is decisive: `APP` — app-control's action — appeared in the **coding-tools** planner's `toolNames` list. A runner in a different process cannot add an action to this process's `runtime.actions`, so this is in-process leakage, not the concurrent-`/tmp` hazard fixed in #25758.

Clean A/B, single variable, same filesystem:

| | planner `toolNames` | fixtures consumed | action order | ENOENT |
|---|---|---|---|---|
| scope off | `APP,FILE,READ,WRITE,EDIT,SHELL,WORKTREE,…` | 6/14 | `[REPLY,REPLY,SHELL,REPLY,REPLY]` | 0 |
| scope on | *(same, minus `APP`)* | **14/14**, 0 unexpected | `[FILE,FILE,SHELL,WORKTREE,WORKTREE]` | 0 |

`scenario-action-scope.ts` scopes `runtime.actions` per scenario and restores afterwards, which also stops a scenario's seed-registered actions from leaking forward into later scenarios.

### A regression this surfaced, and the guard for it

Scoping was initially too aggressive: it could hide a *baseline* action when a peer scenario happened to declare the owning package, which broke `deterministic-browser-computeruse-progress`. The runtime factory now reports which actions exist **only** because of a scenario declaration, so a hidden action produces an actionable error rather than a bare "unknown action". The full lane was re-run to confirm nothing else regressed.

### A second #24842 regression, fixed here because it shares the file

`1c98cbde504` renamed the connector-account namespace (`scenario-account:<account>` → `scenario-account:<scenarioId>:<account>`) without updating the scenario-side copies. A stale copy addresses a different principal, which joins a **third participant to a two-party DM** → `participant_mismatch`, and the scenario throws before turn 1. Fixed by reading the ids the executor already publishes on the seed context, so the recipe is single-sourced and cannot drift again.

## What kind of change is this?

Bug fix (non-breaking to product; changes scenario-runner behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`scenario-action-scope.ts`, then the two call sites in `cli.ts` and `executor.ts`, then the baseline-action report in `runtime-factory.ts`.

## Detailed testing steps

- `bunx vitest run src/scenario-action-scope.test.ts` → 7 pass.
- Batched proof: coding-tools after app-control in one invocation → `EXIT=0`, 3/3 scenarios, **14/14 fixtures, 0 unexpected**, action order `["FILE","FILE","SHELL","WORKTREE","WORKTREE"]`. Alone → `EXIT=0`.
- **Full `pr-deterministic` lane: 29 passed / 13 failed, versus pristine develop 28 / 14 at the same commit — zero new failures, one fixed.** The 13 remaining are pre-existing and unchanged (mostly "unexpected TEXT_SMALL model calls" across lifeops/media/github/skills).
- Unit suite 54 files / 524 tests pass (the baseline had 1 failing).
- Biome clean on all touched files; typecheck adds no new errors.

# Evidence Gate

<!-- evidence-head:621eb643588ce0d2c1d47a17f1b2f13da36f726e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The runner's own planner diagnostics are the evidence: `APP` present in coding-tools' `toolNames` with scoping off, absent with it on, and fixture consumption going 6/14 → 14/14.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Scenario reports and `matrix.json` for the batched run, showing the corrected action order.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The runner's own planner diagnostics are the evidence: `APP` present in coding-tools' `toolNames` with scoping off, absent with it on, and fixture consumption going 6/14 → 14/14.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- `deterministic-coding-tools-actions` *also* has the shared-`/tmp` hazard (constant path `rm -rf`'d in both seed and cleanup) that #25758 fixed for the app-control pair. Both mechanisms are real and were observed separately. It is deliberately **not** fixed here, and the reason is worth recording: the one-line fix that worked for app-control — deriving the root from `realpathSync(os.tmpdir())` plus `process.pid` — **breaks this scenario**. Applied on top of this branch, where the scenario otherwise passes in 7.1 s, it fails in 182 ms with `deterministic model fixtures were not consumed`, so something in the deterministic fixture matching depends on the literal fixture path. Making that scenario concurrency-safe therefore requires making its fixtures path-agnostic first, which is a larger change than this PR should carry.
- Worth noting for reviewers of this PR: on pristine `origin/develop` `deterministic-coding-tools-actions` now fails **even when run alone**, and passes on this branch. The CLI loads every scenario in the directory before filtering execution with `--scenario`, so the plugin union leaks regardless of the filter — this fix restores the standalone case too, not only the batched one.
- `plugins/plugin-form/test/scenarios/restore-stashed.scenario.ts` carries the same stale connector-account string, but that scenario fails earlier for an unrelated reason, so a fix there could not be verified. Reported, not changed.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

