### PR TITLE
fix(shared): reject non-finite device-fit catalog rows

### DIFF
--- a/packages/shared/src/local-inference/device-fit.test.ts
+++ b/packages/shared/src/local-inference/device-fit.test.ts
@@ -110,4 +110,43 @@ describe("selectBestEliza1Fit — biggest tier that fits, 128k target, QJL alway
     expect(fit).not.toBeNull();
     expect(fit?.tierId).toBe("eliza-1-2b");
   });
+
+  it("returns null instead of a NaN-bearing fit when only the NaN row survives the RAM floor (#25906)", () => {
+    // Same catalog as above, but the valid 4 GB tier no longer fits: the
+    // insufficient-RAM path must route to Cloud (null), never hand back the
+    // non-finite row whose `freeRamGb < NaN` guard is always false.
+    const customCatalog = [
+      {
+        id: "tier-nan",
+        minRamGb: Number.NaN,
+        sizeGb: 1,
+        contextLength: 131072,
+        contextStep: 4096,
+      } as unknown as (typeof MODEL_CATALOG)[number],
+      {
+        id: "eliza-1-2b",
+        minRamGb: 4,
+        sizeGb: 1.4,
+        contextLength: 131072,
+        contextStep: 4096,
+      } as unknown as (typeof MODEL_CATALOG)[number],
+    ];
+
+    expect(selectBestEliza1Fit(2, customCatalog)).toBeNull();
+  });
+
+  it("rejects a catalog row whose contextLength is NaN even when its RAM fields are finite (#25906)", () => {
+    const customCatalog = [
+      {
+        id: "tier-nan-ctx",
+        minRamGb: 2,
+        sizeGb: 1.4,
+        contextLength: Number.NaN,
+        contextStep: 4096,
+      } as unknown as (typeof MODEL_CATALOG)[number],
+    ];
+
+    const fit = selectBestEliza1Fit(8, customCatalog);
+    expect(fit).toBeNull();
+  });
 });

--- a/packages/shared/src/local-inference/device-fit.ts
+++ b/packages/shared/src/local-inference/device-fit.ts
@@ -75,6 +75,15 @@ const BYTES_PER_GB = 1024 * 1024 * 1024;
 function kvBytesPerTokenForTier(tier: CatalogModel): number | null {
   const { minRamGb, sizeGb, contextLength } = tier;
   if (minRamGb == null || sizeGb == null || contextLength == null) return null;
+  // Non-finite sizing is a mis-shaped catalog row, not a computable rate —
+  // fail closed here as well so no other caller can derive a NaN window (#25906).
+  if (
+    !Number.isFinite(minRamGb) ||
+    !Number.isFinite(sizeGb) ||
+    !Number.isFinite(contextLength)
+  ) {
+    return null;
+  }
   const kvReserveGb = minRamGb - sizeGb - RUNTIME_OVERHEAD_GB;
   if (kvReserveGb <= 0 || contextLength <= 0) return null;
   return (kvReserveGb * BYTES_PER_GB) / contextLength;
@@ -141,10 +150,23 @@ export function selectBestEliza1Fit(
 
   // Release tiers, largest RAM-floor first. The floor already bakes in a native
   // (128k) q8_0 window, so the first one whose floor fits is the biggest model
-  // that still gets its full window.
+  // that still gets its full window. Rows whose required numeric capacity
+  // fields are non-finite are rejected outright (#25906): `typeof NaN ===
+  // "number"` would otherwise let them survive the filter, and `freeRamGb <
+  // NaN` is false, so a NaN floor skips the fit guard and can surface as a
+  // NaN-bearing Eliza1Fit instead of routing to Cloud. A present-but-NaN
+  // contextLength corrupts the native-window clamp the same way, so it rejects
+  // the row too (null contextLength stays allowed — the target substitutes).
   const tiers = [...catalog]
     .filter(
-      (m) => typeof m.minRamGb === "number" && typeof m.sizeGb === "number",
+      (m) =>
+        typeof m.minRamGb === "number" &&
+        Number.isFinite(m.minRamGb) &&
+        typeof m.sizeGb === "number" &&
+        Number.isFinite(m.sizeGb) &&
+        (m.contextLength == null ||
+          (typeof m.contextLength === "number" &&
+            Number.isFinite(m.contextLength))),
     )
     .sort((a, b) => {
       const bRam =


### PR DESCRIPTION
# Relates to

Closes #25906

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (built directly on develop@dd4eae5 via the Git data API).
- [x] Focused tests pass after sync (exact command and output below).
- [x] A reviewer can confirm the change works from the regressions below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite passes post-sync (below); no unrelated blocker.

# Risks

Low. Rows whose required numeric fields are non-finite are dropped instead of
being sorted last and surviving the fit guard; deterministic selection among
valid rows is unchanged. `kvBytesPerTokenForTier` additionally returns `null`
on non-finite sizing — for the shipped catalog this path is unreachable.

# Background

## What does this PR do?

The tier filter in `selectBestEliza1Fit` accepted any row whose `minRamGb` and
`sizeGb` satisfied `typeof === "number"` — which is true for `NaN`. The
comparator's `Number.isFinite` guard moved such rows to the end of the sort,
but `freeRamGb < NaN` is `false`, so when every valid tier was too large the
selection loop accepted the invalid row and could return an `Eliza1Fit` whose
capacity values were `NaN` instead of routing to Cloud (#25906; landed in
#25664 — its merged 8 GB regression returns the valid tier first and never
reaches this branch).

The fix rejects catalog rows whose required numeric capacity fields are
non-finite before sorting or selection:

- `minRamGb`/`sizeGb` must be finite numbers;
- a present-but-`NaN` `contextLength` rejects the row too (it corrupts the
  native-window clamp the same way); `null` stays allowed because the 128k
  target substitutes;
- `kvBytesPerTokenForTier` also fails closed on non-finite sizing so no other
  caller can derive a `NaN` window from a mis-shaped row.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/local-inference/device-fit.ts` — the tier filter and the
`kvBytesPerTokenForTier` guard — then the two regressions at the end of
`device-fit.test.ts`.

## Detailed testing steps

- `cd packages/shared && bun test src/local-inference/device-fit.test.ts`
  - 10 pass / 0 fail (8 pre-existing + 2 new regressions).
- Regression 1 (the issue's reproduction): the custom catalog with one valid
  4 GB-floor tier plus one `tier-nan` row, called with 2 GB of RAM — the valid
  tier does not fit, and the selector now returns `null` instead of emitting
  the non-finite row.
- Regression 2: a row whose `contextLength` is `NaN` with finite RAM fields is
  rejected even when the RAM floor fits.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:0fda1a2dc7eecbc0c706a36b4524011016525059 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; this is a pure selector function covered by
      deterministic unit tests.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed; the null-vs-NaN-fit outcome is
      asserted directly by the regressions.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - numeric-purity bug whose reproduction (a NaN catalog row + 2 GB RAM)
      is encoded in the test itself.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no logging added or changed; the defect and fix are value-level and
      covered by the assertions.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output; the
      catalog fixtures are plain literals inside the test.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
 10 pass
 0 fail
 44 expect() calls
Ran 10 tests across 1 file. [763.00ms]
```

## Known gaps / failures

None for this change. Full-package `bun run verify` could not run in this
environment; the focused suite above and `biome check` on both touched files
pass locally.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->
