### PR TITLE
fix(cloud): bind Worker e2e health to owned listener

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1121,6 +1121,36 @@ describe("cloud-api worker entrypoint", () => {
     });
   });
 
+  test("exposes an E2E run receipt only inside the explicit local test gate", async () => {
+    const request = new Request("http://127.0.0.1:8787/api/health", {
+      headers: { host: "127.0.0.1:8787" },
+    });
+    const testResponse = await cloudApiWorker.fetch(
+      request,
+      {
+        NODE_ENV: "test",
+        CLOUD_E2E: "1",
+        CLOUD_E2E_RUN_RECEIPT: "run-receipt-1",
+      } as never,
+      {} as never,
+    );
+    expect(await testResponse.json()).toMatchObject({
+      status: "ok",
+      e2eRunReceipt: "run-receipt-1",
+    });
+
+    const productionResponse = await cloudApiWorker.fetch(
+      request,
+      {
+        NODE_ENV: "production",
+        CLOUD_E2E: "1",
+        CLOUD_E2E_RUN_RECEIPT: "must-not-leak",
+      } as never,
+      {} as never,
+    );
+    expect(await productionResponse.text()).not.toContain("must-not-leak");
+  });
+
   test("reports only the served Personal Shared Telegram edge gate state", async () => {
     const response = await cloudApiWorker.fetch(
       new Request("https://api-staging.eliza.app/api/health", {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -621,12 +621,17 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
     hasExactStagingSessionUuidList(
       env.STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS,
     );
+  const e2eRunReceipt =
+    env.NODE_ENV === "test" && env.CLOUD_E2E === "1"
+      ? env.CLOUD_E2E_RUN_RECEIPT?.trim() || null
+      : null;
   return Response.json(
     {
       status: "ok",
       timestamp: Date.now(),
       region: (env as { CF_REGION?: string }).CF_REGION ?? "unknown",
       commit: env.ELIZA_DEPLOY_COMMIT ?? null,
+      ...(e2eRunReceipt ? { e2eRunReceipt } : {}),
       // Self-identify which deployment env answered. Production and staging
       // share the eliza.app zone. Staging claims its
       // exact control-plane names and `*.cloud-staging.eliza.app` before the

--- a/packages/cloud/api/test/e2e/_helpers/worker-health.test.ts
+++ b/packages/cloud/api/test/e2e/_helpers/worker-health.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { waitForWorkerHealth } from "./worker-health";
+
+describe("waitForWorkerHealth", () => {
+  test("recovers from one transient 500 only after the owned receipt answers", async () => {
+    const responses = [
+      new Response("Internal Server Error", {
+        status: 500,
+        headers: {
+          "content-type": "text/plain; charset=UTF-8",
+          server: "workerd",
+        },
+      }),
+      Response.json({ status: "ok", e2eRunReceipt: "owned-run" }),
+    ];
+
+    const result = await waitForWorkerHealth({
+      baseUrl: "http://127.0.0.1:41234",
+      expectedReceipt: "owned-run",
+      timeoutMs: 100,
+      retryIntervalMs: 1,
+      fetchImpl: async () => responses.shift() ?? responses[0],
+    });
+
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0]).toMatchObject({
+      status: 500,
+      server: "workerd",
+      bodyPreview: "Internal Server Error",
+      receipt: null,
+    });
+    expect(result.attempts[0]?.bodySha256).toHaveLength(64);
+    expect(result.attempts[1]).toMatchObject({
+      status: 200,
+      receipt: "owned-run",
+    });
+  });
+
+  test("rejects a healthy response from the wrong listener", async () => {
+    await expect(
+      waitForWorkerHealth({
+        baseUrl: "http://127.0.0.1:41234",
+        expectedReceipt: "owned-run",
+        timeoutMs: 5,
+        retryIntervalMs: 1,
+        fetchImpl: async () =>
+          Response.json({ status: "ok", e2eRunReceipt: "other-run" }),
+      }),
+    ).rejects.toThrow(/receipt owned-run/);
+  });
+
+  test("fails immediately when the owned Worker wrapper exited", async () => {
+    let fetched = false;
+    await expect(
+      waitForWorkerHealth({
+        baseUrl: "http://127.0.0.1:41234",
+        expectedReceipt: "owned-run",
+        serverPid: 42,
+        isProcessAlive: () => false,
+        fetchImpl: async () => {
+          fetched = true;
+          return Response.json({ status: "ok", e2eRunReceipt: "owned-run" });
+        },
+      }),
+    ).rejects.toThrow(/process 42 exited/);
+    expect(fetched).toBe(false);
+  });
+});

--- a/packages/cloud/api/test/e2e/_helpers/worker-health.ts
+++ b/packages/cloud/api/test/e2e/_helpers/worker-health.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 2_000;
+const DEFAULT_RETRY_INTERVAL_MS = 250;
+const MAX_BODY_PREVIEW_BYTES = 256;
+
+export interface WorkerHealthAttempt {
+  attempt: number;
+  status: number | null;
+  contentType: string | null;
+  server: string | null;
+  bodyBytes: number;
+  bodySha256: string | null;
+  bodyPreview: string | null;
+  receipt: string | null;
+  error: string | null;
+}
+
+export interface WaitForWorkerHealthOptions {
+  baseUrl: string;
+  expectedReceipt?: string;
+  serverPid?: number;
+  timeoutMs?: number;
+  attemptTimeoutMs?: number;
+  retryIntervalMs?: number;
+  fetchImpl?: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  isProcessAlive?: (pid: number) => boolean;
+  onAttempt?: (attempt: WorkerHealthAttempt) => void;
+}
+
+export interface WorkerHealthReceipt {
+  attempts: WorkerHealthAttempt[];
+  response: Response;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeBodyPreview(
+  body: string,
+  contentType: string | null,
+): string | null {
+  if (!body) return "";
+  const normalized = body.replace(/[\r\n\t]+/g, " ").trim();
+  if (
+    contentType?.includes("application/json") ||
+    contentType?.startsWith("text/plain")
+  ) {
+    return normalized.slice(0, MAX_BODY_PREVIEW_BYTES);
+  }
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function receiptFromBody(
+  body: string,
+  contentType: string | null,
+): string | null {
+  if (!contentType?.includes("application/json")) return null;
+  try {
+    const parsed = JSON.parse(body) as { e2eRunReceipt?: unknown };
+    return typeof parsed.e2eRunReceipt === "string"
+      ? parsed.e2eRunReceipt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatAttempt(attempt: WorkerHealthAttempt): string {
+  const fields = [
+    `attempt=${attempt.attempt}`,
+    `status=${attempt.status ?? "none"}`,
+    `content-type=${attempt.contentType ?? "none"}`,
+    `server=${attempt.server ?? "none"}`,
+    `body-bytes=${attempt.bodyBytes}`,
+    `body-sha256=${attempt.bodySha256 ?? "none"}`,
+    `receipt=${attempt.receipt ?? "none"}`,
+  ];
+  if (attempt.bodyPreview !== null) {
+    fields.push(`body=${JSON.stringify(attempt.bodyPreview)}`);
+  }
+  if (attempt.error) fields.push(`error=${JSON.stringify(attempt.error)}`);
+  return fields.join(" ");
+}
+
+function formatAttempts(attempts: WorkerHealthAttempt[]): string {
+  if (attempts.length <= 6) return attempts.map(formatAttempt).join(" | ");
+  const omitted = attempts.length - 5;
+  return [
+    ...attempts.slice(0, 2).map(formatAttempt),
+    `... ${omitted} repeated attempt(s) omitted ...`,
+    ...attempts.slice(-3).map(formatAttempt),
+  ].join(" | ");
+}
+
+/**
+ * Wait for the exact Worker owned by the current E2E run.
+ *
+ * A transient non-2xx response may recover inside the bounded window, but a
+ * response is accepted only when it is healthy and carries the caller's unique
+ * run receipt. A dead wrapper process, wrong listener, or persistent unhealthy
+ * response remains a hard failure with a compact diagnostic receipt.
+ */
+export async function waitForWorkerHealth({
+  baseUrl,
+  expectedReceipt,
+  serverPid,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS,
+  retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
+  fetchImpl = fetch,
+  isProcessAlive = defaultIsProcessAlive,
+  onAttempt,
+}: WaitForWorkerHealthOptions): Promise<WorkerHealthReceipt> {
+  const deadline = Date.now() + timeoutMs;
+  const healthUrl = `${normalizeBaseUrl(baseUrl)}/api/health`;
+  const attempts: WorkerHealthAttempt[] = [];
+
+  while (Date.now() < deadline) {
+    if (serverPid && !isProcessAlive(serverPid)) {
+      throw new Error(
+        `Worker e2e target process ${serverPid} exited before ${healthUrl} became healthy`,
+      );
+    }
+
+    let attempt: WorkerHealthAttempt;
+    let response: Response | null = null;
+    try {
+      response = await fetchImpl(healthUrl, {
+        cache: "no-store",
+        signal: AbortSignal.timeout(attemptTimeoutMs),
+      });
+      const body = await response.clone().text();
+      const contentType = response.headers.get("content-type");
+      const receipt = receiptFromBody(body, contentType);
+      attempt = {
+        attempt: attempts.length + 1,
+        status: response.status,
+        contentType,
+        server: response.headers.get("server"),
+        bodyBytes: Buffer.byteLength(body),
+        bodySha256: createHash("sha256").update(body).digest("hex"),
+        bodyPreview: safeBodyPreview(body, contentType),
+        receipt,
+        error: null,
+      };
+      attempts.push(attempt);
+      onAttempt?.(attempt);
+
+      const receiptMatches = expectedReceipt
+        ? receipt === expectedReceipt
+        : true;
+      if (response.ok && receiptMatches) {
+        return { attempts, response };
+      }
+    } catch (error) {
+      attempt = {
+        attempt: attempts.length + 1,
+        status: null,
+        contentType: null,
+        server: null,
+        bodyBytes: 0,
+        bodySha256: null,
+        bodyPreview: null,
+        receipt: null,
+        error: errorMessage(error),
+      };
+      attempts.push(attempt);
+      onAttempt?.(attempt);
+    }
+
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, retryIntervalMs));
+  }
+
+  const identity = expectedReceipt
+    ? ` carrying receipt ${expectedReceipt}`
+    : "";
+  throw new Error(
+    `Worker e2e target did not become healthy at ${healthUrl}${identity}: ${formatAttempts(attempts)}`,
+  );
+}

--- a/packages/cloud/api/test/e2e/preload.ts
+++ b/packages/cloud/api/test/e2e/preload.ts
@@ -23,6 +23,7 @@ import { apiKeysService } from "@elizaos/cloud-shared/lib/services/api-keys";
 import { config } from "dotenv";
 import { eq } from "drizzle-orm";
 import { privateKeyToAccount } from "viem/accounts";
+import { waitForWorkerHealth } from "./_helpers/worker-health";
 import { ensureFixtureSandbox } from "./fixture-sandbox";
 
 for (const envPath of [
@@ -202,12 +203,17 @@ if (process.env.REQUIRE_E2E_SERVER !== "0") {
     process.env.TEST_API_BASE_URL?.trim() ||
     process.env.TEST_BASE_URL?.trim() ||
     "http://localhost:8787";
-  const response = await fetch(`${baseUrl}/api/health`, {
-    signal: AbortSignal.timeout(10_000),
+  const serverPid = Number(process.env.CLOUD_E2E_SERVER_PID);
+  const result = await waitForWorkerHealth({
+    baseUrl,
+    expectedReceipt: process.env.CLOUD_E2E_RUN_RECEIPT?.trim() || undefined,
+    serverPid:
+      Number.isInteger(serverPid) && serverPid > 0 ? serverPid : undefined,
   });
-  if (!response.ok) {
-    throw new Error(
-      `Worker e2e target is not healthy: GET ${baseUrl}/api/health -> ${response.status}`,
+  if (result.attempts.length > 1) {
+    console.warn(
+      `[api-e2e] Worker health recovered after ${result.attempts.length} attempts; ` +
+        "the accepted response matched the current run receipt",
     );
   }
 }

--- a/packages/cloud/api/test/e2e/run-e2e-batches.mjs
+++ b/packages/cloud/api/test/e2e/run-e2e-batches.mjs
@@ -1,9 +1,11 @@
 // Exercises cloud API test e2e run e2e batches behavior with deterministic Worker route fixtures.
 import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { readdirSync } from "node:fs";
 import { createConnection } from "node:net";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { waitForWorkerHealth } from "./_helpers/worker-health.ts";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const appRoot = join(testDir, "..", "..");
@@ -30,10 +32,13 @@ const runSeed =
     Number(process.env.GITHUB_RUN_ATTEMPT || 1) || process.pid;
 const portOffset = Math.abs(runSeed) % 4000;
 const apiPort = process.env.API_DEV_PORT || String(41000 + portOffset);
-const baseUrl =
-  process.env.TEST_API_BASE_URL ||
-  process.env.TEST_BASE_URL ||
-  `http://localhost:${apiPort}`;
+const configuredBaseUrl =
+  process.env.TEST_API_BASE_URL || process.env.TEST_BASE_URL || "";
+const baseUrl = configuredBaseUrl || `http://localhost:${apiPort}`;
+const ownsLocalServer =
+  process.env.REQUIRE_E2E_SERVER !== "0" && !configuredBaseUrl;
+const e2eRunReceipt =
+  process.env.CLOUD_E2E_RUN_RECEIPT || (ownsLocalServer ? randomUUID() : "");
 const configuredDatabaseUrl =
   process.env.TEST_DATABASE_URL || process.env.DATABASE_URL || "";
 const pglitePort = process.env.TEST_PGLITE_PORT || String(46000 + portOffset);
@@ -71,6 +76,7 @@ const e2eEnv = {
   // the wrapper still gets a working KMS.
   NODE_ENV: process.env.NODE_ENV || "test",
   CLOUD_E2E: process.env.CLOUD_E2E || "1",
+  ...(e2eRunReceipt ? { CLOUD_E2E_RUN_RECEIPT: e2eRunReceipt } : {}),
   ELIZA_KMS_BACKEND: process.env.ELIZA_KMS_BACKEND || "memory",
   // Keep the real voice upgrade route reachable in the pinned-Workerd lane.
   // Binary-first coverage closes before token verification, so these inert
@@ -87,12 +93,17 @@ const e2eEnv = {
     process.env.VOICE_REALTIME_ELIZA_AUTHORIZATION || "Bearer e2e-inert",
 };
 
-async function isHealthy() {
+async function isHealthy(serverPid) {
   try {
-    const response = await fetch(`${baseUrl}/api/health`, {
-      signal: AbortSignal.timeout(1_000),
+    await waitForWorkerHealth({
+      baseUrl,
+      expectedReceipt: e2eRunReceipt || undefined,
+      serverPid,
+      timeoutMs: 1_000,
+      attemptTimeoutMs: 750,
+      retryIntervalMs: 100,
     });
-    return response.ok;
+    return true;
   } catch {
     return false;
   }
@@ -106,7 +117,7 @@ async function waitForHealth(processRef) {
         `[api-e2e] dev server exited before becoming healthy (code ${processRef.exitCode})`,
       );
     }
-    if (await isHealthy()) return;
+    if (await isHealthy(processRef.pid)) return;
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
   throw new Error(`[api-e2e] timed out waiting for ${baseUrl}/api/health`);
@@ -159,12 +170,12 @@ function listenerPidsOnPort(port) {
     encoding: "utf8",
   });
   if (lsof.status === 0 && lsof.stdout.trim()) {
-    return lsof.stdout.trim().split(/\s+/);
+    return lsof.stdout.match(/\b\d+\b/g) ?? [];
   }
   const fuser = spawnSync("fuser", [`${port}/tcp`], { encoding: "utf8" });
+  if (fuser.status !== 0) return [];
   const fuserOut = `${fuser.stdout ?? ""} ${fuser.stderr ?? ""}`.trim();
-  if (fuserOut) return fuserOut.split(/\s+/);
-  return [];
+  return fuserOut.match(/\b\d+\b/g) ?? [];
 }
 
 // Reclaim a port held by an orphaned listener. Self-hosted CI runners are
@@ -262,9 +273,16 @@ async function ensurePGliteBridge() {
 
 async function ensureServer() {
   if (process.env.REQUIRE_E2E_SERVER === "0") return null;
-  if (await isHealthy()) return null;
-  if (process.env.TEST_API_BASE_URL || process.env.TEST_BASE_URL) {
+  if (configuredBaseUrl) {
+    if (await isHealthy()) return null;
     throw new Error(`[api-e2e] configured server is not healthy: ${baseUrl}`);
+  }
+
+  const existingListeners = listenerPidsOnPort(apiPort);
+  if (existingListeners.length > 0) {
+    throw new Error(
+      `[api-e2e] refusing pre-existing listener(s) on owned API port ${apiPort}: ${existingListeners.join(",")}`,
+    );
   }
 
   console.log(`[api-e2e] START dev server at ${baseUrl}`);
@@ -312,6 +330,13 @@ const testFiles = readdirSync(testDir)
 const pgliteServer = await ensurePGliteBridge();
 ensureDatabase();
 const server = await ensureServer();
+if (server?.pid) {
+  e2eEnv.CLOUD_E2E_SERVER_PID = String(server.pid);
+  const listenerPids = listenerPidsOnPort(apiPort);
+  console.log(
+    `[api-e2e] OWNED Worker wrapper pid=${server.pid} listener pid=${listenerPids.join(",") || "unknown"} port=${apiPort} receipt=${e2eRunReceipt}`,
+  );
+}
 try {
   for (const testFile of testFiles) {
     console.log(`[api-e2e] START ${testFile}`);

--- a/packages/cloud/scripts/admin/dev/cloud-api-dev.mjs
+++ b/packages/cloud/scripts/admin/dev/cloud-api-dev.mjs
@@ -245,6 +245,14 @@ async function main() {
     ? [
         "--var",
         "NODE_ENV:test",
+        ...(process.env.CLOUD_E2E_RUN_RECEIPT
+          ? [
+              "--var",
+              "CLOUD_E2E:1",
+              "--var",
+              `CLOUD_E2E_RUN_RECEIPT:${process.env.CLOUD_E2E_RUN_RECEIPT}`,
+            ]
+          : []),
         "--var",
         `ELIZA_KMS_BACKEND:${kmsBackend}`,
         ...(localRootKey

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -532,6 +532,8 @@ export interface Bindings {
   NODE_ENV?: string;
   /** Exact local full-stack test gate; never set on deployed Workers. */
   CLOUD_E2E?: string;
+  /** Unique local-only receipt used to bind Worker E2E probes to their owner. */
+  CLOUD_E2E_RUN_RECEIPT?: string;
   /**
    * Git commit stamped at deploy time so `/api/health` can prove which Worker
    * revision is currently served before CI allows another deploy to overwrite it.


### PR DESCRIPTION
## What changed
- bind each locally owned Cloud API E2E Worker to a unique test-only health receipt
- record wrapper and listener PIDs, and reject pre-existing listeners on the owned port
- retry transient health failures for a bounded window, accepting recovery only from the exact owned receipt
- preserve fail-closed behavior for a dead wrapper, wrong listener, or persistent unhealthy response
- capture bounded status, content type, server, body length/hash, and safe body preview for diagnosis

## Why
Cloud CF staging run 32639599744 saw one unlogged 500 between successful Worker E2E files. The repeated Stripe catalog and missing Google OAuth diagnostics were present throughout passing groups and were not causal. A local reproduction passed the full suite under the same absent-credential configuration. The old preload trusted one response and did not prove listener ownership.

## Focused proof
- helper + Worker entry tests: 58 pass, 0 fail
- real Worker E2E group E: 41 pass, 0 fail
- real consecutive Worker E2E groups D/E/F: pass, including both file boundaries
- packages/cloud/api typecheck and production Wrangler dry bundle: pass
- packages/cloud/shared typecheck: pass
- exact Biome and git diff checks: pass

No Stripe or Google test credentials were added, no health contract was weakened, and the receipt is exposed only under NODE_ENV=test plus CLOUD_E2E=1.