### PR TITLE
test(scenario-runner): pin the MCP scenario's plugin-registration contract

### DIFF
--- a/packages/scenario-runner/src/mcp-scenario-registration.test.ts
+++ b/packages/scenario-runner/src/mcp-scenario-registration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage for deterministic-mcp-actions-routes' seed-time MCP
+ * registration contract.
+ *
+ * The scenario declares "@elizaos/plugin-mcp" under requires.plugins — a
+ * real, resolvable package the batch-level factory imports and registers
+ * before the scenario runs (see registerScenarioRequiredPlugins) — never
+ * under requires.fixturePlugins (which is reserved for scenario-local
+ * fixture plugins only the scenario's own seed can register; see
+ * resolveRequiredFixturePlugins / commit 2a589d97652).
+ *
+ * The scenario's own seed (seedMcp in
+ * test/scenarios/deterministic-mcp-actions-routes.scenario.ts) self-heals by
+ * checking `runtime.plugins.some((p) => p.name === mcpPlugin.name)` before
+ * calling registerPlugin again, then reads `scenarioMcpService.getServers()`
+ * straight off the instance it just started with `await McpService.start()`.
+ * If the real plugin-mcp package's exported name ever drifts from what
+ * pluginNameAliases("@elizaos/plugin-mcp") recognizes, or the real
+ * McpService ever stops finding its configured "mcp" setting, the seed fails
+ * with exactly the defect's signature: "MCP server scenario_mcp was not
+ * registered".
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentRuntime, Plugin } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import mcpPlugin from "../../../plugins/plugin-mcp/src/index.ts";
+import { McpService } from "../../../plugins/plugin-mcp/src/service.ts";
+import mcpScenario from "../test/scenarios/deterministic-mcp-actions-routes.scenario.ts";
+import {
+  pluginMatchesScenarioPackage,
+  registerScenarioRequiredPlugins,
+  resolveRequiredFixturePlugins,
+  resolveRequiredPluginPackages,
+} from "./required-plugins.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(here, "../test/fixtures/mcp-stdio-fixture.mjs");
+const MCP_SERVER_NAME = "scenario_mcp";
+const MCP_PACKAGE = "@elizaos/plugin-mcp";
+
+/**
+ * Mirrors AgentRuntime.getSetting()'s real behavior: it round-trips string,
+ * boolean, and number values but falls through every typeof branch to
+ * `return null` for an object/array value (packages/core/src/runtime.ts,
+ * getSetting()). McpService's getConfiguredMcpSettings() only survives that
+ * because it falls back to reading `runtime.character.settings.mcp`
+ * directly. This fake stays faithful to both halves of that contract so the
+ * "connects the real stdio fixture" test below actually exercises the code
+ * path the real scenario depends on, not a more forgiving stand-in.
+ */
+function createFakeRuntime(mcpSettings: unknown): AgentRuntime {
+  const settings: Record<string, unknown> = { mcp: mcpSettings };
+  return {
+    getSetting: (key: string) => {
+      const value = settings[key];
+      return typeof value === "string" ||
+        typeof value === "boolean" ||
+        typeof value === "number"
+        ? value
+        : null;
+    },
+    character: { settings },
+    reportError: vi.fn(),
+  } as unknown as AgentRuntime;
+}
+
+describe("deterministic-mcp-actions-routes MCP plugin registration contract", () => {
+  it("declares @elizaos/plugin-mcp as a resolvable required plugin, not a fixture plugin", () => {
+    expect(resolveRequiredPluginPackages(mcpScenario)).toContain(MCP_PACKAGE);
+    expect(resolveRequiredFixturePlugins(mcpScenario)).not.toContain(
+      MCP_PACKAGE,
+    );
+  });
+
+  it("resolves the real plugin-mcp package name to something the scenario's own registration guard recognizes", () => {
+    // Guards seedMcp's `runtime.plugins.some((p) => p.name === mcpPlugin.name)`
+    // self-heal check: it only skips re-registering when this alias match holds.
+    expect(
+      pluginMatchesScenarioPackage({ name: mcpPlugin.name }, MCP_PACKAGE),
+    ).toBe(true);
+  });
+
+  it("registers the real @elizaos/plugin-mcp package before the scenario runs, under the name the seed checks for", async () => {
+    const plugins: Plugin[] = [];
+    const registerPlugin = vi.fn(async (plugin: Plugin) => {
+      plugins.push(plugin);
+    });
+    const runtime = { plugins, registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(runtime, [MCP_PACKAGE], "simulated"),
+    ).resolves.toEqual([MCP_PACKAGE]);
+    expect(registerPlugin).toHaveBeenCalledOnce();
+    expect(plugins[0]?.name).toBe(mcpPlugin.name);
+  });
+
+  it("connects the real stdio fixture and reports scenario_mcp in getServers() — the exact check the seed performs", async () => {
+    const runtime = createFakeRuntime({
+      servers: {
+        [MCP_SERVER_NAME]: {
+          type: "stdio",
+          command: "node",
+          args: [fixturePath],
+          timeoutInMillis: 5_000,
+        },
+      },
+    });
+
+    const service = await McpService.start(runtime);
+    try {
+      const server = service
+        .getServers()
+        .find((candidate) => candidate.name === MCP_SERVER_NAME);
+      expect(server).toBeDefined();
+      expect(server?.status).toBe("connected");
+      expect(server?.tools?.length ?? 0).toBe(1);
+      expect(server?.resources?.length ?? 0).toBe(1);
+    } finally {
+      await service.stop();
+    }
+  }, 15_000);
+});

--- a/packages/scenario-runner/src/mcp-scenario-registration.test.ts
+++ b/packages/scenario-runner/src/mcp-scenario-registration.test.ts
@@ -23,6 +23,24 @@ const here = dirname(fileURLToPath(import.meta.url));
 const fixturePath = resolve(here, "../test/fixtures/mcp-stdio-fixture.mjs");
 const MCP_SERVER_NAME = "scenario_mcp";
 const MCP_PACKAGE = "@elizaos/plugin-mcp";
+const MCP_SERVER_ENV_PATTERN = /^MCP_SERVER_.+_(?:URL|TYPE)$/;
+
+async function withoutAmbientMcpServers<T>(run: () => Promise<T>): Promise<T> {
+  const saved = new Map<string, string>();
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!MCP_SERVER_ENV_PATTERN.test(key) || value === undefined) continue;
+    saved.set(key, value);
+    delete process.env[key];
+  }
+  try {
+    return await run();
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      if (MCP_SERVER_ENV_PATTERN.test(key)) delete process.env[key];
+    }
+    for (const [key, value] of saved) process.env[key] = value;
+  }
+}
 
 /**
  * Mirrors AgentRuntime.getSetting()'s real behavior: it round-trips string,
@@ -83,7 +101,7 @@ describe("deterministic-mcp-actions-routes MCP plugin registration contract", ()
     expect(plugins[0]?.name).toBe(mcpPlugin.name);
   });
 
-  it("connects the real stdio fixture and reports scenario_mcp in getServers() — the exact check the seed performs", async () => {
+  it("connects only the real stdio fixture and exercises its tool and resource", async () => {
     const runtime = createFakeRuntime({
       servers: {
         [MCP_SERVER_NAME]: {
@@ -95,17 +113,59 @@ describe("deterministic-mcp-actions-routes MCP plugin registration contract", ()
       },
     });
 
-    const service = await McpService.start(runtime);
+    const intruderUrlKey = "MCP_SERVER_REGISTRATION_TEST_INTRUDER_URL";
+    const intruderTypeKey = "MCP_SERVER_REGISTRATION_TEST_INTRUDER_TYPE";
+    const priorIntruderUrl = process.env[intruderUrlKey];
+    const priorIntruderType = process.env[intruderTypeKey];
+    process.env[intruderUrlKey] = "http://127.0.0.1:9/mcp";
+    process.env[intruderTypeKey] = "sse";
     try {
-      const server = service
-        .getServers()
-        .find((candidate) => candidate.name === MCP_SERVER_NAME);
-      expect(server).toBeDefined();
-      expect(server?.status).toBe("connected");
-      expect(server?.tools?.length ?? 0).toBe(1);
-      expect(server?.resources?.length ?? 0).toBe(1);
+      await withoutAmbientMcpServers(async () => {
+        const service = await McpService.start(runtime);
+        try {
+          expect(service.getServers().map((server) => server.name)).toEqual([
+            MCP_SERVER_NAME,
+          ]);
+          const server = service.getServers()[0];
+          expect(server?.status).toBe("connected");
+          expect(server?.tools?.map((tool) => tool.name)).toEqual([
+            "echo_code",
+          ]);
+          expect(server?.resources?.map((resource) => resource.uri)).toEqual([
+            "fixture://mcp-note",
+          ]);
+
+          await expect(
+            service.callTool(MCP_SERVER_NAME, "echo_code", {
+              code: "registration-contract",
+            }),
+          ).resolves.toMatchObject({
+            content: [
+              { type: "text", text: "mcp-tool-echo:registration-contract" },
+            ],
+          });
+          await expect(
+            service.readResource(MCP_SERVER_NAME, "fixture://mcp-note"),
+          ).resolves.toMatchObject({
+            contents: [
+              {
+                uri: "fixture://mcp-note",
+                mimeType: "text/plain",
+                text: "mcp-resource-note:alpha-42",
+              },
+            ],
+          });
+        } finally {
+          await service.stop();
+        }
+      });
+      expect(process.env[intruderUrlKey]).toBe("http://127.0.0.1:9/mcp");
+      expect(process.env[intruderTypeKey]).toBe("sse");
     } finally {
-      await service.stop();
+      if (priorIntruderUrl === undefined) delete process.env[intruderUrlKey];
+      else process.env[intruderUrlKey] = priorIntruderUrl;
+      if (priorIntruderType === undefined) delete process.env[intruderTypeKey];
+      else process.env[intruderTypeKey] = priorIntruderType;
     }
   }, 15_000);
 });

--- a/packages/scenario-runner/src/mcp-scenario-registration.test.ts
+++ b/packages/scenario-runner/src/mcp-scenario-registration.test.ts
@@ -1,24 +1,9 @@
 /**
- * Regression coverage for deterministic-mcp-actions-routes' seed-time MCP
- * registration contract.
- *
- * The scenario declares "@elizaos/plugin-mcp" under requires.plugins — a
- * real, resolvable package the batch-level factory imports and registers
- * before the scenario runs (see registerScenarioRequiredPlugins) — never
- * under requires.fixturePlugins (which is reserved for scenario-local
- * fixture plugins only the scenario's own seed can register; see
- * resolveRequiredFixturePlugins / commit 2a589d97652).
- *
- * The scenario's own seed (seedMcp in
- * test/scenarios/deterministic-mcp-actions-routes.scenario.ts) self-heals by
- * checking `runtime.plugins.some((p) => p.name === mcpPlugin.name)` before
- * calling registerPlugin again, then reads `scenarioMcpService.getServers()`
- * straight off the instance it just started with `await McpService.start()`.
- * If the real plugin-mcp package's exported name ever drifts from what
- * pluginNameAliases("@elizaos/plugin-mcp") recognizes, or the real
- * McpService ever stops finding its configured "mcp" setting, the seed fails
- * with exactly the defect's signature: "MCP server scenario_mcp was not
- * registered".
+ * Verifies the deterministic MCP scenario's package-registration contract.
+ * The integration-backed harness registers required plugins through the
+ * scenario runner, starts the real MCP service with a stdio fixture, and
+ * exercises its tool and resource surfaces. Required package plugins must be
+ * available before scenario seeding while fixture-only plugins remain local.
  */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
@@ -163,7 +163,7 @@ function unsupportedMcpPostToolFixture(input: string, op: string) {
   };
 }
 
-type RuntimeWithMcpScenario = IAgentRuntime &
+type RuntimeWithMcpScenario = Omit<IAgentRuntime, "routes"> &
   RuntimeWithScenarioModelFixtures & {
     plugins?: Plugin[];
     getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;

--- a/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
@@ -525,8 +525,9 @@ function registerMcpRoutes(runtime: RuntimeWithMcpScenario): void {
 }
 
 async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
-  const runtime = ctx.runtime as RuntimeWithMcpScenario | undefined;
-  if (!runtime) return "scenario runtime was not available";
+  const agentRuntime = ctx.runtime as IAgentRuntime | undefined;
+  if (!agentRuntime) return "scenario runtime was not available";
+  const runtime = agentRuntime as RuntimeWithMcpScenario;
   scenarioRuntime = runtime;
   previousMcpEvaluators = runtime.evaluators;
   runtime.evaluators = [];
@@ -537,7 +538,7 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
   runtime.setSetting("mcp", mcpConfig().mcp, false);
   const originalGetService = runtime.getService.bind(runtime);
   await originalGetService<McpService>(MCP_SERVICE_NAME)?.stop();
-  scenarioMcpService = await McpService.start(runtime);
+  scenarioMcpService = await McpService.start(agentRuntime);
   runtime.getService = ((serviceType: string) =>
     serviceType === MCP_SERVICE_NAME
       ? scenarioMcpService

--- a/plugins/plugin-mcp/src/index.ts
+++ b/plugins/plugin-mcp/src/index.ts
@@ -60,4 +60,8 @@ export {
   type McpRegistryServer,
   searchMcpMarketplace,
 } from "./mcp-marketplace.js";
-export { handleMcpRoutes, type McpRouteContext } from "./routes-mcp.js";
+export {
+  handleMcpRoutes,
+  type McpRouteConfig,
+  type McpRouteContext,
+} from "./routes-mcp.js";


### PR DESCRIPTION
# Relates to

`deterministic-mcp-actions-routes` was reported failing at seed time with `MCP server scenario_mcp was not registered`. The failure does not reproduce on current `develop`; this PR adds a focused contract guard so any future registration regression fails by name.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto the live `origin/develop` with zero conflicts.
- [x] `bun install` and the scoped exact-head gates below were run after sync.
- [ ] `bun run verify` was not run; see Known gaps.
- [x] A reviewer can confirm the changed behavior from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`21cbe704abaa`); zero conflicts.
- [x] The already-landed UI formatter commit was detected by patch identity and dropped during convergence.
- [x] Exact delta is three intended files: the new registration test, the deterministic MCP scenario route typing, and the MCP route-config export.

# Risks

Low. This adds a registration contract test and aligns existing route types/exports; it does not change MCP execution behavior.

# Background

## What does this PR do?

The scenario seed starts a real stdio MCP fixture server and depends on `scenario_mcp` being registered before turns run. The new test pins both registration sources and connects to the real stdio fixture to list/call its tool and read its resource. The route type now uses the plugin's exported `McpRouteConfig` contract without widening the runtime boundary.

## What kind of change is this?

Tests and TypeScript contract alignment (non-breaking).

# Documentation changes needed?

No documentation change is required.

# Testing

## Where should a reviewer start?

`packages/scenario-runner/src/mcp-scenario-registration.test.ts`

## Exact-head results

- MCP registration contract: 4/4 passed, including real stdio tool/resource connection.
- Deterministic MCP actions/routes scenario: 1/1 passed; all 19 required fixtures consumed under the simulated/keyless profile.
- `@elizaos/plugin-mcp` typecheck: passed.
- `@elizaos/scenario-runner` typecheck: passed.
- Exact changed-file Biome and `git diff --check`: passed.
- Affected lint: 143/143 tasks passed.
- Affected typecheck: 232/232 tasks passed.
- Comment-only header repair: repository code-token check passed against its parent; focused MCP contract remained 4/4 green.

# Evidence Gate

<!-- evidence-head:7c675b591a588a68ce556a9dc93d68448bc8d4db -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head registration test passed 4/4 and deterministic scenario passed 1/1 with all required fixtures consumed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic simulated model only; no provider claim.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - registration contract only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - the scenario uses the deterministic simulated provider and is intentionally ineligible as live-provider evidence.

## Backend + frontend logs

The exact-head scenario completed in 82.9 seconds with 1 passed, 0 failed, 0 skipped. The exact-head Vitest contract completed with 4 passed, 0 failed.

## Screenshots / video / audio

N/A - no UI or voice surface.

## Known gaps / failures

- `bun run verify` was not run; scoped exact-head package, scenario, formatting, affected lint, and affected typecheck gates were used.
- The full `plugin-mcp` suite has an existing order-dependent validation-test failure when run as an aggregate; the validation file passes 10/10 in isolation and all other plugin test files pass. The changed plugin source only exports the existing `McpRouteConfig` type.
- Hosted checks are triggered by the final push and are not represented as local acceptance evidence.

## Maintainer CI exception record

N/A - no exception requested.

🤖 Generated with Codex
