### PR TITLE
test(cloud): cover stale billing snapshot refresh recovery

### DIFF
--- a/packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts
+++ b/packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts
@@ -317,4 +317,243 @@ test.describe("billing snapshot — backend failure recovery", () => {
     expect(first503).toBeGreaterThanOrEqual(0);
     expect(first200AfterFailure).toBeGreaterThan(first503);
   });
+
+  test("keeps a cached snapshot visible through a failed background refresh and retry", async ({
+    authenticatedPage,
+    stack,
+    seededUser,
+  }) => {
+    const backendFaults = stack.mocks.backendFaults;
+    expect(
+      backendFaults,
+      "stackOptions.backendFaults must expose the server-side fault controller",
+    ).toBeDefined();
+    if (!backendFaults) throw new Error("backend fault controller unavailable");
+
+    const { organizationsRepository } = await import(
+      "@elizaos/cloud-shared/db/repositories/organizations"
+    );
+    const original = await organizationsRepository.findBalanceSnapshotForWrite(
+      seededUser.organizationId,
+    );
+    expect(original, "expected the seeded billing authority").toBeDefined();
+    if (!original) throw new Error("seeded billing authority was not found");
+
+    const originalRevision = Number(original.balance_revision);
+    expect(Number.isSafeInteger(originalRevision)).toBe(true);
+    expect(originalRevision).toBeGreaterThanOrEqual(0);
+    expect(
+      typeof original.credit_balance === "string" ||
+        typeof original.credit_balance === "number",
+    ).toBe(true);
+
+    const originalBalance = String(original.credit_balance);
+    const updatedBalance = "1234.560000";
+    let updatedRevision = originalRevision;
+    const snapshotStatuses: number[] = [];
+    authenticatedPage.on("response", (response) => {
+      if (new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH) {
+        snapshotStatuses.push(response.status());
+      }
+    });
+
+    try {
+      const initialResponsePromise = authenticatedPage.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH &&
+          response.status() === 200,
+      );
+      await authenticatedPage.goto(
+        `${stack.urls.frontend}${LEGACY_BILLING_PAGE_PATH}`,
+        { timeout: 60_000 },
+      );
+      const initialResponse = await initialResponsePromise;
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`${CANONICAL_BILLING_PAGE_PATH}$`),
+      );
+      await expect(
+        authenticatedPage.getByText("$1,000.00", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("No active billable compute", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      expect(await initialResponse.json()).toMatchObject({
+        success: true,
+        data: {
+          v2: {
+            balance: {
+              status: "available",
+              value: { revision: String(originalRevision) },
+            },
+          },
+        },
+      });
+
+      // Leave Billing through the real SPA navigation so the shared QueryClient
+      // keeps the last good tenant-scoped snapshot while Billing unmounts.
+      await authenticatedPage
+        .getByRole("button", { name: "Back to Cloud overview" })
+        .click();
+      await expect(authenticatedPage).toHaveURL(/\/cloud$/);
+
+      await organizationsRepository.update(seededUser.organizationId, {
+        credit_balance: updatedBalance,
+      });
+      const updated = await organizationsRepository.findBalanceSnapshotForWrite(
+        seededUser.organizationId,
+      );
+      expect(updated, "expected the updated billing authority").toBeDefined();
+      if (!updated) throw new Error("updated billing authority was not found");
+      updatedRevision = Number(updated.balance_revision);
+      expect(Number.isSafeInteger(updatedRevision)).toBe(true);
+      expect(updatedRevision).toBeGreaterThan(originalRevision);
+      expect(String(updated.credit_balance)).toBe(updatedBalance);
+
+      backendFaults.setFault({
+        path: BILLING_SNAPSHOT_PATH,
+        method: "GET",
+        status: 503,
+        body: {
+          success: false,
+          error: "Billing snapshot temporarily unavailable",
+          code: "billing_snapshot_unavailable",
+          retryable: true,
+        },
+        headers: { "Retry-After": "1" },
+        delayMs: 10_000,
+        times: 2,
+      });
+
+      const failedRefreshPromise = authenticatedPage.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH &&
+          response.status() === 503,
+      );
+      const refreshRequestPromise = authenticatedPage.waitForRequest(
+        (request) =>
+          new URL(request.url()).pathname === BILLING_SNAPSHOT_PATH &&
+          request.method() === "GET",
+      );
+      await authenticatedPage
+        .getByRole("link", { name: "Add funds", exact: true })
+        .first()
+        .click();
+      await refreshRequestPromise;
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`${CANONICAL_BILLING_PAGE_PATH}$`),
+      );
+
+      // The delayed proxy response leaves enough time to observe the genuine
+      // React Query background-refresh state while cached data remains painted.
+      await expect(
+        authenticatedPage.getByText("$1,000.00", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("No active billable compute", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("Refreshing", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          /Refreshing balance\. Showing the value observed at /,
+        ),
+      ).toBeVisible();
+      expect(backendFaults.faultHits).toBeGreaterThanOrEqual(1);
+      expect(backendFaults.faultHits).toBeLessThanOrEqual(2);
+
+      await failedRefreshPromise;
+      backendFaults.clearFault();
+      await expect(
+        authenticatedPage.getByText("$1,000.00", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("No active billable compute", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          /Could not refresh balance\. Showing the value observed at /,
+        ),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          /Could not refresh\. Showing the snapshot completed at /,
+        ),
+      ).toBeVisible();
+      const retry = authenticatedPage.getByRole("button", {
+        name: "Retry",
+        exact: true,
+      });
+      await expect(retry).toBeVisible();
+      expect(snapshotStatuses).toContain(200);
+      expect(snapshotStatuses.filter((status) => status === 503)).toHaveLength(
+        1,
+      );
+      expect(backendFaults.faultHits).toBeGreaterThanOrEqual(1);
+      expect(backendFaults.faultHits).toBeLessThanOrEqual(2);
+
+      const recoveredResponsePromise = authenticatedPage.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH &&
+          response.status() === 200,
+      );
+      await retry.click();
+      const recoveredResponse = await recoveredResponsePromise;
+      expect(await recoveredResponse.json()).toMatchObject({
+        success: true,
+        data: {
+          v2: {
+            balance: {
+              status: "available",
+              value: {
+                balance: { value: updatedBalance },
+                revision: String(updatedRevision),
+              },
+            },
+          },
+        },
+      });
+
+      await expect(
+        authenticatedPage.getByText("$1,234.56", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("$1,000.00", { exact: true }),
+      ).toBeHidden();
+      await expect(
+        authenticatedPage.getByText("No active billable compute", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          /Could not refresh balance\. Showing the value observed at /,
+        ),
+      ).toBeHidden();
+      await expect(
+        authenticatedPage.getByText(
+          /Could not refresh\. Showing the snapshot completed at /,
+        ),
+      ).toBeHidden();
+      await expect(
+        authenticatedPage.getByText("Refreshing", { exact: true }),
+      ).toBeHidden();
+      expect(backendFaults.faultHits).toBeGreaterThanOrEqual(1);
+      expect(backendFaults.faultHits).toBeLessThanOrEqual(2);
+    } finally {
+      backendFaults.clearFault();
+      await organizationsRepository.update(seededUser.organizationId, {
+        credit_balance: originalBalance,
+      });
+      await organizationsRepository.update(seededUser.organizationId, {
+        balance_revision: originalRevision,
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- add a real Cloud browser E2E for a cached Billing V2 snapshot whose background refresh fails
- prime the tenant/user-scoped QueryClient from a real 200, leave Billing through SPA navigation, mutate the PGlite billing authority, and remount Billing into a delayed server-side 503
- prove the stale balance and empty-compute observation stay visible through refreshing and refresh-failed states, then prove manual Retry replaces them from a real recovered 200
- restore the original balance and trigger-managed revision in `finally`

Relates to #22965. This does not close the umbrella issue.

## Scope and risk

- test-only change: `packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts`
- rebased base: `dd4eae58a3b954276888d83b77324bbb49798b28`
- head: `80d75e402be7893f3ca68fb6a5eb12bf83f63939`
- risk: low; no runtime, UI, schema, or production configuration changes

## Validation

- exact-head full spec: `mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e test tests/billing-snapshot-adversarial.spec.ts --reporter=line,json` — PASS (3/3, 0 flaky, 57.6 s)
- focused stability run on the same patch before the final unrelated-base rebase — PASS (5/5)
- `mise exec node@24.15.0 -- bun run --cwd packages/cloud/e2e typecheck` — PASS
- `mise exec node@24.15.0 -- bunx biome check packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts` — PASS
- `git diff --check origin/develop...HEAD` — PASS
- exact-head JSON report SHA-256: `7d17c313b37b94f37320c0d711e411420072605ad94c446028eaf27afe984469`
- independent review — no P0–P3 findings

`mise exec node@24.15.0 -- bun run verify` reaches the monorepo lint/typecheck fan-out, then fails on pre-existing Biome formatting in:
- `packages/evidence/src/visual-primitives.test.mjs` — base/head blob `72d0c26cca4a66176c23d7f1611f43766e98353b`
- `packages/agent/src/api/health-routes.debug-surrogate.test.ts` — base/head blob `0467408ce40f7411caff838c59a19acc7e0556c5`
- `packages/agent/src/providers/page-scoped-context.safe-sort.test.ts` — base/head blob `73923dbddab00cd1453f4c7f2f811c490b67e1f6`

All three blockers are byte-identical at the rebased base and head. The affected E2E typecheck, Biome check, full spec, and repeat run pass.

## Evidence notes

- browser path: real shared BrowserContext and QueryClient; no `page.route` request interception and no browser reload between cache prime and remount
- backend path: real local Cloud stack and PGlite authority, with the existing server-side fault proxy delaying and returning the controlled 503
- concurrency guard: the fault has two slots to absorb a possible aborted React StrictMode probe while requiring exactly one browser-visible 503
- screenshots / video / OCR: N/A because this is a test-only change and no rendered surface changed
- LLM evidence: N/A

<!-- evidence-head:80d75e402be7893f3ca68fb6a5eb12bf83f63939 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only E2E change; no rendered surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only E2E change; no rendered surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - automated coverage only; no product UI code changed

<!-- evidence-row:backend-logs -->
- [x] [25940-billing-snapshot-adversarial-80d75e40.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25940-billing-snapshot-adversarial-80d75e40.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source changed; browser-visible network and state assertions are exercised by the attached exact-head Playwright report

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - DB balance and revision assertions are contained in the unique exact-head Playwright report; no separate production artifact is generated

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

## Known gaps / failures

- global `bun run verify`: blocked only by the three unchanged upstream Biome failures listed above
- screenshots, video, and OCR: not applicable to a test-only diff with no rendered source change
- live Stripe / production services: not applicable; this scenario exercises Billing snapshot refresh behavior in the repository local Cloud E2E stack

## Maintainer CI exception record

N/A - no exception requested.
