### PR TITLE
fix(agent/cloud): fetch timeout with DEFAULT_*_TIMEOUT_MS + AbortSignal.timeout + AbortSignal.any([caller, timeout]) through response.json() for media-store and cloud fetches

### DIFF
--- a/packages/agent/src/__tests__/regression-timeout.test.ts
+++ b/packages/agent/src/__tests__/regression-timeout.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Behavioral regression for fetch timeout — media-store and cloud fetches.
+ * Proves DEFAULT_*_TIMEOUT_MS budgets, hanging-fetch abort via TimeoutError,
+ * body-stall abort through response.json(), and caller-signal composition.
+ */
+
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CLOUD_FETCH_TIMEOUT_MS,
+  DEFAULT_CLOUD_GITHUB_TOKEN_FETCH_TIMEOUT_MS,
+  autoFetchCloudGithubToken,
+  autoResolveDiscordAppId,
+  fetchJsonWithCloudTimeout,
+} from "../runtime/eliza.ts";
+import { DEFAULT_MEDIA_REHOST_FETCH_TIMEOUT_MS } from "../api/media-runtime.ts";
+import {
+  DEFAULT_MEDIA_FETCH_TIMEOUT_MS,
+  fetchRemoteMedia,
+} from "../../../core/src/media/fetch.ts";
+
+// Preserve original AbortSignal.timeout for 10ms acceleration
+let originalTimeout: typeof AbortSignal.timeout;
+
+function stallUntilAborted(): typeof fetch {
+  return ((_input: RequestInfo | URL, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      if (!signal) throw new Error("expected abort signal");
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    })) as unknown as typeof fetch;
+}
+
+function stallingPinnedFetch(): (typeof fetch) extends never ? never : import("../../../core/src/media/fetch.ts").FetchLike | any {
+  // For fetchRemoteMedia's pinnedFetchImpl shape, we adapt to its params
+  return async (params: any) => {
+    const signal = params?.init?.signal as AbortSignal | undefined;
+    return new Promise<Response>((_resolve, reject) => {
+      if (!signal) throw new Error("expected signal in pinned fetch");
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    });
+  };
+}
+
+describe("fetch timeout regression — media-store and cloud", () => {
+  beforeEach(() => {
+    originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("exposes documented ten-second budgets", () => {
+    expect(DEFAULT_MEDIA_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(DEFAULT_MEDIA_REHOST_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(DEFAULT_CLOUD_FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(DEFAULT_CLOUD_GITHUB_TOKEN_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("aborts a stalled media fetch at the deadline (hanging pinned fetch) — vi.spyOn(AbortSignal,\"timeout\") →10ms + stallUntilAborted", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) =>
+      ms === DEFAULT_MEDIA_FETCH_TIMEOUT_MS ? originalTimeout(10) : originalTimeout(ms),
+    );
+    await expect(
+      fetchRemoteMedia({
+        url: "https://example.com/image.png",
+        maxBytes: 1024 * 1024,
+        lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+        pinnedFetchImpl: stallingPinnedFetch(),
+      }),
+    ).rejects.toMatchObject({ cause: expect.objectContaining({ name: "TimeoutError" }) });
+    expect(vi.spyOn(AbortSignal, "timeout")).toHaveBeenCalled;
+    // Explicitly check spy was called with DEFAULT
+    expect((AbortSignal.timeout as unknown as ReturnType<typeof vi.spyOn>)).toHaveBeenCalledWith(
+      DEFAULT_MEDIA_FETCH_TIMEOUT_MS,
+    );
+  });
+
+  it("aborts a stalled cloud fetch at the deadline (hanging fetch) via fetchJsonWithCloudTimeout", async () => {
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) =>
+      ms === DEFAULT_CLOUD_FETCH_TIMEOUT_MS ? originalTimeout(10) : originalTimeout(ms),
+    );
+    const hanging = stallUntilAborted();
+    await expect(
+      fetchJsonWithCloudTimeout("https://cloud.example.test/json", {}, { fetchImpl: hanging as unknown as typeof fetch }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(DEFAULT_CLOUD_FETCH_TIMEOUT_MS);
+  });
+
+  it("keeps the deadline armed while the media response body stalls (real server) — body-stall", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "image/png", "content-length": "100" });
+      res.write(Buffer.alloc(10));
+      // stall body — never end, deadline must abort readResponseWithLimit
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/image.png`;
+
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => originalTimeout(10));
+
+    try {
+      await expect(
+        fetchRemoteMedia({
+          url,
+          maxBytes: 1024 * 1024,
+          ssrfPolicy: { allowPrivateNetwork: true },
+        }),
+      ).rejects.toSatisfy((err: unknown) => {
+        const e = err as { name?: string; cause?: { name?: string }; code?: string; message?: string };
+        return (
+          e?.cause?.name === "TimeoutError" ||
+          e?.name === "TimeoutError" ||
+          e?.name === "AbortError" ||
+          e?.code === "ECONNRESET" ||
+          (typeof e?.message === "string" && e.message.toLowerCase().includes("aborted"))
+        );
+      });
+      expect(AbortSignal.timeout).toHaveBeenCalled();
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("keeps the deadline armed while the cloud response body stalls through response.json() (real server)", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"success":true,"data":{"accessToken":"x",');
+      // never finish JSON — response.json() must abort via TimeoutError
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as import("node:net").AddressInfo;
+    const url = `http://127.0.0.1:${addr.port}/token`;
+
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => originalTimeout(10));
+
+    try {
+      await expect(
+        fetchJsonWithCloudTimeout(url, {}, { fetchImpl: globalThis.fetch }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("preserves caller AbortError over TimeoutError via AbortSignal.any([caller, timeout])", async () => {
+    const caller = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => originalTimeout(1000));
+    const hanging = stallUntilAborted();
+    const pending = fetchJsonWithCloudTimeout("https://cloud.example.test/json", {}, {
+      signal: caller.signal,
+      fetchImpl: hanging as unknown as typeof fetch,
+    });
+    caller.abort(new DOMException("caller abort", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError", message: "caller abort" });
+    // Verify any composition was used — timeout spy still called
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(DEFAULT_CLOUD_FETCH_TIMEOUT_MS);
+  });
+
+  it("also preserves caller abort for media fetch via AbortSignal.any([caller, timeout])", async () => {
+    const caller = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => originalTimeout(1000));
+    const pending = fetchRemoteMedia({
+      url: "https://example.com/media.png",
+      maxBytes: 1024 * 1024,
+      signal: caller.signal,
+      lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+      pinnedFetchImpl: stallingPinnedFetch(),
+    });
+    caller.abort(new DOMException("media caller abort", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ cause: expect.objectContaining({ name: "AbortError" }) });
+  });
+
+  it("does not call fetch when cloud github token is skipped due to existing env — not.toHaveBeenCalled()", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "existing-token");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "cloud-key");
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", "https://cloud.test");
+    vi.stubEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT", "managed");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const result = await autoFetchCloudGithubToken("agent-1");
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetch when discord app id already set — not.toHaveBeenCalled() again", async () => {
+    vi.stubEnv("DISCORD_APPLICATION_ID", "already-set");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    await autoResolveDiscordAppId("token-override");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("succeeds on fast cloud upstream and passes abort signal, not aborted", async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (!init?.signal) throw new Error("signal missing");
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const result = await fetchJsonWithCloudTimeout("https://cloud.example.test/ok", {}, {
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const signal = (fetchMock.mock.calls[0]?.[1] as RequestInit)?.signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+  });
+});

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -29,6 +29,8 @@ import {
 /** Cap on bytes pulled while rehosting a remote attachment into the store. */
 const REHOST_MAX_BYTES = 50 * 1024 * 1024;
 
+export const DEFAULT_MEDIA_REHOST_FETCH_TIMEOUT_MS = 10_000;
+
 /** Media content types worth rehosting (skip `link` and unknown). */
 const REHOSTABLE_CONTENT_TYPES = new Set([
   "image",
@@ -44,11 +46,21 @@ const REHOSTABLE_CONTENT_TYPES = new Set([
  * `/api/media/<hash>` URL. Returns the served URL, or null on any failure
  * (blocked host, too large, unreachable) so the caller can keep the original.
  */
-async function rehostRemoteMediaUrl(url: string): Promise<string | null> {
+async function rehostRemoteMediaUrl(
+  url: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<string | null> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_MEDIA_REHOST_FETCH_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
   try {
     const { buffer, contentType } = await fetchRemoteMedia({
       url,
       maxBytes: REHOST_MAX_BYTES,
+      signal,
+      timeoutMs,
       lookupFn: nodeLookupFn,
       pinnedFetchImpl: nodePinnedFetch,
     });

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2142,6 +2142,37 @@ export async function resolveConfigEnvVaultRefsForBoot(
   }
 }
 
+export const DEFAULT_CLOUD_FETCH_TIMEOUT_MS = 10_000;
+export const DEFAULT_CLOUD_GITHUB_TOKEN_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Generic JSON fetch with cloud timeout — deadline stays armed through
+ * response.json() so a stalled body still aborts. Caller signal is
+ * composed with the timeout via AbortSignal.any.
+ */
+export async function fetchJsonWithCloudTimeout(
+  url: string,
+  init: RequestInit = {},
+  options: {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<unknown> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CLOUD_FETCH_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  const res = await fetchFn(url, { ...init, signal });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  // Signal remains armed through body consumption; a hanging json stalls aborts via TimeoutError
+  return await res.json();
+}
+
 /**
  * Auto-resolve Discord Application ID from the bot token via Discord API.
  * Called during async runtime init so that users only need a bot token.
@@ -2152,7 +2183,9 @@ export async function resolveConfigEnvVaultRefsForBoot(
 /** @internal Exported for testing. */
 export async function autoResolveDiscordAppId(
   tokenOverride?: string,
-  timeoutMs = 3_000,
+  timeoutMs = DEFAULT_CLOUD_FETCH_TIMEOUT_MS,
+  callerSignal?: AbortSignal,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   if (process.env.DISCORD_APPLICATION_ID) return;
 
@@ -2162,12 +2195,16 @@ export async function autoResolveDiscordAppId(
     process.env.DISCORD_BOT_TOKEN;
   if (!discordToken) return;
 
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
   try {
-    const res = await fetch(
+    const res = await fetchImpl(
       "https://discord.com/api/v10/oauth2/applications/@me",
       {
         headers: { Authorization: `Bot ${discordToken}` },
-        signal: AbortSignal.timeout(timeoutMs),
+        signal,
       },
     );
 
@@ -2218,7 +2255,9 @@ export interface CloudGithubTokenResult {
 /** @internal Exported for testing. */
 export async function autoFetchCloudGithubToken(
   agentId?: string,
-  timeoutMs = 3_000,
+  timeoutMs = DEFAULT_CLOUD_FETCH_TIMEOUT_MS,
+  callerSignal?: AbortSignal,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<CloudGithubTokenResult | null> {
   // Skip if a local token is already configured
   if (process.env.GITHUB_TOKEN || process.env.GITHUB_PAT) return null;
@@ -2232,14 +2271,18 @@ export async function autoFetchCloudGithubToken(
   const managedNs = readAliasedEnv("ELIZA_CLOUD_MANAGED_AGENTS_API_SEGMENT");
   if (!managedNs) return null;
 
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
   try {
     const url = `${cloudBaseUrl}/api/v1/${managedNs}/agents/${encodeURIComponent(agentId)}/github/token`;
-    const res = await fetch(url, {
+    const res = await fetchImpl(url, {
       headers: {
         Authorization: `Bearer ${cloudApiKey}`,
         Accept: "application/json",
       },
-      signal: AbortSignal.timeout(timeoutMs),
+      signal,
     });
 
     if (!res.ok) {

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -42,6 +42,8 @@ export type FetchLike = (
 	init?: RequestInit,
 ) => Promise<Response>;
 
+export const DEFAULT_MEDIA_FETCH_TIMEOUT_MS = 10_000;
+
 export type FetchMediaOptions = {
 	url: string;
 	fetchImpl?: FetchLike;
@@ -49,6 +51,8 @@ export type FetchMediaOptions = {
 	maxBytes?: number;
 	maxRedirects?: number;
 	timeoutMs?: number;
+	/** Caller abort signal — composed with the timeout deadline via AbortSignal.any. */
+	signal?: AbortSignal;
 	/** Require the declared response MIME type to start with this prefix. */
 	requiredContentTypePrefix?: string;
 	/** Reject Content-Encoding other than identity when callers need raw media bytes. */
@@ -165,12 +169,18 @@ async function fetchGuardedMedia(options: FetchMediaOptions): Promise<{
 	finalUrl: string;
 	release: () => Promise<void>;
 }> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_MEDIA_FETCH_TIMEOUT_MS;
+	const timeoutSignal = AbortSignal.timeout(timeoutMs);
+	const compositeSignal = options.signal
+		? AbortSignal.any([options.signal, timeoutSignal])
+		: timeoutSignal;
 	try {
 		return await fetchWithSsrfGuard({
 			url: options.url,
 			fetchImpl: options.fetchImpl,
 			maxRedirects: options.maxRedirects,
-			timeoutMs: options.timeoutMs,
+			timeoutMs: undefined,
+			signal: compositeSignal,
 			policy: options.ssrfPolicy,
 			lookupFn: options.lookupFn,
 			pinnedFetchImpl: options.pinnedFetchImpl,


### PR DESCRIPTION
Bounds media-store and cloud fetches with 10s DEFAULT_*_TIMEOUT_MS, composes caller signal with deadline via `AbortSignal.any([caller, AbortSignal.timeout(DEFAULT)])`, and keeps deadline armed through `response.json()`/body consumption.

### Changes
- **core/media/fetch**: adds `DEFAULT_MEDIA_FETCH_TIMEOUT_MS = 10_000`, threads caller `signal` via `AbortSignal.any`, routes through `fetchWithSsrfGuard` signal
- **agent/api/media-runtime**: adds `DEFAULT_MEDIA_REHOST_FETCH_TIMEOUT_MS = 10_000`, rehost composes `AbortSignal.any([caller, AbortSignal.timeout(DEFAULT)])`
- **agent/runtime/eliza**: adds `DEFAULT_CLOUD_FETCH_TIMEOUT_MS` (+ GITHUB variant), adds `fetchJsonWithCloudTimeout` helper (`AbortSignal.timeout` + `AbortSignal.any` through `response.json()`), `autoFetchCloudGithubToken`/`autoResolveDiscordAppId` now accept `callerSignal`+`fetchImpl` and compose deadline

### Tests
`packages/agent/src/__tests__/regression-timeout.test.ts` calling real functions:
- `vi.spyOn(AbortSignal,"timeout")`→10ms, `stallUntilAborted` hanging-fetch, real `http.createServer` body-stall, `TimeoutError`/ `AbortError` via `AbortSignal.any`, `not.toHaveBeenCalled()`
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/__tests__/regression-timeout.test.ts` — **10 passed**

### Verification
- `gh pr list --search "AbortSignal.timeout" --state open` — 0 hits (no duplicate)
- `bun run --cwd packages/core typecheck` / `agent typecheck` — ok