### PR TITLE
chore(evidence): restore format closure

### DIFF
--- a/packages/evidence/src/visual-primitives.test.mjs
+++ b/packages/evidence/src/visual-primitives.test.mjs
@@ -25,10 +25,22 @@ describe("quantizePalette", () => {
     // written in an order that is the exact reverse of the required rgb order,
     // so insertion-dependent ordering is distinguishable from the tie-break.
     const data = Uint8Array.from([
-      200, 0, 0, 255, // bin { r: 200, g: 8, b: 8 }
-      0, 200, 0, 255, // bin { r: 8, g: 200, b: 8 }
-      0, 0, 200, 255, // bin { r: 8, g: 8, b: 200 }
-      0, 0, 0, 255, // bin { r: 8, g: 8, b: 8 }
+      200,
+      0,
+      0,
+      255, // bin { r: 200, g: 8, b: 8 }
+      0,
+      200,
+      0,
+      255, // bin { r: 8, g: 200, b: 8 }
+      0,
+      0,
+      200,
+      255, // bin { r: 8, g: 8, b: 200 }
+      0,
+      0,
+      0,
+      255, // bin { r: 8, g: 8, b: 8 }
     ]);
 
     const { swatches } = quantizePalette(data);
@@ -44,9 +56,18 @@ describe("quantizePalette", () => {
 
   it("still orders by coverage before applying the rgb tie-break", () => {
     const data = Uint8Array.from([
-      0, 0, 0, 255, // { r: 8, g: 8, b: 8 }
-      200, 0, 0, 255, // { r: 200, g: 8, b: 8 }
-      200, 0, 0, 255,
+      0,
+      0,
+      0,
+      255, // { r: 8, g: 8, b: 8 }
+      200,
+      0,
+      0,
+      255, // { r: 200, g: 8, b: 8 }
+      200,
+      0,
+      0,
+      255,
     ]);
 
     const { swatches } = quantizePalette(data);


### PR DESCRIPTION
## Summary

Apply the pinned Biome 2.5.8 rendering to the single visual-primitives regression fixture that currently fails both Develop Full Format and Develop Gate lint.

No assertions or runtime behavior change.

## Exact source

- base: 7a6ce41b749134546a91766aa1d063e25e33aec1
- head: 58b6a1a0d9db5bf7e2764a8b24d3025503c5c520
- local rollback tag: fix-evidence-format-closure-v1-20260823
- current develop still has the identical failing blob at publication time

## Proof

- exact-file Biome 2.5.8 format: clean
- exact-file Biome 2.5.8 check: clean
- git diff --check: clean
- exact one-commit gitleaks: no leaks
- sparse focused Bun test could not resolve workspace package @elizaos/core, so no assertion ran; no dependency tree was borrowed. Normal installed-workspace PR Static Smoke is the required runtime closure proof.

## Release boundary

No workflow dispatch, deploy, provider traffic, or production action. Cloudflare/Railway remain closed pending the Windows watchdog, Devices migration ordering, and one exact canonical green aggregate.