### PR TITLE
fix(cloud): safe NaN handling in advertising media and days-of-week sort comparators

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -191,7 +191,9 @@ class AdvertisingService {
     return {
       timezone: parsed.data.timezone,
       windows: parsed.data.windows.map((window) => ({
-        daysOfWeek: [...new Set(window.daysOfWeek)].sort((a, b) => a - b),
+        daysOfWeek: [...new Set(window.daysOfWeek)].sort(
+          (a, b) => (Number.isFinite(a) ? a : 0) - (Number.isFinite(b) ? b : 0),
+        ),
         startTime: window.startTime,
         endTime: window.endTime,
       })),

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -924,7 +924,12 @@ export const linkedinAdsProvider: AdProvider = {
   ): Promise<AdProviderCreativeResult> {
     try {
       const { campaignId } = splitExternalCampaignId(externalCampaignId);
-      const primaryMedia = [...input.media].sort((left, right) => left.order - right.order)[0];
+      const primaryMedia = [...input.media].sort(
+        (left, right) =>
+          (Number.isFinite(left.order) ? left.order : 0) -
+            (Number.isFinite(right.order) ? right.order : 0) ||
+          (left.providerAssetId ?? "").localeCompare(right.providerAssetId ?? ""),
+      )[0];
       if (!primaryMedia?.providerAssetId) {
         return {
           success: false,

--- a/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts
@@ -542,4 +542,41 @@ describe("programmaticDspProvider", () => {
     const body = jsonBody(calls[1] as FetchCall) as Record<string, unknown>;
     expect("seat" in body ? body.seat : undefined).toBeUndefined();
   });
+
+  test("safely sorts creative media with non-finite order values", async () => {
+    enqueue({ data: { id: "crv_safe_sort" } });
+    enqueue({ data: { id: "assoc_safe_sort" } });
+
+    const result = await programmaticDspProvider.createCreative(
+      { accessToken: "token" },
+      "adv_1",
+      "adv_1/cmp_1/li_1",
+      {
+        campaignId: "campaign-local",
+        name: "Safe Sort Creative",
+        type: "image",
+        headline: "Try the app",
+        primaryText: "A useful app for builders",
+        callToAction: "learn_more",
+        destinationUrl: "https://example.com/path",
+        media: [
+          {
+            id: "00000000-0000-4000-8000-000000000003",
+            source: "upload",
+            url: "https://cdn.example.com/ad-nan.png",
+            type: "image",
+            order: Number.NaN as unknown as number,
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000002",
+            source: "upload",
+            url: "https://cdn.example.com/ad-first.png",
+            type: "image",
+            order: 1,
+          },
+        ],
+      },
+    );
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts
@@ -289,7 +289,11 @@ function summarizeReport(report: DspReport | undefined): CampaignMetrics {
  * click-through lands in `adomain` + the asset `link`.
  */
 function buildCreativeAd(input: CreateCreativeInput, seatId: string | undefined) {
-  const orderedMedia = [...input.media].sort((a, b) => a.order - b.order);
+  const orderedMedia = [...input.media].sort(
+    (a, b) =>
+      (Number.isFinite(a.order) ? a.order : 0) - (Number.isFinite(b.order) ? b.order : 0) ||
+      (a.providerAssetId ?? "").localeCompare(b.providerAssetId ?? ""),
+  );
   const isVideo = input.type === "video" || orderedMedia.some((m) => m.type === "video");
   let adomain: string[] | undefined;
   if (input.destinationUrl) {

--- a/packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts
@@ -494,7 +494,11 @@ export const redditAdsProvider: AdProvider = {
       const adGroupId =
         compositeAdGroupId ?? (await firstAdGroupForCampaign(credentials, accountId, campaignId));
       const profileId = input.pageId ?? (await firstProfileId(credentials, accountId));
-      const orderedMedia = [...input.media].sort((a, b) => a.order - b.order);
+      const orderedMedia = [...input.media].sort(
+        (a, b) =>
+          (Number.isFinite(a.order) ? a.order : 0) - (Number.isFinite(b.order) ? b.order : 0) ||
+          (a.providerAssetId ?? "").localeCompare(b.providerAssetId ?? ""),
+      );
       const primaryMedia = orderedMedia[0];
       const type =
         input.type === "video" ? "VIDEO" : input.type === "carousel" ? "CAROUSEL" : "IMAGE";

--- a/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts
@@ -494,7 +494,12 @@ export const xTwitterAdsProvider: AdProvider = {
       const { lineItemId } = splitExternalCampaignId(externalCampaignId);
       if (!lineItemId) throw new Error("X Ads creative creation requires a line item id");
       const asUserId = input.pageId ?? (await firstPromotableUser(credentials, accountId));
-      const orderedMedia = [...input.media].sort((left, right) => left.order - right.order);
+      const orderedMedia = [...input.media].sort(
+        (left, right) =>
+          (Number.isFinite(left.order) ? left.order : 0) -
+            (Number.isFinite(right.order) ? right.order : 0) ||
+          (left.providerAssetId ?? "").localeCompare(right.providerAssetId ?? ""),
+      );
       const mediaKeys = orderedMedia
         .map((media) => media.providerAssetId)
         .filter((value): value is string => Boolean(value));


### PR DESCRIPTION
## Summary

Guards numerical comparisons in `packages/cloud/shared/src/lib/services/advertising` across dayparting schedule windows and creative media order across DSP, Reddit, LinkedIn, and X Ads providers with `Number.isFinite(...)` and string tiebreakers to prevent non-finite numbers (`NaN`) from corrupting sort transitivity.

## Changes

- In `packages/cloud/shared/src/lib/services/advertising/index.ts:194`, guard `daysOfWeek` numerical comparison with `Number.isFinite(...)`.
- In `packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts:292`, guard `media.order` with `Number.isFinite(...)` and add `providerAssetId` tiebreaker.
- In `packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts:497`, guard `media.order` with `Number.isFinite(...)` and add `providerAssetId` tiebreaker.
- In `packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts:927`, guard `media.order` with `Number.isFinite(...)` and add `providerAssetId` tiebreaker.
- In `packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts:497`, guard `media.order` with `Number.isFinite(...)` and add `providerAssetId` tiebreaker.
- In `packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts`, add regression unit test for safe creative media sorting with non-finite order values.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2442a86ce5`) |
| --- | --- | --- |
| `bun test packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts` | 24 pass | 25 pass |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/advertising/index.ts packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/advertising/index.ts:190-200`
- `packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.ts:290-300`
- `packages/cloud/shared/src/lib/services/advertising/providers/reddit.ts:495-505`
- `packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts:925-935`
- `packages/cloud/shared/src/lib/services/advertising/providers/x-twitter.ts:495-505`
- `packages/cloud/shared/src/lib/services/advertising/providers/programmatic-dsp.test.ts:545-580`

## Risks

Low. Guarantees deterministic order for advertising media attachments and campaign dayparting windows.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud advertising service adapters)
- [x] `audit:browser` — N/A (Server-side advertising provider integration)
- [x] `build` — Clean build across workspace
- [x] `test` — 25/25 pass in `programmatic-dsp.test.ts`
- [x] `lint` — Biome clean
