### PR TITLE
test(app-core): cover startup-overlay

### DIFF
--- a/packages/app-core/src/runtime/startup-overlay.test.ts
+++ b/packages/app-core/src/runtime/startup-overlay.test.ts
@@ -1,7 +1,9 @@
 /**
  * Coverage for the startup embedding warmup snapshot: progress-percentage
- * parsing, phase transitions, staleness expiry, and the ready-state reset.
- * Module state is reset via vi.resetModules + dynamic import.
+ * parsing, phase transitions, last-write-wins, empty/unparseable detail,
+ * staleness expiry (including the exact STALE_MS boundary), recovery after
+ * ready/stale, and the ready-state reset. Module state is reset via
+ * vi.resetModules + dynamic import. No mocks of the overlay itself.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -51,6 +53,35 @@ describe("parseEmbeddingProgressPercent", () => {
       mod.parseEmbeddingProgressPercent("downloading chunks"),
     ).toBeUndefined();
   });
+
+  it("treats an empty string as missing detail", async () => {
+    const mod = await loadOverlay();
+    expect(mod.parseEmbeddingProgressPercent("")).toBeUndefined();
+  });
+
+  it("keeps 0% and 100% at the clamp bounds", async () => {
+    const mod = await loadOverlay();
+    expect(mod.parseEmbeddingProgressPercent("0%")).toBe(0);
+    expect(mod.parseEmbeddingProgressPercent("100%")).toBe(100);
+  });
+
+  it("allows whitespace between the number and the percent sign", async () => {
+    const mod = await loadOverlay();
+    expect(mod.parseEmbeddingProgressPercent("45 % of 95 MB")).toBe(45);
+  });
+
+  it("uses the first percentage when several appear", async () => {
+    const mod = await loadOverlay();
+    expect(mod.parseEmbeddingProgressPercent("10% then 90%")).toBe(10);
+  });
+
+  it("rounds halves away from zero then clamps past 100", async () => {
+    const mod = await loadOverlay();
+    expect(mod.parseEmbeddingProgressPercent("0.4%")).toBe(0);
+    expect(mod.parseEmbeddingProgressPercent("0.5%")).toBe(1);
+    // 100.5 rounds to 101, then min(100, 101) clamps it.
+    expect(mod.parseEmbeddingProgressPercent("100.5%")).toBe(100);
+  });
 });
 
 describe("getStartupEmbeddingAugmentation", () => {
@@ -92,5 +123,116 @@ describe("getStartupEmbeddingAugmentation", () => {
     // STALE_MS is module-private (not exported); use its documented value.
     vi.advanceTimersByTime(120_000 + 1);
     expect(mod.getStartupEmbeddingAugmentation()).toBeNull();
+  });
+
+  it("keeps a snapshot at exactly STALE_MS and expires one millisecond later", async () => {
+    vi.useFakeTimers();
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("loading", "80% of 100 MB");
+    vi.advanceTimersByTime(120_000);
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "loading",
+      embeddingDetail: "80% of 100 MB",
+      embeddingProgressPct: 80,
+    });
+    vi.advanceTimersByTime(1);
+    expect(mod.getStartupEmbeddingAugmentation()).toBeNull();
+  });
+
+  it("returns only embeddingPhase when detail is omitted", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("checking");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "checking",
+    });
+  });
+
+  it("omits embeddingDetail when the detail string is empty", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("downloading", "");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "downloading",
+    });
+  });
+
+  it("keeps unparseable detail without a progress percentage", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("loading", "fetching shards");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "loading",
+      embeddingDetail: "fetching shards",
+    });
+  });
+
+  it("lets a later update replace phase, detail, and percent", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("checking");
+    mod.updateStartupEmbeddingProgress("downloading", "12% of 40 MB");
+    mod.updateStartupEmbeddingProgress("loading", "88% of 40 MB");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "loading",
+      embeddingDetail: "88% of 40 MB",
+      embeddingProgressPct: 88,
+    });
+  });
+
+  it("still clears when ready is recorded with leftover detail", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("loading", "99% of 40 MB");
+    mod.updateStartupEmbeddingProgress("ready", "loaded nomic-embed");
+    expect(mod.getStartupEmbeddingAugmentation()).toBeNull();
+  });
+
+  it("exposes a later phase after ready cleared the snapshot", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("downloading", "10% of 40 MB");
+    mod.updateStartupEmbeddingProgress("ready");
+    mod.updateStartupEmbeddingProgress("checking");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "checking",
+    });
+  });
+
+  it("does not clear a fresh snapshot on repeated reads", async () => {
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("downloading", "45% of 95 MB");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "downloading",
+      embeddingDetail: "45% of 95 MB",
+      embeddingProgressPct: 45,
+    });
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "downloading",
+      embeddingDetail: "45% of 95 MB",
+      embeddingProgressPct: 45,
+    });
+  });
+
+  it("accepts a fresh update after a stale read cleared the snapshot", async () => {
+    vi.useFakeTimers();
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("downloading", "10% of 40 MB");
+    vi.advanceTimersByTime(120_000 + 1);
+    expect(mod.getStartupEmbeddingAugmentation()).toBeNull();
+    mod.updateStartupEmbeddingProgress("loading", "50% of 40 MB");
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "loading",
+      embeddingDetail: "50% of 40 MB",
+      embeddingProgressPct: 50,
+    });
+  });
+
+  it("refreshes the stale clock when a later update arrives", async () => {
+    vi.useFakeTimers();
+    const mod = await loadOverlay();
+    mod.updateStartupEmbeddingProgress("checking");
+    vi.advanceTimersByTime(100_000);
+    mod.updateStartupEmbeddingProgress("downloading", "20% of 40 MB");
+    vi.advanceTimersByTime(50_000);
+    expect(mod.getStartupEmbeddingAugmentation()).toEqual({
+      embeddingPhase: "downloading",
+      embeddingDetail: "20% of 40 MB",
+      embeddingProgressPct: 20,
+    });
   });
 });


### PR DESCRIPTION

## Summary

Adds remaining unit coverage for `packages/app-core/src/runtime/startup-overlay.ts`. The module already had a colocated suite from #25569; this change extends that same file so the untested branches are recorded as the live code actually behaves.

No production code changes. Diff is the test file only.

Covered now, against the real module (no mocks of the overlay):

- `parseEmbeddingProgressPercent`: empty string, `0%` / `100%` clamp bounds, whitespace before `%`, first-of-several percentages, half-up rounding then clamp past 100
- `updateStartupEmbeddingProgress` / `getStartupEmbeddingAugmentation`: last write wins, omitted and empty detail omit `embeddingDetail`, unparseable detail keeps the string without a percent, `ready` with leftover detail still clears, a later phase is visible after `ready`, repeated reads do not clear a fresh snapshot
- staleness: snapshot stays live at exactly `STALE_MS` (120_000) and expires one millisecond later; a later update refreshes the clock; a fresh update after a stale read is visible

`ready` never remains in the snapshot: `updateStartupEmbeddingProgress("ready")` nulls it immediately. Tests assert that observed reset, not a `ready` augmentation the public API cannot return.

Fork contributor: hosted CI does not run on this PR. Local checks only.

## Evidence

1. `bunx vitest run packages/app-core/src/runtime/startup-overlay.test.ts`
   - Test Files  1 passed (1)
   - Tests  24 passed (24)
   - Re-run immediately before filing against current `origin/develop` source (overlay.ts unchanged vs develop): 24 passed (24), duration 242ms
2. `bunx biome check --write packages/app-core/src/runtime/startup-overlay.test.ts`
   - Checked 1 file in 79ms. No fixes applied.
   - `biome.json` present; `git sparse-checkout list` reports this worktree is not sparse
3. `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'startup-overlay.test'`
   - empty (GREP_EXIT:1). This file introduced zero type errors. Pre-existing errors elsewhere in the package are unrelated.
4. Diff touches only `packages/app-core/src/runtime/startup-overlay.test.ts` (144 insertions, 2 deletions vs `origin/develop`).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0d4b3bbdf9d06b22e416de6b0ec2b0649ce01250 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
