### PR TITLE
test(app-core): cover post-ready

### DIFF
--- a/packages/app-core/src/runtime/startup/post-ready.test.ts
+++ b/packages/app-core/src/runtime/startup/post-ready.test.ts
@@ -1,8 +1,9 @@
 /**
  * Colocated unit coverage for the post-ready boot tail. Asserts resource-slot
- * ownership, contributor ordering, superseded-runtime skip, in-flight identity
- * changes, fire-and-forget voice warmup, and deferred-boot phase stamping.
- * Drives the real module with injected step stubs; no live runtime is started.
+ * ownership, contributor ordering, superseded-runtime skip, mid-tail abort
+ * after each liveness gate, fire-and-forget voice warmup, and deferred-boot
+ * phase stamping. Drives the real module with injected step stubs; no live
+ * runtime is started.
  */
 import {
   _resetDeferredBootStatusForTest,
@@ -44,6 +45,11 @@ const SYNC_THROW_STEPS = [
   "registerSubAgentCredentialBridgeAdapter",
   "startDeferredVoiceWarmup",
 ] as const satisfies ReadonlyArray<StepName>;
+
+const SKIPPED_MESSAGE =
+  "[eliza] post-ready boot tail skipped — runtime superseded";
+const ABORTED_MESSAGE =
+  "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail";
 
 function runtimeNamed(id: string): AgentRuntime {
   return { agentId: id } as AgentRuntime;
@@ -138,9 +144,7 @@ describe("runPostReadyBootTail", () => {
     ).resolves.toBeUndefined();
 
     expect(order).toEqual([]);
-    expect(info).toHaveBeenCalledExactlyOnceWith(
-      "[eliza] post-ready boot tail skipped — runtime superseded",
-    );
+    expect(info).toHaveBeenCalledExactlyOnceWith(SKIPPED_MESSAGE);
     expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
     expect(resources).toEqual({
       tailRuntime: null,
@@ -160,9 +164,7 @@ describe("runPostReadyBootTail", () => {
     await runPostReadyBootTail(superseded, steps, resources);
 
     expect(order).toEqual([]);
-    expect(info).toHaveBeenCalledExactlyOnceWith(
-      "[eliza] post-ready boot tail skipped — runtime superseded",
-    );
+    expect(info).toHaveBeenCalledExactlyOnceWith(SKIPPED_MESSAGE);
     expect(getDeferredBootStatus().phases["app-route-tail"]).toBeUndefined();
     expect(resources.tailRuntime).toBe(live);
   });
@@ -244,25 +246,80 @@ describe("runPostReadyBootTail", () => {
     await expect(warmupFailure).rejects.toThrow("warmup failed");
   });
 
-  it("keeps running after the slot is swapped mid-await and still stamps complete", async () => {
-    const original = runtimeNamed("original");
-    const replacement = runtimeNamed("replacement");
+  it.each([...AWAITED_STEPS])(
+    "aborts later contributors when ownership is lost during %s",
+    async (name) => {
+      const original = runtimeNamed(`original-${name}`);
+      const replacement = runtimeNamed(`replacement-${name}`);
+      const resources = createRuntimeBootResources();
+      resources.tailRuntime = original;
+      const { steps, order } = makeSteps();
+      const info = vi.spyOn(logger, "info");
+      markDeferredBootPhase("app-route-tail", "pending");
+      steps[name] = async () => {
+        order.push(name);
+        resources.tailRuntime = replacement;
+      };
+
+      await expect(
+        runPostReadyBootTail(original, steps, resources),
+      ).resolves.toBeUndefined();
+
+      const failedAt = STEP_ORDER.indexOf(name);
+      expect(order).toEqual(STEP_ORDER.slice(0, failedAt + 1));
+      expect(info).toHaveBeenCalledExactlyOnceWith(ABORTED_MESSAGE);
+      expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
+      expect(resources.tailRuntime).toBe(replacement);
+    },
+  );
+
+  it("still runs the sync credential steps when ownership drops during sensitive adapters", async () => {
+    const original = runtimeNamed("original-sensitive");
+    const replacement = runtimeNamed("replacement-sensitive");
     const resources = createRuntimeBootResources();
     resources.tailRuntime = original;
     const { steps, order } = makeSteps();
-    steps.registerAppRoutePlugins = async () => {
-      order.push("registerAppRoutePlugins");
+    const info = vi.spyOn(logger, "info");
+    markDeferredBootPhase("app-route-tail", "pending");
+    steps.registerCoreSensitiveRequestAdapters = () => {
+      order.push("registerCoreSensitiveRequestAdapters");
       resources.tailRuntime = replacement;
     };
 
     await runPostReadyBootTail(original, steps, resources);
 
-    // The liveness check is only at entry. A swap after that still finishes
-    // the remaining contributors and overwrites the phase — observed, not the
-    // comment's "cannot overwrite" claim.
+    // No gate between the two sync registrars and the credential-bridge
+    // await; the next check is after that await, so adapter + wiring still
+    // run, then the tail aborts before trigger/catalog/warmup.
+    expect(order).toEqual([
+      "registerAppRoutePlugins",
+      "registerRuntimeHooks",
+      "registerCoreSensitiveRequestAdapters",
+      "registerSubAgentCredentialBridgeAdapter",
+      "registerSubAgentCredentialBridge",
+    ]);
+    expect(info).toHaveBeenCalledExactlyOnceWith(ABORTED_MESSAGE);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
+  });
+
+  it("stamps complete even if voice warmup clears the slot — there is no gate after it", async () => {
+    const original = runtimeNamed("original-warmup");
+    const replacement = runtimeNamed("replacement-warmup");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = original;
+    const { steps, order } = makeSteps();
+    const info = vi.spyOn(logger, "info");
+    steps.startDeferredVoiceWarmup = () => {
+      order.push("startDeferredVoiceWarmup");
+      resources.tailRuntime = replacement;
+    };
+
+    await runPostReadyBootTail(original, steps, resources);
+
     expect(order).toEqual([...STEP_ORDER]);
-    expect(resources.tailRuntime).toBe(replacement);
+    expect(info).not.toHaveBeenCalled();
     expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+    expect(resources.tailRuntime).toBe(replacement);
   });
 
   it.each([...AWAITED_STEPS])(

--- a/packages/app-core/src/runtime/startup/post-ready.test.ts
+++ b/packages/app-core/src/runtime/startup/post-ready.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Colocated unit coverage for the post-ready boot tail. Asserts resource-slot
+ * ownership, contributor ordering, superseded-runtime skip, in-flight identity
+ * changes, fire-and-forget voice warmup, and deferred-boot phase stamping.
+ * Drives the real module with injected step stubs; no live runtime is started.
+ */
+import {
+  _resetDeferredBootStatusForTest,
+  getDeferredBootStatus,
+  markDeferredBootPhase,
+} from "@elizaos/agent/runtime/deferred-boot-status";
+import { type AgentRuntime, logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as postReady from "./post-ready.ts";
+import {
+  createRuntimeBootResources,
+  type PostReadyBootSteps,
+  runPostReadyBootTail,
+} from "./post-ready.ts";
+
+const STEP_ORDER = [
+  "registerAppRoutePlugins",
+  "registerRuntimeHooks",
+  "registerCoreSensitiveRequestAdapters",
+  "registerSubAgentCredentialBridgeAdapter",
+  "registerSubAgentCredentialBridge",
+  "ensureTriggerEventBridge",
+  "ensureConnectorTargetCatalog",
+  "startDeferredVoiceWarmup",
+] as const;
+
+type StepName = (typeof STEP_ORDER)[number];
+
+const AWAITED_STEPS = [
+  "registerAppRoutePlugins",
+  "registerRuntimeHooks",
+  "registerSubAgentCredentialBridge",
+  "ensureTriggerEventBridge",
+  "ensureConnectorTargetCatalog",
+] as const satisfies ReadonlyArray<StepName>;
+
+const SYNC_THROW_STEPS = [
+  "registerCoreSensitiveRequestAdapters",
+  "registerSubAgentCredentialBridgeAdapter",
+  "startDeferredVoiceWarmup",
+] as const satisfies ReadonlyArray<StepName>;
+
+function runtimeNamed(id: string): AgentRuntime {
+  return { agentId: id } as AgentRuntime;
+}
+
+function makeSteps(): {
+  steps: PostReadyBootSteps;
+  order: string[];
+  seen: AgentRuntime[];
+} {
+  const order: string[] = [];
+  const seen: AgentRuntime[] = [];
+  const record = (name: StepName) => (runtime: AgentRuntime) => {
+    order.push(name);
+    seen.push(runtime);
+  };
+  const recordAsync = (name: StepName) => async (runtime: AgentRuntime) => {
+    record(name)(runtime);
+  };
+  const steps: PostReadyBootSteps = {
+    registerAppRoutePlugins: recordAsync("registerAppRoutePlugins"),
+    registerRuntimeHooks: recordAsync("registerRuntimeHooks"),
+    registerCoreSensitiveRequestAdapters: record(
+      "registerCoreSensitiveRequestAdapters",
+    ),
+    registerSubAgentCredentialBridgeAdapter: (runtime) => {
+      record("registerSubAgentCredentialBridgeAdapter")(runtime);
+      return true;
+    },
+    registerSubAgentCredentialBridge: recordAsync(
+      "registerSubAgentCredentialBridge",
+    ),
+    ensureTriggerEventBridge: recordAsync("ensureTriggerEventBridge"),
+    ensureConnectorTargetCatalog: recordAsync("ensureConnectorTargetCatalog"),
+    startDeferredVoiceWarmup: record("startDeferredVoiceWarmup"),
+  };
+  return { steps, order, seen };
+}
+
+describe("post-ready exports", () => {
+  it("exposes only the resource factory and the boot-tail runner", () => {
+    expect(Object.keys(postReady).sort()).toEqual([
+      "createRuntimeBootResources",
+      "runPostReadyBootTail",
+    ]);
+  });
+});
+
+describe("createRuntimeBootResources", () => {
+  it("starts every ownership slot empty", () => {
+    expect(createRuntimeBootResources()).toEqual({
+      tailRuntime: null,
+      triggerEventBridge: null,
+      connectorTargetCatalog: null,
+    });
+  });
+
+  it("returns a fresh object each call so two boots do not share slots", () => {
+    const first = createRuntimeBootResources();
+    const second = createRuntimeBootResources();
+    expect(first).not.toBe(second);
+    first.tailRuntime = runtimeNamed("first");
+    first.triggerEventBridge = { stop() {} };
+    first.connectorTargetCatalog = { stop() {} };
+    expect(second).toEqual({
+      tailRuntime: null,
+      triggerEventBridge: null,
+      connectorTargetCatalog: null,
+    });
+  });
+});
+
+describe("runPostReadyBootTail", () => {
+  beforeEach(() => {
+    _resetDeferredBootStatusForTest();
+  });
+
+  afterEach(() => {
+    _resetDeferredBootStatusForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("skips every contributor when the resource slot is empty", async () => {
+    const runtime = runtimeNamed("empty-slot");
+    const resources = createRuntimeBootResources();
+    const { steps, order } = makeSteps();
+    const info = vi.spyOn(logger, "info");
+    markDeferredBootPhase("app-route-tail", "pending");
+
+    await expect(
+      runPostReadyBootTail(runtime, steps, resources),
+    ).resolves.toBeUndefined();
+
+    expect(order).toEqual([]);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      "[eliza] post-ready boot tail skipped — runtime superseded",
+    );
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
+    expect(resources).toEqual({
+      tailRuntime: null,
+      triggerEventBridge: null,
+      connectorTargetCatalog: null,
+    });
+  });
+
+  it("skips when the slot holds a different runtime identity", async () => {
+    const live = runtimeNamed("live");
+    const superseded = runtimeNamed("superseded");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = live;
+    const { steps, order } = makeSteps();
+    const info = vi.spyOn(logger, "info");
+
+    await runPostReadyBootTail(superseded, steps, resources);
+
+    expect(order).toEqual([]);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      "[eliza] post-ready boot tail skipped — runtime superseded",
+    );
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBeUndefined();
+    expect(resources.tailRuntime).toBe(live);
+  });
+
+  it("runs every contributor in declared order for a single matching runtime", async () => {
+    const runtime = runtimeNamed("owner");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const { steps, order, seen } = makeSteps();
+
+    await expect(
+      runPostReadyBootTail(runtime, steps, resources),
+    ).resolves.toBeUndefined();
+
+    expect(order).toEqual([...STEP_ORDER]);
+    expect(seen).toHaveLength(STEP_ORDER.length);
+    expect(seen.every((value) => value === runtime)).toBe(true);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+    expect(resources.tailRuntime).toBe(runtime);
+  });
+
+  it("ignores a false credential-adapter return and still stamps complete", async () => {
+    const runtime = runtimeNamed("adapter-false");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const { steps, order } = makeSteps();
+    steps.registerSubAgentCredentialBridgeAdapter = (received) => {
+      order.push("registerSubAgentCredentialBridgeAdapter");
+      expect(received).toBe(runtime);
+      return false;
+    };
+
+    await runPostReadyBootTail(runtime, steps, resources);
+
+    expect(order).toEqual([...STEP_ORDER]);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+  });
+
+  it("does not await startDeferredVoiceWarmup before stamping complete", async () => {
+    const runtime = runtimeNamed("voice-hang");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const { steps, order } = makeSteps();
+    let release!: () => void;
+    const hung = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const hangWarmup = (): Promise<void> => {
+      order.push("startDeferredVoiceWarmup");
+      return hung;
+    };
+    steps.startDeferredVoiceWarmup =
+      hangWarmup as PostReadyBootSteps["startDeferredVoiceWarmup"];
+
+    await expect(
+      runPostReadyBootTail(runtime, steps, resources),
+    ).resolves.toBeUndefined();
+    expect(order).toEqual([...STEP_ORDER]);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+
+    release();
+    await hung;
+  });
+
+  it("does not reject the tail when voice warmup returns a rejected promise", async () => {
+    const runtime = runtimeNamed("voice-reject");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const { steps } = makeSteps();
+    const warmupFailure = Promise.reject(new Error("warmup failed"));
+    const rejectWarmup = (): Promise<void> => warmupFailure;
+    steps.startDeferredVoiceWarmup =
+      rejectWarmup as PostReadyBootSteps["startDeferredVoiceWarmup"];
+
+    await expect(
+      runPostReadyBootTail(runtime, steps, resources),
+    ).resolves.toBeUndefined();
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+    await expect(warmupFailure).rejects.toThrow("warmup failed");
+  });
+
+  it("keeps running after the slot is swapped mid-await and still stamps complete", async () => {
+    const original = runtimeNamed("original");
+    const replacement = runtimeNamed("replacement");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = original;
+    const { steps, order } = makeSteps();
+    steps.registerAppRoutePlugins = async () => {
+      order.push("registerAppRoutePlugins");
+      resources.tailRuntime = replacement;
+    };
+
+    await runPostReadyBootTail(original, steps, resources);
+
+    // The liveness check is only at entry. A swap after that still finishes
+    // the remaining contributors and overwrites the phase — observed, not the
+    // comment's "cannot overwrite" claim.
+    expect(order).toEqual([...STEP_ORDER]);
+    expect(resources.tailRuntime).toBe(replacement);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+  });
+
+  it.each([...AWAITED_STEPS])(
+    "short-circuits later steps when %s rejects and does not stamp complete",
+    async (name) => {
+      const runtime = runtimeNamed(`reject-${name}`);
+      const resources = createRuntimeBootResources();
+      resources.tailRuntime = runtime;
+      const { steps, order } = makeSteps();
+      const boom = new Error(`${name} failed`);
+      markDeferredBootPhase("app-route-tail", "pending");
+      steps[name] = async () => {
+        order.push(name);
+        throw boom;
+      };
+
+      await expect(
+        runPostReadyBootTail(runtime, steps, resources),
+      ).rejects.toThrow(boom);
+
+      const failedAt = STEP_ORDER.indexOf(name);
+      expect(order).toEqual(STEP_ORDER.slice(0, failedAt + 1));
+      expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
+    },
+  );
+
+  it.each([...SYNC_THROW_STEPS])(
+    "short-circuits later steps when %s throws synchronously and does not stamp complete",
+    async (name) => {
+      const runtime = runtimeNamed(`throw-${name}`);
+      const resources = createRuntimeBootResources();
+      resources.tailRuntime = runtime;
+      const { steps, order } = makeSteps();
+      const boom = new Error(`${name} threw`);
+      markDeferredBootPhase("app-route-tail", "pending");
+      steps[name] = () => {
+        order.push(name);
+        throw boom;
+      };
+
+      await expect(
+        runPostReadyBootTail(runtime, steps, resources),
+      ).rejects.toThrow(boom);
+
+      const failedAt = STEP_ORDER.indexOf(name);
+      expect(order).toEqual(STEP_ORDER.slice(0, failedAt + 1));
+      expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("pending");
+    },
+  );
+
+  it("runs the full tail again when the same runtime is still the owner", async () => {
+    const runtime = runtimeNamed("repeat");
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const first = makeSteps();
+    const second = makeSteps();
+
+    await runPostReadyBootTail(runtime, first.steps, resources);
+    await runPostReadyBootTail(runtime, second.steps, resources);
+
+    expect(first.order).toEqual([...STEP_ORDER]);
+    expect(second.order).toEqual([...STEP_ORDER]);
+    expect(getDeferredBootStatus().phases["app-route-tail"]).toBe("complete");
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app-core/src/runtime/startup/post-ready.ts`, which had no same-named colocated test file. No linked issue; this is additive unit coverage of existing production behaviour.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. The branch is a one-file commit on `origin/develop` (`dd4eae58a3b9`). `packages/app-core/src/runtime/startup/post-ready.ts` is byte-identical between that base and current `origin/develop` (`83d7871746c4`); the suite was re-run against that current source immediately before filing.
- [ ] `bun install` and `bun run verify` were not re-run. This is a test-only addition; focused vitest, biome, and package `tsc --noEmit` (grep for this file) are quoted below.
- [x] A reviewer can confirm the change from the vitest counts and the single-file diff without reading production code.

# Sync with develop

- [x] One-file diff versus `origin/develop`; `post-ready.ts` unchanged between branch base and current `origin/develop`. No conflicts on the added test file.
- [ ] `bun run verify` was not run for this test-only PR. Focused checks are recorded under **Testing** and **Known gaps / failures**.

# Risks

Low. The diff adds only `packages/app-core/src/runtime/startup/post-ready.test.ts`. No production behaviour, exports, or startup ordering changes.

# Background

## What does this PR do?

Adds a colocated Vitest suite that drives the real `createRuntimeBootResources` and `runPostReadyBootTail` exports.

Covered behaviour, as observed on current `origin/develop`:

- Resource factory returns independent all-null slots.
- Empty slot and mismatched runtime identity skip every contributor, log `[eliza] post-ready boot tail skipped — runtime superseded`, and do not stamp `app-route-tail` complete.
- A matching owner runs contributors in declared order: app routes → runtime hooks → sensitive adapters → credential adapter → credential bridge → trigger bridge → connector catalog → voice warmup. Each step receives the same runtime. `app-route-tail` is stamped `complete` only after catalog.
- A `false` return from `registerSubAgentCredentialBridgeAdapter` is ignored; the tail still continues and stamps complete.
- `startDeferredVoiceWarmup` is fire-and-forget (`void`): a hung or rejected warmup promise does not delay or reject the tail.
- Ownership is re-checked after each awaited contributor. Losing the slot mid-tail logs `[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail`, skips remaining contributors, and does **not** stamp complete.
- There is no gate between the two sync registrars and the credential-bridge await: dropping the slot during `registerCoreSensitiveRequestAdapters` still runs the adapter and credential wiring, then aborts before trigger/catalog/warmup.
- There is no gate after voice warmup: clearing the slot inside warmup still stamps complete.
- Awaited rejections and synchronous throws short-circuit later steps and leave a pre-marked `pending` phase unstamped.
- A second successful run on the same owner is not once-only.

`ownsBootResources` is intentionally unexported; tests observe it through skip/abort behaviour.

## What kind of change is this?

Improvements (tests for existing behaviour). No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/runtime/startup/post-ready.test.ts` against `packages/app-core/src/runtime/startup/post-ready.ts`.

## Detailed testing steps

None: automated tests are the review surface.

Re-run against current `origin/develop` `post-ready.ts` (`83d7871746c49e070bb82ab1d7175dd10b3a66de`) immediately before filing:

```text
$ bunx vitest run packages/app-core/src/runtime/startup/post-ready.test.ts
 ✓ packages/app-core/src/runtime/startup/post-ready.test.ts (25 tests) 13ms
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

```text
$ bunx biome check --write packages/app-core/src/runtime/startup/post-ready.test.ts
Checked 1 file in 215ms. No fixes applied.
```

Config was present (`biome.json`, `tsconfig.json`); the worktree is not sparse.

```text
$ cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'post-ready.test.ts' ; echo "EXIT:$?"
EXIT:1
```

`post-ready.test.ts` appears nowhere in the `tsc` output. Pre-existing package errors in other files are unchanged and are not from this diff.

The diff touches only `packages/app-core/src/runtime/startup/post-ready.test.ts`.

Hosted CI does **not** run on this fork contributor PR. Do not infer that GitHub Actions passed.

# Evidence Gate

Evidence matches head `77cdc0767df34475bda06221675fae4a3193fa83`.

- [x] Before full-page screenshots: `N/A - test-only change; no UI surface`
- [x] After full-page screenshots: `N/A - test-only change; no UI surface`
- [x] Walkthrough video: `N/A - test-only change; no UI surface`
- [x] Backend logs: `N/A - unit tests drive injected step stubs; no server boot`
- [x] Frontend logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no persistence, schedule, wallet, or generated artifact`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - unit tests only; no server or UI path.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no UI surface.

### After

N/A - test-only change; no UI surface.

### Walkthrough video

N/A - test-only change; no UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT/omnivoice production change. The suite only asserts that `startDeferredVoiceWarmup` is not awaited.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; focused vitest (25/25), biome (clean), and package `tsc` grep (no hits for this file) are the complete evidence set.
- Hosted GitHub Actions CI does not run on PRs from this fork.
- Receipt/trace was not minted: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:77cdc0767df34475bda06221675fae4a3193fa83 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
