### PR TITLE
test(app-core): cover server-only-host

### DIFF
--- a/packages/app-core/src/runtime/startup/server-only-host.test.ts
+++ b/packages/app-core/src/runtime/startup/server-only-host.test.ts
@@ -1,0 +1,821 @@
+/**
+ * Colocated coverage for the server-only bind-first host. Drives the real
+ * `startServerOnlyHost` orchestrator: port selection, IPC skip-listen, API-bind
+ * failure, deferred onboarding, immediate boot success/empty/throw, post-ready
+ * phase mapping, restart, sandbox register/heartbeat/teardown, and idempotent
+ * close. Socket bind, first-run disk, and Redis are stubbed as I/O seams;
+ * assertions observe host sequencing and projected startup state, not mock echo.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as serverOnlyHostModule from "./server-only-host.ts";
+import {
+  type StartServerOnlyHostOptions,
+  startServerOnlyHost,
+} from "./server-only-host.ts";
+
+const mocks = vi.hoisted(() => {
+  let pendingBoot: (() => Promise<void>) | null = null;
+  return {
+    startApiServer: vi.fn(),
+    shouldDefer: vi.fn(() => false),
+    buildSandboxRegistryFromEnv: vi.fn((): unknown => null),
+    invalidateCorsAllowedPorts: vi.fn(),
+    registerDeferredRuntimeBoot: vi.fn((boot: () => Promise<void>) => {
+      pendingBoot = boot;
+    }),
+    isRuntimeBootDeferred: vi.fn(() => pendingBoot !== null),
+    triggerDeferredRuntimeBoot: vi.fn(async (_reason: string) => {
+      const boot = pendingBoot;
+      if (!boot) return;
+      await boot();
+      pendingBoot = null;
+    }),
+    resetDeferred() {
+      pendingBoot = null;
+    },
+  };
+});
+
+vi.mock("../../api/server.js", () => ({
+  startApiServer: (...args: unknown[]) => mocks.startApiServer(...args),
+}));
+
+vi.mock("../../api/deferred-runtime-boot.js", () => ({
+  shouldDeferRuntimeBootUntilOnboarding: () => mocks.shouldDefer(),
+  registerDeferredRuntimeBoot: (boot: () => Promise<void>) =>
+    mocks.registerDeferredRuntimeBoot(boot),
+  isRuntimeBootDeferred: () => mocks.isRuntimeBootDeferred(),
+  triggerDeferredRuntimeBoot: (reason: string) =>
+    mocks.triggerDeferredRuntimeBoot(reason),
+}));
+
+vi.mock("../../api/server-cors.js", () => ({
+  invalidateCorsAllowedPorts: () => mocks.invalidateCorsAllowedPorts(),
+}));
+
+vi.mock("@elizaos/shared/sandbox-registry", () => ({
+  buildSandboxRegistryFromEnv: () => mocks.buildSandboxRegistryFromEnv(),
+}));
+
+type PostReadyPhase = "pending" | "complete" | "failed";
+
+type StartupUpdate = {
+  phase: string;
+  attempt: number;
+  state: string;
+};
+
+type ApiHandle = {
+  port: number;
+  updateRuntime: ReturnType<typeof vi.fn<(runtime: AgentRuntime) => void>>;
+  updateStartup: ReturnType<typeof vi.fn<(update: StartupUpdate) => void>>;
+  close: ReturnType<typeof vi.fn<() => Promise<void>>>;
+};
+
+type StartApiServerOpts = {
+  port: number;
+  skipListen?: boolean;
+  initialAgentState?: string;
+  onRestart: () => Promise<AgentRuntime | null>;
+};
+
+const ENV_KEYS = [
+  "ELIZA_API_PORT",
+  "ELIZA_PORT",
+  "ELIZA_UI_PORT",
+  "ELIZA_API_EXPOSE_PORT",
+  "ELIZA_BOOT_PROFILE",
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+function isolateEnv(overrides: Record<string, string | undefined> = {}): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function runtimeStub(
+  reportError: AgentRuntime["reportError"] = vi.fn(),
+): AgentRuntime {
+  return { reportError } as unknown as AgentRuntime;
+}
+
+function createApiHandle(port: number): ApiHandle {
+  return {
+    port,
+    updateRuntime: vi.fn(),
+    updateStartup: vi.fn(),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function sandboxStub(overrides?: {
+  register?: () => Promise<void>;
+  unregister?: () => Promise<void>;
+}) {
+  return {
+    register: vi.fn(overrides?.register ?? (async () => {})),
+    unregister: vi.fn(overrides?.unregister ?? (async () => {})),
+    startHeartbeat: vi.fn(),
+    stopHeartbeat: vi.fn(),
+  };
+}
+
+function phasesOf(api: ApiHandle): string[] {
+  return api.updateStartup.mock.calls.map((call) => {
+    const update = call[0];
+    if (!update) {
+      throw new Error("updateStartup called without a snapshot");
+    }
+    return update.phase;
+  });
+}
+
+function lastStartup(api: ApiHandle): StartupUpdate {
+  const update = api.updateStartup.mock.calls.at(-1)?.[0];
+  if (!update) {
+    throw new Error("updateStartup was never called");
+  }
+  return update;
+}
+
+let lastApiOpts: StartApiServerOpts | undefined;
+let infoSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+async function startHost(
+  deps: {
+    options?: StartServerOnlyHostOptions["options"];
+    bootRuntime?: StartServerOnlyHostOptions["bootRuntime"];
+    stopRuntime?: StartServerOnlyHostOptions["stopRuntime"];
+    stopWithoutRuntime?: StartServerOnlyHostOptions["stopWithoutRuntime"];
+    bindPort?: number;
+  } = {},
+): Promise<{
+  runtime: AgentRuntime;
+  result: AgentRuntime | undefined;
+  api: ApiHandle;
+  bootRuntime: ReturnType<
+    typeof vi.fn<StartServerOnlyHostOptions["bootRuntime"]>
+  >;
+  stopRuntime: ReturnType<
+    typeof vi.fn<StartServerOnlyHostOptions["stopRuntime"]>
+  >;
+  stopWithoutRuntime: ReturnType<typeof vi.fn<() => void>>;
+  onReady: ReturnType<
+    typeof vi.fn<
+      NonNullable<
+        StartServerOnlyHostOptions["options"]["onServerOnlyHostReady"]
+      >
+    >
+  >;
+  publishPostReady: ((phase: PostReadyPhase) => void) | undefined;
+}> {
+  const runtime = runtimeStub();
+  const requestedPort = Number(process.env.ELIZA_API_PORT ?? 2138);
+  const api = createApiHandle(deps.bindPort ?? requestedPort);
+  lastApiOpts = undefined;
+  mocks.startApiServer.mockImplementation(async (opts: StartApiServerOpts) => {
+    lastApiOpts = opts;
+    return api;
+  });
+
+  let publishPostReady: ((phase: PostReadyPhase) => void) | undefined;
+  const bootRuntime =
+    deps.bootRuntime ??
+    vi.fn(async (onPostReadyPhase: (phase: PostReadyPhase) => void) => {
+      publishPostReady = onPostReadyPhase;
+      return runtime;
+    });
+  const stopRuntime = deps.stopRuntime ?? vi.fn(async () => {});
+  const stopWithoutRuntime = deps.stopWithoutRuntime ?? vi.fn();
+  const onReady = vi.fn();
+
+  const result = await startServerOnlyHost({
+    options: {
+      onServerOnlyHostReady: onReady,
+      ...deps.options,
+    },
+    bootRuntime,
+    stopRuntime,
+    stopWithoutRuntime,
+  });
+
+  return {
+    runtime,
+    result,
+    api,
+    bootRuntime: bootRuntime as ReturnType<
+      typeof vi.fn<StartServerOnlyHostOptions["bootRuntime"]>
+    >,
+    stopRuntime: stopRuntime as ReturnType<
+      typeof vi.fn<StartServerOnlyHostOptions["stopRuntime"]>
+    >,
+    stopWithoutRuntime: stopWithoutRuntime as ReturnType<
+      typeof vi.fn<() => void>
+    >,
+    onReady,
+    publishPostReady,
+  };
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+  }
+  isolateEnv();
+  mocks.startApiServer.mockReset();
+  mocks.shouldDefer.mockReset();
+  mocks.shouldDefer.mockReturnValue(false);
+  mocks.buildSandboxRegistryFromEnv.mockReset();
+  mocks.buildSandboxRegistryFromEnv.mockReturnValue(null);
+  mocks.invalidateCorsAllowedPorts.mockReset();
+  mocks.registerDeferredRuntimeBoot.mockClear();
+  mocks.isRuntimeBootDeferred.mockClear();
+  mocks.triggerDeferredRuntimeBoot.mockClear();
+  mocks.resetDeferred();
+  lastApiOpts = undefined;
+  infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+  warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  mocks.resetDeferred();
+  infoSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+  restoreEnv();
+});
+
+describe("startServerOnlyHost exports", () => {
+  it("exposes only the bind-first host entry", () => {
+    expect(Object.keys(serverOnlyHostModule).sort()).toEqual([
+      "startServerOnlyHost",
+    ]);
+  });
+});
+
+describe("port selection and listen policy", () => {
+  it("binds the server-only default when ELIZA_API_PORT is unset", async () => {
+    await startHost();
+
+    expect(mocks.startApiServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 2138,
+        skipListen: false,
+        initialAgentState: "starting",
+      }),
+    );
+  });
+
+  it("honors ELIZA_API_PORT through the desktop resolver", async () => {
+    isolateEnv({ ELIZA_API_PORT: "32123" });
+    await startHost();
+
+    expect(mocks.startApiServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 32123,
+        skipListen: false,
+      }),
+    );
+  });
+
+  it("syncs a rebound listener into env and invalidates CORS", async () => {
+    isolateEnv({ ELIZA_API_PORT: "32123" });
+    await startHost({ bindPort: 9999 });
+
+    expect(process.env.ELIZA_API_PORT).toBe("9999");
+    expect(process.env.ELIZA_UI_PORT).toBe("9999");
+    expect(process.env.ELIZA_PORT).toBe("9999");
+    expect(mocks.invalidateCorsAllowedPorts).toHaveBeenCalledOnce();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] API server listening on http://localhost:9999 (agent booting…)",
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] Control UI: http://localhost:9999",
+    );
+  });
+
+  it("skips TCP listen and does not sync a never-bound port in local-agent IPC mode", async () => {
+    const started = await startHost({
+      options: { localAgentMode: true },
+    });
+
+    expect(mocks.startApiServer).toHaveBeenCalledWith(
+      expect.objectContaining({ skipListen: true }),
+    );
+    expect(process.env.ELIZA_API_PORT).toBeUndefined();
+    expect(process.env.ELIZA_UI_PORT).toBeUndefined();
+    expect(mocks.invalidateCorsAllowedPorts).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] Local-agent IPC mode: initializing route kernel without a TCP listener (set ELIZA_API_EXPOSE_PORT=1 to re-open the port)",
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] Local-agent IPC mode: route kernel ready (no TCP listener bound)",
+    );
+    expect(started.onReady).toHaveBeenCalledOnce();
+  });
+
+  it("re-opens the TCP listener when local-agent mode opts in with ELIZA_API_EXPOSE_PORT", async () => {
+    isolateEnv({ ELIZA_API_EXPOSE_PORT: "1" });
+    await startHost({ options: { localAgentMode: true } });
+
+    expect(mocks.startApiServer).toHaveBeenCalledWith(
+      expect.objectContaining({ skipListen: false }),
+    );
+    expect(mocks.invalidateCorsAllowedPorts).toHaveBeenCalledOnce();
+    expect(process.env.ELIZA_API_PORT).toBe("2138");
+  });
+});
+
+describe("API bind failure", () => {
+  it("logs an Error stack, skips boot, and rethrows the bind failure", async () => {
+    const failure = new Error("address in use");
+    mocks.startApiServer.mockRejectedValue(failure);
+    const onReady = vi.fn();
+    const bootRuntime = vi.fn(async () => runtimeStub());
+
+    await expect(
+      startServerOnlyHost({
+        options: { onServerOnlyHostReady: onReady },
+        bootRuntime,
+        stopRuntime: vi.fn(async () => {}),
+        stopWithoutRuntime: vi.fn(),
+      }),
+    ).rejects.toBe(failure);
+
+    expect(bootRuntime).not.toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      `[eliza] API server failed to start: ${failure.stack}`,
+    );
+  });
+
+  it("stringifies a non-Error bind failure and prefers message when stack is missing", async () => {
+    mocks.startApiServer.mockRejectedValueOnce("socket exploded");
+    await expect(
+      startServerOnlyHost({
+        options: {},
+        bootRuntime: vi.fn(async () => runtimeStub()),
+        stopRuntime: vi.fn(async () => {}),
+        stopWithoutRuntime: vi.fn(),
+      }),
+    ).rejects.toBe("socket exploded");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[eliza] API server failed to start: socket exploded",
+    );
+
+    const bare = new Error("bind failed");
+    bare.stack = undefined;
+    mocks.startApiServer.mockRejectedValueOnce(bare);
+    await expect(
+      startServerOnlyHost({
+        options: {},
+        bootRuntime: vi.fn(async () => runtimeStub()),
+        stopRuntime: vi.fn(async () => {}),
+        stopWithoutRuntime: vi.fn(),
+      }),
+    ).rejects.toBe(bare);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[eliza] API server failed to start: bind failed",
+    );
+  });
+});
+
+describe("immediate runtime boot", () => {
+  it("binds first, boots, publishes pending as features-starting, and returns the runtime", async () => {
+    const started = await startHost();
+
+    expect(started.result).toBe(started.runtime);
+    expect(started.api.updateRuntime).toHaveBeenCalledExactlyOnceWith(
+      started.runtime,
+    );
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "runtime-starting",
+      "features-starting",
+    ]);
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "features-starting",
+      attempt: 1,
+      state: "running",
+    });
+    expect(started.onReady).toHaveBeenCalledOnce();
+    const host = started.onReady.mock.calls[0]?.[0];
+    expect(host?.port).toBe(2138);
+    expect(host?.getRuntime()).toBe(started.runtime);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] Server running. Press Ctrl+C to stop.",
+    );
+  });
+
+  it("maps a complete post-ready callback during boot to ready, not features-starting", async () => {
+    const started = await startHost({
+      bootRuntime: vi.fn(async (onPostReadyPhase) => {
+        onPostReadyPhase("complete");
+        return runtimeStub();
+      }),
+    });
+
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "runtime-starting",
+      "ready",
+    ]);
+    expect(lastStartup(started.api).state).toBe("running");
+  });
+
+  it("maps a failed post-ready callback during boot to degraded", async () => {
+    const started = await startHost({
+      bootRuntime: vi.fn(async (onPostReadyPhase) => {
+        onPostReadyPhase("failed");
+        return runtimeStub();
+      }),
+    });
+
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "runtime-starting",
+      "degraded",
+    ]);
+  });
+
+  it("ignores post-ready publishes until the runtime is visible, then projects later phases", async () => {
+    const started = await startHost();
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "runtime-starting",
+      "features-starting",
+    ]);
+
+    started.publishPostReady?.("complete");
+    expect(lastStartup(started.api).phase).toBe("ready");
+
+    started.publishPostReady?.("failed");
+    expect(lastStartup(started.api).phase).toBe("degraded");
+
+    expect(() => started.publishPostReady?.("pending")).toThrow(
+      "Invalid startup transition: degraded -> features-starting",
+    );
+  });
+
+  it("closes the API and rethrows when the initial boot throws", async () => {
+    const failure = new Error("plugin load failed");
+    const started = await startHost({
+      bootRuntime: vi.fn(async () => {
+        throw failure;
+      }),
+    }).catch((error: unknown) => error);
+
+    expect(started).toBe(failure);
+    const api = mocks.startApiServer.mock.results[0]
+      ?.value as Promise<ApiHandle>;
+    const handle = await api;
+    expect(handle.close).toHaveBeenCalledOnce();
+    expect(lastStartup(handle)).toMatchObject({
+      phase: "failed",
+      state: "error",
+    });
+  });
+
+  it("closes the API and returns undefined when boot yields no runtime, without publishing a host", async () => {
+    const started = await startHost({
+      bootRuntime: vi.fn(async () => undefined),
+    });
+
+    expect(started.result).toBeUndefined();
+    expect(started.api.close).toHaveBeenCalledOnce();
+    expect(started.api.updateRuntime).not.toHaveBeenCalled();
+    expect(started.onReady).not.toHaveBeenCalled();
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "failed",
+      state: "error",
+    });
+  });
+});
+
+describe("deferred onboarding boot", () => {
+  it("registers a deferred boot, binds as not_started, and does not boot immediately", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const started = await startHost();
+
+    expect(mocks.registerDeferredRuntimeBoot).toHaveBeenCalledOnce();
+    expect(mocks.isRuntimeBootDeferred()).toBe(true);
+    expect(started.bootRuntime).not.toHaveBeenCalled();
+    expect(started.result).toBeUndefined();
+    expect(mocks.startApiServer).toHaveBeenCalledWith(
+      expect.objectContaining({ initialAgentState: "not_started" }),
+    );
+    expect(phasesOf(started.api)).toEqual(["api-bound", "awaiting-onboarding"]);
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "awaiting-onboarding",
+      state: "not_started",
+      attempt: 0,
+    });
+    expect(started.onReady.mock.calls[0]?.[0]?.getRuntime()).toBeUndefined();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[eliza] Fresh install — agent runtime boot deferred until onboarding commits (onboarding API routes are live)",
+    );
+  });
+
+  it("boots, publishes, and clears deferral when the registered closure succeeds", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const started = await startHost();
+
+    await mocks.triggerDeferredRuntimeBoot("first-run commit");
+
+    expect(started.bootRuntime).toHaveBeenCalledOnce();
+    expect(started.api.updateRuntime).toHaveBeenCalledExactlyOnceWith(
+      started.runtime,
+    );
+    expect(mocks.isRuntimeBootDeferred()).toBe(false);
+    expect(started.onReady.mock.calls[0]?.[0]?.getRuntime()).toBe(
+      started.runtime,
+    );
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "awaiting-onboarding",
+      "runtime-starting",
+      "features-starting",
+    ]);
+    expect(lastStartup(started.api).attempt).toBe(1);
+  });
+
+  it("wraps a deferred boot throw, flips failed, and keeps the registration for retry", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const failure = new Error("migrations failed");
+    await startHost({
+      bootRuntime: vi.fn(async () => {
+        throw failure;
+      }),
+    });
+
+    await expect(
+      mocks.triggerDeferredRuntimeBoot("agent start requested via API"),
+    ).rejects.toMatchObject({
+      message: "Runtime boot after onboarding failed",
+      cause: failure,
+    });
+    expect(mocks.isRuntimeBootDeferred()).toBe(true);
+  });
+
+  it("throws when the deferred boot returns no runtime and keeps the registration", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const started = await startHost({
+      bootRuntime: vi.fn(async () => undefined),
+    });
+
+    await expect(mocks.triggerDeferredRuntimeBoot("retry")).rejects.toThrow(
+      "Runtime boot after onboarding returned no runtime",
+    );
+    expect(mocks.isRuntimeBootDeferred()).toBe(true);
+    expect(started.api.updateRuntime).not.toHaveBeenCalled();
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "failed",
+      state: "error",
+    });
+  });
+});
+
+describe("onRestart", () => {
+  it("funnels a restart into the deferred boot while registration is live", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const started = await startHost();
+    expect(lastApiOpts?.onRestart).toBeTypeOf("function");
+
+    const restarted = await lastApiOpts?.onRestart();
+
+    expect(restarted).toBe(started.runtime);
+    expect(started.bootRuntime).toHaveBeenCalledOnce();
+    expect(started.stopRuntime).not.toHaveBeenCalled();
+    expect(mocks.triggerDeferredRuntimeBoot).toHaveBeenCalledWith(
+      "agent start requested via API",
+    );
+    expect(mocks.isRuntimeBootDeferred()).toBe(false);
+  });
+
+  it("stops the live runtime, reboots, and returns the new runtime", async () => {
+    const first = runtimeStub();
+    const second = runtimeStub();
+    const bootRuntime = vi
+      .fn<StartServerOnlyHostOptions["bootRuntime"]>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const started = await startHost({ bootRuntime });
+
+    const restarted = await lastApiOpts?.onRestart();
+
+    expect(started.stopRuntime).toHaveBeenCalledExactlyOnceWith(
+      first,
+      "server-only restart",
+    );
+    expect(restarted).toBe(second);
+    expect(phasesOf(started.api)).toEqual([
+      "api-bound",
+      "runtime-starting",
+      "features-starting",
+      "runtime-starting",
+      "features-starting",
+    ]);
+    expect(lastStartup(started.api).attempt).toBe(2);
+    expect(started.onReady.mock.calls[0]?.[0]?.getRuntime()).toBe(second);
+  });
+
+  it("publishes failed and rethrows the original boot error on restart", async () => {
+    const failure = new Error("restart boot failed");
+    const bootRuntime = vi
+      .fn<StartServerOnlyHostOptions["bootRuntime"]>()
+      .mockResolvedValueOnce(runtimeStub())
+      .mockRejectedValueOnce(failure);
+    const started = await startHost({ bootRuntime });
+
+    await expect(lastApiOpts?.onRestart()).rejects.toBe(failure);
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "failed",
+      state: "error",
+    });
+    expect(started.api.close).not.toHaveBeenCalled();
+  });
+
+  it("returns null and does not close the API when restart boot yields no runtime", async () => {
+    const bootRuntime = vi
+      .fn<StartServerOnlyHostOptions["bootRuntime"]>()
+      .mockResolvedValueOnce(runtimeStub())
+      .mockResolvedValueOnce(undefined);
+    const started = await startHost({ bootRuntime });
+
+    await expect(lastApiOpts?.onRestart()).resolves.toBeNull();
+    expect(started.api.close).not.toHaveBeenCalled();
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "failed",
+      state: "error",
+    });
+  });
+
+  it("boots without stopRuntime when no runtime is published and deferral is clear", async () => {
+    const started = await startHost({
+      bootRuntime: vi.fn(async () => undefined),
+    });
+    expect(started.result).toBeUndefined();
+    const replacement = runtimeStub();
+    started.bootRuntime.mockResolvedValueOnce(replacement);
+
+    const restarted = await lastApiOpts?.onRestart();
+
+    expect(started.stopRuntime).not.toHaveBeenCalled();
+    expect(restarted).toBe(replacement);
+    expect(started.onReady).not.toHaveBeenCalled();
+  });
+});
+
+describe("sandbox registry", () => {
+  it("registers and starts a 30s heartbeat when env builds a registry", async () => {
+    const registry = sandboxStub();
+    mocks.buildSandboxRegistryFromEnv.mockReturnValue(registry);
+
+    await startHost();
+
+    expect(registry.register).toHaveBeenCalledOnce();
+    expect(registry.startHeartbeat).toHaveBeenCalledExactlyOnceWith(30_000);
+  });
+
+  it("reports a register failure on the runtime and still starts the heartbeat", async () => {
+    const failure = new Error("redis down");
+    const registry = sandboxStub({
+      register: async () => {
+        throw failure;
+      },
+    });
+    mocks.buildSandboxRegistryFromEnv.mockReturnValue(registry);
+    const reportError = vi.fn();
+    const runtime = runtimeStub(reportError);
+
+    await startHost({
+      bootRuntime: vi.fn(async () => runtime),
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here until the next heartbeat succeeds): redis down",
+    );
+    expect(reportError).toHaveBeenCalledExactlyOnceWith(
+      "eliza.sandboxRegistry",
+      failure,
+      { phase: "register" },
+    );
+    expect(registry.startHeartbeat).toHaveBeenCalledExactlyOnceWith(30_000);
+  });
+
+  it("does not report a register failure when no runtime exists yet", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const failure = new Error("redis down");
+    const registry = sandboxStub({
+      register: async () => {
+        throw failure;
+      },
+    });
+    mocks.buildSandboxRegistryFromEnv.mockReturnValue(registry);
+
+    await startHost();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(registry.startHeartbeat).toHaveBeenCalledOnce();
+  });
+});
+
+describe("close", () => {
+  it("stops the API and runtime once, even when close is invoked twice", async () => {
+    const started = await startHost();
+    const host = started.onReady.mock.calls[0]?.[0];
+    if (!host) {
+      throw new Error("onServerOnlyHostReady was not invoked");
+    }
+
+    await host.close();
+    await host.close();
+
+    expect(started.api.close).toHaveBeenCalledTimes(1);
+    expect(started.stopRuntime).toHaveBeenCalledExactlyOnceWith(
+      started.runtime,
+      "server-only shutdown",
+    );
+    expect(started.stopWithoutRuntime).not.toHaveBeenCalled();
+    expect(lastStartup(started.api)).toMatchObject({
+      phase: "stopping",
+      state: "stopped",
+    });
+  });
+
+  it("calls stopWithoutRuntime when closing a host that never published a runtime", async () => {
+    mocks.shouldDefer.mockReturnValue(true);
+    const started = await startHost();
+    const host = started.onReady.mock.calls[0]?.[0];
+    if (!host) {
+      throw new Error("onServerOnlyHostReady was not invoked");
+    }
+
+    await host.close();
+
+    expect(started.stopWithoutRuntime).toHaveBeenCalledOnce();
+    expect(started.stopRuntime).not.toHaveBeenCalled();
+  });
+
+  it("stops the heartbeat and unregisters the sandbox on close", async () => {
+    const registry = sandboxStub();
+    mocks.buildSandboxRegistryFromEnv.mockReturnValue(registry);
+    const started = await startHost();
+    const host = started.onReady.mock.calls[0]?.[0];
+    if (!host) {
+      throw new Error("onServerOnlyHostReady was not invoked");
+    }
+
+    await host.close();
+
+    expect(registry.stopHeartbeat).toHaveBeenCalledOnce();
+    expect(registry.unregister).toHaveBeenCalledOnce();
+  });
+
+  it("warns on unregister failure and still stops the runtime", async () => {
+    const failure = new Error("ttl leftover");
+    const registry = sandboxStub({
+      unregister: async () => {
+        throw failure;
+      },
+    });
+    mocks.buildSandboxRegistryFromEnv.mockReturnValue(registry);
+    const started = await startHost();
+    const host = started.onReady.mock.calls[0]?.[0];
+    if (!host) {
+      throw new Error("onServerOnlyHostReady was not invoked");
+    }
+
+    await host.close();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[eliza] Sandbox unregister failed (keys will expire via TTL): ttl leftover",
+    );
+    expect(started.stopRuntime).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION

## Summary

Adds real unit coverage for `packages/app-core/src/runtime/startup/server-only-host.ts`, the bind-first server-only host that owns API binding, onboarding deferral, runtime publication/restart, sandbox registration, and idempotent shutdown. There is no same-named test file on `develop`. This PR changes no production behaviour.

The suite drives the real `startServerOnlyHost` orchestrator. Socket bind, first-run disk, and Redis are stubbed as I/O seams; assertions observe host sequencing and projected `AppStartupStateMachine` phases, not mock echo.

Recorded behaviour (what the code does):

- Port selection: unset `ELIZA_API_PORT` binds the server-only default `2138`; a set `ELIZA_API_PORT` uses the desktop resolver. A rebound listener is synced into `ELIZA_API_PORT` / `ELIZA_UI_PORT` / `ELIZA_PORT` and CORS ports are invalidated.
- Local-agent IPC (`localAgentMode: true` without `ELIZA_API_EXPOSE_PORT`) initializes the route kernel with `skipListen: true` and does **not** sync a never-bound port. `ELIZA_API_EXPOSE_PORT=1` re-opens TCP listen.
- API bind failure logs `Error.stack` when present, the message when `stack` is missing, or `String(err)` for non-Errors; boot is skipped and the original rejection is rethrown.
- Immediate boot binds first (`initialAgentState: "starting"`), then `runtime-starting` (attempt 1). A still-pending post-ready phase projects `features-starting`. `complete` during boot projects `ready`; `failed` during boot projects `degraded`. Post-ready callbacks before the runtime is published do not emit phases.
- After publish, `complete` → `ready` and `failed` → `degraded`. `pending` from `degraded` throws `Invalid startup transition: degraded -> features-starting` (the real state machine rejects it).
- Initial boot throw: close API, rethrow original, project `failed`/`error`. Initial boot that returns `undefined`: close API, return `undefined`, do **not** invoke `onServerOnlyHostReady`.
- Deferred onboarding: register the boot closure, bind as `not_started`, project `awaiting-onboarding`, do not boot immediately. The registered closure on success updates the runtime; on throw wraps with `Runtime boot after onboarding failed` and keeps the registration; on empty runtime throws `Runtime boot after onboarding returned no runtime` and keeps the registration.
- `onRestart` while deferred funnels into `triggerDeferredRuntimeBoot("agent start requested via API")`. After a live runtime, restart stops with `"server-only restart"`, increments attempt, and returns the new runtime. Restart boot throw rethrows the original (not wrapped) and does not close the API. Restart that yields no runtime returns `null` without closing the API. Restart with no published runtime and clear deferral boots without `stopRuntime`.
- Sandbox: `register()` then `startHeartbeat(30000)`. Register failure logs, calls `runtime.reportError("eliza.sandboxRegistry", err, { phase: "register" })` when a runtime exists, and still starts the heartbeat. Close stops the heartbeat and unregisters; unregister failure warns and still stops the runtime.
- `close` is idempotent: API and runtime stop once. A host that never published a runtime calls `stopWithoutRuntime`.

## Test plan

Hosted CI does **not** run on this fork contributor PR. Local checks against current `origin/develop` (`packages/app-core/src/runtime/startup/server-only-host.ts` is byte-identical to `develop`; parent `83d7871746c49e070bb82ab1d7175dd10b3a66de`):

1. `cd packages/app-core && bunx vitest run src/runtime/startup/server-only-host.test.ts` — **Test Files 1 passed (1), Tests 30 passed (30)** (vitest v4.1.5; 19ms tests / 23.09s total on re-run after refetch).
2. `bunx biome check --write packages/app-core/src/runtime/startup/server-only-host.test.ts` — **Checked 1 file. No fixes applied.** (`biome.json` present; worktree is not sparse).
3. `cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'server-only-host.test'` — **no matches** (the new file introduces zero type errors). Pre-existing errors elsewhere in the package are not this diff.
4. Diff is **one file**: `packages/app-core/src/runtime/startup/server-only-host.test.ts` (821 insertions). Production code is untouched.

## Evidence

N/A — test-only change; no production behaviour to reproduce. Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

# Relates to

Coverage gap: `packages/app-core/src/runtime/startup/server-only-host.ts` had no same-named test file. No linked issue; test-only PR.

- [x] This PR targets `develop` and is based on current `origin/develop` (`83d7871746c49e070bb82ab1d7175dd10b3a66de`) with a single-file commit and zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only diff. Focused vitest + biome + package `tsc` are quoted above. Hosted CI does not run on fork contributor PRs.
- [x] A reviewer can confirm the change from the vitest / biome / tsc counts above without reading production code (there is no production change).

# Sync with develop

- [x] Branch parent is current `origin/develop` at file time (`83d7871746c49e070bb82ab1d7175dd10b3a66de`); zero conflicts.
- [ ] `bun run verify` not run for this test-only PR; focused checks are in the Test plan. Hosted CI does not run on this fork.

# Risks

Low. Test-only addition. No production behaviour change. No losslessness or supersession risk.

# Background

## What does this PR do?

Adds a colocated Vitest suite for `startServerOnlyHost` covering every exported runtime symbol and the observed bind / defer / boot / restart / sandbox / close branches.

## What kind of change is this?

Improvements (tests for existing behaviour; no production change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/runtime/startup/server-only-host.test.ts`, then `bunx vitest run` in `packages/app-core` as quoted above.

## Detailed testing steps

None: automated tests are the change. Re-run the three commands in the Test plan against current `develop`.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model behaviour.

## Backend + frontend logs

N/A - test-only change; no runtime server or UI is started. Vitest output is quoted in the Test plan.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. Diff is one `.test.ts` file.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run; this is a one-file test addition and the focused vitest/biome/tsc gate is quoted above.
- Hosted CI does not run on fork contributor PRs.
- Evidence rows below are N/A because there is no production behaviour and no UI.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b03995556b656b00d18ed984f96264439c7ec218 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
