### PR TITLE
fix(dropbox): use toWellFormedUnicode in dropboxDeepLink to prevent URI malformed error on lone surrogates

### DIFF
--- a/plugins/plugin-dropbox/src/__tests__/client.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/client.test.ts
@@ -414,5 +414,8 @@ describe("helpers", () => {
     );
     expect(dropboxDeepLink("/A B", "folder")).toBe("https://www.dropbox.com/home/A%20B");
     expect(dropboxDeepLink("", "folder")).toBe("https://www.dropbox.com/home");
+    expect(dropboxDeepLink("/A \uD83D/c.txt", "file")).toBe(
+      "https://www.dropbox.com/home/A%20%EF%BF%BD?preview=c.txt"
+    );
   });
 });

--- a/plugins/plugin-dropbox/src/client.ts
+++ b/plugins/plugin-dropbox/src/client.ts
@@ -14,7 +14,7 @@
  * with `DROPBOX_FILE_NOT_TEXT` / `DROPBOX_FILE_TOO_LARGE` instead of returning
  * garbage, so callers can point the user at the temporary link instead.
  */
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode } from "@elizaos/core";
 import { readBoundedResponse } from "./bounded-response.js";
 import type {
   DropboxAccountRef,
@@ -503,16 +503,17 @@ function mapEntry(item: JsonRecord): DropboxEntry {
 /** Deterministic dropbox.com deep link: folders browse in /home, files preview. */
 export function dropboxDeepLink(pathDisplay: string, kind: DropboxEntry["kind"]): string {
   if (!pathDisplay) return "https://www.dropbox.com/home";
-  const encoded = pathDisplay
+  const normalized = toWellFormedUnicode(pathDisplay);
+  const encoded = normalized
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
   if (kind === "folder") {
     return `https://www.dropbox.com/home${encoded}`;
   }
-  const lastSlash = pathDisplay.lastIndexOf("/");
-  const parent = pathDisplay.slice(0, Math.max(lastSlash, 0));
-  const file = pathDisplay.slice(lastSlash + 1);
+  const lastSlash = normalized.lastIndexOf("/");
+  const parent = normalized.slice(0, Math.max(lastSlash, 0));
+  const file = normalized.slice(lastSlash + 1);
   const encodedParent = parent
     .split("/")
     .map((segment) => encodeURIComponent(segment))


### PR DESCRIPTION
## Summary

Ensures `dropboxDeepLink` in `plugins/plugin-dropbox/src/client.ts` normalizes incoming file and folder paths with `toWellFormedUnicode` before invoking `encodeURIComponent`, preventing unhandled `URIError: URI malformed` when paths contain unpaired surrogate characters.

## Changes

- In `plugins/plugin-dropbox/src/client.ts:504`, import `toWellFormedUnicode` from `@elizaos/core` and sanitize `pathDisplay` prior to splitting and percent-encoding path segments.
- In `plugins/plugin-dropbox/src/__tests__/client.test.ts`, add test assertion verifying that `dropboxDeepLink` handles paths with lone surrogate code points without throwing `URIError`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`d7013f3cfc`) |
| --- | --- | --- |
| `bun test src/__tests__/client.test.ts` (in `plugins/plugin-dropbox`) | 20 pass | 20 pass (50 expect() calls) |
| `bunx @biomejs/biome check plugins/plugin-dropbox/src/client.ts plugins/plugin-dropbox/src/__tests__/client.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-dropbox/src/client.ts:500-522`
- `plugins/plugin-dropbox/src/__tests__/client.test.ts:410-418`

## Risks

Low. Replaces lone UTF-16 surrogates with replacement characters (U+FFFD) for URL encoding, ensuring standard compliance and avoiding crashes.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Dropbox plugin deep link generator)
- [x] `audit:browser` — N/A (Client-side URL encoding)
- [x] `build` — Clean build across workspace
- [x] `test` — 20/20 pass in `client.test.ts`
- [x] `lint` — Biome clean
