### PR TITLE
fix(core): safe NaN handling in triage feed recency sort comparators

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/triage-order.safe-sort.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/triage-order.safe-sort.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Total-order contract of the triage feed comparators. `rankScored` documents
+ * itself as needing a total order, but `receivedAtMs` is supplied by whatever
+ * message adapter is registered — first-party adapters already defend this
+ * field (`plugin-x` coerces a non-finite parse to `Date.now()`), so an adapter
+ * that does not is the realistic case the core comparator must survive.
+ *
+ * A non-finite stamp makes the raw subtraction return NaN, which
+ * `Array.prototype.sort` treats as "leave as is" — corrupting the order of
+ * every pair the bad element is compared against, not just that element.
+ * Deterministic: plain fixtures, no runtime, no adapters, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import { rankScored } from "../triage-engine.ts";
+import type { MessageRef } from "../types.ts";
+
+function ref(
+	id: string,
+	receivedAtMs: number,
+	contactWeight?: number,
+): MessageRef {
+	return {
+		id,
+		source: "email" as MessageRef["source"],
+		externalId: `ext-${id}`,
+		from: { identifier: `${id}@example.test` },
+		to: [],
+		snippet: id,
+		receivedAtMs,
+		hasAttachments: false,
+		isRead: false,
+		...(contactWeight === undefined
+			? {}
+			: { triageScore: { contactWeight } as MessageRef["triageScore"] }),
+	} as MessageRef;
+}
+
+const ids = (refs: MessageRef[]): string[] => refs.map((entry) => entry.id);
+
+describe("rankScored total order", () => {
+	it("orders finite stamps newest first", () => {
+		expect(ids(rankScored([ref("a", 10), ref("c", 30), ref("b", 20)]))).toEqual(
+			["c", "b", "a"],
+		);
+	});
+
+	it("keeps the finite stamps correctly ordered when one ref carries NaN", () => {
+		// NaN !== NaN is true, so the equality guard does not fire and the
+		// comparator returns NaN for every pair touching the bad ref.
+		const ranked = ids(
+			rankScored([
+				ref("a", 10),
+				ref("bad", Number.NaN),
+				ref("c", 30),
+				ref("b", 20),
+			]),
+		);
+		expect(ranked.filter((id) => id !== "bad")).toEqual(["c", "b", "a"]);
+		expect(ranked).toHaveLength(4);
+	});
+
+	it("sorts a non-finite stamp as the oldest entry rather than scrambling", () => {
+		expect(
+			ids(rankScored([ref("bad", Number.NaN), ref("c", 30), ref("b", 20)])),
+		).toEqual(["c", "b", "bad"]);
+	});
+
+	it("treats Infinity from an overflowed stamp as non-finite", () => {
+		expect(
+			ids(
+				rankScored([
+					ref("inf", Number.POSITIVE_INFINITY),
+					ref("c", 30),
+					ref("b", 20),
+				]),
+			),
+		).toEqual(["c", "b", "inf"]);
+	});
+
+	it("breaks equal stamps on contact weight, then on id, for a stable total order", () => {
+		const ordered = ids(
+			rankScored([ref("a", 50, 0.1), ref("b", 50, 0.9), ref("c", 50, 0.9)]),
+		);
+		expect(ordered).toEqual(["b", "c", "a"]);
+	});
+
+	it("collapses a NaN contact weight to the documented default weight", () => {
+		// DEFAULT_CONTACT_WEIGHT is 0.5, so the unusable weight ranks between the
+		// 0.9 and 0.1 refs rather than returning NaN and scrambling the group.
+		const ordered = ids(
+			rankScored([
+				ref("a", 50, Number.NaN),
+				ref("b", 50, 0.9),
+				ref("c", 50, 0.1),
+			]),
+		);
+		expect(ordered).toEqual(["b", "a", "c"]);
+	});
+});

--- a/packages/core/src/features/messaging/triage/triage-engine.ts
+++ b/packages/core/src/features/messaging/triage/triage-engine.ts
@@ -121,13 +121,44 @@ export async function scoreMessages(
  * total order, and a missing score carries no relationship information.
  */
 export function rankScored(messages: MessageRef[]): MessageRef[] {
-	return [...messages].sort((a, b) => {
-		if (a.receivedAtMs !== b.receivedAtMs) {
-			return b.receivedAtMs - a.receivedAtMs;
-		}
-		return (
-			(b.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT) -
-			(a.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT)
-		);
-	});
+	return [...messages].sort(compareMessageRefsByRecency);
+}
+
+/**
+ * `receivedAtMs` is supplied by whichever message adapter produced the ref, so
+ * a malformed upstream date can arrive non-finite — first-party adapters
+ * already coerce it (see the `Number.isFinite` guard in the X adapter). A
+ * non-finite stamp reaching the raw subtraction returns NaN, and
+ * `Array.prototype.sort` treats NaN as "leave as is", which corrupts the order
+ * of every pair the bad ref is compared against rather than just that ref.
+ * Note `NaN !== NaN` is true, so an equality guard does not catch it.
+ */
+function receivedAtSortKey(ref: MessageRef): number {
+	return Number.isFinite(ref.receivedAtMs) ? ref.receivedAtMs : 0;
+}
+
+/** Contact weight is model/relationship derived and may be absent or NaN. */
+function contactWeightSortKey(ref: MessageRef): number {
+	const weight = ref.triageScore?.contactWeight;
+	return typeof weight === "number" && Number.isFinite(weight)
+		? weight
+		: DEFAULT_CONTACT_WEIGHT;
+}
+
+/**
+ * Total order for the triage feed: newest first, contact weight breaking
+ * ties, then id so the result is deterministic for otherwise-equal refs.
+ * Shared with `triage-service` so both feed paths order identically.
+ */
+export function compareMessageRefsByRecency(
+	a: MessageRef,
+	b: MessageRef,
+): number {
+	const aAt = receivedAtSortKey(a);
+	const bAt = receivedAtSortKey(b);
+	if (aAt !== bAt) return bAt - aAt;
+	const weightDelta = contactWeightSortKey(b) - contactWeightSortKey(a);
+	if (weightDelta !== 0) return weightDelta;
+	// Code-unit comparison keeps the tie-break locale-independent.
+	return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 }

--- a/packages/core/src/features/messaging/triage/triage-service.ts
+++ b/packages/core/src/features/messaging/triage/triage-service.ts
@@ -19,7 +19,11 @@ import {
 	getDefaultMessageRefStore,
 	type MessageRefStore,
 } from "./message-ref-store.ts";
-import { rankScored, scoreMessages } from "./triage-engine.ts";
+import {
+	compareMessageRefsByRecency,
+	rankScored,
+	scoreMessages,
+} from "./triage-engine.ts";
 import type {
 	DraftRecord,
 	DraftRequest,
@@ -311,7 +315,7 @@ export class TriageService {
 			throw failures[0].error;
 		}
 		this.store.saveMessages(merged);
-		merged.sort((a, b) => b.receivedAtMs - a.receivedAtMs);
+		merged.sort(compareMessageRefsByRecency);
 		const hasMore =
 			requestedLimit === null ? null : merged.length > requestedLimit;
 		return {


### PR DESCRIPTION
# Relates to

Continues the safe-sort sweep across the repository's ordering comparators (same class as merged #25840, #25839, #25836, #25837). This one covers the messaging triage feed in `packages/core`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; `packages/core` typecheck, Biome, and the triage suites all pass.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `4ad81cf3c4fa59b85ae1937ac5b480544c8de3db`; zero conflicts.
- [x] `packages/core` typecheck exits 0 with zero errors post-sync.

# Risks

**Low.** One comparator extracted and reused; no signature change to `rankScored`, no control-flow change. For all-finite input the order is identical to before — the only behavioral difference is that non-finite stamps and weights now get a defined position instead of corrupting neighbouring comparisons.

The added id tie-break is new ordering behavior for refs that were previously *equal* under both keys. That is deliberate: without it `Array.prototype.sort` leaves such pairs in input order, which differs between the two feed paths that produce them.

# Background

## What does this PR do?

`rankScored` documents itself as needing a total order, but built one from a raw subtraction:

```ts
if (a.receivedAtMs !== b.receivedAtMs) {
  return b.receivedAtMs - a.receivedAtMs;
}
return (b.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT)
     - (a.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT);
```

Two defects:

1. **`receivedAtMs` can be non-finite.** It is supplied by whichever message adapter produced the ref. First-party adapters already defend this exact field — `plugins/plugin-x/src/lifeops-message-adapter.ts:95` writes `Number.isFinite(receivedAtMs) ? receivedAtMs : Date.now()`, and `plugin-inbox` uses `Date.parse(...) || Date.now()` — so an adapter that does not guard is the realistic case this comparator must survive. Adapters are pluggable, so core is the last line of defense.

   The `!==` guard does **not** protect it: `NaN !== NaN` is `true`, so a NaN stamp takes the subtraction branch and returns NaN. `Array.prototype.sort` treats a NaN comparator result as "leave as is", which corrupts the order of every pair the bad ref is compared against — not just that ref.

2. **`?? DEFAULT_CONTACT_WEIGHT` only replaces `undefined`, not NaN.** A NaN weight propagated straight into the tie-break subtraction.

Extracts one shared `compareMessageRefsByRecency`: non-finite stamps collapse to `0` (sorted oldest), a non-finite weight collapses to the documented `DEFAULT_CONTACT_WEIGHT`, and equal pairs break on `id` (code-unit, locale-independent) so the order is total.

`triage-service.ts:314` carried the identical raw subtraction on the merged multi-adapter feed and now uses the same comparator, so both feed paths order identically instead of drifting.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as JSDoc on the new comparator.

# Testing

## Where should a reviewer start?

`packages/core/src/features/messaging/triage/__tests__/triage-order.safe-sort.test.ts` — it drives the real exported `rankScored` with plain fixtures (no runtime, no adapters, no IO).

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/features/messaging/triage/__tests__/
```

To confirm the suite is not vacuous, revert `triage-engine.ts` and `triage-service.ts` (keep the test) and re-run — 4 of 6 fail. The remaining 2 are controls that must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9d5b1d9e917f8d4e463463af977965a3bed46d0c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes an ordering comparator in core.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; behavior is list ordering, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure comparator with no logging; the red/green run below is the direct execution record of the real exported function.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed; triage scoring itself is untouched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete orderings produced by the real function are asserted in the suite and shown below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure comparator, no logging.`

### Red — comparators reverted, test unchanged

```
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

Representative failure — a single NaN ref reorders refs that have nothing wrong with them:

```
rankScored total order > sorts a non-finite stamp as the oldest entry rather than scrambling
AssertionError: expected [ 'bad', 'c', 'b' ] to deeply equal [ 'c', 'b', 'bad' ]
```

### Green — with the fix, at this exact head

```
$ npx vitest run src/features/messaging/triage/__tests__/
 Test Files  9 passed (9)
      Tests  55 passed (55)
```

All eight pre-existing triage suites pass unchanged alongside the new one.

## Domain artifacts

Ordering produced by the real exported function:

| input | before | after |
|---|---|---|
| `a=10, bad=NaN, c=30, b=20` | `bad, c, b, a` (finite refs displaced) | `c, b, a, bad` |
| `inf=+Infinity, c=30, b=20` | `inf, c, b` | `c, b, inf` |
| equal stamps, weights `NaN/0.9/0.1` | NaN propagates into the tie-break | `0.9, DEFAULT(0.5), 0.1` |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **`packages/core` typecheck: PASS** (exit 0, zero errors).
- **Biome:** clean on all three changed files.
- Full-repo `bun run verify` was not run to completion; the affected-package gates (core typecheck, Biome, all 9 triage suites) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
