### PR TITLE
test(app-core): cover process-management

### DIFF
--- a/packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Exercises Steward sidecar process-management against the real
+ * `findStewardEntryPoint` and `pipeOutput` implementations using real temp
+ * files and ReadableStreams. Logger spies only observe the structured log
+ * contract; they do not stand in for the module under test.
+ */
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { findStewardEntryPoint, pipeOutput } from "../process-management.ts";
+
+const originalEntryPoint = process.env.STEWARD_ENTRY_POINT;
+const tempDirs: string[] = [];
+
+function makeEntryFile(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "steward-entry-"));
+  tempDirs.push(dir);
+  const file = path.join(dir, "entry.js");
+  writeFileSync(file, "export {}\n");
+  return file;
+}
+
+function bytesStream(
+  chunks: Array<string | Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          typeof chunk === "string" ? encoder.encode(chunk) : chunk,
+        );
+      }
+      controller.close();
+    },
+  });
+}
+
+function failingStream(beforeError?: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (beforeError) {
+        controller.enqueue(new TextEncoder().encode(beforeError));
+      }
+      controller.error(new Error("stream closed"));
+    },
+  });
+}
+
+describe("findStewardEntryPoint", () => {
+  beforeEach(() => {
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalEntryPoint === undefined) {
+      delete process.env.STEWARD_ENTRY_POINT;
+    } else {
+      process.env.STEWARD_ENTRY_POINT = originalEntryPoint;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns the STEWARD_ENTRY_POINT path when that file exists", async () => {
+    const entry = makeEntryFile();
+    process.env.STEWARD_ENTRY_POINT = entry;
+
+    await expect(findStewardEntryPoint()).resolves.toBe(entry);
+    expect(existsSync(entry)).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[StewardSidecar] Found entry point: ${entry}`,
+    );
+  });
+
+  it("accepts an existing directory as the env candidate", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "steward-entry-dir-"));
+    tempDirs.push(dir);
+    process.env.STEWARD_ENTRY_POINT = dir;
+
+    await expect(findStewardEntryPoint()).resolves.toBe(dir);
+  });
+
+  it("does not return a missing STEWARD_ENTRY_POINT path", async () => {
+    const missing = path.join(
+      tmpdir(),
+      `steward-missing-${Date.now()}-${Math.random()}.js`,
+    );
+    process.env.STEWARD_ENTRY_POINT = missing;
+    expect(existsSync(missing)).toBe(false);
+
+    const result = await findStewardEntryPoint();
+    expect(result).not.toBe(missing);
+    if (result !== null) {
+      expect(existsSync(result)).toBe(true);
+    }
+  });
+
+  it("treats an empty STEWARD_ENTRY_POINT as absent", async () => {
+    process.env.STEWARD_ENTRY_POINT = "";
+
+    const result = await findStewardEntryPoint();
+    expect(result).not.toBe("");
+    if (result !== null) {
+      expect(existsSync(result)).toBe(true);
+    }
+  });
+
+  it("returns null when env is unset and no @stwd/api module exists on disk", async () => {
+    delete process.env.STEWARD_ENTRY_POINT;
+
+    const result = await findStewardEntryPoint();
+    if (result === null) {
+      expect(result).toBeNull();
+    } else {
+      expect(existsSync(result)).toBe(true);
+    }
+  });
+
+  it("does not throw when module resolution cannot find @stwd/api", async () => {
+    delete process.env.STEWARD_ENTRY_POINT;
+    const result = await findStewardEntryPoint();
+    expect(
+      result === null || (typeof result === "string" && existsSync(result)),
+    ).toBe(true);
+  });
+});
+
+describe("pipeOutput", () => {
+  beforeEach(() => {
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves immediately for a null stream and never calls onLog", async () => {
+    const onLog = vi.fn();
+    await expect(pipeOutput(null, "stdout", onLog)).resolves.toBeUndefined();
+    expect(onLog).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("resolves without logging when the stream closes empty", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream([]), "stdout", onLog);
+    expect(onLog).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("logs stdout chunks through logger.info and onLog", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["ready on :3200"]), "stdout", onLog);
+
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(onLog).toHaveBeenCalledWith("ready on :3200", "stdout");
+    expect(logger.info).toHaveBeenCalledWith("[Steward] ready on :3200");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs stderr chunks through logger.warn and onLog", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["bind failed"]), "stderr", onLog);
+
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(onLog).toHaveBeenCalledWith("bind failed", "stderr");
+    expect(logger.warn).toHaveBeenCalledWith("[Steward:err] bind failed");
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("strips only trailing whitespace via trimEnd", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["  hello  \n"]), "stdout", onLog);
+    expect(onLog).toHaveBeenCalledWith("  hello", "stdout");
+  });
+
+  it("does not split a single chunk on embedded newlines", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["line-a\nline-b\n"]), "stdout", onLog);
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(onLog).toHaveBeenCalledWith("line-a\nline-b", "stdout");
+  });
+
+  it("skips chunks that are empty after trimEnd", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["\n", "   ", "keep", ""]), "stdout", onLog);
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(onLog).toHaveBeenCalledWith("keep", "stdout");
+  });
+
+  it("invokes onLog once per non-empty chunk in order", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["one", "two", "three"]), "stderr", onLog);
+    expect(onLog.mock.calls).toEqual([
+      ["one", "stderr"],
+      ["two", "stderr"],
+      ["three", "stderr"],
+    ]);
+  });
+
+  it("resolves without onLog when the callback is omitted", async () => {
+    await expect(
+      pipeOutput(bytesStream(["solo"]), "stdout"),
+    ).resolves.toBeUndefined();
+    expect(logger.info).toHaveBeenCalledWith("[Steward] solo");
+  });
+
+  it("swallows a stream read error and still resolves", async () => {
+    const onLog = vi.fn();
+    await expect(
+      pipeOutput(failingStream(), "stderr", onLog),
+    ).resolves.toBeUndefined();
+    expect(onLog).not.toHaveBeenCalled();
+  });
+
+  it("resolves when start() enqueues a chunk then errors in the same turn", async () => {
+    const onLog = vi.fn();
+    await expect(
+      pipeOutput(failingStream("partial-line"), "stdout", onLog),
+    ).resolves.toBeUndefined();
+    // Observed: a same-turn controller.error() rejects the reader before
+    // the enqueued chunk is delivered, so onLog is not invoked.
+    expect(onLog).not.toHaveBeenCalled();
+  });
+
+  it("decodes multi-byte utf-8 in a single chunk", async () => {
+    const onLog = vi.fn();
+    await pipeOutput(bytesStream(["café — 你好"]), "stdout", onLog);
+    expect(onLog).toHaveBeenCalledWith("café — 你好", "stdout");
+  });
+});


### PR DESCRIPTION

# Relates to

No existing issue. `packages/app-core/src/services/steward-sidecar/process-management.ts` had no same-named test file. This PR adds that coverage only.

Definition of Done: test-only change. Scoped vitest / biome / tsc on the new file; not a full `bun run verify` run.

- [x] This PR targets `develop` (base `465ca0d8947c1d7d260cdcf33b14afb0260aa8c2`). `process-management.ts` is unchanged versus current `origin/develop`.
- [ ] Full `bun install` + `bun run verify` was not re-run for this test-only diff. Scoped commands are quoted below.
- [x] A reviewer can confirm the tests from the quoted vitest / biome / tsc output.

# Sync with develop

- [x] Branch is based on `origin/develop` at `465ca0d8947c1d7d260cdcf33b14afb0260aa8c2`. The production file is identical on current `origin/develop`.
- [ ] `bun run verify` not re-run; not a production-behavior change.

# Risks

Low. Adds one vitest file. No production code, exports, routes, or docs change.

# Background

## What does this PR do?

Adds `packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts`, covering the two exported helpers:

- `findStewardEntryPoint` — env override when the path exists (file or directory), skip missing/empty `STEWARD_ENTRY_POINT`, no throw when `@stwd/api` cannot be resolved, return only paths that exist on disk.
- `pipeOutput` — null/empty streams, stdout vs stderr logger prefixes, `trimEnd` (not line-splitting), skip empty chunks, optional `onLog`, UTF-8 decode, and stream-read errors resolving rather than rejecting.

Expectations match observed behavior. In particular, a single chunk with embedded newlines is **not** split, and a same-turn `controller.error()` after `enqueue` rejects the reader before the chunk is delivered.

## What kind of change is this?

Tests only. Behavior-preserving. No production source change.

## Why are we doing this? Any context or related work?

The module previously had no dedicated unit suite. Sidecar start depends on locating the Steward entry and piping child output; those branches were untested.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts`

## Detailed testing steps

Re-run against current `origin/develop` immediately before filing:

```bash
bunx vitest run packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
```

Observed (final pre-file run):

```
Test Files  1 passed (1)
     Tests  18 passed (18)
Duration  5.49s
```

Biome (once):

```
bunx biome check --write packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
Checked 1 file in 15ms. Fixed 1 file.
```

(`biome.json` is present; this checkout is not sparse.)

Typecheck (owning package). New file appears nowhere in `tsc` output:

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'process-management.test.ts' ; echo "EXIT:$?"
EXIT:1
```

Empty grep = this file introduced zero TypeScript errors. Pre-existing package errors, if any, are not from this file.

Hosted CI does **not** run on this fork contributor PR. Do not infer that GitHub Actions passed.

Diff touches only the new test file.

# Evidence Gate

<!-- evidence-head:883871220db497fa647b46f683cd75052676698c -->

Test-only PR; no production behavior change. Heavy bug-fix evidence (origin reproduction, proof-run, over-rejection corpus) does not apply.

- Before screenshots: N/A - no UI surface; test-only diff
- After screenshots: N/A - no UI surface; test-only diff
- Walkthrough video: N/A - no UI surface; test-only diff
- Backend logs: N/A - no runtime/server path change; vitest output quoted above
- Frontend logs: N/A - no frontend change
- LLM trajectory: N/A - no agent/action/provider/prompt/model change
- Domain artifacts: N/A - no DB/memory/wallet/on-chain/audio artifact
- OCR review: N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; no server or UI path change. Vitest counts are quoted in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not re-run; this PR adds one test file and changes no production behavior.
- Hosted GitHub Actions CI does not run on fork PRs from this contributor.
- Interactive `identity.slop.cash` OAuth evidence trace was not finalized (unattended session).

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
