### PR TITLE
test(app-core): cover health-check

### DIFF
--- a/packages/app-core/src/services/steward-sidecar/health-check.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/health-check.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Exercises Steward sidecar `waitForHealthy` against a real loopback `/health`
+ * server. Interval sleep is stubbed so retries stay in-process; fetch, JSON
+ * parse, abort, and timeout branches run the production poller.
+ */
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForHealthy } from "./health-check";
+import { HEALTH_CHECK_INTERVAL_MS, HEALTH_CHECK_TIMEOUT_MS } from "./types";
+
+const sleepMock = vi.hoisted(() => vi.fn(async (_ms: number) => undefined));
+
+vi.mock("./helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./helpers")>();
+  return { ...actual, sleep: sleepMock };
+});
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ server: Server; apiBase: string }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  if (addr === null || typeof addr === "string") {
+    throw new Error("expected a TCP listen address");
+  }
+  return { server, apiBase: `http://127.0.0.1:${addr.port}` };
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+  if (!server) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+describe("waitForHealthy", () => {
+  let server: Server | undefined;
+
+  beforeEach(() => {
+    sleepMock.mockReset();
+    sleepMock.mockImplementation(async () => undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("resolves on the first 200 body with status ok and never sleeps", async () => {
+    const paths: string[] = [];
+    const started = await listen((req, res) => {
+      paths.push(req.url ?? "");
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+
+    await expect(
+      waitForHealthy(started.apiBase, new AbortController()),
+    ).resolves.toBeUndefined();
+
+    expect(paths).toEqual(["/health"]);
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores extra JSON fields when status is ok", async () => {
+    const started = await listen((_req, res) => {
+      sendJson(res, 200, { status: "ok", pid: 12, extra: "ignored" });
+    });
+    server = started.server;
+
+    await expect(
+      waitForHealthy(started.apiBase, new AbortController()),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not treat HTTP 503 as healthy even when the body says status ok", async () => {
+    let polls = 0;
+    const started = await listen((_req, res) => {
+      polls += 1;
+      if (polls === 1) {
+        sendJson(res, 503, { status: "ok" });
+        return;
+      }
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+
+    await waitForHealthy(started.apiBase, new AbortController());
+
+    expect(polls).toBe(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(HEALTH_CHECK_INTERVAL_MS);
+  });
+
+  it("retries a 200 body whose status is not the exact string ok", async () => {
+    let polls = 0;
+    const started = await listen((_req, res) => {
+      polls += 1;
+      if (polls === 1) {
+        sendJson(res, 200, { status: "OK" });
+        return;
+      }
+      if (polls === 2) {
+        sendJson(res, 200, { status: "starting" });
+        return;
+      }
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+
+    await waitForHealthy(started.apiBase, new AbortController());
+
+    expect(polls).toBe(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 200 body with a missing status field", async () => {
+    let polls = 0;
+    const started = await listen((_req, res) => {
+      polls += 1;
+      if (polls === 1) {
+        sendJson(res, 200, {});
+        return;
+      }
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+
+    await waitForHealthy(started.apiBase, new AbortController());
+    expect(polls).toBe(2);
+  });
+
+  it("retries when the 200 body is not JSON", async () => {
+    let polls = 0;
+    const started = await listen((_req, res) => {
+      polls += 1;
+      if (polls === 1) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("not-json");
+        return;
+      }
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+
+    await waitForHealthy(started.apiBase, new AbortController());
+    expect(polls).toBe(2);
+  });
+
+  it("retries a connection failure then succeeds once the port accepts", async () => {
+    const placeholder = await listen((_req, res) => {
+      sendJson(res, 200, { status: "ok" });
+    });
+    const addr = placeholder.server.address();
+    if (addr === null || typeof addr === "string") {
+      throw new Error("expected a TCP listen address");
+    }
+    const port = addr.port;
+    await closeServer(placeholder.server);
+
+    sleepMock.mockImplementation(async () => {
+      if (server) {
+        return;
+      }
+      const live = createServer((_req, res) => {
+        sendJson(res, 200, { status: "ok" });
+      });
+      await new Promise<void>((resolve, reject) => {
+        live.once("error", reject);
+        live.listen(port, "127.0.0.1", () => resolve());
+      });
+      server = live;
+    });
+
+    await expect(
+      waitForHealthy(`http://127.0.0.1:${port}`, new AbortController()),
+    ).resolves.toBeUndefined();
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws Health check aborted when the controller is already aborted", async () => {
+    const started = await listen((_req, res) => {
+      sendJson(res, 200, { status: "ok" });
+    });
+    server = started.server;
+    const abort = new AbortController();
+    abort.abort();
+
+    await expect(waitForHealthy(started.apiBase, abort)).rejects.toThrow(
+      "Health check aborted",
+    );
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it("throws Health check aborted on the next loop after a failed poll", async () => {
+    const abort = new AbortController();
+    const started = await listen((_req, res) => {
+      sendJson(res, 503, { error: "not ready" });
+    });
+    server = started.server;
+
+    sleepMock.mockImplementation(async () => {
+      abort.abort();
+    });
+
+    await expect(waitForHealthy(started.apiBase, abort)).rejects.toThrow(
+      "Health check aborted",
+    );
+    expect(sleepMock).toHaveBeenCalledWith(HEALTH_CHECK_INTERVAL_MS);
+  });
+
+  it("throws after HEALTH_CHECK_TIMEOUT_MS of unsuccessful polls", async () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    sleepMock.mockImplementation(async (ms: number) => {
+      now += ms;
+    });
+
+    const started = await listen((_req, res) => {
+      sendJson(res, 503, { status: "starting" });
+    });
+    server = started.server;
+
+    await expect(
+      waitForHealthy(started.apiBase, new AbortController()),
+    ).rejects.toThrow(
+      `Steward failed to become healthy within ${HEALTH_CHECK_TIMEOUT_MS}ms`,
+    );
+
+    expect(now).toBeGreaterThanOrEqual(HEALTH_CHECK_TIMEOUT_MS);
+    expect(sleepMock).toHaveBeenCalled();
+    expect(
+      sleepMock.mock.calls.every(
+        (call) => call[0] === HEALTH_CHECK_INTERVAL_MS,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/app-core/src/services/steward-sidecar/health-check.ts`, which had no direct test file. Production poller code is unchanged.

The suite drives the real `waitForHealthy` export against a loopback HTTP `/health` server. Interval `sleep` is stubbed only so retries do not burn wall-clock time; fetch, JSON parse, abort, and timeout run the production implementation.

Observed behaviour pinned (what the code does today, not what we wish it did):

- First 200 `{ status: "ok" }` resolves and does not sleep; the request path is `/health`.
- Extra JSON fields are ignored when `status` is `"ok"`.
- HTTP 503 is not treated as healthy even if the body says `{ status: "ok" }` — `response.ok` is checked first.
- A 200 body with `status: "OK"`, `status: "starting"`, or a missing `status` is retried until the exact string `"ok"`.
- A non-JSON 200 body is swallowed by the existing empty catch and retried.
- A connection failure on a closed port is retried, then succeeds once the same port accepts.
- An already-aborted controller throws `Health check aborted` before sleeping.
- Abort during the interval throws `Health check aborted` on the next loop.
- Unsuccessful polls until `HEALTH_CHECK_TIMEOUT_MS` throw `Steward failed to become healthy within 30000ms`.

## Evidence

Test-only change; no production behaviour change. Hosted CI does not run on this fork contributor's PRs — do not infer a GitHub Actions pass from this body.

1. `bunx vitest run packages/app-core/src/services/steward-sidecar/health-check.test.ts`

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Re-fetched `origin/develop` and re-ran immediately before filing. `health-check.ts` is byte-identical to current `origin/develop`; the same 10/10 still pass.

2. `bunx biome check --write packages/app-core/src/services/steward-sidecar/health-check.test.ts` — checked 1 file; one formatting wrap applied; the committed file is that result.

3. `cd packages/app-core && bunx tsc --noEmit` — `health-check.test.ts` appears nowhere in the output (`grep health-check.test.ts` empty). Pre-existing errors in other package files are unchanged and not introduced by this diff.

4. The diff touches only `packages/app-core/src/services/steward-sidecar/health-check.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:79b6ded145fe6d596ddedd1e417cff30528382d9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
