### PR TITLE
test(app-core): cover update-notifier

### DIFF
--- a/packages/app-core/src/services/update-notifier.test.ts
+++ b/packages/app-core/src/services/update-notifier.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit coverage for scheduleUpdateNotification, the fire-and-forget CLI
+ * startup update check. Drives the real export: the one-shot `notified`
+ * guard, checkOnStart / CI / TTY gates, malformed-config resilience, the
+ * stderr notice (including non-stable channel suffix), and the J6 swallow
+ * of a failed registry check. `@elizaos/agent` I/O is stubbed so the suite
+ * never reads eliza.json or hits npm; the notifier itself is not mocked.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const agent = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+  loadElizaConfig: vi.fn(),
+  resolveChannel: vi.fn(),
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  checkForUpdate: agent.checkForUpdate,
+  loadElizaConfig: agent.loadElizaConfig,
+  resolveChannel: agent.resolveChannel,
+}));
+
+type UpdateCheckResult = {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion: string | null;
+  channel: "stable" | "beta" | "nightly";
+  distTag: string;
+  cached: boolean;
+  error: string | null;
+};
+
+const stderr = process.stderr as NodeJS.WriteStream & { isTTY: boolean };
+const ORIGINAL_CI = process.env.CI;
+const ORIGINAL_IS_TTY = Boolean(stderr.isTTY);
+
+function setStderrTty(value: boolean): void {
+  stderr.isTTY = value;
+}
+
+function restoreCi(): void {
+  if (ORIGINAL_CI === undefined) {
+    delete process.env.CI;
+  } else {
+    process.env.CI = ORIGINAL_CI;
+  }
+}
+
+function stripAnsi(value: string): string {
+  const esc = String.fromCharCode(27);
+  return value.replace(new RegExp(`${esc}\\[[0-9;]*m`, "g"), "");
+}
+
+function captureStderrWrite(): {
+  chunks: string[];
+  restore: () => void;
+} {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  }) as typeof process.stderr.write);
+  return {
+    chunks,
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
+async function loadNotifier(): Promise<typeof import("./update-notifier")> {
+  vi.resetModules();
+  return import("./update-notifier");
+}
+
+function updateResult(
+  overrides: Partial<UpdateCheckResult> = {},
+): UpdateCheckResult {
+  return {
+    updateAvailable: true,
+    currentVersion: "1.0.0",
+    latestVersion: "1.1.0",
+    channel: "stable",
+    distTag: "latest",
+    cached: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function writtenText(chunks: string[]): string {
+  return stripAnsi(chunks.join(""));
+}
+
+describe("scheduleUpdateNotification", () => {
+  beforeEach(() => {
+    agent.checkForUpdate.mockReset();
+    agent.loadElizaConfig.mockReset();
+    agent.resolveChannel.mockReset();
+    agent.loadElizaConfig.mockReturnValue({});
+    agent.resolveChannel.mockReturnValue("stable");
+    agent.checkForUpdate.mockResolvedValue(updateResult());
+    delete process.env.CI;
+    setStderrTty(true);
+  });
+
+  afterEach(() => {
+    restoreCi();
+    setStderrTty(ORIGINAL_IS_TTY);
+  });
+
+  it("writes a two-line notice when a newer stable version is available", async () => {
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(agent.resolveChannel).toHaveBeenCalledWith(undefined);
+      const text = writtenText(capture.chunks);
+      expect(text).toContain("Update available:");
+      expect(text).toContain("1.0.0 -> 1.1.0");
+      expect(text).toContain("Run");
+      expect(text).toContain("eliza update");
+      expect(text).toContain("to install");
+      expect(text).not.toContain("(stable)");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("appends the channel name when resolveChannel is not stable", async () => {
+    agent.loadElizaConfig.mockReturnValue({
+      update: { channel: "beta" },
+    });
+    agent.resolveChannel.mockReturnValue("beta");
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.resolveChannel).toHaveBeenCalledWith({ channel: "beta" });
+      expect(writtenText(capture.chunks)).toContain("1.0.0 -> 1.1.0 (beta)");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("appends a nightly suffix the same way as beta", async () => {
+    agent.resolveChannel.mockReturnValue("nightly");
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(writtenText(capture.chunks)).toContain("1.0.0 -> 1.1.0 (nightly)");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("stays silent when updateAvailable is false", async () => {
+    agent.checkForUpdate.mockResolvedValue(
+      updateResult({ updateAvailable: false, latestVersion: "1.0.0" }),
+    );
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("stays silent when latestVersion is null even if updateAvailable is true", async () => {
+    agent.checkForUpdate.mockResolvedValue(
+      updateResult({ updateAvailable: true, latestVersion: null }),
+    );
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("treats an empty latestVersion as missing and stays silent", async () => {
+    agent.checkForUpdate.mockResolvedValue(
+      updateResult({ updateAvailable: true, latestVersion: "" }),
+    );
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("does not query the registry when checkOnStart is exactly false", async () => {
+    agent.loadElizaConfig.mockReturnValue({
+      update: { checkOnStart: false },
+    });
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.loadElizaConfig).toHaveBeenCalledTimes(1);
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("still queries when checkOnStart is true", async () => {
+    agent.loadElizaConfig.mockReturnValue({
+      update: { checkOnStart: true },
+    });
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(writtenText(capture.chunks)).toContain("Update available:");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("does not treat a non-false checkOnStart (0) as an opt-out", async () => {
+    agent.loadElizaConfig.mockReturnValue({
+      update: { checkOnStart: 0 },
+    });
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(writtenText(capture.chunks)).toContain("Update available:");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("does not query the registry when CI is set", async () => {
+    process.env.CI = "1";
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("does not query the registry when stderr is not a TTY", async () => {
+    setStderrTty(false);
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("continues with defaults when loadElizaConfig throws", async () => {
+    agent.loadElizaConfig.mockImplementation(() => {
+      throw new Error("malformed eliza.json");
+    });
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(agent.resolveChannel).toHaveBeenCalledWith(undefined);
+      expect(writtenText(capture.chunks)).toContain("1.0.0 -> 1.1.0");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("swallows a rejected checkForUpdate without writing", async () => {
+    agent.checkForUpdate.mockRejectedValue(new Error("registry unreachable"));
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("is one-shot: a later call is a no-op even after CI is cleared", async () => {
+    process.env.CI = "true";
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      expect(agent.loadElizaConfig).toHaveBeenCalledTimes(1);
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+
+      delete process.env.CI;
+      setStderrTty(true);
+      agent.loadElizaConfig.mockClear();
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.loadElizaConfig).not.toHaveBeenCalled();
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  it("does not query twice when the first call already printed a notice", async () => {
+    const { scheduleUpdateNotification } = await loadNotifier();
+    const capture = captureStderrWrite();
+    try {
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).toHaveBeenCalledTimes(1);
+      expect(writtenText(capture.chunks)).toContain("Update available:");
+
+      agent.checkForUpdate.mockClear();
+      capture.chunks.length = 0;
+      scheduleUpdateNotification();
+      await flush();
+      expect(agent.checkForUpdate).not.toHaveBeenCalled();
+      expect(capture.chunks).toEqual([]);
+    } finally {
+      capture.restore();
+    }
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated vitest suite for `packages/app-core/src/services/update-notifier.ts`, which had no same-named test file in the repository.

The suite drives the real `scheduleUpdateNotification` export. `@elizaos/agent` config/registry I/O is stubbed so the tests never read `eliza.json` or hit npm; the notifier itself is not mocked. Assertions record observed behaviour:

- one-shot `notified` guard (a later call is a no-op even after CI is cleared)
- `update.checkOnStart === false` skips the registry query; `true` and a non-false value (`0`) do not
- truthy `process.env.CI` and a non-TTY stderr skip the registry query
- `loadElizaConfig` throwing continues with defaults and still notifies
- no stderr write when `updateAvailable` is false, or when `latestVersion` is `null` or `""`
- stable channel writes `current -> latest` with no `(stable)` suffix; beta and nightly append `(channel)`
- a rejected `checkForUpdate` is swallowed (J6) and writes nothing

No production code is changed.

## Evidence

Re-fetched `origin/develop` (`e0c8501d6f4afb980daf0440adb875ba05f9e3d8`) and re-ran the suite immediately before filing. Parent of this branch is that SHA.

1. **vitest** (current develop)

```
bunx vitest run packages/app-core/src/services/update-notifier.test.ts

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  7.21s
```

2. **biome**

```
bunx biome check --write packages/app-core/src/services/update-notifier.test.ts
Checked 1 file in 17ms. No fixes applied.
```

Config was present (`biome.json` at the repo root; this checkout is not sparse).

3. **tsc** (`packages/app-core`)

```
cd packages/app-core && bunx tsc --noEmit 2>&1 | grep 'update-notifier.test.ts' ; echo "EXIT:$?"
EXIT:1
```

Empty grep: this test file introduced no TypeScript diagnostic. `tsconfig.json` is present at the repo root.

4. **diff scope**

The branch vs `origin/develop` touches only:

`packages/app-core/src/services/update-notifier.test.ts`

Hosted CI does not run on this fork contributor's pull requests; the counts above are from local `bunx vitest` / `biome` / `tsc` on this checkout. `bun run verify` was not run; this diff adds tests only and does not change production behaviour.

# Relates to

No linked issue. Test-only coverage of an untested CLI startup helper.

# Sync with develop

Rebased onto `origin/develop` `e0c8501d6f4afb980daf0440adb875ba05f9e3d8` with a single test-file commit. Zero conflicts.

# Risks

Low. Test-only; no production behaviour change.

# Background

## What does this PR do?

Adds unit coverage for `scheduleUpdateNotification`.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/services/update-notifier.test.ts` next to the source.

## Detailed testing steps

```
bunx vitest run packages/app-core/src/services/update-notifier.test.ts
```

# Evidence Details

## Real LLM-call trajectory

N/A - test-only coverage; no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no server or UI path; the suite spies on `process.stderr.write` and asserts the notice text.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface; this is a CLI stderr helper covered by unit tests.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

`bun run verify` not run (test-only diff; scoped vitest/biome/tsc quoted above). Hosted CI does not run on fork PRs.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:56b8dffc792377940cb24ab39ed4c3095cc6bd5c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
