### PR TITLE
fix(app-control): safe NaN handling in views search score sort comparator

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-search.safe-sort.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-search.safe-sort.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression coverage for views-search score sort comparator.
+ */
+import { describe, expect, it } from "vitest";
+import { __testCompareScoredView } from "./views-search.ts";
+
+function scored(id: string, score: number) {
+  return { view: { id } as any, score };
+}
+
+describe("compareScoredView", () => {
+  it("sorts descending by score", () => {
+    const sorted = [scored("b", 10), scored("a", 80), scored("c", 40)].sort(__testCompareScoredView);
+    expect(sorted.map((s) => s.view.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("treats NaN/Infinity as NEGATIVE_INFINITY sorted last", () => {
+    const sorted = [scored("nan", Number.NaN), scored("inf", Number.POSITIVE_INFINITY), scored("valid", 5)].sort(__testCompareScoredView);
+    expect(sorted[0].view.id).toBe("valid");
+    expect(sorted.slice(1).map((s) => s.view.id).sort()).toEqual(["inf", "nan"]);
+  });
+
+  it("uses view.id localeCompare as tie-break for equal scores", () => {
+    const sorted = [scored("zebra", 10), scored("apple", 10)].sort(__testCompareScoredView);
+    expect(sorted.map((s) => s.view.id)).toEqual(["apple", "zebra"]);
+  });
+});

--- a/plugins/plugin-app-control/src/actions/views-search.ts
+++ b/plugins/plugin-app-control/src/actions/views-search.ts
@@ -31,6 +31,19 @@ export interface ScoredView {
 	score: number;
 }
 
+function toScoreValue(value: number): number {
+	return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function compareScoredView(a: ScoredView, b: ScoredView): number {
+	const aScore = toScoreValue(a.score);
+	const bScore = toScoreValue(b.score);
+	if (bScore !== aScore) return bScore - aScore;
+	return a.view.id.localeCompare(b.view.id);
+}
+
+export const __testCompareScoredView = compareScoredView;
+
 export function scoreView(view: ViewSummary, query: string): number {
 	const q = query.trim().toLowerCase();
 	if (!q) return 0;
@@ -165,7 +178,7 @@ export async function runViewsSearch({
 	const scored: ScoredView[] = views
 		.map((view) => ({ view, score: scoreView(view, query) }))
 		.filter(({ score }) => score > 0)
-		.sort((a, b) => b.score - a.score);
+		.sort(compareScoredView);
 
 	const text = formatSearchResults(scored, query);
 	await callback?.({ text });


### PR DESCRIPTION
## Summary

- safe NaN handling in `views-search` keyword fallback score sort comparator
- mirrors precedent #25358 / #25832 (96% merged for score sorts; `b.score-a.score` NaN produces non-deterministic ordering)
- NaN/Infinity scores map to `NEGATIVE_INFINITY` (sorted last), finite scores descending with deterministic `view.id.localeCompare` tie-break

## Changes

- `plugins/plugin-app-control/src/actions/views-search.ts:33-48` — add `toScoreValue` guard and `compareScoredView` with id tie-break, export `__testCompareScoredView`, replace `.sort((a,b)=>b.score-a.score)` with named comparator
- `plugins/plugin-app-control/src/actions/views-search.safe-sort.test.ts:1-28` — 3 regression tests: descending order, NaN→-Infinity, id tie-break

## Exact head

| Base | Head |
|------|------|
| origin/develop@465ca0d8 | 31842a41 |

## Risks

Low. Single-file leaf comparator change, no protocol/schema/deploy impact.