### PR TITLE
fix(ui): reject non-finite pending chat turn receipts at the parse boundary

### DIFF
--- a/packages/ui/src/state/pending-chat-turns.receipt-validation.test.ts
+++ b/packages/ui/src/state/pending-chat-turns.receipt-validation.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+/**
+ * Boundary validation for pending chat turn receipts. Receipts are read back
+ * from `localStorage`, which is untrusted persisted input — any extension, any
+ * other script on the origin, or a corrupted write from an older build can put
+ * arbitrary JSON under these keys.
+ *
+ * `typeof x === "number"` accepts the non-finite doubles, and JSON can express
+ * them: `1e999` parses to `Infinity`. An accepted non-finite `sentAt` then
+ * breaks three separate downstream contracts, so the guard belongs at the
+ * parse boundary rather than at each consumer.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  listPendingChatTurns,
+  PENDING_CHAT_TURN_SETTLE_TIMEOUT_MS,
+  persistPendingChatTurn,
+} from "./pending-chat-turns";
+
+const CONVERSATION = "conv-validation";
+const KEY_PREFIX = "eliza:chat:pending-turn:";
+
+function writeRaw(clientMessageId: string, json: string): void {
+  window.localStorage.setItem(
+    `${KEY_PREFIX}${CONVERSATION}:${clientMessageId}`,
+    json,
+  );
+}
+
+function receiptJson(clientMessageId: string, sentAt: string): string {
+  return `{"conversationId":"${CONVERSATION}","clientMessageId":"${clientMessageId}","text":"draft ${clientMessageId}","sentAt":${sentAt},"restoreAt":${sentAt}}`;
+}
+
+describe("pending chat turn receipt validation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("accepts and orders well-formed receipts oldest first", () => {
+    persistPendingChatTurn({
+      conversationId: CONVERSATION,
+      clientMessageId: "b",
+      text: "second",
+      sentAt: 2_000,
+    });
+    persistPendingChatTurn({
+      conversationId: CONVERSATION,
+      clientMessageId: "a",
+      text: "first",
+      sentAt: 1_000,
+    });
+    expect(
+      listPendingChatTurns(CONVERSATION).map((r) => r.clientMessageId),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("rejects a receipt whose sentAt overflows to Infinity", () => {
+    // JSON has no Infinity literal, but 1e999 parses to it.
+    writeRaw("overflow", receiptJson("overflow", "1e999"));
+    expect(listPendingChatTurns(CONVERSATION)).toEqual([]);
+  });
+
+  it("rejects a receipt whose sentAt underflows to -Infinity", () => {
+    writeRaw("underflow", receiptJson("underflow", "-1e999"));
+    expect(listPendingChatTurns(CONVERSATION)).toEqual([]);
+  });
+
+  it("does not let a non-finite receipt displace well-formed ones", () => {
+    // Infinity - Infinity is NaN, and sort treats a NaN comparator result as
+    // "leave as is", so the good receipts stop being ordered by sentAt.
+    persistPendingChatTurn({
+      conversationId: CONVERSATION,
+      clientMessageId: "b",
+      text: "second",
+      sentAt: 2_000,
+    });
+    writeRaw("overflow", receiptJson("overflow", "1e999"));
+    persistPendingChatTurn({
+      conversationId: CONVERSATION,
+      clientMessageId: "a",
+      text: "first",
+      sentAt: 1_000,
+    });
+    expect(
+      listPendingChatTurns(CONVERSATION).map((r) => r.clientMessageId),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("still accepts a receipt whose restoreAt is the persisted settle window", () => {
+    const persisted = persistPendingChatTurn({
+      conversationId: CONVERSATION,
+      clientMessageId: "c",
+      text: "draft",
+      sentAt: 5_000,
+    });
+    expect(persisted.restoreAt).toBe(
+      5_000 + PENDING_CHAT_TURN_SETTLE_TIMEOUT_MS,
+    );
+    expect(listPendingChatTurns(CONVERSATION)).toHaveLength(1);
+  });
+
+  it("rejects a receipt whose restoreAt alone is non-finite", () => {
+    writeRaw(
+      "badrestore",
+      `{"conversationId":"${CONVERSATION}","clientMessageId":"badrestore","text":"d","sentAt":1000,"restoreAt":1e999}`,
+    );
+    expect(listPendingChatTurns(CONVERSATION)).toEqual([]);
+  });
+});

--- a/packages/ui/src/state/pending-chat-turns.ts
+++ b/packages/ui/src/state/pending-chat-turns.ts
@@ -29,8 +29,15 @@ function isReceipt(value: unknown): value is PendingChatTurnReceipt {
     typeof record?.conversationId === "string" &&
     typeof record.clientMessageId === "string" &&
     typeof record.text === "string" &&
-    typeof record.sentAt === "number" &&
-    typeof record.restoreAt === "number" &&
+    // Number.isFinite, not typeof: these come back from localStorage, which is
+    // untrusted persisted input, and `typeof NaN === "number"` while JSON's
+    // `1e999` parses to Infinity. A non-finite stamp survives to break the
+    // sentAt ordering (Infinity - Infinity is NaN), the settle comparison in
+    // clearSettledPendingChatTurns (`timestamp >= sentAt - 60_000` never holds,
+    // so the receipt is never cleared), and the restore delay derived from
+    // restoreAt. Rejecting it here keeps that guard in one place.
+    Number.isFinite(record.sentAt) &&
+    Number.isFinite(record.restoreAt) &&
     record.conversationId.length > 0 &&
     record.clientMessageId.length > 0
   );


### PR DESCRIPTION
# Relates to

Continues the safe-sort / untrusted-input sweep (same class as merged #25840, #25843). This one closes the `localStorage` boundary for pending chat turn receipts in `packages/ui`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `4ad81cf3c4fa59b85ae1937ac5b480544c8de3db`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**Low.** One predicate tightened at a single parse boundary; no signature, control-flow, or storage-format change. A receipt that is well-formed today is still accepted byte-for-byte — the only receipts newly rejected are ones carrying a non-finite stamp, which already could not be ordered, settled, or expired correctly.

The rejected receipt is dropped rather than repaired. That is the existing contract for a malformed receipt (`readReceipt` already returns `null` for unparseable JSON or a wrong-typed field), and a receipt is only a composer-draft recovery aid — the active transcript reload owns server truth, so dropping one cannot lose a sent message.

# Background

## What does this PR do?

Pending chat turn receipts are read back from `localStorage`, which is untrusted persisted input: any extension, any other script on the origin, or a corrupted write from an older build can put arbitrary JSON under these keys.

`isReceipt` validated the stamps with `typeof x === "number"`. That accepts the non-finite doubles, and JSON can express them — `1e999` parses to `Infinity`, and `typeof NaN === "number"` is likewise true. One accepted non-finite `sentAt` then breaks three separate contracts:

1. **Ordering.** `listPendingChatTurns` ends with `receipts.sort((a, b) => a.sentAt - b.sentAt)`. `Infinity - Infinity` is `NaN`, and `Array.prototype.sort` treats a NaN comparator result as "leave as is" — so the *well-formed* receipts stop being ordered by `sentAt` as well, not just the bad one.
2. **Settling.** `clearSettledPendingChatTurns` matches on `message.timestamp >= receipt.sentAt - 60_000`, which never holds against an infinite stamp. The receipt is never recognized as settled, so it is never cleared and the key leaks.
3. **Restore timing.** The composer derives its restore delay from `restoreAt` (`Math.max(0, receipt.restoreAt - Date.now())`).

Fixes it once at the parse boundary with `Number.isFinite`, per the repository rule that untrusted input is validated once and then used as the validated type, rather than re-guarding at each of the three consumers.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/pending-chat-turns.receipt-validation.test.ts` — it drives the real exported `listPendingChatTurns` / `persistPendingChatTurn` against real `localStorage` under jsdom, writing the hostile receipts as raw JSON exactly as a foreign writer would.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/state/pending-chat-turns.receipt-validation.test.ts
```

To confirm the suite is not vacuous, revert `pending-chat-turns.ts` (keep the test) and re-run — 4 of 6 fail. The other 2 are controls covering the well-formed path, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:1c54d39a16f3cf2a1e4f5b87f2477534828cbc94 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a storage-parse predicate in a state module.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a storage-parse predicate in a state module.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is receipt acceptance and ordering, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no rendered component or network call is touched; the jsdom suite below exercises the real `window.localStorage` path directly.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

### Green — with the fix, at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/state/pending-chat-turns.receipt-validation.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

### Consumers still green (no behavior regression)

```
$ npx vitest run --config ./vitest.config.ts src/state/useChatSend.test.tsx src/state/useDataLoaders.conversation-cache.test.tsx
 Test Files  2 passed (2)
      Tests  100 passed (100)
```

Both pre-existing suites that consume `listPendingChatTurns` pass unchanged.

## Domain artifacts

Behavior of the real exported function against a hostile `localStorage` entry:

| stored `sentAt` | before | after |
|---|---|---|
| `1e999` (parses to `Infinity`) | accepted as a receipt | rejected |
| `-1e999` | accepted as a receipt | rejected |
| `1000`, `2000` plus one `1e999` | good receipts returned out of `sentAt` order | `1000`, `2000` in order; bad one dropped |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Consumer suites:** 100/100 pass (`useChatSend`, `useDataLoaders.conversation-cache`).
- `packages/ui` full typecheck and full-repo `bun run verify` were not run to completion for this PR; the affected-module gates (Biome, the new jsdom suite, and both consumer suites) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
