### PR TITLE
fix(core): safe non-finite priority handling in shortcut matching

### DIFF
--- a/packages/core/src/runtime/shortcut-registry.priority-safe.test.ts
+++ b/packages/core/src/runtime/shortcut-registry.priority-safe.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Priority handling in `matchShortcut`. `ShortcutDefinition.priority` is an
+ * optional number on a plugin-supplied definition, and the three decisions that
+ * consume it all guard absence with `?? 0` — which replaces `undefined` but not
+ * a non-finite value that a plugin computed (a bad division, a parsed config
+ * field, an unchecked `Number()`).
+ *
+ * Unlike `confidence`, priority is never floored out: the confidence filter
+ * (`>= SHORTCUT_CONFIDENCE_FLOOR`) drops a NaN confidence before the sort, but
+ * nothing drops a NaN priority. It reaches the explicit-tier sort, the
+ * natural-tier tie-break, and — most consequentially — the ambiguity refusal,
+ * where `NaN === NaN` is false so two genuinely ambiguous matches stop being
+ * recognized as equal-priority and one is executed instead of deferring.
+ *
+ * Deterministic: plain definitions, no runtime, no IO.
+ */
+import { describe, expect, it } from "vitest";
+import type { ShortcutDefinition } from "../types/shortcut.ts";
+import { matchShortcut } from "./shortcut-registry.ts";
+
+function explicit(
+	id: string,
+	alias: string,
+	priority?: number,
+): ShortcutDefinition {
+	return {
+		id,
+		kind: "explicit",
+		aliases: [alias],
+		target: { kind: "navigate", path: `/${id}` },
+		...(priority === undefined ? {} : { priority }),
+	} as ShortcutDefinition;
+}
+
+function natural(
+	id: string,
+	pattern: string,
+	confidence: number,
+	priority?: number,
+): ShortcutDefinition {
+	return {
+		id,
+		kind: "natural",
+		patterns: [{ template: pattern, confidence }],
+		target: { kind: "navigate", path: `/${id}` },
+		...(priority === undefined ? {} : { priority }),
+	} as unknown as ShortcutDefinition;
+}
+
+describe("matchShortcut priority handling", () => {
+	it("picks the highest finite priority among explicit aliases", () => {
+		const match = matchShortcut(
+			[explicit("low", "/go", 1), explicit("high", "/go", 5)],
+			"/go",
+		);
+		expect(match?.shortcut.id).toBe("high");
+	});
+
+	it("does not let a NaN priority win the explicit tier over a real priority", () => {
+		const match = matchShortcut(
+			[explicit("bad", "/go", Number.NaN), explicit("high", "/go", 5)],
+			"/go",
+		);
+		expect(match?.shortcut.id).toBe("high");
+	});
+
+	it("treats a NaN priority as the absent-priority default, not as a winner", () => {
+		// `?? 0` means an absent priority is 0; a NaN priority must rank the same
+		// rather than returning NaN from the comparator.
+		const match = matchShortcut(
+			[explicit("bad", "/go", Number.NaN), explicit("none", "/go")],
+			"/go",
+		);
+		expect(match).not.toBeNull();
+		expect(["bad", "none"]).toContain(match?.shortcut.id);
+	});
+
+	it("still refuses two ambiguous natural matches at equal absent priority", () => {
+		const match = matchShortcut(
+			[natural("a", "open {x}", 0.9), natural("b", "open {x}", 0.9)],
+			"open inbox",
+			{ allowNatural: true },
+		);
+		expect(match).toBeNull();
+	});
+
+	it("refuses ambiguity when both sides carry a non-finite priority", () => {
+		// NaN === NaN is false, so the equal-priority arm of the ambiguity guard
+		// silently stops firing and one of two tied shortcuts is executed.
+		const match = matchShortcut(
+			[
+				natural("a", "open {x}", 0.9, Number.NaN),
+				natural("b", "open {x}", 0.9, Number.NaN),
+			],
+			"open inbox",
+			{ allowNatural: true },
+		);
+		expect(match).toBeNull();
+	});
+
+	it("still resolves a genuine priority difference in the natural tier", () => {
+		const match = matchShortcut(
+			[natural("a", "open {x}", 0.9, 1), natural("b", "open {x}", 0.9, 9)],
+			"open inbox",
+			{ allowNatural: true },
+		);
+		expect(match?.shortcut.id).toBe("b");
+	});
+});

--- a/packages/core/src/runtime/shortcut-registry.ts
+++ b/packages/core/src/runtime/shortcut-registry.ts
@@ -118,6 +118,23 @@ function aliasMatches(raw: string, alias: string): boolean {
 	return false;
 }
 
+/**
+ * Tiebreak priority as a usable number. `priority` is optional on a
+ * plugin-supplied definition, and `?? 0` only replaces `undefined` — a
+ * non-finite value a plugin computed (bad division, parsed config, unchecked
+ * `Number()`) passes straight through. Unlike `confidence`, priority is never
+ * floored out, so it reaches the explicit-tier sort, the natural-tier
+ * tiebreak, and the ambiguity refusal. There `NaN === NaN` is false, which
+ * silently stops two genuinely tied shortcuts from being recognized as
+ * equal-priority and executes one instead of deferring to the LLM.
+ */
+function prioritySortKey(def: ShortcutDefinition): number {
+	const priority = def.priority;
+	return typeof priority === "number" && Number.isFinite(priority)
+		? priority
+		: 0;
+}
+
 function requiredAction(def: ShortcutDefinition): string | undefined {
 	if (def.requiresAction) return def.requiresAction;
 	if (def.target.kind === "action") return def.target.name;
@@ -167,7 +184,7 @@ export function matchShortcut(
 	}
 	if (explicit.length > 0) {
 		explicit.sort(
-			(a, b) => (b.shortcut.priority ?? 0) - (a.shortcut.priority ?? 0),
+			(a, b) => prioritySortKey(b.shortcut) - prioritySortKey(a.shortcut),
 		);
 		return explicit[0] ?? null;
 	}
@@ -204,7 +221,7 @@ export function matchShortcut(
 		.filter((match) => match.confidence >= SHORTCUT_CONFIDENCE_FLOOR)
 		.sort((a, b) => {
 			if (b.confidence !== a.confidence) return b.confidence - a.confidence;
-			return (b.shortcut.priority ?? 0) - (a.shortcut.priority ?? 0);
+			return prioritySortKey(b.shortcut) - prioritySortKey(a.shortcut);
 		});
 	if (eligible.length === 0) return null;
 
@@ -215,7 +232,7 @@ export function matchShortcut(
 		runnerUp &&
 		runnerUp.shortcut.id !== top.shortcut.id &&
 		top.confidence - runnerUp.confidence < SHORTCUT_AMBIGUITY_EPSILON &&
-		(top.shortcut.priority ?? 0) === (runnerUp.shortcut.priority ?? 0)
+		prioritySortKey(top.shortcut) === prioritySortKey(runnerUp.shortcut)
 	) {
 		// Two near-ties at equal priority → ambiguous; defer to the LLM.
 		return null;


### PR DESCRIPTION
# Relates to

Continues the safe-sort sweep across ordering comparators (same class as merged #25840, #25836). This one covers shortcut matching in `packages/core`, where the same unguarded value also gates the ambiguity refusal.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `2b7f2bf9fcb2378c06a8e2c301b0f99b1adcbf1f`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**Low.** One helper added and three call sites routed through it; no signature change to `matchShortcut`, no new branch. A definition with a finite or absent priority behaves exactly as before — `prioritySortKey` returns the same `0` that `?? 0` produced for an absent priority, and returns the value itself when finite.

The only behavior change is for a definition carrying a non-finite priority, which previously could win a tier it should not have won and could suppress the ambiguity refusal.

# Background

## What does this PR do?

`ShortcutDefinition.priority` is an optional number on a **plugin-supplied** definition. All three decisions that consume it guarded absence with `?? 0`, which replaces `undefined` but not a non-finite value a plugin computed from a bad division, a parsed config field, or an unchecked `Number()`.

Unlike `confidence`, priority is never floored out. The confidence filter (`.filter((match) => match.confidence >= SHORTCUT_CONFIDENCE_FLOOR)`) drops a NaN confidence before the sort, so that path is already safe — but nothing drops a NaN priority. It reaches all three consumers:

1. **Explicit-tier sort** — `(b.shortcut.priority ?? 0) - (a.shortcut.priority ?? 0)` returns NaN, and `Array.prototype.sort` treats NaN as "leave as is", so a NaN-priority definition can beat a real one and the wrong shortcut fires.
2. **Natural-tier tiebreak** — the same subtraction, same effect.
3. **The ambiguity refusal** — `(top.shortcut.priority ?? 0) === (runnerUp.shortcut.priority ?? 0)`. `NaN === NaN` is `false`, so two genuinely tied natural matches stop being recognized as equal-priority. Instead of returning `null` and deferring to the LLM, the matcher **executes one of them**. This is the most consequential of the three: the guard exists precisely to refuse acting on an ambiguous utterance.

Adds `prioritySortKey`, which collapses a non-finite priority to the same `0` an absent priority already means, and routes all three sites through it.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/shortcut-registry.priority-safe.test.ts` — it drives the real exported `matchShortcut` with plain definitions (no runtime, no model, no IO), using the same fixture shape as the existing `shortcut-registry.test.ts`.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/runtime/shortcut-registry.priority-safe.test.ts
```

To confirm the suite is not vacuous, revert `shortcut-registry.ts` (keep the test) and re-run — 2 of 6 fail, and they are exactly the two defects above. The other 4 are controls covering ordinary priority resolution and the existing ambiguity refusal, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5e478a53616e1890547c3ef39a87b10224bcdfb5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a matcher in core.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a matcher in core.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is which shortcut matches, and whether an ambiguous utterance is refused, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > does not let a NaN priority win the explicit tier over a real priority
 FAIL > refuses ambiguity when both sides carry a non-finite priority

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

### Green — with the fix, at this exact head

```
$ npx vitest run src/runtime/shortcut-registry.priority-safe.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

### Existing shortcut suites still green (no behavior regression)

```
$ npx vitest run src/runtime/shortcut-registry.test.ts src/runtime/plugin-shortcut-lifecycle.test.ts src/services/message.shortcut-gate.test.ts
 Test Files  3 passed (3)
      Tests  42 passed (42)
```

## Domain artifacts

Behavior of the real exported `matchShortcut`:

| definitions | before | after |
|---|---|---|
| `/go` at priority `NaN` vs priority `5` | NaN-priority definition selected | priority `5` selected |
| two natural matches, both priority `NaN`, equal confidence | one is executed | `null` — deferred to the LLM, as the guard intends |
| two natural matches, priority `1` vs `9` | `9` selected | `9` selected (unchanged) |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **`packages/core` typecheck:** exits 0 with zero errors (verified on this branch's base for the same package earlier in this sweep).
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome, the new suite, and all three pre-existing shortcut suites) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
