### PR TITLE
test(shared): cover format-error

### DIFF
--- a/packages/shared/src/format-error.test.ts
+++ b/packages/shared/src/format-error.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit coverage for browser-safe error formatting helpers in format-error.ts.
+ *
+ * Verifies formatError and formatErrorWithStack across standard Error instances,
+ * custom error shapes, nested causes, plain strings, primitives, and nullish inputs.
+ */
+
+import { describe, expect, it } from "vitest";
+import { formatError, formatErrorWithStack } from "./format-error.js";
+
+describe("format-error", () => {
+  describe("formatError", () => {
+    it("extracts message from standard Error", () => {
+      const error = new Error("Something broke");
+      expect(formatError(error)).toBe("Something broke");
+    });
+
+    it("formats primitive string error", () => {
+      expect(formatError("raw error message")).toBe("raw error message");
+    });
+
+    it("formats null and undefined gracefully", () => {
+      expect(formatError(null)).toBe("null");
+      expect(formatError(undefined)).toBe("undefined");
+    });
+
+    it("formats non-Error values via string coercion", () => {
+      expect(formatError(404)).toBe("404");
+      expect(formatError({ code: "ERR" })).toBe("[object Object]");
+    });
+  });
+
+  describe("formatErrorWithStack", () => {
+    it("includes stack trace when available on Error", () => {
+      const error = new Error("Traceable failure");
+      const formatted = formatErrorWithStack(error);
+      expect(formatted).toContain("Traceable failure");
+      expect(formatted).toContain("Error: Traceable failure");
+    });
+
+    it("falls back to message when stack is unavailable", () => {
+      const error = { message: "No stack here" };
+      expect(formatErrorWithStack(error)).toContain("No stack here");
+    });
+
+    it("formats strings and primitives without error", () => {
+      expect(formatErrorWithStack("simple message")).toBe("simple message");
+      expect(formatErrorWithStack(12345)).toBe("12345");
+      expect(formatErrorWithStack(null)).toBe("null");
+      expect(formatErrorWithStack(undefined)).toBe("undefined");
+    });
+
+    it("formats nested cause details when available", () => {
+      const inner = new Error("Root cause");
+      const outer = new Error("High-level failure", { cause: inner });
+      const formatted = formatErrorWithStack(outer);
+      expect(formatted).toContain("High-level failure");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/format-error.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `formatError` and `formatErrorWithStack` across:
- Standard `Error` instances (message extraction and stack trace inclusion).
- Plain string errors, primitives (numbers), `null`, and `undefined` formatting.
- Non-Error object handling via standard string representation.
- Diagnostic formatting with nested `.cause` error structures.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`11dc597920`) |
| --- | --- | --- |
| `bunx vitest run src/format-error.test.ts` (in `packages/shared`) | N/A (new test file) | 8 passed (8 tests) |
| `bunx @biomejs/biome check packages/shared/src/format-error.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/format-error.test.ts:1-60`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 8/8 passed in `format-error.test.ts`
- [x] `lint` — Biome clean
