### PR TITLE
fix(core): safe NaN handling in hook priority and registeredAt sort comparators

### DIFF
--- a/packages/core/src/services/hook.safe-sort.test.ts
+++ b/packages/core/src/services/hook.safe-sort.test.ts
@@ -1,53 +1,49 @@
 /**
- * Regression for hook priority sort handling of NaN/Infinity.
- * Previously raw subtraction on priority/registeredAt would return NaN and corrupt ordering.
+ * Regression for hook priority sort handling of NaN/Infinity — imports production comparator.
  */
 import { describe, expect, it } from "vitest";
+import { __testCompareHookRegistrations } from "./hook.ts";
+import type { HookRegistration } from "../types/hook.ts";
 
-type HookReg = { id: string; metadata: { priority: number }; registeredAt: number };
-
-function compareHookRegs(a: HookReg, b: HookReg): number {
-  const bP =
-    typeof b.metadata.priority === "number" && Number.isFinite(b.metadata.priority)
-      ? b.metadata.priority
-      : 0;
-  const aP =
-    typeof a.metadata.priority === "number" && Number.isFinite(a.metadata.priority)
-      ? a.metadata.priority
-      : 0;
-  if (bP !== aP) return bP - aP;
-  const bT =
-    typeof b.registeredAt === "number" && Number.isFinite(b.registeredAt)
-      ? b.registeredAt
-      : 0;
-  const aT =
-    typeof a.registeredAt === "number" && Number.isFinite(a.registeredAt) ? a.registeredAt : 0;
-  if (bT !== aT) return aT - bT;
-  return String(a.id).localeCompare(String(b.id));
+function reg(id: string, priority: number, registeredAt: number): HookRegistration {
+  return {
+    id,
+    metadata: {
+      name: id,
+      description: "",
+      source: "runtime",
+      events: [],
+      priority,
+      enabled: true,
+    },
+    handler: async () => {},
+    registeredAt,
+  } as HookRegistration;
 }
 
 describe("hook priority safe-sort", () => {
-  it("treats NaN priority as 0", () => {
-    const regs: HookReg[] = [
-      { id: "b", metadata: { priority: Number.NaN }, registeredAt: 1 },
-      { id: "a", metadata: { priority: 10 }, registeredAt: 1 },
-      { id: "c", metadata: { priority: Number.POSITIVE_INFINITY }, registeredAt: 1 },
+  it("treats NaN/Infinity priority as 0 (sorted after finite)", () => {
+    const regs = [
+      reg("b", Number.NaN, 1),
+      reg("a", 10, 1),
+      reg("c", Number.POSITIVE_INFINITY, 1),
     ];
-    expect([...regs].sort(compareHookRegs).map((r) => r.id)).toEqual(["a", "b", "c"]);
+    expect([...regs].sort(__testCompareHookRegistrations).map((r) => r.id)).toEqual(["a", "b", "c"]);
   });
-
-  it("breaks ties by registeredAt ascending then id", () => {
-    const regs: HookReg[] = [
-      { id: "b", metadata: { priority: 5 }, registeredAt: 20 },
-      { id: "a", metadata: { priority: 5 }, registeredAt: 10 },
-      { id: "c", metadata: { priority: 5 }, registeredAt: Number.NaN },
+  it("sorts by priority desc, then registeredAt asc, then numeric id", () => {
+    const regs = [
+      reg("hook_10_test", 5, 10),
+      reg("hook_9_test", 5, 10),
+      reg("hook_2_test", 5, 10),
     ];
-    expect([...regs].sort(compareHookRegs).map((r) => r.id)).toEqual(["c", "a", "b"]);
+    expect([...regs].sort(__testCompareHookRegistrations).map((r) => r.id)).toEqual([
+      "hook_2_test",
+      "hook_9_test",
+      "hook_10_test",
+    ]);
   });
-
-  it("old comparator would return NaN", () => {
-    const a = { metadata: { priority: Number.NaN }, registeredAt: 1 } as HookReg;
-    const b = { metadata: { priority: 5 }, registeredAt: 1 } as HookReg;
-    expect(Number.isNaN(b.metadata.priority - a.metadata.priority)).toBe(true);
+  it("handles NaN registeredAt as 0", () => {
+    const regs = [reg("a", 5, Number.NaN), reg("b", 5, 10)];
+    expect([...regs].sort(__testCompareHookRegistrations).map((r) => r.id)).toEqual(["a", "b"]);
   });
 });

--- a/packages/core/src/services/hook.safe-sort.test.ts
+++ b/packages/core/src/services/hook.safe-sort.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression for hook priority sort handling of NaN/Infinity.
+ * Previously raw subtraction on priority/registeredAt would return NaN and corrupt ordering.
+ */
+import { describe, expect, it } from "vitest";
+
+type HookReg = { id: string; metadata: { priority: number }; registeredAt: number };
+
+function compareHookRegs(a: HookReg, b: HookReg): number {
+  const bP =
+    typeof b.metadata.priority === "number" && Number.isFinite(b.metadata.priority)
+      ? b.metadata.priority
+      : 0;
+  const aP =
+    typeof a.metadata.priority === "number" && Number.isFinite(a.metadata.priority)
+      ? a.metadata.priority
+      : 0;
+  if (bP !== aP) return bP - aP;
+  const bT =
+    typeof b.registeredAt === "number" && Number.isFinite(b.registeredAt)
+      ? b.registeredAt
+      : 0;
+  const aT =
+    typeof a.registeredAt === "number" && Number.isFinite(a.registeredAt) ? a.registeredAt : 0;
+  if (bT !== aT) return aT - bT;
+  return String(a.id).localeCompare(String(b.id));
+}
+
+describe("hook priority safe-sort", () => {
+  it("treats NaN priority as 0", () => {
+    const regs: HookReg[] = [
+      { id: "b", metadata: { priority: Number.NaN }, registeredAt: 1 },
+      { id: "a", metadata: { priority: 10 }, registeredAt: 1 },
+      { id: "c", metadata: { priority: Number.POSITIVE_INFINITY }, registeredAt: 1 },
+    ];
+    expect([...regs].sort(compareHookRegs).map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("breaks ties by registeredAt ascending then id", () => {
+    const regs: HookReg[] = [
+      { id: "b", metadata: { priority: 5 }, registeredAt: 20 },
+      { id: "a", metadata: { priority: 5 }, registeredAt: 10 },
+      { id: "c", metadata: { priority: 5 }, registeredAt: Number.NaN },
+    ];
+    expect([...regs].sort(compareHookRegs).map((r) => r.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("old comparator would return NaN", () => {
+    const a = { metadata: { priority: Number.NaN }, registeredAt: 1 } as HookReg;
+    const b = { metadata: { priority: 5 }, registeredAt: 1 } as HookReg;
+    expect(Number.isNaN(b.metadata.priority - a.metadata.priority)).toBe(true);
+  });
+});

--- a/packages/core/src/services/hook.ts
+++ b/packages/core/src/services/hook.ts
@@ -197,10 +197,21 @@ export class HookService extends Service implements IHookService {
 				return eligibility.eligible;
 			})
 			.sort((a, b) => {
-				if (b.metadata.priority !== a.metadata.priority) {
-					return b.metadata.priority - a.metadata.priority;
-				}
-				return a.registeredAt - b.registeredAt;
+				const bP =
+					typeof b.metadata.priority === "number" && Number.isFinite(b.metadata.priority)
+						? b.metadata.priority
+						: 0;
+				const aP =
+					typeof a.metadata.priority === "number" && Number.isFinite(a.metadata.priority)
+						? a.metadata.priority
+						: 0;
+				if (bP !== aP) return bP - aP;
+				const bT =
+					typeof b.registeredAt === "number" && Number.isFinite(b.registeredAt) ? b.registeredAt : 0;
+				const aT =
+					typeof a.registeredAt === "number" && Number.isFinite(a.registeredAt) ? a.registeredAt : 0;
+				if (bT !== aT) return aT - bT;
+				return String(a.id).localeCompare(String(b.id));
 			});
 
 		// Execute hooks sequentially (allows payload modification, maintains order)

--- a/packages/core/src/services/hook.ts
+++ b/packages/core/src/services/hook.ts
@@ -119,6 +119,35 @@ function _parseFrontmatter(content: string): HookFrontmatter {
 /**
  * HookService implementation
  */
+export function compareHookRegistrations(
+	a: HookRegistration,
+	b: HookRegistration,
+): number {
+	const bP =
+		typeof b.metadata.priority === "number" &&
+		Number.isFinite(b.metadata.priority)
+			? b.metadata.priority
+			: 0;
+	const aP =
+		typeof a.metadata.priority === "number" &&
+		Number.isFinite(a.metadata.priority)
+			? a.metadata.priority
+			: 0;
+	if (bP !== aP) return bP - aP;
+	const bT =
+		typeof b.registeredAt === "number" && Number.isFinite(b.registeredAt)
+			? b.registeredAt
+			: 0;
+	const aT =
+		typeof a.registeredAt === "number" && Number.isFinite(a.registeredAt)
+			? a.registeredAt
+			: 0;
+	if (bT !== aT) return aT - bT;
+	return String(a.id).localeCompare(String(b.id), undefined, { numeric: true });
+}
+
+export const __testCompareHookRegistrations = compareHookRegistrations;
+
 export class HookService extends Service implements IHookService {
 	static serviceType = ServiceType.HOOKS;
 	capabilityDescription = "Hook registration and execution";
@@ -196,23 +225,7 @@ export class HookService extends Service implements IHookService {
 				const eligibility = this.checkEligibilityInternal(reg);
 				return eligibility.eligible;
 			})
-			.sort((a, b) => {
-				const bP =
-					typeof b.metadata.priority === "number" && Number.isFinite(b.metadata.priority)
-						? b.metadata.priority
-						: 0;
-				const aP =
-					typeof a.metadata.priority === "number" && Number.isFinite(a.metadata.priority)
-						? a.metadata.priority
-						: 0;
-				if (bP !== aP) return bP - aP;
-				const bT =
-					typeof b.registeredAt === "number" && Number.isFinite(b.registeredAt) ? b.registeredAt : 0;
-				const aT =
-					typeof a.registeredAt === "number" && Number.isFinite(a.registeredAt) ? a.registeredAt : 0;
-				if (bT !== aT) return aT - bT;
-				return String(a.id).localeCompare(String(b.id));
-			});
+			.sort(compareHookRegistrations);
 
 		// Execute hooks sequentially (allows payload modification, maintains order)
 		for (const registration of registrations) {


### PR DESCRIPTION
## Summary
Guards hook execution ordering against non-finite priority and timestamps. Previously `b.metadata.priority - a.metadata.priority` and `a.registeredAt - b.registeredAt` returned `NaN` for `NaN`/`Infinity` inputs, causing `Array.prototype.sort` to treat the comparator as 0 and corrupt the total order.

## Changes
- In `packages/core/src/services/hook.ts:199`, guard `priority` with `Number.isFinite` falling back to `0`, guard `registeredAt` similarly, and add `id` tiebreaker via `localeCompare`.
- In `packages/core/src/services/hook.safe-sort.test.ts`, add regression covering `NaN`/`Infinity` priority and `registeredAt` tiebreak.

## Exact-head verification
| Check | Base (`origin/develop`) | Head (`99374500aa`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/services/hook.safe-sort.test.ts` (in `packages/core` via worktree) | N/A (new test) | 3 pass (3 tests) |
| `bunx @biomejs/biome check packages/core/src/services/hook.ts` | 0 errors | 0 errors |

## Reviewer start
- `packages/core/src/services/hook.ts:199-215`
- `packages/core/src/services/hook.safe-sort.test.ts:1-30`

## Risks
Low. Total order preserved, only non-finite inputs gain defined position. For all-finite inputs ordering identical plus deterministic tiebreak.

## Attribution
Authored by @byt61.

## Evidence Gate
- [x] `audit:app` — N/A
- [x] `audit:browser` — N/A
- [x] `build` — Clean
- [x] `test` — 3/3 pass
- [x] `lint` — Biome clean
