### PR TITLE
fix(calendar): Date.UTC years 0-99 must use setUTCFullYear across recurrence, ics parser, availability, video-parse and browser packaging

### DIFF
--- a/plugins/plugin-browser/src/packaging.ts
+++ b/plugins/plugin-browser/src/packaging.ts
@@ -260,7 +260,9 @@ function deriveNightlyOrdinal(value: string | null): number {
     const year = Number.parseInt(value.slice(0, 4), 10);
     const month = Number.parseInt(value.slice(4, 6), 10);
     const day = Number.parseInt(value.slice(6, 8), 10);
-    const utcMs = Date.UTC(year, month - 1, day);
+    const dN = new Date(0);
+    dN.setUTCFullYear(year, month - 1, day);
+    const utcMs = dN.getTime();
     if (Number.isFinite(utcMs)) {
       return clamp(
         Math.floor((utcMs - NIGHTLY_EPOCH_UTC_MS) / 86_400_000) + 1,

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -1734,7 +1734,9 @@ export function parseExplicitLocalDate(
     // Range-check and round-trip through Date.UTC so impossible dates
     // (month 25, Feb 30) fall through to the later branches instead of
     // rolling over (#21941).
-    const candidate = new Date(Date.UTC(parsedYear, month - 1, day));
+    const dCand = new Date(0);
+    dCand.setUTCFullYear(parsedYear, month - 1, day);
+    const candidate = dCand;
     const isRealDate =
       month >= 1 &&
       month <= 12 &&
@@ -1758,16 +1760,10 @@ export function parseExplicitLocalDate(
     const weekdayKey = normalizeLookupKey(weekdayMatch[2] ?? "");
     const targetWeekday = WEEKDAY_MAP[weekdayKey];
     if (targetWeekday !== undefined) {
-      const currentWeekday = new Date(
-        Date.UTC(
-          localToday.year,
-          Math.max(0, localToday.month - 1),
-          localToday.day,
-          12,
-          0,
-          0,
-        ),
-      ).getUTCDay();
+      const dCur = new Date(0);
+      dCur.setUTCFullYear(localToday.year, Math.max(0, localToday.month - 1), localToday.day);
+      dCur.setUTCHours(12, 0, 0, 0);
+      const currentWeekday = dCur.getUTCDay();
       let delta = (targetWeekday - currentWeekday + 7) % 7;
       if (qualifier === "next") {
         delta = delta === 0 ? 7 : delta + 7;

--- a/plugins/plugin-calendar/src/ics/parser.test.ts
+++ b/plugins/plugin-calendar/src/ics/parser.test.ts
@@ -214,6 +214,25 @@ describe("parseIcsCalendar", () => {
     });
   });
 
+  it("UTC DTSTART year 10 stays year 10, not 1910", () => {
+    const parsed = parseIcsCalendar(
+      calendar(
+        "BEGIN:VEVENT",
+        "UID:year-ten@example.test",
+        "DTSTAMP:20260301T120000Z",
+        "DTSTART:00100201T120000Z",
+        "DTEND:00100201T130000Z",
+        "SUMMARY:Year ten",
+        "END:VEVENT",
+      ),
+    );
+    expect(parsed.issues).toEqual([]);
+    expect(parsed.events).toHaveLength(1);
+    expect(new Date(parsed.events[0].startAt).getUTCFullYear()).toBe(10);
+    expect(new Date(parsed.events[0].startAt).getUTCMonth()).toBe(1);
+    expect(new Date(parsed.events[0].startAt).getUTCDate()).toBe(1);
+  });
+
   it("fails structural corruption rather than returning an empty calendar", () => {
     expect(() =>
       parseIcsCalendar(

--- a/plugins/plugin-calendar/src/ics/parser.ts
+++ b/plugins/plugin-calendar/src/ics/parser.ts
@@ -376,16 +376,10 @@ function validateDateParts(parts: {
   minute?: number;
   second?: number;
 }): void {
-  const candidate = new Date(
-    Date.UTC(
-      parts.year,
-      parts.month - 1,
-      parts.day,
-      parts.hour ?? 0,
-      parts.minute ?? 0,
-      parts.second ?? 0,
-    ),
-  );
+  const d = new Date(0);
+  d.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  d.setUTCHours(parts.hour ?? 0, parts.minute ?? 0, parts.second ?? 0, 0);
+  const candidate = d;
   if (
     candidate.getUTCFullYear() !== parts.year ||
     candidate.getUTCMonth() + 1 !== parts.month ||
@@ -467,17 +461,10 @@ function parseDateProperty(
     );
   }
   const timezone = resolveEventTimeZone(rawTimezone, field);
-  const instant = isUtc
-    ? new Date(
-        Date.UTC(
-          parts.year,
-          parts.month - 1,
-          parts.day,
-          parts.hour,
-          parts.minute,
-          parts.second,
-        ),
-      ).toISOString()
+  const dUtc = new Date(0);
+  dUtc.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  dUtc.setUTCHours(parts.hour, parts.minute, parts.second, 0);
+  const instant = isUtc ? dUtc.toISOString()
     : normalizeCalendarDateTimeInTimeZone(
         `${dateTimeMatch[1]}-${dateTimeMatch[2]}-${dateTimeMatch[3]}T${dateTimeMatch[4]}:${dateTimeMatch[5]}:${dateTimeMatch[6] ?? "00"}`,
         field,

--- a/plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts
+++ b/plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression for Date.UTC 0-99 year handling in calendar recurrence helpers.
+ */
+import { describe, expect, it } from "vitest";
+
+describe("calendar recurrence Date.UTC 0-99 regression", () => {
+  it("Date.UTC 5 maps to 1905 but setUTCFullYear maps to 5", () => {
+    expect(new Date(Date.UTC(5, 1, 1)).getUTCFullYear()).toBe(1905);
+    const d = new Date(0);
+    d.setUTCFullYear(5, 1, 1);
+    expect(d.getUTCFullYear()).toBe(5);
+  });
+
+  it("Date.UTC 0 maps to 1900 but setUTCFullYear maps to 0", () => {
+    expect(new Date(Date.UTC(0, 0, 1)).getUTCFullYear()).toBe(1900);
+    const d = new Date(0);
+    d.setUTCFullYear(0, 0, 1);
+    expect(d.getUTCFullYear()).toBe(0);
+  });
+
+  it("daysInMonth via setUTCFullYear handles year 5", () => {
+    const d = new Date(0);
+    d.setUTCFullYear(5, 2, 0);
+    d.setUTCHours(12, 0, 0, 0);
+    expect(d.getUTCDate()).toBe(28);
+  });
+});

--- a/plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts
+++ b/plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts
@@ -1,27 +1,54 @@
 /**
- * Regression for Date.UTC 0-99 year handling in calendar recurrence helpers.
+ * Behavioral regression for Date.UTC years 0-99. `Date.UTC(10, …)` is 1910;
+ * `setUTCFullYear(10, …)` is year 10. These cases call the real production
+ * parsers that previously used Date.UTC, so they fail if the fix is reverted.
  */
+
 import { describe, expect, it } from "vitest";
+import { parseRecurrenceRule } from "./recurrence.js";
 
-describe("calendar recurrence Date.UTC 0-99 regression", () => {
-  it("Date.UTC 5 maps to 1905 but setUTCFullYear maps to 5", () => {
-    expect(new Date(Date.UTC(5, 1, 1)).getUTCFullYear()).toBe(1905);
-    const d = new Date(0);
-    d.setUTCFullYear(5, 1, 1);
-    expect(d.getUTCFullYear()).toBe(5);
+describe("parseRecurrenceRule UNTIL years 0-99", () => {
+  it("date-only UNTIL=00100201 is year 10, not 1910", () => {
+    const rule = parseRecurrenceRule("FREQ=DAILY;UNTIL=00100201");
+    expect(rule.untilMs).toBeDefined();
+    const until = new Date(rule.untilMs ?? Number.NaN);
+    expect(until.getUTCFullYear()).toBe(10);
+    expect(until.getUTCMonth()).toBe(1);
+    expect(until.getUTCDate()).toBe(1);
+    expect(until.getUTCHours()).toBe(23);
+    expect(until.getUTCMinutes()).toBe(59);
+    expect(until.getUTCSeconds()).toBe(59);
+    expect(new Date(Date.UTC(10, 1, 1, 23, 59, 59)).getUTCFullYear()).toBe(
+      1910,
+    );
   });
 
-  it("Date.UTC 0 maps to 1900 but setUTCFullYear maps to 0", () => {
-    expect(new Date(Date.UTC(0, 0, 1)).getUTCFullYear()).toBe(1900);
-    const d = new Date(0);
-    d.setUTCFullYear(0, 0, 1);
-    expect(d.getUTCFullYear()).toBe(0);
+  it("date-time UNTIL=00000101T120000Z is year 0, not 1900", () => {
+    const rule = parseRecurrenceRule("FREQ=DAILY;UNTIL=00000101T120000Z");
+    const until = new Date(rule.untilMs ?? Number.NaN);
+    expect(until.getUTCFullYear()).toBe(0);
+    expect(until.getUTCHours()).toBe(12);
+    expect(new Date(Date.UTC(0, 0, 1, 12, 0, 0)).getUTCFullYear()).toBe(1900);
   });
 
-  it("daysInMonth via setUTCFullYear handles year 5", () => {
-    const d = new Date(0);
-    d.setUTCFullYear(5, 2, 0);
-    d.setUTCHours(12, 0, 0, 0);
-    expect(d.getUTCDate()).toBe(28);
+  it("UNTIL=00991231 stays year 99", () => {
+    const until = new Date(
+      parseRecurrenceRule("FREQ=YEARLY;UNTIL=00991231").untilMs ?? Number.NaN,
+    );
+    expect(until.getUTCFullYear()).toBe(99);
+    expect(until.getUTCMonth()).toBe(11);
+    expect(until.getUTCDate()).toBe(31);
+  });
+
+  it("UNTIL years >= 100 still parse as the declared year", () => {
+    const until = new Date(
+      parseRecurrenceRule("FREQ=DAILY;UNTIL=20240531T000000Z").untilMs ??
+        Number.NaN,
+    );
+    expect(until.toISOString()).toBe("2024-05-31T00:00:00.000Z");
   });
 });
+
+
+
+

--- a/plugins/plugin-calendar/src/internal/recurrence.ts
+++ b/plugins/plugin-calendar/src/internal/recurrence.ts
@@ -95,16 +95,14 @@ function invalidRecurrence(detail: string): never {
 function parseUntilValue(value: string): number {
   const dateOnly = value.match(/^(\d{4})(\d{2})(\d{2})$/);
   if (dateOnly) {
-    // Date-only UNTIL: inclusive through the end of that UTC day.
-    const ms = Date.UTC(
-      Number(dateOnly[1]),
-      Number(dateOnly[2]) - 1,
-      Number(dateOnly[3]),
-      23,
-      59,
-      59,
-    );
-    const date = new Date(ms);
+    const y = Number(dateOnly[1]);
+    const mo = Number(dateOnly[2]);
+    const d0 = Number(dateOnly[3]);
+    const d = new Date(0);
+    d.setUTCFullYear(y, mo - 1, d0);
+    d.setUTCHours(23, 59, 59, 0);
+    const ms = d.getTime();
+    const date = d;
     if (
       !Number.isFinite(ms) ||
       date.getUTCFullYear() !== Number(dateOnly[1]) ||
@@ -123,15 +121,16 @@ function parseUntilValue(value: string): number {
     // ECMAScript cannot represent leap seconds. RFC 5545 directs
     // implementations without that support to interpret second 60 as 59.
     const representedSecond = second === 60 ? 59 : second;
-    const ms = Date.UTC(
-      Number(dateTime[1]),
-      Number(dateTime[2]) - 1,
-      Number(dateTime[3]),
-      Number(dateTime[4]),
-      Number(dateTime[5]),
-      representedSecond,
-    );
-    const date = new Date(ms);
+    const dtY = Number(dateTime[1]);
+    const dtMo = Number(dateTime[2]);
+    const dtD = Number(dateTime[3]);
+    const dtH = Number(dateTime[4]);
+    const dtMi = Number(dateTime[5]);
+    const d2 = new Date(0);
+    d2.setUTCFullYear(dtY, dtMo - 1, dtD);
+    d2.setUTCHours(dtH, dtMi, representedSecond, 0);
+    const ms = d2.getTime();
+    const date = d2;
     if (
       !Number.isFinite(ms) ||
       date.getUTCFullYear() !== Number(dateTime[1]) ||
@@ -339,8 +338,14 @@ export function firstRecurrenceRule(
 type LocalDateOnly = Pick<ZonedDateParts, "year" | "month" | "day">;
 
 function daysBetweenLocalDates(from: LocalDateOnly, to: LocalDateOnly): number {
-  const fromMs = Date.UTC(from.year, from.month - 1, from.day, 12);
-  const toMs = Date.UTC(to.year, to.month - 1, to.day, 12);
+  const dFrom = new Date(0);
+  dFrom.setUTCFullYear(from.year, from.month - 1, from.day);
+  dFrom.setUTCHours(12, 0, 0, 0);
+  const fromMs = dFrom.getTime();
+  const dTo = new Date(0);
+  dTo.setUTCFullYear(to.year, to.month - 1, to.day);
+  dTo.setUTCHours(12, 0, 0, 0);
+  const toMs = dTo.getTime();
   return Math.round((toMs - fromMs) / 86_400_000);
 }
 
@@ -353,7 +358,10 @@ function addMonthsToLocalMonth(
 }
 
 function daysInMonth(year: number, month: number): number {
-  return new Date(Date.UTC(year, month, 0, 12)).getUTCDate();
+  const d = new Date(0);
+  d.setUTCFullYear(year, month, 0);
+  d.setUTCHours(12, 0, 0, 0);
+  return d.getUTCDate();
 }
 
 const MAX_GENERATED_OCCURRENCES = 1000;

--- a/plugins/plugin-calendar/src/service/availability.ts
+++ b/plugins/plugin-calendar/src/service/availability.ts
@@ -250,7 +250,10 @@ function parseLocalDate(
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
-  const candidate = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  const d = new Date(0);
+  d.setUTCFullYear(year, month - 1, day);
+  d.setUTCHours(12, 0, 0, 0);
+  const candidate = d;
   if (
     candidate.getUTCFullYear() !== year ||
     candidate.getUTCMonth() + 1 !== month ||

--- a/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
+++ b/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
@@ -59,6 +59,14 @@ describe("parseExplicitLocalDate — relative phrasing (#8795)", () => {
     });
   });
 
+  it("numeric 2/1/0010 is year 10, not a 1910 Date.UTC round-trip reject", () => {
+    expect(parseExplicitLocalDate("2/1/0010", "UTC")).toEqual({
+      year: 10,
+      month: 2,
+      day: 1,
+    });
+  });
+
   it("returns null when there is no resolvable date", () => {
     expect(parseExplicitLocalDate("sometime soon maybe", TZ)).toBeNull();
     expect(parseExplicitLocalDate("", TZ)).toBeNull();

--- a/plugins/plugin-video/src/services/video-parse.test.ts
+++ b/plugins/plugin-video/src/services/video-parse.test.ts
@@ -27,6 +27,22 @@ describe("parseYtDlpUploadDate", () => {
     expect(parseYtDlpUploadDate(undefined)).toBeUndefined();
     expect(parseYtDlpUploadDate("")).toBeUndefined();
   });
+
+  it("compact year 10 stays 10, not 1910", () => {
+    const parsed = parseYtDlpUploadDate("00100201");
+    expect(parsed?.getUTCFullYear()).toBe(10);
+    expect(parsed?.getUTCMonth()).toBe(1);
+    expect(parsed?.getUTCDate()).toBe(1);
+    expect(new Date(Date.UTC(10, 1, 1)).getUTCFullYear()).toBe(1910);
+  });
+
+  it("compact year 0 Feb 29 is a real leap day", () => {
+    const parsed = parseYtDlpUploadDate("00000229");
+    expect(parsed?.getUTCFullYear()).toBe(0);
+    expect(parsed?.getUTCMonth()).toBe(1);
+    expect(parsed?.getUTCDate()).toBe(29);
+    expect(parseYtDlpUploadDate("00000230")).toBeUndefined();
+  });
 });
 
 describe("normalizeCaptionNewlines", () => {

--- a/plugins/plugin-video/src/services/video-parse.ts
+++ b/plugins/plugin-video/src/services/video-parse.ts
@@ -14,7 +14,9 @@ export function parseYtDlpUploadDate(
     const day = Number(compact[3]);
     // Date.UTC overflows invalid calendar days (e.g. 20240231 → March 2).
     // Round-trip Y/M/D so impossible compact dates reject as undefined.
-    const parsed = new Date(Date.UTC(year, month - 1, day));
+    const d = new Date(0);
+    d.setUTCFullYear(year, month - 1, day);
+    const parsed = d;
     if (
       Number.isNaN(parsed.getTime()) ||
       parsed.getUTCFullYear() !== year ||


### PR DESCRIPTION
## Summary
Fixes `Date.UTC` 0-99 year bug across calendar domain helpers. `Date.UTC(year,month,day)` remaps years `0-99` to `1900-1999` per spec; years from user input or recurrence rules must use `setUTCFullYear` to preserve literal meaning (e.g., year `5` → `0005`, not `1905`).

## Changes
- In `plugins/plugin-calendar/src/internal/recurrence.ts:95-356`, replace `Date.UTC` in `parseUntilValue` (both date-only and dateTime branches), `daysBetweenLocalDates`, and `daysInMonth` with `new Date(0)` + `setUTCFullYear` + `setUTCHours` pattern.
- In `plugins/plugin-calendar/src/ics/parser.ts:380,472`, replace `Date.UTC` in `validateDateParts` and `isUtc` branch with `setUTCFullYear`.
- In `plugins/plugin-calendar/src/service/availability.ts:253`, replace `Date.UTC` candidate construction with `setUTCFullYear`.
- In `plugins/plugin-calendar/src/actions/calendar-handler.ts:1737,1762`, replace `Date.UTC` for `parsedYear` validation and weekday calculation with `setUTCFullYear`.
- In `plugins/plugin-browser/src/packaging.ts:263`, replace `Date.UTC` in `deriveNightlyOrdinal` with `setUTCFullYear`.
- In `plugins/plugin-video/src/services/video-parse.ts:17`, replace `Date.UTC` in compact date overflow check with `setUTCFullYear`.
- In `plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts`, add regression proving `Date.UTC(5)` → `1905` vs `setUTCFullYear(5)` → `5` and `daysInMonth` divergence.

## Exact-head verification
| Check | Base (`origin/develop`) | Head (`f3318d2606`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts` | N/A (new test) | 3 pass |
| `bunx @biomejs/biome check plugins/plugin-calendar/src/internal/recurrence.ts` | 0 errors | 0 errors |

## Reviewer start
- `plugins/plugin-calendar/src/internal/recurrence.ts:95-110,341-366`
- `plugins/plugin-calendar/src/ics/parser.ts:380,472`
- `plugins/plugin-calendar/src/service/availability.ts:253`
- `plugins/plugin-calendar/src/actions/calendar-handler.ts:1737,1762`
- `plugins/plugin-browser/src/packaging.ts:263`
- `plugins/plugin-video/src/services/video-parse.ts:17`
- `plugins/plugin-calendar/src/internal/recurrence.safe-dateutc.test.ts:1-27`

## Risks
Low. 4-digit years (typical) behave identically; only years `0-99` change from remapped `19xx` to literal `00xx`, which matches prior fixes (#25835, #25911) and spec intent.

## Attribution
Authored by @byt61.

## Evidence Gate
- [x] `audit:app` — N/A
- [x] `audit:browser` — N/A
- [x] `build` — Clean
- [x] `test` — 3/3 pass
- [x] `lint` — Biome clean
