### PR TITLE
test(shared): cover branding

### DIFF
--- a/packages/shared/src/config/branding.test.ts
+++ b/packages/shared/src/config/branding.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit coverage for branding tokens and interpolation helpers in branding.ts.
+ *
+ * Verifies default branding constants, app display name fallback, and
+ * appNameInterpolationVars trimming and default value injection.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  appNameInterpolationVars,
+  type BrandingConfig,
+  DEFAULT_APP_DISPLAY_NAME,
+  DEFAULT_BRANDING,
+} from "./branding.js";
+
+describe("branding", () => {
+  it("exports expected default branding configuration", () => {
+    expect(DEFAULT_APP_DISPLAY_NAME).toBe("Eliza");
+    expect(DEFAULT_BRANDING.appName).toBe("Eliza");
+    expect(DEFAULT_BRANDING.orgName).toBe("elizaos");
+    expect(DEFAULT_BRANDING.repoName).toBe("eliza");
+    expect(DEFAULT_BRANDING.hashtag).toBe("#ElizaAgent");
+    expect(DEFAULT_BRANDING.fileExtension).toBe(".eliza-agent");
+    expect(DEFAULT_BRANDING.packageScope).toBe("elizaos");
+    expect(DEFAULT_BRANDING.docsUrl).toBeDefined();
+    expect(DEFAULT_BRANDING.appUrl).toBeDefined();
+    expect(DEFAULT_BRANDING.bugReportUrl).toContain("github.com/elizaos/eliza");
+  });
+
+  describe("appNameInterpolationVars", () => {
+    it("returns trimmed app name when provided", () => {
+      const config: BrandingConfig = {
+        ...DEFAULT_BRANDING,
+        appName: "  CustomAgent  ",
+      };
+      const vars = appNameInterpolationVars(config);
+      expect(vars).toEqual({ appName: "CustomAgent" });
+    });
+
+    it("falls back to DEFAULT_APP_DISPLAY_NAME when appName is empty or only whitespace", () => {
+      const emptyConfig: BrandingConfig = {
+        ...DEFAULT_BRANDING,
+        appName: "",
+      };
+      expect(appNameInterpolationVars(emptyConfig)).toEqual({
+        appName: "Eliza",
+      });
+
+      const whitespaceConfig: BrandingConfig = {
+        ...DEFAULT_BRANDING,
+        appName: "   \t\n  ",
+      };
+      expect(appNameInterpolationVars(whitespaceConfig)).toEqual({
+        appName: "Eliza",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/config/branding.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `DEFAULT_APP_DISPLAY_NAME`, `DEFAULT_BRANDING`, and `appNameInterpolationVars` across:
- Verification of default branding properties (`appName`, `orgName`, `repoName`, `hashtag`, `fileExtension`, `packageScope`, URLs).
- Trimming custom application names passed into `appNameInterpolationVars`.
- Falling back to `DEFAULT_APP_DISPLAY_NAME` ("Eliza") for empty or whitespace-only app names.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`0b5596f9d7`) |
| --- | --- | --- |
| `bunx vitest run src/config/branding.test.ts` (in `packages/shared`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/shared/src/config/branding.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/config/branding.test.ts:1-58`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `branding.test.ts`
- [x] `lint` — Biome clean
