### PR TITLE
test(app): cover cloud-register-all-stub

### DIFF
--- a/packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
+++ b/packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
@@ -1,19 +1,82 @@
+/**
+ * Unit tests for the ELIZA_DISABLE_WEB_SHELL cloud-registration stub. The
+ * suite imports the real stub module (not a mock) and records its no-op
+ * contracts: the four public helpers exist as functions, the sync registers
+ * return undefined, and the private-surface helpers each resolve a fresh
+ * Promise to undefined without throwing.
+ */
 import { describe, expect, it } from "vitest";
+import * as stub from "../cloud-register-all-stub.js";
 import {
   ensurePrivateCloudSurfaces,
   registerAllCloudSurfaces,
   registerPrivateCloudSurfaces,
   registerPublicCloudSurfaces,
-} from "../cloud-register-all-stub.ts";
+} from "../cloud-register-all-stub.js";
 
 describe("cloud-register-all-stub", () => {
-  it("sync registrations are no-ops", () => {
-    expect(() => registerAllCloudSurfaces()).not.toThrow();
-    expect(() => registerPublicCloudSurfaces()).not.toThrow();
+  it("exports the four registration helpers as functions", () => {
+    expect(Object.keys(stub).sort()).toEqual([
+      "ensurePrivateCloudSurfaces",
+      "registerAllCloudSurfaces",
+      "registerPrivateCloudSurfaces",
+      "registerPublicCloudSurfaces",
+    ]);
+    expect(typeof registerAllCloudSurfaces).toBe("function");
+    expect(typeof registerPublicCloudSurfaces).toBe("function");
+    expect(typeof registerPrivateCloudSurfaces).toBe("function");
+    expect(typeof ensurePrivateCloudSurfaces).toBe("function");
   });
 
-  it("async registrations resolve", async () => {
+  it("sync registrations return undefined and do not throw", () => {
+    expect(registerAllCloudSurfaces()).toBeUndefined();
+    expect(registerPublicCloudSurfaces()).toBeUndefined();
+  });
+
+  it("repeated sync registrations stay no-ops", () => {
+    expect(registerAllCloudSurfaces()).toBeUndefined();
+    expect(registerAllCloudSurfaces()).toBeUndefined();
+    expect(registerPublicCloudSurfaces()).toBeUndefined();
+    expect(registerPublicCloudSurfaces()).toBeUndefined();
+  });
+
+  it("private registrations return Promises that resolve to undefined", async () => {
+    const privateResult = registerPrivateCloudSurfaces();
+    const ensureResult = ensurePrivateCloudSurfaces();
+    expect(privateResult).toBeInstanceOf(Promise);
+    expect(ensureResult).toBeInstanceOf(Promise);
+    await expect(privateResult).resolves.toBeUndefined();
+    await expect(ensureResult).resolves.toBeUndefined();
+  });
+
+  it("successive private registrations return distinct promises", async () => {
+    const first = registerPrivateCloudSurfaces();
+    const second = registerPrivateCloudSurfaces();
+    const ensureFirst = ensurePrivateCloudSurfaces();
+    const ensureSecond = ensurePrivateCloudSurfaces();
+    expect(first).not.toBe(second);
+    expect(ensureFirst).not.toBe(ensureSecond);
+    expect(first).not.toBe(ensureFirst);
+    await expect(
+      Promise.all([first, second, ensureFirst, ensureSecond]),
+    ).resolves.toEqual([undefined, undefined, undefined, undefined]);
+  });
+
+  it("concurrent private registrations all resolve", async () => {
+    await expect(
+      Promise.all([
+        registerPrivateCloudSurfaces(),
+        ensurePrivateCloudSurfaces(),
+        registerPrivateCloudSurfaces(),
+      ]),
+    ).resolves.toEqual([undefined, undefined, undefined]);
+  });
+
+  it("mixed sync and async calls stay no-ops", async () => {
+    expect(registerAllCloudSurfaces()).toBeUndefined();
     await expect(registerPrivateCloudSurfaces()).resolves.toBeUndefined();
+    expect(registerPublicCloudSurfaces()).toBeUndefined();
     await expect(ensurePrivateCloudSurfaces()).resolves.toBeUndefined();
+    expect(registerAllCloudSurfaces()).toBeUndefined();
   });
 });


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for
`packages/app/src/shims/cloud-register-all-stub.ts`. Develop already shipped a
same-named suite that only checked `not.toThrow` / `resolves`; this PR expands
that file to record the stub's real no-op contracts.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is based on the latest fetched
      `origin/develop` (`2b7f2bf9fcb2378c06a8e2c301b0f99b1adcbf1f`) with a
      single-file test commit on top.
- [x] A reviewer can confirm the change from the focused Vitest output below.
      Hosted GitHub Actions CI does **not** run on this fork contributor PR;
      do not infer that Actions passed.

# Sync with develop

- [x] Branch parent is current `origin/develop` at
      `2b7f2bf9fcb2378c06a8e2c301b0f99b1adcbf1f`; zero conflicts.
- [x] `bun run verify` was not rerun for this test-only diff. Focused proof is
      the Vitest / Biome / `tsc` counts quoted below.

# Risks

Low. Production stub is unchanged. The suite imports the real module (not a
mock) and records observed no-op behavior: four function exports, sync helpers
return `undefined`, private helpers each return a distinct `Promise` that
resolves to `undefined`, and repeated / concurrent / mixed calls stay no-ops.

# Background

## What does this PR do?

Expands `packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts` so
the `ELIZA_DISABLE_WEB_SHELL` cloud-registration stub is covered as a real
module. Import path is `../cloud-register-all-stub.js` (the `__tests__/`
sibling of the stub; `.js` specifier matches other typecheck-clean shim tests
such as `decimal-js-light.test.ts`).

The stub's public surface is four helpers with no branches, queues, or
comparators:

- `registerAllCloudSurfaces(): void` — empty body, returns `undefined`
- `registerPublicCloudSurfaces(): void` — empty body, returns `undefined`
- `registerPrivateCloudSurfaces(): Promise<void>` — `Promise.resolve()`
- `ensurePrivateCloudSurfaces(): Promise<void>` — `Promise.resolve()`

Successive private calls return distinct promises (`p1 === p2` is false). That
is what the code does, not coalescing from the real `@elizaos/ui` registrars.

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts`

## Detailed testing steps

```bash
bunx vitest run packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
bunx biome check --write packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'cloud-register-all-stub.test' ; echo "EXIT:$?"
```

Focused proof at pushed head `e8986cf1f5765f29d12a080b5928528ea0bcc454`
against `origin/develop` `2b7f2bf9fcb2378c06a8e2c301b0f99b1adcbf1f`:

```text
RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts (7 tests) 4ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  18:58:40
   Duration  157ms (transform 34ms, setup 0ms, import 44ms, tests 4ms, environment 0ms)
```

`bunx biome check --write` on the test file: `Checked 1 file in 82ms. No fixes applied.`

`bunx tsc --noEmit` in `packages/app`, grepped for `cloud-register-all-stub.test`:
empty (grep `EXIT:1`). This file adds zero TypeScript errors versus an
untouched control.

The diff touches only
`packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The
counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:e8986cf1f5765f29d12a080b5928528ea0bcc454 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes; test-only diff.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes; test-only diff.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (7 passed / 7).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; test-only coverage of a no-op stub.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace. Test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production runtime path. Focused Vitest output is quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path.

## Known gaps / failures

Hosted GitHub Actions CI does not run on fork contributor PRs. Local Vitest
(7/7), Biome (clean), and `tsc` (this file absent from output) are the proof
set. No receipt minted: unattended session cannot finalize an interactive
identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
