### PR TITLE
fix(core): normalize non-finite hook priority at the write boundary

### DIFF
--- a/packages/core/src/services/hook.priority-safe-order.test.ts
+++ b/packages/core/src/services/hook.priority-safe-order.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Hook execution ordering. `dispatchToHooks` runs hooks sequentially so each
+ * one can modify the payload before the next sees it, which makes the order
+ * load-bearing rather than cosmetic.
+ *
+ * `HookPriority` is a bare `number`, `register` guards only absence
+ * (`options.priority ?? DEFAULT_HOOK_PRIORITY`), and `setPriority` writes the
+ * caller's value with no validation at all. A non-finite priority therefore
+ * reaches the comparator, where the subtraction returns NaN and
+ * `Array.prototype.sort` leaves the pair as is — silently reordering hooks that
+ * are themselves perfectly well-formed.
+ *
+ * Drives the real service through the real event interceptor it installs on a
+ * minimal fake runtime. No model, no DB.
+ */
+import { describe, expect, it } from "vitest";
+
+import { EventType } from "../types/events";
+import type { IAgentRuntime } from "../types/runtime";
+import { HookService } from "./hook";
+
+const EVENT = EventType.HOOK_SESSION_START;
+
+type Interceptor = (payload: unknown) => Promise<void>;
+
+function makeRuntime(sink: Map<string, Interceptor>): IAgentRuntime {
+	const noop = () => {};
+	return {
+		agentId: "00000000-0000-0000-0000-0000000000aa",
+		logger: { debug: noop, info: noop, warn: noop, error: noop, trace: noop },
+		registerEvent: (eventType: string, handler: Interceptor) => {
+			sink.set(eventType, handler);
+		},
+	} as unknown as IAgentRuntime;
+}
+
+async function runOrder(
+	priorities: Array<{ name: string; priority?: number }>,
+	mutate?: (service: HookService, ids: Map<string, string>) => void,
+): Promise<string[]> {
+	const interceptors = new Map<string, Interceptor>();
+	const service = (await HookService.start(
+		makeRuntime(interceptors),
+	)) as HookService;
+	const order: string[] = [];
+	const ids = new Map<string, string>();
+	for (const spec of priorities) {
+		const id = service.register(
+			EVENT,
+			async () => {
+				order.push(spec.name);
+			},
+			{
+				name: spec.name,
+				...(spec.priority === undefined ? {} : { priority: spec.priority }),
+			},
+		);
+		ids.set(spec.name, id);
+	}
+	mutate?.(service, ids);
+	const interceptor = interceptors.get(EVENT as unknown as string);
+	if (!interceptor) throw new Error("hook interceptor was not registered");
+	await interceptor({});
+	return order;
+}
+
+describe("hook execution order", () => {
+	it("runs higher priority hooks first", async () => {
+		expect(
+			await runOrder([
+				{ name: "low", priority: 1 },
+				{ name: "high", priority: 10 },
+				{ name: "mid", priority: 5 },
+			]),
+		).toEqual(["high", "mid", "low"]);
+	});
+
+	it("does not let a NaN priority preempt every properly-prioritized hook", async () => {
+		// The comparator returns NaN for every pair the bad hook takes part in, so
+		// sort leaves it where it started — ahead of hooks that outrank it.
+		const order = await runOrder([
+			{ name: "bad", priority: Number.NaN },
+			{ name: "p9", priority: 9 },
+			{ name: "p5", priority: 5 },
+			{ name: "p1", priority: 1 },
+		]);
+		expect(order[0]).not.toBe("bad");
+		expect(order.filter((n) => n !== "bad")).toEqual(["p9", "p5", "p1"]);
+	});
+
+	it("treats a NaN priority as the default priority", async () => {
+		// DEFAULT_HOOK_PRIORITY is 0, so an unusable priority must rank below a
+		// positive one and above a negative one instead of returning NaN.
+		expect(
+			await runOrder([
+				{ name: "bad", priority: Number.NaN },
+				{ name: "positive", priority: 5 },
+				{ name: "negative", priority: -5 },
+			]),
+		).toEqual(["positive", "bad", "negative"]);
+	});
+
+	it("does not let setPriority(NaN) promote a hook above its peers", async () => {
+		// setPriority performs no validation at all, so this is the most direct
+		// route for a non-finite priority to reach the comparator.
+		const order = await runOrder(
+			[
+				{ name: "bad", priority: 8 },
+				{ name: "positive", priority: 5 },
+				{ name: "negative", priority: -5 },
+			],
+			(service, ids) => {
+				const id = ids.get("bad");
+				if (id) service.setPriority(id, Number.NaN);
+			},
+		);
+		// DEFAULT_HOOK_PRIORITY is 0, so the demoted hook belongs between them.
+		expect(order).toEqual(["positive", "bad", "negative"]);
+	});
+
+	it("keeps registration order for equal priorities", async () => {
+		expect(
+			await runOrder([
+				{ name: "first", priority: 5 },
+				{ name: "second", priority: 5 },
+			]),
+		).toEqual(["first", "second"]);
+	});
+});

--- a/packages/core/src/services/hook.ts
+++ b/packages/core/src/services/hook.ts
@@ -119,6 +119,26 @@ function _parseFrontmatter(content: string): HookFrontmatter {
 /**
  * HookService implementation
  */
+/**
+ * Hook priority as a usable number. `HookPriority` is a bare `number`, so a
+ * caller can supply a non-finite one — `register` previously guarded only
+ * absence via `?? DEFAULT_HOOK_PRIORITY`, and `setPriority` applied the value
+ * with no validation at all.
+ *
+ * `dispatchToHooks` runs hooks sequentially so each can modify the payload
+ * before the next sees it, which makes the order load-bearing. A non-finite
+ * priority makes the ordering subtraction return NaN, and `Array.prototype.sort`
+ * treats NaN as "leave as is", so the hook keeps its arrival position and
+ * preempts hooks that properly outrank it. Normalizing at both write points
+ * keeps every later reader — ordering, reporting, snapshots — on a finite
+ * value.
+ */
+function normalizeHookPriority(priority: HookPriority | undefined): HookPriority {
+	return typeof priority === "number" && Number.isFinite(priority)
+		? priority
+		: DEFAULT_HOOK_PRIORITY;
+}
+
 export class HookService extends Service implements IHookService {
 	static serviceType = ServiceType.HOOKS;
 	capabilityDescription = "Hook registration and execution";
@@ -251,7 +271,7 @@ export class HookService extends Service implements IHookService {
 			source: options.source ?? "runtime",
 			pluginId: options.pluginId,
 			events: eventArray,
-			priority: options.priority ?? DEFAULT_HOOK_PRIORITY,
+			priority: normalizeHookPriority(options.priority),
 			enabled: true,
 			always: options.always,
 			requires: options.requires,
@@ -390,7 +410,7 @@ export class HookService extends Service implements IHookService {
 	setPriority(hookId: string, priority: HookPriority): void {
 		const registration = this.registry.get(hookId);
 		if (registration) {
-			registration.metadata.priority = priority;
+			registration.metadata.priority = normalizeHookPriority(priority);
 			this.snapshotVersion++;
 		}
 	}


### PR DESCRIPTION
# Relates to

Continues the safe-ordering sweep (same class as merged #25840, #25836). This one covers hook execution order in `packages/core`, where the unguarded value also reaches a public setter.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `db58d18887fcf7d427ae5f61c6ab66a969558317`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**Low.** One helper plus two write-site normalizations; no signature change to `register` or `setPriority`, no new branch, and the comparator itself is untouched. A finite or absent priority behaves exactly as before — `normalizeHookPriority` returns the value when finite and the same `DEFAULT_HOOK_PRIORITY` that `?? DEFAULT_HOOK_PRIORITY` already produced when absent.

The only behavior change is for a non-finite priority, which previously ran ahead of everything and now ranks at the documented default. Normalizing at the write boundary rather than in the comparator means the reporting and snapshot readers of `metadata.priority` also stop seeing NaN.

# Background

## What does this PR do?

`dispatchToHooks` runs hooks sequentially so each one can modify the payload before the next sees it — the code comment says so directly ("Execute hooks sequentially (allows payload modification, maintains order)"). Execution order is therefore load-bearing, not cosmetic.

`HookPriority` is a bare `number` (`packages/core/src/types/hook.ts:29`), so a caller can supply a non-finite one. Two write paths let it through:

- `register` guarded only absence: `priority: options.priority ?? DEFAULT_HOOK_PRIORITY`. `??` replaces `undefined`, not NaN.
- `setPriority(hookId, priority)` is a public method that assigned `registration.metadata.priority = priority` with **no validation at all**.

The value then reaches the ordering comparator:

```ts
if (b.metadata.priority !== a.metadata.priority) {
  return b.metadata.priority - a.metadata.priority;
}
```

`NaN !== NaN` is `true`, so a NaN priority takes the subtraction branch and returns NaN. `Array.prototype.sort` treats a NaN comparator result as "leave as is", so the hook keeps its arrival position rather than sorting to its rank — in practice running **first**, ahead of every hook that properly outranks it.

Normalizes to `DEFAULT_HOOK_PRIORITY` at both write points so ordering, reporting, and snapshot readers all see a finite value.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/core/src/services/hook.priority-safe-order.test.ts` — it drives the real `HookService` through the real event interceptor the service installs, on a minimal fake runtime. No model, no DB.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/services/hook.priority-safe-order.test.ts
```

To confirm the suite is not vacuous, revert `hook.ts` (keep the test) and re-run — 3 of 5 fail. The other 2 are controls covering ordinary priority ordering and the equal-priority arrival tie, which must hold either way.

One honesty note on scope: at these hook counts a NaN priority does **not** observably scramble the *other* hooks' relative order, so the suite does not claim that. It asserts only what is reproducible — that the NaN-priority hook preempts hooks that outrank it, and that it should instead rank at the documented default.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a6d5810df47d3e78477db0beb77e745c23a5133b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes hook registration in core.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes hook registration in core.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is hook execution order, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > does not let a NaN priority preempt every properly-prioritized hook
 FAIL > treats a NaN priority as the default priority
 FAIL > does not let setPriority(NaN) promote a hook above its peers

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

### Green — with the fix, at this exact head

```
$ npx vitest run src/services/hook.priority-safe-order.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Existing hook suites still green (no behavior regression)

```
$ npx vitest run src/services/hook.event-enumeration.test.ts src/plugins/core-security-hooks.test.ts
 Test Files  2 passed (2)
      Tests  3 passed (3)
```

## Domain artifacts

Execution order observed by driving the real service:

| registered hooks | before | after |
|---|---|---|
| `bad=NaN, p9, p5, p1` | `bad, p9, p5, p1` — the garbage priority runs first | `p9, p5, p1, bad` |
| `bad=NaN, positive=5, negative=-5` | `bad, positive, negative` | `positive, bad, negative` (bad at `DEFAULT_HOOK_PRIORITY` = 0) |
| `setPriority(bad, NaN)` after registering at 8 | `bad, positive, negative` | `positive, bad, negative` |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **`packages/core` typecheck:** exits 0 with zero errors (verified for this package earlier in this sweep).
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome, the new suite, and the two pre-existing hook suites) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
