### PR TITLE
test(app): cover es-toolkit-compat-get

### DIFF
--- a/packages/app/src/shims/es-toolkit-compat-get.test.ts
+++ b/packages/app/src/shims/es-toolkit-compat-get.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the `es-toolkit/compat/get` browser shim. The suite drives
+ * the real re-export (named and default) and asserts lodash-style path reads,
+ * defaultValue fallback, prototype-pollution key rejection, and the string
+ * path grammar the Vite alias maps this module onto.
+ */
+import { describe, expect, it } from "vitest";
+import defaultGet, { get } from "./es-toolkit-compat-get.js";
+
+describe("es-toolkit-compat-get exports", () => {
+  it("exposes the same function as the named and default export", () => {
+    expect(typeof get).toBe("function");
+    expect(typeof defaultGet).toBe("function");
+    expect(defaultGet).toBe(get);
+  });
+});
+
+describe("get nullish source", () => {
+  it("returns undefined when the source is null or undefined and no default is given", () => {
+    expect(get(null, "a")).toBeUndefined();
+    expect(get(undefined, "a.b")).toBeUndefined();
+    expect(get(null, ["a"])).toBeUndefined();
+  });
+
+  it("returns defaultValue when the source is null or undefined", () => {
+    expect(get(null, "a", "fallback")).toBe("fallback");
+    expect(get(undefined, ["a", "b"], 0)).toBe(0);
+  });
+});
+
+describe("get simple and array paths", () => {
+  const source = {
+    a: { b: { c: 3 } },
+    items: [{ name: "first" }, { name: "second" }],
+    zero: 0,
+    empty: "",
+    flag: false,
+    none: null,
+    missing: undefined,
+  };
+
+  it("reads a single own key", () => {
+    expect(get({ a: 1 }, "a")).toBe(1);
+  });
+
+  it("reads a nested dot path", () => {
+    expect(get(source, "a.b.c")).toBe(3);
+  });
+
+  it("reads an array path", () => {
+    expect(get(source, ["a", "b", "c"])).toBe(3);
+    expect(get(source, ["items", 1, "name"])).toBe("second");
+  });
+
+  it("reads a numeric path segment on arrays and objects", () => {
+    expect(get(["x", "y"], 1)).toBe("y");
+    expect(get({ 2: "two" }, 2)).toBe("two");
+  });
+
+  it("reads a symbol path as a single segment", () => {
+    const key = Symbol("k");
+    expect(get({ [key]: 7 }, key)).toBe(7);
+  });
+
+  it("returns the source when the path array is empty", () => {
+    expect(get(source, [])).toBe(source);
+  });
+
+  it("reads an empty-string key only when that own key exists", () => {
+    expect(get({ "": "empty-key" }, "")).toBe("empty-key");
+    expect(get(source, "")).toBeUndefined();
+  });
+});
+
+describe("get defaultValue", () => {
+  const source = {
+    zero: 0,
+    empty: "",
+    flag: false,
+    none: null,
+    missing: undefined,
+  };
+
+  it("returns defaultValue for a missing path", () => {
+    expect(get(source, "nope", "fallback")).toBe("fallback");
+    expect(get(source, "a.b.c", "fallback")).toBe("fallback");
+    expect(get(source, ["zero", "child"], "fallback")).toBe("fallback");
+  });
+
+  it("returns defaultValue when the resolved value is undefined", () => {
+    expect(get(source, "missing", "fallback")).toBe("fallback");
+  });
+
+  it("preserves falsy values that are not undefined", () => {
+    expect(get(source, "zero", "fallback")).toBe(0);
+    expect(get(source, "empty", "fallback")).toBe("");
+    expect(get(source, "flag", "fallback")).toBe(false);
+    expect(get(source, "none", "fallback")).toBeNull();
+  });
+
+  it("returns defaultValue when an intermediate value is nullish", () => {
+    expect(get({ a: null }, "a.b", "fallback")).toBe("fallback");
+    expect(get({ a: undefined }, "a.b", "fallback")).toBe("fallback");
+    expect(get({ a: { b: null } }, ["a", "b", "c"], "fallback")).toBe(
+      "fallback",
+    );
+  });
+
+  it("returns defaultValue for a hole in a sparse array", () => {
+    const sparse: unknown[] = [];
+    sparse[1] = "present";
+    expect(get(sparse, 0, "fallback")).toBe("fallback");
+    expect(get(sparse, 1, "fallback")).toBe("present");
+  });
+});
+
+describe("get string path grammar", () => {
+  it("walks bracket numeric indexes mixed with dots", () => {
+    const source = { items: [{ name: "n0" }, { name: "n1" }] };
+    expect(get(source, "items[1].name")).toBe("n1");
+    expect(get(source, "[0][0][0]", "fallback")).toBe("fallback");
+    expect(get([[["z"]]], "[0][0][0]")).toBe("z");
+    expect(get([[["z"]]], "0.0.0")).toBe("z");
+  });
+
+  it("reads quoted bracket keys that contain dots", () => {
+    const source = { a: { "b.c": 11, "d'e": 12 } };
+    expect(get(source, 'a["b.c"]')).toBe(11);
+    expect(get(source, "a['d\\'e']")).toBe(12);
+  });
+
+  it("unescapes quoted bracket contents", () => {
+    const source = { a: { 'x"y': 13 } };
+    expect(get(source, 'a["x\\"y"]')).toBe(13);
+  });
+
+  it("treats a bracket number as a string key, including negatives", () => {
+    expect(get({ a: { "-1": "neg" } }, "a[-1]")).toBe("neg");
+    expect(get([1, 2, 3], "[-1]", "fallback")).toBe("fallback");
+    expect(get({ a: { "1.5": "frac" } }, "a[1.5]")).toBe("frac");
+  });
+
+  it("returns the source for a path of only dots, which parses to no segments", () => {
+    const source = { a: 1 };
+    expect(get(source, ".")).toBe(source);
+    expect(get(source, "..")).toBe(source);
+  });
+});
+
+describe("get prototype-pollution guards", () => {
+  it("refuses __proto__, constructor, and prototype string segments", () => {
+    expect(get({}, "__proto__", "fallback")).toBe("fallback");
+    expect(
+      get({ constructor: { name: "own" } }, "constructor"),
+    ).toBeUndefined();
+    expect(
+      get({ constructor: { name: "own" } }, "constructor", "fallback"),
+    ).toBe("fallback");
+    expect(get({ prototype: { x: 1 } }, "prototype", "fallback")).toBe(
+      "fallback",
+    );
+  });
+
+  it("stops walking when an unsafe segment appears in the middle of a path", () => {
+    const source = { a: { b: 2 } };
+    expect(get(source, "a.constructor.b", "fallback")).toBe("fallback");
+    expect(get(source, ["a", "__proto__", "b"], "fallback")).toBe("fallback");
+    expect(get(source, ["a", "prototype"], "fallback")).toBe("fallback");
+  });
+
+  it("does not treat a differently cased name as unsafe", () => {
+    expect(get({ Constructor: 4 }, "Constructor")).toBe(4);
+    expect(get({ Prototype: 5 }, "Prototype")).toBe(5);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/app/src/shims/es-toolkit-compat-get.ts`, which re-exports lodash-style `get` (named and default) from the local es-toolkit compat shim. The module previously had no same-named test file. This change is test-only: no production source is modified.

The suite imports the real shim (`./es-toolkit-compat-get.js`) and asserts observed behaviour:

- named and default exports are the same function
- null/undefined sources return `undefined` or the provided `defaultValue`
- simple keys, nested dots, array paths, numeric/symbol segments, empty path arrays, and empty-string keys
- `defaultValue` on missing paths, `undefined` leaves, nullish intermediates, and sparse-array holes, while preserving `0` / `""` / `false` / `null`
- bracket/dot path grammar, quoted keys, unescape, negative/fractional bracket keys, and dot-only paths (no segments → the source object)
- `__proto__` / `constructor` / `prototype` string-segment rejection, including mid-path, without treating differently cased names as unsafe

## Evidence

Hosted CI does **not** run on this fork contributor PR. Local checks against current `origin/develop` (implementation of `es-toolkit-compat-get.ts` / `es-toolkit-compat.ts` unchanged vs develop):

1. `bunx vitest run packages/app/src/shims/es-toolkit-compat-get.test.ts`

```
Test Files  1 passed (1)
     Tests  23 passed (23)
```

2. `bunx biome check --write packages/app/src/shims/es-toolkit-compat-get.test.ts` — Checked 1 file, no fixes applied. `biome.json` is present; the checkout is not sparse.

3. `cd packages/app && bunx tsc --noEmit 2>&1 | grep 'es-toolkit-compat-get.test.ts'` — empty (EXIT:1 from grep). The new test file introduced no TypeScript errors.

4. Diff touches only `packages/app/src/shims/es-toolkit-compat-get.test.ts`.

## Test plan

- [x] Vitest collects and passes the new file (23/23)
- [x] Biome clean on the new file
- [x] `tsc --noEmit` does not report the new file
- [ ] Maintainer review / merge

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:61da1788c5f891a47ac6330d7bf000a2e9996b04 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
