### PR TITLE
test(app): cover es-toolkit-compat-last

### DIFF
--- a/packages/app/src/shims/es-toolkit-compat-last.test.ts
+++ b/packages/app/src/shims/es-toolkit-compat-last.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the `es-toolkit/compat/last` browser shim. The suite drives
+ * the real re-export (named and default) and asserts lodash-style last-element
+ * reads for arrays, strings, and array-likes, including empty/nullish input
+ * and falsy last values the length gate still returns.
+ */
+import { describe, expect, it } from "vitest";
+
+import defaultLast, { last } from "./es-toolkit-compat-last.js";
+
+describe("es-toolkit-compat-last exports", () => {
+  it("re-exports the same function as both named last and default", () => {
+    expect(last).toBeTypeOf("function");
+    expect(defaultLast).toBe(last);
+  });
+});
+
+describe("last empty and nullish collection", () => {
+  it("returns undefined for null and undefined", () => {
+    expect(last(null)).toBeUndefined();
+    expect(last(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty array and empty string", () => {
+    expect(last([])).toBeUndefined();
+    expect(last("")).toBeUndefined();
+  });
+
+  it("returns undefined when length is missing or falsy", () => {
+    expect(last({} as ArrayLike<unknown>)).toBeUndefined();
+    expect(last({ length: 0 })).toBeUndefined();
+    expect(last({ 0: "present", length: 0 })).toBeUndefined();
+    expect(last({ 0: "present", length: Number.NaN })).toBeUndefined();
+  });
+});
+
+describe("last single and ordered collections", () => {
+  it("returns the only element of a one-item array", () => {
+    expect(last(["solo"])).toBe("solo");
+    expect(last([0])).toBe(0);
+  });
+
+  it("returns the final element, not the first, of a multi-item array", () => {
+    expect(last(["first", "middle", "last"])).toBe("last");
+    expect(last([1, 2, 3])).toBe(3);
+  });
+
+  it("returns a falsy last element when length is truthy", () => {
+    expect(last([1, 0])).toBe(0);
+    expect(last([1, ""])).toBe("");
+    expect(last([1, false])).toBe(false);
+    expect(last([1, null])).toBeNull();
+    expect(last([1, undefined])).toBeUndefined();
+  });
+});
+
+describe("last array-like values", () => {
+  it("returns the last character of a non-empty string", () => {
+    expect(last("a")).toBe("a");
+    expect(last("abc")).toBe("c");
+  });
+
+  it("reads length-1 from a generic array-like object", () => {
+    const arrayLike: ArrayLike<string> = { 0: "a", 1: "b", 2: "c", length: 3 };
+    expect(last(arrayLike)).toBe("c");
+  });
+
+  it("ignores own keys past length when indexing the last slot", () => {
+    const arrayLike: ArrayLike<string> = {
+      0: "a",
+      1: "b",
+      5: "ignored",
+      length: 2,
+    };
+    expect(last(arrayLike)).toBe("b");
+  });
+
+  it("returns the last typed-array byte", () => {
+    expect(last(new Uint8Array([9, 8, 7]))).toBe(7);
+    expect(last(new Uint8Array(0))).toBeUndefined();
+  });
+
+  it("returns the last arguments value", () => {
+    const fromArguments = (...values: number[]) => last(values);
+    expect(fromArguments()).toBeUndefined();
+    expect(fromArguments(10)).toBe(10);
+    expect(fromArguments(10, 20, 30)).toBe(30);
+  });
+});
+
+describe("last sparse arrays", () => {
+  it("returns the assigned last slot when earlier indexes are holes", () => {
+    const sparse: string[] = [];
+    sparse[2] = "tail";
+    expect(last(sparse)).toBe("tail");
+  });
+
+  it("returns undefined when the last index is a hole", () => {
+    const sparse: Array<string | undefined> = [];
+    sparse[0] = "head";
+    sparse.length = 3;
+    expect(last(sparse)).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated Vitest unit suite for `packages/app/src/shims/es-toolkit-compat-last.ts`, which previously had no same-named test file. Production code is unchanged.

The shim re-exports `last` (named + default) from the local lodash-compatible implementation. The suite imports the real module and records the two live branches: empty/nullish `length` returns `undefined`; otherwise the value at `collection[collection.length - 1]`.

Covered behaviour, as observed:

- named `last` and the default export are the same function
- `null`, `undefined`, empty array, empty string, missing/`0`/`NaN` length → `undefined`
- single-element collections return that element
- multi-element arrays return the final element, not the first
- falsy last values (`0`, `""`, `false`, `null`, `undefined`) are returned when `length` is truthy
- strings, typed arrays, generic array-likes, and own keys past `length` (ignored)
- sparse arrays: assigned last slot vs a hole at the last index

There is no comparator, capacity, or removal API on this helper.

## Test evidence

Evidence head: `21589f2510cf8ee9036fdc4d6844f0106911e982` (parent `origin/develop` `db58d18887fcf7d427ae5f61c6ab66a969558317`).

Re-run against current `origin/develop` immediately before filing:

```
bunx vitest run packages/app/src/shims/es-toolkit-compat-last.test.ts

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

## Lint / types

```
bunx biome check --write packages/app/src/shims/es-toolkit-compat-last.test.ts
Checked 1 file in 27ms. No fixes applied.
```

```
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'es-toolkit-compat-last.test.ts' ; echo "GREP_EXIT:$?"
GREP_EXIT:1
```

`es-toolkit-compat-last.test.ts` does not appear in the typecheck output (grep exit 1 = no matches). Pre-existing errors elsewhere in the package are not from this file.

## Diff scope

Touches only `packages/app/src/shims/es-toolkit-compat-last.test.ts`. No production behaviour change.

We are a **fork contributor**: hosted CI does **not** run on this PR. The counts above are from local `bunx vitest` / `biome` / `tsc` on this checkout. Do not treat GitHub check status as evidence that CI passed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:21589f2510cf8ee9036fdc4d6844f0106911e982 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
