### PR TITLE
test(app-core): cover preload validation status

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/preload-validation.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/preload-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: (...a: unknown[]) => mocks.existsSync(...a),
+    readFileSync: (...a: unknown[]) => mocks.readFileSync(...a),
+    statSync: (...a: unknown[]) => mocks.statSync(...a),
+  },
+}));
+
+import {
+  getElectrobunPreloadStatus,
+  readBuiltPreloadScript,
+} from "./preload-validation.ts";
+
+const fakeFs = {
+  existsSync: (p: string) => mocks.existsSync(p),
+  readFileSync: (p: string, enc: string) => mocks.readFileSync(p, enc),
+  statSync: (p: string) => mocks.statSync(p),
+} as never;
+
+describe("getElectrobunPreloadStatus", () => {
+  it("reports stale when the source is newer than preload", () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.statSync.mockImplementation((p: string) =>
+      p.includes("preload.js") ? { mtimeMs: 100 } : { mtimeMs: 200 },
+    );
+    const status = getElectrobunPreloadStatus("/app", fakeFs);
+    expect(status.preloadExists).toBe(true);
+    expect(status.sourceExists).toBe(true);
+    expect(status.stale).toBe(true);
+  });
+
+  it("reports not stale when preload is newer", () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.statSync.mockImplementation((p: string) =>
+      p.includes("preload.js") ? { mtimeMs: 300 } : { mtimeMs: 200 },
+    );
+    expect(getElectrobunPreloadStatus("/app", fakeFs).stale).toBe(false);
+  });
+
+  it("reports missing pieces without throwing", () => {
+    mocks.existsSync.mockReturnValue(false);
+    const status = getElectrobunPreloadStatus("/app", fakeFs);
+    expect(status.preloadExists).toBe(false);
+    expect(status.stale).toBe(false);
+  });
+});
+
+describe("readBuiltPreloadScript", () => {
+  it("throws when preload is missing", () => {
+    mocks.existsSync.mockReturnValue(false);
+    expect(() => readBuiltPreloadScript("/app", fakeFs)).toThrow(
+      "preload.js is missing",
+    );
+  });
+
+  it("throws when preload is stale", () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.statSync.mockImplementation((p: string) =>
+      p.includes("preload.js") ? { mtimeMs: 100 } : { mtimeMs: 200 },
+    );
+    expect(() => readBuiltPreloadScript("/app", fakeFs)).toThrow("stale");
+  });
+
+  it("throws when preload is empty", () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.statSync.mockReturnValue({ mtimeMs: 300 });
+    mocks.readFileSync.mockReturnValue("   ");
+    expect(() => readBuiltPreloadScript("/app", fakeFs)).toThrow("empty");
+  });
+
+  it("returns the preload content when valid", () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.statSync.mockReturnValue({ mtimeMs: 300 });
+    mocks.readFileSync.mockReturnValue("// preload");
+    expect(readBuiltPreloadScript("/app", fakeFs)).toBe("// preload");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/__tests__/preload-validation.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/preload-validation.test.ts
@@ -17,7 +17,7 @@ vi.mock("node:fs", () => ({
 import {
   getElectrobunPreloadStatus,
   readBuiltPreloadScript,
-} from "./preload-validation.ts";
+} from "../preload-validation.ts";
 
 const fakeFs = {
   existsSync: (p: string) => mocks.existsSync(p),


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 7 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
