### PR TITLE
fix(elizaos): keep openclaw daily-log years 0-99 literal

### DIFF
--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -99,6 +99,22 @@ export interface OcAgentSource {
 
 const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
 
+/**
+ * UTC midnight for calendar parts, keeping years 0-99 literal. `Date.UTC`
+ * remaps them into 1900-1999, and the daily-log filename pattern is `\d{4}`,
+ * so `0099-03-04.md` would land on 1999-03-04 while the record's own `date`
+ * field still reads "0099-03-04" — a self-contradicting row that then tiers
+ * the migrated memory by a timestamp 1900 years off. `OcDailyLog.epochMs` is
+ * documented as "epoch ms of the date at UTC midnight", so it has to agree
+ * with `date`.
+ */
+function utcMidnightMs(year: number, monthIndex: number, day: number): number {
+  const at = new Date(0);
+  at.setUTCFullYear(year, monthIndex, day);
+  at.setUTCHours(0, 0, 0, 0);
+  return at.getTime();
+}
+
 /** Canonical + legacy root-memory filenames (mirrors OC root-memory-files.ts). */
 const ROOT_MEMORY_CANDIDATES = ["MEMORY.md", "memory.md"] as const;
 
@@ -323,7 +339,7 @@ function readSqliteMemory(store: OcSqliteStore): {
     const m = DAILY_RE.exec(base);
     if (m) {
       const [, y, mo, d] = m;
-      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      const epochMs = utcMidnightMs(Number(y), Number(mo) - 1, Number(d));
       dailyLogs.push({
         date: `${y}-${mo}-${d}`,
         epochMs: Number.isNaN(epochMs) ? 0 : epochMs,
@@ -381,7 +397,7 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     const m = DAILY_RE.exec(filename);
     if (m) {
       const [, y, mo, d] = m;
-      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      const epochMs = utcMidnightMs(Number(y), Number(mo) - 1, Number(d));
       dailyLogs.push({
         date: `${y}-${mo}-${d}`,
         epochMs: Number.isNaN(epochMs) ? 0 : epochMs,

--- a/packages/elizaos/src/migrate/openclaw-reader.utc-year.test.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.utc-year.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `OcDailyLog.epochMs` is documented as "epoch ms of the date at UTC midnight",
+ * so it must agree with the `date` string parsed out of the same filename.
+ *
+ * `Date.UTC(year, ...)` remaps years 0-99 into 1900-1999, and the daily-log
+ * filename pattern is `\d{4}`, so `0099-03-04.md` parses to `Number("0099")`
+ * === 99 and lands on 1999-03-04 while `date` still reads "0099-03-04". The
+ * record contradicts itself, and the migration then tiers those memories by a
+ * timestamp 1900 years off.
+ *
+ * Drives the real exported reader against a real temp directory — no mocks.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readOcAgentHome } from "./openclaw-reader.ts";
+
+const made: string[] = [];
+
+function homeWithDailyLogs(names: string[]): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-utc-"));
+  made.push(home);
+  const memoryDir = path.join(home, "memory");
+  fs.mkdirSync(memoryDir, { recursive: true });
+  for (const name of names) {
+    fs.writeFileSync(path.join(memoryDir, name), `log ${name}\n`, "utf8");
+  }
+  return home;
+}
+
+/** UTC midnight for a calendar date, with years 0-99 kept literal. */
+function utcMidnight(year: number, month: number, day: number): number {
+  const d = new Date(0);
+  d.setUTCFullYear(year, month - 1, day);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+afterEach(() => {
+  while (made.length > 0) {
+    const dir = made.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("openclaw daily log epochMs", () => {
+  it("matches the parsed date for an ordinary four-digit year", () => {
+    const source = readOcAgentHome(homeWithDailyLogs(["2026-03-04.md"]), "a");
+    const log = source.dailyLogs.find((l) => l.filename === "2026-03-04.md");
+    expect(log?.date).toBe("2026-03-04");
+    expect(log?.epochMs).toBe(utcMidnight(2026, 3, 4));
+  });
+
+  it("keeps a year in 0-99 literal instead of remapping it into the 1900s", () => {
+    const source = readOcAgentHome(homeWithDailyLogs(["0099-03-04.md"]), "a");
+    const log = source.dailyLogs.find((l) => l.filename === "0099-03-04.md");
+    expect(log?.date).toBe("0099-03-04");
+    expect(log?.epochMs).toBe(utcMidnight(99, 3, 4));
+    // The remapped value Date.UTC produces is 1999-03-04.
+    expect(log?.epochMs).not.toBe(Date.UTC(99, 2, 4));
+    expect(new Date(log?.epochMs ?? 0).getUTCFullYear()).toBe(99);
+  });
+
+  it("keeps year 0000 literal", () => {
+    const source = readOcAgentHome(homeWithDailyLogs(["0000-01-01.md"]), "a");
+    const log = source.dailyLogs.find((l) => l.filename === "0000-01-01.md");
+    expect(new Date(log?.epochMs ?? 0).getUTCFullYear()).toBe(0);
+  });
+
+  it("orders low-year logs before modern ones", () => {
+    const source = readOcAgentHome(
+      homeWithDailyLogs(["2026-03-04.md", "0099-03-04.md"]),
+      "a",
+    );
+    const ordered = [...source.dailyLogs].sort((a, b) => a.epochMs - b.epochMs);
+    expect(ordered.map((l) => l.date)).toEqual(["0099-03-04", "2026-03-04"]);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `Date.UTC` years 0-99 sweep (same class as merged #25835). This one covers the openclaw migration reader in `packages/elizaos`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `db58d18887fcf7d427ae5f61c6ab66a969558317`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**Low.** Two call sites routed through one new local helper; no signature, format, or schema change. For every year >= 100 — which is every realistic daily log — `utcMidnightMs` returns exactly what `Date.UTC` returned, so ordinary migrations are byte-identical.

The behavior change is confined to years 0-99, where the previous value was demonstrably wrong (it disagreed with the record's own `date` field).

# Background

## What does this PR do?

`OcDailyLog.epochMs` is documented as *"epoch ms of the date at UTC midnight"*, so it has to agree with the `date` string parsed from the same filename.

Both daily-log readers built it with `Date.UTC(Number(y), Number(mo) - 1, Number(d))`, and `Date.UTC` remaps years 0-99 into 1900-1999. The four-digit filename pattern (`/^(\d{4})-(\d{2})-(\d{2})\.md$/`) does **not** avoid this, because `Number("0099")` is `99`:

| filename | `date` emitted | `epochMs` emitted |
|---|---|---|
| `0099-03-04.md` | `"0099-03-04"` | 1999-03-04 |
| `0000-01-01.md` | `"0000-01-01"` | 1900-01-01 |

The row contradicts itself, and the migration then tiers those memories by a timestamp up to 1900 years off.

Adds a local `utcMidnightMs` built on `setUTCFullYear`. This matches the intent of core's existing `utcDateMs`, whose own docstring already states that callers *"should prefer this over raw `Date.UTC(y,m,d)` when the year is dynamic"*. `packages/elizaos` does not depend on `@elizaos/core`, so the helper is defined locally rather than imported.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/migrate/openclaw-reader.utc-year.test.ts` — it drives the real exported `readOcAgentHome` against a real temp directory containing real `.md` files. No mocks, no stubbed filesystem.

## Detailed testing steps

```bash
cd packages/elizaos && npx vitest run src/migrate/openclaw-reader.utc-year.test.ts
```

To confirm the suite is not vacuous, revert `openclaw-reader.ts` (keep the test) and re-run — 2 of 4 fail. The other 2 are controls covering an ordinary four-digit year and epoch ordering, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5d9f8b00bef0defb6c80270b2f75d795a40340e0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a migration reader in the CLI package.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a migration reader in the CLI package.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is the epoch timestamp derived from a daily-log filename, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > keeps a year in 0-99 literal instead of remapping it into the 1900s
   AssertionError: expected 920505600000 to be -59037638400000
   (920505600000 is 1999-03-04; the filename says 0099-03-04)
 FAIL > keeps year 0000 literal
   AssertionError: expected 1900 to be +0

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

### Green — with the fix, at this exact head

```
$ npx vitest run src/migrate/openclaw-reader.utc-year.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Domain artifacts

Records emitted by the real `readOcAgentHome` for a temp home containing the named files:

| filename | `date` | `epochMs` before | `epochMs` after |
|---|---|---|---|
| `2026-03-04.md` | `2026-03-04` | 2026-03-04 | 2026-03-04 (unchanged) |
| `0099-03-04.md` | `0099-03-04` | **1999-03-04** | 0099-03-04 |
| `0000-01-01.md` | `0000-01-01` | **1900-01-01** | 0000-01-01 |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **`packages/elizaos` migrate suites:** `migrate.test.ts` fails to collect with `Failed to resolve entry for package "@elizaos/core"` — a missing workspace build artifact, not a behavior failure. It reproduces identically with this PR's change reverted:
  - baseline (fix reverted): `Test Files  2 failed | 1 passed (3)` / `Tests  2 failed | 6 passed (8)` — the 2 failing tests are this PR's own red cases
  - with the fix: `Test Files  1 failed | 2 passed (3)` / `Tests  8 passed (8)` — only the unresolvable-import suite remains
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome, the new suite, and the migrate suite A/B above) are recorded here.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
