### PR TITLE
test(shared): cover dev-settings-table

### DIFF
--- a/packages/shared/src/dev-settings-table.test.ts
+++ b/packages/shared/src/dev-settings-table.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit coverage for plain-text dev settings banner tables in dev-settings-table.ts.
+ *
+ * Exercises cell truncation, word-wrapping, Unicode box drawing (top/mid/bottom rules,
+ * framed rows), narrow layout (framed & unframed), and wide tabular layouts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  boxRow,
+  boxTopRule,
+  type DevSettingsRow,
+  formatDevSettingsTable,
+  formatDevSettingsTableNarrow,
+  truncateCell,
+  wrapToWidth,
+} from "./dev-settings-table.js";
+
+describe("dev-settings-table", () => {
+  describe("truncateCell", () => {
+    it("returns short strings unchanged", () => {
+      expect(truncateCell("hello", 10)).toBe("hello");
+      expect(truncateCell("test", 4)).toBe("test");
+    });
+
+    it("truncates long strings with ellipsis", () => {
+      expect(truncateCell("abcdefghijk", 5)).toBe("abcd…");
+    });
+
+    it("handles small maxWidth without ellipsis", () => {
+      expect(truncateCell("abcdef", 1)).toBe("a");
+      expect(truncateCell("abcdef", 0)).toBe("");
+    });
+  });
+
+  describe("wrapToWidth", () => {
+    it("returns original text when width < 1", () => {
+      expect(wrapToWidth("sample", 0)).toEqual(["sample"]);
+    });
+
+    it("handles empty or whitespace strings", () => {
+      expect(wrapToWidth("", 10)).toEqual([""]);
+      expect(wrapToWidth("   ", 10)).toEqual([""]);
+    });
+
+    it("wraps words at space boundaries", () => {
+      const text = "quick brown fox jumps over lazy dog";
+      const wrapped = wrapToWidth(text, 12);
+      expect(wrapped).toEqual(["quick brown", "fox jumps", "over lazy", "dog"]);
+    });
+
+    it("hard-breaks tokens longer than width", () => {
+      const longToken = "abcdefghijklmnop";
+      const wrapped = wrapToWidth(longToken, 5);
+      expect(wrapped).toEqual(["abcde", "fghij", "klmno", "p"]);
+    });
+  });
+
+  describe("box drawing", () => {
+    it("generates centered box top rule with title", () => {
+      const top = boxTopRule("API", 20);
+      expect(top.startsWith("╭")).toBe(true);
+      expect(top.endsWith("╮")).toBe(true);
+      expect(top).toContain(" API ");
+    });
+
+    it("generates framed row with proper padding", () => {
+      const row = boxRow("Status: OK", 30);
+      expect(row.startsWith("│")).toBe(true);
+      expect(row.endsWith("│")).toBe(true);
+      expect(row).toContain("Status: OK");
+    });
+  });
+
+  describe("formatDevSettingsTableNarrow", () => {
+    const sampleRows: DevSettingsRow[] = [
+      {
+        setting: "ELIZA_PORT",
+        effective: "3000",
+        source: "env (ELIZA_PORT)",
+        change: "Set via export ELIZA_PORT=3000",
+      },
+    ];
+
+    it("formats framed narrow table with Unicode border", () => {
+      const formatted = formatDevSettingsTableNarrow(
+        "App Server",
+        sampleRows,
+        60,
+        true,
+      );
+      expect(formatted).toContain("╭");
+      expect(formatted).toContain("App Server");
+      expect(formatted).toContain("ELIZA_PORT");
+      expect(formatted).toContain("Effective: 3000");
+      expect(formatted).toContain("╰");
+    });
+
+    it("formats unframed narrow table with plain headers", () => {
+      const formatted = formatDevSettingsTableNarrow(
+        "App Server",
+        sampleRows,
+        60,
+        false,
+      );
+      expect(formatted).toContain("=== App Server ===");
+      expect(formatted).toContain("ELIZA_PORT");
+      expect(formatted).toContain("Effective: 3000");
+      expect(formatted).not.toContain("╭");
+    });
+  });
+
+  describe("formatDevSettingsTable", () => {
+    const rows: DevSettingsRow[] = [
+      {
+        setting: "ELIZA_API_BIND",
+        effective: "127.0.0.1",
+        source: "default",
+        change: "export ELIZA_API_BIND=0.0.0.0",
+      },
+    ];
+
+    it("defaults to narrow layout", () => {
+      const formatted = formatDevSettingsTable("Dev Banner", rows);
+      expect(formatted).toContain("Dev Banner");
+      expect(formatted).toContain("ELIZA_API_BIND");
+    });
+
+    it("formats wide layout with table headers when requested", () => {
+      const formatted = formatDevSettingsTable("Dev Banner", rows, {
+        layout: "wide",
+      });
+      expect(formatted).toContain("=== Dev Banner ===");
+      expect(formatted).toContain("Setting");
+      expect(formatted).toContain("Effective");
+      expect(formatted).toContain("Source");
+      expect(formatted).toContain("Change");
+      expect(formatted).toContain("127.0.0.1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/dev-settings-table.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `truncateCell`, `wrapToWidth`, `boxTopRule`, `boxRow`, `formatDevSettingsTableNarrow`, and `formatDevSettingsTable` across:
- Unicode-safe string truncation with ellipsis and zero/single character bounds.
- Word-wrapping across whitespace boundaries, long unbroken tokens, and empty strings.
- Unicode box drawing borders (top rule, row framing).
- Narrow layout formatting with Unicode border and unframed plain header/divider styles.
- Wide 4-column tabular formatting with headers (`Setting`, `Effective`, `Source`, `Change`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`3b309000ef`) |
| --- | --- | --- |
| `bunx vitest run src/dev-settings-table.test.ts` (in `packages/shared`) | N/A (new test file) | 13 passed (13 tests) |
| `bunx @biomejs/biome check packages/shared/src/dev-settings-table.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/dev-settings-table.test.ts:1-141`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 13/13 passed in `dev-settings-table.test.ts`
- [x] `lint` — Biome clean
