### PR TITLE
test(elizaos): cover V1 agent archive format

### DIFF
--- a/packages/elizaos/src/migrate/__tests__/archive-format.test.ts
+++ b/packages/elizaos/src/migrate/__tests__/archive-format.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  pbkdf2Sync: vi.fn(() => Buffer.alloc(32, 7)),
+  randomBytes: vi.fn((size: number) => Buffer.alloc(size, 1)),
+  createCipheriv: vi.fn(),
+}));
+
+vi.mock("node:crypto", () => ({
+  pbkdf2Sync: (...a: unknown[]) => mocks.pbkdf2Sync(...a),
+  randomBytes: (...a: unknown[]) => mocks.randomBytes(...a),
+  createCipheriv: (...a: unknown[]) => mocks.createCipheriv(...a),
+}));
+
+import {
+  buildElizaAgentArchive,
+  MIN_PASSWORD_LENGTH,
+} from "./archive-format.ts";
+
+function fakeCipher() {
+  return {
+    update: vi.fn(() => Buffer.from("cipher")),
+    final: vi.fn(() => Buffer.alloc(0)),
+    getAuthTag: vi.fn(() => Buffer.alloc(16, 9)),
+  };
+}
+
+describe("buildElizaAgentArchive", () => {
+  beforeEach(() => {
+    mocks.randomBytes.mockClear();
+    mocks.createCipheriv.mockClear();
+    mocks.pbkdf2Sync.mockClear();
+  });
+
+  it("rejects short passwords", () => {
+    expect(() => buildElizaAgentArchive({}, "short")).toThrow(
+      `at least ${MIN_PASSWORD_LENGTH} characters`,
+    );
+    expect(() => buildElizaAgentArchive({}, "")).toThrow();
+  });
+
+  it("builds a V1 archive with magic header and fields", () => {
+    mocks.randomBytes.mockClear();
+    mocks.createCipheriv.mockReturnValue(fakeCipher());
+    const archive = buildElizaAgentArchive({ name: "x" }, "password-123456");
+    // 15 magic + 4 iterations + 32 salt + 12 iv + 16 tag + ciphertext
+    expect(archive.length).toBe(15 + 4 + 32 + 12 + 16 + 6);
+    expect(archive.subarray(0, 15).toString()).toBe("ELIZA_AGENT_V1\n");
+    expect(archive.readUInt32BE(15)).toBe(600_000);
+    expect(mocks.pbkdf2Sync).toHaveBeenCalledWith(
+      "password-123456",
+      expect.any(Buffer),
+      600_000,
+      32,
+      "sha256",
+    );
+    expect(mocks.createCipheriv).toHaveBeenCalledWith(
+      "aes-256-gcm",
+      expect.any(Buffer),
+      expect.any(Buffer),
+    );
+  });
+
+  it("gzip-compresses the JSON payload before encryption", () => {
+    mocks.randomBytes.mockClear();
+    mocks.createCipheriv.mockReturnValue(fakeCipher());
+    buildElizaAgentArchive({ a: 1 }, "password-123456");
+    // randomBytes 调用顺序：salt(32) → iv(12)
+    expect(mocks.randomBytes).toHaveBeenCalledTimes(2);
+    expect(mocks.createCipheriv).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/elizaos/src/migrate/__tests__/archive-format.test.ts
+++ b/packages/elizaos/src/migrate/__tests__/archive-format.test.ts
@@ -15,7 +15,7 @@ vi.mock("node:crypto", () => ({
 import {
   buildElizaAgentArchive,
   MIN_PASSWORD_LENGTH,
-} from "./archive-format.ts";
+} from "../archive-format.ts";
 
 function fakeCipher() {
   return {


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
