### PR TITLE
test(vault): cover audit

### DIFF
--- a/packages/vault/test/audit.test.ts
+++ b/packages/vault/test/audit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit coverage for append-only JSONL audit logging in audit.ts.
+ *
+ * Tests single-record appending, automatic timestamp injection, nested directory
+ * creation, error logging and fail-closed behavior on append failure.
+ */
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuditLog } from "../src/audit.js";
+
+describe("AuditLog", () => {
+  let tempDir: string;
+  let auditFilePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-audit-test-"));
+    auditFilePath = path.join(tempDir, "audit", "vault.jsonl");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("appends audit entries to jsonl file and creates parent directories", async () => {
+    const audit = new AuditLog(auditFilePath);
+
+    await audit.record({
+      action: "set",
+      key: "api.key",
+      success: true,
+      caller: "cli",
+    });
+
+    const content = await fs.readFile(auditFilePath, "utf8");
+    const lines = content.trim().split("\n");
+    expect(lines.length).toBe(1);
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.action).toBe("set");
+    expect(parsed.key).toBe("api.key");
+    expect(parsed.success).toBe(true);
+    expect(parsed.caller).toBe("cli");
+    expect(typeof parsed.ts).toBe("number");
+    expect(parsed.ts).toBeGreaterThan(0);
+  });
+
+  it("preserves explicit timestamps when provided", async () => {
+    const audit = new AuditLog(auditFilePath);
+    const customTimestamp = 1700000000000;
+
+    await audit.record({
+      action: "get",
+      key: "db.password",
+      success: false,
+      ts: customTimestamp,
+    });
+
+    const content = await fs.readFile(auditFilePath, "utf8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.ts).toBe(customTimestamp);
+    expect(parsed.action).toBe("get");
+    expect(parsed.key).toBe("db.password");
+    expect(parsed.success).toBe(false);
+  });
+
+  it("appends multiple entries monotonically", async () => {
+    const audit = new AuditLog(auditFilePath);
+
+    await audit.record({ action: "set", key: "k1", success: true });
+    await audit.record({ action: "remove", key: "k1", success: true });
+
+    const content = await fs.readFile(auditFilePath, "utf8");
+    const lines = content.trim().split("\n");
+    expect(lines.length).toBe(2);
+
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+    expect(first.action).toBe("set");
+    expect(second.action).toBe("remove");
+  });
+
+  it("fails closed, logs warning, and re-throws when appending fails", async () => {
+    const warn = vi.fn();
+    const logger = { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+    const invalidPath = path.join("/dev/null/invalid-dir", "vault.jsonl");
+    const audit = new AuditLog(invalidPath, logger);
+
+    await expect(
+      audit.record({ action: "set", key: "test", success: true }),
+    ).rejects.toThrow();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[vault] failed to append audit record"),
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for `packages/vault/src/audit.ts` (`AuditLog`), which had no corresponding test suite in `packages/vault/test/`.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `AuditLog` across:
- Appending audit entries formatted as JSONL and auto-creating parent directories.
- Default timestamp (`ts`) injection and preservation of explicit timestamps.
- Monotonic multi-record logging.
- Fail-closed security behavior: warning logger and re-throwing when filesystem writes fail.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`73977b7b73`) |
| --- | --- | --- |
| `bunx vitest run test/audit.test.ts` (in `packages/vault`) | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check test/audit.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/vault/test/audit.test.ts:1-100`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 passed in `audit.test.ts`
- [x] `lint` — Biome clean
