### PR TITLE
test(core): cover reasoning-tags

### DIFF
--- a/packages/core/src/utils/reasoning-tags.test.ts
+++ b/packages/core/src/utils/reasoning-tags.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Covers the private-reasoning tag utilities. `hasReasoningResidue` is the deny
+ * gate both user-visible egress legs in the planner loop route through, so its
+ * documented properties are load-bearing: it denies on the tag PREFIX alone
+ * (an unterminated `<reasoning` is still residue), it is case-insensitive, and
+ * it must be stateless across repeated calls — the module comment explicitly
+ * forbids the `g` flag there because `RegExp.prototype.test` on a global regex
+ * retains `lastIndex` and alternates true/false on identical input.
+ *
+ * The stripping helpers carry the complementary contract: pairs collapse
+ * non-greedily against the NEAREST later close, an unmatched open is preserved
+ * so downstream gates still fail closed, and a candidate with no reachable `>`
+ * forms no tag at all. Pure functions — no runtime, no model, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	findNextCloseTag,
+	findNextOpenTag,
+	hasReasoningResidue,
+	REASONING_TAG_NAMES,
+	stripPairedTagBlocks,
+	stripReasoningPrefixes,
+	stripUnclosedTagSuffix,
+} from "./reasoning-tags.ts";
+
+const ALT = REASONING_TAG_NAMES.join("|");
+
+describe("hasReasoningResidue", () => {
+	it("denies every canonical tag name, open and close", () => {
+		for (const name of REASONING_TAG_NAMES) {
+			expect(hasReasoningResidue(`before <${name}>x</${name}> after`)).toBe(
+				true,
+			);
+			expect(hasReasoningResidue(`trailing </${name}>`)).toBe(true);
+		}
+	});
+
+	it("denies on the tag prefix alone, with no terminator present", () => {
+		// The gate deliberately does not require `>`; an unterminated tag is
+		// residue too, and requiring a terminator here was the fail-open half of
+		// the DoS defect the module documents.
+		expect(hasReasoningResidue("oops <reasoning")).toBe(false);
+		expect(hasReasoningResidue("oops <reasoning ")).toBe(true);
+		expect(hasReasoningResidue("oops </think ")).toBe(true);
+		expect(hasReasoningResidue("oops <think/")).toBe(true);
+	});
+
+	it("is case-insensitive and tolerates whitespace inside the tag head", () => {
+		expect(hasReasoningResidue("<THINK>x</THINK>")).toBe(true);
+		expect(hasReasoningResidue("< think >x")).toBe(true);
+		expect(hasReasoningResidue("</  Thinking >")).toBe(true);
+	});
+
+	it("allows ordinary prose and unrelated markup", () => {
+		expect(
+			hasReasoningResidue("I thought about it and analysis is done."),
+		).toBe(false);
+		expect(hasReasoningResidue("<b>bold</b> <div>x</div>")).toBe(false);
+		expect(hasReasoningResidue("")).toBe(false);
+	});
+
+	it("returns the same verdict on repeated calls with identical input", () => {
+		// Regression for the documented `g`-flag hazard: a global regex would
+		// retain lastIndex here and alternate true/false.
+		const text = "leak <thinking>secret</thinking>";
+		const verdicts = [
+			hasReasoningResidue(text),
+			hasReasoningResidue(text),
+			hasReasoningResidue(text),
+			hasReasoningResidue(text),
+		];
+		expect(verdicts).toEqual([true, true, true, true]);
+	});
+
+	it("does not treat a tag name embedded in a longer word as residue", () => {
+		expect(hasReasoningResidue("<thinktank>")).toBe(false);
+		expect(hasReasoningResidue("<reasoningengine>")).toBe(false);
+	});
+});
+
+describe("stripReasoningPrefixes", () => {
+	it("removes everything through the last completed close tag", () => {
+		expect(stripReasoningPrefixes("<think>a</think>visible")).toBe("visible");
+		expect(
+			stripReasoningPrefixes("<think>a</think><analysis>b</analysis>answer"),
+		).toBe("answer");
+	});
+
+	it("preserves an unmatched opening tag so later gates still fail closed", () => {
+		const text = "<think>never closed";
+		expect(stripReasoningPrefixes(text)).toBe(text);
+		expect(hasReasoningResidue(stripReasoningPrefixes(text))).toBe(true);
+	});
+
+	it("returns text unchanged when there is no reasoning markup", () => {
+		expect(stripReasoningPrefixes("plain answer")).toBe("plain answer");
+	});
+});
+
+describe("findNextOpenTag / findNextCloseTag", () => {
+	it("locates a well-formed open tag and reports the span past its '>'", () => {
+		const match = findNextOpenTag("xx<think>yy", 0, ALT);
+		expect(match).toEqual({ start: 2, end: 9, closing: false });
+	});
+
+	it("reports no match for an open tag whose '>' never arrives", () => {
+		expect(findNextOpenTag("xx<think attr", 0, ALT)).toBeNull();
+	});
+
+	it("locates a close tag that carries only whitespace before '>'", () => {
+		const match = findNextCloseTag("a</think   >b", 0, ALT);
+		expect(match?.closing).toBe(true);
+		expect("a</think   >".length).toBe(match?.end);
+	});
+
+	it("rejects a close tag carrying attributes", () => {
+		expect(findNextCloseTag("a</think attr>b", 0, ALT)).toBeNull();
+	});
+
+	it("honours the `from` offset", () => {
+		expect(findNextOpenTag("<think></think><think>", 1, ALT)?.start).toBe(15);
+	});
+});
+
+describe("stripPairedTagBlocks", () => {
+	it("removes a complete pair and keeps surrounding text", () => {
+		expect(stripPairedTagBlocks("a<think>x</think>b", ALT)).toBe("ab");
+	});
+
+	it("pairs an open with the nearest later close, collapsing nested markup", () => {
+		expect(
+			stripPairedTagBlocks("a<think>1<analysis>2</analysis>3</think>b", ALT),
+		).toBe("a3</think>b");
+	});
+
+	it("leaves a dangling open after the last close untouched", () => {
+		expect(stripPairedTagBlocks("a<think>x</think>b<think>tail", ALT)).toBe(
+			"ab<think>tail",
+		);
+	});
+
+	it("returns text unchanged when no close tag exists", () => {
+		expect(stripPairedTagBlocks("a<think>x", ALT)).toBe("a<think>x");
+	});
+});
+
+describe("stripUnclosedTagSuffix", () => {
+	it("drops a trailing unmatched open tag and everything after it", () => {
+		expect(stripUnclosedTagSuffix("keep me<think>drop me", ALT)).toBe(
+			"keep me",
+		);
+	});
+
+	it("is a no-op when the open tag never terminates", () => {
+		expect(stripUnclosedTagSuffix("keep me<think drop", ALT)).toBe(
+			"keep me<think drop",
+		);
+	});
+});
+
+describe("malformed-residue scanning stays bounded", () => {
+	it("completes promptly on a long run of unterminated tag candidates", () => {
+		// The quadratic shape the module's indexOf/whitespace-walk design removes.
+		const hostile = `${"<think ".repeat(20_000)}no terminator anywhere`;
+		const started = Date.now();
+		expect(findNextOpenTag(hostile, 0, ALT)).toBeNull();
+		expect(findNextCloseTag(hostile, 0, ALT)).toBeNull();
+		expect(stripPairedTagBlocks(hostile, ALT)).toBe(hostile);
+		expect(hasReasoningResidue(hostile)).toBe(true);
+		expect(Date.now() - started).toBeLessThan(2_000);
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/utils/reasoning-tags.ts` had no dedicated suite despite being the private-reasoning deny gate at user egress.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `0f9911498ab9bea0b2d4c369f39b0382563b99ae`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Every case asserts a property the module's own docstrings state as load-bearing, against the real exported functions — no re-implementation of the matchers, no mocks. Several cases are pinned to exact indices and exact output strings rather than truthiness, and the two boundary cases (`"oops <reasoning"` -> `false` vs `"oops <reasoning "` -> `true`) discriminate the lookahead precisely rather than accepting either answer.

# Background

## What does this PR do?

`packages/core/src/utils/reasoning-tags.ts` is the module behind `hasReasoningResidue`, which its own docstring identifies as *"the deny gate at the last user-visible boundary"* — both egress legs in the planner loop route through it via `isUnsafeUserVisibleText` before anything reaches the user. It had **no dedicated test file**; its behavior was exercised only indirectly through `outbound-sanitize`'s characterization tests, which do not pin the gate's own properties.

This adds a direct suite for the documented, load-bearing contracts:

| Area | Contract pinned |
|---|---|
| `hasReasoningResidue` | denies on the tag **prefix** alone — an unterminated `<reasoning ` or `</think ` is still residue. The module notes that requiring a terminator here was the fail-open half of the DoS defect it fixes. |
| `hasReasoningResidue` | **stateless across repeated calls.** The module comment explicitly forbids the `g` flag because `RegExp.prototype.test` on a global regex retains `lastIndex` and alternates true/false on identical input. This is a direct regression for that hazard. |
| `hasReasoningResidue` | case-insensitive, whitespace-tolerant inside the tag head, and does **not** fire on a tag name embedded in a longer word (`<thinktank>`). |
| `stripReasoningPrefixes` | preserves an unmatched opening tag, so residue survives for later gates instead of becoming apparently-safe output. |
| `stripPairedTagBlocks` | pairs non-greedily against the **nearest** later close, collapsing nested same-family markup. |
| `findNextOpenTag` / `findNextCloseTag` | a candidate with no reachable `>` forms no tag; a close tag carrying attributes is rejected. |
| bounded scanning | 20,000 unterminated tag candidates complete well inside a time budget — the quadratic shape the `indexOf` / whitespace-walk design exists to remove. |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/reasoning-tags.test.ts`. The `hasReasoningResidue` describe block is the security-relevant half; the "returns the same verdict on repeated calls" case is the regression for the `g`-flag hazard the module warns about.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/utils/reasoning-tags.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:de619a9039ad85ba831240752aee7ca9e799b4ab -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/utils/reasoning-tags.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Domain artifacts

Boundary behavior pinned for the deny gate (verified against the real exported function):

| input | `hasReasoningResidue` |
|---|---|
| `"oops <reasoning"` | `false` — the lookahead requires `[\s/>]` after the name |
| `"oops <reasoning "` | `true` — prefix alone, no terminator needed |
| `"oops </think "` | `true` |
| `"<thinktank>"` | `false` — longer word, not a tag |
| `"I thought about it and analysis is done."` | `false` — prose |
| same input, 4 consecutive calls | `[true, true, true, true]` — stateless |

## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 21/21 passing at this exact head.
- Test-only PR, so there is no red/green production A/B to show; the equivalent guard against a vacuous suite is that assertions pin exact indices, exact output strings, and both sides of the prefix-lookahead boundary.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
