### PR TITLE
test(app): cover es-toolkit-compat-throttle

### DIFF
--- a/packages/app/src/shims/es-toolkit-compat-throttle.test.ts
+++ b/packages/app/src/shims/es-toolkit-compat-throttle.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the `es-toolkit/compat/throttle` browser shim. The suite
+ * drives the real re-export (named and default) and records leading invoke,
+ * wait-window coalescing, trailing invoke of the last args, cancel, flush,
+ * this-binding, and clock-skew (`remaining > wait`) behaviour. There is no
+ * queue, comparator, removal, or capacity API.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import throttleDefault, { throttle } from "./es-toolkit-compat-throttle.js";
+
+describe("es-toolkit-compat-throttle exports", () => {
+  it("re-exports the same function as both named throttle and default", () => {
+    expect(throttle).toBeTypeOf("function");
+    expect(throttleDefault).toBe(throttle);
+  });
+});
+
+describe("throttle wait default and leading invoke", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes on every call when wait is omitted (defaults to 0)", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttle(fn);
+    expect(throttled("a")).toBe("a");
+    expect(throttled("b")).toBe("b");
+    expect(calls).toEqual([["a"], ["b"]]);
+  });
+
+  it("invokes immediately on the first call for a positive wait", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return "first";
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("lead")).toBe("first");
+    expect(calls).toEqual([["lead"]]);
+  });
+});
+
+describe("throttle wait window, trailing invoke, and last-args", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the previous result and does not re-invoke inside the wait window", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return calls.length;
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("a")).toBe(1);
+    expect(throttled("b")).toBe(1);
+    expect(throttled("c")).toBe(1);
+    expect(calls).toEqual([["a"]]);
+  });
+
+  it("invokes once more after the wait with the last args of the window", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttle(fn, 100);
+    throttled("first");
+    throttled("second");
+    throttled("third");
+    expect(calls).toEqual([["first"]]);
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual([["first"], ["third"]]);
+  });
+
+  it("schedules only one trailing timer for many calls in the same window", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    const throttled = throttle(fn, 80);
+    throttled(1);
+    throttled(2);
+    throttled(3);
+    throttled(4);
+    vi.advanceTimersByTime(79);
+    expect(calls).toEqual([[1]]);
+    vi.advanceTimersByTime(1);
+    expect(calls).toEqual([[1], [4]]);
+  });
+
+  it("invokes immediately again once the wait has fully elapsed with no pending call", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("a")).toBe("a");
+    vi.advanceTimersByTime(100);
+    expect(throttled("b")).toBe("b");
+    expect(calls).toEqual([["a"], ["b"]]);
+  });
+
+  it("clears a pending trailing timer and invokes immediately when remaining is overdue", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    const throttled = throttle(fn, 100);
+    throttled("lead");
+    vi.setSystemTime(1_000_040);
+    throttled("pending");
+    expect(calls).toEqual([["lead"]]);
+    vi.setSystemTime(1_000_200);
+    throttled("overdue");
+    expect(calls).toEqual([["lead"], ["overdue"]]);
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual([["lead"], ["overdue"]]);
+  });
+
+  it("invokes immediately when the clock moves backwards so remaining exceeds wait", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("before")).toBe("before");
+    vi.setSystemTime(500_000);
+    expect(throttled("after-skew")).toBe("after-skew");
+    expect(calls).toEqual([["before"], ["after-skew"]]);
+  });
+
+  it("applies the last this-binding and args on the trailing invoke", () => {
+    const calls: Array<{ thisArg: unknown; args: unknown[] }> = [];
+    const fn = function fn(this: unknown, ...args: unknown[]) {
+      calls.push({ thisArg: this, args });
+      return args[0];
+    };
+    const throttled = throttle(fn, 50);
+    const firstThis = { id: "first" };
+    const lastThis = { id: "last" };
+    throttled.call(firstThis, "a");
+    throttled.call(lastThis, "b", "c");
+    vi.advanceTimersByTime(50);
+    expect(calls).toEqual([
+      { thisArg: firstThis, args: ["a"] },
+      { thisArg: lastThis, args: ["b", "c"] },
+    ]);
+  });
+});
+
+describe("throttle cancel and flush", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancel drops a pending trailing invoke", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    const throttled = throttle(fn, 100);
+    throttled("lead");
+    throttled("dropped");
+    throttled.cancel();
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual([["lead"]]);
+  });
+
+  it("cancel with no pending timer does not invoke or throw", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    const throttled = throttle(fn, 100);
+    throttled("only");
+    throttled.cancel();
+    expect(calls).toEqual([["only"]]);
+  });
+
+  it("cancel does not reset lastCall, so a call still inside the wait is deferred", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    const throttled = throttle(fn, 100);
+    throttled("lead");
+    throttled("pending");
+    throttled.cancel();
+    throttled("after-cancel");
+    expect(calls).toEqual([["lead"]]);
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual([["lead"], ["after-cancel"]]);
+  });
+
+  it("flush invokes a pending trailing call immediately and returns its result", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("lead")).toBe("lead");
+    throttled("flushed");
+    expect(throttled.flush()).toBe("flushed");
+    expect(calls).toEqual([["lead"], ["flushed"]]);
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual([["lead"], ["flushed"]]);
+  });
+
+  it("flush with no pending timer returns lastResult without invoking again", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return "result";
+    };
+    const throttled = throttle(fn, 100);
+    expect(throttled("lead")).toBe("result");
+    expect(throttled.flush()).toBe("result");
+    expect(calls).toEqual([["lead"]]);
+  });
+
+  it("flush before any call returns undefined", () => {
+    const fn = (..._args: unknown[]) => "unused";
+    const throttled = throttle(fn, 100);
+    expect(throttled.flush()).toBeUndefined();
+  });
+
+  it("selects through the default export identically to the named export", () => {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]) => {
+      calls.push(args);
+      return args[0];
+    };
+    const throttled = throttleDefault(fn, 40);
+    expect(throttled("x")).toBe("x");
+    throttled("y");
+    expect(throttled.flush()).toBe("y");
+    expect(calls).toEqual([["x"], ["y"]]);
+  });
+});


### PR DESCRIPTION

## Summary

`packages/app/src/shims/es-toolkit-compat-throttle.ts` is the Vite alias for `es-toolkit/compat/throttle`. It re-exports named and default `throttle` from the local lodash-compatible implementation and had no same-named test file.

This PR adds only `packages/app/src/shims/es-toolkit-compat-throttle.test.ts`. It imports the real shim (not a mock) and records the behaviour the implementation actually has:

- named and default exports are the same function
- omitted `wait` defaults to `0`, so every call invokes immediately
- first call in a positive window is a leading invoke
- further calls inside the window return the previous result and do not re-invoke
- one trailing timer fires with the last args and `this` of that window
- a later call after the wait with no pending work invokes immediately
- a pending trailing timer is cleared and the call invokes immediately when remaining is overdue
- a backwards clock (`remaining > wait`) invokes immediately
- `cancel` drops a pending trailing invoke and does not reset `lastCall`
- `flush` invokes a pending trailing call and returns its result; with no pending timer it returns `lastResult` without another invoke; before any call it returns `undefined`

There is no queue, comparator, removal, or capacity API on this helper.

No production source changes.

Hosted CI does not run on this fork contributor's PRs. Local checks are the evidence.

## Evidence

1. `bunx vitest run packages/app/src/shims/es-toolkit-compat-throttle.test.ts` against current `origin/develop` (`0f9911498ab9bea0b2d4c369f39b0382563b99ae`): **Test Files 1 passed (1), Tests 17 passed (17)**. Duration 133ms.
2. `bunx biome check --write packages/app/src/shims/es-toolkit-compat-throttle.test.ts`: **Checked 1 file in 615ms. No fixes applied.** `biome.json` and `tsconfig.json` are present; this worktree is not sparse.
3. `cd packages/app && bunx tsc --noEmit 2>&1 | grep 'es-toolkit-compat-throttle.test'`: empty (the new file introduces zero type errors). Pre-existing package errors, if any, are out of scope.
4. Diff vs `origin/develop` is exactly one file: `packages/app/src/shims/es-toolkit-compat-throttle.test.ts` (+260).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:de7cbae3629f7cc857872fec6c413583480d40c4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
