### PR TITLE
test(app): cover es-toolkit-compat-sumBy

### DIFF
--- a/packages/app/src/shims/es-toolkit-compat-sumBy.test.ts
+++ b/packages/app/src/shims/es-toolkit-compat-sumBy.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for the `es-toolkit/compat/sumBy` browser shim. The suite drives
+ * the real re-export (named and default) and records empty/nullish collections,
+ * identity vs iteratee (function, path, matcher), NaN-as-zero, numeric
+ * coercion, IEEE overflow of the running total, and array-like/iterable input.
+ * There is no removal, comparator, or capacity API.
+ */
+import { describe, expect, it } from "vitest";
+
+import sumByDefault, { sumBy } from "./es-toolkit-compat-sumBy.js";
+
+describe("es-toolkit-compat-sumBy exports", () => {
+  it("re-exports the same function as both named sumBy and default", () => {
+    expect(sumBy).toBeTypeOf("function");
+    expect(sumByDefault).toBe(sumBy);
+  });
+
+  it("totals through the default export identically to the named export", () => {
+    const items = [{ n: 1 }, { n: 4 }, { n: 2 }];
+    expect(sumByDefault(items, "n")).toBe(7);
+    expect(sumByDefault(items, "n")).toBe(sumBy(items, "n"));
+  });
+});
+
+describe("sumBy empty, nullish, and single-element collections", () => {
+  it("returns 0 for an empty array, with or without an iteratee", () => {
+    expect(sumBy([])).toBe(0);
+    expect(sumBy([], (n: number) => n)).toBe(0);
+  });
+
+  it("returns 0 for an empty array-like object and empty iterable", () => {
+    expect(sumBy({ length: 0 })).toBe(0);
+    expect(sumBy(new Set<number>())).toBe(0);
+  });
+
+  it("returns 0 when the runtime collection is nullish (toArray yields [])", () => {
+    expect(sumBy(null as unknown as number[])).toBe(0);
+    expect(sumBy(undefined as unknown as number[])).toBe(0);
+  });
+
+  it("returns the only numeric identity element", () => {
+    expect(sumBy([7])).toBe(7);
+    expect(sumBy([0])).toBe(0);
+    expect(sumBy([-7], (n: number) => n)).toBe(-7);
+  });
+
+  it("returns 0 when the sole element's iteratee is NaN (counted as zero)", () => {
+    expect(sumBy([Number.NaN])).toBe(0);
+    expect(sumBy([{ n: Number.NaN }], "n")).toBe(0);
+  });
+});
+
+describe("sumBy identity totals without iteratee", () => {
+  it("adds Number-coerced primitives in encounter order", () => {
+    expect(sumBy([3, 1, 2])).toBe(6);
+    expect(sumBy(["10", "2", "3"])).toBe(15);
+  });
+
+  it("treats an empty string as 0", () => {
+    expect(sumBy(["", "1"])).toBe(1);
+  });
+
+  it("treats null identity as 0 and false as 0, true as 1", () => {
+    expect(sumBy([null, 2, 1])).toBe(3);
+    expect(sumBy([true, false, true])).toBe(2);
+  });
+
+  it("adds Infinity and -Infinity as IEEE values, including a NaN total", () => {
+    expect(sumBy([Number.POSITIVE_INFINITY, 1])).toBe(Number.POSITIVE_INFINITY);
+    expect(sumBy([Number.NEGATIVE_INFINITY, 1])).toBe(Number.NEGATIVE_INFINITY);
+    expect(
+      Number.isNaN(sumBy([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])),
+    ).toBe(true);
+  });
+});
+
+describe("sumBy function and path iteratees", () => {
+  const alpha = { n: 3, nested: { v: 9 } };
+  const beta = { n: 1, nested: { v: 4 } };
+  const gamma = { n: 2, nested: { v: 1 } };
+
+  it("totals a function iteratee", () => {
+    expect(sumBy([alpha, beta, gamma], (item: { n: number }) => item.n)).toBe(
+      6,
+    );
+  });
+
+  it("totals a string property path", () => {
+    expect(sumBy([alpha, beta, gamma], "n")).toBe(6);
+  });
+
+  it("totals a dotted nested path and an array path", () => {
+    expect(sumBy([alpha, beta, gamma], "nested.v")).toBe(14);
+    expect(sumBy([alpha, beta, gamma], ["nested", "v"])).toBe(14);
+  });
+
+  it("totals a symbol key", () => {
+    const key = Symbol("n");
+    const first = { [key]: 8 };
+    const second = { [key]: 3 };
+    expect(sumBy([first, second], key)).toBe(11);
+  });
+
+  it("totals a numeric path segment on arrays", () => {
+    const items = [
+      [0, 10],
+      [0, 20],
+      [0, 5],
+    ];
+    expect(sumBy(items, 1)).toBe(35);
+  });
+
+  it("uses the item itself when iteratee is omitted, null, or undefined", () => {
+    expect(sumBy([1, 3, 2])).toBe(6);
+    expect(sumBy([1, 3, 2], null)).toBe(6);
+    expect(sumBy([1, 3, 2], undefined)).toBe(6);
+  });
+});
+
+describe("sumBy NaN-as-zero, missing paths, and unsafe segments", () => {
+  it("counts NaN iteratee values as 0 and still adds the remaining numbers", () => {
+    const nanItem = { n: Number.NaN };
+    const two = { n: 2 };
+    const one = { n: 1 };
+    expect(sumBy([nanItem, two, one], "n")).toBe(3);
+  });
+
+  it("returns 0 when every iteratee value is NaN", () => {
+    expect(sumBy([Number.NaN, Number.NaN])).toBe(0);
+    expect(sumBy([{}, { x: 1 }])).toBe(0);
+    expect(sumBy([undefined, undefined])).toBe(0);
+    expect(sumBy(["x", "y", {}])).toBe(0);
+  });
+
+  it("counts a missing property as 0 because get yields undefined (NaN)", () => {
+    const withA = { a: 1 };
+    const withoutA = { b: 99 };
+    expect(sumBy([withA, withoutA], "a")).toBe(1);
+    expect(sumBy([withoutA, withoutA], "a")).toBe(0);
+  });
+
+  it("counts unsafe __proto__, constructor, and prototype paths as 0", () => {
+    expect(sumBy([{ n: 1 }, { n: 5 }], "__proto__")).toBe(0);
+    expect(
+      sumBy(
+        [{ constructor: { name: "own" } }, { constructor: { name: "x" } }],
+        "constructor",
+      ),
+    ).toBe(0);
+    expect(sumBy([{ prototype: { x: 1 } }], "prototype")).toBe(0);
+    expect(sumBy([{ a: { b: 9 } }], ["a", "__proto__"])).toBe(0);
+  });
+
+  it("counts sparse holes as 0, which Array.from materialises as undefined", () => {
+    const sparse: number[] = [];
+    sparse[2] = 5;
+    expect(sumBy(sparse)).toBe(5);
+  });
+});
+
+describe("sumBy matcher-object iteratee", () => {
+  it("numbers the boolean match result so each match adds 1 and each miss adds 0", () => {
+    const matching = { t: true, id: "match" };
+    const nonMatching = { t: false, id: "miss" };
+    const alsoMatching = { t: true, id: "match-2" };
+    expect(sumBy([matching, nonMatching, alsoMatching], { t: true })).toBe(2);
+    expect(sumBy([nonMatching, { t: false }], { t: true })).toBe(0);
+  });
+});
+
+describe("sumBy equal values, signed zero, and overflow", () => {
+  it("adds equal iteratee values instead of keeping only the first", () => {
+    const first = { n: 5, id: "first" };
+    const second = { n: 5, id: "second" };
+    expect(sumBy([first, second], "n")).toBe(10);
+  });
+
+  it("starts from +0 so a sum of -0 values is +0", () => {
+    expect(Object.is(sumBy([-0]), 0)).toBe(true);
+    expect(Object.is(sumBy([-0, -0]), 0)).toBe(true);
+  });
+
+  it("overflows IEEE MAX_VALUE + MAX_VALUE to Infinity", () => {
+    expect(sumBy([Number.MAX_VALUE, Number.MAX_VALUE])).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("treats MAX_VALUE and MAX_VALUE + 1 as the same IEEE addend", () => {
+    expect(Number.MAX_VALUE + 1).toBe(Number.MAX_VALUE);
+    expect(sumBy([Number.MAX_VALUE, Number.MAX_VALUE + 1])).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+});
+
+describe("sumBy array-like and iterable collections", () => {
+  it("walks a non-array ArrayLike by numeric indexes", () => {
+    const first = { n: 5 };
+    const second = { n: 2 };
+    const like = { 0: first, 1: second, length: 2 };
+    expect(sumBy(like, "n")).toBe(7);
+  });
+
+  it("walks a Set of primitives in insertion order", () => {
+    expect(sumBy(new Set([3, 1, 2]))).toBe(6);
+  });
+
+  it("walks a generator iterable", () => {
+    function* records() {
+      yield { n: 4 };
+      yield { n: 1 };
+      yield { n: 8 };
+    }
+    expect(sumBy(records(), "n")).toBe(13);
+  });
+
+  it("walks a typed array with the identity iteratee", () => {
+    expect(sumBy(Int8Array.from([1, 9, 3]))).toBe(13);
+    expect(sumBy(new Uint8Array(0))).toBe(0);
+  });
+
+  it("walks a string as an array-like of characters", () => {
+    expect(sumBy("123")).toBe(6);
+    expect(sumBy("")).toBe(0);
+  });
+});


### PR DESCRIPTION

# Relates to

No open issue. `packages/app/src/shims/es-toolkit-compat-sumBy.ts` had no same-named test file in the repository. This PR adds that colocated vitest suite only.

Definition of Done:

- [x] This PR targets `develop` and is based on current `origin/develop` (`0f9911498ab9bea0b2d4c369f39b0382563b99ae`) with a single test-file commit and zero conflicts.
- [x] Focused checks were run after that sync (vitest, biome, package `tsc`). Full `bun run verify` was not re-run for this test-only diff; see Known gaps.
- [x] A reviewer can confirm the change from the quoted vitest/biome/tsc output below without reading production code — there is no production change.

# Sync with develop

- [x] Branch `test/app-es-toolkit-compat-sumBy-coverage` is `origin/develop` plus one commit; zero conflicts.
- [ ] `bun run verify` was not run for this test-only PR. Focused vitest, biome, and `packages/app` `tsc` were run on the current develop-based head instead.

# Risks

Low. Test-only addition. No production behaviour change. The shim remains a re-export of `sumBy` from `./es-toolkit-compat`. Failure mode is a false assertion against observed lodash-compat behaviour, which would fail this suite rather than alter the bundle.

# Background

## What does this PR do?

Adds `packages/app/src/shims/es-toolkit-compat-sumBy.test.ts`. The suite imports the real named and default exports from `./es-toolkit-compat-sumBy.js` (no mocks) and records:

- named and default exports are the same function
- empty / nullish / empty-array-like collections return `0`
- single-element totals, including a NaN iteratee counted as zero
- identity `Number` coercion (numeric strings, `null`→0, booleans, empty string)
- function, string path, dotted/array path, numeric index, and symbol iteratees
- omitted / `null` / `undefined` iteratee uses identity
- NaN, missing paths, and unsafe `__proto__`/`constructor`/`prototype` segments contribute `0`
- matcher-object iteratee counts matches as `1` and misses as `0`
- equal values both add (no first-wins)
- running total starts at `+0`, so a sum of `-0` is `+0`
- IEEE overflow: `MAX_VALUE + MAX_VALUE` → `Infinity`; `Infinity + -Infinity` → `NaN` on the total
- ArrayLike, Set, generator, typed array, and string collections

There is no removal, comparator, or capacity API on `sumBy`. Missing iteratee paths contribute `0`; they are not an error.

## What kind of change is this?

Improvements (tests for existing behaviour). No production code change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/es-toolkit-compat-sumBy.test.ts`, then:

```bash
bunx vitest run packages/app/src/shims/es-toolkit-compat-sumBy.test.ts
```

## Detailed testing steps

Automated tests only. Re-run the command above against current `origin/develop`. Expected: **1 file, 32 tests passed**.

This is a fork contribution. Hosted GitHub Actions CI does **not** run on our PRs. Do not treat a missing Actions check as a pass.

# Evidence Gate

Evidence matches head `1a7c8234d41aab8db7ca5038a2d029451f680b84`.

## Vitest (re-run on current origin/develop immediately before filing)

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app/src/shims/es-toolkit-compat-sumBy.test.ts (32 tests) 4ms

 Test Files  1 passed (1)
      Tests  32 passed (32)
   Duration  139ms (transform 43ms, setup 0ms, import 51ms, tests 4ms, environment 0ms)
```

## Biome

`bunx biome check --write packages/app/src/shims/es-toolkit-compat-sumBy.test.ts`

```
Checked 1 file in 65ms. Fixed 1 file.
```

Config present: `biome.json` and `tsconfig.json` exist at the checkout root; `git sparse-checkout list` reports this worktree is not sparse. The one fix was formatting of a long `expect` line; the committed file is that formatted result.

## tsc

From `packages/app`:

```bash
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'es-toolkit-compat-sumBy.test.ts' ; echo "EXIT:$?"
```

Empty grep (EXIT:1 from grep = no matches). The new test file appears nowhere in `tsc` output. Pre-existing package errors, if any, are not from this file.

## Diff scope

`git diff --name-only origin/develop...HEAD` is exactly:

```
packages/app/src/shims/es-toolkit-compat-sumBy.test.ts
```

# Evidence Details

## Real LLM-call trajectory

N/A - test-only coverage of a numeric collection helper; no agent, action, provider, prompt, or model path.

## Backend + frontend logs

N/A - no server or UI runtime path; the suite drives the shim in vitest.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface. The diff is one `.test.ts` file next to a Vite alias shim.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice, TTS, STT, or transcript change.

## Known gaps / failures

- Full `bun run verify` was not run. This PR adds tests and changes no production behaviour; the required proof is the focused vitest, biome, and package tsc quoted above.
- Hosted CI does not run on fork PRs. Reviewers should re-run `bunx vitest run packages/app/src/shims/es-toolkit-compat-sumBy.test.ts` locally.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1a7c8234d41aab8db7ca5038a2d029451f680b84 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
