### PR TITLE
test(evidence): cover errors

### DIFF
--- a/packages/evidence/src/errors.test.ts
+++ b/packages/evidence/src/errors.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit coverage for typed evidence pipeline errors in errors.ts.
+ *
+ * Exercises EvidenceError and EvidenceValidationError across code tagging,
+ * context dictionaries, cause propagation, prototype chain integrity,
+ * and schema issue tracking.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  EvidenceError,
+  EvidenceValidationError,
+  type ValidationIssue,
+} from "./errors.js";
+
+describe("errors", () => {
+  describe("EvidenceError", () => {
+    it("instantiates with message, code, and context", () => {
+      const err = new EvidenceError("Manifest missing", {
+        code: "MANIFEST_NOT_FOUND",
+        context: { bundleId: "bundle-123" },
+      });
+
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(EvidenceError);
+      expect(err.name).toBe("EvidenceError");
+      expect(err.message).toBe("Manifest missing");
+      expect(err.code).toBe("MANIFEST_NOT_FOUND");
+      expect(err.context).toEqual({ bundleId: "bundle-123" });
+    });
+
+    it("preserves underlying cause when provided", () => {
+      const rootCause = new Error("Disk read failure");
+      const err = new EvidenceError("Failed to load evidence bundle", {
+        code: "BUNDLE_READ_FAILED",
+        cause: rootCause,
+      });
+
+      expect(err.cause).toBe(rootCause);
+    });
+  });
+
+  describe("EvidenceValidationError", () => {
+    it("instantiates with validation issues and maintains prototype hierarchy", () => {
+      const issues: ValidationIssue[] = [
+        { path: "artifacts.0.sha256", message: "Invalid hex hash format" },
+        { path: "timestamp", message: "Must be a finite epoch timestamp" },
+      ];
+
+      const err = new EvidenceValidationError(
+        "Manifest validation failed",
+        issues,
+        {
+          code: "MANIFEST_INVALID",
+          context: { path: "/evidence/manifest.json" },
+        },
+      );
+
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(EvidenceError);
+      expect(err).toBeInstanceOf(EvidenceValidationError);
+      expect(err.name).toBe("EvidenceValidationError");
+      expect(err.message).toBe("Manifest validation failed");
+      expect(err.code).toBe("MANIFEST_INVALID");
+      expect(err.issues).toEqual(issues);
+      expect(err.issues.length).toBe(2);
+      expect(err.context).toEqual({ path: "/evidence/manifest.json" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/evidence/src/errors.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `EvidenceError` and `EvidenceValidationError` across:
- Instantiating typed error instances with classification `code` and structured `context`.
- Preserving `.cause` chains when wrapping underlying failures.
- Carrying field-level `issues` on `EvidenceValidationError`.
- Verifying `instanceof` prototype hierarchies (`Error`, `EvidenceError`, `EvidenceValidationError`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`4dd9015cd5`) |
| --- | --- | --- |
| `bunx vitest run src/errors.test.ts` (in `packages/evidence`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/evidence/src/errors.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/evidence/src/errors.test.ts:1-70`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `errors.test.ts`
- [x] `lint` — Biome clean
