### PR TITLE
fix(agent): keep the conversation soft cap enforceable on unparseable updatedAt

### DIFF
--- a/packages/agent/src/api/memory-bounds.test.ts
+++ b/packages/agent/src/api/memory-bounds.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Covers the bounded in-memory helpers behind the agent API's rate-limit map,
+ * conversation soft cap, log buffer, and static file cache.
+ *
+ * The load-bearing property of all four is that the bound actually holds. For
+ * `evictOldestConversation` that turns on `updatedAt`, which is an ISO string
+ * on a persisted/adapter-shaped record and can therefore be malformed —
+ * `new Date("nope").getTime()` is NaN, and every comparison against NaN is
+ * false, so a corrupt row can never be selected as oldest and the cap silently
+ * stops evicting. Pure functions with injected IO; no runtime, no disk.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  evictOldestConversation,
+  getOrReadCachedFile,
+  pushWithBatchEvict,
+  sweepExpiredEntries,
+} from "./memory-bounds.ts";
+
+describe("sweepExpiredEntries", () => {
+  it("does nothing at or below the threshold", () => {
+    const map = new Map([["a", { count: 1, resetAt: 0 }]]);
+    sweepExpiredEntries(map, 1_000, 1);
+    expect(map.size).toBe(1);
+  });
+
+  it("evicts only entries whose reset time has passed", () => {
+    const map = new Map([
+      ["expired", { count: 1, resetAt: 500 }],
+      ["live", { count: 1, resetAt: 5_000 }],
+      ["also-expired", { count: 1, resetAt: 900 }],
+    ]);
+    sweepExpiredEntries(map, 1_000, 1);
+    expect([...map.keys()]).toEqual(["live"]);
+  });
+
+  it("keeps an entry resetting exactly now", () => {
+    const map = new Map([
+      ["boundary", { count: 1, resetAt: 1_000 }],
+      ["other", { count: 1, resetAt: 9_000 }],
+    ]);
+    sweepExpiredEntries(map, 1_000, 1);
+    expect(map.has("boundary")).toBe(true);
+  });
+});
+
+describe("evictOldestConversation", () => {
+  const conv = (updatedAt: string) => ({ updatedAt });
+
+  it("returns null and evicts nothing at or below the cap", () => {
+    const map = new Map([["a", conv("2026-01-01T00:00:00.000Z")]]);
+    expect(evictOldestConversation(map, 1)).toBeNull();
+    expect(map.size).toBe(1);
+  });
+
+  it("evicts the oldest conversation by updatedAt", () => {
+    const map = new Map([
+      ["new", conv("2026-03-01T00:00:00.000Z")],
+      ["old", conv("2026-01-01T00:00:00.000Z")],
+      ["mid", conv("2026-02-01T00:00:00.000Z")],
+    ]);
+    expect(evictOldestConversation(map, 2)).toBe("old");
+    expect([...map.keys()]).toEqual(["new", "mid"]);
+  });
+
+  it("still enforces the cap when every updatedAt is unparseable", () => {
+    // NaN < Infinity is false, so no candidate is ever selected and the map
+    // grows without bound despite being over cap.
+    const map = new Map([
+      ["a", conv("not-a-date")],
+      ["b", conv("also-bad")],
+      ["c", conv("")],
+    ]);
+    const evicted = evictOldestConversation(map, 2);
+    expect(evicted).not.toBeNull();
+    expect(map.size).toBe(2);
+  });
+
+  it("prefers evicting an unparseable row over a well-formed one", () => {
+    const map = new Map([
+      ["good-new", conv("2026-03-01T00:00:00.000Z")],
+      ["corrupt", conv("garbage")],
+      ["good-old", conv("2026-01-01T00:00:00.000Z")],
+    ]);
+    expect(evictOldestConversation(map, 2)).toBe("corrupt");
+    expect(map.has("corrupt")).toBe(false);
+  });
+
+  it("evicts a conversation stored under the empty-string key", () => {
+    const map = new Map([
+      ["", conv("2026-01-01T00:00:00.000Z")],
+      ["b", conv("2026-05-01T00:00:00.000Z")],
+    ]);
+    expect(evictOldestConversation(map, 1)).toBe("");
+    expect(map.has("")).toBe(false);
+    expect(map.size).toBe(1);
+  });
+});
+
+describe("pushWithBatchEvict", () => {
+  it("appends without evicting below the high-water mark", () => {
+    const buffer = [1, 2];
+    expect(pushWithBatchEvict(buffer, 3, 5, 2)).toBe(3);
+    expect(buffer).toEqual([1, 2, 3]);
+  });
+
+  it("batch-evicts the oldest entries once the high-water mark is passed", () => {
+    const buffer = [1, 2, 3];
+    expect(pushWithBatchEvict(buffer, 4, 3, 2)).toBe(2);
+    expect(buffer).toEqual([3, 4]);
+  });
+
+  it("keeps the buffer bounded across sustained pushes", () => {
+    const buffer: number[] = [];
+    for (let i = 0; i < 100; i += 1) pushWithBatchEvict(buffer, i, 10, 5);
+    expect(buffer.length).toBeLessThanOrEqual(10);
+    expect(buffer.at(-1)).toBe(99);
+  });
+});
+
+describe("getOrReadCachedFile", () => {
+  it("reads on miss and serves the cached body on the next call", () => {
+    const cache = new Map();
+    let reads = 0;
+    const read = () => {
+      reads += 1;
+      return Buffer.from("body");
+    };
+    expect(
+      getOrReadCachedFile(cache, "/a", 1, read, 10, 1_000).toString(),
+    ).toBe("body");
+    expect(
+      getOrReadCachedFile(cache, "/a", 1, read, 10, 1_000).toString(),
+    ).toBe("body");
+    expect(reads).toBe(1);
+  });
+
+  it("re-reads when mtime changes", () => {
+    const cache = new Map();
+    let reads = 0;
+    const read = () => {
+      reads += 1;
+      return Buffer.from("v");
+    };
+    getOrReadCachedFile(cache, "/a", 1, read, 10, 1_000);
+    getOrReadCachedFile(cache, "/a", 2, read, 10, 1_000);
+    expect(reads).toBe(2);
+  });
+
+  it("never caches a file above the size limit", () => {
+    const cache = new Map();
+    const read = () => Buffer.alloc(50);
+    getOrReadCachedFile(cache, "/big", 1, read, 10, 10);
+    expect(cache.size).toBe(0);
+  });
+
+  it("evicts the oldest inserted entry at the entry cap", () => {
+    const cache = new Map();
+    const read = () => Buffer.from("x");
+    getOrReadCachedFile(cache, "/1", 1, read, 2, 1_000);
+    getOrReadCachedFile(cache, "/2", 1, read, 2, 1_000);
+    getOrReadCachedFile(cache, "/3", 1, read, 2, 1_000);
+    expect(cache.size).toBe(2);
+    expect(cache.has("/1")).toBe(false);
+  });
+});

--- a/packages/agent/src/api/memory-bounds.ts
+++ b/packages/agent/src/api/memory-bounds.ts
@@ -43,15 +43,24 @@ export function evictOldestConversation<T extends ConversationLike>(
   if (map.size <= cap) return null;
 
   let oldestKey: string | null = null;
-  let oldestTime = Infinity;
+  let oldestTime = Number.POSITIVE_INFINITY;
   for (const [k, v] of map) {
-    const t = new Date(v.updatedAt).getTime();
-    if (t < oldestTime) {
+    const parsed = new Date(v.updatedAt).getTime();
+    // `updatedAt` is an ISO string on a persisted/adapter-shaped record, so it
+    // can be unparseable. `new Date("nope").getTime()` is NaN and every
+    // comparison against NaN is false, so such a row could never be selected
+    // as oldest — with all rows corrupt nothing was evicted at all and this
+    // soft cap silently stopped bounding memory. A corrupt row is also the
+    // least trustworthy one to keep, so it sorts as the oldest candidate.
+    const t = Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+    if (oldestKey === null || t < oldestTime) {
       oldestTime = t;
       oldestKey = k;
     }
   }
-  if (oldestKey) map.delete(oldestKey);
+  // `!== null` rather than truthiness: "" is a legal Map key, and the falsy
+  // check skipped deleting it while still reporting it as evicted.
+  if (oldestKey !== null) map.delete(oldestKey);
   return oldestKey;
 }
 


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/agent/src/api/memory-bounds.ts`. Same untrusted-timestamp class as merged #25843 and the safe-sort sweep.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `0f9911498ab9bea0b2d4c369f39b0382563b99ae`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**Low.** One selection loop in one pure helper; no signature change, no new dependency. For a map whose `updatedAt` values are all well-formed — the ordinary case — the chosen victim is identical to before, because a finite timestamp still compares exactly as it did.

The behavior changes only where the previous code could not act at all: a corrupt row is now evictable, and an entry under the empty-string key is now actually deleted rather than merely reported as evicted.

# Background

## What does this PR do?

`evictOldestConversation` is the soft cap behind the agent API's in-memory conversation map. It is called at three sites in `conversation-routes.ts` with `cap = 500`.

It selected the victim with:

```ts
const t = new Date(v.updatedAt).getTime();
if (t < oldestTime) { oldestTime = t; oldestKey = k; }
```

`updatedAt` is an ISO string on a persisted/adapter-shaped record, so it can be unparseable — and `new Date("nope").getTime()` is `NaN`, where **every** comparison is false. Two consequences:

1. **The cap stops bounding memory.** A corrupt row can never be selected as oldest. With every row corrupt, `oldestKey` stays `null`, nothing is evicted, and the map grows past `cap` unbounded while the function reports `null` ("no eviction needed"). With a mix, the corrupt rows are precisely the ones that can never be reclaimed, so they accumulate.
2. A corrupt row is also the least trustworthy one to keep, so it is the right victim, not the immortal one.

A non-finite timestamp now sorts as the oldest candidate, and the first entry always seeds the comparison so a victim is always chosen when over cap.

Also fixes an adjacent case in the same function: `if (oldestKey)` is a truthiness check, and `""` is a legal `Map` key. An oldest conversation stored under the empty-string key was **returned as evicted but never deleted**, so the caller believed it had reclaimed an entry that was still in the map.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/memory-bounds.test.ts`, the `evictOldestConversation` block. The module had no test file at all, so the suite also covers the other three helpers (`sweepExpiredEntries`, `pushWithBatchEvict`, `getOrReadCachedFile`) with injected IO — no runtime, no disk.

## Detailed testing steps

```bash
cd packages/agent && npx vitest run src/api/memory-bounds.test.ts
```

To confirm the suite is not vacuous, revert `memory-bounds.ts` (keep the test) and re-run — 3 of 15 fail, and they are exactly the three defects above. The other 12 are controls covering ordinary eviction, the rate-limit sweep, buffer bounding, and the file cache, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:2b2d97f6617e7b98826c3c6a0f3012b522798528 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a pure in-memory helper.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a pure in-memory helper.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is which conversation is evicted at the cap, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > still enforces the cap when every updatedAt is unparseable
 FAIL > prefers evicting an unparseable row over a well-formed one
 FAIL > evicts a conversation stored under the empty-string key

 Test Files  1 failed (1)
      Tests  3 failed | 12 passed (15)
```

### Green — with the fix, at this exact head

```
$ npx vitest run src/api/memory-bounds.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

## Domain artifacts

Behavior of the real exported helper (cap = 2, three entries):

| map contents | before | after |
|---|---|---|
| all three `updatedAt` unparseable | returns `null`, **size stays 3** — cap not enforced | evicts one, size 2 |
| `good-new`, `corrupt`, `good-old` | evicts `good-old`, corrupt row immortal | evicts `corrupt` |
| oldest stored under key `""` (cap = 1) | returns `""` but **does not delete it**, size stays 2 | deletes it, size 1 |
| all well-formed timestamps | evicts the oldest | evicts the oldest (unchanged) |

Call sites bounded by this helper: `packages/agent/src/api/conversation-routes.ts:2968`, `:3031`, `:3593`, each with `cap = 500`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 15/15 passing at this exact head; the module previously had no test file.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
