### PR TITLE
fix(app): build Cloud SDK before web renderer

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -141,7 +141,7 @@
     "cap:sync:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor sync android",
     "cap:open:ios": "node scripts/ensure-capacitor-platform.mjs ios && capacitor open ios",
     "cap:open:android": "node scripts/ensure-capacitor-platform.mjs android && capacitor open android",
-    "prebuild:web": "bun run prebuild",
+    "prebuild:web": "bun run --cwd ../cloud/sdk build && bun run prebuild",
     "build:web": "ELIZA_WEB_ABSOLUTE_BASE=1 node ../../node_modules/@elizaos/vitest-vite/bin/vite.js build && node scripts/verify-chunk-safety.mjs && node scripts/verify-viewport-meta.mjs",
     "verify:chunks": "node scripts/verify-chunk-safety.mjs",
     "predev": "node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos && node ../app-core/scripts/write-homepage-release-data.mjs && node scripts/sync-homepage-assets.mjs",

--- a/packages/app/scripts/web-build-workspace-dependencies.test.mjs
+++ b/packages/app/scripts/web-build-workspace-dependencies.test.mjs
@@ -1,0 +1,23 @@
+/**
+ * Verifies clean production renderer builds compile workspace dependencies
+ * whose package exports intentionally resolve through dist.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const appPackage = JSON.parse(
+  readFileSync(path.join(appDir, "package.json"), "utf8"),
+);
+
+describe("web build workspace dependencies", () => {
+  it("builds the Cloud SDK before preparing the renderer", () => {
+    assert.equal(
+      appPackage.scripts["prebuild:web"],
+      "bun run --cwd ../cloud/sdk build && bun run prebuild",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- build `@elizaos/cloud-sdk` before the production web renderer prebuild
- preserve the production `dist` export boundary instead of adding a source alias
- pin the ordering contract with a package-local deterministic test

## Root cause

Zero-Key browser jobs invoke `bun run --cwd packages/app build:web` after the normal core build. Production Vite resolution intentionally does not enable `eliza-source`, so `@elizaos/cloud-sdk/api-explorer` resolves through `packages/cloud/sdk/dist`. The app prebuild did not compile that workspace dependency, causing all Zero-Key lanes to fail before Playwright started.

## Exact local proof

Base: `0f9911498ab9bea0b2d4c369f39b0382563b99ae`
Head: `721db38c866a382903eb99455d59e3c47dab9b64`

- `bun install --frozen-lockfile`
- `bun test packages/app/scripts/web-build-workspace-dependencies.test.mjs` — 1/1 pass
- Biome check on both changed files — pass
- `bun run build:core` — 60/60 tasks pass
- remove only generated `packages/cloud/sdk/dist`, then `bun run --cwd packages/app build:web` — pass
  - Cloud SDK rebuilt by `prebuild:web`
  - 11,014 renderer modules transformed
  - renderer build manifest emitted
  - chunk-safety and viewport verification pass
- `git diff --check` — pass
- gitleaks one-commit scan — no leaks

## Release boundary

This PR does not deploy or send provider traffic. Cloudflare and Railway staging remain closed until normal review, merge, and one terminal-green canonical Develop Full SHA.