### PR TITLE
test(core): cover action-routing-context

### DIFF
--- a/packages/core/src/runtime/action-routing-context.test.ts
+++ b/packages/core/src/runtime/action-routing-context.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Covers the action-scoped routing context that the runtime wraps around every
+ * action handler so a transitive `useModel` call can read the executing
+ * action's `modelClass`.
+ *
+ * The load-bearing properties are the ones AsyncLocalStorage exists to provide:
+ * the context survives `await` boundaries inside a handler, concurrently
+ * running handlers never observe each other's context, and nesting restores
+ * the outer context on exit. `runWithoutActionRoutingContext` is the seam the
+ * `useModel` resolver uses to make a routed sub-call without re-entering the
+ * routing path and looping, so it must actually clear — not merely shadow.
+ *
+ * Runs against the real module on the real Node manager; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import type { ActionModelClass } from "../types/components.ts";
+import {
+	getActionRoutingContext,
+	runWithActionRoutingContext,
+	runWithoutActionRoutingContext,
+} from "./action-routing-context.ts";
+
+const ctx = (actionName: string, modelClass?: ActionModelClass) => ({
+	actionName,
+	modelClass,
+});
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("action routing context", () => {
+	it("is undefined outside any run", () => {
+		expect(getActionRoutingContext()).toBeUndefined();
+	});
+
+	it("exposes the context synchronously inside the callback", () => {
+		const seen = runWithActionRoutingContext(ctx("SEND"), () =>
+			getActionRoutingContext(),
+		);
+		expect(seen).toEqual({ actionName: "SEND", modelClass: undefined });
+	});
+
+	it("returns the callback's value unchanged", () => {
+		expect(runWithActionRoutingContext(ctx("A"), () => 42)).toBe(42);
+	});
+
+	it("does not leak the context after the run completes", () => {
+		runWithActionRoutingContext(ctx("A"), () => getActionRoutingContext());
+		expect(getActionRoutingContext()).toBeUndefined();
+	});
+
+	it("survives an await boundary inside the handler", async () => {
+		const seen = await runWithActionRoutingContext(ctx("SLOW"), async () => {
+			await tick();
+			return getActionRoutingContext()?.actionName;
+		});
+		expect(seen).toBe("SLOW");
+	});
+
+	it("keeps concurrently running handlers isolated from each other", async () => {
+		const [a, b] = await Promise.all([
+			runWithActionRoutingContext(ctx("A"), async () => {
+				await tick();
+				await tick();
+				return getActionRoutingContext()?.actionName;
+			}),
+			runWithActionRoutingContext(ctx("B"), async () => {
+				await tick();
+				return getActionRoutingContext()?.actionName;
+			}),
+		]);
+		expect([a, b]).toEqual(["A", "B"]);
+	});
+
+	it("restores the outer context when a nested run exits", () => {
+		const observed = runWithActionRoutingContext(ctx("OUTER"), () => {
+			const inner = runWithActionRoutingContext(
+				ctx("INNER"),
+				() => getActionRoutingContext()?.actionName,
+			);
+			return { inner, afterInner: getActionRoutingContext()?.actionName };
+		});
+		expect(observed).toEqual({ inner: "INNER", afterInner: "OUTER" });
+	});
+
+	it("clears the context inside runWithoutActionRoutingContext", () => {
+		const observed = runWithActionRoutingContext(ctx("OUTER"), () => {
+			const cleared = runWithoutActionRoutingContext(() =>
+				getActionRoutingContext(),
+			);
+			return { cleared, restored: getActionRoutingContext()?.actionName };
+		});
+		expect(observed).toEqual({ cleared: undefined, restored: "OUTER" });
+	});
+
+	it("keeps the context cleared across an await inside the cleared run", async () => {
+		const seen = await runWithActionRoutingContext(ctx("OUTER"), async () =>
+			runWithoutActionRoutingContext(async () => {
+				await tick();
+				return getActionRoutingContext();
+			}),
+		);
+		expect(seen).toBeUndefined();
+	});
+
+	it("carries the modelClass hint through to a transitive reader", () => {
+		const seen = runWithActionRoutingContext(
+			ctx("REPLY", "TEXT_LARGE" as ActionModelClass),
+			() => {
+				const deep = () => getActionRoutingContext();
+				return deep();
+			},
+		);
+		expect(seen?.modelClass).toBe("TEXT_LARGE");
+	});
+
+	it("treats an explicitly undefined context as no context", () => {
+		const seen = runWithActionRoutingContext(undefined, () =>
+			getActionRoutingContext(),
+		);
+		expect(seen).toBeUndefined();
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/runtime/action-routing-context.ts` had no dedicated suite despite wrapping every action handler invocation.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `618baa1a85a965a6d92dc3c057a477254b76cde4`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Every case runs the real module on the real Node `AsyncLocalStorage` manager — no injected stack manager, no mocks. The isolation case interleaves two runs at different await depths so a shared-slot implementation would visibly cross-contaminate rather than coincidentally pass, and the clearing cases assert `undefined` explicitly rather than falsiness.

# Background

## What does this PR do?

`packages/core/src/runtime/action-routing-context.ts` exposes the executing action's `modelClass` to any `useModel` call made transitively inside that handler. It had **no dedicated test file**.

This adds a direct suite for the properties AsyncLocalStorage is used here to provide:

| Area | Contract pinned |
|---|---|
| async propagation | the context survives an `await` boundary inside a handler |
| concurrency | two handlers running concurrently, at different await depths, each read back their own context and never each other's |
| nesting | a nested run restores the outer context on exit |
| `runWithoutActionRoutingContext` | genuinely clears rather than shadows, and stays cleared across an `await` inside the cleared run — this is the seam `useModel` uses to make a routed sub-call without re-entering the routing path and looping |
| lifetime | the context does not leak after a run completes; an explicitly `undefined` context reads back as no context |
| payload | the `modelClass` hint reaches a deep transitive reader |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/action-routing-context.test.ts`. The "keeps concurrently running handlers isolated" and "stays cleared across an await" cases are the two that would catch a regression to a shared-slot or shadowing implementation.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/runtime/action-routing-context.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d273d33c707d4d2009995e12001bfc2e53816798 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/runtime/action-routing-context.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 11/11 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that the isolation case interleaves await depths and the clearing cases assert `undefined` explicitly.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
