### PR TITLE
test(auth): cover anthropic

### DIFF
--- a/packages/auth/src/anthropic.test.ts
+++ b/packages/auth/src/anthropic.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit coverage for Anthropic OAuth flow wrapper in anthropic.ts.
+ *
+ * Tests startAnthropicLogin lifecycle (auth URL generation, submitCode hook, credentials promise),
+ * refreshAnthropicToken delegation, and export availability.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  exchangeAnthropicAuthorizationCode,
+  refreshAnthropicToken,
+  startAnthropicLogin,
+} from "./anthropic.js";
+
+describe("anthropic auth", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("exports exchangeAnthropicAuthorizationCode function", () => {
+    expect(typeof exchangeAnthropicAuthorizationCode).toBe("function");
+  });
+
+  it("initiates Anthropic OAuth login and resolves credentials on submitCode", async () => {
+    const mockTokenResponse = {
+      access_token: "mock-access-token",
+      refresh_token: "mock-refresh-token",
+      expires_in: 3600,
+    };
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(mockTokenResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const flow = await startAnthropicLogin();
+
+    expect(typeof flow.authUrl).toBe("string");
+    expect(flow.authUrl).toContain("https://claude.ai/oauth/authorize");
+    expect(typeof flow.submitCode).toBe("function");
+
+    // Extract state from authUrl to construct a valid code#state
+    const url = new URL(flow.authUrl);
+    const state = url.searchParams.get("state") || "test-state";
+
+    // Submit the code
+    flow.submitCode(`mock-code#${state}`);
+
+    const creds = await flow.credentials;
+    expect(creds.access).toBe("mock-access-token");
+    expect(creds.refresh).toBe("mock-refresh-token");
+    expect(creds.expires).toBeGreaterThan(Date.now());
+  });
+
+  it("delegates refreshAnthropicToken to underlying OAuth token exchange", async () => {
+    const mockRefreshResponse = {
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      expires_in: 7200,
+    };
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(mockRefreshResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const creds = await refreshAnthropicToken("existing-refresh-token");
+
+    expect(creds.access).toBe("new-access-token");
+    expect(creds.refresh).toBe("new-refresh-token");
+    expect(creds.expires).toBeGreaterThan(Date.now());
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/auth/src/anthropic.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `startAnthropicLogin`, `refreshAnthropicToken`, and `exchangeAnthropicAuthorizationCode` across:
- `startAnthropicLogin` lifecycle initializing the auth URL, awaiting `submitCode`, and resolving credentials.
- `refreshAnthropicToken` exchanging an existing refresh token for new access credentials.
- Export integrity of `exchangeAnthropicAuthorizationCode`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`bf95d3b27b`) |
| --- | --- | --- |
| `bunx vitest run src/anthropic.test.ts` (in `packages/auth`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/auth/src/anthropic.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/auth/src/anthropic.test.ts:1-82`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `anthropic.test.ts`
- [x] `lint` — Biome clean
