### PR TITLE
test(app): cover eventemitter3

### DIFF
--- a/packages/app/src/shims/eventemitter3.test.ts
+++ b/packages/app/src/shims/eventemitter3.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for the browser `eventemitter3` shim. The suite drives the real
+ * EventEmitter class (named and default) and records empty-queue, single
+ * listener, registration order, once-vs-on removal, missing-item no-ops,
+ * context binding including nullish fallback, and the emit snapshot so a
+ * listener added or removed mid-dispatch does not change who already runs.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import EventEmitterDefault, { EventEmitter } from "./eventemitter3.js";
+
+describe("eventemitter3 exports", () => {
+  it("exports the same class as both named EventEmitter and default", () => {
+    expect(EventEmitter).toBeTypeOf("function");
+    expect(EventEmitterDefault).toBe(EventEmitter);
+  });
+});
+
+describe("eventemitter3 empty queue", () => {
+  it("starts with no names, no listeners, and emit returning false", () => {
+    const emitter = new EventEmitter();
+    expect(emitter.eventNames()).toEqual([]);
+    expect(emitter.listeners("ping")).toEqual([]);
+    expect(emitter.listenerCount("ping")).toBe(0);
+    expect(emitter.emit("ping", 1)).toBe(false);
+  });
+
+  it("treats a missing event as empty for listeners and listenerCount", () => {
+    const emitter = new EventEmitter();
+    const absent = Symbol("absent");
+    expect(emitter.listeners(absent)).toEqual([]);
+    expect(emitter.listenerCount(absent)).toBe(0);
+  });
+});
+
+describe("eventemitter3 addListener / on / once", () => {
+  it("registers a single listener, reports it, and emits args in order", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn();
+    expect(emitter.on("ping", listener)).toBe(emitter);
+    expect(emitter.eventNames()).toEqual(["ping"]);
+    expect(emitter.listeners("ping")).toEqual([listener]);
+    expect(emitter.listenerCount("ping")).toBe(1);
+    expect(emitter.emit("ping", "a", 2)).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("a", 2);
+    expect(emitter.listenerCount("ping")).toBe(1);
+  });
+
+  it("addListener and on both append with once:false and chain this", () => {
+    const emitter = new EventEmitter();
+    const first = vi.fn();
+    const second = vi.fn();
+    expect(emitter.addListener("ping", first)).toBe(emitter);
+    expect(emitter.on("ping", second)).toBe(emitter);
+    emitter.emit("ping", 7);
+    expect(first.mock.invocationCallOrder[0]).toBeLessThan(
+      second.mock.invocationCallOrder[0],
+    );
+    expect(first).toHaveBeenCalledWith(7);
+    expect(second).toHaveBeenCalledWith(7);
+    expect(emitter.listenerCount("ping")).toBe(2);
+  });
+
+  it("once registers a listener that is removed before the first call", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn(function oncePing(this: EventEmitter) {
+      expect(emitter.listenerCount("ping")).toBe(0);
+      expect(emitter.eventNames()).toEqual([]);
+    });
+    expect(emitter.once("ping", listener)).toBe(emitter);
+    expect(emitter.listenerCount("ping")).toBe(1);
+    expect(emitter.emit("ping", "only")).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("only");
+    expect(emitter.emit("ping", "again")).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws TypeError when addListener, on, or once is given a non-function", () => {
+    const emitter = new EventEmitter();
+    const notAFunction = { listener: true } as unknown as () => void;
+    expect(() => emitter.addListener("ping", notAFunction)).toThrow(TypeError);
+    expect(() => emitter.addListener("ping", notAFunction)).toThrow(
+      "The listener must be a function",
+    );
+    expect(() => emitter.on("ping", notAFunction)).toThrow(TypeError);
+    expect(() => emitter.once("ping", notAFunction)).toThrow(
+      "The listener must be a function",
+    );
+    expect(emitter.eventNames()).toEqual([]);
+  });
+
+  it("keeps independent event names, including symbols", () => {
+    const emitter = new EventEmitter();
+    const token = Symbol("token");
+    const stringListener = vi.fn();
+    const symbolListener = vi.fn();
+    emitter.on("ping", stringListener);
+    emitter.on(token, symbolListener);
+    expect(emitter.eventNames()).toEqual(["ping", token]);
+    emitter.emit("ping", 1);
+    emitter.emit(token, 2);
+    expect(stringListener).toHaveBeenCalledWith(1);
+    expect(symbolListener).toHaveBeenCalledWith(2);
+    expect(stringListener).not.toHaveBeenCalledWith(2);
+  });
+});
+
+describe("eventemitter3 emit ordering and snapshot", () => {
+  it("fires listeners in registration order, including a duplicate function", () => {
+    const emitter = new EventEmitter();
+    const order: string[] = [];
+    const shared = () => {
+      order.push("shared");
+    };
+    emitter.on("ping", () => {
+      order.push("first");
+    });
+    emitter.on("ping", shared);
+    emitter.on("ping", shared);
+    emitter.emit("ping");
+    expect(order).toEqual(["first", "shared", "shared"]);
+  });
+
+  it("does not dispatch a listener added during the same emit (copied queue)", () => {
+    const emitter = new EventEmitter();
+    const late = vi.fn();
+    const first = vi.fn(() => {
+      emitter.on("ping", late);
+    });
+    emitter.on("ping", first);
+    emitter.emit("ping");
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(late).not.toHaveBeenCalled();
+    emitter.emit("ping");
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  it("still calls a later listener that another listener removes mid-emit", () => {
+    const emitter = new EventEmitter();
+    const later = vi.fn();
+    const first = vi.fn(() => {
+      emitter.removeListener("ping", later);
+    });
+    emitter.on("ping", first);
+    emitter.on("ping", later);
+    expect(emitter.emit("ping")).toBe(true);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(later).toHaveBeenCalledTimes(1);
+    expect(emitter.listenerCount("ping")).toBe(1);
+  });
+
+  it("does not retrigger the same once listener if it re-emits the event", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn(() => {
+      emitter.emit("ping", "nested");
+    });
+    emitter.once("ping", listener);
+    emitter.emit("ping", "outer");
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("outer");
+  });
+});
+
+describe("eventemitter3 context binding", () => {
+  it("applies the emitter as this when context is omitted", () => {
+    const emitter = new EventEmitter();
+    const seen: unknown[] = [];
+    emitter.on("ping", function onPing(this: unknown) {
+      seen.push(this);
+    });
+    emitter.emit("ping");
+    expect(seen).toEqual([emitter]);
+  });
+
+  it("applies the provided context object as this", () => {
+    const emitter = new EventEmitter();
+    const context = { id: "ctx" };
+    const seen: unknown[] = [];
+    emitter.on(
+      "ping",
+      function onPing(this: unknown, value: unknown) {
+        seen.push(this, value);
+      },
+      context,
+    );
+    emitter.emit("ping", 9);
+    expect(seen).toEqual([context, 9]);
+  });
+
+  it("uses a falsy non-nullish context as this, and falls back for null and undefined", () => {
+    const emitter = new EventEmitter();
+    const seen: unknown[] = [];
+    const record = function recordThis(this: unknown) {
+      seen.push(this);
+    };
+    emitter.on("zero", record, 0);
+    emitter.on("empty", record, "");
+    emitter.on("no", record, false);
+    emitter.on("nil", record, null);
+    emitter.on("void", record, undefined);
+    emitter.emit("zero");
+    emitter.emit("empty");
+    emitter.emit("no");
+    emitter.emit("nil");
+    emitter.emit("void");
+    expect(seen).toEqual([0, "", false, emitter, emitter]);
+  });
+});
+
+describe("eventemitter3 removeListener / off", () => {
+  it("is a no-op when the event or the listener is missing", () => {
+    const emitter = new EventEmitter();
+    const missing = vi.fn();
+    const kept = vi.fn();
+    expect(emitter.removeListener("ghost", missing)).toBe(emitter);
+    emitter.on("ping", kept);
+    expect(emitter.off("ping", missing)).toBe(emitter);
+    expect(emitter.listeners("ping")).toEqual([kept]);
+    emitter.emit("ping");
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the whole event when listener is omitted, including falsy listener", () => {
+    const emitter = new EventEmitter();
+    const first = vi.fn();
+    const second = vi.fn();
+    emitter.on("ping", first);
+    emitter.on("ping", second);
+    expect(emitter.removeListener("ping")).toBe(emitter);
+    expect(emitter.eventNames()).toEqual([]);
+    expect(emitter.emit("ping")).toBe(false);
+    emitter.on("pong", first);
+    emitter.off("pong", undefined);
+    expect(emitter.eventNames()).toEqual([]);
+  });
+
+  it("removes every matching registration of the same function", () => {
+    const emitter = new EventEmitter();
+    const shared = vi.fn();
+    const other = vi.fn();
+    emitter.on("ping", shared);
+    emitter.on("ping", other);
+    emitter.on("ping", shared);
+    emitter.removeListener("ping", shared);
+    expect(emitter.listeners("ping")).toEqual([other]);
+    emitter.emit("ping");
+    expect(shared).not.toHaveBeenCalled();
+    expect(other).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the event key when the last matching listener is removed", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn();
+    emitter.on("ping", listener);
+    emitter.off("ping", listener);
+    expect(emitter.eventNames()).toEqual([]);
+    expect(emitter.listenerCount("ping")).toBe(0);
+  });
+
+  it("keeps a listener when the provided context does not match", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn();
+    const context = { id: "keep" };
+    emitter.on("ping", listener, context);
+    emitter.removeListener("ping", listener, { id: "other" });
+    expect(emitter.listenerCount("ping")).toBe(1);
+    emitter.removeListener("ping", listener, context);
+    expect(emitter.listenerCount("ping")).toBe(0);
+  });
+
+  it("keeps a listener when the once flag does not match", () => {
+    const emitter = new EventEmitter();
+    const onListener = vi.fn();
+    const onceListener = vi.fn();
+    emitter.on("ping", onListener);
+    emitter.once("ping", onceListener);
+    emitter.removeListener("ping", onListener, undefined, true);
+    emitter.removeListener("ping", onceListener, undefined, false);
+    expect(emitter.listenerCount("ping")).toBe(2);
+    emitter.removeListener("ping", onListener, undefined, false);
+    emitter.removeListener("ping", onceListener, undefined, true);
+    expect(emitter.eventNames()).toEqual([]);
+  });
+
+  it("off forwards to removeListener with context and once filters", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn();
+    const context = { id: "ctx" };
+    emitter.once("ping", listener, context);
+    emitter.off("ping", listener, context, true);
+    expect(emitter.listenerCount("ping")).toBe(0);
+  });
+});
+
+describe("eventemitter3 removeAllListeners", () => {
+  it("clears every event when called with no argument", () => {
+    const emitter = new EventEmitter();
+    emitter.on("ping", vi.fn());
+    emitter.on("pong", vi.fn());
+    expect(emitter.removeAllListeners()).toBe(emitter);
+    expect(emitter.eventNames()).toEqual([]);
+    expect(emitter.emit("ping")).toBe(false);
+    expect(emitter.emit("pong")).toBe(false);
+  });
+
+  it("deletes only the named event and leaves others intact", () => {
+    const emitter = new EventEmitter();
+    const kept = vi.fn();
+    emitter.on("ping", vi.fn());
+    emitter.on("pong", kept);
+    emitter.removeAllListeners("ping");
+    expect(emitter.eventNames()).toEqual(["pong"]);
+    emitter.emit("pong", "stay");
+    expect(kept).toHaveBeenCalledWith("stay");
+  });
+
+  it("is a no-op for an event that was never registered", () => {
+    const emitter = new EventEmitter();
+    const kept = vi.fn();
+    emitter.on("ping", kept);
+    expect(emitter.removeAllListeners("ghost")).toBe(emitter);
+    expect(emitter.listeners("ping")).toEqual([kept]);
+  });
+});
+
+describe("eventemitter3 listeners copy", () => {
+  it("returns a new array so mutating it does not change the registry", () => {
+    const emitter = new EventEmitter();
+    const listener = vi.fn();
+    emitter.on("ping", listener);
+    const copy = emitter.listeners("ping");
+    copy.pop();
+    expect(emitter.listeners("ping")).toEqual([listener]);
+    expect(emitter.listenerCount("ping")).toBe(1);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-coverage PR: `packages/app/src/shims/eventemitter3.ts` had no same-named test file in the repository. This adds a real Vitest suite next to the shim (matching sibling shim tests such as `cookie.test.ts` and `debug.test.ts`).

This is a fork contribution from `ss251/eliza`. Hosted GitHub Actions CI does **not** run on our PRs; the commands quoted below were run locally against this head.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Head `136312d5ff6e4034c7f27419efd96669b7cecf23` is one commit on top of `origin/develop` merge-base `0306f0d673149e1842d40be520f162c9493787eb`. Triple-dot diff vs current `origin/develop` is the single test file; zero conflicts on that path.
- [ ] Full `bun run verify` was not re-run for this test-only change. Focused gates below were run on the added file.
- [x] A reviewer can confirm the change from the quoted Vitest / Biome / `tsc` output without reading production code. Production behaviour is unchanged.

# Sync with develop

- [x] Branch parent is `0306f0d673149e1842d40be520f162c9493787eb` (then-current `origin/develop`). The GitHub PR diff vs `develop` is only `packages/app/src/shims/eventemitter3.test.ts`.
- [ ] `bun run verify` not re-run; focused vitest / biome / tsc on the new file are quoted below.

# Risks

Low. Test-only addition. No production file is modified. The suite records the shim's current behaviour (including emit snapshotting, `??` context fallback, and once-removal-before-call). It does not change EventEmitter dispatch.

# Background

## What does this PR do?

Adds `packages/app/src/shims/eventemitter3.test.ts`, a Vitest suite that imports the real shim (`./eventemitter3.js`) and covers every exported symbol and branch:

- named `EventEmitter` and default export are the same class
- empty queue: `eventNames` / `listeners` / `listenerCount` / `emit` → false
- single listener, registration order, duplicate-function ties
- `on` / `addListener` / `once` chaining and TypeError on a non-function listener
- symbol event names stay independent of string names
- emit copies the listener list, so a listener added mid-emit does not run in that turn, and a later listener removed mid-emit still runs
- `once` is removed before the call, so a re-emit from that listener does not retrigger it
- `this` is the emitter when context is omitted, the provided object when set, falsy non-nullish values (`0`, `""`, `false`) as `this`, and null/undefined fall back via `??`
- `removeListener` / `off` no-op for a missing event or listener; omitting the listener deletes the event; last match deletes the map key; context and `once` filters keep non-matches
- `removeAllListeners()` clears all events; a named call leaves others; missing name is a no-op
- `listeners()` returns a copy, so mutating it does not change the registry

## What kind of change is this?

Improvements (test coverage for an existing browser shim). No production behaviour change.

## Why are we doing this? Any context or related work?

The shim is aliased over the `eventemitter3` package in the Vite renderer (`vite.config.ts`). It had no colocated test. Sibling shims already have real suites; this fills the same gap.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/eventemitter3.test.ts`. Drive:

```bash
bunx vitest run packages/app/src/shims/eventemitter3.test.ts --config packages/app/vitest.config.ts
```

## Detailed testing steps

None: automated tests are the evidence. Re-run the command above on this head.

Local results immediately before filing (re-fetched `origin/develop`, source blob `packages/app/src/shims/eventemitter3.ts` identical on working tree / HEAD / `origin/develop`):

```
✓ src/shims/eventemitter3.test.ts (26 tests) 5ms

Test Files  1 passed (1)
     Tests  26 passed (26)
  Duration  474ms
```

Biome (config at repo-root `biome.json`; worktree is not sparse):

```
bunx biome check --write packages/app/src/shims/eventemitter3.test.ts
Checked 1 file in 30ms. Fixed 1 file.
```

(`tsc` does not typecheck Vitest, so passing tests are not a type proof.)

```
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'eventemitter3.test.ts' ; echo "GREP_EXIT:$?"
GREP_EXIT:1
```

Empty grep: this test file introduced zero `tsc` diagnostics. Pre-existing errors elsewhere in the package are not part of this diff.

The diff touches only `packages/app/src/shims/eventemitter3.test.ts`.

# Evidence Gate

Evidence matches head `136312d5ff6e4034c7f27419efd96669b7cecf23`.

<!-- evidence-head:136312d5ff6e4034c7f27419efd96669b7cecf23 -->

This PR adds tests and changes no production behaviour. No UI, network, agent, or native path is involved.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no user flow to walk through.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only change; no backend path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - test-only change; no frontend request.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, wallet, schedule, or generated artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - unit tests of a browser EventEmitter shim; no HTTP or UI.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI.

### Before

N/A - test-only, no UI.

### After

N/A - test-only, no UI.

### Walkthrough video

N/A - test-only, no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not run. This PR adds one test file and does not change production code; focused vitest (26/26), biome, and `tsc` grep are the complete evidence set.
- Hosted CI does not run on this fork PR.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
