### PR TITLE
test(app): cover fast-redact

### DIFF
--- a/packages/app/src/shims/fast-redact.test.ts
+++ b/packages/app/src/shims/fast-redact.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the browser `fast-redact` shim. The suite drives the real
+ * default-exported factory (not a mock) and records its no-op contract: every
+ * options branch returns the same identity redactor, `restore` is identity,
+ * and `serialize` is ignored rather than compiling a string-path redactor.
+ */
+import { describe, expect, it } from "vitest";
+
+import fastRedact from "./fast-redact.js";
+
+describe("fast-redact factory", () => {
+  it("exports a function as the default", () => {
+    expect(fastRedact).toBeTypeOf("function");
+  });
+
+  it("returns the same singleton for an empty options object and no arguments", () => {
+    const omitted = fastRedact();
+    const empty = fastRedact({});
+    expect(omitted).toBeTypeOf("function");
+    expect(empty).toBe(omitted);
+  });
+
+  it("returns the same singleton when paths is missing, undefined, or empty", () => {
+    const missing = fastRedact({});
+    expect(fastRedact({ paths: undefined })).toBe(missing);
+    expect(fastRedact({ paths: [] })).toBe(missing);
+  });
+
+  it("returns the same singleton for a single path and for several paths", () => {
+    const empty = fastRedact();
+    expect(fastRedact({ paths: ["password"] })).toBe(empty);
+    expect(fastRedact({ paths: ["password", "token", "user.secret"] })).toBe(
+      empty,
+    );
+  });
+
+  it("still returns the singleton when a path list contains an empty string", () => {
+    expect(fastRedact({ paths: [""] })).toBe(fastRedact());
+  });
+});
+
+describe("fast-redact identity redactor", () => {
+  it("returns primitives unchanged", () => {
+    const redact = fastRedact({ paths: ["secret"] });
+    expect(redact("plain")).toBe("plain");
+    expect(redact(0)).toBe(0);
+    expect(redact(false)).toBe(false);
+  });
+
+  it("returns null and undefined unchanged", () => {
+    const redact = fastRedact();
+    expect(redact(null)).toBe(null);
+    expect(redact(undefined)).toBe(undefined);
+  });
+
+  it("returns the same object and array references without mutating them", () => {
+    const redact = fastRedact({ paths: ["password", "nested.token"] });
+    const payload = {
+      password: "hunter2",
+      nested: { token: "abc", keep: 1 },
+    };
+    const items = [{ password: "x" }];
+
+    expect(redact(payload)).toBe(payload);
+    expect(payload).toEqual({
+      password: "hunter2",
+      nested: { token: "abc", keep: 1 },
+    });
+    expect(redact(items)).toBe(items);
+    expect(items).toEqual([{ password: "x" }]);
+  });
+
+  it("does not redact listed paths: the factory never compiles a censor", () => {
+    const redact = fastRedact({ paths: ["password"] });
+    const payload = { password: "visible", ok: true };
+    expect(redact(payload)).toEqual({ password: "visible", ok: true });
+  });
+});
+
+describe("fast-redact restore", () => {
+  it("exposes restore as an identity function on the singleton", () => {
+    const redact = fastRedact();
+    expect(redact.restore).toBeTypeOf("function");
+    expect(fastRedact({ paths: ["secret"] }).restore).toBe(redact.restore);
+  });
+
+  it("restore returns the same reference for objects and primitives", () => {
+    const restore = fastRedact().restore;
+    expect(restore).toBeTypeOf("function");
+    const payload = { password: "hunter2" };
+    expect(restore?.(payload)).toBe(payload);
+    expect(restore?.("plain")).toBe("plain");
+    expect(restore?.(null)).toBe(null);
+    expect(restore?.(undefined)).toBe(undefined);
+  });
+
+  it("restore of a value that was never redacted is still identity", () => {
+    const redact = fastRedact({ paths: ["missing"] });
+    const payload = { other: 1 };
+    const restored = redact.restore?.(redact(payload));
+    expect(restored).toBe(payload);
+  });
+});
+
+describe("fast-redact serialize option is ignored", () => {
+  it("does not stringify when serialize is a function", () => {
+    const payload = { password: "hunter2" };
+    const redact = fastRedact({
+      paths: ["password"],
+      serialize: (value: unknown) => JSON.stringify(value),
+    });
+    expect(redact(payload)).toBe(payload);
+    expect(typeof redact(payload)).toBe("object");
+  });
+
+  it("does not change the redactor when serialize is false", () => {
+    const payload = { token: "abc" };
+    const redact = fastRedact({ paths: ["token"], serialize: false });
+    expect(redact).toBe(fastRedact());
+    expect(redact(payload)).toBe(payload);
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/app/src/shims/fast-redact.ts`, which had no same-named test file. No production change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` `4f199840ab6d7522f9512f2858e2a18bdaf39f08` with a single test-file commit (`90255e1ed8bd36db42f7e3c748385faf053da952`).
- [x] Focused checks were run after sync. `bun run verify` was not run: this is a test-only addition with no production behaviour change. Hosted CI does **not** run on this fork PR.
- [x] A reviewer can confirm the suite from the quoted vitest / biome / tsc output below.

# Sync with develop

- [x] Branch parent is current `origin/develop` `4f199840ab6d7522f9512f2858e2a18bdaf39f08` (re-fetched immediately before filing); zero conflicts.
- [x] `bun run verify` was not run (test-only). Package-scoped vitest, biome, and tsc are quoted below.

# Risks

Low. Adds a colocated unit test next to the existing no-op browser shim. No production code, routes, UI, or redaction behaviour change. The suite records that the shim is an identity redactor, so it will fail if a future change starts compiling paths or serializing payloads.

# Background

## What does this PR do?

Adds `packages/app/src/shims/fast-redact.test.ts` covering the real default-exported factory in `packages/app/src/shims/fast-redact.ts`.

Observed behaviour (asserted, not wished):

- Default export is a function.
- Missing options, empty `paths`, a single path, several paths, and an empty-string path all return the **same singleton** redactor.
- The redactor is identity for primitives, `null`, `undefined`, objects, and arrays (same reference, no mutation).
- Listed paths are **not** censored — the factory never compiles a string-path redactor.
- `restore` is the same identity function on that singleton.
- `serialize` as a function or `false` is ignored; the payload is still returned as the original object.

## What kind of change is this?

Tests (non-breaking; no production behaviour change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/fast-redact.test.ts` and `packages/app/src/shims/fast-redact.ts`.

## Detailed testing steps

Re-fetched `origin/develop` and re-ran against that parent immediately before filing:

```text
bunx vitest run packages/app/src/shims/fast-redact.test.ts

 ✓ packages/app/src/shims/fast-redact.test.ts (14 tests) 3ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  19:14:49
   Duration  115ms (transform 27ms, setup 0ms, import 34ms, tests 3ms, environment 0ms)
```

```text
bunx biome check --write packages/app/src/shims/fast-redact.test.ts
Checked 1 file in 16ms. Fixed 1 file.
```

(`biome.json` and `tsconfig.json` exist at the repo root; `git sparse-checkout list` reports this worktree is not sparse.)

```text
cd packages/app && bunx tsc --noEmit -p tsconfig.typecheck.json 2>&1 | grep 'fast-redact'
# no output
GREP_EXIT:1
```

`tsc` exits 1 because of pre-existing errors in other packages (`@extrastu/nuphy-ui` missing, cloud-sdk export mismatches, etc.). **`fast-redact.test.ts` appears nowhere in that output.**

The diff touches only `packages/app/src/shims/fast-redact.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. Do not infer a green Actions check from this filing.

# Evidence Gate

Evidence head: `90255e1ed8bd36db42f7e3c748385faf053da952`

This PR adds tests and changes no production or UI behaviour.

- [x] Before full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] After full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] Walkthrough video: `N/A - test-only, no user flow`
- [x] Backend logs: `N/A - no server path change; vitest drives the shim in-process`
- [x] Frontend console/network logs: `N/A - no frontend request/response`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB/memory/schedule/wallet/audio output`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - test-only; no agent, action, provider, prompt, or model change.`

## Backend + frontend logs

`N/A - no transport path. Vitest output is quoted in Testing.`

## Screenshots (before / after) + video walkthrough

`N/A - test-only, no UI.`

### Before

`N/A - test-only, no UI.`

### After

`N/A - test-only, no UI.`

### Walkthrough video

`N/A - test-only, no UI.`

## Audio / voice walkthrough

`N/A - not a voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; package vitest/biome/tsc are the complete evidence set for this test-only PR.
- `bunx tsc --noEmit -p tsconfig.typecheck.json` in `packages/app` exits 1 on pre-existing errors in other files. The new test file is absent from that output.
- Hosted CI does not run on fork PRs from `ss251`.

## Maintainer CI exception record

`N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:90255e1ed8bd36db42f7e3c748385faf053da952 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
