### PR TITLE
test(app): cover extend

### DIFF
--- a/packages/app/src/shims/extend.test.ts
+++ b/packages/app/src/shims/extend.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for the browser `extend` shim. The suite drives the real default
+ * export (not a mock) and records shallow vs deep folding, left-to-right last
+ * write, nullish source skips, in-place mutation, array/plain-object recursion,
+ * prototype-pollution key skips, and the leading-boolean selector — including
+ * that `typeof deepOrTarget === "boolean"` makes `false` deep-merge too.
+ * There is no comparator, queue, removal, or capacity API.
+ */
+import { describe, expect, it } from "vitest";
+
+import extend from "./extend.js";
+
+describe("extend export", () => {
+  it("exports a default function and no named merge helper", () => {
+    expect(extend).toBeTypeOf("function");
+  });
+});
+
+describe("extend shallow mode: empty, single, and many sources", () => {
+  it("returns the target unchanged when the source list is empty", () => {
+    const target = { a: 1 };
+    expect(extend(target)).toBe(target);
+    expect(target).toEqual({ a: 1 });
+  });
+
+  it("returns a fresh empty object when the only argument is {}", () => {
+    const target = {};
+    expect(extend(target)).toBe(target);
+    expect(target).toEqual({});
+  });
+
+  it("assigns a single source's own enumerable keys onto the target", () => {
+    const target: Record<string, unknown> = { keep: 1 };
+    const result = extend(target, { added: 2 });
+    expect(result).toBe(target);
+    expect(result).toEqual({ keep: 1, added: 2 });
+  });
+
+  it("folds later sources over earlier ones; last write wins a tied key", () => {
+    const target: Record<string, unknown> = { k: "target" };
+    extend(target, { k: "first", extra: 1 }, { k: "second" });
+    expect(target).toEqual({ k: "second", extra: 1 });
+  });
+
+  it("preserves Object.keys insertion order of the mutated target", () => {
+    const target: Record<string, unknown> = { z: 1 };
+    extend(target, { a: 2 }, { m: 3 });
+    expect(Object.keys(target)).toEqual(["z", "a", "m"]);
+  });
+});
+
+describe("extend shallow mode: nullish sources, missing keys, identity", () => {
+  it("skips null and undefined sources and still applies the next source", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    extend(
+      target,
+      null as unknown as object,
+      { b: 2 },
+      undefined as unknown as object,
+      {
+        c: 3,
+      },
+    );
+    expect(target).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("leaves target-only keys in place when the source does not list them", () => {
+    const target: Record<string, unknown> = { keep: 1, other: 2 };
+    extend(target, { other: 9 });
+    expect(target).toEqual({ keep: 1, other: 9 });
+  });
+
+  it("adds a source key that is missing on the target", () => {
+    const target: Record<string, unknown> = {};
+    extend(target, { only: true });
+    expect(target).toEqual({ only: true });
+  });
+
+  it("assigns nested objects and arrays by reference, not by copy", () => {
+    const nested = { x: 1 };
+    const list = [1, 2];
+    const target: Record<string, unknown> = {};
+    extend(target, { nested, list });
+    expect(target.nested).toBe(nested);
+    expect(target.list).toBe(list);
+  });
+
+  it("overwrites a nested object with the source reference in shallow mode", () => {
+    const original = { a: 1 };
+    const replacement = { b: 2 };
+    const target: Record<string, unknown> = { nested: original };
+    extend(target, { nested: replacement });
+    expect(target.nested).toBe(replacement);
+    expect(original).toEqual({ a: 1 });
+  });
+});
+
+describe("extend shallow mode: values, own-enumerable copy, no capacity cap", () => {
+  it("assigns falsy own values including undefined", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    extend(target, {
+      a: 0,
+      b: false,
+      c: "",
+      d: null,
+      e: undefined,
+    });
+    expect(target).toEqual({
+      a: 0,
+      b: false,
+      c: "",
+      d: null,
+      e: undefined,
+    });
+    expect(Object.hasOwn(target, "e")).toBe(true);
+  });
+
+  it("does not copy inherited enumerable keys because Object.entries is own-only", () => {
+    const source = Object.create({ inherited: 9 }) as Record<string, unknown>;
+    source.own = 1;
+    const target: Record<string, unknown> = {};
+    extend(target, source);
+    expect(target).toEqual({ own: 1 });
+  });
+
+  it("does not copy symbol own keys because Object.entries never yields them", () => {
+    const source: Record<string, unknown> = { a: 1 };
+    const key = Symbol("s");
+    Object.defineProperty(source, key, { value: 2, enumerable: true });
+    const target: Record<string, unknown> = {};
+    extend(target, source);
+    expect(target).toEqual({ a: 1 });
+    expect(Object.getOwnPropertySymbols(target)).toEqual([]);
+  });
+
+  it("does not copy non-enumerable own keys", () => {
+    const source: Record<string, unknown> = { visible: 2 };
+    Object.defineProperty(source, "secret", { value: 1, enumerable: false });
+    const target: Record<string, unknown> = {};
+    extend(target, source);
+    expect(target).toEqual({ visible: 2 });
+  });
+
+  it("copies many keys with no capacity or overflow cap", () => {
+    const source: Record<string, number> = {};
+    for (let index = 0; index < 40; index += 1) {
+      source[`k${index}`] = index;
+    }
+    const target: Record<string, number> = {};
+    extend(target, source);
+    expect(Object.keys(target)).toHaveLength(40);
+    expect(target.k0).toBe(0);
+    expect(target.k39).toBe(39);
+  });
+});
+
+describe("extend deep-mode selector", () => {
+  it("treats a leading boolean as the deep flag and uses the next arg as target", () => {
+    const target: Record<string, unknown> = { keep: 1 };
+    const result = extend<Record<string, unknown>>(true, target, { added: 2 });
+    expect(result).toBe(target);
+    expect(target).toEqual({ keep: 1, added: 2 });
+  });
+
+  it("returns the shifted target unchanged when deep mode has no remaining sources", () => {
+    const target = { a: 1 };
+    expect(extend<typeof target>(true, target)).toBe(target);
+    expect(target).toEqual({ a: 1 });
+  });
+
+  it("returns undefined when deep mode is selected with an empty source queue", () => {
+    expect(extend<Record<string, never>>(true)).toBeUndefined();
+  });
+
+  it("deep-merges when the leading boolean is false, because deep is typeof === 'boolean'", () => {
+    const inner = { a: 1 };
+    const target: Record<string, unknown> = { nested: inner };
+    const result = extend<Record<string, unknown>>(false, target, {
+      nested: { b: 2 },
+    });
+    expect(result).toBe(target);
+    expect(target.nested).toBe(inner);
+    expect(inner).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe("extend deep mode: plain objects", () => {
+  it("recurses into nested plain objects and mutates the target's nested record", () => {
+    const inner = { a: 1 };
+    const target: Record<string, unknown> = { nested: inner, keep: true };
+    extend<Record<string, unknown>>(true, target, { nested: { b: 2 } });
+    expect(target.nested).toBe(inner);
+    expect(inner).toEqual({ a: 1, b: 2 });
+    expect(target.keep).toBe(true);
+  });
+
+  it("replaces a nested primitive with a newly allocated plain object", () => {
+    const target: Record<string, unknown> = { nested: 7 };
+    extend<Record<string, unknown>>(true, target, { nested: { a: 1 } });
+    expect(target.nested).toEqual({ a: 1 });
+    expect(target.nested).not.toBe(7);
+  });
+
+  it("assigns a non-plain nested source (Date, class instance) by reference", () => {
+    const date = new Date("2020-01-01T00:00:00.000Z");
+    class Widget {
+      n = 1;
+    }
+    const widget = new Widget();
+    const target: Record<string, unknown> = {
+      date: { stale: true },
+      widget: {},
+    };
+    extend<Record<string, unknown>>(true, target, { date, widget });
+    expect(target.date).toBe(date);
+    expect(target.widget).toBe(widget);
+  });
+
+  it("allocates a fresh {} when the target nested value is not a plain object", () => {
+    const widget = { n: 1 };
+    Object.setPrototypeOf(widget, { tag: "instance" });
+    const target: Record<string, unknown> = { nested: widget };
+    extend<Record<string, unknown>>(true, target, { nested: { a: 1 } });
+    expect(target.nested).toEqual({ a: 1 });
+    expect(target.nested).not.toBe(widget);
+    expect(widget).toEqual({ n: 1 });
+  });
+
+  it("deep-merges Object.create(null) records because null prototype is plain", () => {
+    const inner = Object.assign(
+      Object.create(null) as Record<string, unknown>,
+      {
+        a: 1,
+      },
+    );
+    const target: Record<string, unknown> = { nested: inner };
+    const sourceNested = Object.assign(
+      Object.create(null) as Record<string, unknown>,
+      { b: 2 },
+    );
+    extend<Record<string, unknown>>(true, target, { nested: sourceNested });
+    expect(target.nested).toBe(inner);
+    expect(inner.a).toBe(1);
+    expect(inner.b).toBe(2);
+  });
+
+  it("overwrites a nested object with null because null is not a plain object", () => {
+    const target: Record<string, unknown> = { nested: { a: 1 } };
+    extend<Record<string, unknown>>(true, target, { nested: null });
+    expect(target.nested).toBeNull();
+  });
+});
+
+describe("extend deep mode: arrays", () => {
+  it("recurses into nested arrays by index and keeps extra target elements", () => {
+    const inner = [1, { x: 1 }, 3];
+    const target: Record<string, unknown> = { list: inner };
+    extend<Record<string, unknown>>(true, target, { list: [10, { y: 2 }] });
+    expect(target.list).toBe(inner);
+    expect(inner[0]).toBe(10);
+    expect(inner[1]).toEqual({ x: 1, y: 2 });
+    expect(inner[2]).toBe(3);
+  });
+
+  it("allocates a fresh [] when the target nested value is not an array", () => {
+    const original = { 0: 1 };
+    const target: Record<string, unknown> = { list: original };
+    extend<Record<string, unknown>>(true, target, { list: [10, 20] });
+    expect(target.list).toEqual([10, 20]);
+    expect(target.list).not.toBe(original);
+    expect(Array.isArray(target.list)).toBe(true);
+  });
+
+  it("replaces an array nested value with a plain object by allocating {}", () => {
+    const original = [1, 2];
+    const target: Record<string, unknown> = { nested: original };
+    extend<Record<string, unknown>>(true, target, { nested: { a: 1 } });
+    expect(target.nested).toEqual({ a: 1 });
+    expect(target.nested).not.toBe(original);
+    expect(original).toEqual([1, 2]);
+  });
+
+  it("deep-merges a top-level array target against a later array source", () => {
+    const target = [1, { a: 1 }];
+    const result = extend<typeof target>(true, target, [9, { b: 2 }, 3]);
+    expect(result).toBe(target);
+    expect(target[0]).toBe(9);
+    expect(target[1]).toEqual({ a: 1, b: 2 });
+    expect(target[2]).toBe(3);
+  });
+
+  it("leaves a single-element array target unchanged when there is no source", () => {
+    const target = [42];
+    expect(extend<typeof target>(true, target)).toBe(target);
+    expect(target).toEqual([42]);
+  });
+});
+
+describe("extend prototype-pollution keys", () => {
+  it("skips enumerable own __proto__, constructor, and prototype keys", () => {
+    const source: Record<string, unknown> = {
+      keep: 1,
+      constructor: "c",
+      prototype: "p",
+    };
+    Object.defineProperty(source, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    const target: Record<string, unknown> = {};
+    extend(target, source);
+    expect(target).toEqual({ keep: 1 });
+    expect(Object.hasOwn(target, "__proto__")).toBe(false);
+    expect(Object.hasOwn(target, "constructor")).toBe(false);
+    expect(Object.hasOwn(target, "prototype")).toBe(false);
+  });
+
+  it("still copies a similarly named key that is not in the skip set", () => {
+    const target: Record<string, unknown> = {};
+    extend(target, { proto: 1, construct: 2 });
+    expect(target).toEqual({ proto: 1, construct: 2 });
+  });
+
+  it("skips the same keys in deep mode, including nested records", () => {
+    const nested: Record<string, unknown> = { keep: 1, constructor: "c" };
+    const target: Record<string, unknown> = { nested: {} };
+    extend<Record<string, unknown>>(true, target, { nested });
+    expect(target.nested).toEqual({ keep: 1 });
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/app/src/shims/extend.ts`, which had no same-named test file anywhere in the repo.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and was replayed onto the latest fetched `origin/develop` before filing.
- [x] Reviewers can confirm the recorded behaviour from the committed focused test.

# Risks

Low. Production `extend` is unchanged. The suite drives the real default export: empty source queue, single source, left-to-right last-write ties, nullish source skips, missing-key no-ops, shallow-by-reference nested assign, deep recursion into plain objects and arrays (including extra target array elements kept), non-plain Date/class replacement by reference, `Object.create(null)` as plain, no capacity cap, own-enumerable-only `Object.entries` copy, and `__proto__`/`constructor`/`prototype` skips. There is no comparator, removal, or overflow API.

Observed selector (not jQuery-faithful): `deep` is `typeof deepOrTarget === "boolean"`, so a leading `false` still deep-merges. The suite records that.

# Background

## What does this PR do?

Adds `packages/app/src/shims/extend.test.ts` next to `extend.ts`, matching colocated shim suites such as `cookie.test.ts` and `debug.test.ts`. Import path is `./extend.js`.

Covered behaviour:

- Default export is a function; no named merge helper
- Shallow: empty sources return the same target; single source assign; later sources win tied keys; insertion order preserved
- Null and undefined sources skipped; target-only keys kept; missing source keys added
- Nested objects/arrays assigned by reference in shallow mode
- Falsy own values including `undefined`; inherited/symbol/non-enumerable keys not copied
- Forty keys copy with no capacity cap
- Leading boolean selects deep mode and shifts the target; deep with no remaining sources returns the target; deep with an empty queue returns `undefined`
- Leading `false` still deep-merges because `deep` is the typeof-boolean check
- Deep: nested plain objects mutated in place; primitive nested value replaced with a new `{}`; Date/class instances assigned by reference; non-plain target nested value allocates `{}`; null-prototype records merge; `null` overwrites a nested object
- Deep arrays: index merge keeps extra target elements; non-array target nested value allocates `[]`; array replaced by a plain object allocates `{}`; top-level array target; single-element array with no source
- Enumerable own `__proto__`, `constructor`, and `prototype` skipped in shallow and nested deep copies; similarly named `proto`/`construct` still copy

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/extend.test.ts` — colocated with `extend.ts`. Import path is `./extend.js`.

## Detailed testing steps

```bash
bunx vitest run packages/app/src/shims/extend.test.ts
bunx biome check --write packages/app/src/shims/extend.test.ts
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'extend.test.ts'
```

Focused proof at the pushed head `663042e9e0445b6ef999ca5e2c32c1f26e378e64`, re-run against current `origin/develop` `extend.ts` immediately before filing:

```text
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza
 ✓ packages/app/src/shims/extend.test.ts (34 tests) 5ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
   Start at  19:13:51
   Duration  123ms (transform 35ms, setup 0ms, import 43ms, tests 5ms, environment 0ms)
```

`bunx biome check --write packages/app/src/shims/extend.test.ts`: Checked 1 file in 78ms. Fixed 1 file. The formatted file is the one at this head; 34/34 tests passed after that write.

`bunx tsc --noEmit` in `packages/app`: `extend.test.ts` appears nowhere in the output (`grep 'extend.test.ts'` empty; grep exit 1). This file adds zero new TypeScript errors. Pre-existing errors elsewhere in the package are not this change.

The diff touches only `packages/app/src/shims/extend.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:663042e9e0445b6ef999ca5e2c32c1f26e378e64 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (34 passed / 34).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no UI runtime; unit tests only.
<!-- evidence-row:live-model-transcripts -->
- [x] N/A - no model calls.
<!-- evidence-row:live-model-outputs -->
- [x] N/A - no model calls.
<!-- evidence-row:native-device-proof -->
- [x] N/A - no native/device path.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
