### PR TITLE
test(auth): cover openai-codex

### DIFF
--- a/packages/auth/src/openai-codex.test.ts
+++ b/packages/auth/src/openai-codex.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit coverage for OpenAI Codex OAuth flow in openai-codex.ts.
+ *
+ * Tests startCodexLogin lifecycle, auth URL state extraction, submitCode / close hooks,
+ * and refreshCodexToken token exchange mapping.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { refreshCodexToken, startCodexLogin } from "./openai-codex.js";
+
+describe("openai-codex auth", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("initiates Codex OAuth login and extracts flow state", async () => {
+    const flow = await startCodexLogin();
+
+    expect(typeof flow.authUrl).toBe("string");
+    expect(flow.authUrl).toContain("https://auth.openai.com/oauth/authorize");
+    expect(typeof flow.state).toBe("string");
+    expect(flow.state.length).toBeGreaterThan(0);
+    expect(typeof flow.submitCode).toBe("function");
+    expect(typeof flow.close).toBe("function");
+
+    // Close server cleanly
+    flow.close();
+  });
+
+  it("delegates refreshCodexToken to OAuth refresh flow and formats credentials", async () => {
+    // Construct mock JWT with payload containing account details for access token
+    const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = btoa(
+      JSON.stringify({
+        "https://api.openai.com/auth": {
+          user_id: "user-123",
+          chatgpt_account_id: "acc-456",
+        },
+      }),
+    );
+    const mockJwt = `${header}.${payload}.signature`;
+
+    const mockTokenResponse = {
+      access_token: mockJwt,
+      refresh_token: "new-codex-refresh",
+      expires_in: 3600,
+      id_token: mockJwt,
+    };
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(mockTokenResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const creds = await refreshCodexToken("existing-codex-refresh");
+
+    expect(creds.access).toBe(mockJwt);
+    expect(creds.refresh).toBe("new-codex-refresh");
+    expect(creds.expires).toBeGreaterThan(Date.now());
+    expect(creds.idToken).toBe(mockJwt);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/auth/src/openai-codex.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `startCodexLogin` and `refreshCodexToken` across:
- `startCodexLogin` lifecycle initializing the auth URL, extracting state parameters, exposing `submitCode`, and supporting `close()`.
- `refreshCodexToken` exchanging refresh tokens and extracting account credentials (`access`, `refresh`, `expires`, `idToken`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`5e794aec2a`) |
| --- | --- | --- |
| `bunx vitest run src/openai-codex.test.ts` (in `packages/auth`) | N/A (new test file) | 2 passed (2 tests) |
| `bunx @biomejs/biome check packages/auth/src/openai-codex.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/auth/src/openai-codex.test.ts:1-68`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 2/2 passed in `openai-codex.test.ts`
- [x] `lint` — Biome clean
