### PR TITLE
test(core): cover cloud-topology

### DIFF
--- a/packages/core/src/contracts/cloud-topology.test.ts
+++ b/packages/core/src/contracts/cloud-topology.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Covers the Eliza Cloud topology derivation: account linkage, deployment
+ * runtime, which services are routed through the cloud proxy, and whether the
+ * eliza-cloud plugin should load.
+ *
+ * Two properties are load-bearing. Linkage must treat a `[REDACTED]` API key as
+ * unset — the redaction placeholder is what a sanitized/exported config carries,
+ * so accepting it would report an unlinked account as linked. And a service
+ * counts as cloud-routed only when BOTH its transport is `cloud-proxy` and its
+ * backend is `elizacloud`; either half alone must not load the plugin.
+ *
+ * Pure derivation over plain config records — no runtime, no network, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	ELIZA_CLOUD_SERVICES,
+	isElizaCloudLinkedInConfig,
+	isElizaCloudServiceSelectedInConfig,
+	resolveElizaCloudTopology,
+	shouldLoadElizaCloudPluginInConfig,
+} from "./cloud-topology.ts";
+
+/**
+ * The topology service names are not the routing keys: `inference` is derived
+ * from the `llmText` routing entry. Pinning that mapping here is part of the
+ * contract — a rename on either side should fail this suite.
+ */
+const ROUTING_KEY: Record<string, string> = {
+	inference: "llmText",
+	tts: "tts",
+	media: "media",
+	embeddings: "embeddings",
+	rpc: "rpc",
+};
+
+const cloudRouted = (service: string) => ({
+	serviceRouting: {
+		[ROUTING_KEY[service] ?? service]: {
+			backend: "elizacloud",
+			transport: "cloud-proxy",
+		},
+	},
+});
+
+describe("isElizaCloudLinkedInConfig", () => {
+	it("is false for an absent or empty config", () => {
+		expect(isElizaCloudLinkedInConfig(null)).toBe(false);
+		expect(isElizaCloudLinkedInConfig(undefined)).toBe(false);
+		expect(isElizaCloudLinkedInConfig({})).toBe(false);
+	});
+
+	it("is true when the linked-accounts record marks elizacloud linked", () => {
+		expect(
+			isElizaCloudLinkedInConfig({
+				linkedAccounts: { elizacloud: { status: "linked" } },
+			}),
+		).toBe(true);
+	});
+
+	it("is true when a cloud API key is present", () => {
+		expect(isElizaCloudLinkedInConfig({ cloud: { apiKey: "sk-live" } })).toBe(
+			true,
+		);
+	});
+
+	it("treats the redaction placeholder as unset, in any case", () => {
+		// A sanitized/exported config carries this placeholder; accepting it would
+		// report an unlinked account as linked.
+		expect(
+			isElizaCloudLinkedInConfig({ cloud: { apiKey: "[REDACTED]" } }),
+		).toBe(false);
+		expect(
+			isElizaCloudLinkedInConfig({ cloud: { apiKey: "[redacted]" } }),
+		).toBe(false);
+	});
+
+	it("treats whitespace-only and non-string keys as unset", () => {
+		expect(isElizaCloudLinkedInConfig({ cloud: { apiKey: "   " } })).toBe(
+			false,
+		);
+		expect(isElizaCloudLinkedInConfig({ cloud: { apiKey: 12345 } })).toBe(
+			false,
+		);
+		expect(isElizaCloudLinkedInConfig({ cloud: { apiKey: null } })).toBe(false);
+	});
+
+	it("ignores a non-object cloud section", () => {
+		expect(isElizaCloudLinkedInConfig({ cloud: "nope" })).toBe(false);
+		expect(isElizaCloudLinkedInConfig({ cloud: ["a"] })).toBe(false);
+	});
+});
+
+describe("resolveElizaCloudTopology", () => {
+	it("defaults to local runtime, no provider, and no routed services", () => {
+		const topology = resolveElizaCloudTopology({});
+		expect(topology.runtime).toBe("local");
+		expect(topology.provider).toBeNull();
+		expect(Object.values(topology.services).some(Boolean)).toBe(false);
+		expect(topology.shouldLoadPlugin).toBe(false);
+	});
+
+	it("reports every known service key regardless of routing", () => {
+		const topology = resolveElizaCloudTopology({});
+		expect(Object.keys(topology.services).sort()).toEqual(
+			[...ELIZA_CLOUD_SERVICES].sort(),
+		);
+	});
+
+	it("marks a service routed only when transport and backend both point at cloud", () => {
+		for (const service of ELIZA_CLOUD_SERVICES) {
+			expect(
+				isElizaCloudServiceSelectedInConfig(cloudRouted(service), service),
+			).toBe(true);
+		}
+	});
+
+	it("does not mark a service routed on transport alone", () => {
+		expect(
+			isElizaCloudServiceSelectedInConfig(
+				{
+					serviceRouting: {
+						tts: { backend: "openai", transport: "cloud-proxy" },
+					},
+				},
+				"tts",
+			),
+		).toBe(false);
+	});
+
+	it("does not mark a service routed on backend alone", () => {
+		expect(
+			isElizaCloudServiceSelectedInConfig(
+				{
+					serviceRouting: {
+						tts: { backend: "elizacloud", transport: "direct" },
+					},
+				},
+				"tts",
+			),
+		).toBe(false);
+	});
+
+	it("reports cloud runtime when the deployment target selects it", () => {
+		const topology = resolveElizaCloudTopology({
+			deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+		});
+		expect(topology.runtime).toBe("cloud");
+		expect(topology.provider).toBe("elizacloud");
+	});
+
+	it("keeps linkage independent of routing", () => {
+		const topology = resolveElizaCloudTopology(cloudRouted("media"));
+		expect(topology.services.media).toBe(true);
+		expect(topology.linked).toBe(false);
+	});
+});
+
+describe("shouldLoadElizaCloudPluginInConfig", () => {
+	it("is false for a bare local config", () => {
+		expect(shouldLoadElizaCloudPluginInConfig({})).toBe(false);
+	});
+
+	it("is true when a cloud deployment target is selected", () => {
+		expect(
+			shouldLoadElizaCloudPluginInConfig({
+				deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+			}),
+		).toBe(true);
+	});
+
+	it("is true when any single service is cloud-routed", () => {
+		for (const service of ELIZA_CLOUD_SERVICES) {
+			expect(shouldLoadElizaCloudPluginInConfig(cloudRouted(service))).toBe(
+				true,
+			);
+		}
+	});
+
+	it("is false when a cloud runtime is selected with a non-cloud provider", () => {
+		expect(
+			shouldLoadElizaCloudPluginInConfig({
+				deploymentTarget: { runtime: "cloud", provider: "other" },
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/contracts/cloud-topology.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `4f199840ab6d7522f9512f2858e2a18bdaf39f08`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Every case drives the real exported resolvers over plain config records — no mocked `first-run-options`. The routing cases assert both halves independently (transport-only and backend-only must each be false), and the redaction cases assert `false` rather than falsiness.

# Background

## What does this PR do?

`packages/core/src/contracts/cloud-topology.ts` derives whether the account is linked, the deployment runtime, which services route through the cloud proxy, and whether the eliza-cloud plugin loads. It had **no dedicated test file**.

This adds a direct suite for the load-bearing contracts:

| Area | Contract pinned |
|---|---|
| linkage vs redaction | a `[REDACTED]` API key is treated as **unset**, in any case. That placeholder is exactly what a sanitized or exported config carries, so accepting it would report an unlinked account as linked. |
| linkage input hygiene | whitespace-only, non-string, and `null` keys are unset; a non-object `cloud` section (string, array) is ignored rather than throwing |
| routing | a service is cloud-routed only when **both** transport is `cloud-proxy` **and** backend is `elizacloud` — transport alone and backend alone are each asserted false |
| name mapping | the non-obvious service-to-routing-key mapping is pinned: the `inference` service is derived from the `llmText` routing entry, so a rename on either side now fails this suite |
| plugin loading | true for a cloud deployment target; true when any single service is routed; false for a cloud runtime with a non-cloud provider |
| shape | the resolved topology always reports every key in `ELIZA_CLOUD_SERVICES`, and linkage stays independent of routing |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/contracts/cloud-topology.test.ts`. The `[REDACTED]` cases and the two "transport alone / backend alone" cases are the highest-value guards.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/contracts/cloud-topology.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:052a211d39af1f51ab122fda660ecb08bbca1364 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/contracts/cloud-topology.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 17/17 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that each positive routing case has a matching negative for both halves of the condition.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
