### PR TITLE
test(shared): cover restart

### DIFF
--- a/packages/shared/src/restart.test.ts
+++ b/packages/shared/src/restart.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit coverage for browser-safe restart handler delegation in restart.ts.
+ *
+ * Tests exit code constant export, default no-op handler execution, synchronous
+ * and asynchronous custom handler invocation with optional reason propagation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RESTART_EXIT_CODE,
+  requestRestart,
+  setRestartHandler,
+} from "./restart.js";
+
+describe("restart", () => {
+  beforeEach(() => {
+    // Reset to default no-op handler
+    setRestartHandler(() => {});
+  });
+
+  it("exports RESTART_EXIT_CODE as a non-zero number", () => {
+    expect(typeof RESTART_EXIT_CODE).toBe("number");
+    expect(RESTART_EXIT_CODE).toBeGreaterThan(0);
+  });
+
+  it("safely executes default no-op handler without error", () => {
+    expect(() => requestRestart()).not.toThrow();
+    expect(() => requestRestart("test-reason")).not.toThrow();
+  });
+
+  it("forwards restart request and reason to registered handler", () => {
+    const handler = vi.fn();
+    setRestartHandler(handler);
+
+    requestRestart("reload configuration");
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith("reload configuration");
+  });
+
+  it("supports asynchronous restart handlers", async () => {
+    let finished = false;
+    const asyncHandler = vi.fn(async (reason?: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      finished = true;
+      void reason;
+    });
+
+    setRestartHandler(asyncHandler);
+    const result = requestRestart("graceful shutdown");
+
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+
+    expect(finished).toBe(true);
+    expect(asyncHandler).toHaveBeenCalledWith("graceful shutdown");
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/restart.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `setRestartHandler`, `requestRestart`, and `RESTART_EXIT_CODE` across:
- `RESTART_EXIT_CODE` numeric export validity.
- Safe execution of default no-op handler without error.
- Synchronous custom handler invocation with reason argument propagation.
- Asynchronous custom handler awaiting and completion verification.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`5a86aa4ec3`) |
| --- | --- | --- |
| `bunx vitest run src/restart.test.ts` (in `packages/shared`) | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/shared/src/restart.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/restart.test.ts:1-58`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 passed in `restart.test.ts`
- [x] `lint` — Biome clean
