### PR TITLE
test(shared): cover dev-settings-figlet-heading

### DIFF
--- a/packages/shared/src/dev-settings-figlet-heading.test.ts
+++ b/packages/shared/src/dev-settings-figlet-heading.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit coverage for dev subsystem figlet headings in dev-settings-figlet-heading.ts.
+ *
+ * Tests boxed heading generation across all subsystem banner kinds
+ * (orchestrator, vite, api, electrobun) and table concatenation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type DevSubsystemBannerKind,
+  prependDevSubsystemFigletHeading,
+  renderDevSubsystemFigletHeading,
+} from "./dev-settings-figlet-heading.js";
+
+describe("dev-settings-figlet-heading", () => {
+  const kinds: DevSubsystemBannerKind[] = [
+    "orchestrator",
+    "vite",
+    "api",
+    "electrobun",
+  ];
+
+  it.each(kinds)("renders boxed ASCII heading for subsystem '%s'", (kind) => {
+    const heading = renderDevSubsystemFigletHeading(kind);
+
+    expect(typeof heading).toBe("string");
+    expect(heading.length).toBeGreaterThan(0);
+    expect(heading).toContain(kind.toUpperCase());
+
+    const lines = heading.split("\n");
+    expect(lines.length).toBe(3);
+    expect(lines[1]).toBe(`| ${kind.toUpperCase()} |`);
+  });
+
+  it("prepends figlet heading above settings table with blank line separation", () => {
+    const table = "=== Settings Table ===\nPORT: 3000";
+    const combined = prependDevSubsystemFigletHeading("api", table);
+
+    expect(combined.startsWith(" ")).toBe(true);
+    expect(combined).toContain("| API |");
+    expect(combined).toContain("\n\n=== Settings Table ===");
+    expect(combined.endsWith(table)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/dev-settings-figlet-heading.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `renderDevSubsystemFigletHeading` and `prependDevSubsystemFigletHeading` across:
- Rendering boxed ASCII markers for each subsystem banner kind (`orchestrator`, `vite`, `api`, `electrobun`).
- Prepending formatted figlet headings with double-newline separation before settings tables.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2a8345187f`) |
| --- | --- | --- |
| `bunx vitest run src/dev-settings-figlet-heading.test.ts` (in `packages/shared`) | N/A (new test file) | 5 passed (5 tests) |
| `bunx @biomejs/biome check packages/shared/src/dev-settings-figlet-heading.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/dev-settings-figlet-heading.test.ts:1-44`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 passed in `dev-settings-figlet-heading.test.ts`
- [x] `lint` — Biome clean
