### PR TITLE
test(agent): cover hooks registry

### DIFF
--- a/packages/agent/src/hooks/registry.test.ts
+++ b/packages/agent/src/hooks/registry.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Covers the in-process hook registry and its dispatch.
+ *
+ * The two documented contracts are the ones worth pinning: dispatch order is
+ * specific-first (`command:new`) then general (`command`), and a failing
+ * handler is isolated and logged rather than thrown — one bad hook must not
+ * abort the rest of the fan-out, or a single misbehaving plugin would silently
+ * disable every other hook on the same event.
+ *
+ * Drives the real exported registry; each test clears it first. No runtime.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearHooks,
+  createHookEvent,
+  registerHook,
+  triggerHook,
+} from "./registry.ts";
+import type { HookEvent } from "./types.ts";
+
+const event = (action: string): HookEvent =>
+  createHookEvent("command" as HookEvent["type"], action, "session-1");
+
+beforeEach(() => clearHooks());
+afterEach(() => clearHooks());
+
+describe("createHookEvent", () => {
+  it("builds the payload with an empty default context", () => {
+    const built = createHookEvent("command" as HookEvent["type"], "new", "s1");
+    expect(built).toMatchObject({
+      type: "command",
+      action: "new",
+      sessionKey: "s1",
+      messages: [],
+      context: {},
+    });
+    expect(built.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("carries an explicit context through unchanged", () => {
+    const context = { userId: "u1", nested: { a: 1 } };
+    expect(
+      createHookEvent("command" as HookEvent["type"], "new", "s1", context)
+        .context,
+    ).toEqual(context);
+  });
+
+  it("gives each event its own messages array", () => {
+    const a = createHookEvent("command" as HookEvent["type"], "new", "s1");
+    const b = createHookEvent("command" as HookEvent["type"], "new", "s1");
+    expect(a.messages).not.toBe(b.messages);
+  });
+});
+
+describe("triggerHook dispatch", () => {
+  it("is a no-op when nothing is registered", async () => {
+    await expect(triggerHook(event("new"))).resolves.toBeUndefined();
+  });
+
+  it("runs specific handlers before general ones", async () => {
+    const order: string[] = [];
+    registerHook("command", async () => {
+      order.push("general");
+    });
+    registerHook("command:new", async () => {
+      order.push("specific");
+    });
+    await triggerHook(event("new"));
+    expect(order).toEqual(["specific", "general"]);
+  });
+
+  it("runs multiple handlers on one key in registration order", async () => {
+    const order: string[] = [];
+    registerHook("command", async () => {
+      order.push("first");
+    });
+    registerHook("command", async () => {
+      order.push("second");
+    });
+    await triggerHook(event("new"));
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("does not run a handler registered for a different action", async () => {
+    const order: string[] = [];
+    registerHook("command:reset", async () => {
+      order.push("reset");
+    });
+    await triggerHook(event("new"));
+    expect(order).toEqual([]);
+  });
+
+  it("passes the event through to the handler", async () => {
+    const seen: HookEvent[] = [];
+    registerHook("command:new", async (e) => {
+      seen.push(e);
+    });
+    const dispatched = event("new");
+    await triggerHook(dispatched);
+    expect(seen).toEqual([dispatched]);
+  });
+
+  it("awaits an async handler before running the next", async () => {
+    const order: string[] = [];
+    registerHook("command", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      order.push("slow");
+    });
+    registerHook("command", async () => {
+      order.push("fast");
+    });
+    await triggerHook(event("new"));
+    expect(order).toEqual(["slow", "fast"]);
+  });
+});
+
+describe("triggerHook failure isolation", () => {
+  it("keeps running later handlers after one throws", async () => {
+    const order: string[] = [];
+    registerHook("command:new", async () => {
+      throw new Error("boom");
+    });
+    registerHook("command", async () => {
+      order.push("survivor");
+    });
+    await expect(triggerHook(event("new"))).resolves.toBeUndefined();
+    expect(order).toEqual(["survivor"]);
+  });
+
+  it("does not reject even when every handler throws", async () => {
+    registerHook("command", async () => {
+      throw new Error("one");
+    });
+    registerHook("command", async () => {
+      throw new Error("two");
+    });
+    await expect(triggerHook(event("new"))).resolves.toBeUndefined();
+  });
+
+  it("tolerates a handler that throws a non-Error value", async () => {
+    const order: string[] = [];
+    registerHook("command", async () => {
+      throw "just a string";
+    });
+    registerHook("command", async () => {
+      order.push("after");
+    });
+    await expect(triggerHook(event("new"))).resolves.toBeUndefined();
+    expect(order).toEqual(["after"]);
+  });
+
+  it("tolerates a handler that throws synchronously", async () => {
+    const order: string[] = [];
+    registerHook("command", () => {
+      throw new Error("sync boom");
+    });
+    registerHook("command", async () => {
+      order.push("after");
+    });
+    await expect(triggerHook(event("new"))).resolves.toBeUndefined();
+    expect(order).toEqual(["after"]);
+  });
+});
+
+describe("clearHooks", () => {
+  it("removes every registered handler", async () => {
+    const order: string[] = [];
+    registerHook("command", async () => {
+      order.push("x");
+    });
+    clearHooks();
+    await triggerHook(event("new"));
+    expect(order).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/agent/src/hooks/registry.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `4f199840ab6d7522f9512f2858e2a18bdaf39f08`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Cases drive the real exported registry and real dispatch — no mocked handler list. The failure-isolation cases assert **both** that `triggerHook` resolves **and** that a later handler actually ran, so a regression that swallowed the whole fan-out would still fail.

# Background

## What does this PR do?

`packages/agent/src/hooks/registry.ts` owns hook dispatch for the agent's command events. It had **no dedicated test file**.

This adds a direct suite for the two contracts the module documents in its header:

| Area | Contract pinned |
|---|---|
| dispatch order | specific-first (`command:new`) then general (`command`); multiple handlers on one key run in registration order; handlers are awaited sequentially, so a slow handler is not overtaken by a later one |
| failure isolation | a throwing handler is logged, not rethrown — one bad hook must not abort the rest of the fan-out, or a single misbehaving plugin silently disables every other hook on that event. Covered for an async throw, a **synchronous** throw, a non-`Error` thrown value, and the all-handlers-fail case |
| key matching | a handler registered for a different action (`command:reset`) does not run for `command:new` |
| payload | `createHookEvent` yields an empty default context, a `Date` timestamp, and a per-event `messages` array (not a shared one) |
| lifecycle | dispatch with nothing registered is a no-op; `clearHooks` removes everything |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/hooks/registry.test.ts`, the `triggerHook failure isolation` block — those four cases are the regression guard for the "one bad hook cannot abort the rest" contract.

## Detailed testing steps

```bash
cd packages/agent && npx vitest run src/hooks/registry.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ba402870022f63ff351aa35b079884e56b3f9eeb -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/hooks/registry.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 14/14 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that every isolation case also asserts the surviving handler ran.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
