### PR TITLE
test(agent): cover artifact-share-role-resolver

### DIFF
--- a/packages/agent/src/api/artifact-share-role-resolver.test.ts
+++ b/packages/agent/src/api/artifact-share-role-resolver.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Covers the artifact share-viewer token boundary: minting, verification, and
+ * the read-only route allowlist.
+ *
+ * These tokens are disclosure capabilities handed to non-owner viewers, so the
+ * security-relevant properties are the negative ones. A correctly-signed token
+ * that claims an elevated role must still be rejected — the signature proves
+ * provenance, not entitlement. Verification must never throw on hostile input,
+ * because the resolver contract is `null` (no principal) rather than a 500. And
+ * the route allowlist must stay read-only, so a leaked viewer token cannot
+ * mutate anything or reach the wider API.
+ *
+ * Drives the real exported mint/verify path with a real HMAC secret.
+ */
+import crypto from "node:crypto";
+import type { UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isArtifactShareScopedRoute,
+  issueArtifactShareViewerToken,
+  resolveArtifactShareViewerToken,
+} from "./artifact-share-role-resolver.ts";
+
+const SECRET_ENV = "ELIZA_ARTIFACT_SHARE_TOKEN_SECRET";
+const SECRET = "test-share-secret";
+const ENTITY = "11111111-2222-4333-8444-555555555555" as UUID;
+const NOW_MS = 1_800_000_000_000;
+
+let previousSecret: string | undefined;
+
+beforeEach(() => {
+  previousSecret = process.env[SECRET_ENV];
+  process.env[SECRET_ENV] = SECRET;
+});
+
+afterEach(() => {
+  if (previousSecret === undefined) delete process.env[SECRET_ENV];
+  else process.env[SECRET_ENV] = previousSecret;
+});
+
+/** Mint with an arbitrary payload, correctly signed with the live secret. */
+function signPayload(payload: unknown, secret = SECRET): string {
+  const segment = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(`esv1.${segment}`)
+    .digest()
+    .toString("base64url");
+  return `esv1.${segment}.${signature}`;
+}
+
+describe("issueArtifactShareViewerToken", () => {
+  it("mints a token that verifies back to the same identity", () => {
+    const token = issueArtifactShareViewerToken(
+      { entityId: ENTITY, role: "USER", ttlMs: 60_000 },
+      NOW_MS,
+    );
+    const access = resolveArtifactShareViewerToken(
+      token,
+      Math.floor(NOW_MS / 1000),
+    );
+    expect(access).toEqual({
+      entityId: ENTITY,
+      role: "USER",
+      exp: Math.floor((NOW_MS + 60_000) / 1000),
+    });
+  });
+
+  it("fails fast rather than emitting a dead token when the secret is unset", () => {
+    delete process.env[SECRET_ENV];
+    expect(() =>
+      issueArtifactShareViewerToken(
+        { entityId: ENTITY, role: "USER", ttlMs: 60_000 },
+        NOW_MS,
+      ),
+    ).toThrow();
+  });
+
+  it("rejects a non-UUID entity id", () => {
+    expect(() =>
+      issueArtifactShareViewerToken(
+        { entityId: "not-a-uuid" as UUID, role: "GUEST", ttlMs: 60_000 },
+        NOW_MS,
+      ),
+    ).toThrow();
+  });
+});
+
+describe("resolveArtifactShareViewerToken", () => {
+  const now = Math.floor(NOW_MS / 1000);
+  const validToken = () =>
+    issueArtifactShareViewerToken(
+      { entityId: ENTITY, role: "USER", ttlMs: 60_000 },
+      NOW_MS,
+    );
+
+  it("is inert when the secret is unset", () => {
+    const token = validToken();
+    delete process.env[SECRET_ENV];
+    expect(resolveArtifactShareViewerToken(token, now)).toBeNull();
+  });
+
+  it("returns null for absent input", () => {
+    expect(resolveArtifactShareViewerToken(null, now)).toBeNull();
+    expect(resolveArtifactShareViewerToken(undefined, now)).toBeNull();
+    expect(resolveArtifactShareViewerToken("", now)).toBeNull();
+  });
+
+  it("rejects a correctly-signed token claiming an elevated role", () => {
+    // The signature proves provenance, not entitlement: OWNER/ADMIN must come
+    // from the trunk boundary, never from a share-viewer capability.
+    for (const role of ["OWNER", "ADMIN", "owner", "user", ""]) {
+      const forged = signPayload({ entityId: ENTITY, role, exp: now + 60 });
+      expect(resolveArtifactShareViewerToken(forged, now)).toBeNull();
+    }
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const foreign = signPayload(
+      { entityId: ENTITY, role: "USER", exp: now + 60 },
+      "some-other-secret",
+    );
+    expect(resolveArtifactShareViewerToken(foreign, now)).toBeNull();
+  });
+
+  it("rejects a tampered payload that keeps the original signature", () => {
+    const token = validToken();
+    const [prefix, , signature] = token.split(".");
+    const swapped = Buffer.from(
+      JSON.stringify({
+        entityId: "99999999-2222-4333-8444-555555555555",
+        role: "USER",
+        exp: now + 60,
+      }),
+    ).toString("base64url");
+    expect(
+      resolveArtifactShareViewerToken(`${prefix}.${swapped}.${signature}`, now),
+    ).toBeNull();
+  });
+
+  it("rejects an expired token, including one expiring exactly now", () => {
+    const expired = signPayload({
+      entityId: ENTITY,
+      role: "USER",
+      exp: now - 1,
+    });
+    const boundary = signPayload({ entityId: ENTITY, role: "USER", exp: now });
+    expect(resolveArtifactShareViewerToken(expired, now)).toBeNull();
+    expect(resolveArtifactShareViewerToken(boundary, now)).toBeNull();
+  });
+
+  it("rejects a non-numeric or missing expiry", () => {
+    for (const exp of ["9999999999", null, undefined]) {
+      const token = signPayload({ entityId: ENTITY, role: "USER", exp });
+      expect(resolveArtifactShareViewerToken(token, now)).toBeNull();
+    }
+  });
+
+  it("rejects a non-UUID entity id in an otherwise valid token", () => {
+    const token = signPayload({
+      entityId: "nope",
+      role: "USER",
+      exp: now + 60,
+    });
+    expect(resolveArtifactShareViewerToken(token, now)).toBeNull();
+  });
+
+  it("never throws on malformed token shapes", () => {
+    for (const token of [
+      "garbage",
+      "esv1",
+      "esv1.only-two",
+      "esv1..sig",
+      "esv1.payload.",
+      "wrongprefix.a.b",
+      "esv1.!!!not-base64!!!.@@@",
+      `esv1.${"A".repeat(5_000)}.${"B".repeat(5_000)}`,
+    ]) {
+      expect(() => resolveArtifactShareViewerToken(token, now)).not.toThrow();
+      expect(resolveArtifactShareViewerToken(token, now)).toBeNull();
+    }
+  });
+
+  it("accepts a GUEST role token", () => {
+    const token = issueArtifactShareViewerToken(
+      { entityId: ENTITY, role: "GUEST", ttlMs: 60_000 },
+      NOW_MS,
+    );
+    expect(resolveArtifactShareViewerToken(token, now)?.role).toBe("GUEST");
+  });
+});
+
+describe("isArtifactShareScopedRoute", () => {
+  it("allows exactly the read-only artifact routes", () => {
+    for (const path of [
+      "/api/transcripts",
+      "/api/transcripts/abc",
+      "/api/meetings",
+      "/api/meetings/abc",
+      "/api/files",
+    ]) {
+      expect(isArtifactShareScopedRoute("GET", path)).toBe(true);
+    }
+  });
+
+  it("denies every non-GET method on an allowed path", () => {
+    for (const method of [
+      "POST",
+      "PUT",
+      "PATCH",
+      "DELETE",
+      "HEAD",
+      "OPTIONS",
+    ]) {
+      expect(isArtifactShareScopedRoute(method, "/api/transcripts")).toBe(
+        false,
+      );
+    }
+  });
+
+  it("denies the wider API surface", () => {
+    for (const path of [
+      "/api/agents",
+      "/api/messages",
+      "/api/settings",
+      "/api/transcripts/abc/extra",
+      "/api/meetings/abc/notes",
+      "/api/files/abc",
+      "/api/transcriptsX",
+      "/",
+    ]) {
+      expect(isArtifactShareScopedRoute("GET", path)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/agent/src/api/artifact-share-role-resolver.ts` had no dedicated suite despite being an HMAC capability boundary.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `168daca11e14c87465d1d893616b4c37097338d3`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Cases drive the real exported mint/verify path with a real HMAC secret — no stubbed crypto. The forged-token cases sign hostile payloads with the **live** secret, so they fail if the resolver ever trusts the signature as entitlement rather than provenance; the malformed-input cases assert both `not.toThrow()` and `toBeNull()`, so a regression that raised a 500 would be caught.

# Background

## What does this PR do?

`packages/agent/src/api/artifact-share-role-resolver.ts` is the boundary that lets a non-owner viewer reach the artifact read routes (transcripts / meetings / files) with a per-entity identity. It had **no dedicated test file**.

Because these tokens are disclosure capabilities handed to third parties, the properties worth pinning are the negative ones:

| Area | Contract pinned |
|---|---|
| entitlement vs provenance | a **correctly-signed** token claiming `OWNER`/`ADMIN` is still rejected — the signature proves who minted it, not what it may do. Case variants and an empty role are covered too. |
| signature | a token signed with a different secret is rejected; a tampered payload carrying the original signature is rejected |
| expiry | exclusive — a token expiring exactly `now` is rejected, as is a non-numeric or missing `exp` |
| identity | a non-UUID `entityId` is rejected even when the signature verifies |
| resolver contract | never throws on hostile input. Wrong prefix, wrong segment count, empty segments, non-base64url segments, and 5KB segments all resolve to `null` rather than raising |
| inertness | resolver returns `null` when the signing secret is unset; minting throws rather than emitting a dead token |
| route scope | read-only allowlist: only the five GET artifact routes are in scope. Every non-GET method on an allowed path is denied, as is the wider API surface — including deeper sub-paths (`/api/meetings/abc/notes`) and the `/api/transcriptsX` prefix trap |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/artifact-share-role-resolver.test.ts`, the "rejects a correctly-signed token claiming an elevated role" case — that is the one guarding against a signature being mistaken for entitlement.

## Detailed testing steps

```bash
cd packages/agent && npx vitest run src/api/artifact-share-role-resolver.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:52c31eb1c928ee803ee24f2aa1105c39bac31772 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/api/artifact-share-role-resolver.test.ts
 Test Files  1 passed (1)
      Tests  16 passed (16)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 16/16 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that hostile payloads are signed with the live secret and malformed inputs assert both non-throwing and `null`.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
