### PR TITLE
test(app): cover react-is

### DIFF
--- a/packages/app/src/shims/react-is.test.ts
+++ b/packages/app/src/shims/react-is.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the browser `react-is` shim. The suite drives the real
+ * module (not a mock of `react`) and records `typeOf`'s primitive /
+ * non-element vs element-tag branches, the five type-guards against real
+ * `createElement` / `forwardRef` / `memo` / `createPortal` values, legacy vs
+ * transitional `$$typeof`, missing-field objects, and default-export identity.
+ * There is no queue, capacity, or comparator — only `$$typeof`/`type` matching
+ * as implemented.
+ */
+import { createElement, Fragment, forwardRef, memo } from "react";
+import { createPortal } from "react-dom";
+import { describe, expect, it } from "vitest";
+
+import reactIs, {
+  isElement,
+  isForwardRef,
+  isFragment,
+  isMemo,
+  isPortal,
+  typeOf,
+} from "./react-is.js";
+
+const REACT_ELEMENT_TYPE = Symbol.for("react.transitional.element");
+const REACT_LEGACY_ELEMENT_TYPE = Symbol.for("react.element");
+const REACT_FRAGMENT_TYPE = Symbol.for("react.fragment");
+const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
+const REACT_MEMO_TYPE = Symbol.for("react.memo");
+const REACT_PORTAL_TYPE = Symbol.for("react.portal");
+
+function Comp(): null {
+  return null;
+}
+
+const Fwd = forwardRef(function Fwd(_props: unknown, _ref: unknown) {
+  return null;
+});
+
+const Mem = memo(function Mem() {
+  return null;
+});
+
+describe("react-is exports", () => {
+  it("exposes the same functions on the default object and as named exports", () => {
+    expect(reactIs.isElement).toBe(isElement);
+    expect(reactIs.isForwardRef).toBe(isForwardRef);
+    expect(reactIs.isFragment).toBe(isFragment);
+    expect(reactIs.isMemo).toBe(isMemo);
+    expect(reactIs.isPortal).toBe(isPortal);
+    expect(reactIs.typeOf).toBe(typeOf);
+    expect(Object.keys(reactIs)).toEqual([
+      "isElement",
+      "isForwardRef",
+      "isFragment",
+      "isMemo",
+      "isPortal",
+      "typeOf",
+    ]);
+  });
+});
+
+describe("typeOf primitives and empty values", () => {
+  it("returns undefined for falsy non-objects and every primitive typeof", () => {
+    expect(typeOf(undefined)).toBeUndefined();
+    expect(typeOf(null)).toBeUndefined();
+    expect(typeOf(false)).toBeUndefined();
+    expect(typeOf(0)).toBeUndefined();
+    expect(typeOf(Number.NaN)).toBeUndefined();
+    expect(typeOf("")).toBeUndefined();
+    expect(typeOf(1)).toBeUndefined();
+    expect(typeOf("div")).toBeUndefined();
+    expect(typeOf(true)).toBeUndefined();
+    expect(typeOf(1n)).toBeUndefined();
+    expect(typeOf(Symbol.for("react.element"))).toBeUndefined();
+    expect(typeOf(Fragment)).toBeUndefined();
+    expect(typeOf(Comp)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty object, array, and object without $$typeof", () => {
+    expect(typeOf({})).toBeUndefined();
+    expect(typeOf([])).toBeUndefined();
+    expect(typeOf({ type: "div" })).toBeUndefined();
+  });
+});
+
+describe("typeOf element vs non-element $$typeof", () => {
+  it("returns type for a real createElement node and a transitional tag", () => {
+    const el = createElement("div");
+    expect(typeOf(el)).toBe("div");
+    expect(typeOf({ $$typeof: REACT_ELEMENT_TYPE, type: "span" })).toBe("span");
+  });
+
+  it("returns type for the legacy element tag even when React rejects it", () => {
+    const legacy = { $$typeof: REACT_LEGACY_ELEMENT_TYPE, type: "p" };
+    expect(typeOf(legacy)).toBe("p");
+    expect(isElement(legacy)).toBe(false);
+  });
+
+  it("returns the missing type as-is when the tag matches an element symbol", () => {
+    expect(typeOf({ $$typeof: REACT_ELEMENT_TYPE })).toBeUndefined();
+    expect(typeOf({ $$typeof: REACT_ELEMENT_TYPE, type: 0 })).toBe(0);
+    expect(typeOf({ $$typeof: REACT_ELEMENT_TYPE, type: null })).toBeNull();
+  });
+
+  it("returns $$typeof unchanged when it is not a React element tag", () => {
+    expect(typeOf({ $$typeof: REACT_FORWARD_REF_TYPE })).toBe(
+      REACT_FORWARD_REF_TYPE,
+    );
+    expect(typeOf({ $$typeof: REACT_MEMO_TYPE })).toBe(REACT_MEMO_TYPE);
+    expect(typeOf({ $$typeof: REACT_PORTAL_TYPE })).toBe(REACT_PORTAL_TYPE);
+    expect(typeOf({ $$typeof: REACT_FRAGMENT_TYPE })).toBe(REACT_FRAGMENT_TYPE);
+    const other = Symbol.for("react.context");
+    expect(typeOf({ $$typeof: other })).toBe(other);
+    expect(typeOf({ $$typeof: "not-a-symbol" })).toBe("not-a-symbol");
+  });
+
+  it("returns the component object as type for forwardRef and memo elements", () => {
+    const fwdEl = createElement(Fwd);
+    const memEl = createElement(Mem);
+    expect(typeOf(fwdEl)).toBe(Fwd);
+    expect(typeOf(memEl)).toBe(Mem);
+    expect(typeOf(Fwd)).toBe(REACT_FORWARD_REF_TYPE);
+    expect(typeOf(Mem)).toBe(REACT_MEMO_TYPE);
+  });
+});
+
+describe("isElement", () => {
+  it("is true only for values React itself accepts as elements", () => {
+    expect(isElement(createElement("div"))).toBe(true);
+    expect(isElement(createElement(Fragment))).toBe(true);
+    expect(isElement(createElement(Comp))).toBe(true);
+    expect(isElement(createElement(Fwd))).toBe(true);
+    expect(isElement({ $$typeof: REACT_ELEMENT_TYPE, type: "div" })).toBe(true);
+  });
+
+  it("is false for primitives, empty objects, components, and portals", () => {
+    expect(isElement(undefined)).toBe(false);
+    expect(isElement(null)).toBe(false);
+    expect(isElement("div")).toBe(false);
+    expect(isElement({})).toBe(false);
+    expect(isElement([])).toBe(false);
+    expect(isElement(Comp)).toBe(false);
+    expect(isElement(Fwd)).toBe(false);
+    expect(isElement(Mem)).toBe(false);
+    expect(isElement(Fragment)).toBe(false);
+    const host = document.createElement("div");
+    expect(isElement(createPortal(createElement("span"), host))).toBe(false);
+    expect(
+      isElement({ $$typeof: REACT_LEGACY_ELEMENT_TYPE, type: "div" }),
+    ).toBe(false);
+  });
+});
+
+describe("isFragment", () => {
+  it("is true for a real Fragment element and for either fragment type tag", () => {
+    expect(Fragment).toBe(REACT_FRAGMENT_TYPE);
+    expect(isFragment(createElement(Fragment))).toBe(true);
+    expect(isFragment({ $$typeof: REACT_ELEMENT_TYPE, type: Fragment })).toBe(
+      true,
+    );
+    expect(
+      isFragment({ $$typeof: REACT_ELEMENT_TYPE, type: REACT_FRAGMENT_TYPE }),
+    ).toBe(true);
+    expect(isFragment({ $$typeof: REACT_FRAGMENT_TYPE })).toBe(true);
+  });
+
+  it("is false for non-fragments, the Fragment symbol itself, and missing items", () => {
+    expect(isFragment(undefined)).toBe(false);
+    expect(isFragment(null)).toBe(false);
+    expect(isFragment(Fragment)).toBe(false);
+    expect(isFragment(createElement("div"))).toBe(false);
+    expect(isFragment(createElement(Comp))).toBe(false);
+    expect(isFragment({})).toBe(false);
+    expect(isFragment({ $$typeof: REACT_ELEMENT_TYPE, type: "div" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isForwardRef", () => {
+  it("is true for a forwardRef type object, not for an element of that type", () => {
+    expect(isForwardRef(Fwd)).toBe(true);
+    expect(isForwardRef({ $$typeof: REACT_FORWARD_REF_TYPE })).toBe(true);
+    expect(isForwardRef(createElement(Fwd))).toBe(false);
+  });
+
+  it("is false for missing items, memo, portals, and host elements", () => {
+    expect(isForwardRef(undefined)).toBe(false);
+    expect(isForwardRef(null)).toBe(false);
+    expect(isForwardRef({})).toBe(false);
+    expect(isForwardRef(Mem)).toBe(false);
+    expect(isForwardRef(createElement("div"))).toBe(false);
+  });
+});
+
+describe("isMemo", () => {
+  it("is true for a memo type object, not for an element of that type", () => {
+    expect(isMemo(Mem)).toBe(true);
+    expect(isMemo({ $$typeof: REACT_MEMO_TYPE })).toBe(true);
+    expect(isMemo(createElement(Mem))).toBe(false);
+  });
+
+  it("is false for missing items, forwardRef, and host elements", () => {
+    expect(isMemo(undefined)).toBe(false);
+    expect(isMemo(null)).toBe(false);
+    expect(isMemo({})).toBe(false);
+    expect(isMemo(Fwd)).toBe(false);
+    expect(isMemo(createElement("div"))).toBe(false);
+  });
+});
+
+describe("isPortal", () => {
+  it("is true for a real createPortal value and a portal $$typeof object", () => {
+    const host = document.createElement("div");
+    const portal = createPortal(createElement("span"), host);
+    expect(typeOf(portal)).toBe(REACT_PORTAL_TYPE);
+    expect(isPortal(portal)).toBe(true);
+    expect(isPortal({ $$typeof: REACT_PORTAL_TYPE })).toBe(true);
+  });
+
+  it("is false for missing items, elements, and the other type-guards' matches", () => {
+    expect(isPortal(undefined)).toBe(false);
+    expect(isPortal(null)).toBe(false);
+    expect(isPortal({})).toBe(false);
+    expect(isPortal(createElement("div"))).toBe(false);
+    expect(isPortal(Fwd)).toBe(false);
+    expect(isPortal(Mem)).toBe(false);
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for
`packages/app/src/shims/react-is.ts`. The tree already has a mock-based file at
`packages/app/src/shims/__tests__/react-is.test.ts` (wrong relative import
`./react-is.ts`); sibling shims are covered by a colocated `*.test.ts` next to
the source. This PR adds that colocated real-module suite.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` (branch `test/app-react-is-coverage` at
      `94a214ed3d77720c2d14c8216e2dd0a089fb6b3c`, parent
      `origin/develop` `2a967ef64f40f517a1c0cd7ced294bbbf561e391`).
- [x] Reviewers can confirm the changed behavior from the committed focused test.

# Sync with develop

- [x] Branched from the latest fetched `origin/develop` immediately before
      filing. `packages/app/src/shims/react-is.ts` is unchanged vs that tip.
- [x] `bun run verify` was not re-run: this is a test-only addition of one
      file. Focused vitest / biome / tsc are quoted below.

# Risks

Low. Production `react-is` is unchanged. The suite drives the real module
(named + default exports, `typeOf` primitive/empty/element/legacy/non-element
branches, `isElement` / `isFragment` / `isForwardRef` / `isMemo` / `isPortal`
against real `createElement` / `forwardRef` / `memo` / `createPortal` values
and missing-item objects). There is no queue, capacity, or comparator.

Observed (not aspirational) guard behaviour on the installed React:

- `isForwardRef` / `isMemo` are true for the component type object and false
  for an element created from that type (`typeOf` returns the component, not
  the `forward_ref` / `memo` symbol).
- `isElement` is false for a hand-built `{ $$typeof: Symbol.for("react.element") }`
  legacy tag; `typeOf` still returns `.type` for that tag.
- `Fragment === Symbol.for("react.fragment")`; `isFragment` is false for the
  Fragment symbol itself.

# Background

## What does this PR do?

Adds `packages/app/src/shims/react-is.test.ts`, matching cookie/debug/nprogress
shim layout (`import { describe, expect, it } from "vitest"` and
`from "./react-is.js"`). No `vi.mock` of `react`. Default-export identity is
asserted against the named functions.

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/react-is.test.ts` — same layout as
`packages/app/src/shims/cookie.test.ts`. Import path is `./react-is.js`.

## Detailed testing steps

From `packages/app` (jsdom environment from `vitest.config.ts`):

```bash
bunx vitest run src/shims/react-is.test.ts
bunx biome check --write packages/app/src/shims/react-is.test.ts
# from repo root
cd packages/app && bunx tsc --noEmit 2>&1 | grep 'src/shims/react-is.test.ts'
```

Focused proof at the pushed head `94a214ed3d77720c2d14c8216e2dd0a089fb6b3c`,
re-run after fetching current `origin/develop` (source file identical):

```text
RUN  v4.1.5 /Volumes/thescoho_1TB/Developer/eliza/packages/app
 ✓ src/shims/react-is.test.ts (18 tests) 4ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  19:21:22
   Duration  754ms (transform 69ms, setup 69ms, import 17ms, tests 4ms, environment 577ms)
```

`bunx biome check --write packages/app/src/shims/react-is.test.ts`:
`Checked 1 file in 15ms. Fixed 1 file.` Config was present
(`/Volumes/thescoho_1TB/Developer/eliza/biome.json`); sparse-checkout is not
enabled. The committed file is that formatted result.

`bunx tsc --noEmit` in `packages/app`, grepped for this PR's file:

```text
# grep 'src/shims/react-is.test.ts' — no hits (this file adds zero TS errors)
# grep 'react-is.test.ts' still matches a pre-existing develop error:
src/shims/__tests__/react-is.test.ts(23,8): error TS2307: Cannot find module './react-is.ts' or its corresponding type declarations.
```

That `__tests__` import is not part of this diff.

The diff touches only `packages/app/src/shims/react-is.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The
counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:94a214ed3d77720c2d14c8216e2dd0a089fb6b3c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (18 passed / 18).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact; the proof is the focused Vitest suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no frontend or server path changed. Vitest output is quoted under Testing.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no rendered UI surface.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run (test-only, one new file). Hosted Actions does not
run on this fork. Pre-existing `packages/app/src/shims/__tests__/react-is.test.ts`
TS2307 is unchanged and not in this diff.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
