### PR TITLE
test(core): cover plugin-manager relevance gating

### DIFF
--- a/packages/core/src/features/plugin-manager/providers/relevance.test.ts
+++ b/packages/core/src/features/plugin-manager/providers/relevance.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Covers the relevance-gating helpers for the plugin-manager providers. These
+ * decide whether a dynamic provider injects context into a turn, so both
+ * directions matter: firing on unrelated chat is prompt noise, and failing to
+ * fire hides plugin state the user asked about.
+ *
+ * Two properties are pinned deliberately. `buildKeywordRegex` sorts longest
+ * keyword first — with alternation the first match wins, so an unsorted bank
+ * would let "plugin" shadow "plugin manager" — and it escapes regex
+ * metacharacters, so a plugin name containing `.` cannot become a wildcard that
+ * matches unrelated text. It is also non-global, so repeated `.test()` on the
+ * same input stays stable.
+ *
+ * Pure functions — no runtime, no state, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	buildKeywordRegex,
+	buildProviderKeywords,
+	COMMON_CONNECTOR_KEYWORDS,
+	keywordsFromPluginNames,
+	PLUGIN_MANAGER_BASE_KEYWORDS,
+} from "./relevance.ts";
+
+describe("buildProviderKeywords", () => {
+	it("merges groups, lowercases, trims, and de-duplicates", () => {
+		expect(
+			buildProviderKeywords(["  Plugin  ", "plugin"], ["EXTENSION"]),
+		).toEqual(["plugin", "extension"]);
+	});
+
+	it("skips undefined groups and blank entries", () => {
+		expect(
+			buildProviderKeywords(undefined, ["a", "", "   "], undefined),
+		).toEqual(["a"]);
+	});
+
+	it("returns an empty list when given nothing", () => {
+		expect(buildProviderKeywords()).toEqual([]);
+	});
+});
+
+describe("keywordsFromPluginNames", () => {
+	it("derives the scoped name, unscoped name, unprefixed name, and tokens", () => {
+		const keywords = keywordsFromPluginNames(["@elizaos/plugin-discord"]);
+		expect(keywords).toContain("@elizaos/plugin-discord");
+		expect(keywords).toContain("plugin-discord");
+		expect(keywords).toContain("discord");
+	});
+
+	it("strips an app- prefix as well as plugin-", () => {
+		expect(keywordsFromPluginNames(["app-browser"])).toContain("browser");
+	});
+
+	it("drops generic split tokens that would match everything", () => {
+		// The ignored-token filter applies to the split tokens: "app" is dropped
+		// while the meaningful "storage" token survives.
+		const keywords = keywordsFromPluginNames(["@elizaos/plugin-app-storage"]);
+		expect(keywords).toContain("storage");
+		expect(keywords).not.toContain("app");
+		expect(keywords).not.toContain("plugin");
+	});
+
+	it("does not turn the npm scope into a keyword", () => {
+		expect(keywordsFromPluginNames(["@elizaos/plugin-discord"])).not.toContain(
+			"elizaos",
+		);
+	});
+
+	it("drops single-character tokens", () => {
+		expect(keywordsFromPluginNames(["plugin-a-storage"])).not.toContain("a");
+	});
+
+	it("ignores blank names and de-duplicates across inputs", () => {
+		const keywords = keywordsFromPluginNames([
+			"  ",
+			"@elizaos/plugin-discord",
+			"@elizaos/plugin-discord",
+		]);
+		expect(new Set(keywords).size).toBe(keywords.length);
+	});
+
+	it("lowercases names before deriving keywords", () => {
+		expect(keywordsFromPluginNames(["@ElizaOS/Plugin-Discord"])).toContain(
+			"discord",
+		);
+	});
+});
+
+describe("buildKeywordRegex", () => {
+	it("matches a keyword on a word boundary, case-insensitively", () => {
+		const regex = buildKeywordRegex(["discord"]);
+		expect(regex.test("connect Discord please")).toBe(true);
+		expect(regex.test("discordant opinions")).toBe(false);
+	});
+
+	it("never matches real text when the keyword list is empty", () => {
+		// The empty bank compiles to the never-matching `/$^/` sentinel. Callers
+		// guard on non-empty text before testing, so the only contract that
+		// matters is that no actual content matches.
+		const regex = buildKeywordRegex([]);
+		for (const text of ["plugin", "discord", "anything at all", " "]) {
+			expect(regex.test(text)).toBe(false);
+		}
+	});
+
+	it("orders longer keywords first so a prefix cannot shadow a longer phrase", () => {
+		// Alternation takes the first match, so "plugin" listed first would win.
+		const match = buildKeywordRegex(["plugin", "plugin manager"]).exec(
+			"open the plugin manager",
+		);
+		expect(match?.[1]).toBe("plugin manager");
+	});
+
+	it("escapes regex metacharacters so a name cannot become a wildcard", () => {
+		const regex = buildKeywordRegex(["a.b"]);
+		expect(regex.test("a.b")).toBe(true);
+		expect(regex.test("axb")).toBe(false);
+	});
+
+	it("is not a global regex, so repeated tests are stable", () => {
+		const regex = buildKeywordRegex(["discord"]);
+		const text = "discord";
+		expect([regex.test(text), regex.test(text), regex.test(text)]).toEqual([
+			true,
+			true,
+			true,
+		]);
+	});
+
+	it("ignores blank keywords rather than matching everything", () => {
+		const regex = buildKeywordRegex(["", "   "]);
+		expect(regex.test("anything at all")).toBe(false);
+	});
+});
+
+describe("keyword banks", () => {
+	it("are non-empty, lowercase, and free of duplicates", () => {
+		for (const bank of [
+			PLUGIN_MANAGER_BASE_KEYWORDS,
+			COMMON_CONNECTOR_KEYWORDS,
+		]) {
+			expect(bank.length).toBeGreaterThan(0);
+			expect([...bank]).toEqual(bank.map((k) => k.toLowerCase()));
+			expect(new Set(bank).size).toBe(bank.length);
+		}
+	});
+
+	it("compile into a regex that matches representative phrasing", () => {
+		const regex = buildKeywordRegex([
+			...PLUGIN_MANAGER_BASE_KEYWORDS,
+			...COMMON_CONNECTOR_KEYWORDS,
+		]);
+		for (const text of [
+			"can you install a plugin?",
+			"is discord connected?",
+			"show the plugin manager status",
+		]) {
+			expect(regex.test(text)).toBe(true);
+		}
+		expect(regex.test("what is the weather tomorrow")).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/features/plugin-manager/providers/relevance.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `168daca11e14c87465d1d893616b4c37097338d3`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Cases run the real exported builders and the real compiled regex. Every match assertion has a matching non-match ("Discord" matches, "discordant" does not; `a.b` matches, `axb` does not), and the ordering case asserts the **captured group** rather than just truthiness, so a regression to an unsorted alternation would fail rather than coincidentally pass.

# Background

## What does this PR do?

`packages/core/src/features/plugin-manager/providers/relevance.ts` decides whether the plugin-manager providers inject context into a turn. It had **no dedicated test file**. Both directions matter — firing on unrelated chat is prompt noise, failing to fire hides plugin state the user asked about.

| Area | Contract pinned |
|---|---|
| longest-first ordering | alternation takes the **first** match, so an unsorted bank would let `plugin` shadow `plugin manager`. The test asserts the captured group is the longer phrase. |
| metacharacter escaping | a keyword containing `.` matches only a literal dot — `a.b` matches, `axb` does not — so a plugin name cannot become a wildcard |
| boundaries + case | word-boundary anchored and case-insensitive: "Discord" matches, "discordant" does not |
| statelessness | the compiled regex is not global, so repeated `.test()` on identical input is stable |
| empty inputs | blank keywords and an empty bank never match real text |
| `keywordsFromPluginNames` | scoped name, unscoped name, `plugin-`/`app-` prefix stripping, lowercasing, de-duplication, and the ignored-token filter (drops generic `app`, keeps meaningful `storage`); the npm scope never becomes a keyword |
| `buildProviderKeywords` | merge, trim, lowercase, de-duplicate, skip undefined groups |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/plugin-manager/providers/relevance.test.ts`, the `buildKeywordRegex` block — the longest-first ordering and metacharacter-escaping cases are the two real regression guards.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/features/plugin-manager/providers/relevance.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a9b9aa3729a268e3682d6726898c0244bb83602a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/features/plugin-manager/providers/relevance.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 18/18 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that every match assertion is paired with a non-match and the ordering case inspects the captured group.
- `isProviderRelevant` itself is not covered here: it delegates to the shared `validation/keywords` helpers over runtime `State`, which would require a runtime harness rather than the pure-function coverage this PR adds.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
