### PR TITLE
test(app): cover unpdf

### DIFF
--- a/packages/app/src/shims/unpdf.test.ts
+++ b/packages/app/src/shims/unpdf.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the browser `unpdf` PDF-extraction shim. The suite drives
+ * the real module (not a mock) and records that `extractText` and
+ * `getDocumentProxy` are the only exports and always reject with their
+ * renderer-unavailable Errors, including empty calls, extra arguments the
+ * Node unpdf API would accept, repeated calls, and concurrent calls. There
+ * is no comparator, queue, capacity, or removal API.
+ */
+import { describe, expect, it } from "vitest";
+
+import * as unpdf from "./unpdf.js";
+import { extractText, getDocumentProxy } from "./unpdf.js";
+
+const EXTRACT_UNAVAILABLE =
+  "PDF text extraction is unavailable in the browser renderer.";
+const PROXY_UNAVAILABLE =
+  "PDF document proxy is unavailable in the browser renderer.";
+
+async function expectExtractUnavailable(
+  pending: Promise<{ text: string }>,
+): Promise<void> {
+  await expect(pending).rejects.toMatchObject({
+    name: "Error",
+    message: EXTRACT_UNAVAILABLE,
+  });
+}
+
+async function expectProxyUnavailable(pending: Promise<never>): Promise<void> {
+  await expect(pending).rejects.toMatchObject({
+    name: "Error",
+    message: PROXY_UNAVAILABLE,
+  });
+}
+
+describe("unpdf shim exports", () => {
+  it("exports only extractText and getDocumentProxy as functions", () => {
+    expect(Object.keys(unpdf).sort()).toEqual([
+      "extractText",
+      "getDocumentProxy",
+    ]);
+    expect(typeof unpdf.extractText).toBe("function");
+    expect(typeof unpdf.getDocumentProxy).toBe("function");
+    expect(unpdf.extractText).toBe(extractText);
+    expect(unpdf.getDocumentProxy).toBe(getDocumentProxy);
+  });
+
+  it("has no default export on the module namespace", () => {
+    expect(Object.hasOwn(unpdf, "default")).toBe(false);
+  });
+
+  it("reads a missing export as undefined rather than throwing", () => {
+    const view = unpdf as Record<string, unknown>;
+    expect(view.phonemize).toBeUndefined();
+    expect(view.parsePdf).toBeUndefined();
+    expect(view[""]).toBeUndefined();
+  });
+});
+
+describe("extractText always rejects", () => {
+  it("returns a Promise instead of throwing synchronously", async () => {
+    const pending = extractText();
+    expect(pending).toBeInstanceOf(Promise);
+    await expectExtractUnavailable(pending);
+  });
+
+  it("rejects an empty call with the renderer-unavailable Error", async () => {
+    await expectExtractUnavailable(extractText());
+  });
+
+  it("rejects extra arguments the Node unpdf API would accept", async () => {
+    await expectExtractUnavailable(
+      Reflect.apply(extractText, undefined, [
+        new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      ]),
+    );
+    await expectExtractUnavailable(
+      Reflect.apply(extractText, undefined, [new ArrayBuffer(0)]),
+    );
+    await expectExtractUnavailable(
+      Reflect.apply(extractText, undefined, [
+        { data: new Uint8Array(0) },
+        { mergePages: true },
+      ]),
+    );
+  });
+
+  it("rejects null, undefined, and empty-object payloads the same way", async () => {
+    await expectExtractUnavailable(
+      Reflect.apply(extractText, undefined, [null]),
+    );
+    await expectExtractUnavailable(
+      Reflect.apply(extractText, undefined, [undefined]),
+    );
+    await expectExtractUnavailable(Reflect.apply(extractText, undefined, [{}]));
+  });
+
+  it("returns a distinct rejected Promise on each call", async () => {
+    const first = extractText();
+    const second = extractText();
+    expect(first).not.toBe(second);
+
+    const [a, b] = await Promise.allSettled([first, second]);
+    expect(a).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: EXTRACT_UNAVAILABLE },
+    });
+    expect(b).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: EXTRACT_UNAVAILABLE },
+    });
+    if (a.status === "rejected" && b.status === "rejected") {
+      expect(a.reason).not.toBe(b.reason);
+    }
+  });
+
+  it("rejects every concurrent call independently", async () => {
+    const settled = await Promise.allSettled([
+      extractText(),
+      extractText(),
+      extractText(),
+    ]);
+    expect(settled).toHaveLength(3);
+    for (const result of settled) {
+      expect(result).toMatchObject({
+        status: "rejected",
+        reason: { name: "Error", message: EXTRACT_UNAVAILABLE },
+      });
+    }
+  });
+});
+
+describe("getDocumentProxy always rejects", () => {
+  it("returns a Promise instead of throwing synchronously", async () => {
+    const pending = getDocumentProxy();
+    expect(pending).toBeInstanceOf(Promise);
+    await expectProxyUnavailable(pending);
+  });
+
+  it("rejects an empty call with the renderer-unavailable Error", async () => {
+    await expectProxyUnavailable(getDocumentProxy());
+  });
+
+  it("rejects extra arguments the Node unpdf API would accept", async () => {
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [
+        new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      ]),
+    );
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [new ArrayBuffer(8)]),
+    );
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [{ data: new Uint8Array(0) }]),
+    );
+  });
+
+  it("rejects null, undefined, and empty-object payloads the same way", async () => {
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [null]),
+    );
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [undefined]),
+    );
+    await expectProxyUnavailable(
+      Reflect.apply(getDocumentProxy, undefined, [{}]),
+    );
+  });
+
+  it("returns a distinct rejected Promise on each call", async () => {
+    const first = getDocumentProxy();
+    const second = getDocumentProxy();
+    expect(first).not.toBe(second);
+
+    const [a, b] = await Promise.allSettled([first, second]);
+    expect(a).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: PROXY_UNAVAILABLE },
+    });
+    expect(b).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: PROXY_UNAVAILABLE },
+    });
+    if (a.status === "rejected" && b.status === "rejected") {
+      expect(a.reason).not.toBe(b.reason);
+    }
+  });
+
+  it("rejects every concurrent call independently", async () => {
+    const settled = await Promise.allSettled([
+      getDocumentProxy(),
+      getDocumentProxy(),
+      getDocumentProxy(),
+    ]);
+    expect(settled).toHaveLength(3);
+    for (const result of settled) {
+      expect(result).toMatchObject({
+        status: "rejected",
+        reason: { name: "Error", message: PROXY_UNAVAILABLE },
+      });
+    }
+  });
+});
+
+describe("extractText and getDocumentProxy stay independent", () => {
+  it("uses a distinct unavailable message for each export", async () => {
+    expect(EXTRACT_UNAVAILABLE).not.toBe(PROXY_UNAVAILABLE);
+
+    const [extracted, proxied] = await Promise.allSettled([
+      extractText(),
+      getDocumentProxy(),
+    ]);
+    expect(extracted).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: EXTRACT_UNAVAILABLE },
+    });
+    expect(proxied).toMatchObject({
+      status: "rejected",
+      reason: { name: "Error", message: PROXY_UNAVAILABLE },
+    });
+  });
+
+  it("rejects mixed concurrent calls without one export winning a tie", async () => {
+    const settled = await Promise.allSettled([
+      extractText(),
+      getDocumentProxy(),
+      extractText(),
+      getDocumentProxy(),
+    ]);
+    expect(settled.map((result) => result.status)).toEqual([
+      "rejected",
+      "rejected",
+      "rejected",
+      "rejected",
+    ]);
+    expect(settled[0]).toMatchObject({
+      reason: { message: EXTRACT_UNAVAILABLE },
+    });
+    expect(settled[1]).toMatchObject({
+      reason: { message: PROXY_UNAVAILABLE },
+    });
+    expect(settled[2]).toMatchObject({
+      reason: { message: EXTRACT_UNAVAILABLE },
+    });
+    expect(settled[3]).toMatchObject({
+      reason: { message: PROXY_UNAVAILABLE },
+    });
+  });
+
+  it("keeps the same namespace on dynamic import as on the static binding", async () => {
+    const dynamic = await import("./unpdf.js");
+    expect(dynamic).toBe(unpdf);
+    expect(dynamic.extractText).toBe(extractText);
+    expect(dynamic.getDocumentProxy).toBe(getDocumentProxy);
+  });
+});


### PR DESCRIPTION

# Relates to

No existing issue. Adds unit coverage for `packages/app/src/shims/unpdf.ts`, which had no same-named test file on `origin/develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Base `168daca11e14c87465d1d893616b4c37097338d3`, head `d761f18ac7cf4e29f0d1e75ce8e97b9fd9013302`, 0 behind / 1 ahead, single-file diff.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition. No production module, export, alias, or renderer behavior changes. The shim remains a throwing browser placeholder for Node-only `unpdf`.

# Background

## What does this PR do?

Adds a colocated Vitest suite `packages/app/src/shims/unpdf.test.ts` that drives the real browser `unpdf` shim (not a mock). The module exports only `extractText` and `getDocumentProxy`. Both are `async` functions that always reject with distinct renderer-unavailable `Error`s. The suite records:

- export surface (`extractText`, `getDocumentProxy` only; no default)
- missing names read as `undefined` (no throw)
- empty calls reject; extra arguments the Node unpdf API would accept still reject
- null / undefined / empty-object payloads reject the same way
- each call returns a distinct rejected Promise and a distinct `Error` instance
- concurrent calls reject independently
- mixed `extractText` + `getDocumentProxy` calls keep their own messages (neither export wins a tie)
- dynamic `import("./unpdf.js")` is the same namespace as the static binding

There is no comparator, queue, capacity, or removal API on this shim; those branches do not exist and are not invented.

## What kind of change is this?

Improvements (misc. changes to existing features) — test coverage only.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/unpdf.test.ts` next to `packages/app/src/shims/unpdf.ts`. Layout matches sibling shim tests such as `mammoth.test.ts`.

## Detailed testing steps

None: automated tests are acceptable.

```bash
bunx vitest run packages/app/src/shims/unpdf.test.ts
```

Re-run against current `origin/develop` immediately before filing (base `168daca11e14c87465d1d893616b4c37097338d3`):

```
Test Files  1 passed (1)
     Tests  18 passed (18)
  Duration  242ms
```

`bunx biome check --write packages/app/src/shims/unpdf.test.ts` — Checked 1 file, clean after write.

`cd packages/app && bunx tsc --noEmit 2>&1 | grep unpdf.test.ts` — empty (this file introduced zero type errors). Pre-existing errors elsewhere in the package are unrelated.

The diff touches only `packages/app/src/shims/unpdf.test.ts`.

Hosted CI does **not** run on this fork contributor PR. Do not infer that GitHub Actions passed.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:d761f18ac7cf4e29f0d1e75ce8e97b9fd9013302 -->

This PR adds tests and changes no production behaviour. Heavy bug-fix evidence (origin reproduction, load-bearing revert, over-rejection corpus, proof-run) does not apply.

- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only; no rendered UI surface.
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only; no user flow or UI change.
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - no backend or runtime path change; Vitest drives the shim in-process.
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no frontend network or view change.
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent, action, provider, prompt, or model change.
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain state; the shim always rejects.
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only in-process Vitest run; no server or renderer session.

Quoted Vitest result (re-run after fetch of `origin/develop` `168daca11e14c87465d1d893616b4c37097338d3`):

```
 ✓ packages/app/src/shims/unpdf.test.ts (18 tests) 12ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  19:24:02
   Duration  242ms (transform 69ms, setup 0ms, import 87ms, tests 12ms, environment 0ms)
```

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI pixels.

### Before

N/A - test-only.

### After

N/A - test-only.

### Walkthrough video

N/A - test-only.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT / omnivoice change.

## Known gaps / failures

- `bun run verify` was not re-run. This diff adds one test file and changes no production behaviour. Focused gates (Vitest 18/18, biome clean, tsc grep empty for `unpdf.test.ts`) are quoted above.
- Hosted GitHub Actions CI does not run on fork contributor PRs. No Actions green check is claimed.
- No identity.slop.cash OAuth evidence trace: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
