### PR TITLE
test(core): cover connector-config

### DIFF
--- a/packages/core/src/connectors/connector-config.test.ts
+++ b/packages/core/src/connectors/connector-config.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Covers the shared connector-config inspection helpers.
+ *
+ * The credential-key builders carry a security-relevant property the module
+ * documents explicitly: segments are length-prefixed so distinct identifiers
+ * can never collide into one secret-setting key. Two accounts must not be able
+ * to read each other's credential because their ids differ only by a separator
+ * character — so the collision cases here are adversarial, not cosmetic.
+ *
+ * `isConnectorConfigured` is the single source of truth behind every plugin's
+ * auto-enable predicate, so `enabled: false` must win over present credentials
+ * and each connector-specific branch must be pinned.
+ *
+ * Pure functions — no runtime, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	connectorAccountCredentialSettingKey,
+	connectorBaseCredentialSettingKey,
+	isConnectorConfigured,
+	isGoogleChatConfigured,
+	isWechatConfigured,
+} from "./connector-config.ts";
+
+describe("credential setting keys", () => {
+	it("length-prefixes each segment", () => {
+		expect(
+			connectorAccountCredentialSettingKey("slack", "acct1", "token"),
+		).toBe("CONNECTOR|5:slack|ACCOUNT|5:acct1|5:token");
+		expect(connectorBaseCredentialSettingKey("slack", "token")).toBe(
+			"CONNECTOR|5:slack|BASE|5:token",
+		);
+	});
+
+	it("keeps account and base credentials in separate namespaces", () => {
+		expect(
+			connectorAccountCredentialSettingKey("slack", "acct1", "token"),
+		).not.toBe(connectorBaseCredentialSettingKey("slack", "token"));
+	});
+
+	it("does not collapse ids that differ only by separator character", () => {
+		// The documented reason for length-prefixing: slug normalization would
+		// make these two accounts share one credential.
+		expect(
+			connectorAccountCredentialSettingKey("slack", "support-east", "token"),
+		).not.toBe(
+			connectorAccountCredentialSettingKey("slack", "support_east", "token"),
+		);
+	});
+
+	it("resists a separator injected into an identifier", () => {
+		// Without length prefixes, "a|ACCOUNT|b" could be crafted to reshape the key.
+		const crafted = connectorAccountCredentialSettingKey(
+			"slack",
+			"a|ACCOUNT|b",
+			"token",
+		);
+		const plain = connectorAccountCredentialSettingKey("slack", "a", "token");
+		expect(crafted).not.toBe(plain);
+		expect(crafted).toContain("11:a|ACCOUNT|b");
+	});
+
+	it("keeps a shifted boundary between adjacent segments distinct", () => {
+		expect(connectorAccountCredentialSettingKey("ab", "c", "token")).not.toBe(
+			connectorAccountCredentialSettingKey("a", "bc", "token"),
+		);
+	});
+
+	it("handles empty segments without collapsing them", () => {
+		expect(connectorAccountCredentialSettingKey("slack", "", "token")).toBe(
+			"CONNECTOR|5:slack|ACCOUNT|0:|5:token",
+		);
+	});
+});
+
+describe("isConnectorConfigured", () => {
+	it("rejects a missing or non-object config", () => {
+		for (const value of [null, undefined, "x", 42, true]) {
+			expect(isConnectorConfigured("slack", value)).toBe(false);
+		}
+	});
+
+	it("lets enabled:false win over present credentials", () => {
+		expect(
+			isConnectorConfigured("slack", { enabled: false, botToken: "t" }),
+		).toBe(false);
+	});
+
+	it("accepts any of the universal credential fields", () => {
+		for (const field of ["botToken", "token", "apiKey"]) {
+			expect(isConnectorConfigured("anything", { [field]: "value" })).toBe(
+				true,
+			);
+		}
+	});
+
+	it("rejects an unknown connector with no universal credential", () => {
+		expect(isConnectorConfigured("unknown-connector", { projectId: "p" })).toBe(
+			false,
+		);
+	});
+
+	it("requires both halves for bluebubbles", () => {
+		expect(isConnectorConfigured("bluebubbles", { serverUrl: "u" })).toBe(
+			false,
+		);
+		expect(isConnectorConfigured("bluebubbles", { password: "p" })).toBe(false);
+		expect(
+			isConnectorConfigured("bluebubbles", { serverUrl: "u", password: "p" }),
+		).toBe(true);
+	});
+
+	it("requires both halves for discordLocal", () => {
+		expect(isConnectorConfigured("discordLocal", { clientId: "i" })).toBe(
+			false,
+		);
+		expect(
+			isConnectorConfigured("discordLocal", {
+				clientId: "i",
+				clientSecret: "s",
+			}),
+		).toBe(true);
+	});
+
+	it("accepts any single signal for imessage", () => {
+		expect(isConnectorConfigured("imessage", { cliPath: "/x" })).toBe(true);
+		expect(isConnectorConfigured("imessage", { dbPath: "/x" })).toBe(true);
+		expect(isConnectorConfigured("imessage", { enabled: true })).toBe(true);
+		expect(isConnectorConfigured("imessage", {})).toBe(false);
+	});
+
+	it("accepts legacy and current whatsapp auth shapes", () => {
+		expect(isConnectorConfigured("whatsapp", { authState: "s" })).toBe(true);
+		expect(isConnectorConfigured("whatsapp", { sessionPath: "s" })).toBe(true);
+		expect(isConnectorConfigured("whatsapp", { authDir: "d" })).toBe(true);
+	});
+
+	it("accepts a whatsapp account with authDir, ignoring disabled ones", () => {
+		expect(
+			isConnectorConfigured("whatsapp", {
+				accounts: { a: { authDir: "d" } },
+			}),
+		).toBe(true);
+		expect(
+			isConnectorConfigured("whatsapp", {
+				accounts: { a: { authDir: "d", enabled: false } },
+			}),
+		).toBe(false);
+		expect(
+			isConnectorConfigured("whatsapp", { accounts: { a: { other: 1 } } }),
+		).toBe(false);
+	});
+
+	it("accepts twitch on any single signal", () => {
+		expect(isConnectorConfigured("twitch", { accessToken: "t" })).toBe(true);
+		expect(isConnectorConfigured("twitch", { clientId: "c" })).toBe(true);
+		expect(isConnectorConfigured("twitch", { enabled: true })).toBe(true);
+		expect(isConnectorConfigured("twitch", {})).toBe(false);
+	});
+});
+
+describe("isGoogleChatConfigured", () => {
+	it("requires service-account material, not just a projectId", () => {
+		expect(isGoogleChatConfigured({ projectId: "p" })).toBe(false);
+		expect(isGoogleChatConfigured({ serviceAccountFile: "/key.json" })).toBe(
+			true,
+		);
+		expect(
+			isGoogleChatConfigured({ serviceAccount: { client_email: "a" } }),
+		).toBe(true);
+		expect(isGoogleChatConfigured({ serviceAccountKey: "raw" })).toBe(true);
+	});
+
+	it("treats a blank credential string as unconfigured", () => {
+		expect(isGoogleChatConfigured({ serviceAccount: "   " })).toBe(false);
+	});
+
+	it("lets enabled:false win, at the top level and per account", () => {
+		expect(
+			isGoogleChatConfigured({ enabled: false, serviceAccountFile: "/k.json" }),
+		).toBe(false);
+		expect(
+			isGoogleChatConfigured({
+				accounts: { a: { serviceAccountFile: "/k.json", enabled: false } },
+			}),
+		).toBe(false);
+	});
+
+	it("finds credentials on an enabled account entry", () => {
+		expect(
+			isGoogleChatConfigured({
+				accounts: { a: { serviceAccountFile: "/k.json" } },
+			}),
+		).toBe(true);
+	});
+
+	it("rejects arrays and non-objects", () => {
+		for (const value of [null, undefined, [], "x"]) {
+			expect(isGoogleChatConfigured(value)).toBe(false);
+		}
+	});
+});
+
+describe("isWechatConfigured", () => {
+	it("accepts a top-level apiKey and rejects an empty config", () => {
+		expect(isWechatConfigured({ apiKey: "k" })).toBe(true);
+		expect(isWechatConfigured({})).toBe(false);
+		expect(isWechatConfigured(null)).toBe(false);
+	});
+
+	it("accepts an enabled account with an apiKey and skips disabled ones", () => {
+		expect(isWechatConfigured({ accounts: { a: { apiKey: "k" } } })).toBe(true);
+		expect(
+			isWechatConfigured({ accounts: { a: { apiKey: "k", enabled: false } } }),
+		).toBe(false);
+	});
+
+	it("lets enabled:false win over a present apiKey", () => {
+		expect(isWechatConfigured({ enabled: false, apiKey: "k" })).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/connectors/connector-config.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `3c8996d9f1f60b5561ce51e89f13fdeb611b6339`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The credential-key cases assert exact encoded strings and inequality between crafted pairs, so they fail if the length-prefixing is ever replaced by slug normalization. The predicate cases assert `false` explicitly for each negative branch rather than relying on falsiness, and `enabled: false` is tested **with** credentials present so a regression that short-circuits on the credential would fail.

# Background

## What does this PR do?

`packages/core/src/connectors/connector-config.ts` is the single source of truth behind every connector plugin's auto-enable predicate, plus the builder for connector credential setting keys. It had **no dedicated test file**.

**Credential keys** carry a security-relevant property the module states explicitly — segments are length-prefixed so distinct identifiers can never collide into one secret-setting key. Two accounts must not be able to reach each other's credential, so these cases are adversarial:

| Case | Why it matters |
|---|---|
| `support-east` vs `support_east` | the documented reason slug normalization was rejected — they must not share a credential |
| id containing `\|` and a literal `ACCOUNT` segment | a crafted id must not reshape the key |
| `ab`+`c` vs `a`+`bc` | a shifted boundary between adjacent segments stays distinct |
| empty segment | encodes as `0:` rather than collapsing |
| account vs base | separate namespaces |

**`isConnectorConfigured`** is pinned for `enabled: false` winning over present credentials, the three universal credential fields, an unknown connector defaulting to `false`, and every connector-specific branch: bluebubbles and discordLocal requiring both halves, imessage accepting any single signal, whatsapp accepting legacy and current auth shapes plus per-account `authDir` with disabled accounts skipped, and twitch.

**`isGoogleChatConfigured`** requires real service-account material (a `projectId` alone is not enough), rejects blank credential strings, honours `enabled: false` at both the top level and per account, and rejects arrays. **`isWechatConfigured`** covers the same top-level and per-account shapes.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/connectors/connector-config.test.ts`, the `credential setting keys` block — those five cases are the credential-isolation guard.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/connectors/connector-config.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f162e1fd21da9afd0fc558bb93974678b84b5bc5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/connectors/connector-config.test.ts
 Test Files  1 passed (1)
      Tests  24 passed (24)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 24/24 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that key encodings are asserted as exact strings and every predicate branch has an explicit negative case.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
