### PR TITLE
test(app): cover use-sync-external-store

### DIFF
--- a/packages/app/src/shims/use-sync-external-store.test.ts
+++ b/packages/app/src/shims/use-sync-external-store.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for the browser `use-sync-external-store/shim` re-export. The
+ * suite drives the real module (not a mock of `react`) and records that
+ * `useSyncExternalStore` is React's native hook: export identity, client
+ * snapshot reads, subscription, Object.is snapshot ties, and unsubscribe on
+ * unmount. There is no comparator, queue, capacity, or removal API on the
+ * shim itself — those belong to the store the caller supplies.
+ */
+import {
+  act,
+  createElement,
+  useSyncExternalStore as reactUseSyncExternalStore,
+} from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import * as shim from "./use-sync-external-store.js";
+import { useSyncExternalStore } from "./use-sync-external-store.js";
+
+type Subscribe = (onStoreChange: () => void) => () => void;
+
+type Store<T> = {
+  getSnapshot: () => T;
+  subscribe: Subscribe;
+  set: (next: T) => void;
+  notify: () => void;
+  listenerCount: () => number;
+};
+
+function createStore<T>(initial: T): Store<T> {
+  let snapshot = initial;
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: (): T => snapshot,
+    subscribe: (onStoreChange: () => void): (() => void) => {
+      listeners.add(onStoreChange);
+      return () => {
+        listeners.delete(onStoreChange);
+      };
+    },
+    set: (next: T): void => {
+      snapshot = next;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    notify: (): void => {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    listenerCount: (): number => listeners.size,
+  };
+}
+
+type Harness<T> = {
+  getValue: () => T;
+  renderCount: () => number;
+  unmount: () => void;
+};
+
+const mounted: Array<() => void> = [];
+
+afterEach(() => {
+  for (const unmount of mounted.splice(0)) {
+    unmount();
+  }
+});
+
+function mountHook<T>(hook: () => T): Harness<T> {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root: Root = createRoot(host);
+  let latest: T | undefined;
+  let renders = 0;
+
+  function Probe(): null {
+    latest = hook();
+    renders += 1;
+    return null;
+  }
+
+  act(() => {
+    root.render(createElement(Probe));
+  });
+
+  const unmount = (): void => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+  };
+  mounted.push(unmount);
+
+  return {
+    getValue: (): T => {
+      if (latest === undefined) {
+        throw new Error("hook has not produced a value");
+      }
+      return latest;
+    },
+    renderCount: (): number => renders,
+    unmount,
+  };
+}
+
+describe("use-sync-external-store exports", () => {
+  it("exports only useSyncExternalStore as a named function", () => {
+    expect(Object.keys(shim)).toEqual(["useSyncExternalStore"]);
+    expect(useSyncExternalStore).toBeTypeOf("function");
+    expect(shim.useSyncExternalStore).toBe(useSyncExternalStore);
+  });
+
+  it("re-exports React's native useSyncExternalStore by identity", () => {
+    expect(useSyncExternalStore).toBe(reactUseSyncExternalStore);
+  });
+
+  it("has no default export and no extra names", () => {
+    expect(Object.hasOwn(shim, "default")).toBe(false);
+    expect(Object.hasOwn(shim, "useSyncExternalStoreWithSelector")).toBe(false);
+    expect(
+      (
+        shim as {
+          default?: unknown;
+          useSyncExternalStoreWithSelector?: unknown;
+        }
+      ).default,
+    ).toBeUndefined();
+  });
+});
+
+describe("client snapshot: empty, single, and updated values", () => {
+  it("returns the initial snapshot for an empty listener set that then has one subscriber", () => {
+    const empty: readonly number[] = [];
+    const store = createStore(empty);
+    expect(store.listenerCount()).toBe(0);
+
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+
+    expect(store.listenerCount()).toBe(1);
+    expect(harness.getValue()).toBe(empty);
+    expect(harness.getValue()).toEqual([]);
+  });
+
+  it("returns a single primitive snapshot unchanged", () => {
+    const store = createStore(42);
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    expect(harness.getValue()).toBe(42);
+  });
+
+  it("re-renders with the next snapshot when the store notifies", () => {
+    const store = createStore("idle");
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    expect(harness.getValue()).toBe("idle");
+    const rendersBefore = harness.renderCount();
+
+    act(() => {
+      store.set("live");
+    });
+
+    expect(harness.getValue()).toBe("live");
+    expect(harness.renderCount()).toBeGreaterThan(rendersBefore);
+  });
+
+  it("reads getSnapshot on the client even when getServerSnapshot differs", () => {
+    const store = createStore(7);
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot, () => 0),
+    );
+    expect(harness.getValue()).toBe(7);
+  });
+});
+
+describe("Object.is snapshot ties", () => {
+  it("does not re-render when notify fires and getSnapshot is Object.is-equal", () => {
+    const store = createStore(1);
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    const rendersBefore = harness.renderCount();
+
+    act(() => {
+      store.notify();
+    });
+
+    expect(harness.getValue()).toBe(1);
+    expect(harness.renderCount()).toBe(rendersBefore);
+  });
+
+  it("does not re-render when set writes the same primitive", () => {
+    const store = createStore("same");
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    const rendersBefore = harness.renderCount();
+
+    act(() => {
+      store.set("same");
+    });
+
+    expect(harness.getValue()).toBe("same");
+    expect(harness.renderCount()).toBe(rendersBefore);
+  });
+
+  it("re-renders when a new object snapshot is not Object.is-equal", () => {
+    const first = { n: 1 };
+    const second = { n: 1 };
+    const store = createStore(first);
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    expect(harness.getValue()).toBe(first);
+
+    act(() => {
+      store.set(second);
+    });
+
+    expect(harness.getValue()).toBe(second);
+    expect(harness.getValue()).not.toBe(first);
+  });
+});
+
+describe("subscribe, unsubscribe, and missing listeners", () => {
+  it("unsubscribes on unmount so the listener set is empty again", () => {
+    const store = createStore(0);
+    const harness = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    expect(store.listenerCount()).toBe(1);
+
+    harness.unmount();
+
+    expect(store.listenerCount()).toBe(0);
+    act(() => {
+      store.set(99);
+    });
+    expect(store.listenerCount()).toBe(0);
+  });
+
+  it("treats a second delete of the same listener as a no-op", () => {
+    const listeners = new Set<() => void>();
+    const subscribe: Subscribe = (onStoreChange) => {
+      listeners.add(onStoreChange);
+      return () => {
+        listeners.delete(onStoreChange);
+        listeners.delete(onStoreChange);
+      };
+    };
+    let snapshot = "one";
+    const getSnapshot = (): string => snapshot;
+
+    const harness = mountHook(() =>
+      useSyncExternalStore(subscribe, getSnapshot),
+    );
+    expect(listeners.size).toBe(1);
+    expect(harness.getValue()).toBe("one");
+
+    harness.unmount();
+
+    expect(listeners.size).toBe(0);
+    snapshot = "ignored";
+    expect(listeners.size).toBe(0);
+  });
+
+  it("delivers the same snapshot to every subscriber after one notify", () => {
+    const store = createStore("a");
+    const first = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    const second = mountHook(() =>
+      useSyncExternalStore(store.subscribe, store.getSnapshot),
+    );
+    expect(store.listenerCount()).toBe(2);
+    expect(first.getValue()).toBe("a");
+    expect(second.getValue()).toBe("a");
+
+    act(() => {
+      store.set("b");
+    });
+
+    expect(first.getValue()).toBe("b");
+    expect(second.getValue()).toBe("b");
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage for `packages/app/src/shims/use-sync-external-store.ts`, which had no
same-named test file. Test-only; no production change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop`
      `168daca11e14c87465d1d893616b4c37097338d3` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only
      lane. Focused vitest, biome, and package `tsc` are quoted below.
- [x] A reviewer can confirm the change works without reading the code, from
      the vitest counts below.

# Sync with develop

- [x] Branch parent is current `origin/develop`
      `168daca11e14c87465d1d893616b4c37097338d3`; zero conflicts.
- [ ] `bun run verify` was not run for this test-only PR. Focused checks:

```
cd packages/app && bunx vitest run src/shims/use-sync-external-store.test.ts
# Test Files  1 passed (1)
# Tests  13 passed (13)

bunx biome check --write packages/app/src/shims/use-sync-external-store.test.ts
# Checked 1 file in 29ms. Fixed 1 file.

cd packages/app && bunx tsc --noEmit 2>&1 | grep 'use-sync-external-store.test'
# (no matches — this file introduced zero type errors)
```

We are a fork contributor: hosted CI does **not** run on this PR. Do not treat
the absence of GitHub Actions as a pass.

# Risks

Low. Adds one colocated vitest file. No production source, types, or exports
change.

# Background

## What does this PR do?

Adds unit tests for the browser shim
`packages/app/src/shims/use-sync-external-store.ts`. That module is a named
re-export of React's native `useSyncExternalStore` (React 18+), not a polyfill
with its own queue, comparator, capacity, or removal API.

The suite drives the **real** module (no `vi.mock("react")`) and records:

- export surface: only `useSyncExternalStore`, identical by identity to
  `react.useSyncExternalStore`, no default export
- empty listener set, then a single subscriber, including an empty-array
  snapshot
- a single primitive snapshot
- store notify with a changed snapshot re-renders
- client reads `getSnapshot` even when `getServerSnapshot` differs
- `Object.is` ties: notify / set of the same primitive do not re-render
- a new object snapshot that is not `Object.is`-equal does re-render
- unsubscribe on unmount empties the listener set
- a second `Set.delete` of the same listener is a no-op
- two subscribers both receive the same snapshot after one notify

## What kind of change is this?

Improvements (tests for existing behavior). No production behavior change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/use-sync-external-store.test.ts` and:

```
cd packages/app && bunx vitest run src/shims/use-sync-external-store.test.ts
```

(jsdom is required; the app package Vitest config supplies it.)

## Detailed testing steps

None: Automated tests are acceptable.

Observed on head `21741ec099509fd9181e64fa7e4799d0f4dfb3c9`, re-run after
re-fetching `origin/develop` `168daca11e14c87465d1d893616b4c37097338d3`:

```
Test Files  1 passed (1)
Tests  13 passed (13)
```

Diff touches **only** `packages/app/src/shims/use-sync-external-store.test.ts`.

# Evidence Gate

<!-- evidence-head:21741ec099509fd9181e64fa7e4799d0f4dfb3c9 -->

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`
- [x] After full-page screenshots: `N/A - test-only, no UI surface`
- [x] Walkthrough video: `N/A - test-only, no UI surface`
- [x] Backend logs: `N/A - no server path; unit tests only`
- [x] Frontend console/network logs: `N/A - no rendered UI or network`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB, schedule, wallet, or generated artifact`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change`

## Backend + frontend logs

`N/A - unit tests only; no server or UI path`

## Screenshots (before / after) + video walkthrough

`N/A - test-only, no UI surface`

### Before

`N/A - test-only, no UI surface`

### After

`N/A - test-only, no UI surface`

### Walkthrough video

`N/A - test-only, no UI surface`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change`

## Known gaps / failures

- Hosted CI does not run on fork PRs. Local focused checks are the evidence.
- Package `tsc --noEmit` reports pre-existing errors in unrelated packages
  (e.g. plugin-wallet). This test file appears **nowhere** in that output.
- `bun run verify` was not run; this PR adds tests only.

## Maintainer CI exception record

`N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
