### PR TITLE
test(auth): cover pkce

### DIFF
--- a/packages/auth/src/vendor/pi-oauth/pkce.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/pkce.test.ts
@@ -1,61 +1,90 @@
 /**
- * Unit coverage for PKCE challenge and verifier generation in pkce.ts.
+ * Behavioral coverage for PKCE verifier and S256 challenge generation.
  *
- * Verifies 32-byte entropy, base64url string formatting, URL safety,
- * uniqueness across invocations, and cryptographic SHA-256 digest integrity.
+ * Drives the real Web Crypto path in pkce.ts: 32-byte entropy, base64url
+ * encoding without padding, and SHA-256 challenge derivation. No crypto
+ * or fetch mocks; the S256 check uses Node's independent base64url encoder
+ * rather than the production btoa/replace helper.
  */
 
 import { describe, expect, it } from "vitest";
-import { generatePKCE } from "./pkce.js";
+import { generatePKCE } from "./pkce.ts";
 
-describe("pkce", () => {
-  it("generates valid verifier and challenge strings", async () => {
-    const { verifier, challenge } = await generatePKCE();
+/** RFC 7636 unpadded base64url alphabet (no `+`, `/`, `=`, `.`, or `~`). */
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
 
-    expect(typeof verifier).toBe("string");
-    expect(typeof challenge).toBe("string");
-    expect(verifier.length).toBeGreaterThan(0);
-    expect(challenge.length).toBeGreaterThan(0);
+/**
+ * 32 random bytes encode to 43 unpadded base64url characters (256 bits / 6,
+ * then the leftover 2 bits occupy one more character; standard base64 would
+ * emit a trailing `=` which this encoder strips).
+ */
+const PKCE_BYTE_LENGTH = 32;
+const UNPADDED_BASE64URL_LEN = 43;
+
+async function s256Challenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  );
+  return Buffer.from(digest).toString("base64url");
+}
+
+describe("generatePKCE", () => {
+  it("returns string verifier and challenge keys and nothing else", async () => {
+    const pair = await generatePKCE();
+    expect(Object.keys(pair).sort()).toEqual(["challenge", "verifier"]);
+    expect(typeof pair.verifier).toBe("string");
+    expect(typeof pair.challenge).toBe("string");
   });
 
-  it("conforms to base64url format without standard base64 padding or symbols", async () => {
-    const { verifier, challenge } = await generatePKCE();
-    const base64urlRegex = /^[A-Za-z0-9_-]+$/;
-
-    expect(verifier).toMatch(base64urlRegex);
-    expect(challenge).toMatch(base64urlRegex);
+  it("encodes a 32-byte verifier as 43 unpadded base64url characters", async () => {
+    const { verifier } = await generatePKCE();
+    expect(verifier).toMatch(BASE64URL);
+    expect(verifier).toHaveLength(UNPADDED_BASE64URL_LEN);
     expect(verifier).not.toContain("+");
     expect(verifier).not.toContain("/");
     expect(verifier).not.toContain("=");
+  });
+
+  it("encodes the SHA-256 digest as a 43-character base64url challenge", async () => {
+    const { challenge } = await generatePKCE();
+    expect(challenge).toMatch(BASE64URL);
+    expect(challenge).toHaveLength(UNPADDED_BASE64URL_LEN);
     expect(challenge).not.toContain("+");
     expect(challenge).not.toContain("/");
     expect(challenge).not.toContain("=");
   });
 
-  it("generates cryptographically unique verifiers on consecutive runs", async () => {
+  it("derives the challenge as S256 of the verifier via Node base64url", async () => {
+    const { verifier, challenge } = await generatePKCE();
+    expect(challenge).toBe(await s256Challenge(verifier));
+  });
+
+  it("recomputes the same challenge from the same verifier", async () => {
+    const { verifier, challenge } = await generatePKCE();
+    expect(await s256Challenge(verifier)).toBe(challenge);
+    expect(await s256Challenge(verifier)).toBe(challenge);
+  });
+
+  it("does not use the verifier string as the challenge", async () => {
+    const { verifier, challenge } = await generatePKCE();
+    expect(challenge).not.toBe(verifier);
+  });
+
+  it("emits distinct verifiers and challenges across sequential calls", async () => {
     const first = await generatePKCE();
     const second = await generatePKCE();
-
     expect(first.verifier).not.toBe(second.verifier);
     expect(first.challenge).not.toBe(second.challenge);
   });
 
-  it("produces SHA-256 challenge matching the verifier digest", async () => {
-    const { verifier, challenge } = await generatePKCE();
-
-    const encoder = new TextEncoder();
-    const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(verifier));
-    const bytes = new Uint8Array(hashBuffer);
-
-    let binary = "";
-    for (const b of bytes) {
-      binary += String.fromCharCode(b);
-    }
-    const expectedChallenge = btoa(binary)
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=/g, "");
-
-    expect(challenge).toBe(expectedChallenge);
+  it("emits unique verifiers across concurrent calls", async () => {
+    const pairs = await Promise.all(
+      Array.from({ length: PKCE_BYTE_LENGTH }, () => generatePKCE()),
+    );
+    const verifiers = pairs.map((pair) => pair.verifier);
+    expect(new Set(verifiers).size).toBe(PKCE_BYTE_LENGTH);
+    const challenges = pairs.map((pair) => pair.challenge);
+    expect(new Set(challenges).size).toBe(PKCE_BYTE_LENGTH);
   });
 });


### PR DESCRIPTION

# Relates to

Test-only follow-up to merged #26030. `packages/auth/src/vendor/pi-oauth/pkce.ts` now has a colocated suite; this PR replaces the tautological S256 check (a copy of the production `btoa`/`replace` helper) with independent Node `Buffer.toString("base64url")` verification, locks the 32-byte entropy via exact 43-character unpadded length, and adds concurrent uniqueness plus object-shape assertions. No issue card.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is one commit on current `origin/develop` (`3c8996d9f1f60b5561ce51e89f13fdeb611b6339`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run (test-only one-file change; focused vitest/biome/tsc quoted below). Hosted CI does **not** run on fork contributor PRs.
- [x] A reviewer can confirm the change from the vitest counts and the single-file diff.

# Sync with develop

- [x] Branch parent is `origin/develop` at `3c8996d9f1f60b5561ce51e89f13fdeb611b6339`; zero conflicts.
- [ ] `bun run verify` not run for this test-only diff. Focused gates below.

# Risks

Low. Test-only. No production behavior change. The suite drives the real `generatePKCE` export; crypto is not mocked. Failure mode is a red unit test, not a runtime regression.

# Background

## What does this PR do?

Strengthens `packages/auth/src/vendor/pi-oauth/pkce.test.ts` so it records what `generatePKCE` actually does:

- Returns only `{ verifier, challenge }` strings.
- Encodes 32 random bytes as 43 unpadded base64url characters (RFC 7636 S256 verifier).
- Encodes SHA-256(verifier) as a 43-character base64url challenge.
- Challenge matches Node's independent `Buffer.toString("base64url")` of the SHA-256 digest — not a copy of the production encoder.
- Challenge is deterministic for a given verifier and is not the verifier string.
- Sequential and concurrent calls emit unique verifiers/challenges.

Import is `./pkce.ts`, matching production and the sibling `anthropic-login.test.ts` / `openai-codex-login.test.ts` files.

## What kind of change is this?

Improvements (test-only coverage of existing PKCE helpers). No production source change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/auth/src/vendor/pi-oauth/pkce.test.ts`

## Detailed testing steps

Re-run immediately before filing, against current `origin/develop` plus this test file:

```text
$ bunx vitest run packages/auth/src/vendor/pi-oauth/pkce.test.ts
 ✓ packages/auth/src/vendor/pi-oauth/pkce.test.ts (8 tests) 6ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Biome: root `biome.json` exists and this checkout is not sparse. `!**/vendor` excludes this path (same as sibling vendor tests). A stdin `biome check --write` against the same contents produced no diff. Control: `bunx biome check packages/auth/src/token-expiry.test.ts` → `Checked 1 file in 59ms. No fixes applied.`

tsc: from `packages/auth`, `bunx tsc --noEmit 2>&1 | grep pkce.test.ts` is empty. Five pre-existing `TS2307` errors in `@elizaos/shared` (`@elizaos/core/client-public`) are unrelated; this file appears nowhere in that output.

Diff touches only `packages/auth/src/vendor/pi-oauth/pkce.test.ts`.

# Evidence Gate

Test-only, no production behavior change, no UI. Hosted CI does not run on this fork PR.

- [x] Before screenshots — N/A - test-only, no UI surface
- [x] After screenshots — N/A - test-only, no UI surface
- [x] Walkthrough video — N/A - test-only, no UI surface
- [x] Backend logs — N/A - unit test of Web Crypto PKCE helpers, no server path
- [x] Frontend logs — N/A - no frontend change
- [x] LLM trajectory — N/A - no agent/action/provider/prompt/model change
- [x] Domain artifacts — N/A - no DB/memory/schedule/wallet output
- [x] OCR review — N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

N/A - colocated unit test; no HTTP or UI path.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI.

### Before

N/A - test-only, no UI.

### After

N/A - test-only, no UI.

### Walkthrough video

N/A - test-only, no UI.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run; this is a one-file test change. Focused vitest (8/8), biome (vendor path excluded by config; stdin write clean), and tsc (this file absent from output) are quoted above.
- Receipt / identity.slop.cash OAuth trace was not minted: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
- Hosted GitHub Actions CI does not run on fork contributor PRs; do not read absence of checks as a pass.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b7c6a98b3af63b4ff95c11753d7cc1ef8dbfd99a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
