### PR TITLE
chore(ui): retire NuPhy naming and tighten cloud settings modals

### DIFF
--- a/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.stories.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.stories.tsx
@@ -1,6 +1,6 @@
 /**
- * Visual states for the cloud settings primitives after the NuPhy → canonical
- * migration (#24495): grouped rows with inset separators, every row control
+ * Visual states for the cloud settings primitives: grouped rows with inset
+ * separators, every row control
  * (switch, select, segmented, slider, input, action button), and the modal /
  * confirm dialog compositions, all on Eliza brand tokens.
  */
@@ -8,19 +8,19 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Button } from "../../ui/button";
 import {
+  CloudActionButton,
+  CloudConfirmDialog,
+  CloudInputRow,
+  CloudModal,
+  CloudRow,
+  CloudSegmentedRow,
+  CloudSelectRow,
+  CloudSliderRow,
+  CloudSwitchRow,
   DestructiveSecondaryButton,
-  NuphyActionButton,
-  NuphyConfirmDialog,
-  NuphyInputRow,
-  NuphyModal,
-  NuphyRow,
-  NuphySegmentedRow,
-  NuphySelectRow,
-  NuphySliderRow,
-  NuphySwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "./nuphy-settings-primitives";
+} from "./cloud-settings-primitives";
 
 const meta = {
   title: "Settings/CloudPanelPrimitives",
@@ -45,14 +45,14 @@ function AllRowsDemo() {
           title="Voice"
           footer="Rows keep agent-surface instrumentation and inset separators."
         >
-          <NuphySwitchRow
+          <CloudSwitchRow
             agentId="story-wake-word"
             label="Wake word"
             description="Listen for the wake word while idle."
             checked={wake}
             onCheckedChange={setWake}
           />
-          <NuphyInputRow
+          <CloudInputRow
             agentId="story-wake-word-text"
             label="Word"
             value={word}
@@ -60,7 +60,7 @@ function AllRowsDemo() {
             placeholder="e.g. Hey Eliza"
             disabled={!wake}
           />
-          <NuphySliderRow
+          <CloudSliderRow
             agentId="story-silence-threshold"
             label="Silence threshold"
             description="Auto-stop after this much silence."
@@ -74,7 +74,7 @@ function AllRowsDemo() {
         </SettingsGroup>
 
         <SettingsGroup title="Delivery">
-          <NuphySelectRow
+          <CloudSelectRow
             agentId="story-quality"
             label="Model quality"
             description="Trade speed for accuracy."
@@ -86,7 +86,7 @@ function AllRowsDemo() {
               { value: "best", label: "Best" },
             ]}
           />
-          <NuphySegmentedRow
+          <CloudSegmentedRow
             agentId="story-notify-mode"
             label="Notifications"
             value={tab}
@@ -97,14 +97,14 @@ function AllRowsDemo() {
               { value: "off", label: "Off" },
             ]}
           />
-          <NuphyActionButton
+          <CloudActionButton
             agentId="story-test-notification"
             label="Test notification"
             description="Send a sample to this device."
             buttonLabel="Send test"
             onActivate={() => {}}
           />
-          <NuphyRow
+          <CloudRow
             label="Danger zone"
             description="Destructive-secondary treatment stays on brand orange."
             control={
@@ -134,7 +134,7 @@ function ModalDemo() {
       <Button variant="outline" onClick={() => setConfirmOpen(true)}>
         Open confirm
       </Button>
-      <NuphyModal
+      <CloudModal
         open={open}
         title="Add connector"
         description="Enter connector details."
@@ -151,8 +151,8 @@ function ModalDemo() {
         }
       >
         <p className="text-sm text-muted-foreground">Modal body content.</p>
-      </NuphyModal>
-      <NuphyConfirmDialog
+      </CloudModal>
+      <CloudConfirmDialog
         open={confirmOpen}
         title="Remove connection?"
         description="This disconnects the integration immediately."

--- a/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.test.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.test.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { describe, expect, it } from "vitest";
 
 import { CloudSettingsDragStrip } from "./CloudSettingsPanel";
-import { NuphyModal, SettingsGroup } from "./nuphy-settings-primitives";
+import { CloudModal, SettingsGroup } from "./cloud-settings-primitives";
 
 describe("SettingsGroup", () => {
   it("uses the scoped sibling-row separator contract", () => {
@@ -49,7 +49,7 @@ function ModalHarness() {
         Open connector
       </button>
       <button type="button">Background action</button>
-      <NuphyModal
+      <CloudModal
         open={open}
         title="Add connector"
         description="Enter connector details."
@@ -57,12 +57,12 @@ function ModalHarness() {
       >
         <input aria-label="Connector name" />
         <button type="button">Save connector</button>
-      </NuphyModal>
+      </CloudModal>
     </div>
   );
 }
 
-describe("NuphyModal", () => {
+describe("CloudModal", () => {
   it("contains focus and restores it to the opener when closed", async () => {
     const user = userEvent.setup();
     render(<ModalHarness />);

--- a/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx
@@ -634,12 +634,12 @@ export function CloudModal({
           returnFocusRef.current = null;
         }}
         className={cn(
-          "block w-[min(calc(100vw_-_2rem),28rem)] gap-0 overflow-y-auto rounded-xl border-border bg-card p-0 text-foreground shadow-lg",
+          "block w-[min(calc(100vw_-_2rem),28rem)] gap-0 overflow-y-auto rounded-sm border-border bg-card p-0 sm:p-0 text-foreground shadow-lg",
           maxWidth,
           "max-h-[85vh]",
         )}
       >
-        <div className="border-b border-border px-5 py-4">
+        <div className="border-b border-border px-4 py-2.5">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <DialogTitle className="text-[15px] font-semibold leading-6 text-foreground">
@@ -661,9 +661,9 @@ export function CloudModal({
             </button>
           </div>
         </div>
-        <div className="px-5 py-4">{children}</div>
+        <div className="px-4 py-3">{children}</div>
         {footer ? (
-          <div className="border-t border-border px-5 py-3">{footer}</div>
+          <div className="border-t border-border px-4 py-2.5">{footer}</div>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx
@@ -3,9 +3,7 @@
  * with the package's canonical controls (Switch, Slider, SegmentedControl,
  * FormSelect, Button, Dialog) on Eliza brand tokens. Rows keep agent-surface
  * instrumentation (useAgentElement) so they remain addressable from
- * chat/voice. The exported names retain their historical `Nuphy*` prefix
- * because nine section files import them; the former @extrastu/nuphy-ui
- * dependency and its `.nuphy-scope` token bridge are gone (#24495).
+ * chat/voice.
  */
 
 import type { LucideIcon } from "lucide-react";
@@ -124,7 +122,7 @@ function SettingRowShell({
 
 // ── Switch row ──────────────────────────────────────────────────────────
 
-export interface NuphySwitchRowProps {
+export interface CloudSwitchRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
@@ -140,7 +138,7 @@ export interface NuphySwitchRowProps {
   testId?: string;
 }
 
-export function NuphySwitchRow({
+export function CloudSwitchRow({
   agentId,
   label,
   agentLabel,
@@ -152,7 +150,7 @@ export function NuphySwitchRow({
   agentStatus,
   className,
   testId,
-}: NuphySwitchRowProps) {
+}: CloudSwitchRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLDivElement>({
     id: agentId,
@@ -189,12 +187,12 @@ export function NuphySwitchRow({
 
 // ── Select row ──────────────────────────────────────────────────────────
 
-export interface NuphySelectRowOption {
+export interface CloudSelectRowOption {
   value: string;
   label: string;
 }
 
-export interface NuphySelectRowProps {
+export interface CloudSelectRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
@@ -203,14 +201,14 @@ export interface NuphySelectRowProps {
   iconClassName?: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: NuphySelectRowOption[];
+  options: CloudSelectRowOption[];
   disabled?: boolean;
   group?: string;
   className?: string;
   testId?: string;
 }
 
-export function NuphySelectRow({
+export function CloudSelectRow({
   agentId,
   label,
   agentLabel,
@@ -222,7 +220,7 @@ export function NuphySelectRow({
   group = "settings",
   className,
   testId,
-}: NuphySelectRowProps) {
+}: CloudSelectRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLDivElement>({
     id: agentId,
@@ -265,24 +263,24 @@ export function NuphySelectRow({
 
 // ── Segmented row ───────────────────────────────────────────────────────
 
-export interface NuphySegmentedRowOption {
+export interface CloudSegmentedRowOption {
   value: string;
   label: string;
 }
 
-export interface NuphySegmentedRowProps {
+export interface CloudSegmentedRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
   description?: React.ReactNode;
   value: string;
   onValueChange: (value: string) => void;
-  options: NuphySegmentedRowOption[];
+  options: CloudSegmentedRowOption[];
   group?: string;
   className?: string;
 }
 
-export function NuphySegmentedRow({
+export function CloudSegmentedRow({
   agentId,
   label,
   agentLabel,
@@ -291,7 +289,7 @@ export function NuphySegmentedRow({
   onValueChange,
   options,
   group = "settings",
-}: NuphySegmentedRowProps) {
+}: CloudSegmentedRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLDivElement>({
     id: agentId,
@@ -327,7 +325,7 @@ export function NuphySegmentedRow({
 
 // ── Slider row ──────────────────────────────────────────────────────────
 
-export interface NuphySliderRowProps {
+export interface CloudSliderRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
@@ -344,7 +342,7 @@ export interface NuphySliderRowProps {
   className?: string;
 }
 
-export function NuphySliderRow({
+export function CloudSliderRow({
   agentId,
   label,
   agentLabel,
@@ -358,7 +356,7 @@ export function NuphySliderRow({
   unit,
   disabled = false,
   group = "settings",
-}: NuphySliderRowProps) {
+}: CloudSliderRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLDivElement>({
     id: agentId,
@@ -403,7 +401,7 @@ export function NuphySliderRow({
 
 // ── Input row ───────────────────────────────────────────────────────────
 
-export interface NuphyInputRowProps {
+export interface CloudInputRowProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
@@ -417,7 +415,7 @@ export interface NuphyInputRowProps {
   className?: string;
 }
 
-export function NuphyInputRow({
+export function CloudInputRow({
   agentId,
   label,
   agentLabel,
@@ -428,7 +426,7 @@ export function NuphyInputRow({
   disabled = false,
   type = "text",
   group = "settings",
-}: NuphyInputRowProps) {
+}: CloudInputRowProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLInputElement>({
     id: agentId,
@@ -470,7 +468,7 @@ export function NuphyInputRow({
 
 // ── Action button row ───────────────────────────────────────────────────
 
-export interface NuphyActionButtonProps {
+export interface CloudActionButtonProps {
   agentId: string;
   label: React.ReactNode;
   agentLabel?: string;
@@ -497,7 +495,7 @@ const ACTION_BUTTON_SIZE = {
   lg: "lg",
 } as const;
 
-export function NuphyActionButton({
+export function CloudActionButton({
   agentId,
   label,
   agentLabel,
@@ -508,7 +506,7 @@ export function NuphyActionButton({
   variant = "secondary",
   size = "sm",
   group = "settings",
-}: NuphyActionButtonProps) {
+}: CloudActionButtonProps) {
   const resolvedLabel = agentLabel ?? labelToString(label, agentId);
   const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
     id: agentId,
@@ -543,7 +541,7 @@ export function NuphyActionButton({
 
 // ── Plain row (for custom content / non-standard controls) ──────────────
 
-export interface NuphyRowProps {
+export interface CloudRowProps {
   label: React.ReactNode;
   description?: React.ReactNode;
   control?: React.ReactNode;
@@ -553,7 +551,7 @@ export interface NuphyRowProps {
   "data-testid"?: string;
 }
 
-export function NuphyRow({
+export function CloudRow({
   label,
   description,
   control,
@@ -561,7 +559,7 @@ export function NuphyRow({
   below,
   className,
   ...rest
-}: NuphyRowProps) {
+}: CloudRowProps) {
   const effectiveControl = children ?? control ?? null;
 
   return (
@@ -588,7 +586,7 @@ export function NuphyRow({
 
 // ── Modal / dialog primitives ───────────────────────────────────────────
 
-export interface NuphyModalProps {
+export interface CloudModalProps {
   open: boolean;
   title: string;
   description?: string;
@@ -600,7 +598,7 @@ export interface NuphyModalProps {
 }
 
 /** A brand-styled composition of the shared modal dialog primitive. */
-export function NuphyModal({
+export function CloudModal({
   open,
   title,
   description,
@@ -608,7 +606,7 @@ export function NuphyModal({
   children,
   footer,
   maxWidth = "max-w-md",
-}: NuphyModalProps) {
+}: CloudModalProps) {
   const returnFocusRef = React.useRef<HTMLElement | null>(null);
   const wasOpenRef = React.useRef(false);
   if (
@@ -672,7 +670,7 @@ export function NuphyModal({
   );
 }
 
-export interface NuphyConfirmDialogProps {
+export interface CloudConfirmDialogProps {
   open: boolean;
   title: string;
   description: string;
@@ -686,7 +684,7 @@ export interface NuphyConfirmDialogProps {
 /**
  * A simple confirmation dialog for destructive actions (disconnect, remove).
  */
-export function NuphyConfirmDialog({
+export function CloudConfirmDialog({
   open,
   title,
   description,
@@ -695,9 +693,9 @@ export function NuphyConfirmDialog({
   destructive = false,
   onConfirm,
   onClose,
-}: NuphyConfirmDialogProps) {
+}: CloudConfirmDialogProps) {
   return (
-    <NuphyModal
+    <CloudModal
       open={open}
       title={title}
       onClose={onClose}
@@ -723,12 +721,12 @@ export function NuphyConfirmDialog({
       <p className="text-[14px] leading-5 text-muted-foreground">
         {description}
       </p>
-    </NuphyModal>
+    </CloudModal>
   );
 }
 
 /** A labeled form field wrapper for use inside modals. */
-export function NuphyFormField({
+export function CloudFormField({
   label,
   description,
   children,
@@ -758,7 +756,7 @@ export function NuphyFormField({
 }
 
 /** A text input styled to match the settings panel. */
-export function NuphyTextInput({
+export function CloudTextInput({
   id,
   type = "text",
   value,

--- a/packages/ui/src/components/settings/cloud-panel/sections/AdvancedSection.test.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/AdvancedSection.test.tsx
@@ -30,8 +30,8 @@ vi.mock("../../../../state", () => ({
   useIsPreviewMode: () => false,
 }));
 
-vi.mock("../nuphy-settings-primitives", () => ({
-  NuphyActionButton: ({
+vi.mock("../cloud-settings-primitives", () => ({
+  CloudActionButton: ({
     buttonLabel,
     onActivate,
   }: {
@@ -42,7 +42,7 @@ vi.mock("../nuphy-settings-primitives", () => ({
       {buttonLabel}
     </button>
   ),
-  NuphySwitchRow: () => null,
+  CloudSwitchRow: () => null,
   SettingsGroup: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),

--- a/packages/ui/src/components/settings/cloud-panel/sections/AdvancedSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/AdvancedSection.tsx
@@ -17,11 +17,11 @@ import {
   useIsPreviewMode,
 } from "../../../../state";
 import {
-  NuphyActionButton,
-  NuphySwitchRow,
+  CloudActionButton,
+  CloudSwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 const ERROR_LOGGING_KEY = "errorLogging";
 
@@ -160,7 +160,7 @@ export function AdvancedSection() {
         title="Developer"
         footer="Toggle hidden views and diagnostic logging."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-developer-mode"
           group="cloud-advanced"
           icon={SlidersHorizontal}
@@ -169,7 +169,7 @@ export function AdvancedSection() {
           checked={developerMode}
           onCheckedChange={(checked) => setDeveloperMode(checked)}
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-preview-mode"
           group="cloud-advanced"
           label="Preview mode"
@@ -177,7 +177,7 @@ export function AdvancedSection() {
           checked={previewMode}
           onCheckedChange={(checked) => setPreviewMode(checked)}
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-error-logging"
           group="cloud-advanced"
           label="Error logging"
@@ -191,7 +191,7 @@ export function AdvancedSection() {
         title="Reset"
         footer="Destructive actions. These cannot be undone."
       >
-        <NuphyActionButton
+        <CloudActionButton
           agentId="cloud-reset-app-state"
           group="cloud-advanced"
           agentLabel="Reset app state"
@@ -202,7 +202,7 @@ export function AdvancedSection() {
           size="sm"
           onActivate={handleResetAppState}
         />
-        <NuphyActionButton
+        <CloudActionButton
           agentId="cloud-clear-cache"
           group="cloud-advanced"
           agentLabel="Clear cache"
@@ -213,7 +213,7 @@ export function AdvancedSection() {
           size="sm"
           onActivate={() => void handleClearCache()}
         />
-        <NuphyActionButton
+        <CloudActionButton
           agentId="cloud-sign-out"
           group="cloud-advanced"
           agentLabel="Sign out of Cloud"

--- a/packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx
@@ -40,10 +40,10 @@ import {
 } from "../../../ui/status-badge.helpers";
 import { currentCloudManagementToken } from "../cloud-management-auth";
 import {
-  NuphyRow,
+  CloudRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 /** Maximum length accepted for a (new or edited) cloud agent name. */
 const AGENT_NAME_MAX_LENGTH = 60;
@@ -613,7 +613,7 @@ export function AgentSection() {
       >
         {activeAgent ? (
           <>
-            <NuphyRow
+            <CloudRow
               label={
                 <span className="flex items-center gap-2">
                   <Circle
@@ -637,7 +637,7 @@ export function AgentSection() {
               }
             />
             {otherAgents.length > 0 ? (
-              <NuphyRow
+              <CloudRow
                 label={`${otherAgents.length} other ${otherAgents.length === 1 ? "agent" : "agents"} available`}
                 control={
                   <Button
@@ -654,7 +654,7 @@ export function AgentSection() {
             ) : null}
           </>
         ) : (
-          <NuphyRow label="No active cloud agent on this device." />
+          <CloudRow label="No active cloud agent on this device." />
         )}
       </SettingsGroup>
 
@@ -663,7 +663,7 @@ export function AgentSection() {
         title="Your Cloud Agents"
         footer="Create, rename, start, pause, or delete cloud agents."
       >
-        <NuphyRow
+        <CloudRow
           label="Refresh"
           description="Reload the agent list from Eliza Cloud."
           control={
@@ -680,12 +680,12 @@ export function AgentSection() {
           }
         />
         {loading ? (
-          <NuphyRow
+          <CloudRow
             label="Loading agents…"
             data-testid="cloud-agents-loading"
           />
         ) : loadError ? (
-          <NuphyRow
+          <CloudRow
             label={loadError}
             data-testid="cloud-agents-error"
             control={
@@ -703,7 +703,7 @@ export function AgentSection() {
             }
           />
         ) : agents.length === 0 ? (
-          <NuphyRow
+          <CloudRow
             label="No cloud agents yet"
             description="Create one to get started."
             data-testid="cloud-agents-empty"
@@ -720,7 +720,7 @@ export function AgentSection() {
             const errorMessage = errored ? agent.error_message?.trim() : null;
             const detailsOpen = detailsId === agent.agent_id;
             return (
-              <NuphyRow
+              <CloudRow
                 key={agent.agent_id}
                 data-testid={`cloud-agent-row-${agent.agent_id}`}
                 label={
@@ -889,7 +889,7 @@ export function AgentSection() {
 
         {/* Create new agent — inline form toggled by the + New Agent button. */}
         {showCreate ? (
-          <NuphyRow
+          <CloudRow
             label="New agent"
             description={`Agent name (e.g. ${appName})`}
             control={
@@ -934,7 +934,7 @@ export function AgentSection() {
             }
           />
         ) : (
-          <NuphyRow
+          <CloudRow
             label="New agent"
             description="Create a new cloud agent."
             control={
@@ -950,7 +950,7 @@ export function AgentSection() {
           />
         )}
         {createError ? (
-          <NuphyRow
+          <CloudRow
             label={createError}
             data-testid="cloud-agent-create-error"
           />

--- a/packages/ui/src/components/settings/cloud-panel/sections/ConnectionsSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/ConnectionsSection.tsx
@@ -3,7 +3,7 @@
  *
  * Consolidated view of the cloud-hosted connectors (grouped by category) plus
  * configured MCP servers. Each connector's Connect/Disconnect flow is handled
- * inline through NuPhy-styled modals — token-credential connectors show a form,
+ * inline through the shared settings modals — token-credential connectors show a form,
  * OAuth-redirect connectors initiate the redirect, and destructive actions
  * confirm before executing. MCP servers are created/removed through a modal
  * form that posts to the real `/api/v1/mcps` CRUD routes.
@@ -30,14 +30,14 @@ import {
 } from "../cloud-connector-contracts";
 import { hasCloudManagementCredential } from "../cloud-management-auth";
 import {
+  CloudFormField,
+  CloudModal,
+  CloudRow,
+  CloudTextInput,
   DestructiveSecondaryButton,
-  NuphyFormField,
-  NuphyModal,
-  NuphyRow,
-  NuphyTextInput,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -125,7 +125,7 @@ function ConnectorRow({
   });
 
   return (
-    <NuphyRow
+    <CloudRow
       label={connector.name}
       description={
         state.loading ? "Checking status…" : (state.error ?? state.statusText)
@@ -285,7 +285,7 @@ function ConnectModal({
   };
 
   return (
-    <NuphyModal
+    <CloudModal
       open={connector !== null}
       title={`Connect ${connector.name}`}
       description={
@@ -329,13 +329,13 @@ function ConnectModal({
       {connector.authMode === "token" && connector.fields ? (
         <div className="space-y-4">
           {connector.fields.map((field) => (
-            <NuphyFormField
+            <CloudFormField
               key={field.key}
               label={field.label}
               description={field.description}
               htmlFor={`field-${field.key}`}
             >
-              <NuphyTextInput
+              <CloudTextInput
                 id={`field-${field.key}`}
                 type={field.type ?? "text"}
                 value={fieldValues[field.key] ?? ""}
@@ -346,10 +346,10 @@ function ConnectModal({
                 disabled={busy}
                 autoComplete="off"
               />
-            </NuphyFormField>
+            </CloudFormField>
           ))}
           {connector.id === "discord" && (
-            <NuphyFormField
+            <CloudFormField
               label="Agent"
               description="The agent this Discord bot responds as."
               htmlFor="connect-agent"
@@ -374,7 +374,7 @@ function ConnectModal({
                   </FormSelectItem>
                 ))}
               </FormSelect>
-            </NuphyFormField>
+            </CloudFormField>
           )}
         </div>
       ) : (
@@ -383,7 +383,7 @@ function ConnectModal({
           page. After authorizing, you'll return here automatically.
         </p>
       )}
-    </NuphyModal>
+    </CloudModal>
   );
 }
 
@@ -476,7 +476,7 @@ function DisconnectDialog({
 
   if (!connector) return null;
   return (
-    <NuphyModal
+    <CloudModal
       open={connector !== null}
       title={`Disconnect ${connector.name}?`}
       onClose={onClose}
@@ -535,7 +535,7 @@ function DisconnectDialog({
           can reconnect later.
         </p>
         {needsChoice && (
-          <NuphyFormField
+          <CloudFormField
             label="Connection"
             description="Exactly this connection will be disconnected."
             htmlFor="disconnect-connection"
@@ -560,10 +560,10 @@ function DisconnectDialog({
                 </FormSelectItem>
               ))}
             </FormSelect>
-          </NuphyFormField>
+          </CloudFormField>
         )}
       </div>
-    </NuphyModal>
+    </CloudModal>
   );
 }
 
@@ -625,7 +625,7 @@ function McpAddModal({
   };
 
   return (
-    <NuphyModal
+    <CloudModal
       open={open}
       title="Add MCP Server"
       description="Configure a new Model Context Protocol server for this agent."
@@ -661,56 +661,56 @@ function McpAddModal({
       }
     >
       <div className="space-y-4">
-        <NuphyFormField label="Name" htmlFor="mcp-name">
-          <NuphyTextInput
+        <CloudFormField label="Name" htmlFor="mcp-name">
+          <CloudTextInput
             id="mcp-name"
             value={name}
             onChange={setName}
             placeholder="My MCP Server"
             disabled={busy}
           />
-        </NuphyFormField>
-        <NuphyFormField
+        </CloudFormField>
+        <CloudFormField
           label="Slug"
           description="URL-safe identifier. Auto-generated from name if left blank."
           htmlFor="mcp-slug"
         >
-          <NuphyTextInput
+          <CloudTextInput
             id="mcp-slug"
             value={slug}
             onChange={setSlug}
             placeholder="my-mcp-server"
             disabled={busy}
           />
-        </NuphyFormField>
-        <NuphyFormField
+        </CloudFormField>
+        <CloudFormField
           label="Endpoint URL"
           description="The MCP server's HTTP/SSE endpoint."
           htmlFor="mcp-url"
         >
-          <NuphyTextInput
+          <CloudTextInput
             id="mcp-url"
             value={endpointUrl}
             onChange={setEndpointUrl}
             placeholder="https://my-mcp-server.example.com/sse"
             disabled={busy}
           />
-        </NuphyFormField>
-        <NuphyFormField
+        </CloudFormField>
+        <CloudFormField
           label="Description"
           description="Required. Shown wherever this MCP server is listed."
           htmlFor="mcp-desc"
         >
-          <NuphyTextInput
+          <CloudTextInput
             id="mcp-desc"
             value={description}
             onChange={setDescription}
             placeholder="What does this MCP server provide?"
             disabled={busy}
           />
-        </NuphyFormField>
+        </CloudFormField>
       </div>
-    </NuphyModal>
+    </CloudModal>
   );
 }
 
@@ -729,7 +729,7 @@ function McpRemoveDialog({
   const [error, setError] = useState<string | null>(null);
   if (!mcp) return null;
   return (
-    <NuphyModal
+    <CloudModal
       open={mcp !== null}
       title={`Remove ${mcp.name}?`}
       onClose={onClose}
@@ -781,7 +781,7 @@ function McpRemoveDialog({
         This will remove the MCP server from your agent. You can add it again
         later.
       </p>
-    </NuphyModal>
+    </CloudModal>
   );
 }
 
@@ -835,7 +835,7 @@ function McpRow({
   onRemove: (mcp: McpEntry) => void;
 }) {
   return (
-    <NuphyRow
+    <CloudRow
       label={mcp.name}
       description={mcp.statusText}
       control={
@@ -887,7 +887,7 @@ function CloudDisconnectedEmpty() {
       title="Connections"
       footer="Connect to Eliza Cloud to manage channels."
     >
-      <NuphyRow label="No cloud connection" />
+      <CloudRow label="No cloud connection" />
     </SettingsGroup>
   );
 }
@@ -1004,7 +1004,7 @@ export function ConnectionsSection() {
         title="MCP Servers"
         footer="Model Context Protocol servers extend the agent with tools and data sources."
       >
-        <NuphyRow
+        <CloudRow
           label="Add MCP Server"
           description="Configure a new MCP server for this agent."
           control={
@@ -1019,7 +1019,7 @@ export function ConnectionsSection() {
           }
         />
         {mcpError ? (
-          <NuphyRow
+          <CloudRow
             label="MCP servers unavailable"
             description={mcpError}
             control={
@@ -1037,9 +1037,9 @@ export function ConnectionsSection() {
             }
           />
         ) : mcpLoading ? (
-          <NuphyRow label="Loading MCP servers…" />
+          <CloudRow label="Loading MCP servers…" />
         ) : mcpServers.length === 0 ? (
-          <NuphyRow
+          <CloudRow
             label="No MCP servers"
             description="Add an MCP server to extend your agent with tools."
           />

--- a/packages/ui/src/components/settings/cloud-panel/sections/GeneralSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/GeneralSection.tsx
@@ -9,11 +9,11 @@ import { invokeDesktopBridgeRequest } from "../../../../bridge";
 import { isDesktopPlatform } from "../../../../platform";
 import { useAppSelector } from "../../../../state";
 import {
-  NuphySelectRow,
-  NuphySwitchRow,
+  CloudSelectRow,
+  CloudSwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 const TRAY_CLICK_OPTIONS = [
   { value: "full-menu", label: "Full menu" },
@@ -137,7 +137,7 @@ export function GeneralSection() {
         title={t("settings.desktop", { defaultValue: "Desktop" })}
         footer="Control how Eliza integrates with macOS."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="general-launch-on-login"
           group="general"
           label={t("settings.launchOnLogin", {
@@ -146,14 +146,14 @@ export function GeneralSection() {
           checked={launchOnLogin}
           onCheckedChange={setLaunchOnLogin}
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="general-show-in-dock"
           group="general"
           label={t("settings.showInDock", { defaultValue: "Show in Dock" })}
           checked={showInDock}
           onCheckedChange={setShowInDock}
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="general-record-on-tray-click"
           group="general"
           label={t("settings.recordOnTrayClick", {
@@ -163,7 +163,7 @@ export function GeneralSection() {
           onCheckedChange={setRecordOnTrayClick}
         />
         {recordOnTrayClick ? (
-          <NuphySelectRow
+          <CloudSelectRow
             agentId="general-tray-click-action"
             group="general"
             label={t("settings.trayClickAction", {

--- a/packages/ui/src/components/settings/cloud-panel/sections/NotificationsSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/NotificationsSection.tsx
@@ -12,12 +12,12 @@ import { invokeDesktopBridgeRequest } from "../../../../bridge";
 import { isDesktopPlatform } from "../../../../platform";
 import { useWebPush } from "../../../../state/notifications/useWebPush";
 import {
-  NuphyActionButton,
-  NuphyRow,
-  NuphySwitchRow,
+  CloudActionButton,
+  CloudRow,
+  CloudSwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 /** Coarse push-permission copy, mirroring WebPushSettingsSection. */
 function describePushState(state: ReturnType<typeof useWebPush>["state"]): {
@@ -106,7 +106,7 @@ export function NotificationsSection() {
         title="Push Notifications"
         footer="Enable macOS push notifications for agent messages and alerts."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="notifications-push-toggle"
           agentLabel="Toggle push notifications"
           icon={Bell}
@@ -119,14 +119,14 @@ export function NotificationsSection() {
           }
           onCheckedChange={onPushToggle}
         />
-        <NuphyRow label="Status" description={push.label} />
+        <CloudRow label="Status" description={push.label} />
       </SettingsGroup>
 
       <SettingsGroup
         title="Test"
         footer="Verify notifications are working end-to-end."
       >
-        <NuphyActionButton
+        <CloudActionButton
           agentId="notifications-send-test"
           agentLabel="Send test notification"
           label="Send test notification"

--- a/packages/ui/src/components/settings/cloud-panel/sections/PermissionsSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/PermissionsSection.tsx
@@ -25,11 +25,11 @@ import { useDesktopPermissionsState } from "../../permission-controls.hooks";
 import type { PermissionDef } from "../../permission-types";
 import { hasCloudManagementCredential } from "../cloud-management-auth";
 import {
+  CloudRow,
   DestructiveSecondaryButton,
-  NuphyRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 /* ── Shared status badge ────────────────────────────────────────── */
 
@@ -104,7 +104,7 @@ function DevicePermissionRow({
   onOpenSettings: () => void;
 }) {
   return (
-    <NuphyRow
+    <CloudRow
       label={def.name}
       description={def.description}
       control={
@@ -137,7 +137,7 @@ function DevicePermissionsGroup() {
   if (loading) {
     return (
       <SettingsGroup title="Device permissions">
-        <NuphyRow label="Loading permissions…" />
+        <CloudRow label="Loading permissions…" />
       </SettingsGroup>
     );
   }
@@ -148,7 +148,7 @@ function DevicePermissionsGroup() {
         title="Device permissions"
         footer="This cloud-only build could not read the macOS permission service."
       >
-        <NuphyRow
+        <CloudRow
           label="Permission status unavailable"
           description="No permission was reported as denied or granted."
         />
@@ -254,7 +254,7 @@ function CloudPluginGrantsGroup() {
         title="Cloud plugin grants"
         footer="Connect to Eliza Cloud to manage plugin grants."
       >
-        <NuphyRow label="No cloud connection" />
+        <CloudRow label="No cloud connection" />
       </SettingsGroup>
     );
   }
@@ -265,19 +265,19 @@ function CloudPluginGrantsGroup() {
       footer="Server-side permissions granted to cloud plugins. Revoke a grant to withdraw access immediately."
     >
       {state.kind === "loading" ? (
-        <NuphyRow label="Loading plugin grants…" />
+        <CloudRow label="Loading plugin grants…" />
       ) : state.kind === "missing" ? (
-        <NuphyRow label="Plugin grant tracking is not available on this server." />
+        <CloudRow label="Plugin grant tracking is not available on this server." />
       ) : state.kind === "error" ? (
-        <NuphyRow
+        <CloudRow
           label="Plugin grants unavailable"
           description={state.message}
         />
       ) : state.grants.length === 0 ? (
-        <NuphyRow label="No plugins have been granted permissions." />
+        <CloudRow label="No plugins have been granted permissions." />
       ) : (
         state.grants.map((grant) => (
-          <NuphyRow
+          <CloudRow
             key={grant.grant_id}
             label={grant.plugin_name ?? grant.plugin_id}
             description={[grant.permission, grant.scope]

--- a/packages/ui/src/components/settings/cloud-panel/sections/ShortcutsSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/ShortcutsSection.tsx
@@ -22,12 +22,12 @@ import {
 } from "../../../../state/push-to-talk-hotkey";
 import { Button } from "../../../ui/button";
 import {
-  NuphyRow,
-  NuphySelectRow,
-  NuphySwitchRow,
+  CloudRow,
+  CloudSelectRow,
+  CloudSwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 /** Internal canonical combo form: lowercase modifier names + key, joined by `+`. */
 type Combo = string;
@@ -356,7 +356,7 @@ export function ShortcutsSection() {
           const isPending = pending?.id === shortcut.id;
           const conflictForThis = isPending ? conflict : undefined;
           return (
-            <NuphyRow
+            <CloudRow
               key={shortcut.id}
               label={shortcut.label}
               description={
@@ -438,7 +438,7 @@ export function ShortcutsSection() {
                   </div>
                 ) : null}
               </div>
-            </NuphyRow>
+            </CloudRow>
           );
         })}
       </SettingsGroup>
@@ -447,7 +447,7 @@ export function ShortcutsSection() {
         title="Mouse"
         footer="Use a mouse button as a recording trigger."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="shortcuts-mouse-enabled"
           group="shortcuts"
           icon={Mouse}
@@ -456,7 +456,7 @@ export function ShortcutsSection() {
           checked={mouseEnabled}
           onCheckedChange={setMouseEnabled}
         />
-        <NuphySelectRow
+        <CloudSelectRow
           agentId="shortcuts-mouse-click-action"
           group="shortcuts"
           label="Click action"
@@ -466,7 +466,7 @@ export function ShortcutsSection() {
           options={CLICK_ACTION_OPTIONS}
           disabled={!mouseEnabled}
         />
-        <NuphySelectRow
+        <CloudSelectRow
           agentId="shortcuts-mouse-hold-action"
           group="shortcuts"
           label="Hold action"
@@ -482,7 +482,7 @@ export function ShortcutsSection() {
         title="Recording"
         footer="Protect against accidentally discarding long recordings."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="shortcuts-confirm-cancel-long"
           group="shortcuts"
           label="Confirm cancel on long recordings"
@@ -491,7 +491,7 @@ export function ShortcutsSection() {
           onCheckedChange={setConfirmCancel}
         />
         {confirmCancel ? (
-          <NuphySelectRow
+          <CloudSelectRow
             agentId="shortcuts-cancel-threshold"
             group="shortcuts"
             label="Threshold"

--- a/packages/ui/src/components/settings/cloud-panel/sections/VoiceSection.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/sections/VoiceSection.tsx
@@ -37,14 +37,14 @@ import {
 import { SaveFooter } from "../../../ui/save-footer";
 import { useSettingsSave } from "../../settings-control-primitives.hooks";
 import {
-  NuphyActionButton,
-  NuphyInputRow,
-  NuphySelectRow,
-  NuphySliderRow,
-  NuphySwitchRow,
+  CloudActionButton,
+  CloudInputRow,
+  CloudSelectRow,
+  CloudSliderRow,
+  CloudSwitchRow,
   SettingsGroup,
   SettingsStack,
-} from "../nuphy-settings-primitives";
+} from "../cloud-settings-primitives";
 
 const TTS_CONFIG_KEY = "tts";
 const VOICE_PREFS_CONFIG_KEY = "voice";
@@ -422,7 +422,7 @@ export function VoiceSection() {
     <SettingsStack>
       {configLoadError ? (
         <SettingsGroup title="Voice settings unavailable">
-          <NuphyActionButton
+          <CloudActionButton
             agentId="cloud-voice-config-retry"
             label={configLoadError}
             agentLabel="Retry loading voice settings"
@@ -441,7 +441,7 @@ export function VoiceSection() {
         })}
         footer="Configure how Eliza speaks aloud."
       >
-        <NuphySelectRow
+        <CloudSelectRow
           agentId="cloud-voice-tts-provider"
           label={t("settings.voice.provider", { defaultValue: "Provider" })}
           value={provider}
@@ -452,7 +452,7 @@ export function VoiceSection() {
             { value: "edge", label: "Edge" },
           ]}
         />
-        <NuphySelectRow
+        <CloudSelectRow
           agentId="cloud-voice-tts-voice"
           label={t("common.voice", { defaultValue: "Voice" })}
           value={visibleVoicePresetId ?? ""}
@@ -460,7 +460,7 @@ export function VoiceSection() {
           onValueChange={handleVoiceSelect}
           disabled={!configLoaded || configLoading}
         />
-        <NuphyActionButton
+        <CloudActionButton
           agentId="cloud-voice-tts-test"
           label={t("settings.voice.testVoice", {
             defaultValue: "Test voice",
@@ -479,7 +479,7 @@ export function VoiceSection() {
           }
           variant={voiceTesting ? "destructive" : "ghost"}
         />
-        <NuphySliderRow
+        <CloudSliderRow
           agentId="cloud-voice-tts-speed"
           label={t("settings.voice.speed", { defaultValue: "Speed" })}
           value={speed}
@@ -500,7 +500,7 @@ export function VoiceSection() {
         footer="Configure how Eliza listens and transcribes."
       >
         {profilesLoadError ? (
-          <NuphyActionButton
+          <CloudActionButton
             agentId="cloud-voice-profiles-retry"
             label={profilesLoadError}
             agentLabel="Retry loading voice profiles"
@@ -511,7 +511,7 @@ export function VoiceSection() {
             size="sm"
           />
         ) : null}
-        <NuphySelectRow
+        <CloudSelectRow
           agentId="cloud-voice-stt-profile"
           label={t("settings.voice.voiceProfile", {
             defaultValue: "Voice profile",
@@ -526,7 +526,7 @@ export function VoiceSection() {
             profiles.length === 0
           }
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-voice-vad-autostop"
           label={t("settings.voice.vadAutoStop", {
             defaultValue: "VAD auto-stop",
@@ -538,7 +538,7 @@ export function VoiceSection() {
           }
         />
         {prefs.vadAutoStopEnabled ? (
-          <NuphySliderRow
+          <CloudSliderRow
             agentId="cloud-voice-silence-threshold"
             label={t("settings.voice.silenceThreshold", {
               defaultValue: "Silence threshold",
@@ -552,13 +552,13 @@ export function VoiceSection() {
             disabled={!configLoaded || configLoading}
           />
         ) : null}
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-voice-wake-word"
           label={t("settings.voice.wakeWord", { defaultValue: "Wake word" })}
           checked={wakeWordEnabled}
           onCheckedChange={handleWakeWordToggle}
         />
-        <NuphyInputRow
+        <CloudInputRow
           agentId="cloud-voice-wake-word-text"
           label={t("settings.voice.wakeWordText", { defaultValue: "Word" })}
           value={prefs.wakeWord}
@@ -577,7 +577,7 @@ export function VoiceSection() {
         })}
         footer="Control continuous and voice-triggered conversation modes."
       >
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-voice-continuous-chat"
           label={t("settings.voice.continuousChat", {
             defaultValue: "Continuous chat",
@@ -588,7 +588,7 @@ export function VoiceSection() {
             updatePrefs({ continuous: checked ? "vad-gated" : "off" })
           }
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-voice-intent-autostart-voice"
           label={t("settings.voice.intentAutoStartVoice", {
             defaultValue: "OS intent auto-start voice",
@@ -599,7 +599,7 @@ export function VoiceSection() {
             updatePrefs({ osIntentAutoStartVoice: checked })
           }
         />
-        <NuphySwitchRow
+        <CloudSwitchRow
           agentId="cloud-voice-intent-autostart-transcription"
           label={t("settings.voice.intentAutoStartTranscription", {
             defaultValue: "OS intent auto-start transcription",


### PR DESCRIPTION
## Summary

Follow-up to the merged #26066, carrying two review requests:

1. **Remove the word "NuPhy" from the codebase entirely.** The primitive module renames from `nuphy-settings-primitives` to `cloud-settings-primitives`, and every `Nuphy*` export renames to `Cloud*`:

| Old | New |
| --- | --- |
| `NuphySwitchRow` | `CloudSwitchRow` |
| `NuphySelectRow` | `CloudSelectRow` |
| `NuphySegmentedRow` | `CloudSegmentedRow` |
| `NuphySliderRow` | `CloudSliderRow` |
| `NuphyInputRow` | `CloudInputRow` |
| `NuphyActionButton` | `CloudActionButton` |
| `NuphyRow` | `CloudRow` |
| `NuphyModal` | `CloudModal` |
| `NuphyConfirmDialog` | `CloudConfirmDialog` |
| `NuphyFormField` | `CloudFormField` |
| `NuphyTextInput` | `CloudTextInput` |

`SettingsGroup`, `SettingsStack`, and `DestructiveSecondaryButton` were already neutral. All nine section consumers, the test file, the stories file, and the `AdvancedSection.test.tsx` module mock update together; the last historical "NuPhy" header mentions are dropped. These exports are internal to `packages/ui` (no public subpath), so there is no external compatibility surface.

2. **Tighten modal density** ("modals need to not have so much padding"). The modal composition was double-padded: the base `DialogContent`'s `sm:p-6` survived the `p-0` override, wrapping the already-padded header/body/footer in a 24px shell. Fixed with `sm:p-0`, tighter section paddings (`px-4 py-2.5`/`py-3`), and `rounded-xl` squared to the system `rounded-sm`. The confirm dialog drops from 216px to 148px tall with no dead bands.

## Verification

- `grep -rni nuphy packages scripts plugins` (excluding node_modules): **zero matches** repo-wide.
- `bunx tsc --noEmit -p packages/ui/tsconfig.json`: clean.
- Cloud-panel suite: **62/62 pass**. Biome clean.
- Dialog box probe (Playwright, computed layout): dialog padding 24px → 0px; internal sections stack flush (header 45px, body 44px, footer 57px).

## Evidence

<!-- evidence-head:57d2aa87f6e6f85b64ae173b19bf2d179f700d40 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots (merged #26066 state, `Nuphy*` names, padded modals): [26075-before-padding-allrows.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-before-padding-allrows.png) — the padded-modal before is visible in #26066's inline evidence (same release: `26066-confirm-dialog.png`)

<!-- evidence-row:after-screenshots -->
- After screenshots (renamed exports rendering identically; tight modals): [26075-allrows-desktop.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-allrows-desktop.png) · [26075-allrows-mobile.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-allrows-mobile.png) · [26075-modal-tight.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-modal-tight.png) · [26075-confirm-tight.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-confirm-tight.png)

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: `N/A - two static-state changes (identifier rename with zero pixel delta, and a modal padding reduction fully shown by the before/after stills); no flow changed`

<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - frontend-only change; no server path fires`

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: `N/A - Storybook captures rendered with zero page errors (noted per capture); no runtime network behavior in scope`

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent, model, prompt, provider, or action behavior changed`

<!-- evidence-row:domain-artifacts -->
- Domain artifacts (rename proof + layout probe): repo-wide grep for "nuphy" returns zero matches; Playwright layout probe shows dialog padding 24px → 0px (numbers in Verification). OCR readout doubles as the rendered-copy record: see ocr-review row.

<!-- evidence-row:ocr-review -->
- OCR visual text review (tesseract readout: identical copy before/after the rename; modal copy intact at tight density): [26075-ocr-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-ocr-review.md)

### Inline: modal density fix

#### Confirm dialog — after (148px, was 216px with a 24px dead shell)
![Confirm tight](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-confirm-tight.png)

#### Form modal — after
![Modal tight](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26075-modal-tight.png)

Progresses #24495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
