### PR TITLE
test(agent): guard sandbox-engine teardown against host-owned container names

### DIFF
--- a/packages/agent/src/services/sandbox-engine.test.ts
+++ b/packages/agent/src/services/sandbox-engine.test.ts
@@ -266,7 +266,15 @@ describe("DockerEngine", () => {
     expect(engine.imageExists(MISSING_IMAGE)).toBe(false);
   });
 
-  it("swallows stop and remove failures for a missing container", async () => {
+  it("swallows stop and remove failures for a name the host does not own", async () => {
+    // Teardown ownership guard (#25883): with a daemon installed these calls
+    // issue real stop/rm CLI commands, so coverage must first prove the host
+    // owns no such resource (ps -a also covers stopped containers). A
+    // non-empty listing means a developer's live container carries this name
+    // — skip the destructive assertions rather than touch it.
+    if (engine.listContainers(MISSING_CONTAINER).length > 0) {
+      return;
+    }
     await expect(
       engine.stopContainer(MISSING_CONTAINER),
     ).resolves.toBeUndefined();
@@ -328,7 +336,14 @@ describe("AppleContainerEngine", () => {
     expect(engine.imageExists(MISSING_IMAGE)).toBe(false);
   });
 
-  it("swallows stop and remove failures for a missing container", async () => {
+  it("swallows stop and remove failures for a name the host does not own", async () => {
+    // Teardown ownership guard (#25883): with a daemon installed these calls
+    // issue real stop/rm CLI commands, so coverage must first prove the host
+    // owns no such resource. A non-empty listing means a live container
+    // carries this name — skip the destructive assertions rather than touch it.
+    if (engine.listContainers(MISSING_CONTAINER).length > 0) {
+      return;
+    }
     await expect(
       engine.stopContainer(MISSING_CONTAINER),
     ).resolves.toBeUndefined();


### PR DESCRIPTION
# Relates to

Closes #25883

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (built directly on develop@07b6793 via the Git data API).
- [x] Focused tests pass after sync (exact command and output below).
- [x] A reviewer can confirm the change works from the guard logic below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite passes post-sync (below); no unrelated blocker.

# Risks

Low. Only the two teardown test cases change; when the host lists any container
matching the fixed coverage name, the destructive assertions are skipped —
the error-mapping path is still exercised on every host that does not own the
name (CI runners, the overwhelmingly common case).

# Background

## What does this PR do?

The sandbox-engine coverage suite instantiated the real Docker and Apple
Container engines and unconditionally called `stopContainer` and
`removeContainer` for the fixed name `eliza-sandbox-engine-coverage-missing`
(#25741). When either daemon is installed, those methods invoke the real host
CLI, so a developer or self-hosted runner already owning a container with that
name had the live resource stopped and then force-removed by unit coverage.

Both teardown cases now first prove ownership of the teardown surface:
`listContainers(MISSING_CONTAINER)` runs `ps -a --filter name=...`, which also
covers stopped containers, so a non-empty listing means the host owns a live
resource with that name and the destructive assertions are skipped instead of
touching it. The unit lane can no longer stop or remove any host container it
did not create and uniquely own during the same test.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/sandbox-engine.test.ts` — the two
"swallows stop and remove failures for a name the host does not own" cases
(search `#25883`).

## Detailed testing steps

- `cd packages/agent && bunx vitest run src/services/sandbox-engine.test.ts`
  - 42 pass / 0 fail.
- The issue's destructive reproduction (create a host container named
  `eliza-sandbox-engine-coverage-missing`, run the suite on a machine with the
  daemon) is intentionally not run automatically; with this change that
  scenario takes the skip branch instead of issuing stop/rm.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:88a1a142e3ce580c6b3a60b50704543faaf2b972 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; this is unit-test teardown hygiene.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the guarded behavior needs a machine with a live daemon plus a
      host-owned container carrying the fixed coverage name; the issue itself
      marks that reproduction destructive and not for automatic runs.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no production logging touched; the change is test-file only.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output; the
      guard queries container state read-only via the existing list API.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
 Test Files  1 passed (1)
      Tests  42 passed (42)
```

## Known gaps / failures

None for this change. Full-package `bun run verify` could not run in this
environment; the focused vitest suite above and `biome check` on the touched
file pass locally.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->
