### PR TITLE
test(app): bind deployed Cloud history composer proof

### DIFF
--- a/packages/app/scripts/cloud-live-composer-contract.test.mjs
+++ b/packages/app/scripts/cloud-live-composer-contract.test.mjs
@@ -1,0 +1,37 @@
+/**
+ * Keeps the deployed-renderer continuity proof wired to the shared composer
+ * locator even though the opt-in Cloud smoke is outside the default typecheck.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const livenessContract = readFileSync(
+  path.join(appDir, "test/liveness-contract.ts"),
+  "utf8",
+);
+const cloudLiveSpec = readFileSync(
+  path.join(appDir, "test/ui-smoke/cloud-live.spec.ts"),
+  "utf8",
+);
+
+describe("Cloud live composer contract", () => {
+  it("exports and imports the shared chat composer locator", () => {
+    assert.match(
+      livenessContract,
+      /export function chatComposer\(page: Page\): Locator/,
+    );
+    const livenessImport = cloudLiveSpec.match(
+      /import\s*\{([^}]*)\}\s*from "\.\.\/liveness-contract";/,
+    );
+    assert.ok(
+      livenessImport,
+      "Cloud live spec must import the liveness contract",
+    );
+    assert.match(livenessImport[1], /\bchatComposer\b/);
+    assert.match(cloudLiveSpec, /await chatComposer\(page\)\.click\(\);/);
+  });
+});

--- a/packages/app/test/liveness-contract.ts
+++ b/packages/app/test/liveness-contract.ts
@@ -120,7 +120,7 @@ export async function readLivenessThreadLines(
   );
 }
 
-function chatComposer(page: Page): Locator {
+export function chatComposer(page: Page): Locator {
   return page.locator(CHAT_COMPOSER_SELECTOR).first();
 }
 

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -39,6 +39,7 @@ import {
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
 import {
   assertOnboardingLivenessWithTiming,
+  chatComposer,
   describeAnchoredLiveTurnState,
   findAnchoredLiveTurn,
   isLiveReply,


### PR DESCRIPTION
## Summary

- export the existing shared chat composer locator from the liveness contract
- import that locator in the deployed Cloud renderer continuity proof
- add a deterministic source contract because the opt-in live Cloud smoke is outside the default typecheck

## Root cause

Non-production Cloud release run 32642573516 successfully deployed Worker and Pages at db58d18887fcf7d427ae5f61c6ab66a969558317, then failed renderer certification after a successful history response. The continuity proof called chatComposer(page) without defining or importing chatComposer, producing ReferenceError instead of evaluating restored history.

## Local proof

- node --test packages/app/scripts/cloud-live-composer-contract.test.mjs: 1 pass
- bun test packages/app/scripts/cloud-live-composer-contract.test.mjs: 1 pass
- bun test packages/app/test/liveness-contract.test.ts: 23 pass
- Biome 2.5.8 on all three changed files: clean
- git diff --check: clean
- gitleaks staged diff, 2.50 KB: no leaks

## Release boundary

This PR does not deploy or contact a provider. Cloudflare and Railway remain closed until this head is reviewed and merged and one exact canonical develop SHA is green. The successor non-production release must certify matching Worker, Pages, routing, and renderer identity before Railway is aligned from the identical SHA.