### PR TITLE
test(core): cover validated-model-call

### DIFF
--- a/packages/core/src/runtime/validated-model-call.test.ts
+++ b/packages/core/src/runtime/validated-model-call.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Covers the remote-model parse + schema-validate + reroll wrapper.
+ *
+ * The budget arithmetic is the part worth pinning. Remote models have no
+ * sampler-level grammar, so an out-of-enum value can only be caught here; but
+ * rerolling is a real cost, so the effective budget must be
+ * `min(maxRerolls ?? default, VALIDATION_LEVEL cap)` — a user who dialled
+ * retries down to `trusted`/`fast` must get zero rerolls even though the
+ * module's own default is 2. Getting that wrong either burns tokens the user
+ * opted out of or silently drops the validation the remote path exists for.
+ *
+ * Drives the real wrapper against a fake runtime that counts `useModel` calls;
+ * no network, no model.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IAgentRuntime } from "../types/runtime";
+import {
+	callModelWithValidation,
+	DEFAULT_REMOTE_REROLL_BUDGET,
+	parseAndValidate,
+	rerollBudgetCeilingFromSetting,
+	SchemaValidationFailedError,
+} from "./validated-model-call.ts";
+
+const SCHEMA = {
+	type: "object",
+	properties: { mood: { type: "string", enum: ["calm", "angry"] } },
+	required: ["mood"],
+} as never;
+
+/** Fake runtime whose useModel returns the queued responses in order. */
+function makeRuntime(
+	responses: string[],
+	settings: Record<string, unknown> = {},
+): { runtime: IAgentRuntime; calls: () => number } {
+	let index = 0;
+	let calls = 0;
+	const runtime = {
+		getSetting: (key: string) => settings[key],
+		useModel: async () => {
+			calls += 1;
+			const next = responses[Math.min(index, responses.length - 1)];
+			index += 1;
+			return next;
+		},
+		getModelHandler: () => undefined,
+	} as unknown as IAgentRuntime;
+	return { runtime, calls: () => calls };
+}
+
+const opts = (extra: Record<string, unknown> = {}) =>
+	({
+		modelType: "TEXT_LARGE",
+		params: { prompt: "p" },
+		schema: SCHEMA,
+		validateBeforeReturn: true,
+		...extra,
+	}) as never;
+
+describe("parseAndValidate", () => {
+	it("accepts a schema-valid object", () => {
+		const result = parseAndValidate('{"mood":"calm"}', SCHEMA);
+		expect(result.valid).toBe(true);
+		expect(result.parsed).toEqual({ mood: "calm" });
+		expect(result.errors).toEqual([]);
+	});
+
+	it("reports a parse failure distinctly from a validation failure", () => {
+		const result = parseAndValidate("not json at all", SCHEMA);
+		expect(result.valid).toBe(false);
+		expect(result.parsed).toBeNull();
+		expect(result.parseError).toBeTruthy();
+	});
+
+	it("rejects an out-of-enum value that parses fine", () => {
+		// The exact case remote models produce and the legacy parse-only retry
+		// path let through.
+		const result = parseAndValidate('{"mood":"furious"}', SCHEMA);
+		expect(result.valid).toBe(false);
+		expect(result.parsed).toEqual({ mood: "furious" });
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.parseError).toBeUndefined();
+	});
+
+	it("rejects a missing required property and reports a failed path", () => {
+		const result = parseAndValidate("{}", SCHEMA);
+		expect(result.valid).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+});
+
+describe("rerollBudgetCeilingFromSetting", () => {
+	it("maps the documented VALIDATION_LEVEL values", () => {
+		const cap = (value: unknown) =>
+			rerollBudgetCeilingFromSetting(
+				makeRuntime([], { VALIDATION_LEVEL: value }).runtime,
+			);
+		expect(cap("trusted")).toBe(0);
+		expect(cap("fast")).toBe(0);
+		expect(cap("progressive")).toBe(2);
+		expect(cap("strict")).toBe(3);
+		expect(cap("safe")).toBe(3);
+	});
+
+	it("is case-insensitive", () => {
+		expect(
+			rerollBudgetCeilingFromSetting(
+				makeRuntime([], { VALIDATION_LEVEL: "TRUSTED" }).runtime,
+			),
+		).toBe(0);
+	});
+
+	it("returns undefined for unset or unknown values so no cap applies", () => {
+		for (const value of [undefined, null, 3, "nonsense"]) {
+			expect(
+				rerollBudgetCeilingFromSetting(
+					makeRuntime([], { VALIDATION_LEVEL: value }).runtime,
+				),
+			).toBeUndefined();
+		}
+	});
+});
+
+describe("callModelWithValidation", () => {
+	it("returns on a first-shot valid response without rerolling", async () => {
+		const { runtime, calls } = makeRuntime(['{"mood":"calm"}']);
+		const result = await callModelWithValidation(runtime, opts());
+		expect(result.parsed).toEqual({ mood: "calm" });
+		expect(result.attempts).toBe(1);
+		expect(calls()).toBe(1);
+	});
+
+	it("rerolls past an invalid response and reports the attempt count", async () => {
+		const { runtime, calls } = makeRuntime([
+			'{"mood":"furious"}',
+			'{"mood":"calm"}',
+		]);
+		const result = await callModelWithValidation(runtime, opts());
+		expect(result.parsed).toEqual({ mood: "calm" });
+		expect(result.attempts).toBe(2);
+		expect(calls()).toBe(2);
+	});
+
+	it("gives up after the default budget with a typed error", async () => {
+		const { runtime, calls } = makeRuntime(['{"mood":"furious"}']);
+		await expect(
+			callModelWithValidation(runtime, opts()),
+		).rejects.toBeInstanceOf(SchemaValidationFailedError);
+		// 2 rerolls = 3 total attempts.
+		expect(calls()).toBe(DEFAULT_REMOTE_REROLL_BUDGET + 1);
+	});
+
+	it("honours an explicit smaller reroll budget", async () => {
+		const { runtime, calls } = makeRuntime(['{"mood":"furious"}']);
+		await expect(
+			callModelWithValidation(runtime, opts({ maxRerolls: 0 })),
+		).rejects.toBeInstanceOf(SchemaValidationFailedError);
+		expect(calls()).toBe(1);
+	});
+
+	it("lets VALIDATION_LEVEL cap the budget below the module default", async () => {
+		// `trusted` means the user opted out of retries; the wrapper must not
+		// spend its own default budget anyway.
+		let calls = 0;
+		const runtime = {
+			getSetting: (key: string) =>
+				key === "VALIDATION_LEVEL" ? "trusted" : undefined,
+			useModel: async () => {
+				calls += 1;
+				return '{"mood":"furious"}';
+			},
+			getModelHandler: () => undefined,
+		} as unknown as IAgentRuntime;
+		await expect(
+			callModelWithValidation(runtime, opts()),
+		).rejects.toBeInstanceOf(SchemaValidationFailedError);
+		expect(calls).toBe(1);
+	});
+
+	it("skips validation entirely when the caller opts out", async () => {
+		const { runtime, calls } = makeRuntime(['{"mood":"furious"}']);
+		const result = await callModelWithValidation(
+			runtime,
+			opts({ validateBeforeReturn: false }),
+		);
+		expect(result.attempts).toBe(1);
+		expect(calls()).toBe(1);
+		expect(result.rawResponse).toBe('{"mood":"furious"}');
+	});
+
+	it("rerolls a parse failure too, not just a schema failure", async () => {
+		const { runtime, calls } = makeRuntime([
+			"definitely not json",
+			'{"mood":"calm"}',
+		]);
+		const result = await callModelWithValidation(runtime, opts());
+		expect(result.parsed).toEqual({ mood: "calm" });
+		expect(calls()).toBe(2);
+	});
+
+	it("carries the last raw response on the thrown error", async () => {
+		const { runtime } = makeRuntime(['{"mood":"furious"}']);
+		await callModelWithValidation(runtime, opts()).catch((error: unknown) => {
+			expect(error).toBeInstanceOf(SchemaValidationFailedError);
+			expect((error as SchemaValidationFailedError).message).toBeTruthy();
+		});
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/runtime/validated-model-call.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `a9e294cffc63f8c7d9f64c7415d813f99d7af1ab`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The wrapper is driven against a fake runtime that **counts** `useModel` calls, so every budget case asserts an exact call count rather than just the thrown error — a regression that rerolled too many or too few times fails even though the final outcome looks the same. `parseAndValidate` cases distinguish `parseError` from schema `errors` explicitly.

# Background

## What does this PR do?

`packages/core/src/runtime/validated-model-call.ts` is the only place an out-of-schema **remote** model response is caught: local models are constrained at the sampler by GBNF grammars, remote models are not, so a parse-valid response can still carry an out-of-enum value. It had **no dedicated test file**.

The budget arithmetic is what this pins. The effective budget is `min(maxRerolls ?? default, VALIDATION_LEVEL cap)` — a user who dialled retries down to `trusted`/`fast` must get **zero** rerolls even though the module default is 2. Getting that wrong either burns tokens the user opted out of, or drops the validation the remote path exists for.

| Case | Asserted |
|---|---|
| first-shot valid | exactly 1 model call, `attempts: 1` |
| one invalid then valid | 2 calls, `attempts: 2` |
| never valid | throws `SchemaValidationFailedError` after exactly `DEFAULT_REMOTE_REROLL_BUDGET + 1` calls |
| `maxRerolls: 0` | exactly 1 call |
| `VALIDATION_LEVEL: trusted` | caps **below** the module default — exactly 1 call |
| `validateBeforeReturn: false` | validation skipped, raw response returned, 1 call |
| parse failure | rerolled just like a schema failure |

`parseAndValidate` is pinned for the distinction that motivates the module: an out-of-enum value that parses fine is a *validation* failure with the parsed object intact and **no** `parseError` — exactly what the legacy parse-only retry path let through. `rerollBudgetCeilingFromSetting` covers every documented level, case-insensitivity, and returning `undefined` for unset/unknown so no cap applies.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/validated-model-call.test.ts`, the `callModelWithValidation` block — the call-count assertions are the budget regression guard.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/runtime/validated-model-call.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:565df17222ecd8f6e4bf8cccfe095b3251d8528b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/runtime/validated-model-call.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 15/15 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that every budget case asserts an exact `useModel` call count.
- The automatic local-provider detection path (`isLocalProvider` via a registered model handler) is not covered here — it needs a registered handler on a real runtime rather than the fake used for the budget cases, so it is left out rather than asserted against a stub that would prove little.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
