### PR TITLE
test(cloud): cover audit-dispatcher-singleton

### DIFF
--- a/packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
+++ b/packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
@@ -39,10 +39,7 @@ vi.mock("@/db/client", () => ({
     }),
   },
 }));
-vi.mock(
-  "@/db/schemas/auth-events",
-  async () => await import("../../../shared/src/db/schemas/auth-events.ts"),
-);
+vi.mock("@/db/schemas/auth-events", () => ({ authEvents: {} }));
 
 const originalAuditLogSink = process.env.AUDIT_LOG_SINK;
 

--- a/packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
+++ b/packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Behavioural coverage for the process-global AuditDispatcher singleton:
+ * lazy init, identity, replacement, custom versus default sinks, empty and
+ * single-sink fan-out, and the AUDIT_LOG_SINK LoggerSink branch. There is no
+ * queue, capacity, or comparator — empty sinks, one sink, and swapping a
+ * prior instance are the corresponding edges. The suite drives the real
+ * module. Root Vitest does not load this package's tsconfig path aliases, so
+ * `@/api-app/services/audit` is remapped to the real audit barrel and the
+ * logger/db imports are load-time stubs — assertions cover the singleton,
+ * not those stubs.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AuditDispatcher, type AuditSink, LoggerSink } from "./audit/index.js";
+import { InMemorySink } from "./audit/testing.js";
+import {
+  getAuditDispatcher,
+  initAuditDispatcher,
+  setAuditDispatcher,
+} from "./audit-dispatcher-singleton.js";
+import { auditEventsSink } from "./audit-events.js";
+
+vi.mock(
+  "@/api-app/services/audit",
+  async () => await import("./audit/index.js"),
+);
+vi.mock("@/lib/utils/logger", () => ({
+  logger: {
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    debug: () => undefined,
+  },
+}));
+vi.mock("@/db/client", () => ({
+  dbWrite: {
+    insert: () => ({
+      values: async () => undefined,
+    }),
+  },
+}));
+vi.mock(
+  "@/db/schemas/auth-events",
+  async () => await import("../../../shared/src/db/schemas/auth-events.ts"),
+);
+
+const originalAuditLogSink = process.env.AUDIT_LOG_SINK;
+
+afterEach(() => {
+  if (originalAuditLogSink === undefined) {
+    delete process.env.AUDIT_LOG_SINK;
+  } else {
+    process.env.AUDIT_LOG_SINK = originalAuditLogSink;
+  }
+});
+
+function installedSinks(dispatcher: AuditDispatcher): AuditSink[] {
+  return Reflect.get(dispatcher, "sinks") as AuditSink[];
+}
+
+function loginInput() {
+  return {
+    actor: { type: "user" as const, id: "u_singleton" },
+    action: "auth.login",
+    result: "success" as const,
+  };
+}
+
+describe("audit-dispatcher-singleton", () => {
+  test("initAuditDispatcher with no sinks argument installs the auth_events sink", () => {
+    delete process.env.AUDIT_LOG_SINK;
+    const dispatcher = initAuditDispatcher();
+    const sinks = installedSinks(dispatcher);
+    expect(dispatcher).toBeInstanceOf(AuditDispatcher);
+    expect(sinks).toEqual([auditEventsSink]);
+    expect(getAuditDispatcher()).toBe(dispatcher);
+  });
+
+  test("initAuditDispatcher adds LoggerSink only when AUDIT_LOG_SINK is exactly true", () => {
+    process.env.AUDIT_LOG_SINK = "true";
+    const withLogger = initAuditDispatcher();
+    const withLoggerSinks = installedSinks(withLogger);
+    expect(withLoggerSinks).toHaveLength(2);
+    expect(withLoggerSinks[0]).toBe(auditEventsSink);
+    expect(withLoggerSinks[1]).toBeInstanceOf(LoggerSink);
+    expect(withLoggerSinks[1]?.name).toBe("logger");
+
+    process.env.AUDIT_LOG_SINK = "TRUE";
+    expect(installedSinks(initAuditDispatcher())).toEqual([auditEventsSink]);
+
+    process.env.AUDIT_LOG_SINK = "false";
+    expect(installedSinks(initAuditDispatcher())).toEqual([auditEventsSink]);
+
+    process.env.AUDIT_LOG_SINK = "";
+    expect(installedSinks(initAuditDispatcher())).toEqual([auditEventsSink]);
+  });
+
+  test("initAuditDispatcher with an empty sinks array does not install defaults", async () => {
+    const dispatcher = initAuditDispatcher([]);
+    expect(installedSinks(dispatcher)).toEqual([]);
+    const event = await dispatcher.emit(loginInput());
+    expect(event.action).toBe("auth.login");
+    expect(event.actor.id).toBe("u_singleton");
+    expect(getAuditDispatcher()).toBe(dispatcher);
+  });
+
+  test("initAuditDispatcher with one sink fans out only to that sink", async () => {
+    const memory = new InMemorySink();
+    const dispatcher = initAuditDispatcher([memory]);
+    expect(installedSinks(dispatcher)).toEqual([memory]);
+    await dispatcher.emit(loginInput());
+    expect(memory.snapshot()).toHaveLength(1);
+    expect(memory.snapshot()[0]?.action).toBe("auth.login");
+  });
+
+  test("initAuditDispatcher with several sinks fans out to each of them", async () => {
+    const first = new InMemorySink();
+    const second = new InMemorySink();
+    initAuditDispatcher([first, second]);
+    await getAuditDispatcher().emit(loginInput());
+    expect(first.snapshot()).toHaveLength(1);
+    expect(second.snapshot()).toHaveLength(1);
+    expect(first.snapshot()[0]?.event_id).toBe(second.snapshot()[0]?.event_id);
+  });
+
+  test("initAuditDispatcher replaces the previous process-global instance", () => {
+    const first = initAuditDispatcher([new InMemorySink()]);
+    const second = initAuditDispatcher([new InMemorySink()]);
+    expect(second).not.toBe(first);
+    expect(getAuditDispatcher()).toBe(second);
+    expect(getAuditDispatcher()).not.toBe(first);
+  });
+
+  test("setAuditDispatcher makes getAuditDispatcher return that instance", async () => {
+    const memory = new InMemorySink();
+    const replacement = new AuditDispatcher({ sinks: [memory] });
+    setAuditDispatcher(replacement);
+    expect(getAuditDispatcher()).toBe(replacement);
+    await getAuditDispatcher().emit(loginInput());
+    expect(memory.snapshot()).toHaveLength(1);
+    expect(memory.snapshot()[0]?.result).toBe("success");
+  });
+
+  test("getAuditDispatcher returns the same instance on repeated calls", () => {
+    const dispatcher = initAuditDispatcher([new InMemorySink()]);
+    expect(getAuditDispatcher()).toBe(dispatcher);
+    expect(getAuditDispatcher()).toBe(getAuditDispatcher());
+  });
+
+  test("getAuditDispatcher lazily constructs the default dispatcher once", async () => {
+    delete process.env.AUDIT_LOG_SINK;
+    vi.resetModules();
+    const mod = await import("./audit-dispatcher-singleton.js");
+    const first = mod.getAuditDispatcher();
+    const second = mod.getAuditDispatcher();
+    expect(first).toBe(second);
+    expect(installedSinks(first)).toHaveLength(1);
+    expect(installedSinks(first)[0]?.name).toBe("auth_events_pg");
+  });
+
+  test("the returned dispatcher is a live AuditDispatcher that accepts addSink", async () => {
+    const first = new InMemorySink();
+    const extra = new InMemorySink();
+    const dispatcher = initAuditDispatcher([first]);
+    dispatcher.addSink(extra);
+    await dispatcher.emit(loginInput());
+    expect(first.snapshot()).toHaveLength(1);
+    expect(extra.snapshot()).toHaveLength(1);
+  });
+
+  test("initAuditDispatcher wires a required-sink failure through emit", async () => {
+    const failing: AuditSink = {
+      name: "failing",
+      emit: async () => {
+        throw new Error("boom");
+      },
+    };
+    const dispatcher = initAuditDispatcher([failing]);
+    await expect(dispatcher.emit(loginInput())).rejects.toThrow(
+      "Required audit sink delivery failed: failing",
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/cloud/api/src/services/audit-dispatcher-singleton.ts`, which had no same-named test file. No production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` (`07b6793ab247a6f479c558d918edd3b82895b61e` at file time) with zero conflicts.
- [x] Focused checks: vitest, biome, and package `tsc --noEmit` (this file absent from tsc output). Full `bun run verify` was not re-run for this test-only diff; hosted CI does not run on fork PRs.
- [x] A reviewer can confirm from the vitest counts, biome result, tsc grep, and single-file diff below.

# Sync with develop

- [x] Branch created from current `origin/develop`; zero conflicts.
- [ ] `bun run verify` not re-run for this test-only addition. Exact focused commands are quoted below.

# Risks

Low. Adds one Vitest file next to the existing singleton. No production code, routes, or public API change.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts` covering every exported symbol and branch of the process-global `AuditDispatcher` holder:

- `initAuditDispatcher` default sinks (`auth_events_pg` only)
- `AUDIT_LOG_SINK === "true"` adds `LoggerSink`; `TRUE` / `false` / empty do not (exact string match, as implemented)
- empty sinks array skips defaults; emit still succeeds
- single-sink and multi-sink fan-out
- instance replacement via `initAuditDispatcher` and `setAuditDispatcher`
- `getAuditDispatcher` identity and lazy init
- returned object is a live `AuditDispatcher` (`addSink` works)
- required-sink failure rejects after fan-out

There is no queue, capacity, or comparator. Empty sinks, one sink, and swapping a prior instance are the corresponding edges.

## What kind of change is this?

Improvements (tests for existing behaviour). No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts` and the commands below.

## Detailed testing steps

```
bunx vitest run packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
```

This is a fork contribution. Hosted CI does **not** run on our PRs.

# Evidence Gate

Evidence matches head `640543a4584989549a51dc901e0edc0b7d604c5c`.

<!-- evidence-head:640543a4584989549a51dc901e0edc0b7d604c5c -->

- [x] Before full-page screenshots — N/A - test-only, no UI surface.
- [x] After full-page screenshots — N/A - test-only, no UI surface.
- [x] Walkthrough video — N/A - test-only, no UI surface.
- [x] Backend logs — N/A - unit tests of a process-global holder; no server request path changed.
- [x] Frontend logs — N/A - no frontend change.
- [x] Real-LLM trajectory — N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts — N/A - no DB/memory/schedule/wallet/audio output; the suite inspects in-process dispatcher identity and sinks.
- [x] OCR visual-text review — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only unit coverage; no HTTP path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- Hosted GitHub Actions CI does not run on this fork PR.
- Full `bun run verify` was not re-run; the complete evidence set for this test-only PR is the four items below.

1. **vitest** (re-run against current `origin/develop` immediately before filing):

```
$ bunx vitest run packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

2. **biome** (`biome.json` present; checkout is not sparse):

```
$ bunx biome check --write packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts
Checked 1 file in 74ms. Fixed 1 file.
```

3. **tsc** from `packages/cloud/api` — this test file appears nowhere in the output:

```
$ cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'audit-dispatcher-singleton' ; echo "EXIT:$?"
EXIT:1
```

(`EXIT:1` is grep's no-match status.)

4. **Diff touches only a test file:** `packages/cloud/api/src/services/audit-dispatcher-singleton.test.ts` (183 insertions). No production behaviour change.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
