### PR TITLE
test(shared): cover scheduled-task-execution

### DIFF
--- a/packages/shared/src/contracts/scheduled-task-execution.test.ts
+++ b/packages/shared/src/contracts/scheduled-task-execution.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for scheduled-task execution profile contracts
+ * in scheduled-task-execution.ts.
+ *
+ * Tests vocabulary exports, profile array structure and uniqueness,
+ * and canonical default profile assignment.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TASK_EXECUTION_PROFILE,
+  TASK_EXECUTION_PROFILES,
+  type TaskExecutionProfile,
+} from "./scheduled-task-execution.js";
+
+describe("scheduled-task-execution", () => {
+  it("exports TASK_EXECUTION_PROFILES with expected profile vocabulary", () => {
+    expect(Array.isArray(TASK_EXECUTION_PROFILES)).toBe(true);
+    expect(TASK_EXECUTION_PROFILES).toEqual([
+      "foreground",
+      "bg-light-30s",
+      "bg-heavy-fgs",
+      "notify-only",
+    ]);
+  });
+
+  it("ensures all execution profiles are non-empty unique strings", () => {
+    const unique = new Set(TASK_EXECUTION_PROFILES);
+    expect(unique.size).toBe(TASK_EXECUTION_PROFILES.length);
+
+    for (const profile of TASK_EXECUTION_PROFILES) {
+      expect(typeof profile).toBe("string");
+      expect(profile.length).toBeGreaterThan(0);
+      expect(profile.trim()).toBe(profile);
+    }
+  });
+
+  it("defines DEFAULT_TASK_EXECUTION_PROFILE as 'foreground'", () => {
+    expect(DEFAULT_TASK_EXECUTION_PROFILE).toBe("foreground");
+    expect(
+      TASK_EXECUTION_PROFILES.includes(
+        DEFAULT_TASK_EXECUTION_PROFILE as TaskExecutionProfile,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/contracts/scheduled-task-execution.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `TASK_EXECUTION_PROFILES` and `DEFAULT_TASK_EXECUTION_PROFILE` across:
- Profile array structure and completeness (`foreground`, `bg-light-30s`, `bg-heavy-fgs`, `notify-only`).
- Profile string validation and uniqueness.
- Canonical default execution profile consistency.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`0cc42b3b19`) |
| --- | --- | --- |
| `bunx vitest run src/contracts/scheduled-task-execution.test.ts` (in `packages/shared`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/shared/src/contracts/scheduled-task-execution.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/contracts/scheduled-task-execution.test.ts:1-46`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `scheduled-task-execution.test.ts`
- [x] `lint` — Biome clean
