### PR TITLE
test(cloud): cover testing

### DIFF
--- a/packages/cloud/api/src/services/audit/testing.test.ts
+++ b/packages/cloud/api/src/services/audit/testing.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests InMemorySink record, snapshot isolation, ordering, and clear behaviour.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AuditSink } from "./sink.js";
+import { InMemorySink } from "./testing.js";
+import type { AuditEvent } from "./types.js";
+
+function makeEvent(eventId: string, action: AuditEvent["action"]): AuditEvent {
+  return {
+    event_id: eventId,
+    ts: "2026-08-23T00:00:00.000Z",
+    actor: { type: "user", id: "u_1" },
+    action,
+    result: "success",
+    resource: null,
+  };
+}
+
+describe("InMemorySink", () => {
+  it("names itself memory and leaves required unspecified", () => {
+    const sink = new InMemorySink();
+    expect(sink.name).toBe("memory");
+    const asSink: AuditSink = sink;
+    expect(asSink.required).toBeUndefined();
+  });
+
+  it("snapshots an empty queue as an empty array", () => {
+    const sink = new InMemorySink();
+    expect(sink.snapshot()).toEqual([]);
+  });
+
+  it("records a single emitted event", async () => {
+    const sink = new InMemorySink();
+    const event = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    await sink.emit(event);
+    expect(sink.snapshot()).toEqual([event]);
+    expect(sink.snapshot()[0]).toBe(event);
+  });
+
+  it("preserves insertion order across multiple emits", async () => {
+    const sink = new InMemorySink();
+    const first = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    const second = makeEvent(
+      "22222222-2222-7222-8222-222222222222",
+      "auth.logout",
+    );
+    const third = makeEvent(
+      "33333333-3333-7333-8333-333333333333",
+      "api_key.use",
+    );
+    await sink.emit(first);
+    await sink.emit(second);
+    await sink.emit(third);
+    expect(sink.snapshot()).toEqual([first, second, third]);
+  });
+
+  it("keeps duplicate events instead of collapsing ties", async () => {
+    const sink = new InMemorySink();
+    const event = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    await sink.emit(event);
+    await sink.emit(event);
+    const snap = sink.snapshot();
+    expect(snap).toHaveLength(2);
+    expect(snap[0]).toBe(event);
+    expect(snap[1]).toBe(event);
+  });
+
+  it("returns a copied array so callers cannot mutate the queue", async () => {
+    const sink = new InMemorySink();
+    const event = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    await sink.emit(event);
+    const first = sink.snapshot();
+    first.pop();
+    first.push(
+      makeEvent("44444444-4444-7444-8444-444444444444", "auth.logout"),
+    );
+    expect(sink.snapshot()).toEqual([event]);
+    expect(first).not.toBe(sink.snapshot());
+  });
+
+  it("clears recorded events and is a no-op on an empty queue", async () => {
+    const sink = new InMemorySink();
+    sink.clear();
+    expect(sink.snapshot()).toEqual([]);
+
+    await sink.emit(
+      makeEvent("11111111-1111-7111-8111-111111111111", "auth.login"),
+    );
+    sink.clear();
+    expect(sink.snapshot()).toEqual([]);
+
+    const after = makeEvent(
+      "55555555-5555-7555-8555-555555555555",
+      "auth.logout",
+    );
+    await sink.emit(after);
+    expect(sink.snapshot()).toEqual([after]);
+  });
+
+  it("isolates state across independent sink instances", async () => {
+    const left = new InMemorySink();
+    const right = new InMemorySink();
+    const leftEvent = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    const rightEvent = makeEvent(
+      "22222222-2222-7222-8222-222222222222",
+      "auth.logout",
+    );
+    await left.emit(leftEvent);
+    await right.emit(rightEvent);
+    expect(left.snapshot()).toEqual([leftEvent]);
+    expect(right.snapshot()).toEqual([rightEvent]);
+  });
+
+  it("has no capacity cap: every emit is retained", async () => {
+    const sink = new InMemorySink();
+    const events = Array.from({ length: 8 }, (_, i) =>
+      makeEvent(
+        `aaaaaaaa-aaaa-7aaa-8aaa-${String(i).padStart(12, "0")}`,
+        "auth.login",
+      ),
+    );
+    for (const event of events) {
+      await sink.emit(event);
+    }
+    expect(sink.snapshot()).toEqual(events);
+  });
+
+  it("records an emit before the returned promise settles", () => {
+    const sink = new InMemorySink();
+    const event = makeEvent(
+      "11111111-1111-7111-8111-111111111111",
+      "auth.login",
+    );
+    const pending = sink.emit(event);
+    expect(sink.snapshot()).toEqual([event]);
+    return expect(pending).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/cloud/api/src/services/audit/testing.ts`, which had no colocated `testing.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/cloud/api/src/services/audit/testing.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` at file time; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. `InMemorySink` has no comparator, capacity, or item-removal API — those edges do not exist. Failure mode is a false assertion of observed append/snapshot/clear behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/services/audit/testing.test.ts` driving the real `InMemorySink` class (the only export). No mocks of the system under test. Sibling layout matches `dispatcher.test.ts` in the same directory; import path is `./testing.js`.

Covered behaviour, as observed in the live module:

- `name` is `"memory"`; `required` is unspecified (`undefined` on the `AuditSink` contract, so the dispatcher treats delivery failures as required)
- Empty queue: `snapshot()` is `[]`
- Single `emit` records that event by identity
- Multiple emits preserve insertion order
- Duplicate/tied emits of the same object are both retained (no uniqueness/comparator)
- `snapshot()` returns a copied array; mutating the copy does not change the queue
- `clear()` on an empty queue is a no-op; `clear()` after emit empties; emit after clear starts a new queue
- Independent instances do not share state
- No capacity cap: eight sequential emits are all retained
- `emit` records the event before the returned promise settles (synchronous push, async signature)

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/services/audit/testing.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (the production module is unchanged vs this PR's parent):

```bash
bunx vitest run packages/cloud/api/src/services/audit/testing.test.ts
bunx biome check --write packages/cloud/api/src/services/audit/testing.test.ts
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'testing.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop`):

1. Vitest: **Test Files 1 passed (1), Tests 10 passed (10)** (`bunx vitest run packages/cloud/api/src/services/audit/testing.test.ts`).

```text
 ✓ packages/cloud/api/src/services/audit/testing.test.ts (10 tests) 3ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  19:39:42
   Duration  120ms (transform 29ms, setup 0ms, import 36ms, tests 3ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/cloud/api/src/services/audit/testing.test.ts` — `Checked 1 file in 28ms. No fixes applied.` Config exists at repo-root `biome.json`; `git sparse-checkout list` reports this worktree is not sparse.

3. `tsc --noEmit` in `packages/cloud/api`: **`testing.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors elsewhere in the package are unrelated.

4. Diff touches **only** `packages/cloud/api/src/services/audit/testing.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Test-only PR; no production behaviour change. Heavy bug-fix evidence (origin reproduction, proof-run, over-rejection corpus) does not apply.

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 10 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

# Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. Hosted GitHub Actions CI does not run on fork contributor PRs. No identity.slop.cash receipt: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9bf00162c02c6793d24aee986464de22988e7baa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
