### PR TITLE
test(cloud): cover audit-events

### DIFF
--- a/packages/cloud/api/src/services/audit-events.test.ts
+++ b/packages/cloud/api/src/services/audit-events.test.ts
@@ -9,22 +9,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuditEvent } from "./audit/types.js";
 
-const harness = vi.hoisted(() => {
-  const authEvents = { name: "auth_events" as const };
-  const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
-  const insert = vi.fn((_table: unknown) => ({ values }));
-  return { authEvents, values, insert };
+// bun's vitest compat layer (the runner this package's unit lane uses) has no
+// vi.hoisted, so build the collaborators inside the factories and reach them
+// through the mocked module afterwards.
+vi.mock("@/db/client", () => {
+	const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
+	const insert = vi.fn((_table: unknown) => ({ values }));
+	return { dbWrite: { insert }, __values: values, __insert: insert };
 });
 
-vi.mock("@/db/client", () => ({
-  dbWrite: {
-    insert: harness.insert,
-  },
+vi.mock("@/db/schemas/auth-events", () => ({
+	authEvents: { name: "auth_events" as const },
 }));
 
-vi.mock("@/db/schemas/auth-events", () => ({
-  authEvents: harness.authEvents,
-}));
+const dbClientModule = (await import("@/db/client")) as unknown as {
+	__values: ReturnType<typeof vi.fn>;
+	__insert: ReturnType<typeof vi.fn>;
+};
+const authEventsModule = (await import("@/db/schemas/auth-events")) as unknown as {
+	authEvents: { name: "auth_events" };
+};
+const harness = {
+	values: dbClientModule.__values,
+	insert: dbClientModule.__insert,
+	authEvents: authEventsModule.authEvents,
+};
 
 const { AuditEventsSink, auditEventsSink } = await import("./audit-events");
 

--- a/packages/cloud/api/src/services/audit-events.test.ts
+++ b/packages/cloud/api/src/services/audit-events.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit coverage for AuditEventsSink. The real class maps an AuditEvent onto
+ * the auth_events insert row; dbWrite is a capturing collaborator so each
+ * assertion inspects the mapped values. There is no queue, capacity, or
+ * comparator — the branches are the nullish optional-field mappings and
+ * persistence-error propagation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuditEvent } from "./audit/types.js";
+
+const harness = vi.hoisted(() => {
+  const authEvents = { name: "auth_events" as const };
+  const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
+  const insert = vi.fn((_table: unknown) => ({ values }));
+  return { authEvents, values, insert };
+});
+
+vi.mock("@/db/client", () => ({
+  dbWrite: {
+    insert: harness.insert,
+  },
+}));
+
+vi.mock("@/db/schemas/auth-events", () => ({
+  authEvents: harness.authEvents,
+}));
+
+const { AuditEventsSink, auditEventsSink } = await import("./audit-events");
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    event_id: "0198d3a0-0000-7000-8000-000000000001",
+    ts: "2026-08-23T12:00:00.000Z",
+    actor: { type: "user", id: "user-1" },
+    action: "auth.login",
+    result: "success",
+    resource: null,
+    ...overrides,
+  };
+}
+
+describe("AuditEventsSink", () => {
+  beforeEach(() => {
+    harness.values.mockReset();
+    harness.values.mockResolvedValue(undefined);
+    harness.insert.mockClear();
+  });
+
+  it("exports a required auth_events_pg sink singleton", () => {
+    expect(auditEventsSink).toBeInstanceOf(AuditEventsSink);
+    expect(auditEventsSink.name).toBe("auth_events_pg");
+    expect(auditEventsSink.required).toBe(true);
+    const constructed = new AuditEventsSink();
+    expect(constructed.name).toBe("auth_events_pg");
+    expect(constructed.required).toBe(true);
+  });
+
+  it("inserts into the auth_events table with required fields and null optionals", async () => {
+    const sink = new AuditEventsSink();
+    const event = makeEvent();
+    await sink.emit(event);
+
+    expect(harness.insert).toHaveBeenCalledTimes(1);
+    expect(harness.insert).toHaveBeenCalledWith(harness.authEvents);
+    expect(harness.values).toHaveBeenCalledTimes(1);
+
+    const row = harness.values.mock.calls[0]?.[0];
+    expect(row).toEqual({
+      event_id: event.event_id,
+      ts: new Date("2026-08-23T12:00:00.000Z"),
+      actor_type: "user",
+      actor_id: "user-1",
+      action: "auth.login",
+      result: "success",
+      resource_type: null,
+      resource_id: null,
+      ip: null,
+      ua: null,
+      request_id: null,
+      org_id: null,
+      metadata: null,
+    });
+    expect(row?.ts).toBeInstanceOf(Date);
+    expect(Object.hasOwn(row ?? {}, "expires_at")).toBe(false);
+  });
+
+  it("maps a present resource onto resource_type and resource_id", async () => {
+    const sink = new AuditEventsSink();
+    await sink.emit(
+      makeEvent({
+        resource: { type: "api_key", id: "key-9" },
+      }),
+    );
+    expect(harness.values.mock.calls[0]?.[0]).toMatchObject({
+      resource_type: "api_key",
+      resource_id: "key-9",
+    });
+  });
+
+  it("passes through optional ip, user_agent, request_id, org_id, and metadata", async () => {
+    const sink = new AuditEventsSink();
+    const metadata = {
+      ip: "203.0.113.8",
+      email_hash: "abc",
+      attempt: 2,
+      reused: false,
+      reason: null,
+    };
+    await sink.emit(
+      makeEvent({
+        ip: "203.0.113.8",
+        user_agent: "eliza-cli/1.0",
+        request_id: "req-22",
+        org_id: "org-7",
+        metadata,
+      }),
+    );
+    expect(harness.values.mock.calls[0]?.[0]).toMatchObject({
+      ip: "203.0.113.8",
+      ua: "eliza-cli/1.0",
+      request_id: "req-22",
+      org_id: "org-7",
+      metadata,
+    });
+  });
+
+  it("stores empty strings and an empty metadata object rather than converting them to null", async () => {
+    const sink = new AuditEventsSink();
+    await sink.emit(
+      makeEvent({
+        ip: "",
+        user_agent: "",
+        request_id: "",
+        org_id: "",
+        metadata: {},
+        resource: { type: "", id: "" },
+      }),
+    );
+    expect(harness.values.mock.calls[0]?.[0]).toMatchObject({
+      ip: "",
+      ua: "",
+      request_id: "",
+      org_id: "",
+      metadata: {},
+      resource_type: "",
+      resource_id: "",
+    });
+  });
+
+  it("converts an offset timestamp string to the equivalent Date", async () => {
+    const sink = new AuditEventsSink();
+    await sink.emit(makeEvent({ ts: "2026-08-23T08:00:00.000-04:00" }));
+    const ts = harness.values.mock.calls[0]?.[0]?.ts;
+    expect(ts).toBeInstanceOf(Date);
+    expect((ts as Date).toISOString()).toBe("2026-08-23T12:00:00.000Z");
+  });
+
+  it("copies actor type, actor id, action, and result without rewriting them", async () => {
+    const sink = new AuditEventsSink();
+    await sink.emit(
+      makeEvent({
+        actor: { type: "api_key", id: "ak_1" },
+        action: "api_key.use",
+        result: "denied",
+      }),
+    );
+    expect(harness.values.mock.calls[0]?.[0]).toMatchObject({
+      actor_type: "api_key",
+      actor_id: "ak_1",
+      action: "api_key.use",
+      result: "denied",
+    });
+
+    await sink.emit(
+      makeEvent({
+        actor: { type: "system", id: "cron" },
+        action: "admin.action",
+        result: "failure",
+      }),
+    );
+    expect(harness.values.mock.calls[1]?.[0]).toMatchObject({
+      actor_type: "system",
+      actor_id: "cron",
+      action: "admin.action",
+      result: "failure",
+    });
+  });
+
+  it("rejects when the insert collaborator rejects", async () => {
+    const sink = new AuditEventsSink();
+    const failure = new Error("auth_events write failed");
+    harness.values.mockRejectedValueOnce(failure);
+    await expect(sink.emit(makeEvent())).rejects.toBe(failure);
+  });
+
+  it("writes independent rows for sequential emits, including the exported singleton", async () => {
+    const sink = new AuditEventsSink();
+    const first = makeEvent({
+      event_id: "0198d3a0-0000-7000-8000-00000000000a",
+      actor: { type: "agent", id: "agent-1" },
+    });
+    const second = makeEvent({
+      event_id: "0198d3a0-0000-7000-8000-00000000000b",
+      actor: { type: "service", id: "svc-1" },
+      result: "failure",
+    });
+
+    await sink.emit(first);
+    await sink.emit(second);
+    await auditEventsSink.emit(
+      makeEvent({
+        event_id: "0198d3a0-0000-7000-8000-00000000000c",
+        actor: { type: "system", id: "system-1" },
+      }),
+    );
+
+    expect(harness.insert).toHaveBeenCalledTimes(3);
+    const rows = harness.values.mock.calls.map((call) => call[0]);
+    expect(rows.map((row) => row?.event_id)).toEqual([
+      "0198d3a0-0000-7000-8000-00000000000a",
+      "0198d3a0-0000-7000-8000-00000000000b",
+      "0198d3a0-0000-7000-8000-00000000000c",
+    ]);
+    expect(rows.map((row) => row?.actor_type)).toEqual([
+      "agent",
+      "service",
+      "system",
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/cloud/api/src/services/audit-events.ts`, which previously had no colocated test file. The module exports `AuditEventsSink` (the required `auth_events_pg` sink) and the process singleton `auditEventsSink`. `emit` maps an `AuditEvent` onto `dbWrite.insert(authEvents).values(...)`. This PR drives the real class and inspects the mapped insert row. No production source changes.

Covered behaviour (observed, not aspirational):

- The exported singleton is an `AuditEventsSink` with `name === "auth_events_pg"` and `required === true`; a freshly constructed instance has the same identity fields
- A fully-specified event with `resource: null` and no optional fields inserts into the `auth_events` table with those required columns copied and `resource_type`, `resource_id`, `ip`, `ua`, `request_id`, `org_id`, and `metadata` set to `null`. `expires_at` is not written (the table default stays with the database)
- A present `resource` maps to `resource_type` / `resource_id`; `user_agent` maps to the `ua` column
- Optional `ip`, `user_agent`, `request_id`, `org_id`, and `metadata` pass through when set, including mixed metadata values (string, number, boolean, null)
- Empty strings and an empty metadata object are stored as-is — `??` does not treat `""` or `{}` as missing
- An offset timestamp string is converted with `new Date(event.ts)` (e.g. `2026-08-23T08:00:00.000-04:00` becomes `2026-08-23T12:00:00.000Z`)
- Actor type/id, action, and result are copied without rewriting (`api_key`/`denied`, `system`/`failure`)
- When the insert collaborator rejects, `emit` rejects with that same error
- Sequential emits, including through the exported singleton, write independent rows

There is no queue, capacity, comparator, or removal path in this module.

# Relates to

No linked issue. Test-only coverage for an untested colocated module.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`a9e294cffc63f8c7d9f64c7415d813f99d7af1ab`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change; focused vitest, biome, and package `tsc` results are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the vitest/biome/tsc counts below.

# Sync with develop

- [x] Branch parent is current `origin/develop` `a9e294cffc63f8c7d9f64c7415d813f99d7af1ab`, re-fetched immediately before filing; zero conflicts.
- [ ] `bun run verify` not re-run (test-only, no production change). Focused gates below.

# Risks

Low. Adds tests only; no production behaviour change. Failure mode is a false assertion of the observed insert mapping, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Colocated unit coverage for `packages/cloud/api/src/services/audit-events.ts`.

## What kind of change is this?

Improvements (tests for existing behaviour).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/services/audit-events.test.ts`, then the commands in **Verification**.

## Detailed testing steps

None: automated tests are acceptable.

# Evidence Gate

<!-- evidence-head:fe7e640e8c76d5c8d267e5ff06a5d2a1256b0b02 -->

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model behaviour changed.

## Backend + frontend logs

N/A - test-only change; no server or UI path exercised.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface; the diff is one Vitest file.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Hosted CI does not run on this fork contributor PR. Local vitest, biome, and package `tsc` are the proof.

`bun run verify` was not run; this PR changes no production code.

## Maintainer CI exception record

N/A - no exception requested

## Verification

Exact head: `fe7e640e8c76d5c8d267e5ff06a5d2a1256b0b02` (parent is current `origin/develop` `a9e294cffc63f8c7d9f64c7415d813f99d7af1ab`, re-fetched immediately before filing)

1. Vitest (re-run against current `origin/develop` sources immediately before filing):

```text
bunx vitest run packages/cloud/api/src/services/audit-events.test.ts
 ✓ packages/cloud/api/src/services/audit-events.test.ts (9 tests) 5ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  19:41:03
   Duration  138ms (transform 46ms, setup 0ms, import 55ms, tests 5ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/cloud/api/src/services/audit-events.test.ts` — `Checked 1 file in 25ms. No fixes applied.` Config exists at repo-root `biome.json`; this checkout is not sparse (`git sparse-checkout list` → fatal: this worktree is not sparse).

3. Package typecheck: `cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'audit-events.test.ts'` produced no matches (grep EXIT:1). This file introduced zero TypeScript errors.

4. Diff touches only `packages/cloud/api/src/services/audit-events.test.ts`.

Hosted CI does not run on this fork contributor PR; the counts above are from local `bunx vitest` / `biome` / `tsc` on this head.

## Notes

Test-only change. No production behaviour is modified. Assertions record what the sink does (`??` keeps empty strings, `user_agent` → `ua`, `expires_at` is omitted from the insert) rather than a desired redesign.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
