### PR TITLE
chore(deps): reconcile current workspace lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1107,6 +1107,7 @@
       "name": "@elizaos/synthetic-world",
       "version": "0.0.0",
       "dependencies": {
+        "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
       },
@@ -1136,7 +1137,6 @@
         "@elizaos/core": "workspace:*",
         "@elizaos/logger": "workspace:*",
         "@elizaos/shared": "workspace:*",
-        "@extrastu/nuphy-ui": "^0.3.0",
         "@fontsource/poppins": "^5.2.7",
         "@json-render/core": "0.19.0",
         "@json-render/react": "0.19.0",
@@ -4497,8 +4497,6 @@
     "@ethersproject/web": ["@ethersproject/web@5.8.0", "", { "dependencies": { "@ethersproject/base64": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
-
-    "@extrastu/nuphy-ui": ["@extrastu/nuphy-ui@0.3.0", "", { "dependencies": { "clsx": "^2.1.1", "tailwind-merge": "^2.5.4" }, "peerDependencies": { "lucide-react": ">=0.400.0", "react": ">=18", "react-dom": ">=18" } }, "sha512-cx2yU90bHmT/516lUO2tdwgwiaW3K9JWV5u39A7B4WyUu4mrfVhA7R3vUTGCYhSUOTj/bMTZL3oDQVaWO0R9kA=="],
 
     "@fal-ai/client": ["@fal-ai/client@1.10.1", "", { "dependencies": { "@msgpack/msgpack": "^3.0.0-beta2", "eventsource-parser": "^1.1.2", "robot3": "^0.4.1" } }, "sha512-c3AVeH31OioiI2J1BfW8Cryi1DhUYldnY3X35nv6xLMq3fU2NQOo+eYaR5mL2O8MoHHh+HzXdQuIyanIyeq+ug=="],
 
@@ -10367,8 +10365,6 @@
     "@ethersproject/transactions/@ethersproject/keccak256": ["@ethersproject/keccak256@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "js-sha3": "0.8.0" } }, "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng=="],
 
     "@ethersproject/web/@ethersproject/strings": ["@ethersproject/strings@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/logger": "^5.8.0" } }, "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg=="],
-
-    "@extrastu/nuphy-ui/tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
     "@gemini-wallet/core/@metamask/rpc-errors": ["@metamask/rpc-errors@7.0.2", "", { "dependencies": { "@metamask/utils": "^11.0.1", "fast-safe-stringify": "^2.0.6" } }, "sha512-YYYHsVYd46XwY2QZzpGeU4PSdRhHdxnzkB8piWGvJW2xbikZ3R+epAYEL4q/K8bh9JPTucsUdwRFnACor1aOYw=="],
 


### PR DESCRIPTION
## Summary

Regenerate the root Bun lockfile from current develop with repository-pinned Bun 1.3.14. This is a one-file mechanical release-gate repair kept separate from Shared renderer PR #26081.

## Root cause

PR Static Smoke 32644532589 failed before build, lint, or typecheck because frozen install wanted to rewrite bun.lock. Two already-merged package-manifest changes were absent from the lock:

- f1f37c0a36 added @elizaos/agent to @elizaos/synthetic-world
- e8feab5a8b removed @extrastu/nuphy-ui from @elizaos/ui

The generated delta adds the missing workspace dependency edge and removes the retired NuPhy package plus its now-unreferenced nested resolution.

## Local proof

- bun install --lockfile-only --ignore-scripts generated exactly one changed file
- bun install --frozen-lockfile --lockfile-only --ignore-scripts is stable
- bun.lock SHA-256 remained a7e2c0e39f81015bace0e7911886cadab46f6f486913a6c26c95688aedfe7188 across the frozen verification
- git diff --check: clean
- gitleaks staged diff, 3.08 KB: no leaks

## Boundary

No application source, workflow, deployment, provider, or production state changes. Cloudflare and Railway remain closed until reviewed canonical source is green.