### PR TITLE
test(shared): cover routing-policy

### DIFF
--- a/packages/shared/src/local-inference/routing-policy.test.ts
+++ b/packages/shared/src/local-inference/routing-policy.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit coverage for routing policy definitions and predicates in routing-policy.ts.
+ *
+ * Tests policy list contents, isRoutingPolicy type guard against valid/invalid values,
+ * and DEFAULT_ROUTING_POLICY assignment.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ROUTING_POLICY,
+  isRoutingPolicy,
+  ROUTING_POLICIES,
+} from "./routing-policy.js";
+
+describe("routing-policy", () => {
+  it("exports all expected routing policies in ROUTING_POLICIES", () => {
+    expect(Array.isArray(ROUTING_POLICIES)).toBe(true);
+    expect(ROUTING_POLICIES).toEqual([
+      "manual",
+      "auto",
+      "local-only",
+      "cloud-only",
+      "cheapest",
+      "fastest",
+      "prefer-local",
+      "round-robin",
+    ]);
+  });
+
+  it("validates valid routing policies via isRoutingPolicy", () => {
+    for (const policy of ROUTING_POLICIES) {
+      expect(isRoutingPolicy(policy)).toBe(true);
+    }
+  });
+
+  it("rejects invalid values in isRoutingPolicy", () => {
+    expect(isRoutingPolicy("invalid-policy")).toBe(false);
+    expect(isRoutingPolicy("")).toBe(false);
+    expect(isRoutingPolicy("PREFER-LOCAL")).toBe(false);
+    expect(isRoutingPolicy(123)).toBe(false);
+    expect(isRoutingPolicy(null)).toBe(false);
+    expect(isRoutingPolicy(undefined)).toBe(false);
+    expect(isRoutingPolicy({})).toBe(false);
+    expect(isRoutingPolicy([])).toBe(false);
+  });
+
+  it("sets DEFAULT_ROUTING_POLICY to 'prefer-local'", () => {
+    expect(DEFAULT_ROUTING_POLICY).toBe("prefer-local");
+    expect(isRoutingPolicy(DEFAULT_ROUTING_POLICY)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/local-inference/routing-policy.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `ROUTING_POLICIES`, `isRoutingPolicy`, and `DEFAULT_ROUTING_POLICY` across:
- `ROUTING_POLICIES` full vocabulary contents (`manual`, `auto`, `local-only`, `cloud-only`, `cheapest`, `fastest`, `prefer-local`, `round-robin`).
- `isRoutingPolicy` type guard verification against valid members and non-string/invalid-string inputs.
- `DEFAULT_ROUTING_POLICY` canonical assignment and type compliance.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`9a94b7fde6`) |
| --- | --- | --- |
| `bunx vitest run src/local-inference/routing-policy.test.ts` (in `packages/shared`) | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/shared/src/local-inference/routing-policy.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/local-inference/routing-policy.test.ts:1-51`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 passed in `routing-policy.test.ts`
- [x] `lint` — Biome clean
