### PR TITLE
test(shared): cover terminal-theme

### DIFF
--- a/packages/shared/src/terminal/theme.test.ts
+++ b/packages/shared/src/terminal/theme.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit coverage for CLI terminal theme utilities in theme.ts.
+ *
+ * Tests theme color properties, cyberGreen color helper, isRich predicate,
+ * and conditional colorize helper.
+ */
+
+import { describe, expect, it } from "vitest";
+import { colorize, cyberGreen, isRich, theme } from "./theme.js";
+
+describe("terminal theme", () => {
+  it("exports theme with all required palette functions", () => {
+    expect(typeof theme.accent).toBe("function");
+    expect(typeof theme.accentBright).toBe("function");
+    expect(typeof theme.accentDim).toBe("function");
+    expect(typeof theme.info).toBe("function");
+    expect(typeof theme.success).toBe("function");
+    expect(typeof theme.warn).toBe("function");
+    expect(typeof theme.error).toBe("function");
+    expect(typeof theme.muted).toBe("function");
+    expect(typeof theme.heading).toBe("function");
+    expect(typeof theme.command).toBe("function");
+    expect(typeof theme.option).toBe("function");
+  });
+
+  it("applies theme formatting to text without throwing", () => {
+    const text = "sample message";
+    expect(theme.accent(text)).toBeDefined();
+    expect(theme.info(text)).toBeDefined();
+    expect(theme.heading(text)).toBeDefined();
+  });
+
+  it("exports cyberGreen color function", () => {
+    expect(typeof cyberGreen).toBe("function");
+    expect(cyberGreen("matrix")).toBeDefined();
+  });
+
+  it("evaluates isRich boolean predicate", () => {
+    const rich = isRich();
+    expect(typeof rich).toBe("boolean");
+  });
+
+  describe("colorize", () => {
+    it("returns colored string when rich is true", () => {
+      const mockFormatter = (val: string) => `[colored]${val}[/colored]`;
+      const result = colorize(true, mockFormatter, "hello");
+      expect(result).toBe("[colored]hello[/colored]");
+    });
+
+    it("returns plain string untouched when rich is false", () => {
+      const mockFormatter = (val: string) => `[colored]${val}[/colored]`;
+      const result = colorize(false, mockFormatter, "hello");
+      expect(result).toBe("hello");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/terminal/theme.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `theme`, `cyberGreen`, `isRich`, and `colorize` across:
- `theme` color function map availability (`accent`, `info`, `success`, `warn`, `error`, `muted`, `heading`, `command`, `option`).
- `cyberGreen` color helper function validation.
- `isRich` boolean level check execution.
- `colorize` conditional formatting branch testing (rich vs plain text).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`277e086cb4`) |
| --- | --- | --- |
| `bunx vitest run src/terminal/theme.test.ts` (in `packages/shared`) | N/A (new test file) | 6 passed (6 tests) |
| `bunx @biomejs/biome check packages/shared/src/terminal/theme.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/terminal/theme.test.ts:1-56`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 passed in `theme.test.ts`
- [x] `lint` — Biome clean
