### PR TITLE
test(shared): cover local-inference-paths

### DIFF
--- a/packages/shared/src/local-inference/paths.test.ts
+++ b/packages/shared/src/local-inference/paths.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit coverage for local-inference path resolution helpers in paths.ts.
+ *
+ * Tests path composition for localInferenceRoot, elizaModelsDir, registryPath,
+ * downloadsStagingDir, and isWithinElizaRoot containment predicates.
+ */
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  downloadsStagingDir,
+  elizaModelsDir,
+  isWithinElizaRoot,
+  localInferenceRoot,
+  registryPath,
+} from "./paths.js";
+
+describe("local-inference paths", () => {
+  it("resolves localInferenceRoot ending with local-inference", () => {
+    const root = localInferenceRoot();
+    expect(typeof root).toBe("string");
+    expect(root.endsWith("local-inference")).toBe(true);
+  });
+
+  it("resolves model directory inside local-inference root", () => {
+    const models = elizaModelsDir();
+    expect(models).toBe(path.join(localInferenceRoot(), "models"));
+  });
+
+  it("resolves registry JSON path inside local-inference root", () => {
+    const registry = registryPath();
+    expect(registry).toBe(path.join(localInferenceRoot(), "registry.json"));
+  });
+
+  it("resolves downloads staging directory inside local-inference root", () => {
+    const staging = downloadsStagingDir();
+    expect(staging).toBe(path.join(localInferenceRoot(), "downloads"));
+  });
+
+  describe("isWithinElizaRoot", () => {
+    it("returns true for subpaths strictly inside localInferenceRoot", () => {
+      const insideFile = path.join(
+        localInferenceRoot(),
+        "models",
+        "model.gguf",
+      );
+      const insideDir = path.join(localInferenceRoot(), "downloads", "partial");
+      expect(isWithinElizaRoot(insideFile)).toBe(true);
+      expect(isWithinElizaRoot(insideDir)).toBe(true);
+    });
+
+    it("returns false for the root directory itself", () => {
+      expect(isWithinElizaRoot(localInferenceRoot())).toBe(false);
+    });
+
+    it("returns false for external paths and sibling directories", () => {
+      expect(isWithinElizaRoot("/tmp/other-path")).toBe(false);
+      expect(
+        isWithinElizaRoot(path.join(localInferenceRoot(), "..", "sibling")),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/local-inference/paths.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests path resolution helpers and containment predicates across:
- `localInferenceRoot` directory resolution under state directory.
- `elizaModelsDir`, `registryPath`, and `downloadsStagingDir` subpath resolution.
- `isWithinElizaRoot` boundary verification (true for inside paths; false for root itself, parent paths, and external directories).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`3ce9a7b20e`) |
| --- | --- | --- |
| `bunx vitest run src/local-inference/paths.test.ts` (in `packages/shared`) | N/A (new test file) | 7 passed (7 tests) |
| `bunx @biomejs/biome check packages/shared/src/local-inference/paths.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/local-inference/paths.test.ts:1-63`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 passed in `paths.test.ts`
- [x] `lint` — Biome clean
