### PR TITLE
test(cloud): cover public-paths

### DIFF
--- a/packages/cloud/api/src/steward/public-paths.test.ts
+++ b/packages/cloud/api/src/steward/public-paths.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Isolated unit coverage for the thin-Steward path predicates. The module
+ * has no queue, comparator, or capacity: the live branches are trailing-slash
+ * collapse, exact-path membership, and method dispatch. Tests import the
+ * production helpers and assert the values they return.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  isThinStewardEmailAuthPath,
+  isThinStewardPasskeyLoginOptionsPath,
+  isThinStewardPath,
+  isThinStewardPublicPath,
+} from "./public-paths";
+
+const PUBLIC_PATHS = [
+  "/steward/auth/providers",
+  "/steward/tenants/config",
+] as const;
+
+const EMAIL_AUTH_PATHS = [
+  "/steward/auth/email/send",
+  "/steward/auth/email/code/verify",
+  "/steward/auth/email/status",
+  "/steward/auth/email/otp/send",
+  "/steward/auth/email/otp/verify",
+] as const;
+
+const PASSKEY_LOGIN_OPTIONS = "/steward/auth/passkey/login/options";
+
+const NEAR_MISS_PATHS = [
+  "",
+  "/",
+  "///",
+  "/steward",
+  "/steward/",
+  "/steward/auth",
+  "/steward/auth/",
+  "/steward/auth/providers/extra",
+  "/steward/auth/provider",
+  "/steward/auth/providersx",
+  "/steward/tenants",
+  "/steward/tenants/configs",
+  "/steward/auth/email",
+  "/steward/auth/email/verify",
+  "/steward/auth/email/code",
+  "/steward/auth/email/otp",
+  "/steward/auth/passkey/login/verify",
+  "/steward/auth/passkey/register/options",
+  "/steward/auth/passkey/register/verify",
+  "/steward/vault/keys",
+  "/api/v1/oauth/providers",
+  "/Steward/auth/providers",
+  "/STEWARD/auth/providers",
+  "/steward/auth/Providers",
+  " /steward/auth/providers",
+  "/steward/auth/providers ",
+  "/steward//auth/providers",
+  "/steward/auth/providers?x=1",
+  "/steward/auth/email/send?next=1",
+] as const;
+
+function withTrailingSlashes(pathname: string, count: number): string {
+  return `${pathname}${"/".repeat(count)}`;
+}
+
+describe("isThinStewardPublicPath", () => {
+  test("matches only the two login-critical GET discovery paths", () => {
+    for (const pathname of PUBLIC_PATHS) {
+      expect(isThinStewardPublicPath(pathname)).toBe(true);
+    }
+  });
+
+  test("collapses any number of trailing slashes before comparing", () => {
+    for (const pathname of PUBLIC_PATHS) {
+      expect(isThinStewardPublicPath(withTrailingSlashes(pathname, 1))).toBe(
+        true,
+      );
+      expect(isThinStewardPublicPath(withTrailingSlashes(pathname, 3))).toBe(
+        true,
+      );
+    }
+    expect(
+      isThinStewardPublicPath(
+        withTrailingSlashes("/steward/auth/providers", 100_000),
+      ),
+    ).toBe(true);
+  });
+
+  test("treats the empty string and slash-only paths as root, which is not public", () => {
+    expect(isThinStewardPublicPath("")).toBe(false);
+    expect(isThinStewardPublicPath("/")).toBe(false);
+    expect(isThinStewardPublicPath("///")).toBe(false);
+  });
+
+  test("rejects email, passkey, and other Steward or API near-misses", () => {
+    for (const pathname of EMAIL_AUTH_PATHS) {
+      expect(isThinStewardPublicPath(pathname)).toBe(false);
+    }
+    expect(isThinStewardPublicPath(PASSKEY_LOGIN_OPTIONS)).toBe(false);
+    for (const pathname of NEAR_MISS_PATHS) {
+      expect(isThinStewardPublicPath(pathname)).toBe(false);
+    }
+  });
+});
+
+describe("isThinStewardEmailAuthPath", () => {
+  test("matches each of the five pre-auth email mutation legs", () => {
+    for (const pathname of EMAIL_AUTH_PATHS) {
+      expect(isThinStewardEmailAuthPath(pathname)).toBe(true);
+    }
+  });
+
+  test("collapses trailing slashes on every email leg", () => {
+    for (const pathname of EMAIL_AUTH_PATHS) {
+      expect(isThinStewardEmailAuthPath(withTrailingSlashes(pathname, 1))).toBe(
+        true,
+      );
+      expect(isThinStewardEmailAuthPath(withTrailingSlashes(pathname, 4))).toBe(
+        true,
+      );
+    }
+    expect(
+      isThinStewardEmailAuthPath(
+        withTrailingSlashes("/steward/auth/email/send", 100_000),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match public discovery or passkey-bootstrap paths", () => {
+    for (const pathname of PUBLIC_PATHS) {
+      expect(isThinStewardEmailAuthPath(pathname)).toBe(false);
+    }
+    expect(isThinStewardEmailAuthPath(PASSKEY_LOGIN_OPTIONS)).toBe(false);
+  });
+
+  test("rejects empty, root, prefix, suffix, and case-variant near-misses", () => {
+    for (const pathname of NEAR_MISS_PATHS) {
+      expect(isThinStewardEmailAuthPath(pathname)).toBe(false);
+    }
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/send/extra")).toBe(
+      false,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/otp/verify/x")).toBe(
+      false,
+    );
+  });
+});
+
+describe("isThinStewardPasskeyLoginOptionsPath", () => {
+  test("matches only the pre-WebAuthn login-options path", () => {
+    expect(isThinStewardPasskeyLoginOptionsPath(PASSKEY_LOGIN_OPTIONS)).toBe(
+      true,
+    );
+  });
+
+  test("collapses trailing slashes on the login-options path", () => {
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        withTrailingSlashes(PASSKEY_LOGIN_OPTIONS, 1),
+      ),
+    ).toBe(true);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        withTrailingSlashes(PASSKEY_LOGIN_OPTIONS, 8),
+      ),
+    ).toBe(true);
+  });
+
+  test("leaves registration and verification on the full app", () => {
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/login/verify",
+      ),
+    ).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/register/options",
+      ),
+    ).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/register/verify",
+      ),
+    ).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(`${PASSKEY_LOGIN_OPTIONS}/extra`),
+    ).toBe(false);
+  });
+
+  test("rejects public, email, empty, and case-variant paths", () => {
+    for (const pathname of PUBLIC_PATHS) {
+      expect(isThinStewardPasskeyLoginOptionsPath(pathname)).toBe(false);
+    }
+    for (const pathname of EMAIL_AUTH_PATHS) {
+      expect(isThinStewardPasskeyLoginOptionsPath(pathname)).toBe(false);
+    }
+    expect(isThinStewardPasskeyLoginOptionsPath("")).toBe(false);
+    expect(isThinStewardPasskeyLoginOptionsPath("/")).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/Login/options",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isThinStewardPath", () => {
+  test("GET and HEAD are eligible only for the public discovery paths", () => {
+    for (const method of ["GET", "HEAD", "get", "head", "Get", "Head"]) {
+      for (const pathname of PUBLIC_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(true);
+        expect(
+          isThinStewardPath(method, withTrailingSlashes(pathname, 2)),
+        ).toBe(true);
+      }
+      for (const pathname of EMAIL_AUTH_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(false);
+      }
+      expect(isThinStewardPath(method, PASSKEY_LOGIN_OPTIONS)).toBe(false);
+      expect(isThinStewardPath(method, "/steward/vault/keys")).toBe(false);
+    }
+  });
+
+  test("POST is eligible only for the email legs and passkey login-options", () => {
+    for (const method of ["POST", "post", "Post"]) {
+      for (const pathname of EMAIL_AUTH_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(true);
+      }
+      expect(isThinStewardPath(method, PASSKEY_LOGIN_OPTIONS)).toBe(true);
+      expect(
+        isThinStewardPath(
+          method,
+          withTrailingSlashes(PASSKEY_LOGIN_OPTIONS, 1),
+        ),
+      ).toBe(true);
+      for (const pathname of PUBLIC_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(false);
+      }
+      expect(
+        isThinStewardPath(method, "/steward/auth/passkey/login/verify"),
+      ).toBe(false);
+      expect(
+        isThinStewardPath(method, "/steward/auth/passkey/register/options"),
+      ).toBe(false);
+      expect(isThinStewardPath(method, "/steward/vault/keys")).toBe(false);
+    }
+  });
+
+  test("OPTIONS is eligible for public, email, and passkey-login-options paths", () => {
+    for (const method of ["OPTIONS", "options", "Options"]) {
+      for (const pathname of PUBLIC_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(true);
+      }
+      for (const pathname of EMAIL_AUTH_PATHS) {
+        expect(isThinStewardPath(method, pathname)).toBe(true);
+      }
+      expect(isThinStewardPath(method, PASSKEY_LOGIN_OPTIONS)).toBe(true);
+      expect(isThinStewardPath(method, "/steward/vault/keys")).toBe(false);
+      expect(
+        isThinStewardPath(method, "/steward/auth/passkey/register/options"),
+      ).toBe(false);
+      expect(isThinStewardPath(method, "")).toBe(false);
+      expect(isThinStewardPath(method, "/")).toBe(false);
+    }
+  });
+
+  test("methods outside GET, HEAD, POST, and OPTIONS never match", () => {
+    const eligible = [
+      ...PUBLIC_PATHS,
+      ...EMAIL_AUTH_PATHS,
+      PASSKEY_LOGIN_OPTIONS,
+    ];
+    for (const method of [
+      "PUT",
+      "PATCH",
+      "DELETE",
+      "TRACE",
+      "CONNECT",
+      "",
+      " GET",
+      "GET ",
+    ]) {
+      for (const pathname of eligible) {
+        expect(isThinStewardPath(method, pathname)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. `packages/cloud/api/src/steward/public-paths.ts` had no same-named test file. This PR adds one colocated vitest suite that drives the real module.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Focused checks only: vitest, biome, and package `tsc --noEmit`. This is a
      test-only fork PR; hosted CI does not run on contributor-fork pull requests.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Parent of this head is `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238` (`origin/develop` at push).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change. No production behaviour is modified. The new file
imports the real path predicates and asserts the values they already return.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/steward/public-paths.test.ts`, a colocated vitest
suite for the four exported thin-Steward path helpers:

- `isThinStewardPublicPath`
- `isThinStewardEmailAuthPath`
- `isThinStewardPasskeyLoginOptionsPath`
- `isThinStewardPath`

The production module has no queue, comparator, or capacity. The live branches
are trailing-slash collapse (including empty / slash-only paths collapsing to
root), exact-path membership (public GETs, five email POST legs, one passkey
login-options path), and method dispatch (`GET`/`HEAD` vs `POST` vs `OPTIONS`,
including case folding via `toUpperCase`). Tests record observed behaviour:
query strings, extra segments, case-variant pathnames, and methods outside
`GET`/`HEAD`/`POST`/`OPTIONS` are rejected.

## What kind of change is this?

Improvements (misc. changes to existing features) — tests only.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/steward/public-paths.test.ts`. Diff is that one file.

## Detailed testing steps

```bash
bunx vitest run packages/cloud/api/src/steward/public-paths.test.ts
```

Observed against current `origin/develop` immediately before filing:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
   Duration  143ms
```

```bash
bunx biome check --write packages/cloud/api/src/steward/public-paths.test.ts
```

Observed: `Checked 1 file in 29ms. Fixed 1 file.` The filed bytes are the
post-biome contents. Config proven present: `biome.json` and `tsconfig.json`
exist at the checkout root; `git sparse-checkout list` reports this worktree
is not sparse.

```bash
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'public-paths.test.ts' ; echo "EXIT:$?"
```

Observed: empty grep (no type diagnostics name the new file). `EXIT:1` is
grep's no-match status. Pre-existing package diagnostics, if any, are not
from this file.

Diff touches only `packages/cloud/api/src/steward/public-paths.test.ts`.

Hosted CI does not run on this contributor-fork pull request. Do not treat
GitHub check status as evidence that the suite passed.

# Evidence Gate

Evidence matches head `f9a6e67e6f5ec29c1bfd52b65c20275b2e771860`.

<!-- evidence-head:f9a6e67e6f5ec29c1bfd52b65c20275b2e771860 -->

- [x] Before full-page screenshots — `N/A - test-only; no UI surface`
- [x] After full-page screenshots — `N/A - test-only; no UI surface`
- [x] Walkthrough video — `N/A - test-only; no UI surface`
- [x] Backend logs — `N/A - no production code path changed; vitest output quoted above`
- [x] Frontend console/network logs — `N/A - test-only; no UI surface`
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts — `N/A - path predicates return booleans; no DB/on-chain/audio artifact`
- [x] OCR visual-text review — `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only unit coverage of pure pathname/method predicates.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - test-only.

### After

N/A - test-only.

### Walkthrough video

N/A - test-only.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds one test file and changes no
  production behaviour; focused vitest / biome / package tsc are the complete
  evidence set. Hosted CI does not run on contributor-fork PRs.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth
  trace, so no receipt is attached.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
