### PR TITLE
test(cloud): cover brighter-storage-adapter-s3

### DIFF
--- a/packages/cloud/api/src/stubs/brighter-storage-adapter-s3.test.ts
+++ b/packages/cloud/api/src/stubs/brighter-storage-adapter-s3.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Deterministic unit coverage for the workerd-safe @brighter/storage-adapter-s3
+ * stub. Drives the real module with no mocks: Storage() constructs a
+ * fail-closed adapter, and every method throws so accidental Worker-side S3
+ * use cannot silently succeed. The stub has no queue, comparator, or capacity.
+ */
+
+import { describe, expect, test } from "vitest";
+import { Storage } from "./brighter-storage-adapter-s3";
+
+const UNAVAILABLE =
+  "@brighter/storage-adapter-s3 is unavailable in the Cloudflare Worker bundle. Configure the native R2 binding or S3 route adapter before using this path.";
+
+const METHOD_NAMES = [
+  "write",
+  "read",
+  "stat",
+  "exists",
+  "remove",
+  "list",
+  "presign",
+] as const;
+
+type Adapter = ReturnType<typeof Storage>;
+type AdapterMethod = (typeof METHOD_NAMES)[number];
+
+function expectUnavailable(fn: () => never, method: AdapterMethod): void {
+  expect(fn).toThrowError(UNAVAILABLE);
+  try {
+    fn();
+    throw new Error(`expected Storage().${method}() to throw`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe(UNAVAILABLE);
+  }
+}
+
+describe("brighter-storage-adapter-s3 Worker stub", () => {
+  test("exports Storage as a constructor function that does not throw", () => {
+    expect(typeof Storage).toBe("function");
+    expect(() => Storage()).not.toThrow();
+  });
+
+  test("returns an adapter whose own keys are the seven fail-closed methods in source order", () => {
+    const adapter = Storage();
+    expect(Object.keys(adapter)).toEqual([...METHOD_NAMES]);
+    for (const name of METHOD_NAMES) {
+      expect(Object.hasOwn(adapter, name)).toBe(true);
+      expect(typeof adapter[name]).toBe("function");
+    }
+  });
+
+  test("write throws the unavailable Error", () => {
+    expectUnavailable(Storage().write, "write");
+  });
+
+  test("read throws the unavailable Error", () => {
+    expectUnavailable(Storage().read, "read");
+  });
+
+  test("stat throws the unavailable Error", () => {
+    expectUnavailable(Storage().stat, "stat");
+  });
+
+  test("exists throws the unavailable Error", () => {
+    expectUnavailable(Storage().exists, "exists");
+  });
+
+  test("remove throws the unavailable Error even when the object is missing", () => {
+    // There is no existence check: missing and present keys both throw before
+    // any S3 lookup, because the Worker bundle never configures the adapter.
+    expectUnavailable(Storage().remove, "remove");
+  });
+
+  test("list throws the unavailable Error on an empty listing path", () => {
+    expectUnavailable(Storage().list, "list");
+  });
+
+  test("presign throws the unavailable Error", () => {
+    expectUnavailable(Storage().presign, "presign");
+  });
+
+  test("constructs a new adapter object each call, sharing the module-level thrower", () => {
+    const first = Storage();
+    const second = Storage();
+    expect(first).not.toBe(second);
+    expect(first.write).toBe(first.read);
+    expect(first.write).toBe(second.write);
+    for (const name of METHOD_NAMES) {
+      expect(first[name]).toBe(first.write);
+      expect(second[name]).toBe(first.write);
+    }
+  });
+
+  test("repeated calls on one adapter keep throwing (no capacity, overflow, or unlock)", () => {
+    const adapter: Adapter = Storage();
+    expectUnavailable(adapter.write, "write");
+    expectUnavailable(adapter.write, "write");
+    expectUnavailable(adapter.read, "read");
+    expectUnavailable(adapter.list, "list");
+  });
+
+  test("does not expose queue, comparator, or capacity fields", () => {
+    const adapter = Storage() as Adapter & Record<string, unknown>;
+    expect("queue" in adapter).toBe(false);
+    expect("capacity" in adapter).toBe(false);
+    expect("comparator" in adapter).toBe(false);
+    expect(adapter.queue).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest suite for `packages/cloud/api/src/stubs/brighter-storage-adapter-s3.ts`, which had no `brighter-storage-adapter-s3.test.ts` anywhere in the repository. The suite imports the real module from `./brighter-storage-adapter-s3` and asserts observed behaviour — it does not mock the code under test.

The stub's only export is `Storage()`. It constructs a fail-closed workerd adapter so `@brighter/storage-adapter-s3` can be aliased in `wrangler.toml` without performing S3 I/O in the Worker bundle.

Covered exports and branches (read from the source, then observed under Vitest):

- `Storage` is a function; calling it does not throw
- Returned own keys are exactly `write`, `read`, `stat`, `exists`, `remove`, `list`, `presign` in source order
- Each of those seven methods throws `Error` with the exact unavailable message:
  `@brighter/storage-adapter-s3 is unavailable in the Cloudflare Worker bundle. Configure the native R2 binding or S3 route adapter before using this path.`
- `remove` throws before any existence check (missing vs present is unreachable)
- `list` throws on the empty listing path
- Each `Storage()` call returns a **new object**
- All methods on all instances are the **same** module-level `unavailable` function (object-literal property identity), not per-instance closures
- Repeated calls keep throwing — there is no capacity, overflow, or unlock path
- No `queue`, `capacity`, or `comparator` fields exist on the adapter

There is no comparator, ordering, ties, or overflow API on this module. Those edges are absent; the suite records that absence rather than inventing them.

No production behaviour is changed. The diff is the new test file only.

## Evidence

This is a test-only pull request. Hosted GitHub Actions CI does **not** run on this fork contributor's PRs; the counts below are from a local run against current `origin/develop`, not from Actions. Do not infer that Actions passed.

Re-fetched `origin/develop` immediately before these counts (`4207ca1ab7d41e5d5c4ddac071369cfc7d84a238`). The stub source is unchanged versus that tip.

1. Vitest (root config; the stub has no path aliases, so the suite collects):

```
cd /Volumes/thescoho_1TB/Developer/eliza
bunx vitest run packages/cloud/api/src/stubs/brighter-storage-adapter-s3.test.ts
```

Result on current `origin/develop`: **Test Files  1 passed (1)** / **Tests  12 passed (12)** (Duration 120ms, vitest v4.1.10).

2. Biome: `bunx biome check --write packages/cloud/api/src/stubs/brighter-storage-adapter-s3.test.ts` — `biome.json` and `tsconfig.json` are present; `git sparse-checkout list` reports the checkout is not sparse. Result: `Checked 1 file in 32ms. No fixes applied.`

3. `cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'brighter-storage-adapter-s3.test.ts'` — empty; the new file appears nowhere in the typecheck output (grep EXIT:1). Pre-existing package errors, if any, are not in this file.

4. Diff touches only `packages/cloud/api/src/stubs/brighter-storage-adapter-s3.test.ts` (111 insertions).

# Relates to

No GitHub issue: behavior-preserving unit coverage for an existing Worker stub. Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

# Sync with develop

- [x] Branch parent is `origin/develop` `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238`; single-file commit, zero conflicts.
- [ ] `bun run verify` not re-run (test-only; no production change). Focused checks above.

# Risks

Low. Adds one colocated Vitest file. No production source, exports, wrangler alias, or runtime behaviour change. Failure mode is a failing unit test, not a storage or Worker behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation. The stub already documents the fail-closed Worker contract.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9ddbbe7b8bbb0cce0e78a2b4161bc121b244e94f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
