### PR TITLE
test(shared): cover registry-host

### DIFF
--- a/packages/shared/src/registry-host.test.ts
+++ b/packages/shared/src/registry-host.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit coverage for pluggable UI registry host store manager in registry-host.ts.
+ *
+ * Tests singleton store creation, memoization per key, custom registry host swapping,
+ * and test cleanup reset.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getUiRegistryStore,
+  provideUiRegistryHost,
+  resetUiRegistryHostForTests,
+  type UiRegistryHost,
+} from "./registry-host.js";
+
+describe("registry-host", () => {
+  beforeEach(() => {
+    resetUiRegistryHostForTests();
+  });
+
+  it("creates and memoizes stores per unique key", () => {
+    const factory = vi.fn(() => ({ apps: [] as string[] }));
+
+    const storeA1 = getUiRegistryStore("apps", factory);
+    const storeA2 = getUiRegistryStore("apps", factory);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(storeA1).toBe(storeA2);
+  });
+
+  it("creates independent stores for distinct keys", () => {
+    const storeApps = getUiRegistryStore("apps", () => ({ type: "apps" }));
+    const storeSettings = getUiRegistryStore("settings", () => ({
+      type: "settings",
+    }));
+
+    expect(storeApps).not.toBe(storeSettings);
+    expect(storeApps.type).toBe("apps");
+    expect(storeSettings.type).toBe("settings");
+  });
+
+  it("allows providing a custom UiRegistryHost implementation", () => {
+    const customStore = { custom: true };
+    const customHost: UiRegistryHost = {
+      getStore: vi.fn(<T>(_key: string, _create: () => T) => customStore as T),
+    };
+
+    provideUiRegistryHost(customHost);
+
+    const store = getUiRegistryStore("any-key", () => ({ default: true }));
+
+    expect(customHost.getStore).toHaveBeenCalledTimes(1);
+    expect(store).toBe(customStore);
+  });
+
+  it("resets stores and restores default host via resetUiRegistryHostForTests", () => {
+    const factory = vi.fn(() => ({ count: 1 }));
+
+    getUiRegistryStore("counter", factory);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    resetUiRegistryHostForTests();
+
+    getUiRegistryStore("counter", factory);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/registry-host.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `getUiRegistryStore`, `provideUiRegistryHost`, and `resetUiRegistryHostForTests` across:
- Memoization of store singleton instances per key.
- Independent store isolation across distinct registry keys.
- Custom `UiRegistryHost` provision and delegation.
- Reset lifecycle clearing global stores and restoring the default host.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`1f9e680cff`) |
| --- | --- | --- |
| `bunx vitest run src/registry-host.test.ts` (in `packages/shared`) | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/shared/src/registry-host.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/registry-host.test.ts:1-67`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 passed in `registry-host.test.ts`
- [x] `lint` — Biome clean
