### PR TITLE
test(cloud): cover org-membership

### DIFF
--- a/packages/cloud/api/src/middleware/org-membership.test.ts
+++ b/packages/cloud/api/src/middleware/org-membership.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit coverage for `assertOrgMembership`. Drives the real helper through a
+ * Hono request context and a real `AuditDispatcher` + in-memory sink. `@/`
+ * aliases are redirected to source (or a no-op audit-events sink) so Vitest
+ * can collect the file without the cloud-api tsconfig path map.
+ */
+
+import { Hono } from "hono";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiError } from "../../../shared/src/lib/api/cloud-worker-errors";
+
+vi.mock("@/lib/utils/logger", () => ({
+  logger: {
+    warn: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+vi.mock(
+  "@/lib/api/cloud-worker-errors",
+  () => import("../../../shared/src/lib/api/cloud-worker-errors.ts"),
+);
+
+vi.mock("@/api-app/services/audit", () => import("../services/audit/index.ts"));
+
+vi.mock("../services/audit-events", () => ({
+  auditEventsSink: {
+    name: "auth_events_pg",
+    required: false,
+    emit: async () => undefined,
+  },
+}));
+
+vi.mock("@/db/client", () => ({
+  dbWrite: { insert: () => ({ values: async () => undefined }) },
+}));
+
+const bunTest = await import("bun:test").catch(() => null);
+if (bunTest && typeof bunTest.mock.module === "function") {
+  bunTest.mock.module("@/lib/utils/logger", () => ({
+    logger: {
+      warn: () => undefined,
+      error: () => undefined,
+      info: () => undefined,
+      debug: () => undefined,
+    },
+  }));
+  bunTest.mock.module(
+    "@/lib/api/cloud-worker-errors",
+    () => import("../../../shared/src/lib/api/cloud-worker-errors.ts"),
+  );
+  bunTest.mock.module(
+    "@/api-app/services/audit",
+    () => import("../services/audit/index.ts"),
+  );
+  bunTest.mock.module("../services/audit-events", () => ({
+    auditEventsSink: {
+      name: "auth_events_pg",
+      required: false,
+      emit: async () => undefined,
+    },
+  }));
+  bunTest.mock.module("@/db/client", () => ({
+    dbWrite: { insert: () => ({ values: async () => undefined }) },
+  }));
+}
+
+const { assertOrgMembership } = await import("./org-membership");
+const { AuditDispatcher } = await import("../services/audit");
+const { InMemorySink } = await import("../services/audit/testing");
+const { setAuditDispatcher } = await import(
+  "../services/audit-dispatcher-singleton"
+);
+
+const ACTOR = { id: "user-1", organization_id: "org-A" };
+
+type InvokeInput = {
+  resourceOrgId: string | null | undefined;
+  resourceType?: string;
+  resourceId?: string;
+  headers?: Record<string, string>;
+  requestId?: string;
+};
+
+let sink: InstanceType<typeof InMemorySink>;
+
+beforeEach(() => {
+  sink = new InMemorySink();
+  setAuditDispatcher(
+    new AuditDispatcher({
+      sinks: [sink],
+      onSinkError: () => undefined,
+    }),
+  );
+});
+
+async function invoke(input: InvokeInput): Promise<{
+  status: number;
+  body: { error?: string; code?: string; ok?: boolean };
+}> {
+  const app = new Hono();
+  app.get("/x", async (c) => {
+    if (input.requestId !== undefined) {
+      c.set("requestId", input.requestId);
+    }
+    await assertOrgMembership(ACTOR, input.resourceOrgId, {
+      resourceType: input.resourceType ?? "agent",
+      resourceId: input.resourceId ?? "agent-1",
+      c: c as never,
+    });
+    return c.json({ ok: true });
+  });
+  app.onError((err, c) => {
+    const status =
+      err instanceof ApiError
+        ? err.status
+        : err && typeof err === "object" && "status" in err
+          ? Number((err as { status: number }).status)
+          : 500;
+    const code = err instanceof ApiError ? err.code : undefined;
+    return c.json({ error: err.message, code }, status as never);
+  });
+  const res = await app.request("/x", { headers: input.headers });
+  return {
+    status: res.status,
+    body: (await res.json()) as {
+      error?: string;
+      code?: string;
+      ok?: boolean;
+    },
+  };
+}
+
+describe("assertOrgMembership", () => {
+  test("returns through with no audit event when actor org matches resource org", async () => {
+    const { status, body } = await invoke({ resourceOrgId: "org-A" });
+    expect(status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(sink.snapshot()).toHaveLength(0);
+  });
+
+  test("denies a missing resource org id even when the actor has an org", async () => {
+    for (const resourceOrgId of [null, undefined, ""] as const) {
+      sink.clear();
+      const { status, body } = await invoke({
+        resourceOrgId,
+        resourceType: "secret",
+        resourceId: "s-1",
+      });
+      expect(status).toBe(403);
+      expect(body.error).toBe("Resource not accessible to this organization");
+      expect(body.code).toBe("access_denied");
+      expect(sink.snapshot()).toHaveLength(1);
+      expect(sink.snapshot()[0]?.action).toBe("secret.access");
+      expect(sink.snapshot()[0]?.result).toBe("denied");
+    }
+  });
+
+  test("denies a whitespace-only resource org id (truthy, but not equal)", async () => {
+    const { status } = await invoke({ resourceOrgId: "   " });
+    expect(status).toBe(403);
+    expect(sink.snapshot()).toHaveLength(1);
+  });
+
+  test("denies a case-mismatched org id (comparison is exact)", async () => {
+    const { status } = await invoke({ resourceOrgId: "ORG-A" });
+    expect(status).toBe(403);
+    expect(sink.snapshot()).toHaveLength(1);
+  });
+
+  test("denies a trailing-space org id that is not identical", async () => {
+    const { status } = await invoke({ resourceOrgId: "org-A " });
+    expect(status).toBe(403);
+  });
+
+  test.each([
+    ["api_key", "api_key.use"],
+    ["agent", "agent.config.update"],
+    ["container", "agent.config.update"],
+    ["pooled_credential", "secret.access"],
+    ["secret", "secret.access"],
+    ["workflow", "agent.config.update"],
+    ["unknown-kind", "admin.action"],
+    ["Agent", "admin.action"],
+  ] as const)(
+    "maps resourceType %s to audit action %s on cross-org denial",
+    async (resourceType, action) => {
+      const { status, body } = await invoke({
+        resourceOrgId: "org-B",
+        resourceType,
+        resourceId: "res-9",
+      });
+      expect(status).toBe(403);
+      expect(body.code).toBe("access_denied");
+      const events = sink.snapshot();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.action).toBe(action);
+      expect(events[0]?.result).toBe("denied");
+      expect(events[0]?.actor).toEqual({ type: "user", id: "user-1" });
+      expect(events[0]?.resource).toEqual({ type: resourceType, id: "res-9" });
+      expect(events[0]?.org_id).toBe("org-A");
+      expect(events[0]?.metadata).toEqual({ reason: "cross_org_access" });
+    },
+  );
+
+  test("records the first trimmed x-forwarded-for hop and ignores x-real-ip", async () => {
+    const { status } = await invoke({
+      resourceOrgId: "org-B",
+      headers: {
+        "x-forwarded-for": "  203.0.113.10, 198.51.100.1 ",
+        "x-real-ip": "192.0.2.1",
+        "user-agent": "org-membership-test/1.0",
+      },
+      requestId: "req-77",
+    });
+    expect(status).toBe(403);
+    const event = sink.snapshot()[0];
+    expect(event?.ip).toBe("203.0.113.10");
+    expect(event?.user_agent).toBe("org-membership-test/1.0");
+    expect(event?.request_id).toBe("req-77");
+  });
+
+  test("falls through to x-real-ip when x-forwarded-for is missing", async () => {
+    const { status } = await invoke({
+      resourceOrgId: "org-B",
+      headers: { "x-real-ip": "192.0.2.9" },
+    });
+    expect(status).toBe(403);
+    expect(sink.snapshot()[0]?.ip).toBe("192.0.2.9");
+  });
+
+  test("falls through to x-real-ip when the first forwarded hop trims empty", async () => {
+    const { status } = await invoke({
+      resourceOrgId: "org-B",
+      headers: {
+        "x-forwarded-for": "  , 198.51.100.1",
+        "x-real-ip": "192.0.2.8",
+      },
+    });
+    expect(status).toBe(403);
+    expect(sink.snapshot()[0]?.ip).toBe("192.0.2.8");
+  });
+
+  test("omits ip, user_agent, and request_id when those headers and vars are absent", async () => {
+    const { status } = await invoke({ resourceOrgId: "org-B" });
+    expect(status).toBe(403);
+    const event = sink.snapshot()[0];
+    expect(event?.ip).toBeUndefined();
+    expect(event?.user_agent).toBeUndefined();
+    expect(event?.request_id).toBeUndefined();
+  });
+
+  test("empty resourceType still 403s and records no event (audit schema rejects empty resource.type)", async () => {
+    const { status, body } = await invoke({
+      resourceOrgId: "org-B",
+      resourceType: "",
+      resourceId: "res-9",
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe("access_denied");
+    expect(sink.snapshot()).toHaveLength(0);
+  });
+
+  test("empty resourceId still 403s and records no event (audit schema rejects empty resource.id)", async () => {
+    const { status, body } = await invoke({
+      resourceOrgId: "org-B",
+      resourceId: "",
+    });
+    expect(status).toBe(403);
+    expect(body.code).toBe("access_denied");
+    expect(sink.snapshot()).toHaveLength(0);
+  });
+
+  test("still throws 403 when a required audit sink rejects", async () => {
+    setAuditDispatcher(
+      new AuditDispatcher({
+        sinks: [
+          {
+            name: "failing",
+            emit: async () => {
+              throw new Error("audit sink boom");
+            },
+          },
+        ],
+        onSinkError: () => undefined,
+      }),
+    );
+    const { status, body } = await invoke({ resourceOrgId: "org-B" });
+    expect(status).toBe(403);
+    expect(body.error).toBe("Resource not accessible to this organization");
+    expect(body.code).toBe("access_denied");
+  });
+});


### PR DESCRIPTION

# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/api/src/middleware/org-membership.ts` had no same-named test file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` at `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238` (`git fetch origin develop`; branch created from that tip).
- [ ] `bun install` and `bun run verify` were not run. This is a test-only addition; scoped vitest, biome, and tsc evidence is recorded below. Hosted CI does not run on fork contributor PRs.
- [x] A reviewer can confirm the suite without reading production code: `bunx vitest run packages/cloud/api/src/middleware/org-membership.test.ts` is 20 passed / 1 file.

# Sync with develop

- [x] Branch is `origin/develop` (`4207ca1ab7d4`) plus one commit. Zero conflicts.
- [ ] `bun run verify` was not run (test-only PR; see Known gaps).

# Risks

Low. No production code changes. The suite records the live helper: matching org ids pass with no audit event; missing, empty, whitespace, case-mismatched, and trailing-space org ids 403; resource-type strings map to the existing audit actions; empty `resourceType`/`resourceId` still 403 because the audit schema rejects empty resource fields and emit failure is swallowed; a required sink failure still 403s.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/middleware/org-membership.test.ts` next to the helper. It drives real `assertOrgMembership` through a Hono request and a real `AuditDispatcher` with `InMemorySink`. Collaborator aliases that Vitest cannot resolve (`@/lib/...`, `@/db/client`, the DB-backed `audit-events` sink) are redirected so the suite collects; assertions are against HTTP status, `access_denied`, and sink contents, not against stub return values.

## What kind of change is this?

Tests only. No production behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
bunx vitest run packages/cloud/api/src/middleware/org-membership.test.ts
```

## Detailed testing steps

None: Automated tests are acceptable.

Observed on this head (`d843936f0e4790377a843316a594f8c55acc9901`), after refetching `origin/develop`:

```
bunx vitest run packages/cloud/api/src/middleware/org-membership.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

```
bunx biome check --write packages/cloud/api/src/middleware/org-membership.test.ts
 Checked 1 file in 46ms. Fixed 1 file.
```

(config exists: `biome.json` present; `git sparse-checkout list` reports this worktree is not sparse.)

```
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'org-membership.test'
# empty; grep exit 1
```

The test file appears nowhere in the tsc output. Pre-existing package errors (for example `@cloudflare/playwright`, `@noble/hashes/sha2.js`) are unrelated.

Diff vs `origin/develop` is exactly one file: `packages/cloud/api/src/middleware/org-membership.test.ts`.

Hosted CI does not run on this fork contributor PR; do not treat GitHub check status as proof.

# Evidence Gate

<!-- evidence-head:d843936f0e4790377a843316a594f8c55acc9901 -->

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`
- [x] After full-page screenshots: `N/A - test-only, no UI surface`
- [x] Walkthrough video: `N/A - test-only, no UI surface`
- [x] Backend logs: `N/A - unit tests of assertOrgMembership; no Worker request path`
- [x] Frontend logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - in-memory audit sink inspected by the suite`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - unit tests only; no Worker or UI path.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI surface.

### Before

N/A - test-only, no UI surface.

### After

N/A - test-only, no UI surface.

### Walkthrough video

N/A - test-only, no UI surface.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds tests and changes no production behaviour; scoped vitest (20/20), biome, and tsc (test file absent from errors) are the evidence set.
- Hosted CI does not run on fork contributor PRs.
- Receipt / identity.slop.cash OAuth trace was not finalized: unattended session cannot complete the interactive consent click.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
