### PR TITLE
test(shared): cover lifeops-connector-degradation

### DIFF
--- a/packages/shared/src/contracts/lifeops-connector-degradation.test.ts
+++ b/packages/shared/src/contracts/lifeops-connector-degradation.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit coverage for LifeOps connector degradation contracts
+ * in lifeops-connector-degradation.ts.
+ *
+ * Tests degradation axes vocabulary completeness, uniqueness, string formatting,
+ * and interface compatibility.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  LIFEOPS_CONNECTOR_DEGRADATION_AXES,
+  type LifeOpsConnectorDegradation,
+} from "./lifeops-connector-degradation.js";
+
+describe("lifeops-connector-degradation", () => {
+  it("exports LIFEOPS_CONNECTOR_DEGRADATION_AXES array with expected items", () => {
+    expect(Array.isArray(LIFEOPS_CONNECTOR_DEGRADATION_AXES)).toBe(true);
+    expect(LIFEOPS_CONNECTOR_DEGRADATION_AXES).toEqual([
+      "missing-scope",
+      "rate-limited",
+      "disconnected",
+      "auth-expired",
+      "session-revoked",
+      "delivery-degraded",
+      "helper-disconnected",
+      "retry-idempotent",
+      "hold-expired",
+      "transport-offline",
+      "blocked-resume",
+    ]);
+  });
+
+  it("ensures all degradation axes are non-empty unique kebab-case strings", () => {
+    const unique = new Set(LIFEOPS_CONNECTOR_DEGRADATION_AXES);
+    expect(unique.size).toBe(LIFEOPS_CONNECTOR_DEGRADATION_AXES.length);
+
+    for (const axis of LIFEOPS_CONNECTOR_DEGRADATION_AXES) {
+      expect(typeof axis).toBe("string");
+      expect(axis.length).toBeGreaterThan(0);
+      expect(axis).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("validates structural typing for LifeOpsConnectorDegradation", () => {
+    const record: LifeOpsConnectorDegradation = {
+      axis: "auth-expired",
+      code: "TOKEN_EXPIRED",
+      message: "The OAuth refresh token has expired",
+      retryable: false,
+    };
+
+    expect(LIFEOPS_CONNECTOR_DEGRADATION_AXES.includes(record.axis)).toBe(true);
+    expect(record.retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/contracts/lifeops-connector-degradation.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `LIFEOPS_CONNECTOR_DEGRADATION_AXES` across:
- Degradation axes array composition and completeness.
- String validation, non-emptiness, uniqueness, and kebab-case formatting across all degradation axes.
- Structural interface compatibility with `LifeOpsConnectorDegradation`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`8390609c64`) |
| --- | --- | --- |
| `bunx vitest run src/contracts/lifeops-connector-degradation.test.ts` (in `packages/shared`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/shared/src/contracts/lifeops-connector-degradation.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/contracts/lifeops-connector-degradation.test.ts:1-55`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `lifeops-connector-degradation.test.ts`
- [x] `lint` — Biome clean
