### PR TITLE
test(cloud): cover sink

### DIFF
--- a/packages/cloud/api/src/services/audit/sink.test.ts
+++ b/packages/cloud/api/src/services/audit/sink.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests LoggerSink identity, optional-delivery flag, and structured-logger forwarding.
+ *
+ * Vitest cannot resolve the `@/lib/*` alias that `sink.ts` imports, so the mock
+ * below is the logger collaborator surface. LoggerSink, AuditDispatcher, and
+ * InMemorySink are the real modules.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/lib/utils/logger";
+import { AuditDispatcher } from "./dispatcher.js";
+import { type AuditSink, LoggerSink } from "./sink.js";
+import { InMemorySink } from "./testing.js";
+import type { AuditEvent } from "./types.js";
+
+vi.mock("@/lib/utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function sampleEvent(extra?: {
+  ip?: string;
+  user_agent?: string;
+  request_id?: string;
+  org_id?: string;
+  metadata?: AuditEvent["metadata"];
+  resource?: AuditEvent["resource"];
+  result?: AuditEvent["result"];
+}): AuditEvent {
+  return {
+    event_id: "01234567-89ab-7def-8123-456789abcdef",
+    ts: "2026-08-23T12:00:00.000Z",
+    actor: { type: "user", id: "u_123" },
+    action: "auth.login",
+    result: extra?.result ?? "success",
+    resource: extra?.resource === undefined ? null : extra.resource,
+    ...(extra?.ip !== undefined ? { ip: extra.ip } : {}),
+    ...(extra?.user_agent !== undefined
+      ? { user_agent: extra.user_agent }
+      : {}),
+    ...(extra?.request_id !== undefined
+      ? { request_id: extra.request_id }
+      : {}),
+    ...(extra?.org_id !== undefined ? { org_id: extra.org_id } : {}),
+    ...(extra?.metadata !== undefined ? { metadata: extra.metadata } : {}),
+  };
+}
+
+describe("LoggerSink", () => {
+  beforeEach(() => {
+    vi.spyOn(logger, "info")
+      .mockReset()
+      .mockImplementation(() => undefined);
+    vi.spyOn(logger, "error")
+      .mockReset()
+      .mockImplementation(() => undefined);
+    vi.spyOn(logger, "warn")
+      .mockReset()
+      .mockImplementation(() => undefined);
+    vi.spyOn(logger, "debug")
+      .mockReset()
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("satisfies AuditSink as the optional named logger implementation", () => {
+    const sink: AuditSink = new LoggerSink();
+    expect(sink.name).toBe("logger");
+    expect(sink.required).toBe(false);
+    expect(typeof sink.emit).toBe("function");
+  });
+
+  it("keeps name and required stable across independent instances", () => {
+    const a = new LoggerSink();
+    const b = new LoggerSink();
+    expect(a).not.toBe(b);
+    expect(a.name).toBe("logger");
+    expect(b.name).toBe("logger");
+    expect(a.required).toBe(false);
+    expect(b.required).toBe(false);
+  });
+
+  it("forwards the event to logger.info without copying or mutating it", async () => {
+    const sink = new LoggerSink();
+    const event = sampleEvent({
+      ip: "1.2.3.4",
+      metadata: { method: "password" },
+    });
+    const before = structuredClone(event);
+
+    const payloads: unknown[] = [];
+    vi.spyOn(logger, "info").mockImplementation((...args: unknown[]) => {
+      payloads.push(args[1]);
+    });
+
+    const result = await sink.emit(event);
+
+    expect(result).toBeUndefined();
+    expect(event).toEqual(before);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith("[AuditSink] event emitted", {
+      audit: event,
+    });
+    expect((payloads[0] as { audit: AuditEvent }).audit).toBe(event);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it("forwards every optional AuditEvent field the caller supplied", async () => {
+    const sink = new LoggerSink();
+    const event = sampleEvent({
+      ip: "203.0.113.9",
+      user_agent: "ua/1.0",
+      request_id: "req_1",
+      org_id: "org_1",
+      resource: { type: "session", id: "sess_1" },
+      result: "denied",
+      metadata: { reason: "mfa" },
+    });
+
+    await sink.emit(event);
+
+    expect(logger.info).toHaveBeenCalledWith("[AuditSink] event emitted", {
+      audit: event,
+    });
+  });
+
+  it("forwards a required-fields-only event with resource null", async () => {
+    const sink = new LoggerSink();
+    const event = sampleEvent();
+    expect(event.resource).toBeNull();
+    expect(event.ip).toBeUndefined();
+    expect(event.metadata).toBeUndefined();
+
+    await sink.emit(event);
+
+    expect(logger.info).toHaveBeenCalledWith("[AuditSink] event emitted", {
+      audit: event,
+    });
+  });
+
+  it("emits sequential events in call order, one log line each", async () => {
+    const sink = new LoggerSink();
+    const first = sampleEvent({ request_id: "r1" });
+    const second = sampleEvent({ request_id: "r2", result: "failure" });
+    const payloads: unknown[] = [];
+    vi.spyOn(logger, "info").mockImplementation((...args: unknown[]) => {
+      payloads.push(args[1]);
+    });
+
+    await sink.emit(first);
+    await sink.emit(second);
+
+    expect(logger.info).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
+      "[AuditSink] event emitted",
+      { audit: first },
+    );
+    expect(logger.info).toHaveBeenNthCalledWith(
+      2,
+      "[AuditSink] event emitted",
+      { audit: second },
+    );
+    expect((payloads[0] as { audit: AuditEvent }).audit).toBe(first);
+    expect((payloads[1] as { audit: AuditEvent }).audit).toBe(second);
+  });
+
+  it("rejects with the same error when logger.info throws", async () => {
+    const boom = new Error("log boom");
+    vi.spyOn(logger, "info").mockImplementation(() => {
+      throw boom;
+    });
+    const sink = new LoggerSink();
+
+    await expect(sink.emit(sampleEvent())).rejects.toBe(boom);
+  });
+
+  it("does not fail AuditDispatcher fan-out when logger.info throws", async () => {
+    const boom = new Error("log boom");
+    vi.spyOn(logger, "info").mockImplementation(() => {
+      throw boom;
+    });
+    const mem = new InMemorySink();
+    const onSinkError = vi.fn();
+    const dispatcher = new AuditDispatcher({
+      sinks: [new LoggerSink(), mem],
+      onSinkError,
+    });
+
+    const emitted = await dispatcher.emit({
+      actor: { type: "user", id: "u_123" },
+      action: "auth.login",
+      result: "success",
+      metadata: { ip: "1.2.3.4", email_hash: "h", ua: "ua" },
+    });
+
+    expect(emitted.action).toBe("auth.login");
+    expect(mem.snapshot()).toHaveLength(1);
+    expect(mem.snapshot()[0]?.event_id).toBe(emitted.event_id);
+    expect(onSinkError).toHaveBeenCalledOnce();
+    expect(onSinkError.mock.calls[0]?.[0]).toEqual({
+      sink: "logger",
+      error: boom,
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/cloud/api/src/services/audit/sink.ts`, which had no same-named test file anywhere in the repo.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on latest `origin/develop` with zero conflicts.
- [x] Focused checks: vitest, biome, and package `tsc --noEmit` (this file absent from tsc output). Full `bun run verify` was not re-run for this test-only diff; hosted CI does not run on fork PRs.
- [x] A reviewer can confirm from the vitest counts, biome result, tsc grep, and single-file diff below.

# Sync with develop

- [x] Branch created from current `origin/develop`; zero conflicts.
- [ ] `bun run verify` not re-run for this test-only addition. Exact focused commands are quoted below.

# Risks

Low. Adds one Vitest file next to the existing audit sink. No production code, routes, or public API change.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/services/audit/sink.test.ts` covering every exported symbol of the audit sink module.

`sink.ts` is a small contract plus `LoggerSink`. There is no queue, comparator, capacity, or item-removal API; those edges do not exist. The suite records the behaviour the code actually has:

- `LoggerSink` satisfies `AuditSink` with `name === "logger"` and `required === false` (the dispatcher treats anything other than `false` as required)
- independent instances share that contract and are not the same object
- `emit` forwards the same event object to `logger.info` as `{ audit: event }` with message `[AuditSink] event emitted`, without copying or mutating it
- optional fields (`ip`, `user_agent`, `request_id`, `org_id`, `resource`, `metadata`, `result`) are forwarded when present
- a required-fields-only event with `resource: null` is forwarded as-is
- sequential emits produce one log line each, in call order, with payload identity preserved
- when `logger.info` throws, `emit` rejects with that same error
- because `required === false`, `AuditDispatcher` still fans out to other sinks and resolves when `LoggerSink` fails (observed via a real `InMemorySink`)

`LoggerSink`, `AuditDispatcher`, and `InMemorySink` are the real modules. The `@/lib/utils/logger` specifier is the production collaborator; Vitest's root alias map cannot resolve it, so the test substitutes the same `info`/`error`/`warn`/`debug` surface and asserts `LoggerSink`'s call shape — not a mock that returns X then expects X.

## What kind of change is this?

Improvements (tests for existing behaviour). No production change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/services/audit/sink.test.ts`. Layout, vitest imports, and `.js` relative imports match the sibling `dispatcher.test.ts`.

## Detailed testing steps

This is a fork contribution. Hosted GitHub Actions CI does **not** run on our PRs. Do not infer that Actions passed.

```bash
bunx vitest run packages/cloud/api/src/services/audit/sink.test.ts
bunx biome check --write packages/cloud/api/src/services/audit/sink.test.ts
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'sink.test.ts' ; echo "EXIT:$?"
```

Re-run against current `origin/develop` immediately before filing (develop SHA `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238`, PR head `0954e832f6b07ec7683873d9d6d73d5cf278e446`):

```text
RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/eliza

 ✓ packages/cloud/api/src/services/audit/sink.test.ts (8 tests) 8ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  19:47:10
   Duration  276ms (transform 83ms, setup 0ms, import 154ms, tests 8ms, environment 0ms)
```

`bunx biome check --write packages/cloud/api/src/services/audit/sink.test.ts`: `Checked 1 file in 10ms. No fixes applied.`

`bunx tsc --noEmit` from `packages/cloud/api`, grepped for `sink.test.ts`: empty (grep exit 1). The new file appears nowhere in the typecheck output. Pre-existing errors elsewhere in the package are not this change.

The diff touches only `packages/cloud/api/src/services/audit/sink.test.ts`.

# Evidence Gate

Test-only PR. No production behaviour change. Heavy bug-fix evidence (origin reproduction, load-bearing revert, over-rejection corpus, proof-run.mjs) does not apply.

- [x] Before full-page screenshots — N/A - test-only, no UI surface.
- [x] After full-page screenshots — N/A - test-only, no UI surface.
- [x] Walkthrough video — N/A - test-only, no UI surface.
- [x] Backend logs — quoted Vitest output above; no server request path changed.
- [x] Frontend logs — N/A - no frontend change.
- [x] Real-LLM trajectory — N/A - no agent/action/provider/prompt/model change. Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
- [x] Domain artifacts — N/A - no DB/memory/schedule/wallet/audio output; the suite inspects in-process sink identity and emit forwarding.
- [x] OCR visual-text review — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: focused Vitest output quoted above (1 file, 8 passed / 8). Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - test-only, no UI surface.

## Audio / voice walkthrough

N/A - no voice / transcript / TTS / STT change.

## Known gaps / failures

- Full `bun run verify` was not re-run; this PR adds tests only.
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0954e832f6b07ec7683873d9d6d73d5cf278e446 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
