### PR TITLE
test(core): cover evaluator-priorities

### DIFF
--- a/packages/core/src/services/evaluator-priorities.test.ts
+++ b/packages/core/src/services/evaluator-priorities.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit coverage for canonical evaluator priorities in evaluator-priorities.ts.
+ *
+ * Tests priority value constants, relative ordering across functional evaluator
+ * groups (form < inbound capture < reflection < memory < experience < skill),
+ * and numeric positivity.
+ */
+
+import { describe, expect, it } from "vitest";
+import { EvaluatorPriority } from "./evaluator-priorities.js";
+
+describe("evaluator-priorities", () => {
+	it("defines positive numeric priorities for all evaluator stages", () => {
+		for (const [name, priority] of Object.entries(EvaluatorPriority)) {
+			expect(typeof priority).toBe("number");
+			expect(priority).toBeGreaterThan(0);
+			expect(Number.isFinite(priority)).toBe(true);
+			void name;
+		}
+	});
+
+	it("enforces stage ordering: FORM precedes inbound captures and reflection", () => {
+		expect(EvaluatorPriority.FORM).toBeLessThan(
+			EvaluatorPriority.INBOUND_ATTACHMENT_IMAGE,
+		);
+		expect(EvaluatorPriority.INBOUND_ATTACHMENT_IMAGE).toBeLessThan(
+			EvaluatorPriority.INBOUND_LINK_EXTRACTION,
+		);
+		expect(EvaluatorPriority.INBOUND_LINK_EXTRACTION).toBeLessThan(
+			EvaluatorPriority.REFLECTION_FACTS,
+		);
+	});
+
+	it("enforces reflection pipeline dependency ordering (facts < preferences < relationships < identity < success)", () => {
+		expect(EvaluatorPriority.REFLECTION_FACTS).toBeLessThan(
+			EvaluatorPriority.REFLECTION_PREFERENCES,
+		);
+		expect(EvaluatorPriority.REFLECTION_PREFERENCES).toBeLessThan(
+			EvaluatorPriority.REFLECTION_RELATIONSHIPS,
+		);
+		expect(EvaluatorPriority.REFLECTION_RELATIONSHIPS).toBeLessThan(
+			EvaluatorPriority.REFLECTION_IDENTITY,
+		);
+		expect(EvaluatorPriority.REFLECTION_IDENTITY).toBeLessThan(
+			EvaluatorPriority.REFLECTION_SUCCESS,
+		);
+	});
+
+	it("enforces memory and skill ordering (memory < experience < skill refinement)", () => {
+		expect(EvaluatorPriority.REFLECTION_SUCCESS).toBeLessThan(
+			EvaluatorPriority.MEMORY_SUMMARY,
+		);
+		expect(EvaluatorPriority.MEMORY_SUMMARY).toBeLessThan(
+			EvaluatorPriority.MEMORY_LONG_TERM,
+		);
+		expect(EvaluatorPriority.MEMORY_LONG_TERM).toBeLessThan(
+			EvaluatorPriority.EXPERIENCE,
+		);
+		expect(EvaluatorPriority.EXPERIENCE).toBeLessThan(
+			EvaluatorPriority.SKILL_PROPOSAL,
+		);
+		expect(EvaluatorPriority.SKILL_PROPOSAL).toBeLessThan(
+			EvaluatorPriority.SKILL_REFINEMENT,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/services/evaluator-priorities.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `EvaluatorPriority` across:
- Positive numeric constant definition for all evaluator stages.
- Stage precedence verification (FORM preceding inbound captures and reflection).
- Reflection dependency ordering (`REFLECTION_FACTS` < `REFLECTION_PREFERENCES` < `REFLECTION_RELATIONSHIPS` < `REFLECTION_IDENTITY` < `REFLECTION_SUCCESS`).
- Memory, experience, and skill stage ordering (`MEMORY_SUMMARY` < `MEMORY_LONG_TERM` < `EXPERIENCE` < `SKILL_PROPOSAL` < `SKILL_REFINEMENT`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`3ca408f698`) |
| --- | --- | --- |
| `bunx vitest run src/services/evaluator-priorities.test.ts` (in `packages/core`) | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/core/src/services/evaluator-priorities.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/services/evaluator-priorities.test.ts:1-66`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 passed in `evaluator-priorities.test.ts`
- [x] `lint` — Biome clean
