### PR TITLE
test(cloud): cover elizaos-core-test-contract

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
@@ -94,8 +94,11 @@ function expectUnavailable(fn: () => unknown, name: string): void {
 }
 
 describe("elizaos-core-test-contract fail-loud stub", () => {
-  test("exports the sixteen stand-ins in source order and nothing else", () => {
-    expect(Object.keys(contract)).toEqual([...EXPORT_NAMES]);
+  test("exports exactly the sixteen stand-ins and nothing else", () => {
+    // A module namespace object orders its own keys in code-unit order, not
+    // source order, so compare as sorted sets rather than coupling the
+    // assertion to how the export list happens to be written.
+    expect([...Object.keys(contract)].sort()).toEqual([...EXPORT_NAMES].sort());
     expect(Object.keys(contract)).toHaveLength(16);
   });
 

--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Deterministic unit coverage for the fail-loud @elizaos/core test-contract
+ * stub. Drives the real module with no mocks: every function and constructor
+ * throws before any core runtime work, object proxies throw on get and set,
+ * and the document-list capability symbol is a unique local Symbol. The stub
+ * has no queue, comparator, or capacity.
+ */
+
+import { describe, expect, test } from "vitest";
+import * as contract from "./elizaos-core-test-contract";
+import {
+  ChannelType,
+  canRequesterMutateDocument,
+  DatabaseAdapter,
+  DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  decryptedCharacter,
+  documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility,
+  encryptedCharacter,
+  logger,
+  normalizePairingPageOptions,
+  Service,
+  validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams,
+  validateDocumentRequesterContext,
+  validateQueryEntitiesPagination,
+  validateUuid,
+} from "./elizaos-core-test-contract";
+
+const FUNCTIONS = {
+  canRequesterMutateDocument,
+  decryptedCharacter,
+  documentMutationSnapshotMatches,
+  documentRoleHasGlobalVisibility,
+  encryptedCharacter,
+  normalizePairingPageOptions,
+  validateDocumentFragmentQueryParams,
+  validateDocumentListQueryParams,
+  validateDocumentRequesterContext,
+  validateQueryEntitiesPagination,
+  validateUuid,
+} as const;
+
+const CONSTRUCTORS = {
+  DatabaseAdapter,
+  Service,
+} as const;
+
+const OBJECTS = {
+  ChannelType,
+  logger,
+} as const;
+
+const FUNCTION_NAMES = Object.keys(FUNCTIONS) as Array<keyof typeof FUNCTIONS>;
+const CONSTRUCTOR_NAMES = Object.keys(CONSTRUCTORS) as Array<
+  keyof typeof CONSTRUCTORS
+>;
+const OBJECT_NAMES = Object.keys(OBJECTS) as Array<keyof typeof OBJECTS>;
+
+const EXPORT_NAMES = [
+  "canRequesterMutateDocument",
+  "ChannelType",
+  "DatabaseAdapter",
+  "decryptedCharacter",
+  "DOCUMENT_LIST_QUERY_CAPABILITY_VERSION",
+  "documentMutationSnapshotMatches",
+  "documentRoleHasGlobalVisibility",
+  "encryptedCharacter",
+  "logger",
+  "normalizePairingPageOptions",
+  "Service",
+  "validateDocumentFragmentQueryParams",
+  "validateDocumentListQueryParams",
+  "validateDocumentRequesterContext",
+  "validateQueryEntitiesPagination",
+  "validateUuid",
+] as const;
+
+function unavailableMessage(name: string): string {
+  return `@elizaos/core ${name} is outside this test path`;
+}
+
+function expectUnavailable(fn: () => unknown, name: string): void {
+  const message = unavailableMessage(name);
+  expect(fn).toThrowError(message);
+  try {
+    fn();
+    throw new Error(`expected ${name} to throw`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe(message);
+  }
+}
+
+describe("elizaos-core-test-contract fail-loud stub", () => {
+  test("exports the sixteen stand-ins in source order and nothing else", () => {
+    expect(Object.keys(contract)).toEqual([...EXPORT_NAMES]);
+    expect(Object.keys(contract)).toHaveLength(16);
+  });
+
+  test("does not expose queue, comparator, or capacity fields", () => {
+    const record = contract as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect(record.queue).toBeUndefined();
+    expect(record.capacity).toBeUndefined();
+    expect(record.comparator).toBeUndefined();
+  });
+
+  test("function and constructor exports are distinct closures, not a shared thrower", () => {
+    expect(validateUuid).not.toBe(encryptedCharacter);
+    expect(canRequesterMutateDocument).not.toBe(
+      documentMutationSnapshotMatches,
+    );
+    expect(DatabaseAdapter).not.toBe(Service);
+    // Object.is: wrapping a throwing proxy in expect() trips the get trap.
+    expect(Object.is(ChannelType, logger)).toBe(false);
+  });
+
+  describe("unavailable functions", () => {
+    test.each(FUNCTION_NAMES)(
+      "%s is a function that throws the unavailable Error with no arguments",
+      (name) => {
+        const fn = FUNCTIONS[name];
+        expect(typeof fn).toBe("function");
+        expectUnavailable(fn, name);
+      },
+    );
+
+    test.each(FUNCTION_NAMES)(
+      "%s throws the same Error when extra arguments are supplied (no comparator or overflow handling)",
+      (name) => {
+        const fn = FUNCTIONS[name];
+        expectUnavailable(
+          () => fn("single-element", { overflow: true }, undefined),
+          name,
+        );
+      },
+    );
+
+    test.each(FUNCTION_NAMES)(
+      "%s keeps throwing on repeated calls (no unlock after the first miss)",
+      (name) => {
+        const fn = FUNCTIONS[name];
+        expectUnavailable(fn, name);
+        expectUnavailable(fn, name);
+      },
+    );
+  });
+
+  describe("unavailable constructors", () => {
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s is a class whose constructor throws the unavailable Error",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new () => never;
+        expect(typeof Ctor).toBe("function");
+        expectUnavailable(() => new Ctor(), name);
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s throws the same Error when constructed with extra arguments",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new (...args: unknown[]) => never;
+        expectUnavailable(() => new Ctor("overflow"), name);
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s cannot be invoked without new (class constructor TypeError, not the unavailable Error)",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as unknown as () => void;
+        expect(Ctor).toThrow(TypeError);
+        try {
+          Ctor();
+          throw new Error(`expected ${name}() without new to throw`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(TypeError);
+          expect((error as Error).message).not.toBe(unavailableMessage(name));
+        }
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s keeps throwing on repeated `new` (no capacity or unlock)",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new () => never;
+        expectUnavailable(() => new Ctor(), name);
+        expectUnavailable(() => new Ctor(), name);
+      },
+    );
+  });
+
+  describe("unavailable object proxies", () => {
+    test.each(OBJECT_NAMES)(
+      "%s is a null-prototype object whose own key list is empty",
+      (name) => {
+        const value = OBJECTS[name];
+        expect(typeof value).toBe("object");
+        expect(value === null).toBe(false);
+        expect(Object.getPrototypeOf(value)).toBeNull();
+        expect(Object.keys(value)).toEqual([]);
+        expect(Object.getOwnPropertyNames(value)).toEqual([]);
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s throws the unavailable Error on get of a present-looking property",
+      (name) => {
+        expectUnavailable(() => Reflect.get(OBJECTS[name], "info"), name);
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s throws the unavailable Error on get of a missing property (no silent miss)",
+      (name) => {
+        expectUnavailable(
+          () => Reflect.get(OBJECTS[name], "doesNotExist"),
+          name,
+        );
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s throws the unavailable Error on set of a missing property",
+      (name) => {
+        expectUnavailable(
+          () => Reflect.set(OBJECTS[name], "doesNotExist", "value"),
+          name,
+        );
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s throws the unavailable Error on set even when the assigned value is empty",
+      (name) => {
+        expectUnavailable(
+          () => Reflect.set(OBJECTS[name], "queue", undefined),
+          name,
+        );
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s `in` checks do not throw: the proxy has no `has` trap, so missing keys are false",
+      (name) => {
+        const value = OBJECTS[name];
+        expect("info" in value).toBe(false);
+        expect("queue" in value).toBe(false);
+        expect("doesNotExist" in value).toBe(false);
+      },
+    );
+
+    test.each(OBJECT_NAMES)(
+      "%s keeps throwing on repeated get and set (no unlock)",
+      (name) => {
+        const value = OBJECTS[name];
+        expectUnavailable(() => Reflect.get(value, "error"), name);
+        expectUnavailable(() => Reflect.get(value, "error"), name);
+        expectUnavailable(() => Reflect.set(value, "level", "info"), name);
+        expectUnavailable(() => Reflect.set(value, "level", "info"), name);
+      },
+    );
+  });
+
+  describe("DOCUMENT_LIST_QUERY_CAPABILITY_VERSION", () => {
+    test("is a unique local Symbol, not a globally interned one", () => {
+      expect(typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION).toBe("symbol");
+      expect(DOCUMENT_LIST_QUERY_CAPABILITY_VERSION.description).toBe(
+        "DOCUMENT_LIST_QUERY_CAPABILITY_VERSION outside this test path",
+      );
+      expect(DOCUMENT_LIST_QUERY_CAPABILITY_VERSION).not.toBe(
+        Symbol.for(
+          "DOCUMENT_LIST_QUERY_CAPABILITY_VERSION outside this test path",
+        ),
+      );
+      expect(DOCUMENT_LIST_QUERY_CAPABILITY_VERSION).not.toBe(
+        Symbol("DOCUMENT_LIST_QUERY_CAPABILITY_VERSION outside this test path"),
+      );
+    });
+
+    test("is stable for the lifetime of the module (single interned export)", () => {
+      expect(DOCUMENT_LIST_QUERY_CAPABILITY_VERSION).toBe(
+        DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+      );
+    });
+  });
+
+  test("empty extra-argument lists and a single dummy argument take the same throw path", () => {
+    expectUnavailable(validateUuid, "validateUuid");
+    expectUnavailable(() => validateUuid(), "validateUuid");
+    expectUnavailable(() => validateUuid("one"), "validateUuid");
+  });
+});


### PR DESCRIPTION

Adds real unit coverage for the fail-loud `@elizaos/core` test-contract stub at `packages/cloud/api/src/stubs/elizaos-core-test-contract.ts`. That module had no same-named test file. This PR adds only `packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts`. Production code is unchanged.

# Relates to

No linked issue. Test-only coverage of an uncovered fail-loud stub used by DB-free cloud tests.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on `origin/develop` `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238` with a one-file commit and zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the vitest / biome / tsc output quoted below.

# Sync with develop

- [x] Commit parent is current `origin/develop` at push time (`4207ca1ab7d41e5d5c4ddac071369cfc7d84a238`); zero conflicts.
- [ ] `bun run verify` was not run. This is a test-only one-file PR. Focused vitest, biome, and package `tsc --noEmit` were run instead; see **Known gaps / failures**.

# Risks

Low. The diff is a new vitest file that imports the real stub and asserts the throw / proxy / Symbol behaviour the module already has. No production path, no Worker bundle, no schema, no docs.

# Background

## What does this PR do?

Covers every exported stand-in in `elizaos-core-test-contract.ts`:

- Eleven `unavailableFunction` exports throw `Error` (`@elizaos/core <name> is outside this test path`) with no arguments, extra arguments, and on repeated calls. Arguments are ignored; there is no comparator or overflow path.
- `DatabaseAdapter` and `Service` throw that same `Error` on `new`, including extra constructor arguments, and keep throwing. Invoking either class without `new` throws `TypeError`, not the unavailable `Error`.
- `ChannelType` and `logger` are null-prototype proxies. `get` and `set` throw, including missing keys and empty assigned values. The `in` operator does not throw (`has` is untrapped), so missing keys are `false`.
- `DOCUMENT_LIST_QUERY_CAPABILITY_VERSION` is a unique local `Symbol` (not `Symbol.for`) with description `DOCUMENT_LIST_QUERY_CAPABILITY_VERSION outside this test path`.
- The module has no queue, comparator, or capacity fields.

The suite drives the real module. No mocks.

## What kind of change is this?

Improvements (test coverage only; no production behaviour change).

## Why are we doing this?

The stub is a fail-loud stand-in for core exports that DB-free cloud tests bind only through unreachable transitive paths. It had no colocated test. Coverage records what the code does so a later production edit cannot silently change the throw contract.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts`, then the commands below.

## Detailed testing steps

Automated tests. Hosted CI does **not** run on this fork PR; the counts below are from local runs against the stub as it exists on current `origin/develop`.

```text
$ bunx vitest run packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
 Test Files  1 passed (1)
      Tests  61 passed (61)

$ bunx biome check --write packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts
Checked 1 file in 16ms. No issues.

$ cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'elizaos-core-test-contract.test.ts' ; echo "EXIT:$?"
GREP_EXIT:1
```

`GREP_EXIT:1` means the new test file appears nowhere in `tsc` output. Pre-existing errors in other package files (for example `../shared/src/lib/services/doordash-browser-run.ts` missing `@cloudflare/playwright`) are unchanged and are not introduced by this PR.

# Evidence Gate

Evidence head: `38c6e43b4487e98ef2b30bb16dc2e2c7228da3db`

Test-only PR; no production behaviour change. The complete evidence set is the four items required for that class of change:

1. `bunx vitest run packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts` — **1 file, 61 tests passed** (re-run after re-fetching current `origin/develop`; source SHA `30b7692a7df138ee587196ae7ca009931ae7ac45` matches `origin/develop`).
2. `bunx biome check --write packages/cloud/api/src/stubs/elizaos-core-test-contract.test.ts` — clean.
3. `bunx tsc --noEmit` in `packages/cloud/api` — this test file is absent from the output.
4. Diff touches only that test file.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - test-only PR; no UI surface.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no production runtime path; the suite asserts throws from the stub in-process.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB, memory, schedule, wallet, or generated-file change.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - test-only; no HTTP or UI path.`

## Screenshots (before / after) + video walkthrough

`N/A - test-only; no UI surface.`

## Audio / voice walkthrough

`N/A - not a voice/TTS/STT change.`

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; the required bar is focused vitest, biome, and package `tsc --noEmit`.
- Hosted GitHub Actions CI does not run on fork PRs from `ss251`. Reviewers should reproduce with the vitest command above.
- Package `tsc --noEmit` still reports pre-existing errors in unrelated files (`doordash-browser-run.ts`, `cloud-worker-env.ts`, `sql-principal.ts`). The new test file is not among them.

## Maintainer CI exception record

`N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:38c6e43b4487e98ef2b30bb16dc2e2c7228da3db -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
