### PR TITLE
fix(app-control): safe NaN handling in views create/show and capability score sort comparators

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-comparators.ts
+++ b/plugins/plugin-app-control/src/actions/views-comparators.ts
@@ -1,0 +1,60 @@
+/**
+ * Lightweight scored-view comparators — pure, no heavy deps.
+ * Extracted so regression tests can import without pulling @elizaos/core
+ * (which transitively imports @noble/hashes). Guards remain defensive:
+ * scores are normally literal integers but Number.isFinite treats any
+ * unexpected Infinity/NaN as 0 so sort never returns NaN.
+ */
+
+export function compareScoredView(
+	a: { view: { id: string }; score: number },
+	b: { view: { id: string }; score: number },
+): number {
+	const bS =
+		typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+	const aS =
+		typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+	if (bS !== aS) return bS - aS;
+	return String(a.view.id).localeCompare(String(b.view.id));
+}
+
+export function compareScoredViewShow(
+	a: { view: { id: string }; score: number },
+	b: { view: { id: string }; score: number },
+): number {
+	const bS =
+		typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+	const aS =
+		typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+	if (bS !== aS) return bS - aS;
+	return String(a.view.id).localeCompare(String(b.view.id));
+}
+
+export function compareCandidateScore(
+	a: { candidate: { id: string }; score: number },
+	b: { candidate: { id: string }; score: number },
+): number {
+	const bS =
+		typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+	const aS =
+		typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+	if (bS !== aS) return bS - aS;
+	return String(a.candidate.id).localeCompare(String(b.candidate.id));
+}
+
+export function compareScoredViewClose(
+	a: { view: { id: string }; score: number },
+	b: { view: { id: string }; score: number },
+): number {
+	const bS =
+		typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+	const aS =
+		typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+	if (bS !== aS) return bS - aS;
+	return String(a.view.id).localeCompare(String(b.view.id));
+}
+
+export const __testCompareScoredView = compareScoredView;
+export const __testCompareScoredViewShow = compareScoredViewShow;
+export const __testCompareCandidateScore = compareCandidateScore;
+export const __testCompareScoredViewClose = compareScoredViewClose;

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -140,7 +140,20 @@ function rankViewMatches(
 		}
 		if (score > 0) ranked.push({ view, score });
 	}
-	ranked.sort((a, b) => b.score - a.score);
+	ranked.sort((a, b) => {
+		const bS =
+			typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+		const aS =
+			typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+		if (bS !== aS) return bS - aS;
+		return String(
+			(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
+		).localeCompare(
+			String(
+				(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
+			),
+		);
+	});
 	return ranked;
 }
 

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -29,6 +29,7 @@ import {
 } from "./scaffold-env.js";
 import { buildVerifiedPluginTaskParameters } from "./verified-plugin-task.js";
 import type { ViewSummary } from "./views-client.js";
+import { compareScoredView } from "./views-comparators.ts";
 import { seedGuiViewScaffold } from "./views-create-scaffold.js";
 import { writeViewHeroAsset } from "./views-hero.js";
 import { isRestrictedPlatform } from "./views-platform.js";
@@ -122,6 +123,11 @@ function tokenize(value: string): string[] {
 		.filter((t) => t.length > 1 && !STOP_WORDS.has(t));
 }
 
+export {
+	__testCompareScoredView,
+	compareScoredView,
+} from "./views-comparators.ts";
+
 function rankViewMatches(
 	intent: string,
 	views: readonly ViewSummary[],
@@ -140,20 +146,7 @@ function rankViewMatches(
 		}
 		if (score > 0) ranked.push({ view, score });
 	}
-	ranked.sort((a, b) => {
-		const bS =
-			typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-		const aS =
-			typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-		if (bS !== aS) return bS - aS;
-		return String(
-			(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
-		).localeCompare(
-			String(
-				(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
-			),
-		);
-	});
+	ranked.sort(compareScoredView);
 	return ranked;
 }
 

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -312,7 +312,20 @@ function resolveView(
 	const scored = views
 		.map((v) => ({ view: v, score: scoreView(v, target) }))
 		.filter(({ score }) => score > 0)
-		.sort((a, b) => b.score - a.score);
+		.sort((a, b) => {
+			const bS =
+				typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+			const aS =
+				typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+			if (bS !== aS) return bS - aS;
+			return String(
+				(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
+			).localeCompare(
+				String(
+					(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
+				),
+			);
+		});
 
 	if (scored.length === 0) return { kind: "none" };
 	if (scored.length === 1) return { kind: "match", view: scored[0].view };

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -23,6 +23,7 @@ import {
 import { matchViewCommand } from "./view-command-matcher.js";
 import { isRealtimeVoiceTurn } from "./view-delivery.js";
 import type { ViewSummary, ViewsClient } from "./views-client.js";
+import { compareScoredViewShow } from "./views-comparators.ts";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
 import { scoreView } from "./views-search.js";
 
@@ -291,6 +292,11 @@ export function resolveIntentView(text: string | undefined): string | null {
 	return null;
 }
 
+export {
+	__testCompareScoredViewShow,
+	compareScoredViewShow,
+} from "./views-comparators.ts";
+
 function resolveView(
 	target: string,
 	views: readonly ViewSummary[],
@@ -312,20 +318,7 @@ function resolveView(
 	const scored = views
 		.map((v) => ({ view: v, score: scoreView(v, target) }))
 		.filter(({ score }) => score > 0)
-		.sort((a, b) => {
-			const bS =
-				typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-			const aS =
-				typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-			if (bS !== aS) return bS - aS;
-			return String(
-				(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
-			).localeCompare(
-				String(
-					(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
-				),
-			);
-		});
+		.sort(compareScoredViewShow);
 
 	if (scored.length === 0) return { kind: "none" };
 	if (scored.length === 1) return { kind: "match", view: scored[0].view };

--- a/plugins/plugin-app-control/src/actions/views.safe-sort.test.ts
+++ b/plugins/plugin-app-control/src/actions/views.safe-sort.test.ts
@@ -1,30 +1,48 @@
 /**
- * Regression for app-control views score sort handling.
+ * Regression for app-control views score comparators — imports production comparators.
  */
 import { describe, expect, it } from "vitest";
+import {
+	__testCompareCandidateScore,
+	__testCompareScoredView,
+	__testCompareScoredViewClose,
+	__testCompareScoredViewShow,
+} from "./views-comparators.ts";
 
-type Scored = { view: { id: string }; score: number };
-function compareScored(a: Scored, b: Scored): number {
-  const bS = typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-  const aS = typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-  if (bS !== aS) return bS - aS;
-  return String(a.view.id).localeCompare(String(b.view.id));
+function scoredView(id: string, score: number) {
+	return { view: { id } as any, score };
+}
+function scoredCandidate(id: string, score: number) {
+	return { candidate: { id } as any, score };
 }
 
 describe("app-control views safe-sort", () => {
-  it("treats NaN score as 0", () => {
-    const rows: Scored[] = [
-      { view: { id: "b" }, score: Number.NaN },
-      { view: { id: "a" }, score: 10 },
-      { view: { id: "c" }, score: Number.POSITIVE_INFINITY },
-    ];
-    expect([...rows].sort(compareScored).map(r => r.view.id)).toEqual(["a", "b", "c"]);
-  });
-  it("breaks ties by view id", () => {
-    const rows: Scored[] = [
-      { view: { id: "b" }, score: 5 },
-      { view: { id: "a" }, score: 5 },
-    ];
-    expect([...rows].sort(compareScored).map(r => r.view.id)).toEqual(["a", "b"]);
-  });
+	it("views-create: treats NaN/Infinity as 0", () => {
+		const rows = [
+			scoredView("b", Number.NaN),
+			scoredView("a", 10),
+			scoredView("c", Number.POSITIVE_INFINITY),
+		];
+		expect(
+			[...rows].sort(__testCompareScoredView).map((r) => r.view.id),
+		).toEqual(["a", "b", "c"]);
+	});
+	it("views-show: tie-break by view id", () => {
+		const rows = [scoredView("b", 5), scoredView("a", 5)];
+		expect(
+			[...rows].sort(__testCompareScoredViewShow).map((r) => r.view.id),
+		).toEqual(["a", "b"]);
+	});
+	it("views candidate: tie-break by candidate id", () => {
+		const rows = [scoredCandidate("zebra", 10), scoredCandidate("apple", 10)];
+		expect(
+			[...rows].sort(__testCompareCandidateScore).map((r) => r.candidate.id),
+		).toEqual(["apple", "zebra"]);
+	});
+	it("views close: sorts descending", () => {
+		const rows = [scoredView("b", 10), scoredView("a", 80)];
+		expect(
+			[...rows].sort(__testCompareScoredViewClose).map((r) => r.view.id),
+		).toEqual(["a", "b"]);
+	});
 });

--- a/plugins/plugin-app-control/src/actions/views.safe-sort.test.ts
+++ b/plugins/plugin-app-control/src/actions/views.safe-sort.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression for app-control views score sort handling.
+ */
+import { describe, expect, it } from "vitest";
+
+type Scored = { view: { id: string }; score: number };
+function compareScored(a: Scored, b: Scored): number {
+  const bS = typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+  const aS = typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+  if (bS !== aS) return bS - aS;
+  return String(a.view.id).localeCompare(String(b.view.id));
+}
+
+describe("app-control views safe-sort", () => {
+  it("treats NaN score as 0", () => {
+    const rows: Scored[] = [
+      { view: { id: "b" }, score: Number.NaN },
+      { view: { id: "a" }, score: 10 },
+      { view: { id: "c" }, score: Number.POSITIVE_INFINITY },
+    ];
+    expect([...rows].sort(compareScored).map(r => r.view.id)).toEqual(["a", "b", "c"]);
+  });
+  it("breaks ties by view id", () => {
+    const rows: Scored[] = [
+      { view: { id: "b" }, score: 5 },
+      { view: { id: "a" }, score: 5 },
+    ];
+    expect([...rows].sort(compareScored).map(r => r.view.id)).toEqual(["a", "b"]);
+  });
+});

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1235,7 +1235,28 @@ function correctCapabilityOperationFamily(
 			candidate,
 			score: countIntersection(requestTokens, capabilityTokens(candidate)),
 		}))
-		.sort((left, right) => right.score - left.score);
+		.sort((left, right) => {
+			const rS =
+				typeof right.score === "number" && Number.isFinite(right.score)
+					? right.score
+					: 0;
+			const lS =
+				typeof left.score === "number" && Number.isFinite(left.score)
+					? left.score
+					: 0;
+			if (rS !== lS) return rS - lS;
+			return String(
+				(left as { view?: { id?: string } }).view?.id ??
+					(left as { id?: string }).id ??
+					"",
+			).localeCompare(
+				String(
+					(right as { view?: { id?: string } }).view?.id ??
+						(right as { id?: string }).id ??
+						"",
+				),
+			);
+		});
 	// Multiple semantic siblings are corrected only when the user's nouns make
 	// one a unique best match; a tie preserves the planner decision rather than
 	// guessing between collection and single-record reads.
@@ -1833,7 +1854,20 @@ function resolveCloseTargetView(
 	const scored = views
 		.map((view) => ({ view, score: scoreView(view, target) }))
 		.filter(({ score }) => score > 0)
-		.sort((a, b) => b.score - a.score);
+		.sort((a, b) => {
+			const bS =
+				typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
+			const aS =
+				typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
+			if (bS !== aS) return bS - aS;
+			return String(
+				(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
+			).localeCompare(
+				String(
+					(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
+				),
+			);
+		});
 	if (scored.length === 0) return { kind: "none" };
 	if (scored.length === 1) return { kind: "match", view: scored[0].view };
 

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1159,6 +1159,13 @@ type CapabilityCorrection =
 	| { kind: "capability"; capability: ViewCapability }
 	| { kind: "reject"; reason: string };
 
+export {
+	__testCompareCandidateScore,
+	__testCompareScoredViewClose,
+	compareCandidateScore,
+	compareScoredViewClose,
+} from "./views-comparators.ts";
+
 function correctCapabilityOperationFamily(
 	view: ViewSummary,
 	capability: ViewCapability,
@@ -1235,28 +1242,7 @@ function correctCapabilityOperationFamily(
 			candidate,
 			score: countIntersection(requestTokens, capabilityTokens(candidate)),
 		}))
-		.sort((left, right) => {
-			const rS =
-				typeof right.score === "number" && Number.isFinite(right.score)
-					? right.score
-					: 0;
-			const lS =
-				typeof left.score === "number" && Number.isFinite(left.score)
-					? left.score
-					: 0;
-			if (rS !== lS) return rS - lS;
-			return String(
-				(left as { view?: { id?: string } }).view?.id ??
-					(left as { id?: string }).id ??
-					"",
-			).localeCompare(
-				String(
-					(right as { view?: { id?: string } }).view?.id ??
-						(right as { id?: string }).id ??
-						"",
-				),
-			);
-		});
+		.sort(compareCandidateScore);
 	// Multiple semantic siblings are corrected only when the user's nouns make
 	// one a unique best match; a tie preserves the planner decision rather than
 	// guessing between collection and single-record reads.
@@ -1854,20 +1840,7 @@ function resolveCloseTargetView(
 	const scored = views
 		.map((view) => ({ view, score: scoreView(view, target) }))
 		.filter(({ score }) => score > 0)
-		.sort((a, b) => {
-			const bS =
-				typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-			const aS =
-				typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-			if (bS !== aS) return bS - aS;
-			return String(
-				(a.view as { id?: string })?.id ?? (a as { id?: string }).id ?? "",
-			).localeCompare(
-				String(
-					(b.view as { id?: string })?.id ?? (b as { id?: string }).id ?? "",
-				),
-			);
-		});
+		.sort(compareScoredViewClose);
 	if (scored.length === 0) return { kind: "none" };
 	if (scored.length === 1) return { kind: "match", view: scored[0].view };
 


### PR DESCRIPTION
## Summary
Guards app-control views score comparators against non-finite `score` values. Previously `b.score - a.score` returned `NaN` for `NaN`/`Infinity`, causing `Array.prototype.sort` to treat comparator as 0 and corrupt view ranking; ties were also non-deterministic.

## Changes
- In `plugins/plugin-app-control/src/actions/views-create.ts:143`, guard `score` with `Number.isFinite` fallback `0` and add `view.id` tiebreaker.
- In `plugins/plugin-app-control/src/actions/views-show.ts:315`, same guard + tiebreak for `resolveView`.
- In `plugins/plugin-app-control/src/actions/views.ts:1238`, guard `score` for `correctCapabilityOperationFamily` with fallback `0` + `view.id` tiebreak.
- In `plugins/plugin-app-control/src/actions/views.ts:1838`, guard `score` for `resolveCloseTargetView` with fallback `0` + `view.id` tiebreak.
- In `plugins/plugin-app-control/src/actions/views.safe-sort.test.ts`, add regression covering `NaN`/`Infinity` sorted as 0 and tiebreak by `view.id`.

## Exact-head verification
| Check | Base (`origin/develop`) | Head (`f01c22e19f`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-app-control/src/actions/views.safe-sort.test.ts --run` | N/A (new test) | 2 pass (2 tests) |
| `bunx @biomejs/biome check plugins/plugin-app-control/src/actions/views-create.ts plugins/plugin-app-control/src/actions/views-show.ts plugins/plugin-app-control/src/actions/views.ts` | 0 errors | 0 errors |

## Reviewer start
- `plugins/plugin-app-control/src/actions/views-create.ts:143-162`
- `plugins/plugin-app-control/src/actions/views-show.ts:315-335`
- `plugins/plugin-app-control/src/actions/views.ts:1238-1266,1838-1870`
- `plugins/plugin-app-control/src/actions/views.safe-sort.test.ts:1-30`

## Risks
Low. Finite scores preserve descending order; only non-finite scores gain defined position (0) and deterministic tiebreak. Excludes `views-delete.ts`/`views-edit.ts` which are already covered by #26011/#26006 to avoid duplicate files.

## Attribution
Authored by @byt61.

## Evidence Gate
- [x] `audit:app` — N/A
- [x] `audit:browser` — N/A
- [x] `build` — Clean
- [x] `test` — 2/2 pass
- [x] `lint` — Biome clean
