### PR TITLE
test(cloud): cover unpdf

### DIFF
--- a/packages/cloud/api/src/stubs/unpdf.test.ts
+++ b/packages/cloud/api/src/stubs/unpdf.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Deterministic unit coverage for the workerd-safe unpdf stub. Drives the
+ * real module with no mocks: every named export and every default-surface
+ * method throws the sidecar-not-worker Error before any PDF work. The stub
+ * has no queue, comparator, or capacity.
+ */
+
+import { describe, expect, test } from "vitest";
+import * as unpdf from "./unpdf";
+import workerUnpdfSurface, {
+  definePDFJSModule,
+  extractImages,
+  extractText,
+  getDocumentProxy,
+  getMeta,
+  getResolvedPDFJS,
+  renderPageAsImage,
+} from "./unpdf";
+
+const NOT_AVAILABLE =
+  "unpdf is not available on Cloudflare Workers — PDF text extraction runs on the Node sidecar (cloud/INFRA.md).";
+
+const NAMED_EXPORTS = {
+  definePDFJSModule,
+  extractImages,
+  extractText,
+  getDocumentProxy,
+  getMeta,
+  getResolvedPDFJS,
+  renderPageAsImage,
+} as const;
+
+const NAMED_EXPORT_NAMES = [
+  "definePDFJSModule",
+  "extractImages",
+  "extractText",
+  "getDocumentProxy",
+  "getMeta",
+  "getResolvedPDFJS",
+  "renderPageAsImage",
+] as const;
+
+type NamedExport = (typeof NAMED_EXPORT_NAMES)[number];
+
+const DEFAULT_KEYS = [
+  "definePDFJSModule",
+  "extractImages",
+  "extractText",
+  "getDocumentProxy",
+  "getMeta",
+  "getResolvedPDFJS",
+  "renderPageAsImage",
+] as const;
+
+function expectUnavailable(fn: () => unknown, name: string): void {
+  expect(fn).toThrowError(NOT_AVAILABLE);
+  try {
+    fn();
+    throw new Error(`expected ${name} to throw`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe(NOT_AVAILABLE);
+  }
+}
+
+describe("unpdf Worker stub", () => {
+  test("module namespace exposes the seven throwers plus default, sorted", () => {
+    expect(Object.keys(unpdf).sort()).toEqual([
+      "default",
+      ...NAMED_EXPORT_NAMES,
+    ]);
+    expect(Object.keys(unpdf)).toHaveLength(8);
+  });
+
+  test("named exports are the same functions as the namespace properties", () => {
+    expect(typeof unpdf.definePDFJSModule).toBe("function");
+    expect(unpdf.definePDFJSModule).toBe(definePDFJSModule);
+    expect(typeof unpdf.extractImages).toBe("function");
+    expect(unpdf.extractImages).toBe(extractImages);
+    expect(typeof unpdf.extractText).toBe("function");
+    expect(unpdf.extractText).toBe(extractText);
+    expect(typeof unpdf.getDocumentProxy).toBe("function");
+    expect(unpdf.getDocumentProxy).toBe(getDocumentProxy);
+    expect(typeof unpdf.getMeta).toBe("function");
+    expect(unpdf.getMeta).toBe(getMeta);
+    expect(typeof unpdf.getResolvedPDFJS).toBe("function");
+    expect(unpdf.getResolvedPDFJS).toBe(getResolvedPDFJS);
+    expect(typeof unpdf.renderPageAsImage).toBe("function");
+    expect(unpdf.renderPageAsImage).toBe(renderPageAsImage);
+  });
+
+  test("default export is the worker surface object, not a thrower", () => {
+    expect(workerUnpdfSurface).toBe(unpdf.default);
+    expect(typeof workerUnpdfSurface).toBe("object");
+    expect(workerUnpdfSurface).not.toBeNull();
+    expect(Object.getPrototypeOf(workerUnpdfSurface)).toBe(Object.prototype);
+    expect(Array.isArray(workerUnpdfSurface)).toBe(false);
+  });
+
+  test("default surface own keys are the seven throwers in source order", () => {
+    expect(Object.keys(workerUnpdfSurface)).toEqual([...DEFAULT_KEYS]);
+    expect(Object.getOwnPropertyNames(workerUnpdfSurface)).toEqual([
+      ...DEFAULT_KEYS,
+    ]);
+  });
+
+  test("default surface methods are the same identities as the named exports", () => {
+    for (const name of NAMED_EXPORT_NAMES) {
+      expect(workerUnpdfSurface[name]).toBe(NAMED_EXPORTS[name]);
+    }
+  });
+
+  test("throwers are distinct closures that share one error message, not one function", () => {
+    expect(extractText).not.toBe(getDocumentProxy);
+    expect(extractText).not.toBe(definePDFJSModule);
+    expect(extractImages).not.toBe(renderPageAsImage);
+    expect(getMeta).not.toBe(getResolvedPDFJS);
+  });
+
+  test("does not expose queue, comparator, or capacity fields", () => {
+    const record = workerUnpdfSurface as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect(record.queue).toBeUndefined();
+    expect(record.capacity).toBeUndefined();
+    expect(record.comparator).toBeUndefined();
+  });
+
+  test("reads a missing export as undefined rather than throwing", () => {
+    const view = unpdf as unknown as Record<string, unknown>;
+    expect(view.parsePdf).toBeUndefined();
+    expect(view.phonemize).toBeUndefined();
+    expect(view[""]).toBeUndefined();
+    expect("queue" in view).toBe(false);
+  });
+
+  test("deleting a missing queue key is a no-op and leaves the seven methods", () => {
+    const record = workerUnpdfSurface as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    const deleted = delete record.queue;
+    expect(deleted).toBe(true);
+    expect(Object.keys(workerUnpdfSurface)).toEqual([...DEFAULT_KEYS]);
+    expect(workerUnpdfSurface.extractText).toBe(extractText);
+  });
+
+  test("is not frozen or sealed", () => {
+    expect(Object.isFrozen(workerUnpdfSurface)).toBe(false);
+    expect(Object.isSealed(workerUnpdfSurface)).toBe(false);
+    expect(Object.isExtensible(workerUnpdfSurface)).toBe(true);
+  });
+
+  test("dynamic import resolves to the same module singleton", async () => {
+    const again = await import("./unpdf");
+    expect(again.extractText).toBe(extractText);
+    expect(again.default).toBe(workerUnpdfSurface);
+    expect(again).toBe(unpdf);
+  });
+});
+
+describe("unavailable throwers", () => {
+  test.each(NAMED_EXPORT_NAMES)(
+    "%s is a function that throws the unavailable Error with no arguments",
+    (name: NamedExport) => {
+      const fn = NAMED_EXPORTS[name];
+      expect(typeof fn).toBe("function");
+      expectUnavailable(fn, name);
+    },
+  );
+
+  test.each(NAMED_EXPORT_NAMES)(
+    "%s throws the same Error when extra arguments the Node unpdf API would accept are supplied",
+    (name: NamedExport) => {
+      const fn = NAMED_EXPORTS[name];
+      expectUnavailable(
+        () =>
+          Reflect.apply(fn, undefined, [
+            new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+          ]),
+        name,
+      );
+      expectUnavailable(
+        () => Reflect.apply(fn, undefined, [new ArrayBuffer(0)]),
+        name,
+      );
+      expectUnavailable(
+        () =>
+          Reflect.apply(fn, undefined, [
+            "single-element",
+            { overflow: true },
+            undefined,
+          ]),
+        name,
+      );
+    },
+  );
+
+  test.each(NAMED_EXPORT_NAMES)(
+    "%s keeps throwing on repeated calls (no unlock after the first miss)",
+    (name: NamedExport) => {
+      const fn = NAMED_EXPORTS[name];
+      expectUnavailable(fn, name);
+      expectUnavailable(fn, name);
+    },
+  );
+
+  test.each(NAMED_EXPORT_NAMES)(
+    "%s throws synchronously rather than returning a rejected Promise",
+    (name: NamedExport) => {
+      const fn = NAMED_EXPORTS[name];
+      let thrown: unknown;
+      try {
+        const result = fn();
+        throw new Error(
+          `expected ${name} to throw synchronously, got ${String(result)}`,
+        );
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toBe(NOT_AVAILABLE);
+      expect(thrown).not.toBeInstanceOf(Promise);
+    },
+  );
+
+  test.each(NAMED_EXPORT_NAMES)(
+    "%s on the default surface throws the same Error as the named export",
+    (name: NamedExport) => {
+      expectUnavailable(workerUnpdfSurface[name], name);
+    },
+  );
+
+  test("empty extra-argument lists and a single dummy argument take the same throw path", () => {
+    expectUnavailable(extractText, "extractText");
+    expectUnavailable(
+      () => Reflect.apply(extractText, undefined, []),
+      "extractText",
+    );
+    expectUnavailable(
+      () => Reflect.apply(extractText, undefined, ["one"]),
+      "extractText",
+    );
+  });
+
+  test("each call allocates a fresh Error instance (no shared thrown object)", () => {
+    let first: unknown;
+    let second: unknown;
+    try {
+      extractText();
+    } catch (error) {
+      first = error;
+    }
+    try {
+      extractText();
+    } catch (error) {
+      second = error;
+    }
+    expect(first).toBeInstanceOf(Error);
+    expect(second).toBeInstanceOf(Error);
+    expect(first).not.toBe(second);
+    expect((first as Error).message).toBe((second as Error).message);
+  });
+
+  test("concurrent calls each throw independently (no queue or overflow)", async () => {
+    const outcomes = await Promise.all(
+      NAMED_EXPORT_NAMES.map(async (name) => {
+        try {
+          NAMED_EXPORTS[name]();
+          return { name, threw: false as const };
+        } catch (error) {
+          return {
+            name,
+            threw: true as const,
+            message: (error as Error).message,
+          };
+        }
+      }),
+    );
+    for (const outcome of outcomes) {
+      expect(outcome.threw).toBe(true);
+      if (outcome.threw) {
+        expect(outcome.message).toBe(NOT_AVAILABLE);
+      }
+    }
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/cloud/api/src/stubs/unpdf.ts`, which previously had no adjacent unit test. The stub is the Cloudflare Worker bundle stand-in for `unpdf`: every named export and every method on the default surface throws a clear sidecar-not-worker Error instead of returning empty PDF text (#21327).

This PR changes no production behaviour. The diff is one new test file.

## What the suite records

The tests drive the real module with no mocks and assert the behaviour the stub actually has:

- Module namespace exports the seven throwers plus `default`.
- Named exports are the same function identities as the default-surface methods.
- Default-surface own keys are those seven names in source order.
- Throwers are distinct closures that share one error message, not one shared function.
- Every export throws synchronously (not a rejected Promise) with the exact message:
  `unpdf is not available on Cloudflare Workers — PDF text extraction runs on the Node sidecar (cloud/INFRA.md).`
- Empty calls, extra arguments the Node unpdf API would accept (`Uint8Array`, empty `ArrayBuffer`, dummy overflow args), repeated calls, and concurrent calls all take the same throw path.
- Each call allocates a fresh `Error` instance.
- Missing exports read as `undefined`; there is no queue, comparator, or capacity; deleting a missing `queue` key is a no-op.
- Dynamic `import("./unpdf")` resolves to the same module singleton.

## Evidence (test-only)

Re-fetched `origin/develop` and re-ran against that tree immediately before filing. Hosted CI does **not** run on this fork PR; these are local counts.

1. **vitest** (passes):

```
bunx vitest run packages/cloud/api/src/stubs/unpdf.test.ts

 Test Files  1 passed (1)
      Tests  49 passed (49)
```

2. **biome** (clean; `biome.json` is present and the checkout is not sparse):

```
bunx biome check --write packages/cloud/api/src/stubs/unpdf.test.ts
Checked 1 file in 12ms. No fixes applied.
```

3. **tsc** in `packages/cloud/api` — `unpdf.test.ts` appears nowhere in the output (zero new errors from this file). Pre-existing package errors, if any, are not this change.

```
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'unpdf.test.ts' ; echo "EXIT:$?"
EXIT:1
```

(`grep` exit 1 = no matches.)

4. Diff touches only `packages/cloud/api/src/stubs/unpdf.test.ts`.

No `proof-run.mjs`, origin reproduction, or evidence trace: this is a test-only PR and an unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bf1149bb7716207e9eb39abbefd099f3a54ddee2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
