### PR TITLE
test(cloud): cover ssh2

### DIFF
--- a/packages/cloud/api/src/stubs/ssh2.test.ts
+++ b/packages/cloud/api/src/stubs/ssh2.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Deterministic unit coverage for the workerd-safe ssh2 compatibility shim.
+ * Drives the real module with no mocks: Client and Server constructors throw
+ * before any native binding load, and the utils proxy throws on get so an
+ * accidental Worker-side SSH call is visible immediately. The stub has no
+ * queue, comparator, or capacity.
+ */
+
+import { describe, expect, test } from "vitest";
+import * as stub from "./ssh2";
+import workerSsh2Surface, { Client, Server, utils } from "./ssh2";
+
+const NOT_AVAILABLE =
+  "ssh2 is not available on Cloudflare Workers — proxy to the Node sidecar (cloud/INFRA.md).";
+
+const EXPORT_NAMES = ["Client", "Server", "default", "utils"] as const;
+
+const DEFAULT_KEYS = ["Client", "Server", "utils"] as const;
+
+const CONSTRUCTORS = {
+  Client,
+  Server,
+} as const;
+
+const CONSTRUCTOR_NAMES = Object.keys(CONSTRUCTORS) as Array<
+  keyof typeof CONSTRUCTORS
+>;
+
+function expectUnavailable(fn: () => unknown, label: string): void {
+  expect(fn).toThrowError(NOT_AVAILABLE);
+  try {
+    fn();
+    throw new Error(`expected ${label} to throw`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe(NOT_AVAILABLE);
+  }
+}
+
+describe("ssh2 Worker stub", () => {
+  test("exports Client, Server, utils, and default and nothing else", () => {
+    expect([...Object.keys(stub)].sort()).toEqual([...EXPORT_NAMES]);
+    expect(Object.keys(stub)).toHaveLength(4);
+  });
+
+  test("does not expose queue, comparator, or capacity fields", () => {
+    const record = stub as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect(record.queue).toBeUndefined();
+    expect(record.capacity).toBeUndefined();
+    expect(record.comparator).toBeUndefined();
+  });
+
+  test("default export is a distinct object whose own keys are Client, Server, utils in source order", () => {
+    expect(workerSsh2Surface).toBe(stub.default);
+    expect(workerSsh2Surface).not.toBe(stub);
+    expect(Object.keys(workerSsh2Surface)).toEqual([...DEFAULT_KEYS]);
+    expect(workerSsh2Surface.Client).toBe(Client);
+    expect(workerSsh2Surface.Server).toBe(Server);
+    expect(workerSsh2Surface.utils).toBe(utils);
+  });
+
+  test("Client and Server are distinct class constructors", () => {
+    expect(typeof Client).toBe("function");
+    expect(typeof Server).toBe("function");
+    expect(Client).not.toBe(Server);
+    expect(Client.name).toBe("Client");
+    expect(Server.name).toBe("Server");
+    expect(Object.getOwnPropertyNames(Client.prototype)).toEqual([
+      "constructor",
+    ]);
+    expect(Object.getOwnPropertyNames(Server.prototype)).toEqual([
+      "constructor",
+    ]);
+  });
+
+  test("dynamic import resolves to the same module singleton", async () => {
+    const again = await import("./ssh2");
+    expect(again.Client).toBe(Client);
+    expect(again.Server).toBe(Server);
+    expect(again.utils).toBe(utils);
+    expect(again.default).toBe(workerSsh2Surface);
+  });
+
+  describe("unavailable constructors", () => {
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s is a class whose constructor throws the unavailable Error",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new () => never;
+        expect(typeof Ctor).toBe("function");
+        expectUnavailable(() => new Ctor(), `new ${name}()`);
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s throws the same Error when constructed with extra arguments (no overflow handling)",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new (...args: unknown[]) => never;
+        expectUnavailable(
+          () => new Ctor("single-element", { overflow: true }, undefined),
+          `new ${name}(extra)`,
+        );
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s cannot be invoked without new (class constructor TypeError, not the unavailable Error)",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as unknown as () => void;
+        expect(Ctor).toThrow(TypeError);
+        try {
+          Ctor();
+          throw new Error(`expected ${name}() without new to throw`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(TypeError);
+          expect((error as Error).message).not.toBe(NOT_AVAILABLE);
+        }
+      },
+    );
+
+    test.each(CONSTRUCTOR_NAMES)(
+      "%s keeps throwing on repeated `new` (no capacity or unlock)",
+      (name) => {
+        const Ctor = CONSTRUCTORS[name] as new () => never;
+        expectUnavailable(() => new Ctor(), `new ${name}() first`);
+        expectUnavailable(() => new Ctor(), `new ${name}() second`);
+      },
+    );
+  });
+
+  describe("utils proxy", () => {
+    test("is a null-own-key object whose prototype is Object.prototype", () => {
+      expect(typeof utils).toBe("object");
+      expect(utils === null).toBe(false);
+      expect(Array.isArray(utils)).toBe(false);
+      expect(Object.getPrototypeOf(utils)).toBe(Object.prototype);
+      expect(Object.keys(utils)).toEqual([]);
+      expect(Object.getOwnPropertyNames(utils)).toEqual([]);
+      expect(Object.isFrozen(utils)).toBe(false);
+      expect(Object.isSealed(utils)).toBe(false);
+      expect(Object.isExtensible(utils)).toBe(true);
+    });
+
+    test("throws the unavailable Error on get of a present-looking ssh2 helper", () => {
+      expectUnavailable(() => Reflect.get(utils, "parseKey"), "utils.parseKey");
+    });
+
+    test("throws the unavailable Error on get of a missing property (no silent miss)", () => {
+      expectUnavailable(
+        () => Reflect.get(utils, "doesNotExist"),
+        "utils.doesNotExist",
+      );
+    });
+
+    test("throws the unavailable Error on get of an empty string key (single empty element)", () => {
+      expectUnavailable(() => Reflect.get(utils, ""), 'utils[""]');
+    });
+
+    test("`in` checks do not throw: the proxy has no `has` trap, so missing keys are false", () => {
+      expect("parseKey" in utils).toBe(false);
+      expect("queue" in utils).toBe(false);
+      expect("doesNotExist" in utils).toBe(false);
+      expect("" in utils).toBe(false);
+    });
+
+    test("deleting a missing key is a no-op and leaves the own-key list empty", () => {
+      const record = utils as Record<string, unknown>;
+      expect("doesNotExist" in record).toBe(false);
+      const deleted = delete record.doesNotExist;
+      expect(deleted).toBe(true);
+      expect(Object.keys(utils)).toEqual([]);
+      expect(Object.getOwnPropertyNames(utils)).toEqual([]);
+    });
+
+    test("set of a missing key succeeds (no set trap); get still throws; delete restores the empty own-key list", () => {
+      const record = utils as Record<string, unknown>;
+      expect("probeKey" in record).toBe(false);
+      record.probeKey = "single-element";
+      expect("probeKey" in record).toBe(true);
+      expect(Object.keys(utils)).toEqual(["probeKey"]);
+      expectUnavailable(
+        () => Reflect.get(utils, "probeKey"),
+        "utils.probeKey after set",
+      );
+      const deleted = delete record.probeKey;
+      expect(deleted).toBe(true);
+      expect("probeKey" in record).toBe(false);
+      expect(Object.keys(utils)).toEqual([]);
+    });
+
+    test("keeps throwing on repeated get (no unlock after the first miss)", () => {
+      expectUnavailable(
+        () => Reflect.get(utils, "parseKey"),
+        "utils.parseKey first",
+      );
+      expectUnavailable(
+        () => Reflect.get(utils, "parseKey"),
+        "utils.parseKey second",
+      );
+    });
+
+    test("String and JSON.stringify throw because both look up properties through get", () => {
+      expectUnavailable(() => String(utils), "String(utils)");
+      expectUnavailable(() => JSON.stringify(utils), "JSON.stringify(utils)");
+    });
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/cloud/api/src/stubs/ssh2.ts`, which had no colocated `ssh2.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/cloud/api/src/stubs/ssh2.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` (`88fccb0d61b78c543372cdba8383277a5ed84536`) at file time; zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. The ssh2 Worker stub has no queue, comparator, or capacity API — those edges do not exist, and the suite asserts their absence rather than inventing them. Failure mode is a false assertion of observed constructor/proxy behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/cloud/api/src/stubs/ssh2.test.ts` driving the real Worker compatibility shim (no mocks of the system under test). Sibling layout matches `elizaos-core-test-contract.test.ts` and `brighter-storage-adapter-s3.test.ts` in the same directory; import path is `./ssh2`.

Covered behaviour, as observed in the live module:

- Namespace exports are exactly `Client`, `Server`, `utils`, and `default`
- Default export is a distinct `{ Client, Server, utils }` object whose values are the named exports
- `Client` and `Server` are distinct class constructors; their prototypes only own `constructor`
- `new Client()` / `new Server()` throw `Error` with the sidecar-not-Worker message (not `TypeError`)
- Extra constructor arguments take the same throw path (no overflow handling)
- Calling either class without `new` throws `TypeError` ("Cannot call a class constructor … without |new|"), not the unavailable `Error`
- Repeated `new` keeps throwing (no capacity or unlock)
- `utils` is a `Proxy` over `{}`: own-key list is empty; prototype is `Object.prototype`
- `get` on a present-looking helper (`parseKey`), a missing key, or an empty-string key all throw the unavailable `Error`
- `in` checks do not throw (no `has` trap); missing keys are `false`
- Deleting a missing key is a no-op and leaves the own-key list empty
- Assignment to a missing key succeeds (no `set` trap); subsequent `get` still throws; `delete` restores the empty own-key list
- `String(utils)` and `JSON.stringify(utils)` throw because both look up properties through `get`
- Dynamic `import("./ssh2")` returns the same module singleton

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/stubs/ssh2.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (the production module is unchanged vs this PR's parent):

```bash
bunx vitest run packages/cloud/api/src/stubs/ssh2.test.ts
bunx biome check --write packages/cloud/api/src/stubs/ssh2.test.ts
cd packages/cloud/api && bunx tsc --noEmit 2>&1 | grep 'ssh2.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop`):

1. Vitest: **Test Files 1 passed (1), Tests 22 passed (22)** (`bunx vitest run packages/cloud/api/src/stubs/ssh2.test.ts`).

```text
 ✓ packages/cloud/api/src/stubs/ssh2.test.ts (22 tests) 5ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  19:56:31
   Duration  125ms (transform 32ms, setup 0ms, import 39ms, tests 5ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/cloud/api/src/stubs/ssh2.test.ts` — `Checked 1 file in 25ms. Fixed 1 file.` The committed bytes are that formatted result. Config exists at repo-root `biome.json`; `git sparse-checkout list` reports this worktree is not sparse.

3. `tsc --noEmit` in `packages/cloud/api`: **`ssh2.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors elsewhere in the package are unrelated.

4. Diff touches **only** `packages/cloud/api/src/stubs/ssh2.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Test-only PR; no production behaviour change. Heavy bug-fix evidence (origin reproduction, proof-run, over-rejection corpus) does not apply.

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 22 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

# Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. Hosted GitHub Actions CI does not run on fork contributor PRs. No identity.slop.cash receipt: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:97bb621418fed44861fe4acaa1b996e96dbf4ecd -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
