### PR TITLE
fix(ui): bootstrap first-run step — brand tokens, visible CTA, real state stories

### DIFF
--- a/packages/ui/src/components/setup/BootstrapStep.stories.tsx
+++ b/packages/ui/src/components/setup/BootstrapStep.stories.tsx
@@ -1,4 +1,12 @@
-/** Storybook stories for BootstrapStep — default, invalid-token, rate-limited, server-not-ready, and verifying states. */
+/**
+ * Storybook stories for BootstrapStep — default, invalid-token, rate-limited,
+ * server-not-ready, and verifying states. Error/verifying states are reached
+ * through play functions (paste a token and submit) because the component only
+ * surfaces them after an exchange attempt; without the interaction every
+ * story renders the idle form. The decorator mirrors the runtime
+ * BootstrapGateShell (dark `bg-bg text-txt` shell), not a light panel, so the
+ * first-run text tokens render against their real background.
+ */
 
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
@@ -19,8 +27,8 @@ const translationValue: TranslationContextValue = {
 function TranslationDecorator({ children }: { children: ReactNode }) {
   return (
     <TranslationCtx.Provider value={translationValue}>
-      <div className="mx-auto min-h-96 max-w-xl bg-[#f5f7fa] p-8">
-        {children}
+      <div className="dark relative flex min-h-96 w-full flex-col items-center justify-center bg-bg p-8 text-txt">
+        <div className="w-full max-w-xl">{children}</div>
       </div>
     </TranslationCtx.Provider>
   );
@@ -63,6 +71,48 @@ const pendingExchange = (_token: string): Promise<BootstrapExchangeResult> =>
   // Never resolves — keeps the form stuck in the "Verifying…" state.
   new Promise(() => {});
 
+/** Minimal assertion helper (no @storybook/test in repo — see home-widget-card). */
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`BootstrapStep story: ${message}`);
+}
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  // React overrides the value setter; go through the prototype so the
+  // change event reaches React's onChange.
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function waitForText(
+  root: HTMLElement,
+  text: string,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (root.textContent?.includes(text)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert(false, `expected text to appear: "${text.slice(0, 60)}"`);
+}
+
+/** Paste a token and submit so the story lands in its post-exchange state. */
+async function submitToken(canvasElement: HTMLElement, expectedText: string) {
+  const input = canvasElement.querySelector<HTMLInputElement>(
+    'input[type="password"]',
+  );
+  assert(input, "token input renders");
+  setNativeInputValue(input, "bs_test_token_1234");
+  const form = canvasElement.querySelector("form");
+  assert(form, "form renders");
+  form.requestSubmit();
+  await waitForText(canvasElement, expectedText);
+}
+
 const meta = {
   title: "Setup/BootstrapStep",
   component: BootstrapStep,
@@ -93,11 +143,23 @@ export const InvalidToken: Story = {
   args: {
     exchangeFn: invalidTokenExchange,
   },
+  play: async ({ canvasElement }) => {
+    await submitToken(
+      canvasElement,
+      "Token invalid, expired, or already used. Bootstrap tokens are single-use — rotate from your Eliza Cloud dashboard to get a new one.",
+    );
+  },
 };
 
 export const RateLimited: Story = {
   args: {
     exchangeFn: rateLimitedExchange,
+  },
+  play: async ({ canvasElement }) => {
+    await submitToken(
+      canvasElement,
+      "Too many attempts — wait a minute and try again.",
+    );
   },
 };
 
@@ -105,10 +167,27 @@ export const ServerNotReady: Story = {
   args: {
     exchangeFn: serverNotReadyExchange,
   },
+  play: async ({ canvasElement }) => {
+    await submitToken(
+      canvasElement,
+      "The server is not ready. Reload the page and try again.",
+    );
+  },
 };
 
 export const Verifying: Story = {
   args: {
     exchangeFn: pendingExchange,
+  },
+  play: async ({ canvasElement }) => {
+    const input = canvasElement.querySelector<HTMLInputElement>(
+      'input[type="password"]',
+    );
+    assert(input, "token input renders");
+    setNativeInputValue(input, "bs_test_token_1234");
+    const form = canvasElement.querySelector("form");
+    assert(form, "form renders");
+    form.requestSubmit();
+    await waitForText(canvasElement, "Verifying…");
   },
 };

--- a/packages/ui/src/components/setup/BootstrapStep.tsx
+++ b/packages/ui/src/components/setup/BootstrapStep.tsx
@@ -294,7 +294,7 @@ export function BootstrapStep({ onAdvance, exchangeFn }: BootstrapStepProps) {
       <div
         className={cn(
           "rounded-sm px-4 py-3",
-          "border border-[rgba(240,185,11,0.18)] bg-[rgba(240,185,11,0.07)]",
+          "border border-accent/20 bg-accent/10",
         )}
       >
         <p

--- a/packages/ui/src/components/setup/setup-classes.ts
+++ b/packages/ui/src/components/setup/setup-classes.ts
@@ -16,14 +16,12 @@ export const setupReadableTextFaintClassName =
   "text-[var(--first-run-text-faint)] [text-shadow:var(--first-run-text-shadow-muted)]";
 export const setupHelperTextClassName = `text-xs leading-relaxed ${setupReadableTextMutedClassName}`;
 export const setupFieldLabelClassName = `text-xs font-semibold uppercase tracking-[0.14em] ${setupReadableTextMutedClassName}`;
-export const setupTextSupportClassName =
-  "rounded-sm bg-[var(--first-run-text-support-bg)] px-3 py-2 my-2";
 const setupInputSurfaceClassName = "bg-[var(--first-run-input-bg)]";
 export const setupInputClassName = `h-12 w-full rounded-sm px-4 text-left ${setupReadableTextPrimaryClassName} transition-[border-color,background-color] duration-200 placeholder:text-[var(--first-run-text-subtle)]    ${setupInputSurfaceClassName}`;
 
 export const setupEyebrowClass = `text-center text-xs font-semibold uppercase tracking-[0.3em] ${setupReadableTextMutedClassName}`;
 export const setupTitleClass = `text-center text-xl font-light leading-[1.4] ${setupReadableTextStrongClassName}`;
-export const setupDescriptionClass = `mx-auto max-w-[36ch] text-center text-sm leading-relaxed ${setupReadableTextMutedClassName} ${setupTextSupportClassName}`;
+export const setupDescriptionClass = `mx-auto my-2 max-w-[36ch] text-center text-sm leading-relaxed ${setupReadableTextMutedClassName}`;
 export const setupHeaderBlockClass = "mb-5 max-md:mb-4";
 export const setupFooterClass =
   "mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 pt-4";

--- a/packages/ui/src/components/setup/setup-step-chrome.tsx
+++ b/packages/ui/src/components/setup/setup-step-chrome.tsx
@@ -5,7 +5,7 @@
 export function SetupStepDivider() {
   return (
     <div className="my-4 flex items-center gap-3 before:h-px before:flex-1 before: before:from-transparent before:via-[var(--first-run-divider)] before:to-transparent after:h-px after:flex-1 after: after:from-transparent after:via-[var(--first-run-divider)] after:to-transparent">
-      <div className="h-1.5 w-1.5 shrink-0 rotate-45 bg-[rgba(240,185,11,0.4)]" />
+      <div className="h-1.5 w-1.5 shrink-0 rotate-45 bg-accent/40" />
     </div>
   );
 }

--- a/packages/ui/src/styles/brand-gold.css
+++ b/packages/ui/src/styles/brand-gold.css
@@ -85,8 +85,6 @@
   --first-run-panel-shadow: none;
   --first-run-input-bg: rgba(255, 255, 255, 0.7);
   --first-run-input-border: transparent;
-  --first-run-text-support-bg: rgba(255, 255, 255, 0.46);
-  --first-run-text-support-shadow: none;
   --first-run-divider: rgba(31, 41, 55, 0.16);
   --first-run-footer-border: rgba(31, 41, 55, 0.14);
   --first-run-link: var(--accent);
@@ -149,8 +147,6 @@
   --first-run-panel-shadow: none;
   --first-run-input-bg: rgba(255, 255, 255, 0.7);
   --first-run-input-border: transparent;
-  --first-run-text-support-bg: rgba(255, 255, 255, 0.46);
-  --first-run-text-support-shadow: none;
 
   --first-run-divider: rgba(31, 41, 55, 0.16);
   --first-run-footer-border: rgba(31, 41, 55, 0.14);
@@ -208,7 +204,6 @@
   --first-run-text-faint: rgba(160, 160, 172, 0.76);
   --first-run-text-stroke: rgba(0, 0, 0, 0.42);
   --first-run-input-bg: rgba(255, 255, 255, 0.08);
-  --first-run-text-support-bg: rgba(255, 255, 255, 0.06);
   --first-run-card-bg: rgba(255, 255, 255, 0.05);
   --first-run-card-bg-hover: rgba(255, 255, 255, 0.09);
   --first-run-panel-bg: rgba(255, 255, 255, 0.05);

--- a/packages/ui/src/styles/brand-gold.css
+++ b/packages/ui/src/styles/brand-gold.css
@@ -213,6 +213,14 @@
   --first-run-card-bg-hover: rgba(255, 255, 255, 0.09);
   --first-run-panel-bg: rgba(255, 255, 255, 0.05);
   --first-run-roster-bg: rgba(255, 255, 255, 0.07);
+  /* Primary action: the light-mode 18% tint fill turns near-black on a dark
+     canvas while its foreground stays near-black (ratio ~1.0 — an invisible
+     Activate button). Use the solid brand accent with its dark label. */
+  --first-run-accent-bg: var(--accent);
+  --first-run-accent-bg-hover: var(--accent-hover);
+  --first-run-accent-border: transparent;
+  --first-run-accent-border-hover: transparent;
+  --first-run-accent-foreground: var(--accent-foreground);
 }
 
 [data-testid="companion-header-chat-controls"] > button {


### PR DESCRIPTION
## Summary

First application of the systematic surface-audit workflow: rank every Storybook surface by a composite offender score (banned hues, contrast failures, broken states, stray typography/spacing), pick the worst page, drill in with the full `better-*` review, fix, and verify. The worst page-level surface was **Setup/BootstrapStep** — the cloud container-activation screen every provisioned user must pass through — scoring 69.5 (next worst page: 42).

## Findings and fixes (better-interface consolidated review)

| # | Severity | Domain | Location | Problem | Fix |
| --- | --- | --- | --- | --- | --- |
| 1 | HIGH | colors | `setup-classes.ts` primary action + dark scope | The Activate button's light-mode fill (`rgba(240,185,11,0.18)`) composites to near-black on the dark runtime canvas while its foreground stays near-black — pixel luminance spread 37, an effectively invisible primary CTA | Dark scope now maps `--first-run-accent-bg/hover/foreground` to the solid brand `--accent`/`--accent-hover`/`--accent-foreground` |
| 2 | HIGH | ui (state coverage) | `BootstrapStep.stories.tsx` | All five stories (Default/InvalidToken/RateLimited/ServerNotReady/Verifying) rendered byte-identical screenshots — error and verifying states were unreachable without a submit, so the catalog and story-gate covered none of them | Play functions paste a token, submit, and assert each state's copy appears; decorator now mirrors the runtime `BootstrapGateShell` dark shell instead of a fictional light panel |
| 3 | MEDIUM | colors | `setup-step-chrome.tsx:8`, `BootstrapStep.tsx` help panel | Binance-gold `#f0b90b` literals (divider diamond, help-panel border/fill) — off-brand palette remnant | Mapped to `bg-accent/40`, `border-accent/20 bg-accent/10` |

Verified clean during review (no change needed): keyboard path (form submit + escape hatch both real buttons), labels (`SetupField` wires `aria-describedby`/`aria-invalid`, danger messages announce assertively), the "Start over" dead-end escape hatch, paste not blocked on the token input, 320px narrow rendering.

## Verification

- Pixel-luminance: enabled Activate button spread 37 → **115** (readable); heading 227; description 109. Error state now renders visibly (orange `--danger` message + invalid input ring + solid orange CTA — see evidence).
- `bun run --cwd packages/ui test -- src/components/setup/`: 15/15 pass; typecheck clean; Biome clean.
- Play-driven stories confirmed live: ServerNotReady shows "The server is not ready…", Verifying shows the busy label.

## Evidence

<!-- evidence-head:4719eae1f4991282225c0a3027198bb77453ad46 -->

<!-- evidence-row:before-screenshots -->
- Before (all five states rendered this identical washed-out light panel; md5-identical screenshots): [26117-before-servernotready.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-before-servernotready.png) · narrow: [26117-before-narrow.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-before-narrow.png)

<!-- evidence-row:after-screenshots -->
- After (real error state, solid accent CTA, dark runtime shell): [26117-after-servernotready.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-after-servernotready.png) · enabled CTA: [26117-after-enabled.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-after-enabled.png)

<!-- evidence-row:walkthrough-video -->
- Walkthrough video (idle → typing enables CTA → ServerNotReady error → InvalidToken error → Verifying busy): https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - Storybook-only component change; the real exchange path is mocked per story`

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: `N/A - zero page errors across all captures (asserted per capture in the audit scripts)`

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent, model, prompt, provider, or action behavior changed`

<!-- evidence-row:domain-artifacts -->
- Domain artifacts (offender ranking, weights, and all measurements): [26117-audit-ranking.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-audit-ranking.txt)

<!-- evidence-row:ocr-review -->
- OCR visual text review (tesseract readout: before has no error copy at all; after reads 'The server is not ready. Reload the page and try again.'): [26117-ocr-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-ocr-review.md)

### Inline

#### Before — every state identical, washed out, invisible CTA
![before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-before-servernotready.png)

#### After — ServerNotReady actually shows its error; brand accent CTA
![after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/26117-after-servernotready.png)

## The workflow (reusable)

1. Composite offender score per surface from the dynamic audit datasets (contrast fails ×4, banned hues ×1.5, broken states ×3, stray type/spacing ×1).
2. Pick the worst **page-level** surface (components inherit fixes from pages above them in the token chain).
3. Full `better-interface` review on that page: accessibility → layout → writing → typography → colors → ui.
4. Fix in the project idiom, verify by pixel, ship with evidence.

Next candidates by score: `CloudUI/Docs/OpenApiViewer` (42 — syntax-palette ruling needed first), `Cockpit/CockpitView` (18.4 — contrast), `Conversations/ConversationsSidebar` (15.6 — game-modal blues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
