### PR TITLE
test(cloud): cover mammoth

### DIFF
--- a/packages/cloud/api/src/stubs/mammoth.test.ts
+++ b/packages/cloud/api/src/stubs/mammoth.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Deterministic unit coverage for the fail-loud Cloudflare Workers mammoth
+ * stub. Drives the real module with no mocks: every extractor throws before
+ * any DOCX work, the images proxy throws on get, and the default surface
+ * re-exports the same identities. The stub has no queue, comparator, or
+ * capacity.
+ */
+
+import { describe, expect, test } from "vitest";
+import * as mammoth from "./mammoth";
+import workerMammothSurface, {
+  convertToHtml,
+  convertToMarkdown,
+  embedStyleMap,
+  extractRawText,
+  images,
+} from "./mammoth";
+
+const NOT_AVAILABLE =
+  "mammoth is not available on Cloudflare Workers — DOCX text extraction runs on the Node sidecar (cloud/INFRA.md).";
+
+const FUNCTIONS = {
+  convertToHtml,
+  convertToMarkdown,
+  embedStyleMap,
+  extractRawText,
+} as const;
+
+const FUNCTION_NAMES = Object.keys(FUNCTIONS) as Array<keyof typeof FUNCTIONS>;
+
+const NAMED_EXPORT_KEYS = [
+  "convertToHtml",
+  "convertToMarkdown",
+  "default",
+  "embedStyleMap",
+  "extractRawText",
+  "images",
+] as const;
+
+const DEFAULT_KEYS = [
+  "convertToHtml",
+  "convertToMarkdown",
+  "embedStyleMap",
+  "extractRawText",
+  "images",
+] as const;
+
+function expectUnavailable(fn: () => unknown, name: string): void {
+  expect(fn).toThrowError(NOT_AVAILABLE);
+  try {
+    fn();
+    throw new Error(`expected ${name} to throw`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe(NOT_AVAILABLE);
+  }
+}
+
+describe("mammoth Worker stub", () => {
+  test("exports the six stand-ins and nothing else", () => {
+    // Namespace key order is loader-dependent (Bun vs Vitest); membership is not.
+    expect(Object.keys(mammoth).sort()).toEqual([...NAMED_EXPORT_KEYS]);
+    expect(Object.getOwnPropertyNames(mammoth).sort()).toEqual([
+      ...NAMED_EXPORT_KEYS,
+    ]);
+    expect(Object.keys(mammoth)).toHaveLength(6);
+  });
+
+  test("does not expose queue, comparator, or capacity fields", () => {
+    const record = mammoth as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect(record.queue).toBeUndefined();
+    expect(record.capacity).toBeUndefined();
+    expect(record.comparator).toBeUndefined();
+  });
+
+  test("function exports are distinct closures, not a shared thrower", () => {
+    expect(extractRawText).not.toBe(convertToHtml);
+    expect(convertToHtml).not.toBe(convertToMarkdown);
+    expect(convertToMarkdown).not.toBe(embedStyleMap);
+    expect(extractRawText).not.toBe(embedStyleMap);
+  });
+
+  test("default export is the same object identity as the module default", () => {
+    expect(workerMammothSurface).toBe(mammoth.default);
+  });
+
+  test("default surface own keys match source order and alias the named exports", () => {
+    expect(Object.keys(workerMammothSurface)).toEqual([...DEFAULT_KEYS]);
+    expect(workerMammothSurface.convertToHtml).toBe(convertToHtml);
+    expect(workerMammothSurface.convertToMarkdown).toBe(convertToMarkdown);
+    expect(workerMammothSurface.embedStyleMap).toBe(embedStyleMap);
+    expect(workerMammothSurface.extractRawText).toBe(extractRawText);
+    expect(workerMammothSurface.images).toBe(images);
+  });
+
+  test("default surface is a plain extensible object, not frozen or sealed", () => {
+    expect(Object.getPrototypeOf(workerMammothSurface)).toBe(Object.prototype);
+    expect(Array.isArray(workerMammothSurface)).toBe(false);
+    expect(Object.isFrozen(workerMammothSurface)).toBe(false);
+    expect(Object.isSealed(workerMammothSurface)).toBe(false);
+    expect(Object.isExtensible(workerMammothSurface)).toBe(true);
+  });
+
+  test("deleting a missing queue key on the default surface is a no-op", () => {
+    const record = workerMammothSurface as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    const deleted = delete record.queue;
+    expect(deleted).toBe(true);
+    expect(Object.keys(workerMammothSurface)).toEqual([...DEFAULT_KEYS]);
+    expect(workerMammothSurface.extractRawText).toBe(extractRawText);
+  });
+
+  describe("unavailable extractors", () => {
+    test.each(FUNCTION_NAMES)(
+      "%s is a zero-arity function that throws the unavailable Error with no arguments",
+      (name) => {
+        const fn = FUNCTIONS[name];
+        expect(typeof fn).toBe("function");
+        expect(fn.length).toBe(0);
+        expectUnavailable(fn, name);
+      },
+    );
+
+    test.each(FUNCTION_NAMES)(
+      "%s throws the same Error when extra arguments are supplied (no comparator or overflow handling)",
+      (name) => {
+        const fn = FUNCTIONS[name] as (...args: unknown[]) => never;
+        expectUnavailable(
+          () => fn("single-element", { overflow: true }, undefined),
+          name,
+        );
+      },
+    );
+
+    test.each(FUNCTION_NAMES)(
+      "%s throws the same Error when invoked with new (constructor path still fail-closed)",
+      (name) => {
+        const fn = FUNCTIONS[name] as unknown as new () => never;
+        expectUnavailable(() => new fn(), name);
+      },
+    );
+
+    test.each(FUNCTION_NAMES)(
+      "%s keeps throwing on repeated calls (no unlock after the first miss)",
+      (name) => {
+        const fn = FUNCTIONS[name];
+        expectUnavailable(fn, name);
+        expectUnavailable(fn, name);
+      },
+    );
+  });
+
+  test("empty extra-argument lists and a single dummy argument take the same throw path", () => {
+    const withArgs = extractRawText as (...args: unknown[]) => never;
+    expectUnavailable(extractRawText, "extractRawText");
+    expectUnavailable(() => extractRawText(), "extractRawText");
+    expectUnavailable(() => withArgs("one"), "extractRawText");
+  });
+
+  describe("images proxy", () => {
+    test("is a null-own-key object whose prototype is Object.prototype", () => {
+      expect(typeof images).toBe("object");
+      expect(images === null).toBe(false);
+      expect(Object.getPrototypeOf(images)).toBe(Object.prototype);
+      expect(Object.keys(images)).toEqual([]);
+      expect(Object.getOwnPropertyNames(images)).toEqual([]);
+    });
+
+    test("throws the unavailable Error on get of a present-looking property", () => {
+      expectUnavailable(() => Reflect.get(images, "img"), "images.img");
+    });
+
+    test("throws the unavailable Error on get of a missing property (no silent miss)", () => {
+      expectUnavailable(
+        () => Reflect.get(images, "doesNotExist"),
+        "images.doesNotExist",
+      );
+    });
+
+    test("`in` checks do not throw: the proxy has no `has` trap, so missing keys are false", () => {
+      expect("img" in images).toBe(false);
+      expect("queue" in images).toBe(false);
+      expect("doesNotExist" in images).toBe(false);
+    });
+
+    test("set of a missing property succeeds (no set trap) but get still throws", () => {
+      const record = images as Record<string, unknown>;
+      expect(Reflect.set(record, "queue", undefined)).toBe(true);
+      expect("queue" in record).toBe(true);
+      expectUnavailable(() => Reflect.get(record, "queue"), "images.queue");
+      expect(delete record.queue).toBe(true);
+      expect("queue" in record).toBe(false);
+      expect(Object.keys(images)).toEqual([]);
+    });
+
+    test("deleting a missing item is a no-op and does not unlock get", () => {
+      const record = images as Record<string, unknown>;
+      expect(delete record.doesNotExist).toBe(true);
+      expect("doesNotExist" in record).toBe(false);
+      expectUnavailable(
+        () => Reflect.get(record, "doesNotExist"),
+        "images.doesNotExist",
+      );
+    });
+
+    test("keeps throwing on repeated get (no unlock after the first miss)", () => {
+      expectUnavailable(() => Reflect.get(images, "img"), "images.img");
+      expectUnavailable(() => Reflect.get(images, "img"), "images.img");
+    });
+
+    test("does not expose comparator or capacity fields via `in`", () => {
+      expect("capacity" in images).toBe(false);
+      expect("comparator" in images).toBe(false);
+    });
+  });
+
+  test("dynamic import resolves to the same module singleton", async () => {
+    const again = await import("./mammoth");
+    expect(again.extractRawText).toBe(extractRawText);
+    expect(again.convertToHtml).toBe(convertToHtml);
+    expect(again.images).toBe(images);
+    expect(again.default).toBe(workerMammothSurface);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named Vitest unit suite for `packages/cloud/api/src/stubs/mammoth.ts`, the fail-loud Cloudflare Workers bundle shim for the Node-only DOCX parser. The stub had no same-named test file. This change is test-only: no production module, export, or Worker alias is modified.

The suite drives the real stub (no mocks) and records observed behaviour:

- Named exports are `extractRawText`, `convertToHtml`, `convertToMarkdown`, `embedStyleMap`, `images`, plus `default`.
- Each extractor is a distinct zero-arity function that throws `Error` (not `TypeError`) with the sidecar-unavailable message, including empty calls, extra arguments, `new`, and repeated calls. There is no queue, comparator, capacity, or unlock after a miss.
- `images` is a `Proxy` of `{}` with only a `get` trap: get of a present-looking or missing key throws; `in` does not throw and missing keys are `false`; `set` of a missing key succeeds (no set trap) but subsequent get still throws; deleting a missing item is a no-op.
- The default surface aliases the same function and proxy identities in source key order.

## Evidence

Hosted CI does **not** run on this fork contributor PR. Local counts against current `origin/develop` (re-fetched immediately before filing):

1. `bunx vitest run packages/cloud/api/src/stubs/mammoth.test.ts` — **1 file, 33 tests passed**.
2. `bunx biome check --write packages/cloud/api/src/stubs/mammoth.test.ts` — **Checked 1 file, no fixes applied**.
3. `cd packages/cloud/api && bunx tsc --noEmit` — `mammoth.test.ts` appears **nowhere** in the output. Pre-existing errors in other package files are unchanged.
4. The diff touches **only** `packages/cloud/api/src/stubs/mammoth.test.ts`.

## Test plan

- [x] Vitest collects and passes the new suite against current `origin/develop`
- [x] Biome clean on the new file
- [x] `tsc --noEmit` in `@elizaos/cloud-api` does not report the new file
- [ ] Maintainer: optional scan of the stub vs `packages/core/src/features/documents/parsers.ts` destructure (`extractRawText`) remains fail-closed

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9ac879e56a6f0da60904f198a40ba7bfdc6e3f9a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
