### PR TITLE
test(agent): cover tool-call-cache-registry

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/registry.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/registry.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit coverage for cacheable tool whitelist registry in registry.ts.
+ *
+ * Tests CACHEABLE_TOOL_REGISTRY entries, resolveToolDescriptor fallback
+ * and override handling, and isCacheable lookup predicate.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CACHEABLE_TOOL_REGISTRY,
+  isCacheable,
+  resolveToolDescriptor,
+} from "./registry.js";
+
+describe("tool-call-cache registry", () => {
+  it("exports CACHEABLE_TOOL_REGISTRY with default cacheable tools", () => {
+    expect(CACHEABLE_TOOL_REGISTRY.web_search).toBeDefined();
+    expect(CACHEABLE_TOOL_REGISTRY.web_search.cacheable).toBe(true);
+
+    expect(CACHEABLE_TOOL_REGISTRY.web_fetch).toBeDefined();
+    expect(CACHEABLE_TOOL_REGISTRY.web_fetch.cacheable).toBe(true);
+
+    expect(CACHEABLE_TOOL_REGISTRY.file_read).toBeDefined();
+    expect(CACHEABLE_TOOL_REGISTRY.file_read.cacheable).toBe(true);
+
+    expect(CACHEABLE_TOOL_REGISTRY.rag_search).toBeDefined();
+    expect(CACHEABLE_TOOL_REGISTRY.knowledge_lookup).toBeDefined();
+  });
+
+  describe("resolveToolDescriptor", () => {
+    it("resolves registered tool descriptor with its default TTL and version", () => {
+      const descriptor = resolveToolDescriptor("web_search");
+      expect(descriptor.name).toBe("web_search");
+      expect(descriptor.cacheable).toBe(true);
+      expect(descriptor.version).toBe("1");
+      expect(descriptor.ttlMs).toBeGreaterThan(0);
+    });
+
+    it("applies overrides to TTL and version when provided", () => {
+      const custom = resolveToolDescriptor("web_search", {
+        ttlMs: 5000,
+        version: "2",
+      });
+
+      expect(custom.ttlMs).toBe(5000);
+      expect(custom.version).toBe("2");
+      expect(custom.cacheable).toBe(true);
+    });
+
+    it("returns non-cacheable descriptor for unregistered tools", () => {
+      const unregistered = resolveToolDescriptor("send_email");
+      expect(unregistered.name).toBe("send_email");
+      expect(unregistered.cacheable).toBe(false);
+      expect(unregistered.ttlMs).toBe(0);
+      expect(unregistered.version).toBe("1");
+    });
+  });
+
+  describe("isCacheable", () => {
+    it("returns true for registered cacheable tools", () => {
+      expect(isCacheable("web_search")).toBe(true);
+      expect(isCacheable("web_fetch")).toBe(true);
+      expect(isCacheable("file_read")).toBe(true);
+    });
+
+    it("returns false for unregistered tools and empty names", () => {
+      expect(isCacheable("execute_code")).toBe(false);
+      expect(isCacheable("")).toBe(false);
+      expect(isCacheable("unknown_tool")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/agent/src/runtime/tool-call-cache/registry.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `CACHEABLE_TOOL_REGISTRY`, `resolveToolDescriptor`, and `isCacheable` across:
- `CACHEABLE_TOOL_REGISTRY` entries verification (`web_search`, `web_fetch`, `file_read`, `rag_search`, `knowledge_lookup`).
- `resolveToolDescriptor` resolving registered defaults, applying overrides (`ttlMs`, `version`), and fallback descriptor for unregistered tools.
- `isCacheable` lookup predicate accuracy.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`0a24af8fa7`) |
| --- | --- | --- |
| `bunx vitest run src/runtime/tool-call-cache/registry.test.ts` (in `packages/agent`) | N/A (new test file) | 6 passed (6 tests) |
| `bunx @biomejs/biome check packages/agent/src/runtime/tool-call-cache/registry.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/runtime/tool-call-cache/registry.test.ts:1-72`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 passed in `registry.test.ts`
- [x] `lint` — Biome clean