### PR TITLE
test(core): cover conditional-tests

### DIFF
--- a/packages/core/src/testing/conditional-tests.test.ts
+++ b/packages/core/src/testing/conditional-tests.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit coverage for conditional test runners in conditional-tests.ts.
+ *
+ * Tests describeIf, itIf, and testIf returning active runners when true
+ * and skip runners when false.
+ */
+
+import { describe, expect, it, test } from "vitest";
+import { describeIf, itIf, testIf } from "./conditional-tests.js";
+
+describe("conditional-tests", () => {
+	describe("describeIf", () => {
+		it("returns describe when condition is true", () => {
+			expect(describeIf(true)).toBe(describe);
+		});
+
+		it("returns a skip suite function when condition is false", () => {
+			const runner = describeIf(false);
+			expect(typeof runner).toBe("function");
+			expect(runner).not.toBe(describe);
+		});
+	});
+
+	describe("itIf", () => {
+		it("returns it when condition is true", () => {
+			expect(itIf(true)).toBe(it);
+		});
+
+		it("returns a skip test function when condition is false", () => {
+			const runner = itIf(false);
+			expect(typeof runner).toBe("function");
+			expect(runner).not.toBe(it);
+		});
+	});
+
+	describe("testIf", () => {
+		it("returns test when condition is true", () => {
+			expect(testIf(true)).toBe(test);
+		});
+
+		it("returns a skip test function when condition is false", () => {
+			const runner = testIf(false);
+			expect(typeof runner).toBe("function");
+			expect(runner).not.toBe(test);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/testing/conditional-tests.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `describeIf`, `itIf`, and `testIf` across:
- `describeIf` returning active `describe` runner when `true` and skip runner when `false`.
- `itIf` returning active `it` runner when `true` and skip runner when `false`.
- `testIf` returning active `test` runner when `true` and skip runner when `false`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`14af6221a1`) |
| --- | --- | --- |
| `bunx vitest run src/testing/conditional-tests.test.ts` (in `packages/core`) | N/A (new test file) | 6 passed (6 tests) |
| `bunx @biomejs/biome check packages/core/src/testing/conditional-tests.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/testing/conditional-tests.test.ts:1-47`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 passed in `conditional-tests.test.ts`
- [x] `lint` — Biome clean
