### PR TITLE
test(app-core): cover steward-sidecar-types

### DIFF
--- a/packages/app-core/src/services/steward-sidecar/types.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/types.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit coverage for Steward Sidecar types and constants in types.ts.
+ *
+ * Tests default constants (port, max restarts, health check timings, backoff timings,
+ * tenant / agent ids and names, credentials file path).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CREDENTIALS_FILE,
+  DEFAULT_AGENT_ID,
+  DEFAULT_AGENT_NAME,
+  DEFAULT_MAX_RESTARTS,
+  DEFAULT_PORT,
+  DEFAULT_TENANT_ID,
+  DEFAULT_TENANT_NAME,
+  HEALTH_CHECK_INTERVAL_MS,
+  HEALTH_CHECK_TIMEOUT_MS,
+  INITIAL_BACKOFF_MS,
+  MAX_BACKOFF_MS,
+} from "./types.js";
+
+describe("steward-sidecar types and constants", () => {
+  it("exports valid networking and execution constants", () => {
+    expect(DEFAULT_PORT).toBe(3200);
+    expect(DEFAULT_MAX_RESTARTS).toBe(5);
+    expect(HEALTH_CHECK_INTERVAL_MS).toBe(500);
+    expect(HEALTH_CHECK_TIMEOUT_MS).toBe(30_000);
+    expect(INITIAL_BACKOFF_MS).toBe(1_000);
+    expect(MAX_BACKOFF_MS).toBe(30_000);
+  });
+
+  it("exports valid identity and storage constants", () => {
+    expect(DEFAULT_TENANT_ID).toBe("elizaos-desktop");
+    expect(DEFAULT_TENANT_NAME).toBe("Desktop");
+    expect(DEFAULT_AGENT_ID).toBe("eliza-wallet");
+    expect(DEFAULT_AGENT_NAME).toBe("eliza-wallet");
+    expect(CREDENTIALS_FILE).toBe("credentials.json");
+  });
+
+  it("enforces timing relationships", () => {
+    expect(HEALTH_CHECK_INTERVAL_MS).toBeLessThan(HEALTH_CHECK_TIMEOUT_MS);
+    expect(INITIAL_BACKOFF_MS).toBeLessThanOrEqual(MAX_BACKOFF_MS);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/app-core/src/services/steward-sidecar/types.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests steward sidecar constants and timing relationships across:
- Networking and execution constants (`DEFAULT_PORT`, `DEFAULT_MAX_RESTARTS`, `HEALTH_CHECK_INTERVAL_MS`, `HEALTH_CHECK_TIMEOUT_MS`, `INITIAL_BACKOFF_MS`, `MAX_BACKOFF_MS`).
- Identity and storage constants (`DEFAULT_TENANT_ID`, `DEFAULT_TENANT_NAME`, `DEFAULT_AGENT_ID`, `DEFAULT_AGENT_NAME`, `CREDENTIALS_FILE`).
- Timing relationship invariants.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`da995f8db0`) |
| --- | --- | --- |
| `bunx vitest run src/services/steward-sidecar/types.test.ts` (in `packages/app-core`) | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/app-core/src/services/steward-sidecar/types.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/services/steward-sidecar/types.test.ts:1-45`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 passed in `types.test.ts`
- [x] `lint` — Biome clean
