### PR TITLE
test(cloud): cover seed-pricing

### DIFF
--- a/packages/cloud/e2e/src/helpers/seed-pricing.test.ts
+++ b/packages/cloud/e2e/src/helpers/seed-pricing.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic unit coverage of the cloud e2e seedModelPricing helper.
+ * Drives the real seeder and captures the payload it hands to
+ * aiPricingRepository.createMany: always one input row then one output row,
+ * with observed defaults, overrides, String() unit prices, and a shared
+ * effective_from stamped one day in the past. The helper has no queue,
+ * comparator, capacity, or item-removal API.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as seedPricing from "./seed-pricing";
+import { seedModelPricing } from "./seed-pricing";
+
+type SeededPricingRow = {
+  billing_source: string;
+  provider: string;
+  model: string;
+  product_family: "language";
+  unit: "tokens";
+  currency: "USD";
+  dimension_key: "*";
+  dimensions: Record<string, never>;
+  source_kind: "manual";
+  source_url: string;
+  is_active: boolean;
+  effective_from: Date;
+  charge_type: string;
+  unit_price: string;
+};
+
+const { createMany } = vi.hoisted(() => ({
+  createMany: vi.fn<
+    (entries: SeededPricingRow[]) => Promise<SeededPricingRow[]>
+  >(async (entries) => entries),
+}));
+
+vi.mock("@elizaos/cloud-shared/db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    createMany,
+  },
+}));
+
+const DAY_MS = 86_400_000;
+const DEFAULT_INPUT_PER_TOKEN = 0.00000015;
+const DEFAULT_OUTPUT_PER_TOKEN = 0.0000006;
+
+function lastBatch(): SeededPricingRow[] {
+  expect(createMany).toHaveBeenCalledTimes(1);
+  const batch = createMany.mock.calls[0]?.[0];
+  if (batch === undefined) {
+    throw new Error("createMany was not called with a row batch");
+  }
+  return batch;
+}
+
+afterEach(() => {
+  createMany.mockClear();
+  vi.useRealTimers();
+});
+
+describe("seedModelPricing exports", () => {
+  test("exports only seedModelPricing", () => {
+    expect(Object.keys(seedPricing)).toEqual(["seedModelPricing"]);
+    expect(seedPricing.seedModelPricing).toBe(seedModelPricing);
+  });
+
+  test("does not expose queue, comparator, capacity, or item-removal fields", () => {
+    const record = seedPricing as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect("remove" in record).toBe(false);
+    expect(record.queue).toBeUndefined();
+    expect(record.capacity).toBeUndefined();
+    expect(record.comparator).toBeUndefined();
+  });
+});
+
+describe("seedModelPricing", () => {
+  test("writes exactly one input row and one output row in that order", async () => {
+    await seedModelPricing({ model: "openai/gpt-4o-mini" });
+    const batch = lastBatch();
+    expect(batch).toHaveLength(2);
+    expect(batch[0]?.charge_type).toBe("input");
+    expect(batch[1]?.charge_type).toBe("output");
+  });
+
+  test("returns undefined (Promise<void>) even when createMany returns the rows", async () => {
+    await expect(
+      seedModelPricing({ model: "openai/gpt-4o-mini" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("applies openai defaults and the test source URL when optionals are omitted", async () => {
+    await seedModelPricing({ model: "openai/gpt-4o-mini" });
+    const [input, output] = lastBatch();
+    expect(input).toMatchObject({
+      billing_source: "openai",
+      provider: "openai",
+      model: "openai/gpt-4o-mini",
+      product_family: "language",
+      unit: "tokens",
+      currency: "USD",
+      dimension_key: "*",
+      dimensions: {},
+      source_kind: "manual",
+      source_url: "test://seed-pricing",
+      is_active: true,
+      charge_type: "input",
+      unit_price: String(DEFAULT_INPUT_PER_TOKEN),
+    });
+    expect(output).toMatchObject({
+      billing_source: "openai",
+      provider: "openai",
+      model: "openai/gpt-4o-mini",
+      charge_type: "output",
+      unit_price: String(DEFAULT_OUTPUT_PER_TOKEN),
+    });
+  });
+
+  test("String() of the default per-token rates is scientific notation, not a padded decimal", async () => {
+    await seedModelPricing({ model: "m" });
+    const [input, output] = lastBatch();
+    expect(input?.unit_price).toBe("1.5e-7");
+    expect(output?.unit_price).toBe("6e-7");
+    expect(input?.unit_price).not.toBe("0.00000015");
+    expect(output?.unit_price).not.toBe("0.0000006");
+  });
+
+  test("overrides billingSource and provider independently", async () => {
+    await seedModelPricing({
+      model: "openai/gpt-4o-mini",
+      billingSource: "bitrouter",
+      provider: "openai",
+    });
+    const batch = lastBatch();
+    for (const row of batch) {
+      expect(row.billing_source).toBe("bitrouter");
+      expect(row.provider).toBe("openai");
+      expect(row.model).toBe("openai/gpt-4o-mini");
+    }
+  });
+
+  test("String()s custom per-token rates onto the matching charge_type row", async () => {
+    await seedModelPricing({
+      model: "custom-model",
+      inputPerToken: 0.002,
+      outputPerToken: 0.004,
+    });
+    const [input, output] = lastBatch();
+    expect(input?.unit_price).toBe("0.002");
+    expect(output?.unit_price).toBe("0.004");
+  });
+
+  test("treats explicit 0 as a price, not as a missing optional (?? not ||)", async () => {
+    await seedModelPricing({
+      model: "zero-model",
+      inputPerToken: 0,
+      outputPerToken: 0,
+    });
+    const [input, output] = lastBatch();
+    expect(input?.unit_price).toBe("0");
+    expect(output?.unit_price).toBe("0");
+  });
+
+  test("treats explicit undefined optionals as missing and applies defaults", async () => {
+    await seedModelPricing({
+      model: "undef-model",
+      inputPerToken: undefined,
+      outputPerToken: undefined,
+      billingSource: undefined,
+      provider: undefined,
+    });
+    const [input, output] = lastBatch();
+    expect(input?.billing_source).toBe("openai");
+    expect(input?.provider).toBe("openai");
+    expect(input?.unit_price).toBe(String(DEFAULT_INPUT_PER_TOKEN));
+    expect(output?.unit_price).toBe(String(DEFAULT_OUTPUT_PER_TOKEN));
+  });
+
+  test("passes an empty model string through rather than substituting a default", async () => {
+    await seedModelPricing({ model: "" });
+    const batch = lastBatch();
+    expect(batch[0]?.model).toBe("");
+    expect(batch[1]?.model).toBe("");
+  });
+
+  test("stamps a shared effective_from exactly one day behind Date.now()", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:00.000Z"));
+    const expected = new Date(
+      new Date("2026-08-23T12:00:00.000Z").getTime() - DAY_MS,
+    );
+    await seedModelPricing({ model: "timed" });
+    const [input, output] = lastBatch();
+    expect(input?.effective_from).toEqual(expected);
+    expect(output?.effective_from).toEqual(expected);
+    expect(output?.effective_from).toBe(input?.effective_from);
+  });
+
+  test("does not grow or shrink the batch (no capacity or overflow behaviour)", async () => {
+    await seedModelPricing({
+      model: "overflow",
+      inputPerToken: Number.MAX_VALUE,
+      outputPerToken: Number.MIN_VALUE,
+    });
+    const batch = lastBatch();
+    expect(batch).toHaveLength(2);
+    expect(batch[0]?.unit_price).toBe(String(Number.MAX_VALUE));
+    expect(batch[1]?.unit_price).toBe(String(Number.MIN_VALUE));
+  });
+
+  test("propagates a createMany rejection and does not swallow it", async () => {
+    const failure = new Error("insert failed");
+    createMany.mockRejectedValueOnce(failure);
+    await expect(seedModelPricing({ model: "failing" })).rejects.toBe(failure);
+    expect(createMany).toHaveBeenCalledTimes(1);
+  });
+
+  test("String()s NaN and Infinity rather than substituting the default rates", async () => {
+    await seedModelPricing({
+      model: "nonfinite",
+      inputPerToken: Number.NaN,
+      outputPerToken: Number.POSITIVE_INFINITY,
+    });
+    const [input, output] = lastBatch();
+    expect(input?.unit_price).toBe("NaN");
+    expect(output?.unit_price).toBe("Infinity");
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/cloud/e2e/src/helpers/seed-pricing.ts`, which had no colocated `seed-pricing.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/cloud/e2e/src/helpers/seed-pricing.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted vitest / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` at file time (`88fccb0d61b78c543372cdba8383277a5ed84536`); zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped vitest + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. `seedModelPricing` has no comparator, capacity, or item-removal API — those edges do not exist. Failure mode is a false assertion of the observed createMany payload, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/cloud/e2e/src/helpers/seed-pricing.test.ts` driving the real `seedModelPricing` export (the only export). The helper dynamically imports `aiPricingRepository` and always calls `createMany` with two catalog rows. The suite captures that collaborator so it does not require a live DATABASE_URL / PGlite stack; it does not mock `seedModelPricing` itself, and it does not assert a mock's canned return value.

Sibling layout matches `packages/cloud/e2e/src/helpers/shared-runtime.test.ts` (colocated `*.test.ts` next to the helper) and the vitest `describe`/`test`/`expect` imports used by other cloud unit suites. Import path is `./seed-pricing`.

Covered behaviour, as observed in the live module (not wished-for behaviour):

- Only export is `seedModelPricing`; no queue / comparator / capacity / remove API
- Always writes exactly two rows, input then output — never an empty batch and never a single row
- Default `billing_source` and `provider` are `"openai"`; default rates are `0.00000015` input and `0.0000006` output
- `String()` of those defaults is scientific notation (`"1.5e-7"`, `"6e-7"`), not a padded decimal — that is what JS `String(number)` produces here
- Optional overrides (`billingSource`, `provider`, `inputPerToken`, `outputPerToken`) are applied independently
- Explicit `0` is a price (`??`, not `||`); explicit `undefined` falls back to the defaults
- Empty `model` is passed through as `""`
- Both rows share one `effective_from` Date instance stamped `Date.now() - 86_400_000`
- `Number.MAX_VALUE` / `Number.MIN_VALUE` still produce a two-row batch (no overflow handling)
- `createMany` rejection propagates; the helper does not swallow it
- `NaN` / `Infinity` are `String()`'d to `"NaN"` / `"Infinity"` rather than replaced by the default rates

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/e2e/src/helpers/seed-pricing.test.ts` (the only file in the diff).

## Detailed testing steps

Re-run against current `origin/develop` (the production module is unchanged vs this PR's parent):

```bash
bunx vitest run packages/cloud/e2e/src/helpers/seed-pricing.test.ts
bunx biome check --write packages/cloud/e2e/src/helpers/seed-pricing.test.ts
cd packages/cloud/e2e && bunx tsc --noEmit 2>&1 | grep 'seed-pricing.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop` at `88fccb0d61b78c543372cdba8383277a5ed84536`):

1. Vitest: **Test Files 1 passed (1), Tests 15 passed (15)** (`bunx vitest run packages/cloud/e2e/src/helpers/seed-pricing.test.ts`).

```text
 ✓ packages/cloud/e2e/src/helpers/seed-pricing.test.ts (15 tests) 6ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  20:00:42
   Duration  124ms (transform 35ms, setup 0ms, import 44ms, tests 6ms, environment 0ms)
```

2. Biome: `bunx biome check --write packages/cloud/e2e/src/helpers/seed-pricing.test.ts` — `Checked 1 file in 77ms. Fixed 1 file.` (import sort). The committed file is that formatted result. Config exists at repo-root `biome.json`; `git sparse-checkout list` reports this worktree is not sparse.

3. `tsc --noEmit` in `packages/cloud/e2e`: **`seed-pricing.test.ts` appears nowhere** (`GREP_EXIT:1`). Pre-existing errors elsewhere in the package are unrelated.

4. Diff touches **only** `packages/cloud/e2e/src/helpers/seed-pricing.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Test-only PR; no production behaviour change. Heavy bug-fix evidence (origin reproduction, proof-run, over-rejection corpus) does not apply.

evidence-head: `5ff93cb9b025c82ff873aed2546ab6ed25c2095a`

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; vitest counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused vitest output: 1 file passed, 15 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no audio/voice path.

## Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. Hosted GitHub Actions CI does not run on fork contributor PRs. No identity.slop.cash receipt: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5ff93cb9b025c82ff873aed2546ab6ed25c2095a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
