### PR TITLE
test(shared): cover config-cloud-providers

### DIFF
--- a/packages/shared/src/config/config.test.ts
+++ b/packages/shared/src/config/config.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit coverage for cloud provider config migration helpers in config.ts.
+ *
+ * Tests isCloudActiveFromProviders array search and migrateCloudEnabledToProviders
+ * backwards-compatibility upgrade behaviors.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isCloudActiveFromProviders,
+  migrateCloudEnabledToProviders,
+} from "./config.js";
+
+describe("config cloud providers", () => {
+  describe("isCloudActiveFromProviders", () => {
+    it("returns true when providers array contains 'elizacloud'", () => {
+      expect(isCloudActiveFromProviders(["elizacloud"])).toBe(true);
+      expect(
+        isCloudActiveFromProviders(["openai", "elizacloud", "anthropic"]),
+      ).toBe(true);
+    });
+
+    it("returns false when providers does not contain 'elizacloud' or is empty/null/undefined", () => {
+      expect(isCloudActiveFromProviders(["openai"])).toBe(false);
+      expect(isCloudActiveFromProviders([])).toBe(false);
+      expect(isCloudActiveFromProviders(null)).toBe(false);
+      expect(isCloudActiveFromProviders(undefined)).toBe(false);
+    });
+  });
+
+  describe("migrateCloudEnabledToProviders", () => {
+    it("returns unchanged config when cloud.enabled is not true", () => {
+      const config1 = { cloud: { enabled: false } };
+      expect(migrateCloudEnabledToProviders(config1)).toBe(config1);
+
+      const config2 = {};
+      expect(migrateCloudEnabledToProviders(config2)).toBe(config2);
+    });
+
+    it("appends 'elizacloud' to providers when cloud.enabled is true", () => {
+      const config = {
+        cloud: { enabled: true },
+        providers: ["openai"],
+      };
+
+      const migrated = migrateCloudEnabledToProviders(config);
+      expect(migrated.providers).toEqual(["openai", "elizacloud"]);
+    });
+
+    it("initializes providers array with 'elizacloud' if providers was undefined", () => {
+      const config = {
+        cloud: { enabled: true },
+      };
+
+      const migrated = migrateCloudEnabledToProviders(config);
+      expect(migrated.providers).toEqual(["elizacloud"]);
+    });
+
+    it("returns unchanged config if 'elizacloud' is already in providers", () => {
+      const config = {
+        cloud: { enabled: true },
+        providers: ["elizacloud"],
+      };
+
+      const migrated = migrateCloudEnabledToProviders(config);
+      expect(migrated).toBe(config);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/config/config.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests `isCloudActiveFromProviders` and `migrateCloudEnabledToProviders` across:
- `isCloudActiveFromProviders` checking presence of `elizacloud` in providers array and falsey / empty handling.
- `migrateCloudEnabledToProviders` backwards-compatibility upgrade when `cloud.enabled` is `true`.
- Idempotency when `elizacloud` is already present or `cloud.enabled` is not set.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`88412a59f8`) |
| --- | --- | --- |
| `bunx vitest run src/config/config.test.ts` (in `packages/shared`) | N/A (new test file) | 6 passed (6 tests) |
| `bunx @biomejs/biome check packages/shared/src/config/config.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/config/config.test.ts:1-69`

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Test-only change)
- [x] `audit:browser` — N/A (Test-only change)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 passed in `config.test.ts`
- [x] `lint` — Biome clean
