### PR TITLE
style(cloud): format audit event coverage

### DIFF
--- a/packages/cloud/api/src/services/audit-events.test.ts
+++ b/packages/cloud/api/src/services/audit-events.test.ts
@@ -13,26 +13,28 @@ import type { AuditEvent } from "./audit/types.js";
 // vi.hoisted, so build the collaborators inside the factories and reach them
 // through the mocked module afterwards.
 vi.mock("@/db/client", () => {
-	const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
-	const insert = vi.fn((_table: unknown) => ({ values }));
-	return { dbWrite: { insert }, __values: values, __insert: insert };
+  const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
+  const insert = vi.fn((_table: unknown) => ({ values }));
+  return { dbWrite: { insert }, __values: values, __insert: insert };
 });
 
 vi.mock("@/db/schemas/auth-events", () => ({
-	authEvents: { name: "auth_events" as const },
+  authEvents: { name: "auth_events" as const },
 }));
 
 const dbClientModule = (await import("@/db/client")) as unknown as {
-	__values: ReturnType<typeof vi.fn>;
-	__insert: ReturnType<typeof vi.fn>;
+  __values: ReturnType<typeof vi.fn>;
+  __insert: ReturnType<typeof vi.fn>;
 };
-const authEventsModule = (await import("@/db/schemas/auth-events")) as unknown as {
-	authEvents: { name: "auth_events" };
+const authEventsModule = (await import(
+  "@/db/schemas/auth-events"
+)) as unknown as {
+  authEvents: { name: "auth_events" };
 };
 const harness = {
-	values: dbClientModule.__values,
-	insert: dbClientModule.__insert,
-	authEvents: authEventsModule.authEvents,
+  values: dbClientModule.__values,
+  insert: dbClientModule.__insert,
+  authEvents: authEventsModule.authEvents,
 };
 
 const { AuditEventsSink, auditEventsSink } = await import("./audit-events");


### PR DESCRIPTION
## Summary

Apply the missing Biome formatting to the Cloud audit-events coverage added by #26087.

#26106 was merged while its Static Smoke was red on this base-only formatter drift. This follow-up is intentionally one file and whitespace-only.

## Validation

Base: `develop@095c7a4c0163bc24f6c9f71699c518bda5664813`
Head: `3901770f7e417eb8ff07efdc95307108a2505e7b`

- affected `lint:check`: 143/143 tasks passed
- targeted audit-events Vitest: 9/9 passed
- independent review: no P0-P3 findings; semantic equivalence confirmed
- `git diff --check`: passed

<!-- evidence-head:3901770f7e417eb8ff07efdc95307108a2505e7b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - whitespace-only test formatting; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - whitespace-only test formatting; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing behavior changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - formatter check and targeted test are listed in validation

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact
