### PR TITLE
fix(agent): preserve explicit registry scopes

### DIFF
--- a/packages/agent/src/services/plugin-installer.test.ts
+++ b/packages/agent/src/services/plugin-installer.test.ts
@@ -335,6 +335,56 @@ describe("installPlugin approval boundary", () => {
     });
     expect(mkdir).not.toHaveBeenCalled();
   });
+
+  it("rejects a canonical package from a different explicit scope before filesystem or process effects", async () => {
+    await useIsolatedState();
+    vi.spyOn(registryClient, "getPluginInfo").mockResolvedValue(
+      registryInfo({
+        name: "@attacker/plugin-x",
+        npm: {
+          package: "@attacker/plugin-x",
+          v0Version: null,
+          v1Version: null,
+          v2Version: "2.4.1",
+        },
+      }),
+    );
+    const mkdir = vi.spyOn(fs, "mkdir");
+
+    const result = await installPlugin("@elizaos/plugin-x");
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/scope.*does not match/i),
+    });
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects same-scope package drift for an explicit request before effects", async () => {
+    await useIsolatedState();
+    vi.spyOn(registryClient, "getPluginInfo").mockResolvedValue(
+      registryInfo({
+        name: "@elizaos/plugin-y",
+        npm: {
+          package: "@elizaos/plugin-y",
+          v0Version: null,
+          v1Version: null,
+          v2Version: "2.4.1",
+        },
+      }),
+    );
+    const mkdir = vi.spyOn(fs, "mkdir");
+
+    const result = await installPlugin("@elizaos/plugin-x");
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/package.*does not match/i),
+    });
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("package-manager lock provenance", () => {

--- a/packages/agent/src/services/plugin-installer.ts
+++ b/packages/agent/src/services/plugin-installer.ts
@@ -31,6 +31,7 @@ import { ElizaError, logger, resolveStateDir } from "@elizaos/core";
 import { createSerialise, requestRestart } from "@elizaos/shared";
 import { loadElizaConfig, saveElizaConfig } from "../config/config.js";
 import { getPluginInfo, type RegistryPluginInfo } from "./registry-client.js";
+import { normalizePluginLookupAlias } from "./registry-client-queries.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -169,6 +170,52 @@ export interface UninstallResult {
   pluginName: string;
   requiresRestart: boolean;
   error?: string;
+}
+
+function explicitNpmScope(name: string): string | null {
+  const match = /^(@[a-zA-Z0-9][\w.-]*)\/[a-zA-Z0-9][\w.-]*$/.exec(name.trim());
+  return match?.[1] ?? null;
+}
+
+function assertExplicitRequestMatchesPackage(
+  requestedName: string,
+  resolvedPackageName: string,
+): void {
+  const normalizedRequest = normalizePluginLookupAlias(requestedName);
+  const requestedScope = explicitNpmScope(normalizedRequest);
+  if (!requestedScope) return;
+
+  const resolvedScope = explicitNpmScope(resolvedPackageName);
+  if (resolvedScope !== requestedScope) {
+    throw new ElizaError(
+      `Requested package scope "${requestedScope}" does not match registry package scope "${resolvedScope ?? "unscoped"}"`,
+      {
+        code: "PLUGIN_INSTALL_SCOPE_MISMATCH",
+        context: {
+          requestedName: requestedName.trim(),
+          requestedScope,
+          resolvedPackageName,
+          resolvedScope,
+        },
+        severity: "fatal",
+      },
+    );
+  }
+
+  if (resolvedPackageName !== normalizedRequest) {
+    throw new ElizaError(
+      `Requested package "${normalizedRequest}" does not match registry package "${resolvedPackageName}"`,
+      {
+        code: "PLUGIN_INSTALL_PACKAGE_MISMATCH",
+        context: {
+          requestedName: requestedName.trim(),
+          normalizedRequest,
+          resolvedPackageName,
+        },
+        severity: "fatal",
+      },
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -456,6 +503,7 @@ async function _installPlugin(
   let plan: PluginInstallPlan;
   try {
     plan = resolvePluginInstallPlan(info, requestedVersionOrOptions);
+    assertExplicitRequestMatchesPackage(pluginName, plan.packageName);
   } catch (err) {
     // error-policy:J1 installPlugin translates validation failures into its
     // established structured result boundary.

--- a/packages/agent/src/services/registry-client-queries.test.ts
+++ b/packages/agent/src/services/registry-client-queries.test.ts
@@ -180,14 +180,14 @@ describe("getPluginInfoFromRegistry", () => {
     );
   });
 
-  it("does not apply @elizaos prefix tries when the lookup already starts with @", () => {
+  it("does not cross scopes when the lookup already starts with @", () => {
     const elizaos = plugin({ name: "@elizaos/plugin-discord" });
+    const registry = new Map([[elizaos.name, elizaos]]);
+
     expect(
-      getPluginInfoFromRegistry(
-        new Map([[elizaos.name, elizaos]]),
-        "@other/plugin-discord",
-      ),
-    ).toBe(elizaos);
+      getPluginInfoFromRegistry(registry, "@other/plugin-discord"),
+    ).toBeNull();
+    expect(getPluginInfoFromRegistry(registry, "plugin-discord")).toBe(elizaos);
   });
 
   it("matches a case-insensitive key suffix and npm.package / name aliases", () => {

--- a/packages/agent/src/services/registry-client-queries.ts
+++ b/packages/agent/src/services/registry-client-queries.ts
@@ -37,18 +37,22 @@ export function getPluginInfoFromRegistry(
   let p = registry.get(name);
   if (p) return p;
 
-  const requestedBare = name.replace(/^@[^/]+\//, "").toLowerCase();
+  // An explicit npm scope is a publisher boundary, not a display alias. The
+  // public wrapper may try an explicitly enumerated spelling correction first,
+  // but a missing scoped key must never fall through to another publisher's
+  // suffix, npm-package, or route-slug alias.
+  if (name.startsWith("@")) return null;
 
-  if (!name.startsWith("@")) {
-    p = registry.get(`@elizaos/${name}`);
-    if (p) return p;
+  const requestedBare = name.toLowerCase();
 
-    p = registry.get(`@elizaos/plugin-${name}`);
-    if (p) return p;
+  p = registry.get(`@elizaos/${name}`);
+  if (p) return p;
 
-    p = registry.get(`@elizaos/app-${name}`);
-    if (p) return p;
-  }
+  p = registry.get(`@elizaos/plugin-${name}`);
+  if (p) return p;
+
+  p = registry.get(`@elizaos/app-${name}`);
+  if (p) return p;
 
   for (const [key, value] of registry) {
     if (key.toLowerCase().endsWith(`/${requestedBare}`)) return value;

--- a/packages/agent/src/services/registry-client-types.test.ts
+++ b/packages/agent/src/services/registry-client-types.test.ts
@@ -418,14 +418,15 @@ describe("getPluginInfoFromRegistry over RegistryPluginInfo", () => {
     expect(getPluginInfoFromRegistry(registry, "calendar")).toBe(appPrefixed);
   });
 
-  it("returns the first insertion-order key whose suffix matches the bare name", () => {
+  it("reserves insertion-order suffix matching for unscoped input", () => {
     const first = plugin({ name: "@aaa/sql", gitRepo: "aaa/sql" });
     const second = plugin({ name: "@bbb/sql", gitRepo: "bbb/sql" });
     const registry = new Map<string, RegistryPluginInfo>([
       [first.name, first],
       [second.name, second],
     ]);
-    expect(getPluginInfoFromRegistry(registry, "@foo/sql")).toBe(first);
+    expect(getPluginInfoFromRegistry(registry, "@foo/sql")).toBeNull();
+    expect(getPluginInfoFromRegistry(registry, "sql")).toBe(first);
   });
 
   it("matches a npm.package alias after prefix tries miss", () => {

--- a/packages/agent/src/services/registry-client.test.ts
+++ b/packages/agent/src/services/registry-client.test.ts
@@ -523,6 +523,15 @@ describe("getPluginInfo", () => {
     expect(await getPluginInfo("obsidan")).toEqual(obsidian);
     expect(await getPluginInfo("@elizaos/plugin-obsidan")).toEqual(obsidian);
   });
+
+  it("never resolves an explicit scope to a different publisher", async () => {
+    const attacker = plugin({ name: "@attacker/plugin-x" });
+    fetchImpl = async () => new Map([[attacker.name, attacker]]);
+    const { getPluginInfo } = await loadModule();
+
+    expect(await getPluginInfo("@elizaos/plugin-x")).toBeNull();
+    expect(await getPluginInfo("plugin-x")).toEqual(attacker);
+  });
 });
 
 describe("searchPlugins", () => {

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -406,7 +406,11 @@ export async function refreshRegistry(): Promise<
   return refresh;
 }
 
-/** Look up a plugin by name (exact → @elizaos/ prefix → bare suffix). */
+/**
+ * Look up a plugin by name. Explicitly scoped requests are exact-only apart
+ * from the enumerated spelling aliases; unscoped input may use the @elizaos
+ * prefixes, bare suffixes, npm aliases, and app route slugs.
+ */
 export async function getPluginInfo(
   name: string,
 ): Promise<RegistryPluginInfo | null> {


### PR DESCRIPTION
# Relates to

Closes #25881.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at final verification (`88fccb0d61b78c543372cdba8383277a5ed84536`) with zero conflicts.
- [x] The available affected checks were run after sync; the unrelated offline workspace/typecheck blocker is recorded below.
- [x] A reviewer can confirm the behavior from the focused regression tests and their no-effects assertions below.

# Sync with develop

- [x] Rebased onto `origin/develop` at final verification; zero conflicts.
- [x] Affected tests and static checks pass post-sync; the exact unrelated full-verification blocker is documented in **Known gaps / failures**.

# Risks

Medium. This changes plugin registry resolution and adds a defense at the installation boundary. Explicitly scoped requests become deliberately stricter; unscoped aliases, route slugs, and suffix matching remain compatible and covered.

# Background

## What does this PR do?

- Stops a missing `@scope/package` lookup before suffix, npm-package, or route-slug fallback can select another publisher.
- Keeps the existing explicitly enumerated `obsidan` spelling alias.
- Independently binds an explicitly scoped install request to the canonical registry package before directory creation or child-process execution.
- Rejects both cross-scope drift and same-scope package-name drift with structured fatal validation errors.

## What kind of change is this?

Security bug fix (non-breaking for unscoped lookup behavior).

# Documentation changes needed?

No user documentation change is needed. The service API comment now documents the scoped-versus-unscoped lookup contract.

# Testing

## Where should a reviewer start?

Start with `registry-client-queries.ts` for the lookup boundary and `plugin-installer.ts` for the pre-effect install defense. The adjacent tests cover cross-scope lookup, same-scope drift, unscoped compatibility, and absence of filesystem/process effects.

## Detailed testing steps

Run in the agent package:

```bash
vitest run src/services/registry-client-types.test.ts src/services/registry-client.test.ts src/services/plugin-installer.test.ts
vitest run src/services/registry-client-queries.test.ts -t '^(?!.*orders by score then stars).*$'
```

Results on exact head `b7cf86019a1ad5de6562e615ab771649834ab190`:

- 97/97 broader affected tests passed.
- 25/25 registry-query tests passed; one unrelated baseline test was explicitly excluded and is documented below.
- Scoped Biome check passed for all seven changed files.
- `git diff --check` passed.

# Evidence Gate

<!-- evidence-head:b7cf86019a1ad5de6562e615ab771649834ab190 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a service lookup and installer validation change with no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the affected path is a pure registry query plus a pre-effect validation boundary; focused automated assertions are the applicable evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, generated file, or other domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no running backend or frontend request path changed. The tests assert the rejected install never reaches `fs.mkdir` or process execution.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Full `bun install` / `bun run verify` was not available in the credential-free, network-disabled environment: the pre-existing cached workspace install lacks multiple unrelated package dependencies. Network installation was intentionally not performed. The attempted package typecheck produced unrelated missing-module and existing workspace errors, with no changed-file-specific error observed.
- The untouched `registry-client-queries.test.ts` case `orders by score then stars` fails identically on the original base `4207ca1ab7d41e5d5c4ddac071369cfc7d84a238`: the test expects insertion order for a score/star tie while production applies its existing deterministic name tiebreak. The 25 other query tests pass on this PR.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-goal-100]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0QGKEPV78NQC9JMTNW22WZQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T14:32:41.947Z","completed_at":"2026-08-23T14:36:29.834Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T14:32:42.536Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e3ab84316b6d94412580c6619ed0c58ef52e35e7926e04018d2858bf0a01f126","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a622c531-3999-4778-9d2c-3a1dd0a2c4ea","object_id":"sha256:e3ab84316b6d94412580c6619ed0c58ef52e35e7926e04018d2858bf0a01f126","sha256":"e3ab84316b6d94412580c6619ed0c58ef52e35e7926e04018d2858bf0a01f126"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Y-cTLOhCcBsNGH7_EzRdbyHDQfNGdaqvixPX05ZKn1ujkgtBWOZK5vGHj3iNI9O2icHeYu4j1TsKbHRbtYyRBg"}} -->
