### PR TITLE
test(cloud): cover service-interface

### DIFF
--- a/packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for the `CloudSetupSessionService` contract: the five operations
+ * and their input/result types, driven through the real
+ * `MockCloudSetupSessionService` reference implementation. Deterministic clock
+ * and id generation; no mocked return values.
+ */
+
+import { describe, expect, it } from "vitest";
+import { MockCloudSetupSessionService } from "../mock-service.js";
+import type {
+  CloudSetupSessionService,
+  FinalizeHandoffInput,
+  SendMessageInput,
+  SendMessageResult,
+  StartSessionInput,
+} from "../service-interface.js";
+
+function makeService(provisioningTurns = 1): CloudSetupSessionService {
+  let counter = 0;
+  return new MockCloudSetupSessionService({
+    now: () => 1_000_000 + counter,
+    randomId: () => `id_${++counter}`,
+    provisioningTurns,
+  });
+}
+
+describe("service-interface module", () => {
+  it("is a types-only ESM module with no runtime exports", async () => {
+    const mod = await import("../service-interface.js");
+    expect(Object.keys(mod)).toEqual([]);
+  });
+});
+
+describe("CloudSetupSessionService.startSession", () => {
+  it("accepts StartSessionInput and returns a provisioning envelope", async () => {
+    const service: CloudSetupSessionService = makeService();
+    const input: StartSessionInput = { tenantId: "tenant_a" };
+    const envelope = await service.startSession(input);
+    expect(envelope.tenantId).toBe("tenant_a");
+    expect(envelope.containerStatus).toBe("provisioning");
+    expect(envelope.sessionId).toBe("id_1");
+    expect(envelope.containerId).toBe("id_2");
+    // randomId runs twice (sessionId, containerId) before now() is read.
+    expect(envelope.createdAt).toBe(1_000_002);
+  });
+
+  it("accepts an empty tenantId string rather than inventing a default", async () => {
+    const service = makeService();
+    const input: StartSessionInput = { tenantId: "" };
+    const envelope = await service.startSession(input);
+    expect(envelope.tenantId).toBe("");
+  });
+
+  it("issues independent session ids for two starts with the same tenant", async () => {
+    const service = makeService();
+    const first = await service.startSession({ tenantId: "shared" });
+    const second = await service.startSession({ tenantId: "shared" });
+    expect(first.sessionId).not.toBe(second.sessionId);
+    expect(first.tenantId).toBe("shared");
+    expect(second.tenantId).toBe("shared");
+  });
+
+  it("returns a copy so mutating the envelope does not change stored status", async () => {
+    const service = makeService();
+    const envelope = await service.startSession({ tenantId: "tenant_a" });
+    envelope.containerStatus = "failed";
+    const stored = await service.getStatus(envelope.sessionId);
+    expect(stored.containerStatus).not.toBe("failed");
+  });
+});
+
+describe("CloudSetupSessionService.sendMessage", () => {
+  it("returns SendMessageResult replies and owner.name on the first turn", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    const input: SendMessageInput = {
+      sessionId: started.sessionId,
+      message: "Shaw",
+    };
+    const result: SendMessageResult = await service.sendMessage(input);
+    expect(result.replies).toHaveLength(1);
+    expect(result.replies[0]?.role).toBe("agent");
+    expect(result.facts).toHaveLength(1);
+    expect(result.facts[0]?.key).toBe("owner.name");
+    expect(result.facts[0]?.value).toBe("Shaw");
+    expect(result.facts[0]?.source).toBe("user");
+    expect(result.facts[0]?.confidence).toBe(0.6);
+  });
+
+  it("extracts owner.language on the second turn and empty facts after that", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    await service.sendMessage({
+      sessionId: started.sessionId,
+      message: "Shaw",
+    });
+    const language = await service.sendMessage({
+      sessionId: started.sessionId,
+      message: "English",
+    });
+    expect(language.facts).toHaveLength(1);
+    expect(language.facts[0]?.key).toBe("owner.language");
+    expect(language.facts[0]?.value).toBe("English");
+    expect(language.facts[0]?.confidence).toBe(0.7);
+
+    const later = await service.sendMessage({
+      sessionId: started.sessionId,
+      message: "next",
+    });
+    expect(later.facts).toEqual([]);
+    expect(later.replies).toHaveLength(1);
+  });
+
+  it("records an empty message as the fact value instead of skipping the turn", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    const result = await service.sendMessage({
+      sessionId: started.sessionId,
+      message: "",
+    });
+    expect(result.facts[0]?.value).toBe("");
+    expect(result.replies).toHaveLength(1);
+  });
+
+  it("rejects sendMessage for a missing sessionId", async () => {
+    const service = makeService();
+    const input: SendMessageInput = {
+      sessionId: "missing",
+      message: "hello",
+    };
+    await expect(service.sendMessage(input)).rejects.toThrow(
+      /unknown setup session: missing/,
+    );
+  });
+
+  it("keeps the last tour line once turn count overflows the script", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    let last = "";
+    for (let turn = 0; turn < 8; turn++) {
+      const result = await service.sendMessage({
+        sessionId: started.sessionId,
+        message: `turn-${turn}`,
+      });
+      last = result.replies[0]?.content ?? "";
+    }
+    expect(last).toBe(
+      "All set. As soon as your container is ready I'll move this conversation into it.",
+    );
+  });
+});
+
+describe("CloudSetupSessionService.getStatus", () => {
+  it("rejects getStatus for a missing sessionId", async () => {
+    const service = makeService();
+    await expect(service.getStatus("missing")).rejects.toThrow(
+      /unknown setup session: missing/,
+    );
+  });
+
+  it("stays provisioning until the configured poll count, then stays ready", async () => {
+    const service = makeService(2);
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    const first = await service.getStatus(started.sessionId);
+    expect(first.containerStatus).toBe("provisioning");
+    const second = await service.getStatus(started.sessionId);
+    expect(second.containerStatus).toBe("ready");
+    const extra = await service.getStatus(started.sessionId);
+    expect(extra.containerStatus).toBe("ready");
+  });
+
+  it("isolates status polls across two sessions", async () => {
+    const service = makeService(2);
+    const first = await service.startSession({ tenantId: "a" });
+    const second = await service.startSession({ tenantId: "b" });
+    await service.getStatus(first.sessionId);
+    const secondStatus = await service.getStatus(second.sessionId);
+    expect(secondStatus.containerStatus).toBe("provisioning");
+    const firstReady = await service.getStatus(first.sessionId);
+    expect(firstReady.containerStatus).toBe("ready");
+  });
+});
+
+describe("CloudSetupSessionService.finalizeHandoff", () => {
+  it("rejects finalizeHandoff for a missing sessionId", async () => {
+    const service = makeService();
+    const input: FinalizeHandoffInput = {
+      sessionId: "missing",
+      containerId: "container_xyz",
+    };
+    await expect(service.finalizeHandoff(input)).rejects.toThrow(
+      /unknown setup session: missing/,
+    );
+  });
+
+  it("rejects finalizeHandoff while the container is still provisioning", async () => {
+    const service = makeService(10);
+    const started = await service.startSession({ tenantId: "tenant_b" });
+    await expect(
+      service.finalizeHandoff({
+        sessionId: started.sessionId,
+        containerId: "c",
+      }),
+    ).rejects.toThrow(/provisioning/);
+  });
+
+  it("uses FinalizeHandoffInput.containerId, not the session container id", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    await service.sendMessage({
+      sessionId: started.sessionId,
+      message: "Shaw",
+    });
+    await service.getStatus(started.sessionId);
+    const input: FinalizeHandoffInput = {
+      sessionId: started.sessionId,
+      containerId: "container_xyz",
+    };
+    const handoff = await service.finalizeHandoff(input);
+    expect(handoff.containerId).toBe("container_xyz");
+    expect(handoff.containerId).not.toBe(started.containerId);
+    expect(handoff.sessionId).toBe(started.sessionId);
+    expect(handoff.tenantId).toBe("tenant_a");
+    expect(handoff.transcript.length).toBeGreaterThan(0);
+    expect(handoff.facts.length).toBeGreaterThan(0);
+    expect(handoff.memoryIds).toEqual(handoff.transcript.map((m) => m.id));
+  });
+
+  it("finalizes with an empty facts list when no messages were sent", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    await service.getStatus(started.sessionId);
+    const handoff = await service.finalizeHandoff({
+      sessionId: started.sessionId,
+      containerId: "c",
+    });
+    expect(handoff.facts).toEqual([]);
+    expect(handoff.transcript).toHaveLength(1);
+    expect(handoff.transcript[0]?.role).toBe("agent");
+  });
+});
+
+describe("CloudSetupSessionService.cancel", () => {
+  it("resolves void and then treats the session as missing", async () => {
+    const service = makeService();
+    const started = await service.startSession({ tenantId: "tenant_a" });
+    const result = await service.cancel(started.sessionId);
+    expect(result).toBeUndefined();
+    await expect(service.getStatus(started.sessionId)).rejects.toThrow(
+      /unknown setup session/,
+    );
+    await expect(
+      service.sendMessage({
+        sessionId: started.sessionId,
+        message: "hi",
+      }),
+    ).rejects.toThrow(/unknown setup session/);
+    await expect(
+      service.finalizeHandoff({
+        sessionId: started.sessionId,
+        containerId: "c",
+      }),
+    ).rejects.toThrow(/unknown setup session/);
+  });
+
+  it("rejects cancel for a missing sessionId", async () => {
+    const service = makeService();
+    await expect(service.cancel("missing")).rejects.toThrow(
+      /unknown setup session: missing/,
+    );
+  });
+
+  it("does not cancel a sibling session", async () => {
+    const service = makeService();
+    const kept = await service.startSession({ tenantId: "keep" });
+    const dropped = await service.startSession({ tenantId: "drop" });
+    await service.cancel(dropped.sessionId);
+    const status = await service.getStatus(kept.sessionId);
+    expect(status.sessionId).toBe(kept.sessionId);
+    expect(status.tenantId).toBe("keep");
+  });
+});


### PR DESCRIPTION

# Relates to

Adds the missing same-named unit suite for `packages/cloud/sdk/src/cloud-setup-session/service-interface.ts`, which had no `service-interface.test.ts` on `develop`. Test-only; no production behaviour change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` with a single-file commit (`packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts` only).
- [ ] `bun install` and `bun run verify` were not re-run for this test-only change. Focused gates below were run on the new file.
- [x] A reviewer can confirm the change from the quoted bun test / biome / tsc counts (no UI surface).

We are a **fork contributor**: hosted CI does **not** run on this PR. Do not treat GitHub check status as evidence that CI passed.

# Sync with develop

- [x] Commit parent is current `origin/develop` at file time (`095c7a4c0163bc24f6c9f71699c518bda5664813`); zero conflicts; diff is one test file.
- [ ] `bun run verify` not re-run (test-only; scoped bun test + biome + tsc quoted below).

# Risks

Low. Adds tests only; no production behaviour change. `service-interface.ts` is a types-only module (five operations and four input/result interfaces). It has no comparator, capacity, or item-removal API of its own — those edges are exercised only as observed on the real `MockCloudSetupSessionService` reference implementation bound as `CloudSetupSessionService`. Failure mode is a false assertion of observed session behaviour, which would fail the suite rather than ship a runtime change.

# Background

## What does this PR do?

Adds `packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts` driving the real `CloudSetupSessionService` contract. Runtime exports on the module itself are empty (types-only ESM); behaviour is the five operations implemented by `MockCloudSetupSessionService`, typed as `CloudSetupSessionService`. The suite does not mock those operations' return values.

Sibling layout matches `packages/cloud/sdk/src/cloud-setup-session/__tests__/mock-service.test.ts` and `policy.test.ts` (`vitest` `describe`/`it`/`expect`, import from `../service-interface.js`). The owning package's unit lane is `bun test` (`packages/cloud/sdk/package.json` `"test": "bun test src && ..."`), so counts below are from `bun test`, not root vitest.

Covered behaviour, as observed in the live reference implementation (not wished-for behaviour):

- Types-only module: `Object.keys(await import("../service-interface.js"))` is `[]`
- `StartSessionInput.tenantId` is stored as given, including `""`; no default tenant is invented
- `startSession` returns a provisioning envelope; `createdAt` is read after two `randomId` calls (`1_000_002` with the injected clock, not `1_000_000`)
- Two starts with the same tenant get independent session ids
- Returned envelopes are copies; mutating `containerStatus` on the return value does not change stored status
- `SendMessageInput` first turn extracts `owner.name` at confidence `0.6`; second turn extracts `owner.language` at `0.7`; later turns return `facts: []`
- Empty message is recorded as the fact value `""` rather than skipping the turn
- Missing `sessionId` on send/getStatus/finalize/cancel throws `unknown setup session: missing`
- Tour-script overflow keeps the last canned line rather than wrapping or throwing
- `getStatus` stays `provisioning` until the configured poll count, then stays `ready` on extra polls
- Status polls are isolated across two sessions
- `finalizeHandoff` while provisioning throws `/provisioning/`; once ready, `FinalizeHandoffInput.containerId` wins over the session's container id
- Finalize with no messages yields `facts: []` and the opening agent transcript
- `cancel` resolves `undefined`, then every subsequent op treats the session as missing; a sibling session is not cancelled

## What kind of change is this?

Tests only (behaviour-preserving coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts` (the only file in the diff).

## Detailed testing steps

The `@elizaos/cloud-sdk` unit lane is `bun test`, not vitest. Re-run against current `origin/develop` (the production module is unchanged vs this PR's parent):

```bash
bun test packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts
bunx biome check --write packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts
cd packages/cloud/sdk && bunx tsc --noEmit 2>&1 | grep 'service-interface.test.ts' ; echo "GREP_EXIT:$?"
```

Observed immediately before filing (re-run after re-fetching `origin/develop` at `095c7a4c0163bc24f6c9f71699c518bda5664813`):

1. bun test: **20 pass, 0 fail**, 1 file, 53 `expect()` calls (`bun test packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts`).

```text
 20 pass
 0 fail
 53 expect() calls
Ran 20 tests across 1 file. [166.00ms]
```

2. Biome: `bunx biome check --write packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts` — `Checked 1 file in 23ms. Fixed 1 file.` (signature wrap). The committed file is that formatted result. Config exists at repo-root `biome.json`; `git sparse-checkout list` reports this worktree is not sparse.

3. `tsc --noEmit` in `packages/cloud/sdk`: **TSC_EXIT:0**. `service-interface.test.ts` appears nowhere (`GREP_EXIT:1`).

4. Diff touches **only** `packages/cloud/sdk/src/cloud-setup-session/__tests__/service-interface.test.ts`.

Hosted CI does not run on fork PRs; the counts above are local, not GitHub Actions.

# Evidence Gate

Test-only PR; no production behaviour change. Heavy bug-fix evidence (origin reproduction, proof-run, over-rejection corpus) does not apply.

- [x] Before screenshots: N/A - test-only, no rendered UI surface.
- [x] After screenshots: N/A - test-only, no rendered UI surface.
- [x] Walkthrough video: N/A - test-only, no user flow.
- [x] Backend logs: N/A - no production path change; bun test counts quoted above.
- [x] Frontend logs: N/A - no frontend change.
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- [x] Domain artifacts: N/A - unit tests only; no DB/wallet/audio artifact.
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model path.

## Backend + frontend logs

N/A - no production behaviour change. Focused bun test output: 1 file, 20 pass, 0 fail.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no audio/voice path.

## Known gaps / failures

None in the added file. `bun run verify` was not run; this is a test-only single-file PR. Hosted GitHub Actions CI does not run on fork contributor PRs. No identity.slop.cash receipt: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:302e06fe84cd2118d64f581af74b404c81af79fc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
