### PR TITLE
test(cloud): cover wallet-login

### DIFF
--- a/packages/cloud/e2e/src/helpers/wallet-login.test.ts
+++ b/packages/cloud/e2e/src/helpers/wallet-login.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Deterministic unit coverage of the cloud e2e wallet-login helpers:
+ * SIWE session passthrough, SeededUser adaptation, and privileged elevation
+ * after a real handshake. Drives the real module through a fetch shim that
+ * runs viem signature validation; repository writes are captured at the
+ * cloud-shared boundary. Run with
+ * `bun test packages/cloud/e2e/src/helpers/wallet-login.test.ts` (the
+ * package's Playwright lane matches only `tests/`).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { validateSIWEMessage } from "@elizaos/cloud-shared/lib/utils/siwe-helpers";
+import type { SiweTestLoginResult } from "./wallet-login";
+
+type UserUpdate = { id: string; data: Record<string, unknown> };
+type OrgUpdate = { id: string; data: Record<string, unknown> };
+
+const userUpdates: UserUpdate[] = [];
+const orgUpdates: OrgUpdate[] = [];
+
+let userUpdateImpl: (
+  id: string,
+  data: Record<string, unknown>,
+) => Promise<unknown> = async (id, data) => {
+  userUpdates.push({ id, data });
+  return { id, ...data };
+};
+
+let orgUpdateImpl: (
+  id: string,
+  data: Record<string, unknown>,
+) => Promise<unknown> = async (id, data) => {
+  orgUpdates.push({ id, data });
+  return { id, ...data };
+};
+
+mock.module("@elizaos/cloud-shared/db/repositories/users", () => ({
+  usersRepository: {
+    update: (id: string, data: Record<string, unknown>) =>
+      userUpdateImpl(id, data),
+  },
+}));
+
+mock.module("@elizaos/cloud-shared/db/repositories/organizations", () => ({
+  organizationsRepository: {
+    update: (id: string, data: Record<string, unknown>) =>
+      orgUpdateImpl(id, data),
+  },
+}));
+
+const { asSeededUser, loginAsSeededUser, loginWithTestWallet } = await import(
+  "./wallet-login"
+);
+const walletLogin = await import("./wallet-login");
+
+const NONCE_DOMAIN = "localhost:3000";
+const NONCE_URI = "http://localhost:3000";
+const HARDHAT_ACCOUNT1_KEY =
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as const;
+const HARDHAT_ACCOUNT1_ADDRESS = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const SESSION_API_KEY = "eliza_test_account_key_0123456789";
+const SESSION_USER_ID = "00000000-0000-4000-8000-000000000001";
+const SESSION_ORG_ID = "00000000-0000-4000-8000-000000000002";
+
+type RecordedFetch = {
+  url: string;
+  method: string | undefined;
+  headers: Record<string, string>;
+  body: string | undefined;
+};
+
+type SiweShimOptions = {
+  nonceStatus?: number;
+  nonceText?: string;
+  verifyStatus?: number;
+  verifyBody?: unknown;
+  tamper?: boolean;
+};
+
+const originalFetch = globalThis.fetch;
+
+function headerRecord(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (headers === undefined) return out;
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      out[key.toLowerCase()] = value;
+    });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      out[key.toLowerCase()] = value;
+    }
+    return out;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    out[key.toLowerCase()] = value;
+  }
+  return out;
+}
+
+function installSiweFetch(opts: SiweShimOptions = {}): RecordedFetch[] {
+  const calls: RecordedFetch[] = [];
+  const issuedNonces = new Set<string>();
+
+  globalThis.fetch = (async (
+    input: Request | string | URL,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const recorded: RecordedFetch = {
+      url,
+      method: init?.method,
+      headers: headerRecord(init?.headers),
+      body: init?.body === undefined ? undefined : String(init.body),
+    };
+    calls.push(recorded);
+
+    if (url.includes("/api/auth/siwe/nonce")) {
+      if (opts.nonceStatus !== undefined && opts.nonceStatus !== 200) {
+        return new Response(opts.nonceText ?? "nonce unavailable", {
+          status: opts.nonceStatus,
+        });
+      }
+      const nonce = `n${issuedNonces.size}${Math.random().toString(16).slice(2)}`;
+      issuedNonces.add(nonce);
+      return new Response(
+        JSON.stringify({
+          nonce,
+          domain: NONCE_DOMAIN,
+          uri: NONCE_URI,
+          chainId: 1,
+          version: "1",
+          statement: "Sign in to Eliza Cloud",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (url.includes("/api/auth/siwe/verify")) {
+      if (opts.verifyBody !== undefined) {
+        return new Response(JSON.stringify(opts.verifyBody), {
+          status: opts.verifyStatus ?? 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (opts.verifyStatus !== undefined && opts.verifyStatus !== 200) {
+        return new Response("verify unavailable", {
+          status: opts.verifyStatus,
+        });
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        message: string;
+        signature: `0x${string}`;
+      };
+      const message = opts.tamper
+        ? body.message.replace(/Nonce: \w+/, "Nonce: forged000")
+        : body.message;
+      try {
+        const { address } = await validateSIWEMessage(
+          message,
+          body.signature,
+          NONCE_DOMAIN,
+        );
+        return new Response(
+          JSON.stringify({
+            apiKey: SESSION_API_KEY,
+            address,
+            isNewAccount: true,
+            user: {
+              id: SESSION_USER_ID,
+              wallet_address: address,
+              organization_id: SESSION_ORG_ID,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "SIWE verification failed" }),
+          {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  return calls;
+}
+
+function sessionLogin(
+  overrides: Partial<SiweTestLoginResult> = {},
+): SiweTestLoginResult {
+  return {
+    apiKey: SESSION_API_KEY,
+    address: HARDHAT_ACCOUNT1_ADDRESS,
+    userId: SESSION_USER_ID,
+    organizationId: SESSION_ORG_ID,
+    isNewAccount: true,
+    privateKey: HARDHAT_ACCOUNT1_KEY,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  userUpdates.length = 0;
+  orgUpdates.length = 0;
+  userUpdateImpl = async (id, data) => {
+    userUpdates.push({ id, data });
+    return { id, ...data };
+  };
+  orgUpdateImpl = async (id, data) => {
+    orgUpdates.push({ id, data });
+    return { id, ...data };
+  };
+});
+
+describe("wallet-login exports", () => {
+  test("exports the three runtime helpers and re-exports no extra values", () => {
+    expect(Object.keys(walletLogin).sort()).toEqual([
+      "asSeededUser",
+      "loginAsSeededUser",
+      "loginWithTestWallet",
+    ]);
+    expect(walletLogin.asSeededUser).toBe(asSeededUser);
+    expect(walletLogin.loginAsSeededUser).toBe(loginAsSeededUser);
+    expect(walletLogin.loginWithTestWallet).toBe(loginWithTestWallet);
+  });
+
+  test("does not expose a queue, comparator, capacity, or item-removal API", () => {
+    const record = walletLogin as unknown as Record<string, unknown>;
+    expect("queue" in record).toBe(false);
+    expect("capacity" in record).toBe(false);
+    expect("comparator" in record).toBe(false);
+    expect("remove" in record).toBe(false);
+  });
+});
+
+describe("asSeededUser", () => {
+  test("maps ids and apiKey, blanks email, and prefixes stewardUserId with wallet-", () => {
+    expect(asSeededUser(sessionLogin())).toEqual({
+      userId: SESSION_USER_ID,
+      organizationId: SESSION_ORG_ID,
+      stewardUserId: `wallet-${HARDHAT_ACCOUNT1_ADDRESS.toLowerCase()}`,
+      email: "",
+      apiKey: SESSION_API_KEY,
+    });
+  });
+
+  test("lowercases a mixed-case checksum address in stewardUserId only", () => {
+    const seeded = asSeededUser(sessionLogin());
+    expect(seeded.stewardUserId).toBe(
+      "wallet-0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+    );
+    expect(seeded.userId).toBe(SESSION_USER_ID);
+    expect(seeded.organizationId).toBe(SESSION_ORG_ID);
+  });
+
+  test("leaves an already-lowercase address lowercase", () => {
+    const address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const seeded = asSeededUser(sessionLogin({ address }));
+    expect(seeded.stewardUserId).toBe(`wallet-${address}`);
+  });
+
+  test("passes userId, organizationId, and apiKey through without rewriting case", () => {
+    const seeded = asSeededUser(
+      sessionLogin({
+        userId: "User-Mixed",
+        organizationId: "Org-Mixed",
+        apiKey: "Key-Mixed",
+      }),
+    );
+    expect(seeded.userId).toBe("User-Mixed");
+    expect(seeded.organizationId).toBe("Org-Mixed");
+    expect(seeded.apiKey).toBe("Key-Mixed");
+  });
+
+  test("does not copy address, isNewAccount, or privateKey onto SeededUser", () => {
+    const seeded = asSeededUser(sessionLogin({ isNewAccount: false }));
+    expect(seeded).not.toHaveProperty("address");
+    expect(seeded).not.toHaveProperty("isNewAccount");
+    expect(seeded).not.toHaveProperty("privateKey");
+    expect(Object.keys(seeded).sort()).toEqual([
+      "apiKey",
+      "email",
+      "organizationId",
+      "stewardUserId",
+      "userId",
+    ]);
+  });
+
+  test("empty address yields the wallet- prefix with nothing after it", () => {
+    expect(asSeededUser(sessionLogin({ address: "" })).stewardUserId).toBe(
+      "wallet-",
+    );
+  });
+
+  test("throws when address is missing because toLowerCase is required", () => {
+    expect(() =>
+      asSeededUser(
+        sessionLogin({
+          address: undefined as unknown as string,
+        }),
+      ),
+    ).toThrow();
+  });
+});
+
+describe("loginWithTestWallet", () => {
+  test("completes a real SIWE handshake and returns the session", async () => {
+    installSiweFetch();
+    const session = await loginWithTestWallet(NONCE_URI);
+
+    expect(session.apiKey).toBe(SESSION_API_KEY);
+    expect(session.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(session.isNewAccount).toBe(true);
+    expect(session.userId).toBe(SESSION_USER_ID);
+    expect(session.organizationId).toBe(SESSION_ORG_ID);
+    expect(session.privateKey).toMatch(/^0x[0-9a-fA-F]{64}$/);
+  });
+
+  test("signs in deterministically when a private key is supplied", async () => {
+    installSiweFetch();
+    const a = await loginWithTestWallet(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    const b = await loginWithTestWallet(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    expect(a.address).toBe(b.address);
+    expect(a.address).toBe(HARDHAT_ACCOUNT1_ADDRESS);
+    expect(a.privateKey).toBe(HARDHAT_ACCOUNT1_KEY);
+    expect(b.privateKey).toBe(HARDHAT_ACCOUNT1_KEY);
+  });
+
+  test("omitting the private key mints a fresh wallet each call", async () => {
+    installSiweFetch();
+    const a = await loginWithTestWallet(NONCE_URI);
+    const b = await loginWithTestWallet(NONCE_URI);
+    expect(a.address).not.toBe(b.address);
+    expect(a.privateKey).not.toBe(b.privateKey);
+  });
+
+  test("strips a trailing slash on baseUrl before requesting the nonce", async () => {
+    const calls = installSiweFetch();
+    await loginWithTestWallet(`${NONCE_URI}/`);
+    expect(calls[0]?.url).toBe(`${NONCE_URI}/api/auth/siwe/nonce?chainId=1`);
+    expect(calls[1]?.url).toBe(`${NONCE_URI}/api/auth/siwe/verify`);
+  });
+
+  test("requests the default chainId=1 nonce and posts origin + JSON verify", async () => {
+    const calls = installSiweFetch();
+    await loginWithTestWallet(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.url).toBe(`${NONCE_URI}/api/auth/siwe/nonce?chainId=1`);
+    expect(calls[0]?.headers.accept).toBe("application/json");
+
+    expect(calls[1]?.method).toBe("POST");
+    expect(calls[1]?.headers["content-type"]).toBe("application/json");
+    expect(calls[1]?.headers.origin).toBe(NONCE_URI);
+    const posted = JSON.parse(calls[1]?.body ?? "{}") as {
+      message: string;
+      signature: string;
+    };
+    expect(posted.message).toContain(HARDHAT_ACCOUNT1_ADDRESS);
+    expect(posted.signature).toMatch(/^0x[0-9a-fA-F]+$/);
+  });
+
+  test("throws on a failed nonce request and never hits verify", async () => {
+    const calls = installSiweFetch({ nonceStatus: 503, nonceText: "warming" });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE nonce request failed: 503 warming/,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toContain("/api/auth/siwe/nonce");
+  });
+
+  test("throws on a rejected signature and does not return a dead key", async () => {
+    installSiweFetch({ tamper: true });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE verify failed: 401/,
+    );
+  });
+
+  test("throws on a non-OK verify status", async () => {
+    installSiweFetch({ verifyStatus: 500 });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE verify failed: 500 verify unavailable/,
+    );
+  });
+
+  test("throws when verify omits apiKey, user id, or organization id", async () => {
+    installSiweFetch({
+      verifyBody: {
+        apiKey: "",
+        address: HARDHAT_ACCOUNT1_ADDRESS,
+        isNewAccount: true,
+        user: { id: SESSION_USER_ID, organization_id: SESSION_ORG_ID },
+      },
+    });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE verify returned an incomplete session/,
+    );
+
+    installSiweFetch({
+      verifyBody: {
+        apiKey: SESSION_API_KEY,
+        address: HARDHAT_ACCOUNT1_ADDRESS,
+        isNewAccount: true,
+        user: { organization_id: SESSION_ORG_ID },
+      },
+    });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE verify returned an incomplete session/,
+    );
+
+    installSiweFetch({
+      verifyBody: {
+        apiKey: SESSION_API_KEY,
+        address: HARDHAT_ACCOUNT1_ADDRESS,
+        isNewAccount: true,
+        user: { id: SESSION_USER_ID },
+      },
+    });
+    await expect(loginWithTestWallet(NONCE_URI)).rejects.toThrow(
+      /SIWE verify returned an incomplete session/,
+    );
+  });
+});
+
+describe("loginAsSeededUser", () => {
+  test("returns an elevated SeededUser from the real SIWE session", async () => {
+    installSiweFetch();
+    const seeded = await loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    const normalized = HARDHAT_ACCOUNT1_ADDRESS.toLowerCase();
+
+    expect(seeded).toEqual({
+      userId: SESSION_USER_ID,
+      organizationId: SESSION_ORG_ID,
+      stewardUserId: `wallet:evm:${normalized}`,
+      email: `${normalized}@e2e.test`,
+      apiKey: SESSION_API_KEY,
+    });
+  });
+
+  test("uses wallet:evm: steward ids, not the asSeededUser wallet- prefix", async () => {
+    installSiweFetch();
+    const loginShaped = asSeededUser(sessionLogin());
+    const elevated = await loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    expect(loginShaped.stewardUserId.startsWith("wallet-")).toBe(true);
+    expect(elevated.stewardUserId.startsWith("wallet:evm:")).toBe(true);
+    expect(elevated.stewardUserId).not.toBe(loginShaped.stewardUserId);
+    expect(elevated.email).not.toBe(loginShaped.email);
+  });
+
+  test("elevates the user to admin with a verified address-derived email and name", async () => {
+    installSiweFetch();
+    await loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    const normalized = HARDHAT_ACCOUNT1_ADDRESS.toLowerCase();
+
+    expect(userUpdates).toEqual([
+      {
+        id: SESSION_USER_ID,
+        data: {
+          email: `${normalized}@e2e.test`,
+          email_verified: true,
+          name: `wallet-${normalized.slice(2, 10)}`,
+          role: "admin",
+        },
+      },
+    ]);
+    expect(userUpdates[0]?.data.name).toBe("wallet-70997970");
+  });
+
+  test("funds the org at 1000.000000 and copies billing_email from the user", async () => {
+    installSiweFetch();
+    await loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    const normalized = HARDHAT_ACCOUNT1_ADDRESS.toLowerCase();
+
+    expect(orgUpdates).toEqual([
+      {
+        id: SESSION_ORG_ID,
+        data: {
+          credit_balance: "1000.000000",
+          billing_email: `${normalized}@e2e.test`,
+        },
+      },
+    ]);
+  });
+
+  test("writes the user row before the organization row", async () => {
+    const order: string[] = [];
+    userUpdateImpl = async (id, data) => {
+      order.push("user");
+      userUpdates.push({ id, data });
+      return { id, ...data };
+    };
+    orgUpdateImpl = async (id, data) => {
+      order.push("org");
+      orgUpdates.push({ id, data });
+      return { id, ...data };
+    };
+    installSiweFetch();
+    await loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY);
+    expect(order).toEqual(["user", "org"]);
+  });
+
+  test("does not write repositories when SIWE verify fails", async () => {
+    installSiweFetch({ tamper: true });
+    await expect(loginAsSeededUser(NONCE_URI)).rejects.toThrow(
+      /SIWE verify failed/,
+    );
+    expect(userUpdates).toEqual([]);
+    expect(orgUpdates).toEqual([]);
+  });
+
+  test("does not write the org when user elevation throws", async () => {
+    userUpdateImpl = async () => {
+      throw new Error("user update failed");
+    };
+    installSiweFetch();
+    await expect(
+      loginAsSeededUser(NONCE_URI, HARDHAT_ACCOUNT1_KEY),
+    ).rejects.toThrow("user update failed");
+    expect(orgUpdates).toEqual([]);
+  });
+
+  test("omitting the private key still elevates the minted wallet account", async () => {
+    installSiweFetch();
+    const seeded = await loginAsSeededUser(NONCE_URI);
+    expect(seeded.userId).toBe(SESSION_USER_ID);
+    expect(seeded.organizationId).toBe(SESSION_ORG_ID);
+    expect(seeded.email).toMatch(/^0x[0-9a-f]{40}@e2e\.test$/);
+    expect(seeded.stewardUserId).toMatch(/^wallet:evm:0x[0-9a-f]{40}$/);
+    expect(userUpdates).toHaveLength(1);
+    expect(orgUpdates).toHaveLength(1);
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. `packages/cloud/e2e/src/helpers/wallet-login.ts` had no same-named test file on `origin/develop`. This PR adds that coverage only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`095c7a4c0163bc24f6c9f71699c518bda5664813`) with a single test-file commit on top.
- [ ] `bun install` and `bun run verify` were not run for this test-only change. Focused evidence is quoted below.
- [x] A reviewer can confirm the change from the quoted `bun test`, biome, and tsc results without reading the production helper.

# Sync with develop

- [x] Branch parent is `origin/develop` at `095c7a4c0163bc24f6c9f71699c518bda5664813`; one file, zero conflicts.
- [ ] `bun run verify` not run; this diff adds tests and changes no production behaviour.

# Risks

Low. Test-only addition. No production code, no API, no schema, no prompt, no UI.

# Background

## What does this PR do?

Adds `packages/cloud/e2e/src/helpers/wallet-login.test.ts`, a `bun:test` suite for the three runtime helpers in `wallet-login.ts`:

- `loginWithTestWallet` — real SIWE handshake (nonce → viem sign → verify) through a fetch shim that runs `validateSIWEMessage`; covers omitted vs supplied private key, trailing-slash baseUrl, default `chainId=1`, nonce/verify/incomplete-session failures.
- `asSeededUser` — observed mapping: empty email, `stewardUserId` = `wallet-` + lowercased address; does not copy `address` / `isNewAccount` / `privateKey`. Mixed-case, already-lowercase, empty, and missing address.
- `loginAsSeededUser` — same handshake plus the privileged elevation the helper actually writes: admin + verified `${address}@e2e.test`, name `wallet-` + first 8 hex chars, org `credit_balance` `1000.000000`, and `stewardUserId` `wallet:evm:${address}` (not the `wallet-` prefix `asSeededUser` uses). User row is written before org; SIWE or user-update failure skips the later write.

The helper has no queue, comparator, capacity, or item-removal API; the suite records that.

## What kind of change is this?

Improvements — tests for existing helpers. No production behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/e2e/src/helpers/wallet-login.test.ts`. The package Playwright lane matches only `tests/`; this file is collected by `bun test`, matching the committed sibling `shared-runtime.test.ts`.

## Detailed testing steps

Re-run on the PR head:

```bash
bun test packages/cloud/e2e/src/helpers/wallet-login.test.ts
```

Observed on current `origin/develop` immediately before filing (helper source unchanged vs this parent):

```
bun test v1.3.14 (0d9b296a)
 26 pass
 0 fail
 72 expect() calls
Ran 26 tests across 1 file. [300.00ms]
 packages/cloud/e2e/src/helpers/wallet-login.ts        |  100.00 |  100.00 |
```

Biome (config present at repo-root `biome.json`; worktree is not sparse):

```
bunx biome check --write packages/cloud/e2e/src/helpers/wallet-login.test.ts
Checked 1 file in 22ms. Fixed 1 file.
```

Re-check after the write was clean (the one fix was formatting of the new file). The quoted suite above is the post-biome run.

`bunx tsc --noEmit` in `packages/cloud/e2e`: this test file appears **nowhere** in the output (`grep wallet-login.test.ts` empty, grep exit 1). Pre-existing errors in cloud-shared / ui / plugins are unrelated.

This is a fork PR (`ss251/eliza` → `elizaOS/eliza`). Hosted CI does **not** run on our PRs. Do not read a missing check as a pass.

# Evidence Gate

Evidence head: `302936dc0171ebd0099070cbe7f268d61f247103`

The diff touches **only** `packages/cloud/e2e/src/helpers/wallet-login.test.ts`.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no user flow to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production path changed; bun test output is quoted in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/wallet/on-chain production write; repository updates are captured in-process at the test boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only; bun test output quoted above.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no UI.

### After

N/A - test-only change; no UI.

### Walkthrough video

N/A - test-only change; no UI.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scope is one new test file; package `tsc --noEmit` has pre-existing errors in other packages that do not mention this file.
- Hosted GitHub Actions CI does not run on fork PRs from `ss251`. Reviewers should run `bun test packages/cloud/e2e/src/helpers/wallet-login.test.ts` locally.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:302936dc0171ebd0099070cbe7f268d61f247103 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
