### PR TITLE
test(shared): cover update-status

### DIFF
--- a/packages/shared/src/contracts/update-status.test.ts
+++ b/packages/shared/src/contracts/update-status.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for agent self-update status contracts and Zod schemas.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  AgentInstallMethodSchema,
+  AgentUpdateAuthoritySchema,
+  AgentUpdateNextActionSchema,
+  AgentUpdateStatusSchema,
+  ReleaseChannelSchema,
+} from "./update-status.js";
+
+describe("ReleaseChannelSchema", () => {
+  it("accepts valid release channels", () => {
+    expect(ReleaseChannelSchema.parse("stable")).toBe("stable");
+    expect(ReleaseChannelSchema.parse("beta")).toBe("beta");
+    expect(ReleaseChannelSchema.parse("nightly")).toBe("nightly");
+  });
+
+  it("rejects invalid release channels", () => {
+    expect(() => ReleaseChannelSchema.parse("alpha")).toThrow();
+    expect(() => ReleaseChannelSchema.parse("")).toThrow();
+    expect(() => ReleaseChannelSchema.parse(null)).toThrow();
+    expect(() => ReleaseChannelSchema.parse(123)).toThrow();
+  });
+});
+
+describe("AgentInstallMethodSchema", () => {
+  it("accepts known install methods", () => {
+    const methods = [
+      "npm-global",
+      "bun-global",
+      "homebrew",
+      "snap",
+      "apt",
+      "flatpak",
+      "local-dev",
+      "unknown",
+    ] as const;
+
+    for (const method of methods) {
+      expect(AgentInstallMethodSchema.parse(method)).toBe(method);
+    }
+  });
+
+  it("rejects unknown install methods in the strict enum schema", () => {
+    expect(() => AgentInstallMethodSchema.parse("cargo")).toThrow();
+    expect(() => AgentInstallMethodSchema.parse("")).toThrow();
+    expect(() => AgentInstallMethodSchema.parse(undefined)).toThrow();
+  });
+});
+
+describe("AgentUpdateAuthoritySchema", () => {
+  it("accepts valid update authorities", () => {
+    const authorities = [
+      "package-manager",
+      "os-package-manager",
+      "developer",
+      "operator",
+    ] as const;
+
+    for (const auth of authorities) {
+      expect(AgentUpdateAuthoritySchema.parse(auth)).toBe(auth);
+    }
+  });
+
+  it("rejects invalid update authorities", () => {
+    expect(() => AgentUpdateAuthoritySchema.parse("root")).toThrow();
+    expect(() => AgentUpdateAuthoritySchema.parse("admin")).toThrow();
+  });
+});
+
+describe("AgentUpdateNextActionSchema", () => {
+  it("accepts valid next actions", () => {
+    const actions = [
+      "run-package-manager-command",
+      "run-git-pull",
+      "review-installation",
+      "none",
+    ] as const;
+
+    for (const action of actions) {
+      expect(AgentUpdateNextActionSchema.parse(action)).toBe(action);
+    }
+  });
+
+  it("rejects invalid next actions", () => {
+    expect(() => AgentUpdateNextActionSchema.parse("restart")).toThrow();
+  });
+});
+
+describe("AgentUpdateStatusSchema", () => {
+  const validStatus = {
+    currentVersion: "1.0.0",
+    channel: "stable" as const,
+    installMethod: "bun-global" as const,
+    updateAuthority: "package-manager" as const,
+    nextAction: "run-package-manager-command" as const,
+    canAutoUpdate: true,
+    canExecuteUpdate: false,
+    remoteDisplay: true,
+    updateCommand: "bun update -g @elizaos/agent",
+    updateInstructions: "Run the update command in your terminal",
+    updateAvailable: true,
+    latestVersion: "1.1.0",
+    channels: {
+      stable: "1.1.0",
+      beta: "1.2.0-beta.1",
+      nightly: null,
+    },
+    distTags: {
+      stable: "1.1.0",
+      beta: "1.2.0-beta.1",
+      nightly: "1.3.0-nightly.20260823",
+    },
+    lastCheckAt: "2026-08-23T12:00:00.000Z",
+    error: null,
+  };
+
+  it("parses a complete valid status object", () => {
+    const result = AgentUpdateStatusSchema.parse(validStatus);
+    expect(result.currentVersion).toBe("1.0.0");
+    expect(result.channel).toBe("stable");
+    expect(result.updateAvailable).toBe(true);
+    expect(result.latestVersion).toBe("1.1.0");
+    expect(result.channels.stable).toBe("1.1.0");
+    expect(result.channels.nightly).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it("allows string installMethod extensions in AgentUpdateStatusSchema", () => {
+    const customMethod = {
+      ...validStatus,
+      installMethod: "docker-container",
+    };
+    const result = AgentUpdateStatusSchema.parse(customMethod);
+    expect(result.installMethod).toBe("docker-container");
+  });
+
+  it("allows optional fields to be omitted", () => {
+    const minimalStatus = {
+      currentVersion: "1.0.0",
+      channel: "beta" as const,
+      installMethod: "local-dev" as const,
+      updateAvailable: false,
+      latestVersion: null,
+      channels: {
+        stable: "1.0.0",
+        beta: "1.0.0",
+        nightly: "1.0.0",
+      },
+      distTags: {
+        stable: "1.0.0",
+        beta: "1.0.0",
+        nightly: "1.0.0",
+      },
+      lastCheckAt: null,
+      error: "Network timeout during check",
+    };
+    const result = AgentUpdateStatusSchema.parse(minimalStatus);
+    expect(result.updateAuthority).toBeUndefined();
+    expect(result.nextAction).toBeUndefined();
+    expect(result.canAutoUpdate).toBeUndefined();
+    expect(result.updateCommand).toBeUndefined();
+    expect(result.error).toBe("Network timeout during check");
+  });
+
+  it("strictly rejects extraneous unexpected properties", () => {
+    const withExtra = {
+      ...validStatus,
+      unexpectedField: "malicious",
+    };
+    expect(() => AgentUpdateStatusSchema.parse(withExtra)).toThrow();
+  });
+
+  it("rejects missing required fields", () => {
+    const { currentVersion, ...missingVersion } = validStatus;
+    expect(() => AgentUpdateStatusSchema.parse(missingVersion)).toThrow();
+
+    const { updateAvailable, ...missingAvailable } = validStatus;
+    expect(() => AgentUpdateStatusSchema.parse(missingAvailable)).toThrow();
+
+    const { channels, ...missingChannels } = validStatus;
+    expect(() => AgentUpdateStatusSchema.parse(missingChannels)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/contracts/update-status.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `ReleaseChannelSchema`: parsing "stable", "beta", "nightly" and rejecting invalid values.
- `AgentInstallMethodSchema`: parsing all known install methods and rejecting invalid enum entries.
- `AgentUpdateAuthoritySchema`: parsing valid update authorities ("package-manager", "os-package-manager", "developer", "operator") and rejecting invalid values.
- `AgentUpdateNextActionSchema`: validating all valid next actions and rejecting unrecognized actions.
- `AgentUpdateStatusSchema`: validating complete status payloads, optional fields, string extension for installMethod, strict rejection of unrecognized properties, and required property constraints.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`e6e08131ca`) |
| --- | --- | --- |
| `bunx vitest run packages/shared/src/contracts/update-status.test.ts` | N/A (new test file) | 13 passed (13 tests) |
| `bunx @biomejs/biome check packages/shared/src/contracts/update-status.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/contracts/update-status.test.ts:1-187`

## Risks

Low. Test-only contribution with no changes to production code or contracts.

## Attribution

Authored by @byt61.

<!-- evidence-head:e6e08131ca7e1b39de16cf8d1bdfe7b43bdd9c18 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested