### PR TITLE
test(cloud): cover blooio

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Exercises Blooio adapter exports — media allowlisting, webhook parse
+ * branches, signature checks, and v2/v4 outbound routing — against the real
+ * module with a deterministic stubbed provider fetch.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import {
+  ALLOWED_MEDIA_DOMAINS,
+  BLOOIO_REQUEST_TIMEOUT_MS,
+  BlooioApiResponseError,
+  BlooioConfigurationError,
+  blooioAdapter,
+  blooioFetch,
+  isValidMediaUrl,
+} from "./blooio";
+import {
+  type ChatEvent,
+  PlatformDeliveryError,
+  type WebhookConfig,
+} from "./types";
+
+const SECRET = "whsec_test_secret";
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function sign(rawBody: string, secret: string, ageSeconds = 0): string {
+  const timestamp = Math.floor(Date.now() / 1000) - ageSeconds;
+  const hmac = crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest("hex");
+  return `t=${timestamp},v1=${hmac}`;
+}
+
+function signedRequest(header: string | null): Request {
+  const headers = new Headers();
+  if (header !== null) headers.set("x-blooio-signature", header);
+  return new Request("https://gateway.example/webhook/eliza-app/blooio", {
+    method: "POST",
+    headers,
+  });
+}
+
+function config(overrides: Partial<WebhookConfig> = {}): WebhookConfig {
+  return {
+    apiKey: "bl_live_test",
+    blooioWebhookSecret: SECRET,
+    fromNumber: "+15550001111",
+    ...overrides,
+  };
+}
+
+function chatEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
+  return {
+    platform: "blooio",
+    messageId: "msg_abc123",
+    chatId: "+15551234567",
+    senderId: "+15551234567",
+    text: "hey eliza",
+    rawPayload: {},
+    ...overrides,
+  };
+}
+
+function v2Payload(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    event: "message.received",
+    message_id: "msg_abc123",
+    sender: "+15551234567",
+    text: "hey eliza",
+    protocol: "imessage",
+    is_group: false,
+    ...overrides,
+  });
+}
+
+function v4Payload(
+  dataOverrides: Record<string, unknown> = {},
+  envelopeOverrides: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    id: "evt_abc123",
+    type: "message.received",
+    created_at: 1_786_244_262_331,
+    ...envelopeOverrides,
+    data: {
+      id: "msg_v4_abc123",
+      chat_id: "chat_abc123",
+      channel_id: "ch_abc123",
+      channel_type: "blooio",
+      sender: "+15551234567",
+      recipient: "+15550001111",
+      text: "hey from v4",
+      protocol: "imessage",
+      is_group: false,
+      attachments: [],
+      ...dataOverrides,
+    },
+  });
+}
+
+function stubFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) =>
+    handler(String(input), init ?? {})) as typeof fetch;
+}
+
+describe("blooio exported constants and helpers", () => {
+  test("pins the owned hop timeout", () => {
+    expect(BLOOIO_REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+
+  test("pins the runtime-local media domain allowlist", () => {
+    expect([...ALLOWED_MEDIA_DOMAINS]).toEqual([
+      "blooio.com",
+      "backend.blooio.com",
+      "api.blooio.com",
+      "media.blooio.com",
+    ]);
+  });
+
+  test("identifies the adapter platform", () => {
+    expect(blooioAdapter.platform).toBe("blooio");
+  });
+
+  test("rejects a non-positive blooioFetch timeout before dispatch", async () => {
+    let called = false;
+    stubFetch(async () => {
+      called = true;
+      return new Response("{}", { status: 200 });
+    });
+
+    await expect(
+      blooioFetch("https://api.blooio.com/v4/messages", undefined, 0),
+    ).rejects.toThrow(/timer-safe positive integers/);
+    expect(called).toBe(false);
+  });
+
+  test("returns the provider response for a successful blooioFetch hop", async () => {
+    stubFetch(async (url, init) => {
+      expect(url).toBe("https://api.blooio.com/v4/messages");
+      expect(init.method).toBe("POST");
+      return new Response("hop-ok", { status: 200 });
+    });
+
+    const response = await blooioFetch("https://api.blooio.com/v4/messages", {
+      method: "POST",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hop-ok");
+  });
+});
+
+describe("isValidMediaUrl", () => {
+  test("accepts https URLs on allowlisted hosts and their subdomains", () => {
+    expect(isValidMediaUrl("https://blooio.com/a.gif")).toBe(true);
+    expect(isValidMediaUrl("https://cdn.blooio.com/a.gif")).toBe(true);
+    expect(isValidMediaUrl("https://backend.blooio.com/a.png")).toBe(true);
+    expect(isValidMediaUrl("https://cdn.backend.blooio.com/a.png")).toBe(true);
+    expect(isValidMediaUrl("https://api.blooio.com/v4/files/a.heic")).toBe(
+      true,
+    );
+    expect(isValidMediaUrl("https://media.blooio.com/files/a.jpg")).toBe(true);
+    expect(isValidMediaUrl("https://cdn.media.blooio.com/files/a.jpg")).toBe(
+      true,
+    );
+  });
+
+  test("lowercases the hostname before matching", () => {
+    expect(isValidMediaUrl("https://MEDIA.BLOOIO.COM/files/a.jpg")).toBe(true);
+  });
+
+  test("rejects http, foreign hosts, suffix spoofs, and unparseable input", () => {
+    expect(isValidMediaUrl("http://media.blooio.com/a.jpg")).toBe(false);
+    expect(isValidMediaUrl("ftp://media.blooio.com/a.jpg")).toBe(false);
+    expect(isValidMediaUrl("https://notblooio.com/a.jpg")).toBe(false);
+    expect(isValidMediaUrl("https://evilblooio.com/a.jpg")).toBe(false);
+    expect(isValidMediaUrl("https://blooio.com.evil.com/a.jpg")).toBe(false);
+    expect(isValidMediaUrl("https://media.blooio.com.evil.com/a.jpg")).toBe(
+      false,
+    );
+    expect(isValidMediaUrl("not a url")).toBe(false);
+    expect(isValidMediaUrl("")).toBe(false);
+  });
+});
+
+describe("BlooioApiResponseError", () => {
+  test("marks 5xx provider rejections uncertain and not retryable", () => {
+    const error = new BlooioApiResponseError(
+      503,
+      "Blooio rejected delivery (503)",
+    );
+    expect(error).toBeInstanceOf(PlatformDeliveryError);
+    expect(error.name).toBe("BlooioApiResponseError");
+    expect(error).toMatchObject({
+      status: 503,
+      deliveryStatus: "uncertain",
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: false,
+      providerStatus: 503,
+    });
+  });
+
+  test("marks a 429 retryable and other 4xx as failed", () => {
+    expect(new BlooioApiResponseError(429, "limited")).toMatchObject({
+      deliveryStatus: "failed",
+      retryable: true,
+      providerStatus: 429,
+    });
+    expect(new BlooioApiResponseError(400, "bad")).toMatchObject({
+      deliveryStatus: "failed",
+      retryable: false,
+      providerStatus: 400,
+    });
+  });
+});
+
+describe("BlooioConfigurationError", () => {
+  test("records the missing account sender for a legacy group chat", () => {
+    const error = new BlooioConfigurationError("grp_legacy_123");
+    expect(error).toBeInstanceOf(PlatformDeliveryError);
+    expect(error.name).toBe("BlooioConfigurationError");
+    expect(error.message).toBe(
+      "Missing fromNumber for Blooio legacy group reply",
+    );
+    expect(error).toMatchObject({
+      deliveryStatus: "failed",
+      code: "BLOOIO_LEGACY_GROUP_FROM_NUMBER_MISSING",
+      retryable: false,
+      context: {
+        setting: "fromNumber",
+        chatId: "grp_legacy_123",
+      },
+    });
+  });
+});
+
+describe("blooioAdapter.verifyWebhook", () => {
+  test("accepts a header that still contains t= and v1= among extra parts", async () => {
+    const body = v2Payload();
+    const [timestampPart, signaturePart] = sign(body, SECRET).split(",");
+    const ok = await blooioAdapter.verifyWebhook(
+      signedRequest(`${timestampPart},extra=1,${signaturePart}`),
+      body,
+      config(),
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("rejects a header whose v1= part is padded with a leading space", async () => {
+    const body = v2Payload();
+    const [timestampPart, signaturePart] = sign(body, SECRET).split(",");
+    const ok = await blooioAdapter.verifyWebhook(
+      signedRequest(`${timestampPart}, ${signaturePart}`),
+      body,
+      config(),
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("rejects a correctly timestamped signature of the wrong length", async () => {
+    const body = v2Payload();
+    const header = sign(body, SECRET);
+    const ok = await blooioAdapter.verifyWebhook(
+      signedRequest(`${header}00`),
+      body,
+      config(),
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("rejects when the configured webhook secret is an empty string", async () => {
+    const body = v2Payload();
+    const ok = await blooioAdapter.verifyWebhook(
+      signedRequest(sign(body, SECRET)),
+      body,
+      config({ blooioWebhookSecret: "" }),
+    );
+    expect(ok).toBe(false);
+  });
+});
+
+describe("blooioAdapter.extractEvent", () => {
+  test("infers a legacy group from a grp_ chat id when is_group is omitted", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({
+        chat_id: "GRP_legacy_123",
+        is_group: undefined,
+        external_id: "+15551234567",
+        internal_id: "+15550001111",
+        sender: undefined,
+      }),
+    );
+    expect(event).toMatchObject({
+      chatId: "GRP_legacy_123",
+      chatType: "group",
+      senderId: "+15551234567",
+      channelId: "+15550001111",
+    });
+  });
+
+  test("uses a v4 message id when message_id is absent", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4Payload({ message_id: undefined, id: "msg_from_id" }),
+    );
+    expect(event?.messageId).toBe("msg_from_id");
+  });
+
+  test("infers a v4 group from a present group object when is_group is omitted", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4Payload({ is_group: undefined, group: { group_id: "grp_1" } }),
+    );
+    expect(event?.chatType).toBe("group");
+  });
+
+  test("prefers received_at over timestamp and converts epoch seconds", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({ received_at: 1_786_244_262, timestamp: 99 }),
+    );
+    expect(event?.providerSentAtMs).toBe(1_786_244_262_000);
+  });
+
+  test("omits providerSentAtMs for non-positive timestamps", async () => {
+    expect(
+      (await blooioAdapter.extractEvent(v2Payload({ timestamp: 0 })))
+        ?.providerSentAtMs,
+    ).toBeUndefined();
+    expect(
+      (await blooioAdapter.extractEvent(v2Payload({ timestamp: -5 })))
+        ?.providerSentAtMs,
+    ).toBeUndefined();
+  });
+
+  test("omits providerSentAtMs when the converted instant is not a safe integer", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({ timestamp: 9_100_000_000_000_000 }),
+    );
+    expect(event?.providerSentAtMs).toBeUndefined();
+  });
+
+  test("treats an exact 1e11 timestamp as milliseconds, not seconds", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({ timestamp: 100_000_000_000 }),
+    );
+    expect(event?.providerSentAtMs).toBe(100_000_000_000);
+  });
+
+  test("accepts raw string attachments and keeps existing text", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({
+        attachments: [
+          "https://media.blooio.com/files/photo.jpg",
+          "https://evil.example/steal.jpg",
+        ],
+      }),
+    );
+    expect(event?.text).toBe("hey eliza");
+    expect(event?.mediaUrls).toEqual([
+      "https://media.blooio.com/files/photo.jpg",
+    ]);
+  });
+
+  test("synthesizes text from allowlisted media when the body is empty", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({
+        text: "",
+        attachments: [
+          { url: "https://media.blooio.com/a.jpg", name: "a" },
+          { url: "https://api.blooio.com/b.png", name: "b" },
+        ],
+      }),
+    );
+    expect(event?.text).toBe(
+      "[media: https://media.blooio.com/a.jpg, https://api.blooio.com/b.png]",
+    );
+    expect(event?.mediaUrls).toEqual([
+      "https://media.blooio.com/a.jpg",
+      "https://api.blooio.com/b.png",
+    ]);
+  });
+
+  test("still emits an event when attachments exist but every URL is rejected", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({
+        text: "",
+        attachments: [{ url: "https://evil.example/steal.jpg" }],
+      }),
+    );
+    expect(event).toMatchObject({
+      messageId: "msg_abc123",
+      senderId: "+15551234567",
+      text: "",
+    });
+    expect(event?.mediaUrls).toBeUndefined();
+  });
+
+  test("skips a delivery whose only sender candidate is whitespace", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v2Payload({ sender: undefined, external_id: "   " }),
+    );
+    expect(event).toBeNull();
+  });
+
+  test("skips a v4 envelope that is not message.received", async () => {
+    const event = await blooioAdapter.extractEvent(
+      v4Payload({}, { type: "message.delivered" }),
+    );
+    expect(event).toBeNull();
+  });
+});
+
+describe("blooioAdapter.sendReply", () => {
+  test("POSTs a case-insensitive chat_ id to the encoded v4 chat resource", async () => {
+    const captured: Array<{ url: string; body: unknown }> = [];
+    stubFetch(async (url, init) => {
+      captured.push({ url, body: JSON.parse(String(init.body)) });
+      return Response.json({ id: "out_1" });
+    });
+
+    await blooioAdapter.sendReply(
+      config(),
+      chatEvent({ chatId: "CHAT_a/b" }),
+      "hello",
+    );
+
+    expect(captured).toEqual([
+      {
+        url: "https://api.blooio.com/v4/chats/CHAT_a%2Fb/messages",
+        body: { text: "hello" },
+      },
+    ]);
+  });
+
+  test("encodes a legacy grp_ chat id on the v2 messages path", async () => {
+    const captured: Array<{ url: string; body: unknown }> = [];
+    stubFetch(async (url, init) => {
+      captured.push({ url, body: JSON.parse(String(init.body)) });
+      return Response.json({ message_id: "out_legacy" });
+    });
+
+    await blooioAdapter.sendReply(
+      config(),
+      chatEvent({ chatId: "grp_a/b", chatType: "group" }),
+      "hello group",
+    );
+
+    expect(captured).toEqual([
+      {
+        url: "https://api.blooio.com/v2/api/chats/grp_a%2Fb/messages",
+        body: { text: "hello group", from_number: "+15550001111" },
+      },
+    ]);
+  });
+
+  test("prefers the provider id field and trims the receipt", async () => {
+    stubFetch(async () =>
+      Response.json({ id: "  out_id  ", message_id: "out_message" }),
+    );
+
+    await expect(
+      blooioAdapter.sendReplyWithReceipt?.(
+        config(),
+        chatEvent(),
+        "remember this",
+      ),
+    ).resolves.toEqual({ providerMessageIds: ["out_id"] });
+  });
+
+  test("uses message_id when id is not a string", async () => {
+    stubFetch(async () => Response.json({ id: 17, message_id: "out_msg" }));
+
+    await expect(
+      blooioAdapter.sendReplyWithReceipt?.(config(), chatEvent(), "hi"),
+    ).resolves.toEqual({ providerMessageIds: ["out_msg"] });
+  });
+
+  test("keeps a 5xx rejection uncertain", async () => {
+    stubFetch(async () => new Response("upstream", { status: 503 }));
+
+    await expect(
+      blooioAdapter.sendReply(config(), chatEvent(), "hi"),
+    ).rejects.toMatchObject({
+      name: "BlooioApiResponseError",
+      deliveryStatus: "uncertain",
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: false,
+      providerStatus: 503,
+    });
+  });
+
+  test("rejects whitespace-only and non-object receipts as uncertain", async () => {
+    for (const body of ["   ", "[]", "42", "not-json"]) {
+      stubFetch(async () => new Response(body, { status: 200 }));
+      await expect(
+        blooioAdapter.sendReplyWithReceipt?.(config(), chatEvent(), "hi"),
+      ).rejects.toMatchObject({
+        deliveryStatus: "uncertain",
+        code: "DELIVERY_RECEIPT_INVALID",
+        retryable: false,
+      });
+    }
+  });
+});
+
+describe("blooioAdapter typing indicators", () => {
+  test("posts a v2 read receipt with X-From-Number and encoded chat id", async () => {
+    const captured: Array<{
+      url: string;
+      method: string;
+      headers: Headers;
+    }> = [];
+    stubFetch(async (url, init) => {
+      captured.push({
+        url,
+        method: init.method ?? "GET",
+        headers: new Headers(init.headers),
+      });
+      return new Response(null, { status: 200 });
+    });
+
+    await blooioAdapter.sendTypingIndicator(
+      config(),
+      chatEvent({ chatId: "+15551234567" }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.url).toBe(
+      "https://api.blooio.com/v2/api/chats/%2B15551234567/read",
+    );
+    expect(captured[0]?.method).toBe("POST");
+    expect(captured[0]?.headers.get("Authorization")).toBe(
+      "Bearer bl_live_test",
+    );
+    expect(captured[0]?.headers.get("X-From-Number")).toBe("+15550001111");
+  });
+
+  test("omits X-From-Number on the v2 read path when fromNumber is missing", async () => {
+    const capturedHeaders: Headers[] = [];
+    stubFetch(async (_url, init) => {
+      capturedHeaders.push(new Headers(init.headers));
+      return new Response(null, { status: 200 });
+    });
+
+    await blooioAdapter.sendTypingIndicator(
+      config({ fromNumber: undefined }),
+      chatEvent({ chatId: "grp_legacy_123" }),
+    );
+
+    expect(capturedHeaders).toHaveLength(1);
+    expect(capturedHeaders[0]?.has("X-From-Number")).toBe(false);
+  });
+
+  test("swallows a rejected v2 read receipt", async () => {
+    stubFetch(async () => new Response("nope", { status: 500 }));
+
+    await expect(
+      blooioAdapter.sendTypingIndicator(config(), chatEvent()),
+    ).resolves.toBeUndefined();
+  });
+
+  test("swallows a rejected v4 typing hop when the paired read succeeded", async () => {
+    stubFetch(async (url) => {
+      if (url.endsWith("/read")) return new Response(null, { status: 200 });
+      return new Response("busy", { status: 429 });
+    });
+
+    await expect(
+      blooioAdapter.sendTypingIndicator(
+        config(),
+        chatEvent({ chatId: "chat_group_123" }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not stop typing without an api key or a v4 chat id", async () => {
+    let called = false;
+    stubFetch(async () => {
+      called = true;
+      return new Response(null, { status: 200 });
+    });
+
+    await blooioAdapter.stopTypingIndicator?.(
+      config({ apiKey: undefined }),
+      chatEvent({ chatId: "chat_abc123" }),
+    );
+    await blooioAdapter.stopTypingIndicator?.(
+      config(),
+      chatEvent({ chatId: "grp_legacy_123" }),
+    );
+    expect(called).toBe(false);
+  });
+
+  test("swallows a rejected stop-typing request", async () => {
+    stubFetch(async () => new Response("nope", { status: 500 }));
+
+    await expect(
+      blooioAdapter.stopTypingIndicator?.(
+        config(),
+        chatEvent({ chatId: "chat_abc123" }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION

# Relates to

Test-coverage addition for `packages/cloud/services/gateway-webhook/src/adapters/blooio.ts`, which had no same-named unit test file. No product issue; this is a test-only PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop` (`3563aec86aa05ccd62686008e496d1ee2da6cc30`) with a single added test file and zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — **not run**. This is a test-only change; the scoped bar below (`bun test`, biome, package tsc grep) is the evidence set. We are a fork contributor: hosted CI does **not** run on this PR.
- [x] A reviewer can confirm the change works without reading the code, from the `bun test` counts quoted below.

# Sync with develop

- [x] Branch parent is `origin/develop` at `3563aec86aa05ccd62686008e496d1ee2da6cc30`; zero conflicts (new file only).
- [ ] `bun run verify` — not run; see Known gaps. Scoped checks:

This package's unit lane is `bun test` (`packages/cloud/services/gateway-webhook/package.json` `"test": "bun test"`), not vitest.

```
bun test packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts
  39 pass
  0 fail
  74 expect() calls
  Ran 39 tests across 1 file. [241.00ms]

bunx biome check --write packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts
  Checked 1 file in 108ms. No fixes applied.

cd packages/cloud/services/gateway-webhook && bunx tsc --noEmit 2>&1 | grep 'blooio.test.ts' ; echo "EXIT:$?"
  (empty)
  EXIT:1
  Pre-existing package errors elsewhere are unchanged; this file appears nowhere in tsc output.
```

Re-run against current `origin/develop` sources (`blooio.ts` sha `a3a225d7c79900743568f872cabdc5fbd2c14f18`) immediately before filing: the same 39 cases passed.

# Risks

Low. Adds one `bun:test` file next to the adapter. No production source, routes, types, or exports change. The suite drives the real module (`blooioAdapter`, `blooioFetch`, `isValidMediaUrl`, error classes, allowlist). `globalThis.fetch` is stubbed only at the provider HTTP edge, matching `twilio.test.ts`.

# Background

## What does this PR do?

Adds `packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts` covering every exported symbol and the adapter branches that were not pinned by a same-named file:

- `BLOOIO_REQUEST_TIMEOUT_MS`, `ALLOWED_MEDIA_DOMAINS`, `blooioAdapter.platform`
- `blooioFetch`: invalid timeout rejected before dispatch; successful hop returns the provider body
- `isValidMediaUrl`: allowlisted hosts and subdomains, hostname lowercasing, http/ftp, suffix spoofs, unparseable input
- `BlooioApiResponseError`: 5xx → `uncertain` / not retryable; 429 retryable; other 4xx failed
- `BlooioConfigurationError`: missing `fromNumber` for a legacy `grp_` chat, including `context.setting` / `context.chatId`
- `verifyWebhook`: extra header parts still accepted; leading space on `v1=` rejected; length-mismatched signature rejected; empty webhook secret rejected
- `extractEvent`: `grp_` infers group when `is_group` is omitted; v4 `id` used when `message_id` is absent; v4 `group` object infers group; `received_at` preferred over `timestamp` with epoch-seconds conversion; non-positive and unsafe-integer timestamps omitted; exact `1e11` treated as milliseconds; string attachments filtered; empty body synthesizes `[media: …]`; attachments that all fail the allowlist still emit an event with empty text (observed); whitespace-only sender skipped; non-`message.received` v4 envelopes skipped
- `sendReply` / `sendReplyWithReceipt`: case-insensitive `chat_` path with `encodeURIComponent`; legacy `grp_` v2 path; `id` preferred and trimmed over `message_id`; numeric `id` falls through to `message_id`; 5xx stays `uncertain`; whitespace / array / number / invalid JSON receipts are `DELIVERY_RECEIPT_INVALID`
- typing: v2 read receipt sends `X-From-Number` and encodes `+`; omitted when `fromNumber` is missing; rejected v2 read and v4 typing hops are swallowed; `stopTypingIndicator` no-ops without an API key or a v4 chat id and swallows provider rejection

Expectations match observed behaviour (for example, an inbound payload with attachments that are all rejected still produces a `ChatEvent` with empty `text` and no `mediaUrls`).

## What kind of change is this?

Improvements (test coverage only; no production behaviour change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts` (the only file in the diff).

## Detailed testing steps

```
bun test packages/cloud/services/gateway-webhook/src/adapters/blooio.test.ts
```

Observed on current `origin/develop` (`3563aec86aa05ccd62686008e496d1ee2da6cc30`) immediately before filing:

```
  39 pass
  0 fail
  Ran 39 tests across 1 file.
```

Hosted CI does not run on fork contributor PRs; do not infer a green Actions run.

# Evidence Gate

<!-- evidence-head:5b70d3930bf1471a340e3de51abab2a56a968db7 -->

Diff touches only a test file. Frontend/UI/video/LLM evidence does not apply.

- [x] Before full-page screenshots: `N/A - test-only, no UI surface`
- [x] After full-page screenshots: `N/A - test-only, no UI surface`
- [x] Walkthrough video: `N/A - test-only, no UI surface`
- [x] Backend logs: `N/A - no production path changed; bun test drives the adapter in-process`
- [x] Frontend console/network logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB, wallet, or scheduled-item change`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only adapter coverage; no HTTP service or UI.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. Scoped evidence is `bun test` (39 pass / 0 fail / 1 file), `bunx biome check --write` (clean), and `bunx tsc --noEmit` in `packages/cloud/services/gateway-webhook` with `blooio.test.ts` absent from the output.
- Hosted GitHub Actions CI does not run on this fork contributor PR.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
