### PR TITLE
test(vault): cover internal-utils

### DIFF
--- a/packages/vault/src/internal-utils.test.ts
+++ b/packages/vault/src/internal-utils.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for vault internal validation and surrogate-safe string utilities.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  assertKey,
+  optsCaller,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "./internal-utils.js";
+
+describe("assertKey", () => {
+  it("accepts valid keys up to 256 characters", () => {
+    expect(() => assertKey("api_key")).not.toThrow();
+    expect(() => assertKey("a")).not.toThrow();
+    expect(() => assertKey("a".repeat(256))).not.toThrow();
+  });
+
+  it("throws TypeError on non-string inputs", () => {
+    // @ts-expect-error test invalid input type
+    expect(() => assertKey(null)).toThrow(TypeError);
+    // @ts-expect-error test invalid input type
+    expect(() => assertKey(undefined)).toThrow(TypeError);
+    // @ts-expect-error test invalid input type
+    expect(() => assertKey(123)).toThrow(TypeError);
+    // @ts-expect-error test invalid input type
+    expect(() => assertKey({})).toThrow(TypeError);
+  });
+
+  it("throws TypeError on empty or whitespace-only keys", () => {
+    expect(() => assertKey("")).toThrow(TypeError);
+    expect(() => assertKey("   ")).toThrow(TypeError);
+    expect(() => assertKey("\t\n")).toThrow(TypeError);
+  });
+
+  it("throws TypeError on keys exceeding 256 characters", () => {
+    expect(() => assertKey("a".repeat(257))).toThrow(
+      "vault: key must be 256 characters or fewer",
+    );
+  });
+});
+
+describe("optsCaller", () => {
+  it("extracts caller when present in options", () => {
+    expect(optsCaller({ caller: "admin-service" })).toEqual({
+      caller: "admin-service",
+    });
+  });
+
+  it("returns empty object when caller is absent or empty", () => {
+    expect(optsCaller({})).toEqual({});
+    expect(optsCaller({ caller: undefined })).toEqual({});
+    expect(optsCaller({ caller: "" })).toEqual({});
+  });
+});
+
+describe("toWellFormedUnicode", () => {
+  it("preserves well-formed ASCII and Unicode text", () => {
+    expect(toWellFormedUnicode("hello world")).toBe("hello world");
+    expect(toWellFormedUnicode("caf\u00e9")).toBe("caf\u00e9");
+    expect(toWellFormedUnicode("\uD83D\uDE00")).toBe("\uD83D\uDE00");
+  });
+
+  it("sanitizes lone high or low surrogates", () => {
+    const loneHigh = "bad \uD800 char";
+    const loneLow = "bad \uDC00 char";
+
+    const wellFormedHigh = toWellFormedUnicode(loneHigh);
+    const wellFormedLow = toWellFormedUnicode(loneLow);
+
+    expect(wellFormedHigh).not.toContain("\uD800");
+    expect(wellFormedLow).not.toContain("\uDC00");
+  });
+});
+
+describe("truncateWellFormed", () => {
+  it("returns empty string for non-positive or non-finite maxLength", () => {
+    expect(truncateWellFormed("hello", 0)).toBe("");
+    expect(truncateWellFormed("hello", -5)).toBe("");
+    expect(truncateWellFormed("hello", Number.NaN)).toBe("");
+  });
+
+  it("returns original text when text length is within maxLength", () => {
+    expect(truncateWellFormed("short", 10)).toBe("short");
+    expect(truncateWellFormed("exact", 5)).toBe("exact");
+  });
+
+  it("truncates normal ASCII string at boundary", () => {
+    expect(truncateWellFormed("hello world", 5)).toBe("hello");
+  });
+
+  it("avoids splitting surrogate pairs across the truncation boundary", () => {
+    // Emoji "\uD83D\uDE00" (grinning face) is 2 code units: \uD83D (high) + \uDE00 (low)
+    const text = "abc\uD83D\uDE00def"; // length 8: 'a'(0), 'b'(1), 'c'(2), '\uD83D'(3), '\uDE00'(4), 'd'(5)...
+
+    // Truncating at index 4 would split the pair after the high surrogate \uD83D.
+    // truncateWellFormed should back off by 1 to index 3 ("abc") to prevent a lone high surrogate.
+    expect(truncateWellFormed(text, 4)).toBe("abc");
+
+    // Truncating at index 5 includes both surrogates ("abc\uD83D\uDE00")
+    expect(truncateWellFormed(text, 5)).toBe("abc\uD83D\uDE00");
+  });
+});

--- a/packages/vault/test/internal-utils.test.ts
+++ b/packages/vault/test/internal-utils.test.ts
@@ -8,7 +8,7 @@ import {
   optsCaller,
   toWellFormedUnicode,
   truncateWellFormed,
-} from "./internal-utils.js";
+} from "../src/internal-utils.js";
 
 describe("assertKey", () => {
   it("accepts valid keys up to 256 characters", () => {


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/vault/src/internal-utils.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `assertKey`: validating string length, non-empty / whitespace constraints, and type requirements.
- `optsCaller`: caller extraction from option records.
- `toWellFormedUnicode`: ensuring well-formed unicode strings are preserved and lone surrogates are sanitized.
- `truncateWellFormed`: safe string truncation preventing splitting of UTF-16 surrogate pairs (e.g. emoji), non-positive/non-finite length bounds, and exact/within-bounds preservation.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`58e343ac91`) |
| --- | --- | --- |
| `bunx vitest run packages/vault/src/internal-utils.test.ts` | N/A (new test file) | 12 passed (12 tests) |
| `bunx @biomejs/biome check packages/vault/src/internal-utils.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/vault/src/internal-utils.test.ts:1-104`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:58e343ac9110747ef14bbcb1a00b20d7677fd82a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested