### PR TITLE
test(cloud): cover conversations

### DIFF
--- a/packages/cloud/shared/src/db/crypto/conversations.test.ts
+++ b/packages/cloud/shared/src/db/crypto/conversations.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Behavioral unit tests for conversation-message content encryption.
+ *
+ * Drives the real `encryptConversationContent` / `decryptConversationContent`
+ * helpers through the in-process MemoryKmsAdapter selected when NODE_ENV=test.
+ * Ciphertext is bound to `conversation_messages` + message id + `content` via
+ * AAD; these cases record that binding and the AEAD fail-closed paths.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { decryptConversationContent, encryptConversationContent } from "./conversations";
+import type { EncryptedField } from "./field-crypto";
+import { resetKmsClientForTests } from "./kms-client";
+
+const ORG_A = "org-conversations-a";
+const ORG_B = "org-conversations-b";
+const MESSAGE_A = "00000000-0000-4000-8000-0000000000aa";
+const MESSAGE_B = "00000000-0000-4000-8000-0000000000bb";
+
+beforeEach(() => {
+  resetKmsClientForTests();
+});
+
+function xorFirstByte(b64: string): string {
+  const bytes = Buffer.from(b64, "base64");
+  if (bytes.length === 0) {
+    throw new Error("expected non-empty base64 payload");
+  }
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+  return bytes.toString("base64");
+}
+
+describe("encryptConversationContent / decryptConversationContent", () => {
+  test("round-trips ordinary UTF-8 content", async () => {
+    const plaintext = "hello world";
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe(plaintext);
+  });
+
+  test("round-trips an empty string", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "");
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe("");
+  });
+
+  test("round-trips a single character", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "x");
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe("x");
+  });
+
+  test("preserves leading/trailing whitespace (no normalization)", async () => {
+    const plaintext = "  keep me  \n";
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe(plaintext);
+  });
+
+  test("round-trips unicode, emoji, and newlines", async () => {
+    const plaintext = "hello — 世界\n🚀\tline two";
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe(plaintext);
+  });
+
+  test("round-trips a long payload", async () => {
+    const plaintext = "msg-".repeat(4096);
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe(plaintext);
+  });
+
+  test("returns a complete EncryptedField envelope that does not leak plaintext", async () => {
+    const plaintext = "secret conversation body";
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(enc.ciphertext.length).toBeGreaterThan(0);
+    expect(enc.nonce.length).toBeGreaterThan(0);
+    expect(enc.auth_tag.length).toBeGreaterThan(0);
+    expect(enc.kms_key_id.length).toBeGreaterThan(0);
+    expect(enc.kms_key_version).toBeGreaterThanOrEqual(1);
+    expect(enc.ciphertext).not.toContain(plaintext);
+    expect(Buffer.from(enc.ciphertext, "base64").toString("utf8")).not.toContain(plaintext);
+  });
+
+  test("two encrypts of the same plaintext produce distinct nonce and ciphertext", async () => {
+    const plaintext = "same body twice";
+    const a = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    const b = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(await decryptConversationContent(MESSAGE_A, a)).toBe(plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, b)).toBe(plaintext);
+  });
+
+  test("ciphertext is bound to the message id (AAD) — cross-row decrypt fails closed", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "bound to A");
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe("bound to A");
+    await expect(decryptConversationContent(MESSAGE_B, enc)).rejects.toThrow();
+  });
+
+  test("swapping envelopes across message ids fails closed in both directions", async () => {
+    const encA = await encryptConversationContent(ORG_A, MESSAGE_A, "alpha");
+    const encB = await encryptConversationContent(ORG_A, MESSAGE_B, "beta");
+    await expect(decryptConversationContent(MESSAGE_B, encA)).rejects.toThrow();
+    await expect(decryptConversationContent(MESSAGE_A, encB)).rejects.toThrow();
+    expect(await decryptConversationContent(MESSAGE_A, encA)).toBe("alpha");
+    expect(await decryptConversationContent(MESSAGE_B, encB)).toBe("beta");
+  });
+
+  test("tampered ciphertext fails closed", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "do not mutate");
+    const tampered: EncryptedField = { ...enc, ciphertext: xorFirstByte(enc.ciphertext) };
+    await expect(decryptConversationContent(MESSAGE_A, tampered)).rejects.toThrow();
+  });
+
+  test("tampered nonce fails closed", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "do not mutate");
+    const tampered: EncryptedField = { ...enc, nonce: xorFirstByte(enc.nonce) };
+    await expect(decryptConversationContent(MESSAGE_A, tampered)).rejects.toThrow();
+  });
+
+  test("tampered auth_tag fails closed", async () => {
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, "do not mutate");
+    const tampered: EncryptedField = { ...enc, auth_tag: xorFirstByte(enc.auth_tag) };
+    await expect(decryptConversationContent(MESSAGE_A, tampered)).rejects.toThrow();
+  });
+
+  test("decrypt uses the stored kms_key_id (org id is not an input to decrypt)", async () => {
+    const plaintext = "org-agnostic decrypt";
+    const enc = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    expect(enc.kms_key_id).toContain(ORG_A);
+    expect(await decryptConversationContent(MESSAGE_A, enc)).toBe(plaintext);
+  });
+
+  test("different orgs encrypt under different key ids", async () => {
+    const plaintext = "shared wording";
+    const encA = await encryptConversationContent(ORG_A, MESSAGE_A, plaintext);
+    const encB = await encryptConversationContent(ORG_B, MESSAGE_A, plaintext);
+    expect(encA.kms_key_id).not.toBe(encB.kms_key_id);
+    expect(encA.kms_key_id).toContain(ORG_A);
+    expect(encB.kms_key_id).toContain(ORG_B);
+    expect(await decryptConversationContent(MESSAGE_A, encA)).toBe(plaintext);
+    expect(await decryptConversationContent(MESSAGE_A, encB)).toBe(plaintext);
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for
`packages/cloud/shared/src/db/crypto/conversations.ts`, which had no same-named
test file in the tree.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest fetched `origin/develop` (`3563aec86aa05ccd62686008e496d1ee2da6cc30`) with zero conflicts.
- [x] Focused `bun test`, `biome check`, and `tsc --noEmit` (grep of this file) were run after that sync. Full `bun run verify` was not run; this is a test-only addition of one file.
- [x] A reviewer can confirm the helpers' behavior from the committed suite without reading production code.

# Sync with develop

- [x] Branch is `origin/develop` at `3563aec86aa05ccd62686008e496d1ee2da6cc30` plus the single test-file commit.
- [x] Full `bun run verify` was not run (test-only PR; scoped bun test / biome / tsc quoted below).

# Risks

Low. Production `conversations.ts` is unchanged. The suite drives the real
`encryptConversationContent` / `decryptConversationContent` helpers through the
in-process MemoryKmsAdapter (NODE_ENV=test): round-trip, empty/single/long/unicode
payloads, whitespace preservation, envelope shape, distinct nonces, AAD row-binding,
cross-org key ids, and AEAD fail-closed on tampered ciphertext/nonce/auth_tag.

# Background

## What does this PR do?

Adds a colocated `bun:test` suite for the conversation-message content encryption
helpers. Coverage is behavior, not mocks: encrypt/decrypt against the real module,
including the AAD bind to `conversation_messages` + message id + `content`.

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/crypto/conversations.test.ts` — same directory as
`kms-client.test.ts` and `agent-backups.roundtrip.test.ts`, which also import
from `bun:test`. Import path is `./conversations`. `@elizaos/cloud-shared`
owns this lane with `bun test` via `scripts/run-bun-tests.mjs` (not root vitest);
do not infer a green vitest run.

## Detailed testing steps

```bash
# owning runner for packages/cloud/shared
bun test packages/cloud/shared/src/db/crypto/conversations.test.ts
bunx biome check --write packages/cloud/shared/src/db/crypto/conversations.test.ts
cd packages/cloud/shared && bunx tsc --noEmit 2>&1 | grep 'conversations.test.ts'
```

Focused proof at the pushed head `645f14d38f9f689daa53238778a86a78a49c5e99`,
re-run after fetching current `origin/develop`:

```text
bun test v1.3.14 (0d9b296a)

packages/cloud/shared/src/db/crypto/conversations.test.ts:
✓ encryptConversationContent / decryptConversationContent > round-trips ordinary UTF-8 content
✓ encryptConversationContent / decryptConversationContent > round-trips an empty string
✓ encryptConversationContent / decryptConversationContent > round-trips a single character
✓ encryptConversationContent / decryptConversationContent > preserves leading/trailing whitespace (no normalization)
✓ encryptConversationContent / decryptConversationContent > round-trips unicode, emoji, and newlines
✓ encryptConversationContent / decryptConversationContent > round-trips a long payload
✓ encryptConversationContent / decryptConversationContent > returns a complete EncryptedField envelope that does not leak plaintext
✓ encryptConversationContent / decryptConversationContent > two encrypts of the same plaintext produce distinct nonce and ciphertext
✓ encryptConversationContent / decryptConversationContent > ciphertext is bound to the message id (AAD) — cross-row decrypt fails closed
✓ encryptConversationContent / decryptConversationContent > swapping envelopes across message ids fails closed in both directions
✓ encryptConversationContent / decryptConversationContent > tampered ciphertext fails closed
✓ encryptConversationContent / decryptConversationContent > tampered nonce fails closed
✓ encryptConversationContent / decryptConversationContent > tampered auth_tag fails closed
✓ encryptConversationContent / decryptConversationContent > decrypt uses the stored kms_key_id (org id is not an input to decrypt)
✓ encryptConversationContent / decryptConversationContent > different orgs encrypt under different key ids

 15 pass
 0 fail
 33 expect() calls
Ran 15 tests across 1 file. [705.00ms]
```

`bunx biome check --write` on the new file: `Checked 1 file in 16ms. No fixes applied.`
Config proven present (`biome.json` + `tsconfig.json` at repo root; this checkout is not sparse).

`bunx tsc --noEmit` in `packages/cloud/shared`: this file appears nowhere in the
output (`grep 'conversations.test.ts'` empty, grep exit 1). The package
`tsconfig.json` excludes `**/*.test.ts`, so the new file adds zero TypeScript
errors versus an untouched control. Pre-existing errors in other files (e.g.
`src/db/push-schema-for-tests.ts`) are unrelated.

The diff touches only
`packages/cloud/shared/src/db/crypto/conversations.test.ts` (140 insertions).

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The
counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:645f14d38f9f689daa53238778a86a78a49c5e99 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused `bun test` output at the pushed head (15 passed / 0 failed / 1 file).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / wallet / scheduled-item artifacts; encrypt/decrypt is in-process MemoryKms.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR adds unit tests for field-level crypto helpers; it does not change
agent/action/provider/prompt/model behavior.

## Backend + frontend logs

Backend: focused `bun test` output quoted above (15 pass / 0 fail / 1 file).
Frontend: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice / TTS / STT change.

## Known gaps / failures

- Full `bun run verify` was not run. Scoped proof is `bun test` (15/15), biome
  (clean), and `tsc --noEmit` grep of this file (empty).
- Hosted GitHub Actions CI does not run on fork contributor PRs.
- No identity.slop.cash receipt: unattended session cannot complete interactive OAuth.

## Maintainer CI exception record

N/A - no exception requested

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
