### PR TITLE
test(cloud): cover agent-backups

### DIFF
--- a/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
+++ b/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for agent-backup `state_data` field encryption and its envelope type guard.
+ *
+ * The harness is deterministic and drives the real module: MemoryKmsAdapter is
+ * selected by `createKmsClient()` when NODE_ENV=test. Durability-across-restart
+ * cases live in the sibling roundtrip suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AgentBackupDeltaData,
+  AgentBackupStateData,
+  AgentBackupStoredStateData,
+  EncryptedAgentBackupStateData,
+} from "../schemas/agent-sandboxes";
+import {
+  decryptAgentBackupStateData,
+  encryptAgentBackupStateData,
+  isEncryptedAgentBackupStateData,
+} from "./agent-backups";
+import { resetKmsClientForTests } from "./kms-client";
+
+const ORG = "org-agent-backups-unit";
+const BACKUP_ID = "backup-unit-0001";
+const BACKUP_ID_B = "backup-unit-0002";
+
+function sampleState(): AgentBackupStateData {
+  return {
+    memories: [{ role: "user", text: "hello — 世界", timestamp: 1 }],
+    config: { name: "Unit Agent", nested: { n: 1 } },
+    workspaceFiles: { "notes.md": "# notes" },
+  };
+}
+
+function sampleDelta(): AgentBackupDeltaData {
+  return {
+    filesChanged: { "notes.md": "# changed" },
+    filesRemoved: ["old.txt"],
+    configChanged: { name: "Renamed" },
+    configRemoved: ["plugins"],
+    memoriesBaseCount: 3,
+    memoriesAppended: [{ role: "assistant", text: "ok", timestamp: 2 }],
+  };
+}
+
+function envelope(): EncryptedAgentBackupStateData {
+  return {
+    kind: "encrypted-agent-backup-state",
+    algorithm: "kms-aes-256-gcm",
+    ciphertext: "Y2lwaGVy",
+    nonce: "bm9uY2U=",
+    auth_tag: "dGFn",
+    kms_key_id: "org/test/dek",
+    kms_key_version: 1,
+  };
+}
+
+function asStored(value: unknown): AgentBackupStoredStateData {
+  return value as AgentBackupStoredStateData;
+}
+
+beforeEach(() => {
+  resetKmsClientForTests();
+});
+
+afterEach(() => {
+  resetKmsClientForTests();
+});
+
+describe("isEncryptedAgentBackupStateData", () => {
+  test("rejects non-objects", () => {
+    expect(isEncryptedAgentBackupStateData(undefined)).toBe(false);
+    expect(isEncryptedAgentBackupStateData(null)).toBe(false);
+    expect(isEncryptedAgentBackupStateData("encrypted-agent-backup-state")).toBe(false);
+    expect(isEncryptedAgentBackupStateData(1)).toBe(false);
+    expect(isEncryptedAgentBackupStateData(true)).toBe(false);
+  });
+
+  test("rejects arrays and empty objects", () => {
+    expect(isEncryptedAgentBackupStateData([])).toBe(false);
+    expect(isEncryptedAgentBackupStateData({})).toBe(false);
+  });
+
+  test("rejects a missing or wrong kind", () => {
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), kind: "other" })).toBe(false);
+    const { kind: _kind, ...rest } = envelope();
+    expect(isEncryptedAgentBackupStateData(rest)).toBe(false);
+  });
+
+  test("rejects a missing or wrong algorithm", () => {
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), algorithm: "aes-256-gcm" })).toBe(
+      false,
+    );
+    const { algorithm: _algorithm, ...rest } = envelope();
+    expect(isEncryptedAgentBackupStateData(rest)).toBe(false);
+  });
+
+  test("rejects non-string ciphertext, nonce, auth_tag, or kms_key_id", () => {
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), ciphertext: 1 })).toBe(false);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), nonce: null })).toBe(false);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), auth_tag: undefined })).toBe(false);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), kms_key_id: { id: "x" } })).toBe(false);
+    const { ciphertext: _c, ...noCipher } = envelope();
+    expect(isEncryptedAgentBackupStateData(noCipher)).toBe(false);
+  });
+
+  test("rejects a missing or non-number kms_key_version", () => {
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), kms_key_version: "1" })).toBe(false);
+    const { kms_key_version: _v, ...rest } = envelope();
+    expect(isEncryptedAgentBackupStateData(rest)).toBe(false);
+  });
+
+  test("accepts a complete envelope, including extra fields and numeric edge versions", () => {
+    expect(isEncryptedAgentBackupStateData(envelope())).toBe(true);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), extra: true })).toBe(true);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), kms_key_version: 0 })).toBe(true);
+    expect(isEncryptedAgentBackupStateData({ ...envelope(), kms_key_version: Number.NaN })).toBe(
+      true,
+    );
+    expect(
+      isEncryptedAgentBackupStateData({
+        ...envelope(),
+        ciphertext: "",
+        nonce: "",
+        auth_tag: "",
+        kms_key_id: "",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("encryptAgentBackupStateData", () => {
+  test("returns the same object when the input is already an envelope", async () => {
+    const stored = envelope();
+    const again = await encryptAgentBackupStateData(ORG, BACKUP_ID, stored);
+    expect(again).toBe(stored);
+  });
+
+  test("seals plaintext full-state and delta payloads", async () => {
+    const state = sampleState();
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, state);
+    expect(isEncryptedAgentBackupStateData(sealed)).toBe(true);
+    expect(sealed.kind).toBe("encrypted-agent-backup-state");
+    expect(sealed.algorithm).toBe("kms-aes-256-gcm");
+    expect(typeof sealed.ciphertext).toBe("string");
+    expect(typeof sealed.nonce).toBe("string");
+    expect(typeof sealed.auth_tag).toBe("string");
+    expect(typeof sealed.kms_key_id).toBe("string");
+    expect(typeof sealed.kms_key_version).toBe("number");
+    expect(JSON.stringify(sealed)).not.toContain("hello — 世界");
+    expect(state.memories[0]?.text).toBe("hello — 世界");
+
+    const delta = sampleDelta();
+    const sealedDelta = await encryptAgentBackupStateData(ORG, BACKUP_ID, delta);
+    expect(isEncryptedAgentBackupStateData(sealedDelta)).toBe(true);
+    expect(JSON.stringify(sealedDelta)).not.toContain("# changed");
+  });
+
+  test("seals a near-envelope that fails the type guard instead of passing it through", async () => {
+    const almost = asStored({ ...envelope(), kind: "not-an-envelope" });
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, almost);
+    expect(sealed).not.toBe(almost);
+    expect(isEncryptedAgentBackupStateData(sealed)).toBe(true);
+    expect(sealed.kind).toBe("encrypted-agent-backup-state");
+  });
+
+  test("seals empty collections", async () => {
+    const empty: AgentBackupStateData = {
+      memories: [],
+      config: {},
+      workspaceFiles: {},
+    };
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, empty);
+    expect(isEncryptedAgentBackupStateData(sealed)).toBe(true);
+    const restored = await decryptAgentBackupStateData(BACKUP_ID, sealed);
+    expect(restored).toEqual(empty);
+  });
+});
+
+describe("decryptAgentBackupStateData", () => {
+  test("returns the same object when the input is not an envelope", async () => {
+    const state = sampleState();
+    expect(await decryptAgentBackupStateData(BACKUP_ID, state)).toBe(state);
+
+    const delta = sampleDelta();
+    expect(await decryptAgentBackupStateData(BACKUP_ID, delta)).toBe(delta);
+
+    const almost = asStored({ ...envelope(), algorithm: "plain" });
+    expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(almost);
+  });
+
+  test("round-trips full-state and delta payloads", async () => {
+    const state = sampleState();
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, state);
+    expect(await decryptAgentBackupStateData(BACKUP_ID, sealed)).toEqual(state);
+
+    const delta = sampleDelta();
+    const sealedDelta = await encryptAgentBackupStateData(ORG, BACKUP_ID, delta);
+    expect(await decryptAgentBackupStateData(BACKUP_ID, sealedDelta)).toEqual(delta);
+  });
+
+  test("rejects ciphertext bound to a different backup row", async () => {
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, sampleState());
+    await expect(decryptAgentBackupStateData(BACKUP_ID_B, sealed)).rejects.toThrow();
+  });
+
+  test("double-encrypt is a no-op and decrypt of plaintext is a no-op", async () => {
+    const state = sampleState();
+    const sealed = await encryptAgentBackupStateData(ORG, BACKUP_ID, state);
+    const again = await encryptAgentBackupStateData(ORG, BACKUP_ID, sealed);
+    expect(again).toBe(sealed);
+    expect(await decryptAgentBackupStateData(BACKUP_ID, again)).toEqual(state);
+    expect(await decryptAgentBackupStateData(BACKUP_ID, state)).toBe(state);
+  });
+});


### PR DESCRIPTION

# Relates to

Coverage gap: `packages/cloud/shared/src/db/crypto/agent-backups.ts` had no same-named test file. The sibling `agent-backups.roundtrip.test.ts` covers org-DEK durability across KMS restart; this PR adds `agent-backups.test.ts` for the envelope type guard and encrypt/decrypt branch behaviour. No issue is linked.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (parent `ee7d24557d13`).
- [ ] `bun run verify` was not run for this test-only change. Focused package gates below were run instead.
- [x] A reviewer can confirm the change from the quoted `bun test` / biome / tsc results.

# Sync with develop

- [x] Rebased onto `origin/develop` at `ee7d24557d13af8f05a46a727630ee9233f71d13`; zero conflicts.
- [ ] `bun run verify` not run (test-only, no production change). Focused commands are quoted in Testing.

# Risks

Low. Test-only. No production behaviour change. The suite drives the real module (MemoryKmsAdapter selected when `NODE_ENV=test`) and records observed behaviour, including that `kms_key_version: NaN` and empty-string envelope fields still satisfy the type guard because the implementation only checks `typeof === "number"` / `typeof === "string"`.

# Background

## What does this PR do?

Adds `packages/cloud/shared/src/db/crypto/agent-backups.test.ts` covering every exported symbol:

- `isEncryptedAgentBackupStateData`: non-objects, null, arrays, empty objects, missing/wrong `kind` and `algorithm`, non-string ciphertext/nonce/auth_tag/kms_key_id, missing/non-number `kms_key_version`, extra fields, version `0`/`NaN`, empty-string fields.
- `encryptAgentBackupStateData`: already-encrypted identity (same object), sealing of full-state and delta plaintext, near-envelope that fails the guard is sealed rather than passed through, empty collections round-trip.
- `decryptAgentBackupStateData`: plaintext full-state/delta/near-envelope identity, round-trip equality, AAD mismatch across backup row ids throws, double-encrypt is a no-op.

## What kind of change is this?

Tests / coverage only. No production source change.

# Documentation changes needed?

No. Production API and comments are unchanged.

# Testing

`@elizaos/cloud-shared` unit tests are collected by `bun test` (`scripts/run-bun-tests.mjs`), not root vitest. Counts below are from `bun test`, re-run after rebasing onto current `origin/develop`.

## Where should a reviewer start?

`packages/cloud/shared/src/db/crypto/agent-backups.test.ts` (the only file in the diff) next to `agent-backups.ts`.

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/db/crypto/agent-backups.test.ts
```

Observed on this head, after rebase onto `origin/develop` (`ee7d24557d13`):

```
15 pass
0 fail
50 expect() calls
Ran 15 tests across 1 file.
```

`packages/cloud/shared/src/db/crypto/agent-backups.ts` reports 100% function and line coverage from this file.

```bash
bunx biome check --write packages/cloud/shared/src/db/crypto/agent-backups.test.ts
```

Clean (Checked 1 file; one formatting wrap applied, then clean). Root `biome.json` is present; this checkout is not sparse.

```bash
cd packages/cloud/shared && bunx tsc --noEmit 2>&1 | grep 'agent-backups.test.ts' ; echo "EXIT:$?"
```

Empty grep (EXIT:1). This file introduces zero new TypeScript errors.

Hosted CI does not run on fork contributor PRs. Do not treat GitHub check status as evidence for this PR.

Diff touches only the new test file.

# Evidence Gate

Test-only; no production behaviour change. No UI, no agent/prompt path, no backend HTTP path.

- Before screenshots: N/A - test-only, no rendered UI surface.
- After screenshots: N/A - test-only, no rendered UI surface.
- Walkthrough video: N/A - test-only, no user flow.
- Backend logs: N/A - no server/runtime path changed; `bun test` output is the execution record.
- Frontend logs: N/A - no frontend surface.
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model change.
- Domain artifacts: N/A - in-process MemoryKmsAdapter; no DB/media/wallet artifact.
- OCR review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - test-only unit suite. Command output:

```
15 pass
0 fail
50 expect() calls
Ran 15 tests across 1 file.
```

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - not a voice/TTS/STT change.

## Known gaps / failures

- `bun run verify` was not run. This PR adds one test file and changes no production behaviour; the required evidence set is the focused `bun test`, biome, and tsc grep above.
- Fork contributor: hosted CI does not run on this PR.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5b359e8cad90a775fe5953e37c4637f945e39468 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
