### PR TITLE
test(cloud): cover field-crypto

### DIFF
--- a/packages/cloud/shared/src/db/crypto/field-crypto.test.ts
+++ b/packages/cloud/shared/src/db/crypto/field-crypto.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Behavioral coverage for cloud-shared field encryption, HMAC blind-index, and
+ * lookup-value normalization. Drives the real module against the in-process
+ * MemoryKMS that `getKmsClient()` selects when NODE_ENV=test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { orgKey } from "@elizaos/core/security/kms";
+import {
+  blindIndex,
+  decryptField,
+  type EncryptedField,
+  encryptField,
+  normalizeEmail,
+  normalizePhone,
+  normalizeWallet,
+} from "./field-crypto";
+import { resetKmsClientForTests } from "./kms-client";
+
+const ORG_A = "org-field-crypto-a";
+const ORG_B = "org-field-crypto-b";
+const COORDS = {
+  table: "users",
+  rowId: "00000000-0000-4000-8000-000000000001",
+  column: "email",
+};
+
+beforeEach(() => {
+  resetKmsClientForTests();
+});
+
+afterEach(() => {
+  resetKmsClientForTests();
+});
+
+function xorFirstByte(b64: string): string {
+  const bytes = Buffer.from(b64, "base64");
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+  return bytes.toString("base64");
+}
+
+describe("encryptField / decryptField", () => {
+  test("round-trips empty, ASCII, whitespace, and UTF-8 plaintext", async () => {
+    for (const plaintext of ["", "secret", "  padded  ", "hello — 世界", "emoji 🔐"]) {
+      const field = await encryptField(ORG_A, plaintext, COORDS);
+      expect(await decryptField(field, COORDS)).toBe(plaintext);
+    }
+  });
+
+  test("returns base64 envelope fields and the org DEK identity", async () => {
+    const field: EncryptedField = await encryptField(ORG_A, "payload", COORDS);
+    expect(field.kms_key_id).toBe(orgKey(ORG_A, "dek"));
+    expect(field.kms_key_version).toBeGreaterThanOrEqual(1);
+    expect(Number.isInteger(field.kms_key_version)).toBe(true);
+    for (const part of [field.ciphertext, field.nonce, field.auth_tag]) {
+      expect(part.length).toBeGreaterThan(0);
+      expect(Buffer.from(part, "base64").length).toBeGreaterThan(0);
+    }
+    expect(field.ciphertext).not.toContain("payload");
+  });
+
+  test("distinct orgs bind distinct DEK identifiers", async () => {
+    const a = await encryptField(ORG_A, "same-plain", COORDS);
+    const b = await encryptField(ORG_B, "same-plain", COORDS);
+    expect(a.kms_key_id).toBe(orgKey(ORG_A, "dek"));
+    expect(b.kms_key_id).toBe(orgKey(ORG_B, "dek"));
+    expect(a.kms_key_id).not.toBe(b.kms_key_id);
+  });
+
+  test("repeated encrypts of the same plaintext use fresh nonces", async () => {
+    const first = await encryptField(ORG_A, "same-plain", COORDS);
+    const second = await encryptField(ORG_A, "same-plain", COORDS);
+    expect(first.nonce).not.toBe(second.nonce);
+    expect(first.ciphertext).not.toBe(second.ciphertext);
+    expect(await decryptField(first, COORDS)).toBe("same-plain");
+    expect(await decryptField(second, COORDS)).toBe("same-plain");
+  });
+
+  test("empty table, row, and column coords still round-trip when they match", async () => {
+    const emptyCoords = { table: "", rowId: "", column: "" };
+    const field = await encryptField(ORG_A, "bound-to-empty-aad", emptyCoords);
+    expect(await decryptField(field, emptyCoords)).toBe("bound-to-empty-aad");
+  });
+
+  test("AAD mismatch on table, row, or column fails closed", async () => {
+    const field = await encryptField(ORG_A, "secret", COORDS);
+    await expect(decryptField(field, { ...COORDS, table: "other" })).rejects.toThrow();
+    await expect(decryptField(field, { ...COORDS, rowId: "row-b" })).rejects.toThrow();
+    await expect(decryptField(field, { ...COORDS, column: "phone" })).rejects.toThrow();
+  });
+
+  test("tampered ciphertext, nonce, or auth tag fails closed", async () => {
+    const field = await encryptField(ORG_A, "secret", COORDS);
+    await expect(
+      decryptField({ ...field, ciphertext: xorFirstByte(field.ciphertext) }, COORDS),
+    ).rejects.toThrow();
+    await expect(
+      decryptField({ ...field, nonce: xorFirstByte(field.nonce) }, COORDS),
+    ).rejects.toThrow();
+    await expect(
+      decryptField({ ...field, auth_tag: xorFirstByte(field.auth_tag) }, COORDS),
+    ).rejects.toThrow();
+  });
+
+  test("decrypt after a memory-KMS reset fails closed because the DEK is gone", async () => {
+    const field = await encryptField(ORG_A, "orphan-me", COORDS);
+    resetKmsClientForTests();
+    await expect(decryptField(field, COORDS)).rejects.toThrow();
+  });
+});
+
+describe("blindIndex", () => {
+  test("is deterministic for the same value and purpose", async () => {
+    const a = await blindIndex("foo@bar.com", "users-email");
+    const b = await blindIndex("foo@bar.com", "users-email");
+    expect(a).toBe(b);
+    expect(Buffer.from(a, "base64").length).toBeGreaterThan(0);
+  });
+
+  test("domain-separates purposes and values", async () => {
+    const email = await blindIndex("alice", "users-email");
+    const phone = await blindIndex("alice", "users-phone");
+    const other = await blindIndex("bob", "users-email");
+    expect(email).not.toBe(phone);
+    expect(email).not.toBe(other);
+  });
+
+  test("indexes the empty string and unicode without throwing", async () => {
+    const emptyA = await blindIndex("", "users-email");
+    const emptyB = await blindIndex("", "users-email");
+    expect(emptyA).toBe(emptyB);
+    const unicode = await blindIndex("ユーザー@例.jp", "users-email");
+    expect(unicode).not.toBe(emptyA);
+    expect(Buffer.from(unicode, "base64").length).toBeGreaterThan(0);
+  });
+});
+
+describe("normalizeEmail", () => {
+  test("trims surrounding whitespace and lowercases", () => {
+    expect(normalizeEmail("  FOO@BAR.com  ")).toBe("foo@bar.com");
+    expect(normalizeEmail("foo@bar.com")).toBe("foo@bar.com");
+    expect(normalizeEmail("   ")).toBe("");
+    expect(normalizeEmail("")).toBe("");
+  });
+});
+
+describe("normalizePhone", () => {
+  test("strips spaces, dashes, and parentheses while keeping a leading plus", () => {
+    expect(normalizePhone("+1 (555) 010-1234")).toBe("+15550101234");
+    expect(normalizePhone("  555-0101234 ")).toBe("5550101234");
+    expect(normalizePhone("+")).toBe("+");
+    expect(normalizePhone("   ")).toBe("");
+  });
+
+  test("does not strip characters outside spaces, dashes, and parentheses", () => {
+    expect(normalizePhone("+1.555.010.1234")).toBe("+1.555.010.1234");
+    expect(normalizePhone("555/010/1234")).toBe("555/010/1234");
+    expect(normalizePhone("ext 12")).toBe("ext12");
+  });
+});
+
+describe("normalizeWallet", () => {
+  test("lowercases EVM addresses via chainType even without a 0x prefix", () => {
+    expect(normalizeWallet("ABCDEF", "evm")).toBe("abcdef");
+    expect(normalizeWallet("  0xABCDEF  ", "evm")).toBe("0xabcdef");
+  });
+
+  test("lowercases any 0x-prefixed address regardless of chainType", () => {
+    expect(normalizeWallet("0xABCDEF")).toBe("0xabcdef");
+    expect(normalizeWallet("0xABCDEF", null)).toBe("0xabcdef");
+    expect(normalizeWallet("0xABCDEF", "solana")).toBe("0xabcdef");
+  });
+
+  test("preserves case for non-EVM, non-0x addresses after trim", () => {
+    const sol = "ABCdef123XYZ";
+    expect(normalizeWallet(sol, "solana")).toBe(sol);
+    expect(normalizeWallet(`  ${sol}  `, "bitcoin")).toBe(sol);
+    expect(normalizeWallet(sol, null)).toBe(sol);
+    expect(normalizeWallet(sol)).toBe(sol);
+  });
+
+  test("treats chainType as an exact lowercase match, so EVM without 0x stays as-is", () => {
+    expect(normalizeWallet("AbCdEf", "EVM")).toBe("AbCdEf");
+    expect(normalizeWallet("AbCdEf", "Evm")).toBe("AbCdEf");
+  });
+
+  test("trims whitespace-only input to an empty string", () => {
+    expect(normalizeWallet("   ")).toBe("");
+    expect(normalizeWallet("   ", "evm")).toBe("");
+  });
+});


### PR DESCRIPTION

# Relates to

Test-only coverage for `packages/cloud/shared/src/db/crypto/field-crypto.ts`, which had no same-named test file. No linked issue; this does not change production behaviour.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the current `origin/develop` (`ee7d24557d13af8f05a46a727630ee9233f71d13`) with a single-file commit and zero conflicts.
- [x] Focused package checks were run after sync. Full `bun run verify` was not run: this diff adds tests only and changes no production behaviour. Exact focused counts are below.
- [x] A reviewer can confirm the suite from the quoted `bun test` output without reading the implementation.

# Sync with develop

- [x] Branch parent is current `origin/develop` `ee7d24557d13af8f05a46a727630ee9233f71d13`; zero conflicts.
- [ ] `bun run verify` not run for this test-only change. Focused `bun test`, `bunx biome check --write`, and `bunx tsc --noEmit` on `@elizaos/cloud-shared` are quoted below.

# Risks

Low. Adds a unit test file only. No production code, schema, crypto, or API change.

# Background

## What does this PR do?

Adds `packages/cloud/shared/src/db/crypto/field-crypto.test.ts`, a real `bun:test` suite that drives the live `encryptField` / `decryptField` / `blindIndex` / `normalizeEmail` / `normalizePhone` / `normalizeWallet` exports against in-process MemoryKMS (`NODE_ENV=test`).

Covered behaviour, observed from the source (not guessed):

- encrypt/decrypt round-trip of empty, ASCII, whitespace, and UTF-8 plaintext
- envelope fields are non-empty base64; `kms_key_id` is `orgKey(orgId, "dek")`
- distinct orgs bind distinct DEK identifiers
- repeated encrypts of the same plaintext use fresh nonces
- empty table/row/column coords still round-trip when AAD matches
- AAD mismatch on table, row, or column fails closed
- tampered ciphertext, nonce, or auth tag fails closed
- decrypt after a MemoryKMS reset fails closed because the DEK is gone
- `blindIndex` is deterministic, purpose- and value-domain-separated, and accepts empty/unicode input
- `normalizeEmail` trims and lowercases
- `normalizePhone` strips spaces/dashes/parentheses, keeps `+`, and does **not** strip dots or slashes
- `normalizeWallet` lowercases `chainType === "evm"` or `0x`-prefixed input; preserves case otherwise; `"EVM"` without `0x` is **not** lowercased (strict `===`)

The package unit lane is `bun test` (`packages/cloud/shared` `test` script → `scripts/run-bun-tests.mjs`). This file imports `bun:test` and does not use `vi.hoisted`.

## What kind of change is this?

Improvements (tests for existing field-crypto helpers). No production behaviour change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/crypto/field-crypto.test.ts`. Run:

```bash
bun test packages/cloud/shared/src/db/crypto/field-crypto.test.ts
```

## Detailed testing steps

Automated tests. Hosted CI does **not** run on this fork contributor PR; the counts below were observed locally against current `origin/develop`.

Observed immediately before filing, after fetching `origin/develop` (`ee7d24557d13af8f05a46a727630ee9233f71d13`):

```
bun test v1.3.14 (0d9b296a)

packages/cloud/shared/src/db/crypto/field-crypto.test.ts:
  19 pass
  0 fail
  61 expect() calls
Ran 19 tests across 1 file. [658.00ms]
```

`packages/cloud/shared/src/db/crypto/field-crypto.ts` reported 100% funcs / 100% lines in that run.

Biome (config present at repo-root `biome.json`; worktree is not sparse):

```
bunx biome check --write packages/cloud/shared/src/db/crypto/field-crypto.test.ts
Checked 1 file in 18ms. Fixed 1 file.
```

The rewrite was import-type ordering only. The suite was re-run after that rewrite and still reported 19 pass / 0 fail.

Typecheck in the owning package; the new file appears nowhere in the output:

```
cd packages/cloud/shared && bunx tsc --noEmit 2>&1 | grep 'field-crypto.test' ; echo "EXIT:$?"
EXIT:1
```

(`EXIT:1` is grep's no-match status. `field-crypto.test.ts` introduced zero `tsc` errors. Pre-existing errors elsewhere in the package are not this diff.)

Diff touches only the new test file:

```
packages/cloud/shared/src/db/crypto/field-crypto.test.ts
```

# Evidence Gate

Evidence matches exact commit `56676098aa0c2165f78821ab93a5a8a81f85838d`.
<!-- evidence-head:56676098aa0c2165f78821ab93a5a8a81f85838d -->

- [x] Before full-page screenshots — `N/A - test-only change; no UI surface`
- [x] After full-page screenshots — `N/A - test-only change; no UI surface`
- [x] Walkthrough video — `N/A - test-only change; no UI flow`
- [x] Backend logs — `N/A - no production code path changed; bun test output quoted above`
- [x] Frontend console/network logs — `N/A - no frontend change`
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts — `N/A - no DB/wallet/on-chain/media artefact; unit suite is the artefact`
- [x] OCR visual-text review — `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

N/A - test-only; no server or client runtime path changed. The bun test summary above is the execution proof.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice / TTS / STT change.

## Known gaps / failures

- Full `bun run verify` was not run. This is a one-file test-only PR; the required evidence is the focused bun test, biome, and tsc results quoted above.
- Hosted GitHub Actions CI does not run on PRs from this fork. Do not treat missing Actions checks as a test failure.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
