### PR TITLE
test(app-core): cover register.config

### DIFF
--- a/packages/app-core/src/cli/program/register.config.test.ts
+++ b/packages/app-core/src/cli/program/register.config.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for CLI config command registration and command tree.
+ */
+
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerConfigCli } from "./register.config.js";
+
+function makeProgram(): {
+  program: Command;
+  out: string[];
+  err: string[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (chunk) => {
+      out.push(chunk);
+    },
+    writeErr: (chunk) => {
+      err.push(chunk);
+    },
+  });
+  return { program, out, err };
+}
+
+describe("registerConfigCli", () => {
+  it("registers the config command group and subcommands", () => {
+    const { program } = makeProgram();
+    expect(program.commands).toEqual([]);
+
+    registerConfigCli(program);
+
+    const configCmd = program.commands.find((cmd) => cmd.name() === "config");
+    expect(configCmd).toBeDefined();
+    expect(configCmd?.description()).toBe("Config helpers (get/path)");
+
+    const subcommands = configCmd?.commands.map((cmd) => cmd.name());
+    expect(subcommands).toEqual(["get", "path", "show"]);
+  });
+
+  it("registers get <key> with required argument", () => {
+    const { program } = makeProgram();
+    registerConfigCli(program);
+
+    const configCmd = program.commands.find((cmd) => cmd.name() === "config");
+    const getCmd = configCmd?.commands.find((cmd) => cmd.name() === "get");
+
+    expect(getCmd).toBeDefined();
+    expect(getCmd?.description()).toBe("Get a config value");
+    expect(getCmd?.registeredArguments.map((arg) => arg.name())).toEqual([
+      "key",
+    ]);
+  });
+
+  it("registers path command", () => {
+    const { program } = makeProgram();
+    registerConfigCli(program);
+
+    const configCmd = program.commands.find((cmd) => cmd.name() === "config");
+    const pathCmd = configCmd?.commands.find((cmd) => cmd.name() === "path");
+
+    expect(pathCmd).toBeDefined();
+    expect(pathCmd?.description()).toBe("Print the resolved config file path");
+  });
+
+  it("registers show command with options", () => {
+    const { program } = makeProgram();
+    registerConfigCli(program);
+
+    const configCmd = program.commands.find((cmd) => cmd.name() === "config");
+    const showCmd = configCmd?.commands.find((cmd) => cmd.name() === "show");
+
+    expect(showCmd).toBeDefined();
+    expect(showCmd?.description()).toBe(
+      "Display all configuration values grouped by section",
+    );
+
+    const optionFlags = showCmd?.options.map((opt) => opt.flags);
+    expect(optionFlags).toContain("-a, --all");
+    expect(optionFlags).toContain("--json");
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/app-core/src/cli/program/register.config.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `registerConfigCli`: command registration on Commander program instances.
- Subcommand tree verification (`get <key>`, `path`, `show`).
- Command options validation (`-a, --all`, `--json` for `config show`).
- Required argument specifications for `config get <key>`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`404afe664e`) |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/cli/program/register.config.test.ts` | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/app-core/src/cli/program/register.config.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/cli/program/register.config.test.ts:1-85`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:404afe664e5417726db1e3f2e0a4979d344b91a5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested