### PR TITLE
test(cloud): cover platform-credentials

### DIFF
--- a/packages/cloud/shared/src/db/crypto/platform-credentials.test.ts
+++ b/packages/cloud/shared/src/db/crypto/platform-credentials.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Behavioral unit tests for `platform_credentials` PII field encryption.
+ *
+ * Drives the real `encryptPlatformCredentialField` / `decryptPlatformCredentialField`
+ * helpers through the in-process MemoryKmsAdapter selected when NODE_ENV=test.
+ * Ciphertext is bound to `platform_credentials` + row id + column via AAD;
+ * these cases record that binding, the three encrypted columns, and the AEAD
+ * fail-closed paths. There is no same-named suite elsewhere in the repo.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { EncryptedField } from "./field-crypto";
+import { resetKmsClientForTests } from "./kms-client";
+import {
+  decryptPlatformCredentialField,
+  encryptPlatformCredentialField,
+} from "./platform-credentials";
+
+const ORG_A = "org-platform-credentials-a";
+const ORG_B = "org-platform-credentials-b";
+const ROW_A = "00000000-0000-4000-8000-0000000000aa";
+const ROW_B = "00000000-0000-4000-8000-0000000000bb";
+
+const COLUMNS = ["platform_user_id", "platform_email", "platform_display_name"] as const;
+
+type Column = (typeof COLUMNS)[number];
+
+beforeEach(() => {
+  resetKmsClientForTests();
+});
+
+function xorFirstByte(b64: string): string {
+  const bytes = Buffer.from(b64, "base64");
+  if (bytes.length === 0) {
+    throw new Error("expected non-empty base64 payload");
+  }
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+  return bytes.toString("base64");
+}
+
+describe("encryptPlatformCredentialField / decryptPlatformCredentialField", () => {
+  test("round-trips each encrypted column independently", async () => {
+    const values: Record<Column, string> = {
+      platform_user_id: "discord:9999",
+      platform_email: "alice@discord.example",
+      platform_display_name: "Alice Example",
+    };
+    for (const column of COLUMNS) {
+      const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, column, values[column]);
+      expect(await decryptPlatformCredentialField(ROW_A, column, enc)).toBe(values[column]);
+    }
+  });
+
+  test("round-trips an empty string on every column", async () => {
+    for (const column of COLUMNS) {
+      const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, column, "");
+      expect(await decryptPlatformCredentialField(ROW_A, column, enc)).toBe("");
+    }
+  });
+
+  test("round-trips a single character", async () => {
+    const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_user_id", "x");
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_user_id", enc)).toBe("x");
+  });
+
+  test("preserves leading/trailing whitespace (no email or display-name normalization)", async () => {
+    const email = "  Alice@Example.COM  \n";
+    const name = "  Display Name  ";
+    const encEmail = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_email", email);
+    const encName = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_display_name",
+      name,
+    );
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", encEmail)).toBe(email);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_display_name", encName)).toBe(
+      name,
+    );
+  });
+
+  test("round-trips unicode, emoji, and newlines", async () => {
+    const plaintext = "hello — 世界\n🚀\tline two";
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_display_name",
+      plaintext,
+    );
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_display_name", enc)).toBe(
+      plaintext,
+    );
+  });
+
+  test("round-trips a long payload", async () => {
+    const plaintext = "id-".repeat(4096);
+    const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_user_id", plaintext);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_user_id", enc)).toBe(plaintext);
+  });
+
+  test("returns a complete EncryptedField envelope that does not leak plaintext", async () => {
+    const plaintext = "secret-platform-user";
+    const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_user_id", plaintext);
+    expect(enc.ciphertext.length).toBeGreaterThan(0);
+    expect(enc.nonce.length).toBeGreaterThan(0);
+    expect(enc.auth_tag.length).toBeGreaterThan(0);
+    expect(enc.kms_key_id.length).toBeGreaterThan(0);
+    expect(enc.kms_key_version).toBeGreaterThanOrEqual(1);
+    expect(enc.ciphertext).not.toContain(plaintext);
+    expect(Buffer.from(enc.ciphertext, "base64").toString("utf8")).not.toContain(plaintext);
+  });
+
+  test("two encrypts of the same plaintext produce distinct nonce and ciphertext", async () => {
+    const plaintext = "same body twice";
+    const a = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_email", plaintext);
+    const b = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_email", plaintext);
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", a)).toBe(plaintext);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", b)).toBe(plaintext);
+  });
+
+  test("ciphertext is bound to the row id (AAD) — cross-row decrypt fails closed", async () => {
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_user_id",
+      "bound to A",
+    );
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_user_id", enc)).toBe("bound to A");
+    await expect(decryptPlatformCredentialField(ROW_B, "platform_user_id", enc)).rejects.toThrow();
+  });
+
+  test("swapping envelopes across row ids fails closed in both directions", async () => {
+    const encA = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_email", "alpha");
+    const encB = await encryptPlatformCredentialField(ORG_A, ROW_B, "platform_email", "beta");
+    await expect(decryptPlatformCredentialField(ROW_B, "platform_email", encA)).rejects.toThrow();
+    await expect(decryptPlatformCredentialField(ROW_A, "platform_email", encB)).rejects.toThrow();
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", encA)).toBe("alpha");
+    expect(await decryptPlatformCredentialField(ROW_B, "platform_email", encB)).toBe("beta");
+  });
+
+  test("ciphertext is bound to the column (AAD) — cross-column decrypt fails closed", async () => {
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_email",
+      "alice@example.com",
+    );
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", enc)).toBe(
+      "alice@example.com",
+    );
+    await expect(decryptPlatformCredentialField(ROW_A, "platform_user_id", enc)).rejects.toThrow();
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_display_name", enc),
+    ).rejects.toThrow();
+  });
+
+  test("swapping envelopes across columns fails closed in both directions", async () => {
+    const encId = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_user_id",
+      "discord:1",
+    );
+    const encName = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_display_name",
+      "Ada",
+    );
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_display_name", encId),
+    ).rejects.toThrow();
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_user_id", encName),
+    ).rejects.toThrow();
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_user_id", encId)).toBe(
+      "discord:1",
+    );
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_display_name", encName)).toBe(
+      "Ada",
+    );
+  });
+
+  test("tampered ciphertext fails closed", async () => {
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_user_id",
+      "do not mutate",
+    );
+    const tampered: EncryptedField = { ...enc, ciphertext: xorFirstByte(enc.ciphertext) };
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_user_id", tampered),
+    ).rejects.toThrow();
+  });
+
+  test("tampered nonce fails closed", async () => {
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_email",
+      "do not mutate",
+    );
+    const tampered: EncryptedField = { ...enc, nonce: xorFirstByte(enc.nonce) };
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_email", tampered),
+    ).rejects.toThrow();
+  });
+
+  test("tampered auth_tag fails closed", async () => {
+    const enc = await encryptPlatformCredentialField(
+      ORG_A,
+      ROW_A,
+      "platform_display_name",
+      "do not mutate",
+    );
+    const tampered: EncryptedField = { ...enc, auth_tag: xorFirstByte(enc.auth_tag) };
+    await expect(
+      decryptPlatformCredentialField(ROW_A, "platform_display_name", tampered),
+    ).rejects.toThrow();
+  });
+
+  test("decrypt uses the stored kms_key_id (org id is not an input to decrypt)", async () => {
+    const plaintext = "org-agnostic decrypt";
+    const enc = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_user_id", plaintext);
+    expect(enc.kms_key_id).toContain(ORG_A);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_user_id", enc)).toBe(plaintext);
+  });
+
+  test("different orgs encrypt under different key ids", async () => {
+    const plaintext = "shared wording";
+    const encA = await encryptPlatformCredentialField(ORG_A, ROW_A, "platform_email", plaintext);
+    const encB = await encryptPlatformCredentialField(ORG_B, ROW_A, "platform_email", plaintext);
+    expect(encA.kms_key_id).not.toBe(encB.kms_key_id);
+    expect(encA.kms_key_id).toContain(ORG_A);
+    expect(encB.kms_key_id).toContain(ORG_B);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", encA)).toBe(plaintext);
+    expect(await decryptPlatformCredentialField(ROW_A, "platform_email", encB)).toBe(plaintext);
+  });
+});


### PR DESCRIPTION

# Relates to

No issue. Operator-requested test-only coverage for
`packages/cloud/shared/src/db/crypto/platform-credentials.ts`, which had no
same-named test file in the repository. `crypto.test.ts` already had a thin
round-trip of two columns; this suite is the dedicated same-named file and
records the remaining contract (third column, empty/unicode payloads, AAD
row+column binding, AEAD tamper fail-closed).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Parent is `ee7d24557d13af8f05a46a727630ee9233f71d13`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition. No production code, no schema, no encryption algorithm
change. The suite drives the real helpers through MemoryKmsAdapter
(`NODE_ENV=test`); a false green would require the real AEAD path to succeed
on tampered ciphertext, which these cases reject.

# Background

## What does this PR do?

Adds `packages/cloud/shared/src/db/crypto/platform-credentials.test.ts`.

`platform-credentials.ts` exports two functions:

- `encryptPlatformCredentialField(orgId, rowId, column, plaintext)`
- `decryptPlatformCredentialField(rowId, column, field)`

Columns: `platform_user_id`, `platform_email`, `platform_display_name`.
AAD is `platform_credentials|<rowId>|<column>`. Decrypt does not take `orgId`;
it uses the `kms_key_id` stored on the envelope.

The suite records observed behavior of the real module (no mocks, no
`vi.hoisted`):

- round-trip of every column, including empty string, single character,
  whitespace (no email/display-name normalization), unicode/emoji, and a long
  payload
- complete `EncryptedField` envelope that does not leak plaintext
- distinct nonce/ciphertext on two encrypts of the same plaintext
- cross-row and cross-column AAD reject
- tampered ciphertext, nonce, and auth_tag fail closed
- different orgs encrypt under different key ids

## What kind of change is this?

Improvements (misc. changes to existing features) — tests only.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/crypto/platform-credentials.test.ts`.
Owning package unit lane is `bun test` (`packages/cloud/shared` script
`test` → `scripts/run-bun-tests.mjs`), not root vitest. This file imports
`bun:test`.

## Detailed testing steps

From repo root, after `git fetch origin develop` (filing-time recount):

```
bun test packages/cloud/shared/src/db/crypto/platform-credentials.test.ts
```

Observed (filing-time, current tree / current `origin/develop`):

```
 17 pass
 0 fail
 45 expect() calls
Ran 17 tests across 1 file. [622.00ms]
```

`platform-credentials.ts` reports 100% funcs / 100% lines under that run.

Biome (config present at repo-root `biome.json`; worktree is not sparse):

```
bunx biome check --write packages/cloud/shared/src/db/crypto/platform-credentials.test.ts
Checked 1 file in 13ms. Fixed 1 file.
```

`tsc --noEmit` from `packages/cloud/shared`:

```
cd packages/cloud/shared && bunx tsc --noEmit 2>&1 | grep 'platform-credentials.test.ts' ; echo "EXIT:$?"
GREP_EXIT:1
```

Our file appears nowhere in tsc output. Pre-existing errors in other files
(drizzle-orm duplicate-instantiation, `@cloudflare/playwright` missing types,
plugin-sql) are not introduced by this PR.

Diff touches only the new test file.

Hosted CI does **not** run on this fork PR. Do not treat a missing GitHub
Actions check as a pass. Local bun test / biome / tsc-grep are the evidence.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:295f570b6d7607f909601ba82f9cd00a752d9d08 -->

Test-only change. No UI, no backend route, no agent prompt/model path.

- [x] Before full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] After full-page screenshots: `N/A - test-only, no rendered UI surface`
- [x] Walkthrough video: `N/A - test-only, no user flow`
- [x] Backend logs: `N/A - no production path change; bun test output quoted in Testing`
- [x] Frontend console/network logs: `N/A - no frontend change`
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`
- [x] Domain artifacts: `N/A - no DB/wallet/scheduled-item mutation`
- [x] OCR visual-text review: `N/A - no rendered visual surface`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change`

## Backend + frontend logs

`N/A - test-only; bun test summary is in Testing`

## Screenshots (before / after) + video walkthrough

`N/A - test-only, no rendered UI surface`

## Audio / voice walkthrough

`N/A - not a voice/TTS/STT change`

## Known gaps / failures

- `bun run verify` was not run. This is a single-file test addition; the
  complete evidence set is bun test, biome, and tsc-grep of the new file.
  Fork PRs do not receive hosted CI.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth
  trace, so no 15% evidence-bonus receipt is attached.

## Maintainer CI exception record

`N/A - no exception requested`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
