### PR TITLE
test(agent): cover owner-contact-helpers

### DIFF
--- a/packages/agent/src/api/owner-contact-helpers.test.ts
+++ b/packages/agent/src/api/owner-contact-helpers.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for owner contact configuration helpers.
+ */
+
+import { describe, expect, it } from "vitest";
+import { setOwnerContact } from "./owner-contact-helpers.js";
+
+describe("setOwnerContact", () => {
+  it("returns false when source is missing or empty", () => {
+    const config = {};
+    expect(setOwnerContact(config, { source: "" })).toBe(false);
+    // @ts-expect-error test undefined source
+    expect(setOwnerContact(config, { source: undefined })).toBe(false);
+  });
+
+  it("initializes nested config path and populates contact entry", () => {
+    const config: Record<string, unknown> = {};
+
+    const modified = setOwnerContact(config, {
+      source: "telegram",
+      channelId: "12345678",
+      entityId: "uuid-1234",
+      roomId: "room-5678",
+    });
+
+    expect(modified).toBe(true);
+    expect(config).toEqual({
+      agents: {
+        defaults: {
+          ownerContacts: {
+            telegram: {
+              channelId: "12345678",
+              entityId: "uuid-1234",
+              roomId: "room-5678",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("does not write empty contact updates and returns false", () => {
+    const config: Record<string, unknown> = {};
+    const modified = setOwnerContact(config, {
+      source: "whatsapp",
+    });
+
+    expect(modified).toBe(false);
+    expect(
+      (config as { agents?: { defaults?: { ownerContacts?: unknown } } }).agents
+        ?.defaults?.ownerContacts,
+    ).toEqual({});
+  });
+
+  it("returns false when contact fields are identical to existing entry", () => {
+    const config = {
+      agents: {
+        defaults: {
+          ownerContacts: {
+            discord: {
+              channelId: "987654",
+              entityId: "user-1",
+            },
+          },
+        },
+      },
+    };
+
+    const modified = setOwnerContact(config, {
+      source: "discord",
+      channelId: "987654",
+      entityId: "user-1",
+    });
+
+    expect(modified).toBe(false);
+  });
+
+  it("updates existing contact entry and returns true when changed", () => {
+    const config = {
+      agents: {
+        defaults: {
+          ownerContacts: {
+            discord: {
+              channelId: "987654",
+              entityId: "user-1",
+            },
+          },
+        },
+      },
+    };
+
+    const modified = setOwnerContact(config, {
+      source: "discord",
+      channelId: "987654",
+      entityId: "user-1",
+      roomId: "new-room-id",
+    });
+
+    expect(modified).toBe(true);
+    expect(config.agents.defaults.ownerContacts.discord).toEqual({
+      channelId: "987654",
+      entityId: "user-1",
+      roomId: "new-room-id",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/agent/src/api/owner-contact-helpers.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `setOwnerContact` input validation when source is missing or empty.
- Recursive initialization of `config.agents.defaults.ownerContacts`.
- Property mapping for `channelId`, `entityId`, and `roomId`.
- Change detection (returns `false` if unchanged or empty, `true` when written).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`5137bec474`) |
| --- | --- | --- |
| `bunx vitest run packages/agent/src/api/owner-contact-helpers.test.ts` | N/A (new test file) | 5 passed (5 tests) |
| `bunx @biomejs/biome check packages/agent/src/api/owner-contact-helpers.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/api/owner-contact-helpers.test.ts:1-106`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:5137bec474593dcc6b647e38e137e7df964ec0b2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested