### PR TITLE
test(core): cover extractor-pipeline

### DIFF
--- a/packages/core/src/actions/extractor-pipeline.test.ts
+++ b/packages/core/src/actions/extractor-pipeline.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Deterministic unit tests for `runExtractorPipeline`. The suite drives the
+ * real orchestration (first pass → parse → optional repair → parse) with a
+ * queued `useModel` collaborator and real parsers. Failures, non-text
+ * responses, falsy-but-non-null parses, and trajectory purpose tags are the
+ * observed contracts — not aspirational ones.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.ts";
+import { getTrajectoryContext } from "../trajectory-context.ts";
+import { type IAgentRuntime, ModelType } from "../types";
+import { runExtractorPipeline } from "./extractor-pipeline.ts";
+import { parseJsonModelRecord } from "./json-model-output.ts";
+
+type ModelCall = {
+	modelType: string;
+	prompt: string;
+	purpose: string | undefined;
+};
+
+type Report = {
+	scope: string;
+	error: unknown;
+	context: unknown;
+};
+
+function parseInteger(raw: string): number | null {
+	const trimmed = raw.trim();
+	if (!/^-?\d+$/.test(trimmed)) {
+		return null;
+	}
+	return Number(trimmed);
+}
+
+function makeRuntime(handler: (call: ModelCall) => unknown): {
+	runtime: IAgentRuntime;
+	calls: ModelCall[];
+	reports: Report[];
+	warns: Array<{ payload: unknown; message: unknown }>;
+} {
+	const calls: ModelCall[] = [];
+	const reports: Report[] = [];
+	const warns: Array<{ payload: unknown; message: unknown }> = [];
+	const runtime = {
+		useModel: async (modelType: string, params: { prompt: string }) => {
+			const call: ModelCall = {
+				modelType,
+				prompt: params.prompt,
+				purpose: getTrajectoryContext()?.purpose,
+			};
+			calls.push(call);
+			return handler(call);
+		},
+		reportError: (scope: string, error: unknown, context?: unknown) => {
+			reports.push({ scope, error, context });
+		},
+		logger: {
+			warn: (payload: unknown, message?: unknown) => {
+				warns.push({ payload, message });
+			},
+		},
+	} as unknown as IAgentRuntime;
+	return { runtime, calls, reports, warns };
+}
+
+describe("runExtractorPipeline", () => {
+	it("returns the first-pass parse without issuing a repair call", async () => {
+		const { runtime, calls, reports } = makeRuntime(() => '{"name":"ada"}');
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "extract the name",
+			parser: parseJsonModelRecord<{ name: string }>,
+			buildRepairPrompt: (raw) => `repair: ${raw}`,
+		});
+
+		expect(result).toEqual({
+			parsed: { name: "ada" },
+			raw: '{"name":"ada"}',
+			repaired: false,
+		});
+		expect(calls).toEqual([
+			{
+				modelType: ModelType.TEXT_LARGE,
+				prompt: "extract the name",
+				purpose: "lifeops-extractor-first-pass",
+			},
+		]);
+		expect(reports).toEqual([]);
+	});
+
+	it("defaults modelType to TEXT_LARGE when omitted", async () => {
+		const { runtime, calls } = makeRuntime(() => "7");
+
+		await runExtractorPipeline({
+			runtime,
+			prompt: "n",
+			parser: parseInteger,
+		});
+
+		expect(calls[0]?.modelType).toBe(ModelType.TEXT_LARGE);
+		expect(calls[0]?.modelType).toBe("TEXT_LARGE");
+	});
+
+	it("forwards an explicit modelType to the first pass", async () => {
+		const { runtime, calls } = makeRuntime(() => "1");
+
+		await runExtractorPipeline({
+			runtime,
+			prompt: "n",
+			parser: parseInteger,
+			modelType: ModelType.TEXT_SMALL,
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.modelType).toBe(ModelType.TEXT_SMALL);
+	});
+
+	it("returns a parse miss without repair when buildRepairPrompt is omitted", async () => {
+		const { runtime, calls } = makeRuntime(() => "not-json");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "extract",
+			parser: parseJsonModelRecord,
+		});
+
+		expect(result).toEqual({
+			parsed: null,
+			raw: "not-json",
+			repaired: false,
+		});
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.prompt).toBe("extract");
+	});
+
+	it("does not treat a missing buildRepairPrompt the same as an empty repair prompt", async () => {
+		const { runtime, calls } = makeRuntime(() => "x");
+
+		const without = await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: () => null,
+		});
+		expect(without.repaired).toBe(false);
+		expect(calls).toHaveLength(1);
+
+		const { runtime: withEmpty, calls: emptyCalls } = makeRuntime(() => "x");
+		const withEmptyPrompt = await runExtractorPipeline({
+			runtime: withEmpty,
+			prompt: "p",
+			parser: () => null,
+			buildRepairPrompt: () => "",
+		});
+		expect(withEmptyPrompt.repaired).toBe(true);
+		expect(emptyCalls).toHaveLength(2);
+		expect(emptyCalls[1]?.prompt).toBe("");
+	});
+
+	it("issues one repair pass and returns the repaired parse", async () => {
+		const outputs = ["not-json", '{"name":"grace"}'];
+		const { runtime, calls } = makeRuntime(() => {
+			const next = outputs.shift();
+			if (next === undefined) {
+				throw new Error("unexpected extra useModel call");
+			}
+			return next;
+		});
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "extract the name",
+			parser: parseJsonModelRecord<{ name: string }>,
+			buildRepairPrompt: (raw) => `fix ${raw}`,
+			modelType: ModelType.TEXT_MEDIUM,
+		});
+
+		expect(result).toEqual({
+			parsed: { name: "grace" },
+			raw: '{"name":"grace"}',
+			repaired: true,
+		});
+		expect(calls).toEqual([
+			{
+				modelType: ModelType.TEXT_MEDIUM,
+				prompt: "extract the name",
+				purpose: "lifeops-extractor-first-pass",
+			},
+			{
+				modelType: ModelType.TEXT_MEDIUM,
+				prompt: "fix not-json",
+				purpose: "lifeops-extractor-repair-pass",
+			},
+		]);
+	});
+
+	it("returns repaired:true with parsed:null when the repair pass also misses", async () => {
+		const outputs = ["first-miss", "still-miss"];
+		const { runtime } = makeRuntime(() => outputs.shift() ?? "overflow");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "extract",
+			parser: parseJsonModelRecord,
+			buildRepairPrompt: (raw) => `retry ${raw}`,
+		});
+
+		expect(result).toEqual({
+			parsed: null,
+			raw: "still-miss",
+			repaired: true,
+		});
+	});
+
+	it("hands the exact first-pass raw string to buildRepairPrompt", async () => {
+		const seen: string[] = [];
+		const outputs = ["  {bad}  ", '{"ok":true}'];
+		const { runtime } = makeRuntime(() => outputs.shift() ?? "");
+
+		await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: parseJsonModelRecord,
+			buildRepairPrompt: (raw) => {
+				seen.push(raw);
+				return `repair(${raw})`;
+			},
+		});
+
+		expect(seen).toEqual(["  {bad}  "]);
+	});
+
+	it("treats a parsed 0 as success and skips repair", async () => {
+		const { runtime, calls } = makeRuntime(() => "0");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: parseInteger,
+			buildRepairPrompt: () => "must-not-run",
+		});
+
+		expect(result).toEqual({ parsed: 0, raw: "0", repaired: false });
+		expect(calls).toHaveLength(1);
+	});
+
+	it("treats a parsed false as success and skips repair", async () => {
+		const { runtime, calls } = makeRuntime(() => "false");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: (raw) => (raw === "false" ? false : null),
+			buildRepairPrompt: () => "must-not-run",
+		});
+
+		expect(result).toEqual({ parsed: false, raw: "false", repaired: false });
+		expect(calls).toHaveLength(1);
+	});
+
+	it("treats a parsed empty string as success and skips repair", async () => {
+		const { runtime, calls } = makeRuntime(() => "present");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: (raw) => (raw.length > 0 ? "" : null),
+			buildRepairPrompt: () => "must-not-run",
+		});
+
+		expect(result).toEqual({
+			parsed: "",
+			raw: "present",
+			repaired: false,
+		});
+		expect(calls).toHaveLength(1);
+	});
+
+	it("accepts an empty-string model response and still runs the parser", async () => {
+		const seen: string[] = [];
+		const { runtime } = makeRuntime(() => "");
+
+		const result = await runExtractorPipeline({
+			runtime,
+			prompt: "p",
+			parser: (raw) => {
+				seen.push(raw);
+				return null;
+			},
+		});
+
+		expect(seen).toEqual([""]);
+		expect(result).toEqual({ parsed: null, raw: "", repaired: false });
+	});
+
+	it("throws EXTRACTOR_NON_TEXT_RESPONSE for a numeric first-pass result", async () => {
+		const { runtime, calls, reports, warns } = makeRuntime(() => 42);
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+			}),
+		).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "EXTRACTOR_NON_TEXT_RESPONSE",
+			message: "Extractor model returned a non-text response",
+			context: { responseType: "number" },
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(reports).toHaveLength(1);
+		expect(reports[0]?.scope).toBe("ExtractorPipeline.model");
+		expect(reports[0]?.context).toEqual({ modelType: ModelType.TEXT_LARGE });
+		expect(reports[0]?.error).toBeInstanceOf(ElizaError);
+		expect(warns).toEqual([
+			{
+				payload: {
+					src: "lifeops:extractor-pipeline",
+					error: "Extractor model returned a non-text response",
+				},
+				message: "Extractor pipeline model call failed",
+			},
+		]);
+	});
+
+	it("records responseType object when the first-pass result is null", async () => {
+		const { runtime, reports } = makeRuntime(() => null);
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+			}),
+		).rejects.toMatchObject({
+			code: "EXTRACTOR_NON_TEXT_RESPONSE",
+			context: { responseType: "object" },
+		});
+
+		expect(reports).toHaveLength(1);
+		expect(reports[0]?.error).toBeInstanceOf(ElizaError);
+		expect(reports[0]?.error).toMatchObject({
+			code: "EXTRACTOR_NON_TEXT_RESPONSE",
+			context: { responseType: "object" },
+		});
+	});
+
+	it("records responseType undefined when the first-pass result is undefined", async () => {
+		const { runtime } = makeRuntime(() => undefined);
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+			}),
+		).rejects.toMatchObject({
+			code: "EXTRACTOR_NON_TEXT_RESPONSE",
+			context: { responseType: "undefined" },
+		});
+	});
+
+	it("throws EXTRACTOR_NON_TEXT_RESPONSE for a non-text repair result", async () => {
+		const outputs: unknown[] = ["not-an-int", { text: "3" }];
+		const { runtime, calls, reports } = makeRuntime(() => outputs.shift());
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+				buildRepairPrompt: () => "repair-me",
+			}),
+		).rejects.toMatchObject({
+			code: "EXTRACTOR_NON_TEXT_RESPONSE",
+			context: { responseType: "object" },
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(calls[1]?.prompt).toBe("repair-me");
+		expect(reports[0]?.scope).toBe("ExtractorPipeline.model");
+	});
+
+	it("reports and rethrows a first-pass useModel failure without a repair attempt", async () => {
+		const boom = new Error("upstream 503");
+		const { runtime, calls, reports, warns } = makeRuntime(() => {
+			throw boom;
+		});
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+				buildRepairPrompt: () => "must-not-run",
+			}),
+		).rejects.toBe(boom);
+
+		expect(calls).toHaveLength(1);
+		expect(reports).toEqual([
+			{
+				scope: "ExtractorPipeline.model",
+				error: boom,
+				context: { modelType: ModelType.TEXT_LARGE },
+			},
+		]);
+		expect(warns[0]?.payload).toEqual({
+			src: "lifeops:extractor-pipeline",
+			error: "upstream 503",
+		});
+	});
+
+	it("reports and rethrows a repair-pass useModel failure", async () => {
+		const boom = new Error("repair provider down");
+		let pass = 0;
+		const { runtime, calls, reports } = makeRuntime(() => {
+			pass += 1;
+			if (pass === 1) {
+				return "not-an-int";
+			}
+			throw boom;
+		});
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+				buildRepairPrompt: () => "repair",
+				modelType: ModelType.TEXT_NANO,
+			}),
+		).rejects.toBe(boom);
+
+		expect(calls).toHaveLength(2);
+		expect(reports).toEqual([
+			{
+				scope: "ExtractorPipeline.model",
+				error: boom,
+				context: { modelType: ModelType.TEXT_NANO },
+			},
+		]);
+	});
+
+	it("stringifies a non-Error throw in the warn payload and rethrows it", async () => {
+		const { runtime, reports, warns } = makeRuntime(() => {
+			throw "bare-string-failure";
+		});
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: parseInteger,
+			}),
+		).rejects.toBe("bare-string-failure");
+
+		expect(reports[0]?.error).toBe("bare-string-failure");
+		expect(warns[0]?.payload).toEqual({
+			src: "lifeops:extractor-pipeline",
+			error: "bare-string-failure",
+		});
+	});
+
+	it("reports a parser throw as ExtractorPipeline.model and does not repair", async () => {
+		const parserError = new Error("parser exploded");
+		const { runtime, calls, reports } = makeRuntime(() => "12");
+
+		await expect(
+			runExtractorPipeline({
+				runtime,
+				prompt: "p",
+				parser: () => {
+					throw parserError;
+				},
+				buildRepairPrompt: () => "must-not-run",
+			}),
+		).rejects.toBe(parserError);
+
+		expect(calls).toHaveLength(1);
+		expect(reports).toEqual([
+			{
+				scope: "ExtractorPipeline.model",
+				error: parserError,
+				context: { modelType: ModelType.TEXT_LARGE },
+			},
+		]);
+	});
+});


### PR DESCRIPTION

# Relates to

Test-coverage contribution for `packages/core/src/actions/extractor-pipeline.ts`, which had no same-named test file. No production issue is being closed.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on current `origin/develop`
      (`63921891d959229988028f0d948c868b1f45b1a6`) with a single-file commit
      and zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (vitest / biome / tsc counts).

# Sync with develop

- [x] Commit parent is current `origin/develop` (`63921891d959229988028f0d948c868b1f45b1a6`); zero conflicts.
- [ ] `bun run verify` was not run (see **Known gaps / failures**). Focused
      vitest, biome, and package `tsc --noEmit` were run instead.

# Risks

Low. Test-only addition. No production code, exports, or runtime behavior
change. The suite records observed `runExtractorPipeline` contracts (first-pass
parse, optional repair, falsy-but-non-null parses, non-text `ElizaError`,
model-failure report-and-rethrow). It does not assert aspirational behavior.

# Background

## What does this PR do?

Adds `packages/core/src/actions/extractor-pipeline.test.ts`, a deterministic
Vitest suite for `runExtractorPipeline`. It drives the real module with a queued
`useModel` collaborator and real parsers (`parseJsonModelRecord`, integer
parse). Covered branches:

- first-pass success (no repair call)
- default `modelType` (`TEXT_LARGE`) and explicit `modelType` forwarding
- parse miss with no `buildRepairPrompt` (no second model call)
- empty `buildRepairPrompt` still issues a repair call (`repaired: true`)
- repair success and double-miss (`parsed: null`, `repaired: true`)
- exact first-pass raw handed to `buildRepairPrompt`
- falsy-but-non-null parses (`0`, `false`, `""`) skip repair
- empty-string model output is still parsed
- non-text first-pass and repair results throw `EXTRACTOR_NON_TEXT_RESPONSE`
  (`responseType` number / object / undefined)
- first-pass and repair-pass `useModel` failures report
  `ExtractorPipeline.model` and rethrow; no repair after a first-pass throw
- non-Error throws are stringified in the warn payload
- parser throws are reported as `ExtractorPipeline.model` and do not repair
  (observed catch wrapping)
- trajectory purposes `lifeops-extractor-first-pass` and
  `lifeops-extractor-repair-pass`

## What kind of change is this?

Improvements (misc. changes to existing features) — test-only coverage.

## Why are we doing this? Any context or related work?

`packages/core/src/actions/extractor-pipeline.ts` had no same-named test file.
The pipeline is the shared first-pass / repair orchestrator used by argument
extraction. Missing coverage left parse-miss, repair, non-text, and failure
reporting unasserted.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/actions/extractor-pipeline.test.ts` and
`packages/core/src/actions/extractor-pipeline.ts`. Diff is that one new test
file.

## Detailed testing steps

None: Automated tests are acceptable.

```bash
cd /path/to/eliza
bunx vitest run packages/core/src/actions/extractor-pipeline.test.ts
bunx biome check packages/core/src/actions/extractor-pipeline.test.ts
cd packages/core && bunx tsc --noEmit 2>&1 | grep extractor-pipeline.test ; echo "GREP_EXIT:$?"
```

We are a fork contributor (`ss251/eliza`). Hosted CI does **not** run on this
PR. Do not treat GitHub check status as evidence.

# Evidence Gate

Evidence matches this PR head. Hosted CI does not run on fork PRs.

<!-- evidence-head:3c317064444706ca9be916490e26750d3c6a7841 -->

This is a test-only change with no rendered UI, no backend HTTP path, and no
live-model production behavior change.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only; no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production runtime path; suite is in-process Vitest.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - `useModel` is a queued collaborator; no live LLM call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB / memory / chain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only; `useModel` is a deterministic queue, not a live provider.

## Backend + frontend logs

N/A - no server or UI process.

## Screenshots (before / after) + video walkthrough

N/A - test-only; no UI.

### Before

N/A - test-only; no UI.

### After

N/A - test-only; no UI.

### Walkthrough video

N/A - test-only; no UI.

## Audio / voice walkthrough

N/A - no voice / TTS / STT change.

## Focused command evidence (re-run against current origin/develop)

Parent: `origin/develop` `63921891d959229988028f0d948c868b1f45b1a6`
Head: `3c317064444706ca9be916490e26750d3c6a7841`
Diff: only `packages/core/src/actions/extractor-pipeline.test.ts`

`biome.json` and `tsconfig.json` are present at the checkout root. The worktree
is not sparse (`git sparse-checkout list` → fatal: this worktree is not sparse).
`packages/core` test script is `node ../scripts/run-vitest.mjs run` (Vitest, not
`bun test`). No `vi.hoisted`.

### vitest

```
bunx vitest run packages/core/src/actions/extractor-pipeline.test.ts

 ✓ packages/core/src/actions/extractor-pipeline.test.ts (20 tests) 6ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  20:23:23
   Duration  449ms (transform 282ms, setup 0ms, import 366ms, tests 6ms, environment 0ms)
```

Re-fetched `origin/develop` immediately before this quote. Same 20/20 after the
parent SHA above.

### biome

```
bunx biome check --write packages/core/src/actions/extractor-pipeline.test.ts
Checked 1 file in 14ms. No fixes applied.
```

Config: `/Volumes/thescoho_1TB/Developer/eliza/biome.json` present.

### tsc

```
cd packages/core && bunx tsc --noEmit 2>&1 | grep 'extractor-pipeline.test' ; echo "GREP_EXIT:$?"
GREP_EXIT:1
```

The new test file appears nowhere in `tsc --noEmit` output (grep miss is the
pass). Pre-existing package errors, if any, are not in this file.

The diff touches only the new test file.

## Known gaps / failures

- `bun run verify` was not run. Operator scoped this test-only PR to vitest,
  biome, and package `tsc --noEmit`. Those three are quoted above.
- Hosted GitHub Actions CI does not run on fork PRs. Reviewers should re-run
  the vitest command locally against current `develop`.
- No identity.slop.cash OAuth trace: unattended session cannot finalize an
  interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
