### PR TITLE
test(shared): cover is-native-server

### DIFF
--- a/packages/shared/src/platform/is-native-server.test.ts
+++ b/packages/shared/src/platform/is-native-server.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for server-side native platform detection.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { isNativeServerPlatform } from "./is-native-server.js";
+
+describe("isNativeServerPlatform", () => {
+  const originalCapacitor = (globalThis as Record<string, unknown>).Capacitor;
+
+  afterEach(() => {
+    if (originalCapacitor === undefined) {
+      delete (globalThis as Record<string, unknown>).Capacitor;
+    } else {
+      (globalThis as Record<string, unknown>).Capacitor = originalCapacitor;
+    }
+  });
+
+  it("returns false in standard Node/Bun environments without Capacitor global", () => {
+    delete (globalThis as Record<string, unknown>).Capacitor;
+    expect(isNativeServerPlatform()).toBe(false);
+  });
+
+  it("returns false when Capacitor global exists without isNativePlatform", () => {
+    (globalThis as Record<string, unknown>).Capacitor = {};
+    expect(isNativeServerPlatform()).toBe(false);
+
+    (globalThis as Record<string, unknown>).Capacitor = {
+      isNativePlatform: undefined,
+    };
+    expect(isNativeServerPlatform()).toBe(false);
+  });
+
+  it("returns false when Capacitor.isNativePlatform() returns false", () => {
+    (globalThis as Record<string, unknown>).Capacitor = {
+      isNativePlatform: () => false,
+    };
+    expect(isNativeServerPlatform()).toBe(false);
+  });
+
+  it("returns true when running inside native mobile shell with Capacitor.isNativePlatform() true", () => {
+    (globalThis as Record<string, unknown>).Capacitor = {
+      isNativePlatform: () => true,
+    };
+    expect(isNativeServerPlatform()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/platform/is-native-server.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `isNativeServerPlatform` fallback to `false` when `globalThis.Capacitor` is absent.
- Graceful `false` return when `Capacitor` is defined without `isNativePlatform`.
- Negative case when `Capacitor.isNativePlatform()` returns `false`.
- Positive case when running within a Capacitor native mobile shell (`isNativePlatform()` returns `true`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`7b6e1539a9`) |
| --- | --- | --- |
| `bunx vitest run packages/shared/src/platform/is-native-server.test.ts` | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/shared/src/platform/is-native-server.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/platform/is-native-server.test.ts:1-47`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:7b6e1539a921708ec3a48440567d63f817051000 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested