### PR TITLE
test(app-core): cover boot-profile

### DIFF
--- a/packages/app-core/src/boot-profile.test.ts
+++ b/packages/app-core/src/boot-profile.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for boot profile timing and lap logger.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("boot-profile", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("disables profiling and suppresses stderr logs when ELIZA_BOOT_PROFILE is unset", async () => {
+    delete process.env.ELIZA_BOOT_PROFILE;
+    delete process.env.ELIZA_API_PROCESS_SPAWNED_AT_MS;
+    delete process.env.ELIZA_PROCESS_SPAWNED_AT_MS;
+
+    const { bootLap, bootProfileEnabled } = await import("./boot-profile.js");
+
+    expect(bootProfileEnabled()).toBe(false);
+
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    bootLap("start:test");
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("enables profiling and writes formatted elapsed times to stderr when ELIZA_BOOT_PROFILE is 1", async () => {
+    const spawnTime = Date.now() - 50;
+    process.env.ELIZA_BOOT_PROFILE = "1";
+    process.env.ELIZA_API_PROCESS_SPAWNED_AT_MS = String(spawnTime);
+
+    const { bootLap, bootProfileEnabled } = await import("./boot-profile.js");
+
+    expect(bootProfileEnabled()).toBe(true);
+
+    const writes: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    bootLap("init:config");
+    bootLap("start:api");
+
+    expect(writes).toHaveLength(2);
+
+    expect(writes[0]).toContain("[boot-profile]");
+    expect(writes[0]).toContain("init:config".padEnd(40));
+    expect(writes[0]).toMatch(/\+\d+ms/);
+    expect(writes[0]).toMatch(/\(\u0394\d+ms\)/);
+
+    expect(writes[1]).toContain("[boot-profile]");
+    expect(writes[1]).toContain("start:api".padEnd(40));
+    expect(writes[1]).toMatch(/\+\d+ms/);
+    expect(writes[1]).toMatch(/\(\u0394\d+ms\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/app-core/src/boot-profile.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `bootProfileEnabled` boolean reporting when disabled and enabled.
- Disabled state suppresses all stderr writes.
- Enabled state (`ELIZA_BOOT_PROFILE="1"`) validates prefix format `[boot-profile] `, 40-character label padding, `+sinceSpawn` and `ΔsinceLast` output to `process.stderr`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`37f3dd8da8`) |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/boot-profile.test.ts` | N/A (new test file) | 2 passed (2 tests) |
| `bunx @biomejs/biome check packages/app-core/src/boot-profile.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/boot-profile.test.ts:1-67`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:37f3dd8da841ca32f42fd420fa1a9b26e78ab0a5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested