### PR TITLE
fix(ui): preserve completed turns across lagging history

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-warming-absorption-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-warming-absorption-e2e.mjs
@@ -13,7 +13,8 @@
  *      `Retry-After: 1`), then the real streamed reply.
  *   2. Assert the optimistic bubble stays pending across both barriers with
  *      NO Retry chip and NO error notice, and the first non-warming response
- *      lands as the reply (pre-fix: the turn failed with a Retry chip).
+ *      lands as the reply even when the required history refresh temporarily
+ *      omits its receipt-backed rows (pre-fix: the completed turn vanished).
  *   3. Reload with `?scenario=credits`: assert the 402 renders the terminal
  *      out-of-credits turn with the server's message and no Retry chip.
  *
@@ -47,6 +48,7 @@ const assistantWithText = (p, text) =>
 
 const MESSAGE = "first message to a fresh shared agent";
 const REPLY = "caches warmed while your send stayed pending";
+const OLDER_REPLY = "Earlier shared-agent answer";
 const CREDITS_MESSAGE = "out of credits";
 
 await runBrowserFixtureE2E(
@@ -107,6 +109,10 @@ await runBrowserFixtureE2E(
     assert(
       (await assistantWithText(page, REPLY)) === 1,
       "first non-warming response is the turn's reply",
+    );
+    assert(
+      (await assistantWithText(page, OLDER_REPLY)) === 1,
+      "stale history rows are retained without replacing the completed turn",
     );
     assert(
       (await retryChips(page)) === 0,

--- a/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
@@ -5,7 +5,8 @@
 // (`client.setRequestTransport`) so the production retry loop, SSE parsing,
 // and error classification all execute in a real browser. Scenarios via
 // `?scenario=`: default replays the issue's exact first-turn sequence
-// (`agent_cache_warming` 503 → `shared_runtime_cache_warming` 503 → reply);
+// (`agent_cache_warming` 503 → `shared_runtime_cache_warming` 503 → reply →
+// temporarily stale history refresh);
 // `credits` answers the send with the canonical `insufficient_credits` 402.
 // Paired with run-warming-absorption-e2e.mjs.
 
@@ -39,6 +40,8 @@ const CONVERSATION: Conversation = {
 // `Retry-After: 1` — and the third attempt streams the real first reply.
 
 const REPLY = "Here — caches warmed while your send stayed pending.";
+const OLDER_USER = "Earlier shared-agent question";
+const OLDER_REPLY = "Earlier shared-agent answer";
 const CREDITS_MESSAGE =
   "You're out of credits. Add funds to keep chatting with your agent.";
 
@@ -66,6 +69,7 @@ function sseReply(): Response {
     agentName: "Eliza",
     messageId: "srv-a-1",
     userMessageId: "srv-u-1",
+    historyRefreshRequired: true,
   });
   return new Response(`data: ${done}\n\n`, {
     status: 200,
@@ -112,11 +116,14 @@ function Harness(): React.JSX.Element {
   const setConversationMessages = React.useCallback<
     UseChatSendDeps["setConversationMessages"]
   >((value) => {
-    setMessagesState((prev) => {
-      const next = typeof value === "function" ? value(prev) : value;
-      conversationMessagesRef.current = next;
-      return next;
-    });
+    // Mirror useChatState's production contract: callbacks read and update the
+    // ref synchronously before React schedules the visual state commit.
+    const next =
+      typeof value === "function"
+        ? value(conversationMessagesRef.current)
+        : value;
+    conversationMessagesRef.current = next;
+    setMessagesState(next);
   }, []);
 
   const [chatSending, setChatSending] = React.useState(false);
@@ -161,7 +168,25 @@ function Harness(): React.JSX.Element {
     chatSendBusyRef: React.useRef(false),
     chatSendNonceRef: React.useRef(0),
     loadConversations: async () => conversationsRef.current,
-    loadConversationMessages: async () => ({ ok: true as const }),
+    loadConversationMessages: async () => {
+      if (scenario === "warming") {
+        setConversationMessages([
+          {
+            id: "srv-u-older",
+            role: "user",
+            text: OLDER_USER,
+            timestamp: Date.now() - 60_000,
+          },
+          {
+            id: "srv-a-older",
+            role: "assistant",
+            text: OLDER_REPLY,
+            timestamp: Date.now() - 59_000,
+          },
+        ]);
+      }
+      return { ok: true as const };
+    },
     elizaCloudEnabled: false,
     elizaCloudConnected: false,
     pollCloudCredits: async () => true,
@@ -274,7 +299,7 @@ function Harness(): React.JSX.Element {
         <p style={{ opacity: 0.7, marginTop: 12, lineHeight: 1.6 }}>
           {scenario === "credits"
             ? "The agent behind this fixture answers the send with the canonical insufficient_credits 402."
-            : "The agent behind this fixture 503s the first two sends with the named warming barriers, then replies — the #18045 repro sequence."}
+            : "The agent behind this fixture 503s the first two sends with the named warming barriers, replies, then returns a temporarily stale history view — the hosted regression sequence."}
         </p>
       </div>
       {notice ? (

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -1065,6 +1065,117 @@ describe("useChatSend action handoff", () => {
     ).toBe(false);
   });
 
+  it("preserves a completed turn when the post-send history refresh temporarily lags its receipts", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Hello from Eliza.",
+      completed: true,
+      userMessageId: "persisted-current-user",
+      messageId: "persisted-current-assistant",
+      historyRefreshRequired: true,
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const staleHistory: ConversationMessage[] = [
+      {
+        id: "persisted-older-user",
+        role: "user",
+        text: "Earlier question",
+        timestamp: Date.now() - 60_000,
+      },
+      {
+        id: "persisted-older-assistant",
+        role: "assistant",
+        text: "Earlier answer",
+        timestamp: Date.now() - 59_000,
+      },
+    ];
+    vi.mocked(deps.loadConversationMessages).mockImplementation(async () => {
+      // Real Cloud history can be briefly behind the successful stream receipt.
+      // It is still authoritative for older rows, but must not erase the exact
+      // just-completed turn while those receipt ids converge into the listing.
+      deps.setConversationMessages(staleHistory);
+      return { ok: true };
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello with unique marker", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(
+      deps.conversationMessagesRef.current.map(({ id, role, text }) => ({
+        id,
+        role,
+        text,
+      })),
+    ).toEqual([
+      ...staleHistory.map(({ id, role, text }) => ({ id, role, text })),
+      {
+        id: "persisted-current-user",
+        role: "user",
+        text: "hello with unique marker",
+      },
+      {
+        id: "persisted-current-assistant",
+        role: "assistant",
+        text: "Hello from Eliza.",
+      },
+    ]);
+  });
+
+  it("does not duplicate a completed turn once history contains both receipt ids", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Hello from Eliza.",
+      completed: true,
+      userMessageId: "persisted-current-user",
+      messageId: "persisted-current-assistant",
+      historyRefreshRequired: true,
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    vi.mocked(deps.loadConversationMessages).mockImplementation(async () => {
+      deps.setConversationMessages([
+        {
+          id: "persisted-current-user",
+          role: "user",
+          text: "hello with unique marker",
+          timestamp: Date.now(),
+        },
+        {
+          id: "persisted-current-assistant",
+          role: "assistant",
+          text: "Hello from Eliza.",
+          timestamp: Date.now() + 1,
+        },
+      ]);
+      return { ok: true };
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello with unique marker", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(
+      deps.conversationMessagesRef.current.filter(
+        (message) => message.id === "persisted-current-user",
+      ),
+    ).toHaveLength(1);
+    expect(
+      deps.conversationMessagesRef.current.filter(
+        (message) => message.id === "persisted-current-assistant",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("opens a workflow created by a completed chat action", async () => {
     mocks.client.sendConversationMessageStream.mockResolvedValue({
       text: 'Created workflow "Daily digest".',

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -189,6 +189,44 @@ interface AssistantTurnOrigin {
   persistedUserMessageId?: string;
 }
 
+interface CompletedTurnHistorySnapshot {
+  userReceiptId: string;
+  assistantReceiptId: string | undefined;
+  user: ConversationMessage | null;
+  assistant: ConversationMessage | null;
+}
+
+function captureCompletedTurnForHistoryRefresh(
+  messages: readonly ConversationMessage[],
+  ids: {
+    userReceiptId: string;
+    assistantReceiptId?: string;
+    optimisticUserMessageId: string;
+    optimisticAssistantMessageId: string;
+  },
+): CompletedTurnHistorySnapshot {
+  return {
+    userReceiptId: ids.userReceiptId,
+    assistantReceiptId: ids.assistantReceiptId,
+    user:
+      messages.find(
+        (message) =>
+          message.role === "user" &&
+          (message.id === ids.userReceiptId ||
+            message.id === ids.optimisticUserMessageId ||
+            message.clientRenderId === ids.optimisticUserMessageId),
+      ) ?? null,
+    assistant:
+      messages.find(
+        (message) =>
+          message.role === "assistant" &&
+          (message.id === ids.assistantReceiptId ||
+            message.id === ids.optimisticAssistantMessageId ||
+            message.clientRenderId === ids.optimisticAssistantMessageId),
+      ) ?? null,
+  };
+}
+
 /**
  * Whether another user turn follows the turn that owns a local assistant row.
  *
@@ -1405,6 +1443,84 @@ export function useChatSend(deps: UseChatSendDeps) {
     [setConversationMessagesForConversation],
   );
 
+  // A successful stream can carry durable user/assistant receipt ids before the
+  // follow-up history endpoint exposes those rows.
+  // When an action or compatibility response requires that immediate refresh,
+  // the full replacement must retain the exact completed local turn until the
+  // history view converges. Match only receipt/client-render ids for the user
+  // row; merge missing rows adjacent to each other without duplicating server
+  // truth.
+  const preserveCompletedTurnAfterHistoryRefresh = useCallback(
+    (
+      conversationId: string | null,
+      turn: {
+        user: ConversationMessage;
+        assistant: ConversationMessage | null;
+        userReceiptId: string;
+        assistantReceiptId?: string;
+      },
+    ) => {
+      setConversationMessagesForConversation(conversationId, (prev) => {
+        const userIds = new Set(
+          [turn.userReceiptId, turn.user.id, turn.user.clientRenderId].filter(
+            (value): value is string => Boolean(value),
+          ),
+        );
+        const userIndex = prev.findIndex(
+          (message) =>
+            message.role === "user" &&
+            (userIds.has(message.id) ||
+              (message.clientRenderId
+                ? userIds.has(message.clientRenderId)
+                : false)),
+        );
+        const assistant = turn.assistant;
+        const assistantIds = new Set(
+          [
+            turn.assistantReceiptId,
+            assistant?.id,
+            assistant?.clientRenderId,
+          ].filter((value): value is string => Boolean(value)),
+        );
+        let assistantIndex = assistant
+          ? prev.findIndex(
+              (message) =>
+                message.role === "assistant" &&
+                (assistantIds.has(message.id) ||
+                  (message.clientRenderId
+                    ? assistantIds.has(message.clientRenderId)
+                    : false)),
+            )
+          : -1;
+        if (assistant && assistantIndex < 0 && !turn.assistantReceiptId) {
+          assistantIndex = prev.findIndex(
+            (message) =>
+              message.role === "assistant" &&
+              message.text.trim() === assistant.text.trim() &&
+              Math.abs(message.timestamp - assistant.timestamp) <=
+                SENT_TURN_MATCH_SLACK_MS,
+          );
+        }
+
+        if (userIndex >= 0 && (!assistant || assistantIndex >= 0)) return prev;
+
+        const next = [...prev];
+        if (userIndex < 0 && assistantIndex >= 0) {
+          next.splice(assistantIndex, 0, turn.user);
+          return next;
+        }
+        if (userIndex >= 0 && assistant && assistantIndex < 0) {
+          next.splice(userIndex + 1, 0, assistant);
+          return next;
+        }
+        next.push(turn.user);
+        if (assistant) next.push(assistant);
+        return next;
+      });
+    },
+    [setConversationMessagesForConversation],
+  );
+
   const runQueuedChatSend = useCallback(
     async (turn: Omit<QueuedChatSend, "resolve" | "reject">) => {
       const hasAttachedImages = Boolean(turn.images?.length);
@@ -1698,6 +1814,21 @@ export function useChatSend(deps: UseChatSendDeps) {
           setActionNotice(message, "error", 8_000);
         });
 
+        const completedTurnSnapshot =
+          data.completed && data.userMessageId
+            ? captureCompletedTurnForHistoryRefresh(
+                conversationMessagesRef.current,
+                {
+                  userReceiptId: data.userMessageId,
+                  ...(data.messageId
+                    ? { assistantReceiptId: data.messageId }
+                    : {}),
+                  optimisticUserMessageId: userMsgId,
+                  optimisticAssistantMessageId: assistantMsgId,
+                },
+              )
+            : null;
+
         // Direct replies already carry both committed memory ids, so reloading
         // the whole transcript would add a DB round trip, replace every message
         // object, and race the terminal frame. Action callbacks are the only
@@ -1710,6 +1841,19 @@ export function useChatSend(deps: UseChatSendDeps) {
             !data.userMessageId)
         ) {
           await loadConversationMessages(convId);
+          if (completedTurnSnapshot?.user) {
+            preserveCompletedTurnAfterHistoryRefresh(convId, {
+              user: completedTurnSnapshot.user,
+              assistant: completedTurnSnapshot.assistant,
+              userReceiptId: completedTurnSnapshot.userReceiptId,
+              ...(completedTurnSnapshot.assistantReceiptId
+                ? {
+                    assistantReceiptId:
+                      completedTurnSnapshot.assistantReceiptId,
+                  }
+                : {}),
+            });
+          }
           // The reload above full-replaces the thread; a stopped reply is often
           // NOT persisted server-side, so re-attach the partial the user watched
           // stream in (no-op / no duplicate when the server kept it).
@@ -2090,7 +2234,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       chatAbortRef,
       chatInputRef,
       chatPendingImagesRef,
-      conversationMessagesRef.current.filter,
+      conversationMessagesRef,
       conversationsRef,
       isConversationCommitActive,
       setActiveConversationId,
@@ -2103,6 +2247,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       dropEmptyAssistantPlaceholder,
       reattachInterruptedPartial,
       restoreEvictedUserTurn,
+      preserveCompletedTurnAfterHistoryRefresh,
       setConversations,
       setActionNotice,
       setChatInput,


### PR DESCRIPTION
Closes #26175.

## What changed

- Preserve the exact receipt-backed completed user/assistant turn when an immediate required history refresh temporarily lags those rows.
- Retain older server history and avoid duplicates once the exact receipt IDs appear.
- Extend the real-browser warming fixture through the hosted failure sequence: named 503 barriers, successful SSE receipts, then stale history.

## Root-cause evidence

- Staging Cloud run: `32645709309` at source `88fccb0d61b78c543372cdba8383277a5ed84536`.
- Diagnostic job/artifact: job `97211212138`, artifact `9495046745`, digest `0355b5118688b...`.
- The stream completed with user/assistant receipt IDs, then the required history reload returned 18 older user + 18 older assistant rows without the current turn. Full replacement erased the completed current rows.

## Exact-head verification

- Base: `98a550c111df09c276980d719762bd3074d34c79`
- Head: `fb59f0d69bc80110503cba24387bc64f8f38e5d2`
- `bun run --cwd packages/ui test src/state/useChatSend.test.tsx` — PASS, 91/91
- `bun run --cwd packages/ui typecheck` — PASS
- `bunx biome check <four changed files>` — PASS
- `bun run --cwd packages/ui test:warming-absorption-e2e` — PASS; screenshots and WebM manually reviewed locally
- `git diff --check origin/develop...HEAD` — PASS
- `git diff origin/develop...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` — PASS, no leaks

## Evidence matrix

| Evidence | Result |
|---|---|
| Before screenshot | Hosted diagnostic showed successful send followed by missing current marker rows; artifact above. |
| After desktop screenshots | Captured by browser fixture: pending, reconciled reply + older history, terminal credits state. |
| Walkthrough video | Captured `warming-absorption.webm`; the deterministic fixture exercises production `useChatSend -> streamChatEndpoint -> rawRequest -> ChatOverlay`. |
| Console/page errors | PASS: zero page errors. |
| Network behavior | Two named warming 503s absorbed, then one successful SSE receipt; stale refresh no longer erases the turn. |
| Mobile | N/A for this state-reconciliation draft: component behavior is viewport-independent; hosted responsive acceptance remains a staging gate after review/merge. |
| Backend logs | N/A: no backend source changed. |

## Release boundary

Draft only. Do not deploy this unreviewed head. After review/merge and green canonical Develop Full, serialize one exact canonical SHA through Cloudflare Worker + Pages + routing certificate, then Railway from the identical SHA. No provider traffic is needed for this PR.
