### PR TITLE
fix(agent): reject credential-bearing registry URLs

### DIFF
--- a/packages/agent/src/services/registry-client-endpoints.test.ts
+++ b/packages/agent/src/services/registry-client-endpoints.test.ts
@@ -184,6 +184,25 @@ describe("parseRegistryEndpointUrl", () => {
     expect(parsed.hostname).toBe("[2001:4860:4860::8888]");
   });
 
+  it("rejects URLs containing a username or password without echoing them", () => {
+    for (const url of [
+      "https://alice@1.1.1.1/registry",
+      "https://:s3cr3t@1.1.1.1/registry",
+      "https://alice:s3cr3t@1.1.1.1/registry",
+    ]) {
+      let thrown: unknown;
+      try {
+        parseRegistryEndpointUrl(url);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(String(thrown)).not.toContain("alice");
+      expect(String(thrown)).not.toContain("s3cr3t");
+    }
+  });
+
   it("rejects a relative or empty value as not an absolute URL", () => {
     expect(() => parseRegistryEndpointUrl("not-a-url")).toThrow(
       "Endpoint URL must be a valid absolute URL",
@@ -578,6 +597,18 @@ describe("mergeCustomEndpoints", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       '[registry-client] Endpoint "insecure" (http://example.com/registry) blocked: Error: Endpoint URL must use https://',
     );
+  });
+
+  it("redacts credentials from diagnostics for a legacy configured URL", async () => {
+    const legacyUrl = "https://alice:s3cr3t@1.1.1.1/registry";
+    await mergeCustomEndpoints(new Map(), [endpoint(legacyUrl, "legacy")]);
+
+    expect(fetchWithSsrfGuard).not.toHaveBeenCalled();
+    const warnings = vi.mocked(logger.warn).mock.calls.flat().map(String);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("https://1.1.1.1/registry");
+    expect(warnings[0]).not.toContain("alice");
+    expect(warnings[0]).not.toContain("s3cr3t");
   });
 
   it("does not fetch when DNS cannot resolve the hostname", async () => {

--- a/packages/agent/src/services/registry-client-endpoints.ts
+++ b/packages/agent/src/services/registry-client-endpoints.ts
@@ -77,6 +77,18 @@ export function isDefaultEndpoint(url: string, defaultUrl: string): boolean {
   return normaliseEndpointUrl(url) === normaliseEndpointUrl(defaultUrl);
 }
 
+/** Format a configured endpoint for diagnostics without exposing URL userinfo. */
+export function redactEndpointUrlForDiagnostic(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    parsed.username = "";
+    parsed.password = "";
+    return parsed.toString();
+  } catch {
+    return "<invalid endpoint URL>";
+  }
+}
+
 export function parseRegistryEndpointUrl(rawUrl: string): URL {
   let parsed: URL;
   try {
@@ -87,6 +99,10 @@ export function parseRegistryEndpointUrl(rawUrl: string): URL {
 
   if (parsed.protocol !== "https:") {
     throw new Error("Endpoint URL must use https://");
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error("Endpoint URL must not include credentials");
   }
 
   const hostname = normalizeHostLike(parsed.hostname);
@@ -181,11 +197,12 @@ async function fetchSingleEndpoint(
   url: string,
   label: string,
 ): Promise<Map<string, RegistryPluginInfo> | null> {
+  const diagnosticUrl = redactEndpointUrlForDiagnostic(url);
   const { rejection, endpoint } =
     await resolveRegistryEndpointUrlRejection(url);
   if (rejection || !endpoint) {
     logger.warn(
-      `[registry-client] Endpoint "${label}" (${url}) blocked: ${rejection ?? "validation failed"}`,
+      `[registry-client] Endpoint "${label}" (${diagnosticUrl}) blocked: ${rejection ?? "validation failed"}`,
     );
     return null;
   }
@@ -205,7 +222,7 @@ async function fetchSingleEndpoint(
     try {
       if (!resp.ok) {
         logger.warn(
-          `[registry-client] Endpoint "${label}" (${url}): ${resp.status} ${resp.statusText}`,
+          `[registry-client] Endpoint "${label}" (${diagnosticUrl}): ${resp.status} ${resp.statusText}`,
         );
         return null;
       }
@@ -217,7 +234,7 @@ async function fetchSingleEndpoint(
     }
     if (!data.registry || typeof data.registry !== "object") {
       logger.warn(
-        `[registry-client] Endpoint "${label}" (${url}): missing registry field`,
+        `[registry-client] Endpoint "${label}" (${diagnosticUrl}): missing registry field`,
       );
       return null;
     }
@@ -264,7 +281,7 @@ async function fetchSingleEndpoint(
     // error-policy:J1 a failing custom endpoint degrades to a warning and is
     // skipped — the built-in registry map remains the source of truth.
     logger.warn(
-      `[registry-client] Endpoint "${label}" (${url}) failed: ${String(err)}`,
+      `[registry-client] Endpoint "${label}" (${diagnosticUrl}) failed: ${String(err)}`,
     );
     return null;
   }

--- a/packages/agent/src/services/registry-client.test.ts
+++ b/packages/agent/src/services/registry-client.test.ts
@@ -23,6 +23,7 @@ let fetchImpl: () => Promise<Map<string, RegistryPluginInfo>>;
 let fetchCalls = 0;
 let config: { plugins?: { registryEndpoints?: RegistryEndpoint[] } };
 let configLoadError: Error | null = null;
+let configSaveCalls = 0;
 let mergeCalls: Array<{
   pluginCount: number;
   endpoints: RegistryEndpoint[];
@@ -39,6 +40,7 @@ vi.mock("../config/config.ts", () => ({
     return config;
   },
   saveElizaConfig: (next: typeof config) => {
+    configSaveCalls += 1;
     config = next;
   },
 }));
@@ -165,6 +167,7 @@ beforeEach(async () => {
   fetchImpl = async () => new Map();
   config = {};
   configLoadError = null;
+  configSaveCalls = 0;
   mergeCalls = [];
   localPlugins = [];
 });
@@ -283,6 +286,25 @@ describe("addRegistryEndpoint", () => {
       addRegistryEndpoint("bad", "https://localhost/registry"),
     ).toThrow('Endpoint host "localhost" is blocked');
   });
+
+  it("rejects URL credentials before writing them to config", async () => {
+    const credentialUrl = "https://alice:s3cr3t@1.1.1.1/registry";
+    const { addRegistryEndpoint } = await loadModule();
+
+    let thrown: unknown;
+    try {
+      addRegistryEndpoint("private", credentialUrl);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).not.toContain("alice");
+    expect(String(thrown)).not.toContain("s3cr3t");
+    expect(configSaveCalls).toBe(0);
+    expect(JSON.stringify(config)).not.toContain("alice");
+    expect(JSON.stringify(config)).not.toContain("s3cr3t");
+  });
 });
 
 describe("removeRegistryEndpoint", () => {
@@ -314,6 +336,23 @@ describe("removeRegistryEndpoint", () => {
     expect(() => removeRegistryEndpoint(CUSTOM_ENDPOINT_URL)).toThrow(
       `Endpoint not found: ${CUSTOM_ENDPOINT_URL}`,
     );
+  });
+
+  it("redacts credentials from a missing legacy endpoint error", async () => {
+    const credentialUrl = "https://alice:s3cr3t@1.1.1.1/registry";
+    const { removeRegistryEndpoint } = await loadModule();
+
+    let thrown: unknown;
+    try {
+      removeRegistryEndpoint(credentialUrl);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).toContain("https://1.1.1.1/registry");
+    expect(String(thrown)).not.toContain("alice");
+    expect(String(thrown)).not.toContain("s3cr3t");
   });
 });
 

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -23,6 +23,7 @@ import {
   mergeCustomEndpoints,
   normaliseEndpointUrl,
   parseRegistryEndpointUrl,
+  redactEndpointUrlForDiagnostic,
 } from "./registry-client-endpoints.ts";
 import {
   applyLocalWorkspaceApps,
@@ -230,7 +231,9 @@ export function removeRegistryEndpoint(url: string): void {
     (ep) => normaliseEndpointUrl(ep.url) !== normalised,
   );
   if (updated.length === endpoints.length) {
-    throw new Error(`Endpoint not found: ${url}`);
+    throw new Error(
+      `Endpoint not found: ${redactEndpointUrlForDiagnostic(url)}`,
+    );
   }
   if (!cfg.plugins) cfg.plugins = {};
   cfg.plugins.registryEndpoints = updated;
@@ -244,7 +247,11 @@ export function toggleRegistryEndpoint(url: string, enabled: boolean): void {
   const cfg = loadElizaConfig();
   const endpoints = cfg.plugins?.registryEndpoints ?? [];
   const ep = endpoints.find((e) => normaliseEndpointUrl(e.url) === normalised);
-  if (!ep) throw new Error(`Endpoint not found: ${url}`);
+  if (!ep) {
+    throw new Error(
+      `Endpoint not found: ${redactEndpointUrlForDiagnostic(url)}`,
+    );
+  }
   ep.enabled = enabled;
   if (!cfg.plugins) cfg.plugins = {};
   cfg.plugins.registryEndpoints = endpoints;


### PR DESCRIPTION
# Relates to

Closes #25882.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at final verification (`37db2c9dfc1f078c23ed81c29a7d0fe04fdd1094`) with zero conflicts.
- [x] The available affected checks were run after sync; the unrelated offline workspace/typecheck blocker is recorded below.
- [x] A reviewer can confirm the behavior from the focused regression tests, zero-write assertion, and mutation proof below.

# Sync with develop

- [x] Rebased onto `origin/develop` at final verification; zero conflicts.
- [x] Affected tests and static checks pass post-sync; the exact unrelated full-verification blocker is documented in **Known gaps / failures**.

# Risks

Medium. This tightens custom registry endpoint validation and changes endpoint text in diagnostics. Credential-free endpoint behavior is unchanged; legacy credential-bearing entries are blocked before fetch and displayed without URL userinfo.

# Background

## What does this PR do?

- Rejects a non-empty URL username or password before custom endpoint config can be written.
- Formats every configured endpoint diagnostic without URL userinfo and uses a generic label for malformed legacy values.
- Applies the same redaction to remove/toggle not-found errors so credential-bearing input is never echoed.
- Covers username-only, password-only, combined credentials, zero persistence, legacy warnings, and thrown errors.

## What kind of change is this?

Security bug fix.

# Documentation changes needed?

No user documentation change is needed. The internal helper comment documents the diagnostic-redaction contract.

# Testing

## Where should a reviewer start?

Start with `registry-client-endpoints.ts` for the parser and diagnostic formatter, then the adjacent endpoint and registry-client tests for the persistence and legacy-config boundaries.

## Detailed testing steps

Run from the repository root:

```bash
vitest run packages/agent/src/services/registry-client.test.ts packages/agent/src/services/registry-client-endpoints.test.ts --config packages/agent/vitest.config.ts
biome check packages/agent/src/services/registry-client-endpoints.ts packages/agent/src/services/registry-client-endpoints.test.ts packages/agent/src/services/registry-client.ts packages/agent/src/services/registry-client.test.ts
```

Results on exact head `c019bb4450257dd8865d47e947b688ceb11f4482`:

- 81/81 affected tests passed in a credential-free, network-disabled container.
- Disabling only the new userinfo guard made all three targeted security behaviors fail; restoring it made them pass.
- Scoped Biome passed for all four changed files.
- `git diff --check` passed and the exact-head worktree was clean.

# Evidence Gate

<!-- evidence-head:c019bb4450257dd8865d47e947b688ceb11f4482 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a service validation and diagnostic-redaction change with no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused automated assertions directly capture the endpoint logger and verify both credentials are absent.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the regression test proves rejected credentials cause zero config writes and leave saved config clean.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

No live backend or frontend is required. The affected service tests capture the real logger seam, assert a legacy credential-bearing URL is not fetched, retain the safe host/path in the warning, and prove neither username nor password appears.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Full `bun install` / `bun run verify` was not available in the credential-free, network-disabled environment: the pre-existing cached workspace install lacks many unrelated optional and workspace dependencies. Network installation was intentionally not performed. The attempted agent-package typecheck produced unrelated missing-module and existing workspace errors, with no changed-file-specific error observed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-goal-100]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0QJSCHA3RKXEWHJ6RBZEZRT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T15:10:53.482Z","completed_at":"2026-08-23T15:13:23.408Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T15:10:54.310Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"38290397a302d4912b1ade8524d638be1864d80b457c760c6d8347ce881d7f33","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e8dbc102-403d-4b5d-935d-7828311cc88d","object_id":"sha256:38290397a302d4912b1ade8524d638be1864d80b457c760c6d8347ce881d7f33","sha256":"38290397a302d4912b1ade8524d638be1864d80b457c760c6d8347ce881d7f33"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"N2RW8eW8W_DNcxcqcHatRTs0skdLLsJtJgqiz_XQS-N-ULWe_9QPrBES5zP4WvVs5EnbfDEeVjbpAw9rvq2PCw"}} -->
