### PR TITLE
test(agent): cover context-signal

### DIFF
--- a/packages/agent/src/actions/context-signal.test.ts
+++ b/packages/agent/src/actions/context-signal.test.ts
@@ -232,6 +232,35 @@ describe("hasContextSignalSyncForKey", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    ["values.language", { values: { language: "zh-CN" } }],
+    ["top-level preferredLanguage", { preferredLanguage: "zh-CN" }],
+    ["config.ui.language", { config: { ui: { language: "zh-CN" } } }],
+  ])("resolves the locale from state %s", (_source, stateShape) => {
+    expect(
+      hasContextSignalSyncForKey(
+        messageWith("邮件"),
+        stateShape as unknown as State,
+        "gmail",
+        { includeAllLocales: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the first non-blank state locale candidate", () => {
+    const state = {
+      values: { preferredLanguage: "   ", language: "zh-CN" },
+      preferredLanguage: "en",
+      config: { ui: { language: "en" } },
+    } as unknown as State;
+
+    expect(
+      hasContextSignalSyncForKey(messageWith("邮件"), state, "gmail", {
+        includeAllLocales: false,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("hasSelectedActionContext", () => {


### PR DESCRIPTION

## Summary

- cover locale resolution from `state.values.language`, top-level `state.preferredLanguage`, and `state.config.ui.language`
- verify blank higher-priority locale values fall through to the first non-blank candidate
- exercise the real context-signal implementation and shared keyword lexicon without mocking the module under test

## Validation

- `bunx vitest run packages/agent/src/actions/context-signal.test.ts` — 1 file passed, 37 tests passed
- `bunx biome check --write packages/agent/src/actions/context-signal.test.ts` — checked 1 file and applied formatting; the resulting diff passes `git diff --check`
- `cd packages/agent && bunx tsc --noEmit` — exits 1 on pre-existing errors elsewhere in the shared checkout; `grep 'context-signal.test.ts'` produced no output (exit 1), so this file adds zero TypeScript errors
- diff touches only `packages/agent/src/actions/context-signal.test.ts`

Hosted CI does not run on pull requests from this fork.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da0087de41474d7cd7e2df10de20925d97f87634 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
