### PR TITLE
test(shared): cover detail-extension-registry

### DIFF
--- a/packages/shared/src/apps/detail-extension-registry.test.ts
+++ b/packages/shared/src/apps/detail-extension-registry.test.ts
@@ -21,6 +21,7 @@ function makeApp(
     launchType: "overlay",
     launchUrl: null,
     icon: "test-icon",
+    heroImage: null,
     capabilities: [],
     stars: 0,
     repository: "",

--- a/packages/shared/src/apps/detail-extension-registry.test.ts
+++ b/packages/shared/src/apps/detail-extension-registry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for app detail extension component registry.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { RegistryAppInfo } from "../contracts/apps.js";
+import {
+  getAppDetailExtension,
+  registerDetailExtension,
+} from "./detail-extension-registry.js";
+import type { AppDetailExtensionComponent } from "./detail-extension-types.js";
+
+function makeApp(
+  uiExtension?: RegistryAppInfo["uiExtension"],
+): RegistryAppInfo {
+  return {
+    name: "test-app",
+    displayName: "Test App",
+    description: "App description",
+    category: "tools",
+    launchType: "overlay",
+    launchUrl: null,
+    icon: "test-icon",
+    capabilities: [],
+    stars: 0,
+    repository: "",
+    latestVersion: null,
+    supports: { v0: false, v1: false, v2: true },
+    npm: {
+      package: "test-app",
+      v0Version: null,
+      v1Version: null,
+      v2Version: null,
+    },
+    uiExtension,
+  };
+}
+
+describe("detail extension registry", () => {
+  it("registers and retrieves component for app with matching detailPanelId", () => {
+    const dummyComponent: AppDetailExtensionComponent = (() =>
+      null) as unknown as AppDetailExtensionComponent;
+
+    registerDetailExtension("my-custom-panel", dummyComponent);
+
+    const appWithExtension = makeApp({
+      detailPanelId: "my-custom-panel",
+    });
+
+    const retrieved = getAppDetailExtension(appWithExtension);
+    expect(retrieved).toBe(dummyComponent);
+  });
+
+  it("returns null when app has no uiExtension or detailPanelId", () => {
+    const appWithoutExtension = makeApp(undefined);
+    expect(getAppDetailExtension(appWithoutExtension)).toBeNull();
+
+    const appWithEmptyId = makeApp({
+      detailPanelId: "",
+    });
+    expect(getAppDetailExtension(appWithEmptyId)).toBeNull();
+  });
+
+  it("returns null when detailPanelId is not registered in the registry", () => {
+    const appWithUnregisteredId = makeApp({
+      detailPanelId: "unregistered-panel-123",
+    });
+    expect(getAppDetailExtension(appWithUnregisteredId)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/apps/detail-extension-registry.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `registerDetailExtension` and `getAppDetailExtension` component registration and lookup.
- Returns null when `detailPanelId` is missing, empty, or unregistered.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`65bebe2b22`) |
| --- | --- | --- |
| `bunx vitest run packages/shared/src/apps/detail-extension-registry.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/shared/src/apps/detail-extension-registry.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/apps/detail-extension-registry.test.ts:1-72`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:65bebe2b22307a74584909ef0aa27f5d3b804779 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested