### PR TITLE
test(cloud): repair backup identity assertion typecheck

### DIFF
--- a/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
+++ b/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
@@ -186,7 +186,7 @@ describe("decryptAgentBackupStateData", () => {
     expect(await decryptAgentBackupStateData(BACKUP_ID, delta)).toBe(delta);
 
     const almost = asStored({ ...envelope(), algorithm: "plain" });
-    expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(almost);
+    expect(Object.is(await decryptAgentBackupStateData(BACKUP_ID, almost), almost)).toBe(true);
   });
 
   test("round-trips full-state and delta payloads", async () => {


### PR DESCRIPTION
Closes #26183.

## What changed

Use `Object.is` for the near-envelope passthrough identity assertion. This preserves the real reference-identity check without asking the typed `expect.toBe` overload to accept `AgentBackupStoredStateData` where the decrypt result is `AgentBackupPlainStateData`.

No production crypto code or types changed.

## Evidence

- Base: `d869e63ac01cd9bca61ca75013103187943d0831`
- Head: `6c53c39df858a7397768d082ba7a31b33f811b96`
- Reproduced in Develop Full `32647635992` and PR smoke `32647752075`: `packages/cloud/shared/src/db/crypto/agent-backups.test.ts:189` TS2769.
- Base and renderer-PR blobs were identical (`67afa35431c445de8749388857b5ee80fd14acf2`), proving upstream drift.
- `git diff --check origin/develop...HEAD` — PASS
- Changed diff gitleaks scan — PASS, no leaks
- Local dependency-heavy typecheck intentionally not regenerated while host disk was under the active headroom freeze; this draft exists to obtain the repository-standard frozen hosted typecheck on the exact head.

## Scope boundary

One test line only. No production behavior, Cloudflare/Railway mutation, provider traffic, or renderer source is included.
