### PR TITLE
test(core): cover subaction-dispatch

### DIFF
--- a/packages/core/src/actions/subaction-dispatch.test.ts
+++ b/packages/core/src/actions/subaction-dispatch.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for umbrella action subaction normalization, reading, and dispatch.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	CANONICAL_SUBACTION_KEY,
+	DEFAULT_SUBACTION_KEYS,
+	dispatchSubaction,
+	normalizeSubaction,
+	readSubaction,
+} from "./subaction-dispatch.js";
+
+describe("subaction-dispatch", () => {
+	it("normalizes subaction names handling whitespace, dashes, and casing", () => {
+		expect(normalizeSubaction(" CREATE ")).toBe("create");
+		expect(normalizeSubaction("spawn-agent")).toBe("spawn_agent");
+		expect(normalizeSubaction("list_all_tasks")).toBe("list_all_tasks");
+		expect(normalizeSubaction("")).toBeUndefined();
+		expect(normalizeSubaction(null)).toBeUndefined();
+		expect(normalizeSubaction(123)).toBeUndefined();
+	});
+
+	it("reads subaction from canonical and legacy parameter keys", () => {
+		const allowed = ["create", "list", "delete"] as const;
+
+		// Canonical key 'action'
+		expect(readSubaction({ action: "create" }, { allowed })).toBe("create");
+
+		// Legacy key 'subaction'
+		expect(readSubaction({ subaction: "list" }, { allowed })).toBe("list");
+
+		// Legacy key 'op'
+		expect(readSubaction({ op: "delete" }, { allowed })).toBe("delete");
+
+		// Falls back to defaultValue when missing
+		expect(readSubaction({}, { allowed, defaultValue: "list" })).toBe("list");
+	});
+
+	it("applies alias mapping during subaction resolution", () => {
+		const allowed = ["create", "list"] as const;
+		const aliases = { add: "create" as const, get: "list" as const };
+
+		expect(readSubaction({ action: "add" }, { allowed, aliases })).toBe(
+			"create",
+		);
+		expect(readSubaction({ action: "get" }, { allowed, aliases })).toBe("list");
+	});
+
+	it("returns undefined for disallowed or unknown subactions", () => {
+		const allowed = ["create", "list"] as const;
+
+		expect(readSubaction({ action: "destroy" }, { allowed })).toBeUndefined();
+	});
+
+	it("dispatches to matching handler in handler map", async () => {
+		const createHandler = vi.fn(async (ctx: { taskId: string }) => ({
+			success: true,
+			text: `Created ${ctx.taskId}`,
+		}));
+		const listHandler = vi.fn(async () => ({
+			success: true,
+			text: "Listed",
+		}));
+
+		const handlers = {
+			create: createHandler,
+			list: listHandler,
+		};
+
+		const result = await dispatchSubaction("create", handlers, {
+			taskId: "task-1",
+		});
+		expect(result).toEqual({ success: true, text: "Created task-1" });
+		expect(createHandler).toHaveBeenCalledWith({ taskId: "task-1" });
+		expect(listHandler).not.toHaveBeenCalled();
+	});
+
+	it("returns UNKNOWN_SUBACTION error result for missing or unknown subaction", async () => {
+		const handlers = {
+			create: async () => ({ success: true }),
+		};
+
+		// Missing subaction
+		const missingResult = await dispatchSubaction(
+			undefined,
+			handlers as unknown as { create: () => Promise<{ success: boolean }> },
+			undefined,
+		);
+		expect(missingResult.success).toBe(false);
+		expect(missingResult.error).toBe("UNKNOWN_SUBACTION");
+		expect(missingResult.text).toBe("Missing subaction");
+
+		// Unknown subaction
+		const unknownResult = await dispatchSubaction(
+			"delete" as unknown as "create",
+			handlers,
+			undefined,
+		);
+		expect(unknownResult.success).toBe(false);
+		expect(unknownResult.error).toBe("UNKNOWN_SUBACTION");
+		expect(unknownResult.text).toBe("Unknown subaction: delete");
+	});
+
+	it("exports canonical and default subaction keys", () => {
+		expect(CANONICAL_SUBACTION_KEY).toBe("action");
+		expect(DEFAULT_SUBACTION_KEYS).toContain("action");
+		expect(DEFAULT_SUBACTION_KEYS).toContain("subaction");
+		expect(DEFAULT_SUBACTION_KEYS).toContain("op");
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/actions/subaction-dispatch.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `normalizeSubaction` whitespace, dash, and casing handling.
- `readSubaction` resolution across canonical (`action`) and legacy alias keys (`subaction`, `op`), aliases mapping, and default value fallbacks.
- `dispatchSubaction` handler mapping routing, context passing, and `UNKNOWN_SUBACTION` error results for missing/unknown subactions.
- Canonical discriminator constant exports.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2511950b0a`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/actions/subaction-dispatch.test.ts` | N/A (new test file) | 7 passed (7 tests) |
| `bunx @biomejs/biome check packages/core/src/actions/subaction-dispatch.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/actions/subaction-dispatch.test.ts:1-111`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:2511950b0ac217273850365cdca6c85509999d39 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested