### PR TITLE
test(cloud): type the near-envelope passthrough identity assertion against the stored union

### DIFF
--- a/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
+++ b/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
@@ -186,7 +186,12 @@ describe("decryptAgentBackupStateData", () => {
     expect(await decryptAgentBackupStateData(BACKUP_ID, delta)).toBe(delta);
 
     const almost = asStored({ ...envelope(), algorithm: "plain" });
-    expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(almost);
+    // The passthrough branch returns the stored value unchanged, so the typed
+    // identity matcher must widen to the stored union the way the runtime does
+    // (#26183); the plain return type alone cannot name the passed-through shape.
+    expect<AgentBackupStoredStateData>(
+      await decryptAgentBackupStateData(BACKUP_ID, almost),
+    ).toBe(almost);
   });
 
   test("round-trips full-state and delta payloads", async () => {


### PR DESCRIPTION
# Relates to

Closes #26183

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (built directly on develop@1cbfaf5 via the Git data API).
- [x] Focused tests pass after sync (exact command and output below).
- [x] A reviewer can confirm the change works from the one widened assertion.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite passes post-sync (below); no unrelated blocker.

# Risks

None. One test assertion's type parameter changes; runtime behavior, the
near-envelope passthrough semantics, and every production crypto type are
untouched.

# Background

## What does this PR do?

#26157 added the intentionally invalid near-envelope passthrough case with

```ts
const almost = asStored({ ...envelope(), algorithm: "plain" });
expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(almost);
```

`decryptAgentBackupStateData` returns `Promise<AgentBackupPlainStateData>`, so
the typed identity matcher's parameter became `AgentBackupPlainStateData`,
while `almost` is `AgentBackupStoredStateData` (`Plain | EncryptedEnvelope`) —
not assignable in that direction, and current `develop` fails Cloud API
typecheck with TS2769 (#26183; observed in Develop Full `32647635992` and
renderer Static Smoke `32647752075`).

The assertion now widens the matcher's type parameter to
`AgentBackupStoredStateData` — exactly the union the passthrough branch returns
at runtime (`if (!isEncryptedAgentBackupStateData(stateData)) return stateData`).
The plain return value is assignable to the stored union, `toBe(almost)` type
matches on both sides, and no cast or production type weakening is involved.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The one changed assertion in
`packages/cloud/shared/src/db/crypto/agent-backups.test.ts` (search `#26183`).

## Detailed testing steps

- `cd packages/cloud/shared && bun test src/db/crypto/agent-backups.test.ts`
  - 15 pass / 0 fail — the passthrough identity behavior is unchanged.
- Typecheck: the file produces no diagnostics; `AgentBackupPlainStateData` is
  assignable to the widened `AgentBackupStoredStateData` matcher parameter, so
  TS2769 on this line is gone while the Cloud API typecheck closure is restored
  on a clean develop checkout (CI runs it against the exact base tree).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:65267508ff85b1a97696f7e40f599a883170303f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; a typecheck-level test correction.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable outcome is a compiler diagnostic on CI, reproduced
      by the linked failing runs (Develop Full 32647635992, Static Smoke
      32647752075) and asserted indirectly by the typecheck passing.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime logging touched; the suite passes unchanged.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - not an agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, or on-chain output.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused suite output:

```
 15 pass
 0 fail
 50 expect() calls
Ran 15 tests across 1 file. [941.00ms]
```

## Known gaps / failures

None for this change. A full local `tsc --noEmit` of the package cannot run in
this environment against a mixed checkout; the changed file itself produces no
diagnostics and CI's Cloud API typecheck runs against the exact base tree.

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"ZCode"} -->
