### PR TITLE
test(core): cover app-registry

### DIFF
--- a/packages/core/src/app-registry.test.ts
+++ b/packages/core/src/app-registry.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for curated Eliza app registry singleton.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	type ElizaCuratedAppDefinition,
+	getRegisteredCuratedApps,
+	registerCuratedApp,
+} from "./app-registry.js";
+
+describe("app-registry", () => {
+	it("registers and retrieves curated app definitions", () => {
+		const appDef: ElizaCuratedAppDefinition = {
+			slug: "discord-bot",
+			canonicalName: "@elizaos/plugin-discord",
+			aliases: ["discord", "discord-app"],
+		};
+
+		registerCuratedApp(appDef);
+
+		const apps = getRegisteredCuratedApps();
+		const found = apps.find((app) => app.slug === "discord-bot");
+
+		expect(found).toEqual(appDef);
+	});
+
+	it("updates existing app definition when registering with same slug", () => {
+		const originalDef: ElizaCuratedAppDefinition = {
+			slug: "telegram-bot",
+			canonicalName: "@elizaos/plugin-telegram",
+			aliases: ["telegram"],
+		};
+		const updatedDef: ElizaCuratedAppDefinition = {
+			slug: "telegram-bot",
+			canonicalName: "@elizaos/plugin-telegram-v2",
+			aliases: ["telegram", "tg"],
+		};
+
+		registerCuratedApp(originalDef);
+		registerCuratedApp(updatedDef);
+
+		const apps = getRegisteredCuratedApps();
+		const matching = apps.filter((app) => app.slug === "telegram-bot");
+
+		expect(matching).toHaveLength(1);
+		expect(matching[0]).toEqual(updatedDef);
+	});
+
+	it("returns a defensive copy of the registered entries array", () => {
+		const apps1 = getRegisteredCuratedApps();
+		const apps2 = getRegisteredCuratedApps();
+
+		expect(apps1).not.toBe(apps2);
+		expect(apps1).toEqual(apps2);
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/app-registry.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- Curated app definition registration and retrieval (`registerCuratedApp`, `getRegisteredCuratedApps`).
- In-place replacement when re-registering an app definition with an existing `slug`.
- Defensive copy returns for registered curated apps.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`a10b3da609`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/app-registry.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/core/src/app-registry.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/app-registry.test.ts:1-57`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:a10b3da60906586098d73469853db8c43ba28394 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested