### PR TITLE
test(app-core): cover profile-utils

### DIFF
--- a/packages/app-core/src/cli/profile-utils.test.ts
+++ b/packages/app-core/src/cli/profile-utils.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for CLI state profile name validation and normalization.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isValidProfileName, normalizeProfileName } from "./profile-utils.js";
+
+describe("profile-utils", () => {
+  describe("isValidProfileName", () => {
+    it("accepts valid alphanumeric, dash, and underscore profile names", () => {
+      expect(isValidProfileName("dev")).toBe(true);
+      expect(isValidProfileName("stage_01")).toBe(true);
+      expect(isValidProfileName("test-profile-2")).toBe(true);
+      expect(isValidProfileName("a")).toBe(true);
+    });
+
+    it("rejects empty or invalid profile names", () => {
+      expect(isValidProfileName("")).toBe(false);
+      expect(isValidProfileName("-leading-dash")).toBe(false);
+      expect(isValidProfileName("_leading-underscore")).toBe(false);
+      expect(isValidProfileName("invalid/slash")).toBe(false);
+      expect(isValidProfileName("with space")).toBe(false);
+      expect(isValidProfileName("a".repeat(65))).toBe(false);
+    });
+  });
+
+  describe("normalizeProfileName", () => {
+    it("trims and returns valid non-default profile names", () => {
+      expect(normalizeProfileName(" dev ")).toBe("dev");
+      expect(normalizeProfileName("stage-1")).toBe("stage-1");
+    });
+
+    it("returns null for empty, undefined, null, or invalid input", () => {
+      expect(normalizeProfileName(undefined)).toBeNull();
+      expect(normalizeProfileName(null)).toBeNull();
+      expect(normalizeProfileName("")).toBeNull();
+      expect(normalizeProfileName("   ")).toBeNull();
+      expect(normalizeProfileName("invalid/path")).toBeNull();
+    });
+
+    it("returns null for reserved 'default' profile name (case-insensitive)", () => {
+      expect(normalizeProfileName("default")).toBeNull();
+      expect(normalizeProfileName("DEFAULT")).toBeNull();
+      expect(normalizeProfileName(" Default ")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/app-core/src/cli/profile-utils.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `isValidProfileName` regex charset validation, boundary lengths, and path safety.
- `normalizeProfileName` trimming, invalid input handling, and folding of reserved `default` profile to `null`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`cb571113a0`) |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/cli/profile-utils.test.ts` | N/A (new test file) | 5 passed (5 tests) |
| `bunx @biomejs/biome check packages/app-core/src/cli/profile-utils.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/cli/profile-utils.test.ts:1-47`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:cb571113a025c38e7a6a53ed609d2cb77570e21b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested