### PR TITLE
fix(cloud): type the non-envelope passthrough assertion in agent-backups test

### DIFF
--- a/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
+++ b/packages/cloud/shared/src/db/crypto/agent-backups.test.ts
@@ -186,7 +186,9 @@ describe("decryptAgentBackupStateData", () => {
     expect(await decryptAgentBackupStateData(BACKUP_ID, delta)).toBe(delta);
 
     const almost = asStored({ ...envelope(), algorithm: "plain" });
-    expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(almost);
+    expect(await decryptAgentBackupStateData(BACKUP_ID, almost)).toBe(
+      almost as unknown as ReturnType<typeof sampleState>,
+    );
   });
 
   test("round-trips full-state and delta payloads", async () => {


### PR DESCRIPTION
@lalalune — typecheck unblock, dead-PR-CI leak class (#24412/#24762/#25225 lineage).

Run 32648004291 `Deploy API Worker`:
```
../shared/src/db/crypto/agent-backups.test.ts(189,71): error TS2769: No overload matches this call.
```

The passthrough test asserts `decrypt(...)` (typed as plain state) `toBe(almost)` where `almost` is the wider stored union; bun-types' `toBe<X = T>(NoInfer<X>)` rejects it. Cast at the assertion — runtime behavior (identity passthrough of a non-envelope) unchanged.

Receipts (PR CI dead): package typecheck exit 0 (tsc + worker-bundle dry-run); `bun test agent-backups.test.ts` 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)