### PR TITLE
test(app-core): cover server-config-filter

### DIFF
--- a/packages/app-core/src/api/server-config-filter.test.ts
+++ b/packages/app-core/src/api/server-config-filter.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for API server config redaction and sensitive key filtering.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  CONFIG_FILTER_UNBOUNDED,
+  filterConfigEnvForResponse,
+  SENSITIVE_ENV_RESPONSE_KEYS,
+} from "./server-config-filter.js";
+
+describe("server-config-filter", () => {
+  it("redacts sensitive keys in object properties", () => {
+    const config = {
+      name: "test-agent",
+      apiKey: "sk-live-12345",
+      database: {
+        password: "secret_db_password",
+        connectionString: "postgres://user:pass@localhost/db",
+        host: "localhost",
+      },
+    };
+
+    const filtered = filterConfigEnvForResponse(config);
+
+    expect(filtered.name).toBe("test-agent");
+    expect(filtered.apiKey).toBe("[REDACTED]");
+    expect(filtered.database).toEqual({
+      password: "[REDACTED]",
+      connectionString: "[REDACTED]",
+      host: "localhost",
+    });
+  });
+
+  it("strips SENSITIVE_ENV_RESPONSE_KEYS from env block", () => {
+    const config = {
+      env: {
+        PUBLIC_URL: "https://example.com",
+        EVM_PRIVATE_KEY: "0x12345",
+        GITHUB_TOKEN: "ghp_abc",
+        PORT: 3000,
+      },
+    };
+
+    const filtered = filterConfigEnvForResponse(config);
+    const env = filtered.env as Record<string, unknown>;
+
+    expect(env.PUBLIC_URL).toBe("https://example.com");
+    expect(env.PORT).toBe(3000);
+    expect("EVM_PRIVATE_KEY" in env).toBe(false);
+    expect("GITHUB_TOKEN" in env).toBe(false);
+  });
+
+  it("fails with ElizaError when cyclic graphs are encountered", () => {
+    const cyclic: Record<string, unknown> = { name: "cycle" };
+    cyclic.self = cyclic;
+
+    try {
+      filterConfigEnvForResponse(cyclic);
+      expect.unreachable("should have thrown ElizaError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElizaError);
+      expect((err as ElizaError).code).toBe(CONFIG_FILTER_UNBOUNDED);
+    }
+  });
+
+  it("preserves empty values without crashing", () => {
+    const emptyConfig = {};
+    expect(filterConfigEnvForResponse(emptyConfig)).toEqual({});
+
+    const configWithEmptyFields = {
+      emptyString: "",
+      nullField: null,
+      undefinedField: undefined,
+    };
+    expect(filterConfigEnvForResponse(configWithEmptyFields)).toEqual({
+      emptyString: "",
+      nullField: null,
+      undefinedField: undefined,
+    });
+  });
+
+  it("exports known sensitive env response keys", () => {
+    expect(SENSITIVE_ENV_RESPONSE_KEYS.has("EVM_PRIVATE_KEY")).toBe(true);
+    expect(SENSITIVE_ENV_RESPONSE_KEYS.has("DATABASE_URL")).toBe(true);
+    expect(SENSITIVE_ENV_RESPONSE_KEYS.has("ELIZAOS_CLOUD_API_KEY")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/app-core/src/api/server-config-filter.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- Redaction of sensitive fields in object structures (`apiKey`, `password`, `connectionString`).
- Filtering of sensitive environment variables from config env blocks (`EVM_PRIVATE_KEY`, `GITHUB_TOKEN`).
- Cycle detection raising `CONFIG_FILTER_UNBOUNDED` fatal errors.
- Handling empty and nullish config payload gracefully.
- Exported sensitive env keys set definition.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`715bd0154e`) |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/api/server-config-filter.test.ts` | N/A (new test file) | 5 passed (5 tests) |
| `bunx @biomejs/biome check packages/app-core/src/api/server-config-filter.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/api/server-config-filter.test.ts:1-89`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:715bd0154ea37df765fe3a022d4a8f81414e1d02 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested