### PR TITLE
test(vault): cover crypto

### DIFF
--- a/packages/vault/src/crypto.test.ts
+++ b/packages/vault/src/crypto.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for AES-256-GCM envelope encryption and decryption with AAD.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CryptoError,
+  decrypt,
+  encrypt,
+  generateMasterKey,
+  KEY_BYTES,
+} from "./crypto.js";
+
+describe("vault crypto", () => {
+  it("generates a 32-byte master key", () => {
+    const key = generateMasterKey();
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(KEY_BYTES);
+  });
+
+  it("encrypts and decrypts plaintext roundtrip with authenticated additional data", () => {
+    const masterKey = generateMasterKey();
+    const secret = "sk-ant-api-key-very-secret-value-12345";
+    const slotAad = "ANTHROPIC_API_KEY:default";
+
+    const ciphertext = encrypt(masterKey, secret, slotAad);
+
+    expect(ciphertext.startsWith("v1:")).toBe(true);
+    expect(ciphertext.split(":")).toHaveLength(4);
+
+    const decrypted = decrypt(masterKey, ciphertext, slotAad);
+    expect(decrypted).toBe(secret);
+  });
+
+  it("fails decryption if master key does not match", () => {
+    const masterKeyA = generateMasterKey();
+    const masterKeyB = generateMasterKey();
+    const ciphertext = encrypt(masterKeyA, "secret-text", "slot1");
+
+    expect(() => decrypt(masterKeyB, ciphertext, "slot1")).toThrowError(
+      CryptoError,
+    );
+  });
+
+  it("fails decryption if AAD differs (slot swap prevention)", () => {
+    const masterKey = generateMasterKey();
+    const ciphertext = encrypt(masterKey, "secret-text", "slotA");
+
+    expect(() => decrypt(masterKey, ciphertext, "slotB")).toThrowError(
+      CryptoError,
+    );
+  });
+
+  it("fails with CryptoError on invalid key length", () => {
+    const shortKey = Buffer.alloc(16);
+    expect(() => encrypt(shortKey, "text", "aad")).toThrowError(
+      /master key must be 32 bytes/,
+    );
+    expect(() => decrypt(shortKey, "v1:a:b:c", "aad")).toThrowError(
+      /master key must be 32 bytes/,
+    );
+  });
+
+  it("fails with CryptoError on malformed ciphertext envelopes", () => {
+    const masterKey = generateMasterKey();
+
+    expect(() => decrypt(masterKey, "invalid-format", "aad")).toThrowError(
+      /malformed ciphertext/,
+    );
+    expect(() => decrypt(masterKey, "v2:a:b:c", "aad")).toThrowError(
+      /unsupported version/,
+    );
+    expect(() =>
+      decrypt(masterKey, "v1:bad!nonce:bad!tag:bad!ct", "aad"),
+    ).toThrowError(/malformed ciphertext/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/vault/src/crypto.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `generateMasterKey` 32-byte key generation.
- AES-256-GCM authenticated encryption and decryption roundtrip with AAD (`encrypt`, `decrypt`).
- Decryption failure on mismatched master keys and swapped AAD contexts.
- Bounds and format validation against malformed ciphertext envelopes and invalid key sizes.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`51bd611737`) |
| --- | --- | --- |
| `bunx vitest run packages/vault/src/crypto.test.ts` | N/A (new test file) | 6 passed (6 tests) |
| `bunx @biomejs/biome check packages/vault/src/crypto.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/vault/src/crypto.test.ts:1-77`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:51bd611737a54c6c2e3fe0a0527558818987485c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested