### PR TITLE
test(agent): cover health-routes

### DIFF
--- a/packages/agent/src/api/health-routes.test.ts
+++ b/packages/agent/src/api/health-routes.test.ts
@@ -128,9 +128,16 @@ describe("handleHealthRoutes dispatch", () => {
 describe("handleHealthRoutes GET /api/status", () => {
   it("reports the boot snapshot, uptime, restart state, and response readiness", async () => {
     const startedAt = Date.now() - 1_500;
+    // `detectRuntimeModel` resolves the live provider first and only falls
+    // back to `state.model`. Stub the receipt it reads first
+    // (`getLastResolvedModelProvider`) so the reported label comes from the
+    // runtime rather than from whichever provider API key happens to be in
+    // the ambient environment -- without it this case only passes on a machine
+    // with OPENAI_API_KEY set.
     const runtime = {
       getModel: (modelType: string) =>
         modelType === ModelType.TEXT_LARGE ? () => undefined : undefined,
+      getLastResolvedModelProvider: () => "openai",
     } as unknown as AgentRuntime;
     const { ctx, json, error } = makeContext("/api/status", {
       state: makeState({


### PR DESCRIPTION

## Summary

- add colocated unit coverage for the real `handleHealthRoutes` dispatcher
- cover status readiness, trusted and untrusted health responses, terminal database behavior, plugin/connector/service summaries, runtime snapshot defaults, validation, ordering, serialization, caching, and failure translation
- cover the exported debug integer parser and can-respond predicate without changing production behavior

## Validation

- `bunx vitest run packages/agent/src/api/health-routes.test.ts` — 1 file passed, 13 tests passed
- `bunx biome check --write packages/agent/src/api/health-routes.test.ts` — checked 1 file; formatting applied cleanly
- `cd packages/agent && bunx tsc --noEmit` — package check remains red on pre-existing/shared-checkout diagnostics; `health-routes.test.ts` appears nowhere after fixing the suite's initial TS2352 (`grep` exit 1; 225 diagnostic lines remain elsewhere)
- diff against current `origin/develop` adds only `packages/agent/src/api/health-routes.test.ts`

Hosted CI does not run for this fork contribution. The focused test was re-run after fetching current `origin/develop` immediately before filing.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5499dea6ebb31d34927e732d2458a5b2a9dc9886 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
