### PR TITLE
test(vault): cover profiles

### DIFF
--- a/packages/vault/src/profiles.test.ts
+++ b/packages/vault/src/profiles.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for vault profile resolution and per-context routing rules.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ROUTING_KEY } from "./inventory.js";
+import {
+  type RoutingConfig,
+  readRoutingConfig,
+  resolveActiveValue,
+  writeRoutingConfig,
+} from "./profiles.js";
+import type { Vault } from "./vault.js";
+
+function makeMockVault(store: Record<string, string> = {}): Vault {
+  const data = new Map<string, string>(Object.entries(store));
+  return {
+    async get(key: string) {
+      const val = data.get(key);
+      if (val === undefined) throw new Error(`key not found: ${key}`);
+      return val;
+    },
+    async set(key: string, value: string) {
+      data.set(key, value);
+    },
+    async has(key: string) {
+      return data.has(key);
+    },
+    async delete(key: string) {
+      data.delete(key);
+    },
+  } as unknown as Vault;
+}
+
+describe("vault profiles and routing", () => {
+  it("reads and writes routing configuration", async () => {
+    const vault = makeMockVault();
+    const config: RoutingConfig = {
+      rules: [
+        {
+          keyPattern: "OPENROUTER_API_KEY",
+          scope: { kind: "agent", agentId: "agent-123" },
+          profileId: "work",
+        },
+      ],
+      defaultProfile: "personal",
+    };
+
+    await writeRoutingConfig(vault, config);
+    const readBack = await readRoutingConfig(vault);
+
+    expect(readBack).toEqual(config);
+  });
+
+  it("returns empty routing configuration on missing or invalid routing blob", async () => {
+    const vaultEmpty = makeMockVault();
+    expect(await readRoutingConfig(vaultEmpty)).toEqual({ rules: [] });
+
+    const vaultInvalid = makeMockVault({
+      [ROUTING_KEY]: "invalid-non-json-string",
+    });
+    expect(await readRoutingConfig(vaultInvalid)).toEqual({ rules: [] });
+  });
+
+  it("resolves active profile value matching agent routing rule", async () => {
+    const vault = makeMockVault({
+      "_meta.OPENROUTER_API_KEY": JSON.stringify({
+        profiles: [{ id: "work" }, { id: "personal" }],
+        activeProfile: "personal",
+      }),
+      "OPENROUTER_API_KEY.profile.work": "sk-or-work-key",
+      "OPENROUTER_API_KEY.profile.personal": "sk-or-personal-key",
+      [ROUTING_KEY]: JSON.stringify({
+        rules: [
+          {
+            keyPattern: "OPENROUTER_API_KEY",
+            scope: { kind: "agent", agentId: "agent-work" },
+            profileId: "work",
+          },
+        ],
+      }),
+    });
+
+    // Agent work rule matches
+    const workVal = await resolveActiveValue(vault, "OPENROUTER_API_KEY", {
+      agentId: "agent-work",
+    });
+    expect(workVal).toBe("sk-or-work-key");
+
+    // Unmatched agent falls back to activeProfile (personal)
+    const personalVal = await resolveActiveValue(vault, "OPENROUTER_API_KEY", {
+      agentId: "agent-other",
+    });
+    expect(personalVal).toBe("sk-or-personal-key");
+  });
+
+  it("falls back to legacy bare key when no profiles exist", async () => {
+    const vault = makeMockVault({
+      OPENAI_API_KEY: "sk-openai-bare-key",
+    });
+
+    const val = await resolveActiveValue(vault, "OPENAI_API_KEY");
+    expect(val).toBe("sk-openai-bare-key");
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/vault/src/profiles.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `readRoutingConfig` and `writeRoutingConfig` roundtrip and fallback on unparseable/empty configs.
- `resolveActiveValue` routing priority (agent context rules -> activeProfile -> fallback to bare key).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`11d4056532`) |
| --- | --- | --- |
| `bunx vitest run packages/vault/src/profiles.test.ts` | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/vault/src/profiles.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/vault/src/profiles.test.ts:1-105`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:11d4056532bcceceab209347249e2e538fd3ef82 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested