### PR TITLE
test(agent): cover permissions-routes-extra

### DIFF
--- a/packages/agent/src/api/permissions-routes-extra.test.ts
+++ b/packages/agent/src/api/permissions-routes-extra.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Exercises the additional permissions route dispatcher against deterministic
+ * configuration state and injected persistence/capability collaborators. The
+ * suite drives the real handler without starting an HTTP server.
+ */
+import type http from "node:http";
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  handlePermissionsExtraRoutes,
+  type PermissionsExtraRouteContext,
+} from "./permissions-routes-extra.ts";
+
+function makeContext(
+  method: string,
+  pathname: string,
+  options: {
+    config?: ElizaConfig;
+    agentAutomationMode?: "connectors-only" | "full";
+    body?: object | null;
+  } = {},
+) {
+  const json = vi.fn<PermissionsExtraRouteContext["json"]>();
+  const error = vi.fn<PermissionsExtraRouteContext["error"]>();
+  const readJsonBody: PermissionsExtraRouteContext["readJsonBody"] = async <
+    T extends object,
+  >() => (options.body ?? null) as T | null;
+  const saveElizaConfig =
+    vi.fn<PermissionsExtraRouteContext["saveElizaConfig"]>();
+  const resolveTradePermissionMode =
+    vi.fn<PermissionsExtraRouteContext["resolveTradePermissionMode"]>();
+  const canUseLocalTradeExecution =
+    vi.fn<PermissionsExtraRouteContext["canUseLocalTradeExecution"]>();
+  const parseAgentAutomationMode =
+    vi.fn<PermissionsExtraRouteContext["parseAgentAutomationMode"]>();
+  const persistAgentAutomationMode =
+    vi.fn<PermissionsExtraRouteContext["persistAgentAutomationMode"]>();
+  const state: PermissionsExtraRouteContext["state"] = {
+    config: options.config ?? ({} as ElizaConfig),
+    agentAutomationMode: options.agentAutomationMode,
+  };
+  const ctx: PermissionsExtraRouteContext = {
+    req: {} as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method,
+    pathname,
+    state,
+    json,
+    error,
+    readJsonBody,
+    saveElizaConfig,
+    resolveTradePermissionMode,
+    canUseLocalTradeExecution,
+    parseAgentAutomationMode,
+    persistAgentAutomationMode,
+  };
+
+  return {
+    ctx,
+    state,
+    json,
+    error,
+    readJsonBody,
+    saveElizaConfig,
+    resolveTradePermissionMode,
+    canUseLocalTradeExecution,
+    parseAgentAutomationMode,
+    persistAgentAutomationMode,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handlePermissionsExtraRoutes dispatch", () => {
+  it("does not claim unrelated paths or unsupported methods", async () => {
+    const unrelated = makeContext("GET", "/api/permissions/unknown");
+    const wrongMethod = makeContext("POST", "/api/permissions/automation-mode");
+
+    await expect(handlePermissionsExtraRoutes(unrelated.ctx)).resolves.toBe(
+      false,
+    );
+    await expect(handlePermissionsExtraRoutes(wrongMethod.ctx)).resolves.toBe(
+      false,
+    );
+    expect(unrelated.json).not.toHaveBeenCalled();
+    expect(wrongMethod.json).not.toHaveBeenCalled();
+  });
+});
+
+describe("handlePermissionsExtraRoutes automation mode", () => {
+  it.each([
+    [undefined, "full"],
+    ["connectors-only" as const, "connectors-only"],
+  ])("reports configured mode %s as %s", async (configured, expected) => {
+    const { ctx, json } = makeContext(
+      "GET",
+      "/api/permissions/automation-mode",
+      { agentAutomationMode: configured },
+    );
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      mode: expected,
+      options: ["connectors-only", "full"],
+    });
+  });
+
+  it("stops after the body reader handles an invalid request", async () => {
+    const { ctx, json, error, parseAgentAutomationMode } = makeContext(
+      "PUT",
+      "/api/permissions/automation-mode",
+    );
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(parseAgentAutomationMode).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unrecognized automation mode", async () => {
+    const { ctx, error, saveElizaConfig, parseAgentAutomationMode } =
+      makeContext("PUT", "/api/permissions/automation-mode", {
+        body: { mode: "unattended" },
+      });
+    parseAgentAutomationMode.mockReturnValue(null);
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(parseAgentAutomationMode).toHaveBeenCalledWith("unattended");
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      'Invalid mode. Expected "connectors-only" or "full".',
+      400,
+    );
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("persists and returns a recognized automation mode", async () => {
+    const {
+      ctx,
+      state,
+      json,
+      saveElizaConfig,
+      parseAgentAutomationMode,
+      persistAgentAutomationMode,
+    } = makeContext("PUT", "/api/permissions/automation-mode", {
+      body: { mode: "connectors-only" },
+    });
+    parseAgentAutomationMode.mockReturnValue("connectors-only");
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(persistAgentAutomationMode).toHaveBeenCalledWith(
+      state,
+      "connectors-only",
+    );
+    expect(saveElizaConfig).toHaveBeenCalledWith(state.config);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      mode: "connectors-only",
+      options: ["connectors-only", "full"],
+    });
+  });
+});
+
+describe("handlePermissionsExtraRoutes trade mode", () => {
+  it("reports the resolved mode and non-consuming execution capabilities", async () => {
+    const { ctx, json, resolveTradePermissionMode, canUseLocalTradeExecution } =
+      makeContext("GET", "/api/permissions/trade-mode");
+    resolveTradePermissionMode.mockReturnValue("agent-auto");
+    canUseLocalTradeExecution.mockImplementation((_mode, isAgent) => isAgent);
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(resolveTradePermissionMode).toHaveBeenCalledWith(ctx.state.config);
+    expect(canUseLocalTradeExecution).toHaveBeenNthCalledWith(
+      1,
+      "agent-auto",
+      false,
+    );
+    expect(canUseLocalTradeExecution).toHaveBeenNthCalledWith(
+      2,
+      "agent-auto",
+      true,
+      undefined,
+      { consumeAgentQuota: false },
+    );
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      tradePermissionMode: "agent-auto",
+      canUserLocalExecute: false,
+      canAgentAutoTrade: true,
+    });
+  });
+
+  it("stops after the body reader handles an invalid trade request", async () => {
+    const { ctx, json, error, saveElizaConfig } = makeContext(
+      "PUT",
+      "/api/permissions/trade-mode",
+    );
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect(json).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "", "full", "AGENT-AUTO"])(
+    "rejects invalid trade mode %s",
+    async (mode) => {
+      const { ctx, error, saveElizaConfig } = makeContext(
+        "PUT",
+        "/api/permissions/trade-mode",
+        { body: { mode } },
+      );
+
+      await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+      expect(error).toHaveBeenCalledWith(
+        ctx.res,
+        'mode must be "user-sign-only", "manual-local-key", or "agent-auto"',
+        400,
+      );
+      expect(saveElizaConfig).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["user-sign-only", "manual-local-key", "agent-auto"] as const)(
+    "stores and reports allowed trade mode %s",
+    async (mode) => {
+      const config = {} as ElizaConfig;
+      const { ctx, json, saveElizaConfig, canUseLocalTradeExecution } =
+        makeContext("PUT", "/api/permissions/trade-mode", {
+          config,
+          body: { mode },
+        });
+      canUseLocalTradeExecution.mockImplementation(
+        (candidate, isAgent) => candidate === mode && isAgent,
+      );
+
+      await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+      expect(config.features).toEqual({ tradePermissionMode: mode });
+      expect(saveElizaConfig).toHaveBeenCalledWith(config);
+      expect(json).toHaveBeenCalledWith(ctx.res, {
+        ok: true,
+        tradePermissionMode: mode,
+        canUserLocalExecute: false,
+        canAgentAutoTrade: true,
+      });
+      expect(canUseLocalTradeExecution).toHaveBeenNthCalledWith(
+        2,
+        mode,
+        true,
+        undefined,
+        {
+          consumeAgentQuota: false,
+        },
+      );
+    },
+  );
+
+  it("preserves existing feature configuration when updating trade mode", async () => {
+    const config = {
+      features: { trustedLocal: true, tradePermissionMode: "user-sign-only" },
+    } as unknown as ElizaConfig;
+    const { ctx } = makeContext("PUT", "/api/permissions/trade-mode", {
+      config,
+      body: { mode: "manual-local-key" },
+    });
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(config.features).toEqual({
+      trustedLocal: true,
+      tradePermissionMode: "manual-local-key",
+    });
+  });
+
+  it("returns the updated mode when persistence throws", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const { ctx, json, saveElizaConfig } = makeContext(
+      "PUT",
+      "/api/permissions/trade-mode",
+      { body: { mode: "agent-auto" } },
+    );
+    saveElizaConfig.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    await expect(handlePermissionsExtraRoutes(ctx)).resolves.toBe(true);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[api] Trade-mode config save failed: disk full",
+    );
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ ok: true, tradePermissionMode: "agent-auto" }),
+    );
+  });
+});


### PR DESCRIPTION

## Summary

- add focused unit coverage for the real `handlePermissionsExtraRoutes` dispatcher
- cover automation-mode reads and writes, trade-mode capability reporting and updates, invalid bodies and values, persistence failure, and unrelated-route fallthrough
- touch only the new test file; production behavior is unchanged

## Validation

- `bunx vitest run packages/agent/src/api/permissions-routes-extra.test.ts` — 1 file passed, 17 tests passed
- `bunx biome check --write packages/agent/src/api/permissions-routes-extra.test.ts` — checked 1 file successfully (1 formatting fix applied)
- `cd packages/agent && bunx tsc --noEmit` — package command exited 1 with 50 diagnostics already present in the active shared checkout; `permissions-routes-extra.test.ts` appears 0 times in the output, so this file adds zero TypeScript diagnostics
- diff: 1 new test file, 305 insertions, 0 deletions

Hosted CI does not run on fork pull requests; the local focused validation above is the available verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2d98fee355f45401bcab4cf210a54e555b1fb20b -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
