### PR TITLE
test(shared): cover character-presets-characters

### DIFF
--- a/packages/shared/src/character-presets.characters.test.ts
+++ b/packages/shared/src/character-presets.characters.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for built-in character definitions and localization variants data table.
+ */
+
+import { describe, expect, it } from "vitest";
+import { CHARACTER_DEFINITIONS } from "./character-presets.characters.js";
+
+const REQUIRED_LANGUAGES = [
+  "en",
+  "zh-CN",
+  "ko",
+  "es",
+  "pt",
+  "vi",
+  "tl",
+] as const;
+
+describe("character-presets.characters", () => {
+  it("contains unique valid character definition records", () => {
+    expect(CHARACTER_DEFINITIONS.length).toBeGreaterThan(0);
+
+    const ids = new Set<string>();
+    for (const char of CHARACTER_DEFINITIONS) {
+      expect(char.id).toBeDefined();
+      expect(typeof char.id).toBe("string");
+      expect(ids.has(char.id)).toBe(false);
+      ids.add(char.id);
+
+      expect(char.name).toBeDefined();
+      expect(typeof char.name).toBe("string");
+      expect(Array.isArray(char.bio)).toBe(true);
+      expect(char.bio.length).toBeGreaterThan(0);
+      expect(typeof char.system).toBe("string");
+      expect(Array.isArray(char.adjectives)).toBe(true);
+      expect(Array.isArray(char.topics)).toBe(true);
+      expect(Array.isArray(char.messageExamples)).toBe(true);
+      expect(char.style).toBeDefined();
+      expect(Array.isArray(char.style.all)).toBe(true);
+      expect(Array.isArray(char.style.chat)).toBe(true);
+      expect(Array.isArray(char.style.post)).toBe(true);
+    }
+  });
+
+  it("includes all supported language variants for each character", () => {
+    for (const char of CHARACTER_DEFINITIONS) {
+      expect(char.variants).toBeDefined();
+      for (const lang of REQUIRED_LANGUAGES) {
+        const variant = char.variants[lang];
+        expect(variant).toBeDefined();
+        expect(typeof variant.catchphrase).toBe("string");
+        expect(variant.catchphrase.length).toBeGreaterThan(0);
+        expect(typeof variant.hint).toBe("string");
+        expect(variant.hint.length).toBeGreaterThan(0);
+        expect(Array.isArray(variant.postExamples)).toBe(true);
+      }
+    }
+  });
+
+  it("includes the canonical default eliza persona with templates", () => {
+    const eliza = CHARACTER_DEFINITIONS.find((c) => c.id === "eliza");
+    expect(eliza).toBeDefined();
+    expect(eliza?.name).toBe("Eliza");
+    expect(eliza?.templates).toBeDefined();
+    expect(eliza?.templates?.authFailedReply).toBeDefined();
+    expect(eliza?.templates?.rateLimitedReply).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/character-presets.characters.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- Completeness and structural validity of `CHARACTER_DEFINITIONS` records (id uniqueness, bio, system prompt, adjectives, topics, message examples, style rules).
- Inclusion of all required language variants (`en`, `zh-CN`, `ko`, `es`, `pt`, `vi`, `tl`) with catchphrases, hints, and post examples.
- Default persona configuration and failure reply template overrides (`authFailedReply`, `rateLimitedReply`).

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`179e5e8567`) |
| --- | --- | --- |
| `bunx vitest run packages/shared/src/character-presets.characters.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/shared/src/character-presets.characters.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/character-presets.characters.test.ts:1-67`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:179e5e85675e49edda7eb8a03eb0ecc3f0b40cf7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested