### PR TITLE
test(core): cover route-helpers

### DIFF
--- a/packages/core/src/api/route-helpers.test.ts
+++ b/packages/core/src/api/route-helpers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pins the compile-time contracts shared by core route dispatchers, including
+ * request metadata, helper signatures, and the two app-package context shapes.
+ */
+import type http from "node:http";
+import { describe, expectTypeOf, it } from "vitest";
+import type { ReadJsonBodyOptions } from "./http-helpers.js";
+import type {
+	AppPackageRouteContext,
+	AppPackageRouteDispatchContext,
+	RouteHelpers,
+	RouteRequestContext,
+	RouteRequestMeta,
+} from "./route-helpers.js";
+
+interface ExpectedRouteRequestMeta {
+	req: http.IncomingMessage;
+	res: http.ServerResponse;
+	method: string;
+	pathname: string;
+}
+
+interface ExpectedRouteHelpers {
+	json: (res: http.ServerResponse, data: unknown, status?: number) => void;
+	error: (res: http.ServerResponse, message: string, status?: number) => void;
+	readJsonBody: <T extends object>(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		options?: ReadJsonBodyOptions,
+	) => Promise<T | null>;
+}
+
+describe("route helper contracts", () => {
+	it("exposes the request and response metadata used for route matching", () => {
+		expectTypeOf<RouteRequestMeta>().toEqualTypeOf<ExpectedRouteRequestMeta>();
+	});
+
+	it("preserves responder status arguments and the generic body reader", () => {
+		expectTypeOf<RouteHelpers>().toEqualTypeOf<ExpectedRouteHelpers>();
+	});
+
+	it("combines request metadata with every shared route helper", () => {
+		expectTypeOf<RouteRequestContext>().toEqualTypeOf<
+			ExpectedRouteRequestMeta & ExpectedRouteHelpers
+		>();
+	});
+
+	it("binds app-package body reads while retaining JSON and error responders", () => {
+		expectTypeOf<AppPackageRouteContext>().toEqualTypeOf<
+			ExpectedRouteRequestMeta & {
+				url: URL;
+				runtime: unknown | null;
+				json: ExpectedRouteHelpers["json"];
+				error: ExpectedRouteHelpers["error"];
+				readJsonBody: <T extends object = Record<string, unknown>>(
+					options?: ReadJsonBodyOptions,
+				) => Promise<T | null>;
+			}
+		>();
+	});
+
+	it("extends the full dispatch context with URL and nullable runtime state", () => {
+		expectTypeOf<AppPackageRouteDispatchContext>().toEqualTypeOf<
+			ExpectedRouteRequestMeta &
+				ExpectedRouteHelpers & {
+					url: URL;
+					runtime: unknown | null;
+				}
+		>();
+	});
+});


### PR DESCRIPTION

## Summary

- add a focused Vitest contract suite for all five exports from `packages/core/src/api/route-helpers.ts`
- pin request metadata, responder signatures, generic JSON body readers, and both app-package context compositions
- keep production behavior unchanged; the target module is type-only and has no runtime branches

## Validation

- `bunx vitest run packages/core/src/api/route-helpers.test.ts` — 1 test file passed, 5 tests passed
- `bunx biome check --write packages/core/src/api/route-helpers.test.ts` — checked 1 file, no fixes applied
- `(cd packages/core && bunx tsc --noEmit)` — exit 0; `route-helpers.test.ts` appeared nowhere in compiler output (grep exit 1)
- diff is one new test file only: 71 insertions, 0 deletions

Hosted CI does not run for this fork-contributor pull request; the commands above were run locally against current `origin/develop` (`ea910bda7ae68ac109e943f4b4be590da7587e8c`).

## Evidence

N/A — test-only type-contract coverage with no production, UI, model, native, or integration behavior change.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:03e27a4edc0ef7113a3aa2c83f750ec7b6c80b07 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
