### PR TITLE
test(skills): cover formatter

### DIFF
--- a/packages/skills/src/formatter.test.ts
+++ b/packages/skills/src/formatter.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for prompt formatting of skills and command spec generation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildSkillCommandSpecs,
+  formatSkillEntriesForPrompt,
+  formatSkillSummary,
+  formatSkillsForPrompt,
+  formatSkillsList,
+} from "./formatter.js";
+import type { Skill, SkillEntry } from "./types.js";
+
+describe("skills formatter", () => {
+  const sampleSkill1: Skill = {
+    name: "fetch-web",
+    description: "Fetches url content",
+    filePath: "/skills/fetch-web/SKILL.md",
+  };
+
+  const sampleSkill2: Skill = {
+    name: "internal-skill",
+    description: "Internal tasks only",
+    disableModelInvocation: true,
+  };
+
+  it("formats visible skills for system prompt and excludes disabled ones", () => {
+    const formatted = formatSkillsForPrompt([sampleSkill1, sampleSkill2]);
+
+    expect(formatted).toContain("available_skills:");
+    expect(formatted).toContain("- name: fetch-web");
+    expect(formatted).toContain("description: Fetches url content");
+    expect(formatted).toContain("location: /skills/fetch-web/SKILL.md");
+    expect(formatted).not.toContain("internal-skill");
+  });
+
+  it("returns empty string when no skills are visible to model", () => {
+    expect(formatSkillsForPrompt([])).toBe("");
+    expect(formatSkillsForPrompt([sampleSkill2])).toBe("");
+  });
+
+  it("formats SkillEntry items through formatSkillEntriesForPrompt", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: sampleSkill1,
+        frontmatter: {},
+        invocation: {},
+      },
+      {
+        skill: { name: "disabled-entry", description: "Disabled" },
+        frontmatter: {},
+        invocation: { disableModelInvocation: true },
+      },
+    ];
+
+    const formatted = formatSkillEntriesForPrompt(entries);
+    expect(formatted).toContain("- name: fetch-web");
+    expect(formatted).not.toContain("disabled-entry");
+  });
+
+  it("builds sanitized and deduplicated skill command specifications", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "Web Search!", description: "Search the web" },
+        frontmatter: {},
+      },
+      {
+        skill: { name: "web_search", description: "Duplicate command name" },
+        frontmatter: {},
+      },
+      {
+        skill: { name: "Non Invocable", description: "Hidden" },
+        frontmatter: {},
+        invocation: { userInvocable: false },
+      },
+    ];
+
+    const specs = buildSkillCommandSpecs(entries, new Set(["help"]));
+
+    expect(specs).toHaveLength(2);
+    expect(specs[0].name).toBe("web_search");
+    expect(specs[0].skillName).toBe("Web Search!");
+    expect(specs[1].name).toBe("web_search_1");
+  });
+
+  it("formats summary and skill list representations", () => {
+    expect(formatSkillSummary(sampleSkill1)).toBe(
+      "fetch-web: Fetches url content",
+    );
+
+    const list = formatSkillsList([sampleSkill1]);
+    expect(list).toBe("fetch-web: Fetches url content");
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/skills/src/formatter.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `formatSkillsForPrompt` and `formatSkillEntriesForPrompt` formatting visible skills and filtering disabled ones.
- Handling empty skills arrays and skills without model invocation permissions.
- `buildSkillCommandSpecs` sanitization, unique suffix deduplication, and user-invocable filtering.
- `formatSkillSummary` and `formatSkillsList` formatting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`466710a050`) |
| --- | --- | --- |
| `bunx vitest run packages/skills/src/formatter.test.ts` | N/A (new test file) | 5 passed (5 tests) |
| `bunx @biomejs/biome check packages/skills/src/formatter.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/skills/src/formatter.test.ts:1-95`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:466710a0508daafde01725ffdc3e848157b2e54a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested