### PR TITLE
test(core): cover deployment-types

### DIFF
--- a/packages/core/src/contracts/deployment-types.test.ts
+++ b/packages/core/src/contracts/deployment-types.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Pins the deployment-target runtime literals and their configuration type
+ * contract without involving runtime services or external integrations.
+ */
+
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+	DEPLOYMENT_TARGET_RUNTIMES,
+	type DeploymentTargetConfig,
+	type DeploymentTargetRuntime,
+} from "./deployment-types.ts";
+
+describe("deployment target contracts", () => {
+	it("keeps the supported runtimes in canonical order", () => {
+		expect(DEPLOYMENT_TARGET_RUNTIMES).toEqual(["local", "cloud", "remote"]);
+	});
+
+	it("derives the runtime union from the exported literals", () => {
+		expectTypeOf<DeploymentTargetRuntime>().toEqualTypeOf<
+			(typeof DEPLOYMENT_TARGET_RUNTIMES)[number]
+		>();
+	});
+
+	it("keeps provider and remote connection fields optional and bounded", () => {
+		expectTypeOf<DeploymentTargetConfig>().toEqualTypeOf<{
+			runtime: "local" | "cloud" | "remote";
+			provider?: "elizacloud" | "remote";
+			remoteApiBase?: string;
+			remoteAccessToken?: string;
+		}>();
+
+		const local: DeploymentTargetConfig = { runtime: "local" };
+		const remote: DeploymentTargetConfig = {
+			runtime: "remote",
+			provider: "remote",
+			remoteApiBase: "https://runtime.example.test",
+			remoteAccessToken: "token",
+		};
+
+		expect(local).toEqual({ runtime: "local" });
+		expect(remote.provider).toBe("remote");
+	});
+});


### PR DESCRIPTION

## Summary

- add a focused Vitest suite for `packages/core/src/contracts/deployment-types.ts`
- pin the deployment runtime literals and their canonical order
- verify the exported runtime and configuration type contracts, including optional provider and remote connection fields

## Validation

- `bunx vitest run packages/core/src/contracts/deployment-types.test.ts` — 1 test file passed, 3 tests passed against current `origin/develop` (`17f81984b03ae656c359f54c97f1d16bf1ae3854`)
- `bunx biome check --write packages/core/src/contracts/deployment-types.test.ts` — checked 1 file successfully
- `cd packages/core && bunx tsc --noEmit` — emitted no diagnostics; `deployment-types.test.ts` appeared nowhere in the output
- diff contains only the new test file: 43 insertions, 0 deletions

Hosted CI does not run on pull requests from this fork.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:72a13c02de9cc26a997ada983430f9eb38272ba0 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
