### PR TITLE
test(core): cover mime-sniffer

### DIFF
--- a/packages/core/src/media/mime-sniffer.test.ts
+++ b/packages/core/src/media/mime-sniffer.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for binary MIME type sniffing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sniffMime } from "./mime-sniffer.js";
+
+describe("mime-sniffer", () => {
+	it("returns undefined for undefined buffer", async () => {
+		expect(await sniffMime(undefined)).toBeUndefined();
+	});
+
+	it("sniffs PNG image magic bytes", async () => {
+		const pngHeader = Buffer.from([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+			0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+			0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+		]);
+
+		const mime = await sniffMime(pngHeader);
+		expect(mime).toBe("image/png");
+	});
+
+	it("sniffs JPEG image magic bytes", async () => {
+		const jpegHeader = Buffer.from([
+			0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+			0x01, 0x01, 0x00, 0x60, 0x00, 0x60, 0x00, 0x00, 0xff, 0xdb, 0x00, 0x43,
+		]);
+
+		const mime = await sniffMime(jpegHeader);
+		expect(mime).toBe("image/jpeg");
+	});
+
+	it("returns undefined for non-identifiable random or text bytes", async () => {
+		const plainText = Buffer.from(
+			"Hello world plain text content without magic header",
+		);
+		expect(await sniffMime(plainText)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/media/mime-sniffer.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `sniffMime` handling `undefined` gracefully.
- Magic byte detection for PNG and JPEG image buffers.
- Fallback for plain text / unrecognizable byte sequences.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`d114845f3f`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/media/mime-sniffer.test.ts` | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/core/src/media/mime-sniffer.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/media/mime-sniffer.test.ts:1-40`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:d114845f3fd040ef8f1d70154096f9c55c05e7d3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested