### PR TITLE
test(core): cover evaluation-corpus

### DIFF
--- a/packages/core/src/capability-selection/evaluation-corpus.test.ts
+++ b/packages/core/src/capability-selection/evaluation-corpus.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Verifies the built-in capability-selection evaluation fixtures against the
+ * real retrieval and account-selection pipeline. The suite is deterministic
+ * and mock-free, and also checks the corpus helpers' normalized defaults.
+ */
+import { describe, expect, it } from "vitest";
+import { runCapabilitySelectionEvaluation } from "./evaluation";
+import {
+	CAPABILITY_EVALUATION_CATALOG,
+	CAPABILITY_EVALUATION_CORPUS,
+} from "./evaluation-corpus";
+
+type CorpusCase = (typeof CAPABILITY_EVALUATION_CORPUS)[number];
+
+function selectionFor(name: string): NonNullable<CorpusCase["selection"]> {
+	const evalCase = CAPABILITY_EVALUATION_CORPUS.find(
+		(candidate) => candidate.name === name,
+	);
+	if (evalCase === undefined || evalCase.selection === null) {
+		throw new Error(`Expected a selection fixture named ${name}`);
+	}
+	return evalCase.selection;
+}
+
+describe("capability evaluation catalog", () => {
+	it("provides the complete ordered cross-domain capability set", () => {
+		expect(
+			CAPABILITY_EVALUATION_CATALOG.map(({ capabilityId, domain }) => ({
+				capabilityId,
+				domain,
+			})),
+		).toEqual([
+			{ capabilityId: "email.message.send", domain: "email" },
+			{ capabilityId: "email.message.search", domain: "email" },
+			{ capabilityId: "calendar.event.create", domain: "calendar" },
+			{ capabilityId: "messaging.chat.send", domain: "messaging" },
+			{ capabilityId: "files.document.search", domain: "files" },
+			{ capabilityId: "payments.transfer.create", domain: "payments" },
+			{ capabilityId: "contacts.person.search", domain: "contacts" },
+			{ capabilityId: "commerce.order.create", domain: "commerce" },
+			{ capabilityId: "health.metrics.read", domain: "health" },
+			{ capabilityId: "code.repository.search", domain: "code" },
+		]);
+		expect(
+			new Set(CAPABILITY_EVALUATION_CATALOG.map((entry) => entry.capabilityId))
+				.size,
+		).toBe(CAPABILITY_EVALUATION_CATALOG.length);
+		expect(
+			CAPABILITY_EVALUATION_CATALOG.every(
+				(entry) =>
+					entry.keywords.length > 0 &&
+					entry.operations.length > 0 &&
+					entry.promptTokenEstimate > 0,
+			),
+		).toBe(true);
+	});
+
+	it("keeps the exported fixture collections immutable", () => {
+		expect(Object.isFrozen(CAPABILITY_EVALUATION_CATALOG)).toBe(true);
+		expect(Object.isFrozen(CAPABILITY_EVALUATION_CORPUS)).toBe(true);
+
+		const cheapest = selectionFor(
+			"unambiguous email send selects the cheapest healthy account",
+		);
+		expect(cheapest.accounts.every((account) => Object.isFrozen(account))).toBe(
+			true,
+		);
+		expect(
+			cheapest.accounts.every((account) =>
+				Object.isFrozen(account.capabilities),
+			),
+		).toBe(true);
+	});
+});
+
+describe("capability evaluation corpus", () => {
+	it("passes every declared scenario through the real evaluation pipeline", () => {
+		const report = runCapabilitySelectionEvaluation(
+			CAPABILITY_EVALUATION_CATALOG,
+			CAPABILITY_EVALUATION_CORPUS,
+		);
+
+		expect(report.summary).toMatchObject({ total: 12, passed: 12, failed: 0 });
+		expect(report.cases.every((result) => result.failures.length === 0)).toBe(
+			true,
+		);
+		expect(
+			report.cases.map((result) => result.selection?.outcome ?? null),
+		).toEqual([
+			"selected",
+			"selected",
+			null,
+			null,
+			"denied",
+			"unavailable",
+			"denied",
+			"unavailable",
+			"unavailable",
+			"selected",
+			"unavailable",
+			"selected",
+		]);
+	});
+
+	it("normalizes account and signal defaults while retaining explicit overrides", () => {
+		const cheapest = selectionFor(
+			"unambiguous email send selects the cheapest healthy account",
+		);
+		expect(cheapest.accounts[0]).toMatchObject({
+			accountId: "acct-email-work",
+			providerId: "google-mail",
+			mode: "cloud",
+			status: "connected",
+			displayName: null,
+			lastUsedAt: "2026-08-01T00:00:00.000Z",
+		});
+		expect(cheapest.signals).toEqual([
+			{
+				accountId: "acct-email-work",
+				healthy: true,
+				region: "us",
+				unitCostMicros: 10,
+			},
+			{
+				accountId: "acct-email-personal",
+				healthy: true,
+				region: "eu",
+				unitCostMicros: 5,
+			},
+		]);
+
+		const revoked = selectionFor(
+			"only-revoked accounts surface account_revoked",
+		);
+		expect(revoked.accounts[0]).toMatchObject({
+			accountId: "acct-email-legacy",
+			mode: "cloud",
+			status: "revoked",
+			lastUsedAt: null,
+		});
+		expect(revoked.signals[0]).toEqual({
+			accountId: "acct-email-legacy",
+			healthy: true,
+			region: "us",
+			unitCostMicros: 10,
+		});
+	});
+});


### PR DESCRIPTION

## Summary

- add a same-named, mock-free unit suite for the built-in capability evaluation catalog and corpus
- verify the ordered cross-domain catalog, uniqueness and completeness invariants, and fixture immutability
- execute all 12 corpus scenarios through the real retrieval and account-selection evaluation pipeline
- cover normalized account/signal defaults alongside explicit revoked, region, cost, and recency fixture overrides

## Validation

- `bunx vitest run packages/core/src/capability-selection/evaluation-corpus.test.ts` — 1 test file passed, 4 tests passed
- `bunx biome check --write packages/core/src/capability-selection/evaluation-corpus.test.ts` — checked 1 file; formatting applied successfully
- `cd packages/core && bunx tsc --noEmit 2>&1 | grep 'evaluation-corpus.test.ts'; echo "EXIT:$?"` — no diagnostics named the new test file (`EXIT:1` from grep)
- diff scope: one new test file, 148 additions and 0 deletions; no production behavior changed

Hosted CI does not run for fork-originated pull requests; the local focused validation above is the available evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a8f55d3cb40eb96fee33b0c91d852d9269c6087f -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
