### PR TITLE
test(cloud): cover hono-next-style-params

### DIFF
--- a/packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts
+++ b/packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Coverage for hono-next-style-params.
+ */
+import { describe, expect, it } from "vitest";
+
+import { nextStyleParams } from "./hono-next-style-params.js";
+
+function mockCtx(params: Record<string, string | undefined>, splat?: string) {
+  return {
+    req: {
+      param: (name: string) => {
+        if (name === "*") return splat;
+        return params[name];
+      },
+    },
+  } as never;
+}
+
+describe("nextStyleParams", () => {
+  it("resolves single param", async () => {
+    const c = mockCtx({ id: "abc" });
+    const r = nextStyleParams(c, [{ name: "id", splat: false }] as const);
+    expect(await r.params).toEqual({ id: "abc" });
+  });
+
+  it("resolves splat param", async () => {
+    const c = mockCtx({}, "a/b/c");
+    const r = nextStyleParams(c, [{ name: "path", splat: true }] as const);
+    expect(await r.params).toEqual({ path: ["a", "b", "c"] });
+  });
+
+  it("handles empty splat", async () => {
+    const c = mockCtx({}, "");
+    const r = nextStyleParams(c, [{ name: "path", splat: true }] as const);
+    expect(await r.params).toEqual({ path: [] });
+  });
+
+  it("handles undefined splat", async () => {
+    const c = mockCtx({}, undefined);
+    const r = nextStyleParams(c, [{ name: "path", splat: true }] as const);
+    expect(await r.params).toEqual({ path: [] });
+  });
+
+  it("ignores missing non-splat", async () => {
+    const c = mockCtx({});
+    const r = nextStyleParams(c, [{ name: "id", splat: false }] as const);
+    expect(await r.params).toEqual({});
+  });
+
+  it("filters empty segments in splat", async () => {
+    const c = mockCtx({}, "a//b/");
+    const r = nextStyleParams(c, [{ name: "path", splat: true }] as const);
+    expect(await r.params).toEqual({ path: ["a", "b"] });
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:9f64b968566d224fa1beee0a963158787af66eed -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/api/hono-next-style-params.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop (e.g. `registry-host`); verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) → Green (restored)

**Red — proves non-vacuous (imports real export):**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop

 ❯ packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts (6 tests | 2 failed) 5ms
     × resolves splat param 3ms
     × filters empty segments in splat 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts > nextStyleParams > resolves splat param
AssertionError: expected { path: [] } to deeply equal { path: [ 'a', 'b', 'c' ] }

- Expected
+ Received

  {
-   "path": [
-     "a",
-     "b",
-     "c",
-   ],
+   "path": [],
  }

 ❯ packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts:29:28
     27|     const c = mockCtx({}, "a/b/c");
     28|     const r = nextStyleParams(c, [{ name: "path", splat: true }] as co…
     29|     expect(await r.params).toEqual({ path: ["a", "b", "c"] });
       |                            ^
     30|   });
     31|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts > nextStyleParams > filters empty segments in splat
AssertionError: expected { path: [] } to deeply equal { path: [ 'a', 'b' ] }

- Expected
+ Received

  {
-   "path": [
-     "a",
-     "b",
-   ],
+   "path": [],
  }

 ❯ packages/cloud/shared/src/lib/api/hono-next-style-params.test.ts:53:28
     51|     const c = mockCtx({}, "a//b/");
     52|     const r = nextStyleParams(c, [{ name: "path", splat: true }] as co…
     53|     expect(await r.params).toEqual({ path: ["a", "b"] });
       |                            ^
     54|   });
     55| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
   Start at  22:56:30
   Duration  89ms (transform 19ms, setup 0ms, import 24ms, tests 5ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  22:56:29
   Duration  84ms (transform 19ms, setup 0ms, import 23ms, tests 2ms, environment 0ms)
```

**Biome clean:** `biome check --write` passed.

