### PR TITLE
test(core): cover side-effect-claims

### DIFF
--- a/packages/core/src/services/message/side-effect-claims.test.ts
+++ b/packages/core/src/services/message/side-effect-claims.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for ungrounded side-effect assertion detection and empty tracked work state claims.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	replyClaimsCompletedSideEffect,
+	replyClaimsEmptyTrackedWorkState,
+} from "./side-effect-claims.js";
+
+describe("side-effect-claims", () => {
+	describe("replyClaimsCompletedSideEffect", () => {
+		it("detects English first-person completed side effect claims", () => {
+			expect(
+				replyClaimsCompletedSideEffect("I've set a reminder for your meeting."),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("I scheduled the appointment for 3pm."),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("Done — your reminders are set."),
+			).toBe(true);
+			expect(replyClaimsCompletedSideEffect("Added todo: buy groceries.")).toBe(
+				true,
+			);
+		});
+
+		it("ignores consent-seeking offers and questions", () => {
+			expect(
+				replyClaimsCompletedSideEffect("Should I set a reminder for 9am?"),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect("Would you like me to schedule a task?"),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"When I set a reminder, I'll let you know.",
+				),
+			).toBe(false);
+		});
+
+		it("detects multilingual side effect assertions (Spanish, Portuguese, Chinese, Korean)", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"He guardado el recordatorio para mañana.",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("Já salvei a sua tarefa no calendário."),
+			).toBe(true);
+			expect(replyClaimsCompletedSideEffect("我已经帮你把提醒设置好了。")).toBe(
+				true,
+			);
+			expect(replyClaimsCompletedSideEffect("알림을 설정했어요.")).toBe(true);
+		});
+
+		it("returns false on empty or whitespace strings", () => {
+			expect(replyClaimsCompletedSideEffect("")).toBe(false);
+			expect(replyClaimsCompletedSideEffect("   ")).toBe(false);
+		});
+	});
+
+	describe("replyClaimsEmptyTrackedWorkState", () => {
+		it("detects claims asserting empty or absent tracked work state", () => {
+			expect(replyClaimsEmptyTrackedWorkState("Your task list is empty.")).toBe(
+				true,
+			);
+			expect(replyClaimsEmptyTrackedWorkState("No tasks logged today.")).toBe(
+				true,
+			);
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"I don't have today's log in front of me.",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"Nothing is on your schedule for tomorrow.",
+				),
+			).toBe(true);
+		});
+
+		it("ignores conditional or question assertions about empty state", () => {
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"If your task list is empty, we can create one.",
+				),
+			).toBe(false);
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"Is your schedule clear for this afternoon?",
+				),
+			).toBe(false);
+		});
+
+		it("returns false on empty string", () => {
+			expect(replyClaimsEmptyTrackedWorkState("")).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/services/message/side-effect-claims.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `replyClaimsCompletedSideEffect` detecting English past/perfective assertions, state claims, and headline completions.
- Filtering out consent-seeking questions and condition openers.
- Multilingual completed side-effect detection (es, pt, zh, ko).
- `replyClaimsEmptyTrackedWorkState` detecting assertions of empty logs/tasks/schedules while allowing conditional/inquiry phrasing.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`f3fcd4d512`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/services/message/side-effect-claims.test.ts` | N/A (new test file) | 7 passed (7 tests) |
| `bunx @biomejs/biome check packages/core/src/services/message/side-effect-claims.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/services/message/side-effect-claims.test.ts:1-100`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:f3fcd4d5122026ed9a2d5351da7a1304397e326f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested