### PR TITLE
test(core): cover _factCandidates

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/_factCandidates.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/_factCandidates.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Deterministic unit coverage for fact-candidate persistence, including adapter
+ * availability, optional fields, SQL escaping, and database failure propagation.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, UUID } from "../../../types/index.ts";
+import {
+	type FactCandidateRecord,
+	recordFactCandidate,
+} from "./_factCandidates.ts";
+
+const AGENT_ID = "00000000-0000-4000-8000-0000000000aa" as UUID;
+const ENTITY_ID = "00000000-0000-4000-8000-0000000000bb" as UUID;
+const EXISTING_FACT_ID = "00000000-0000-4000-8000-0000000000cc" as UUID;
+const EVIDENCE_MESSAGE_ID = "00000000-0000-4000-8000-0000000000dd" as UUID;
+
+function makeRuntime(db: unknown): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		adapter: { db },
+	} as unknown as IAgentRuntime;
+}
+
+function rawSqlText(query: unknown): string {
+	const chunks = (query as { queryChunks: Array<{ value: string[] }> })
+		.queryChunks;
+	return chunks.flatMap((chunk) => chunk.value).join("");
+}
+
+describe("recordFactCandidate", () => {
+	it("does nothing when the runtime database is unavailable", async () => {
+		await expect(
+			recordFactCandidate(makeRuntime(undefined), {
+				entityId: ENTITY_ID,
+				kind: "merge",
+				proposedText: "The user lives in Berlin",
+			}),
+		).resolves.toBeUndefined();
+
+		await expect(
+			recordFactCandidate(makeRuntime({ execute: "not callable" }), {
+				entityId: ENTITY_ID,
+				kind: "merge",
+				proposedText: "The user lives in Berlin",
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("inserts a complete contradiction candidate with escaped SQL literals", async () => {
+		const execute = vi.fn(async () => undefined);
+		const candidate: FactCandidateRecord = {
+			entityId: ENTITY_ID,
+			kind: "contradict",
+			existingFactId: EXISTING_FACT_ID,
+			proposedText: "The user's home is Paris",
+			reason: "The user said they're moving",
+			evidenceMessageId: EVIDENCE_MESSAGE_ID,
+		};
+
+		await recordFactCandidate(makeRuntime({ execute }), candidate);
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		const sqlText = rawSqlText(execute.mock.calls[0]?.[0]);
+		expect(sqlText).toContain(`'${AGENT_ID}'`);
+		expect(sqlText).toContain(`'${ENTITY_ID}'`);
+		expect(sqlText).toContain("'contradict'");
+		expect(sqlText).toContain(`'${EXISTING_FACT_ID}'`);
+		expect(sqlText).toContain("'The user''s home is Paris'");
+		expect(sqlText).toContain("0.6");
+		expect(sqlText).toContain(
+			`'{"reason":"The user said they''re moving","evidenceMessageId":"${EVIDENCE_MESSAGE_ID}"}'::jsonb`,
+		);
+		expect(sqlText).toContain("'pending'");
+	});
+
+	it("uses NULL and an empty evidence object when optional fields are absent", async () => {
+		const execute = vi.fn(async () => undefined);
+
+		await recordFactCandidate(makeRuntime({ execute }), {
+			entityId: ENTITY_ID,
+			kind: "merge",
+			proposedText: "The user lives in Berlin",
+		});
+
+		const sqlText = rawSqlText(execute.mock.calls[0]?.[0]);
+		expect(sqlText).toContain("'merge'");
+		expect(sqlText).toMatch(/'merge',\s+NULL,\s+'The user lives in Berlin'/);
+		expect(sqlText).toContain("'{}'::jsonb");
+	});
+
+	it("propagates database execution failures", async () => {
+		const failure = new Error("database unavailable");
+		const execute = vi.fn(async () => {
+			throw failure;
+		});
+
+		await expect(
+			recordFactCandidate(makeRuntime({ execute }), {
+				entityId: ENTITY_ID,
+				kind: "merge",
+				proposedText: "The user lives in Berlin",
+			}),
+		).rejects.toBe(failure);
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for `recordFactCandidate`
- verify unavailable adapter handling, complete and minimal SQL row construction, SQL literal escaping, and database error propagation
- import and exercise the exported `FactCandidateRecord` contract against the real module

## Validation

- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/_factCandidates.test.ts` — 1 test file passed, 4 tests passed
- `bunx biome check --write packages/core/src/features/advanced-capabilities/evaluators/_factCandidates.test.ts` — checked 1 file successfully and formatted the new file
- `(cd packages/core && bunx tsc --noEmit)` — exit 0; `_factCandidates.test.ts` appeared nowhere in the output
- diff is one new test file only: 105 insertions, 0 deletions; production behavior is unchanged

Hosted CI does not run for pull requests from this fork, so no hosted CI result is claimed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:739369e8d2845a375f704253085ca002d96601d5 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
