### PR TITLE
test(skills): cover resolver

### DIFF
--- a/packages/skills/src/resolver.test.ts
+++ b/packages/skills/src/resolver.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for skills directory path resolution, caching, and atomic skill promotion.
+ */
+
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSkillsDirCache,
+  getCuratedActiveDir,
+  getProposedSkillsDir,
+  getSkillsDir,
+  promoteSkill,
+} from "./resolver.js";
+
+describe("skills resolver", () => {
+  const originalEnv = process.env.ELIZAOS_BUNDLED_SKILLS_DIR;
+  let testTempDir: string;
+
+  beforeEach(() => {
+    clearSkillsDirCache();
+    testTempDir = join(
+      tmpdir(),
+      `test-skills-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testTempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    clearSkillsDirCache();
+    if (originalEnv !== undefined) {
+      process.env.ELIZAOS_BUNDLED_SKILLS_DIR = originalEnv;
+    } else {
+      delete process.env.ELIZAOS_BUNDLED_SKILLS_DIR;
+    }
+    rmSync(testTempDir, { recursive: true, force: true });
+  });
+
+  it("resolves bundled skills directory via environment override", () => {
+    process.env.ELIZAOS_BUNDLED_SKILLS_DIR = testTempDir;
+    const resolved = getSkillsDir();
+    expect(resolved).toBe(testTempDir);
+  });
+
+  it("resolves curated active and proposed directories", () => {
+    const activeDir = getCuratedActiveDir();
+    const proposedDir = getProposedSkillsDir();
+
+    expect(activeDir).toContain("skills");
+    expect(activeDir.endsWith("active")).toBe(true);
+    expect(proposedDir.endsWith("proposed")).toBe(true);
+  });
+
+  it("validates skill name and rejects invalid characters in promoteSkill", () => {
+    expect(() => promoteSkill("Invalid_Skill_Name")).toThrow(
+      /Invalid skill name/,
+    );
+    expect(() => promoteSkill("skill/with/slashes")).toThrow(
+      /Invalid skill name/,
+    );
+  });
+
+  it("throws when promoting nonexistent proposed skill", () => {
+    expect(() => promoteSkill("nonexistent-skill")).toThrow(/not found/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/skills/src/resolver.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `getSkillsDir` resolving custom directories via `ELIZAOS_BUNDLED_SKILLS_DIR`.
- `getCuratedActiveDir` and `getProposedSkillsDir` resolving curated active and proposed directories.
- `promoteSkill` name validation and missing directory rejection.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`e9a5ca7871`) |
| --- | --- | --- |
| `bunx vitest run packages/skills/src/resolver.test.ts` | N/A (new test file) | 4 passed (4 tests) |
| `bunx @biomejs/biome check packages/skills/src/resolver.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/skills/src/resolver.test.ts:1-67`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:e9a5ca7871c2bfc4dba7807e6d3c1a917ea29a4e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested