### PR TITLE
test(core): cover persist-character-patch

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Exercises the shared personality character-patch write path with deterministic
+ * persistence-service fakes, including mutation ordering and failure handling.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Character, IAgentRuntime } from "../../../../../types/index.ts";
+import type { CharacterPersistenceServiceLike } from "../../character-persistence.ts";
+import { persistCharacterPatch } from "./persist-character-patch.ts";
+
+function createRuntime(
+	character: Character,
+	service: CharacterPersistenceServiceLike | null,
+): IAgentRuntime {
+	return {
+		character,
+		getService: vi.fn(() => service),
+	} as unknown as IAgentRuntime;
+}
+
+describe("persistCharacterPatch", () => {
+	it("short-circuits an empty patch without looking up persistence", async () => {
+		const character: Character = { name: "Original", bio: ["unchanged"] };
+		const runtime = createRuntime(character, null);
+
+		await expect(persistCharacterPatch(runtime, {})).resolves.toEqual({
+			success: true,
+		});
+		expect(runtime.getService).not.toHaveBeenCalled();
+		expect(runtime.character).toEqual(character);
+	});
+
+	it("applies a shallow replacement when no persistence service is registered", async () => {
+		const originalStyle = { all: ["warm"], chat: ["brief"] };
+		const replacementStyle = { all: ["direct"] };
+		const character: Character = { name: "Original", style: originalStyle };
+		const runtime = createRuntime(character, null);
+
+		await expect(
+			persistCharacterPatch(runtime, {
+				name: "Updated",
+				style: replacementStyle,
+			}),
+		).resolves.toEqual({ success: true });
+		expect(runtime.character).toBe(character);
+		expect(runtime.character).toEqual({
+			name: "Updated",
+			style: replacementStyle,
+		});
+		expect(runtime.character.style).not.toBe(originalStyle);
+	});
+
+	it("persists complete before-and-after snapshots before mutating the live character", async () => {
+		const character: Character = {
+			name: "Original",
+			bio: ["before"],
+			topics: ["existing"],
+		};
+		let runtime: IAgentRuntime;
+		const persistCharacter = vi.fn(async () => {
+			expect(runtime.character).toEqual(character);
+			return { success: true };
+		});
+		const service: CharacterPersistenceServiceLike = { persistCharacter };
+		runtime = createRuntime(character, service);
+
+		await expect(
+			persistCharacterPatch(runtime, {
+				bio: ["after"],
+				topics: [],
+			}),
+		).resolves.toEqual({ success: true });
+		expect(persistCharacter).toHaveBeenCalledWith({
+			character: {
+				name: "Original",
+				bio: ["after"],
+				topics: [],
+			},
+			previousCharacter: {
+				name: "Original",
+				bio: ["before"],
+				topics: ["existing"],
+			},
+			previousName: "Original",
+			source: "agent",
+		});
+		expect(runtime.character).toEqual({
+			name: "Original",
+			bio: ["after"],
+			topics: [],
+		});
+	});
+
+	it("returns a persistence failure without mutating the live character", async () => {
+		const character: Character = { name: "Original", bio: ["before"] };
+		const failure = { success: false, error: "disk unavailable" };
+		const service: CharacterPersistenceServiceLike = {
+			persistCharacter: vi.fn(async () => failure),
+		};
+		const runtime = createRuntime(character, service);
+
+		await expect(
+			persistCharacterPatch(runtime, { name: "Rejected", bio: ["after"] }),
+		).resolves.toBe(failure);
+		expect(runtime.character).toEqual({ name: "Original", bio: ["before"] });
+	});
+
+	it("omits previousName when the live character name is not a string", async () => {
+		const character = { name: 42, bio: ["before"] } as unknown as Character;
+		const persistCharacter = vi.fn(async () => ({ success: true }));
+		const runtime = createRuntime(character, { persistCharacter });
+
+		await persistCharacterPatch(runtime, { bio: ["after"] });
+
+		expect(persistCharacter).toHaveBeenCalledWith(
+			expect.objectContaining({ previousName: undefined }),
+		);
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for the shared `persistCharacterPatch` write path
- verify the empty-patch short circuit, no-service fallback, shallow field replacement, persistence payload and mutation ordering, persistence failure handling, and non-string previous-name handling
- change no production code

## Validation

- `bunx vitest run packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts` — 1 test file passed, 5 tests passed on current `origin/develop`
- `bunx biome check --write packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts` — checked 1 file; no fixes applied
- `(cd packages/core && bunx tsc --noEmit)` — exited 0; `persist-character-patch.test.ts` appeared 0 times in output
- diff contains only the new test file: 118 insertions, 0 deletions

Hosted CI does not run for this fork contribution; the local commands above are the available validation evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:54b54a5cba2a4cfaf93f17b1ea76f69841538caa -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
