### PR TITLE
test(shared): cover boot-config-store

### DIFF
--- a/packages/shared/src/config/boot-config-store.test.ts
+++ b/packages/shared/src/config/boot-config-store.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for global boot config store and character catalog resolution.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type AppBootConfig,
+  type CharacterCatalogData,
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  resolveCharacterCatalog,
+  setBootConfig,
+} from "./boot-config-store.js";
+
+describe("boot-config-store", () => {
+  it("manages boot config in global store", () => {
+    const initial = getBootConfig();
+    expect(initial.cloudApiBase).toBe(DEFAULT_BOOT_CONFIG.cloudApiBase);
+    expect(initial.preferSharedCloudTier).toBe(true);
+
+    const customConfig: AppBootConfig = {
+      branding: { name: "Custom Eliza" },
+      cloudApiBase: "https://custom.eliza.app",
+      preferSharedCloudTier: false,
+      autoUpgradeSharedToDedicated: true,
+    };
+
+    setBootConfig(customConfig);
+    const updated = getBootConfig();
+    expect(updated.branding?.name).toBe("Custom Eliza");
+    expect(updated.cloudApiBase).toBe("https://custom.eliza.app");
+    expect(updated.preferSharedCloudTier).toBe(false);
+    expect(updated.autoUpgradeSharedToDedicated).toBe(true);
+  });
+
+  it("resolves character catalog assets and injected characters", () => {
+    const catalogData: CharacterCatalogData = {
+      assets: [
+        {
+          id: 1,
+          slug: "eliza-default",
+          title: "Eliza Default",
+          sourceName: "eliza_default_vrm",
+        },
+        {
+          id: 2,
+          slug: "eliza-cyber",
+          title: "Eliza Cyber",
+          sourceName: "eliza_cyber_vrm",
+        },
+      ],
+      injectedCharacters: [
+        {
+          name: "Cyber Eliza",
+          catchphrase: "I am from the future",
+          avatarAssetId: 2,
+        },
+      ],
+    };
+
+    const resolved = resolveCharacterCatalog(catalogData);
+
+    expect(resolved.assetCount).toBe(2);
+    expect(resolved.defaultAsset?.slug).toBe("eliza-default");
+    expect(resolved.defaultAsset?.compressedVrmPath).toBe(
+      "vrms/eliza-default.vrm.gz",
+    );
+    expect(resolved.defaultAsset?.rawVrmPath).toBe("vrms/eliza-default.vrm");
+    expect(resolved.defaultAsset?.previewPath).toBe(
+      "vrms/previews/eliza-default.png",
+    );
+
+    expect(resolved.injectedCharacterCount).toBe(1);
+    const char = resolved.getInjectedCharacter("I am from the future");
+    expect(char?.name).toBe("Cyber Eliza");
+    expect(char?.avatarAsset.slug).toBe("eliza-cyber");
+
+    expect(resolved.getAsset(2)?.slug).toBe("eliza-cyber");
+    expect(resolved.getAsset(999)?.slug).toBe("eliza-default"); // falls back to default
+  });
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/shared/src/config/boot-config-store.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- Global `setBootConfig` and `getBootConfig` state persistence and default configuration fallback.
- `resolveCharacterCatalog` asset path expansions, fallback defaults, and injected character resolution.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`1c044666b0`) |
| --- | --- | --- |
| `bunx vitest run packages/shared/src/config/boot-config-store.test.ts` | N/A (new test file) | 2 passed (2 tests) |
| `bunx @biomejs/biome check packages/shared/src/config/boot-config-store.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/shared/src/config/boot-config-store.test.ts:1-81`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:1c044666b0ac09f52669c9f92f006612c1b13421 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested