### PR TITLE
test(core): cover long-term-memories

### DIFF
--- a/packages/core/src/features/advanced-memory/schemas/long-term-memories.test.ts
+++ b/packages/core/src/features/advanced-memory/schemas/long-term-memories.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Deterministic unit coverage for the advanced-memory long-term memory table
+ * definition, including its complete column, index, and constraint contracts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { longTermMemories } from "./long-term-memories.ts";
+
+describe("longTermMemories", () => {
+	it("defines the public long-term memory table", () => {
+		expect(longTermMemories.name).toBe("long_term_memories");
+		expect(longTermMemories.schema).toBe("public");
+	});
+
+	it("defines every required and optional memory column", () => {
+		expect(longTermMemories.columns).toEqual({
+			id: {
+				name: "id",
+				type: "varchar(36)",
+				primaryKey: true,
+				notNull: true,
+			},
+			agent_id: { name: "agent_id", type: "varchar(36)", notNull: true },
+			entity_id: { name: "entity_id", type: "varchar(36)", notNull: true },
+			category: { name: "category", type: "text", notNull: true },
+			content: { name: "content", type: "text", notNull: true },
+			metadata: { name: "metadata", type: "jsonb" },
+			embedding: { name: "embedding", type: "real[]" },
+			confidence: { name: "confidence", type: "real", default: 1 },
+			source: { name: "source", type: "text" },
+			created_at: {
+				name: "created_at",
+				type: "timestamp",
+				notNull: true,
+				default: "now()",
+			},
+			updated_at: {
+				name: "updated_at",
+				type: "timestamp",
+				notNull: true,
+				default: "now()",
+			},
+			last_accessed_at: { name: "last_accessed_at", type: "timestamp" },
+			access_count: { name: "access_count", type: "integer", default: 0 },
+		});
+	});
+
+	it("indexes entity lookup first and exposes each secondary lookup", () => {
+		expect(longTermMemories.indexes).toEqual({
+			long_term_memories_agent_entity_idx: {
+				name: "long_term_memories_agent_entity_idx",
+				columns: [
+					{ expression: "agent_id", isExpression: false },
+					{ expression: "entity_id", isExpression: false },
+				],
+				isUnique: false,
+			},
+			long_term_memories_category_idx: {
+				name: "long_term_memories_category_idx",
+				columns: [{ expression: "category", isExpression: false }],
+				isUnique: false,
+			},
+			long_term_memories_confidence_idx: {
+				name: "long_term_memories_confidence_idx",
+				columns: [{ expression: "confidence", isExpression: false }],
+				isUnique: false,
+			},
+			long_term_memories_created_at_idx: {
+				name: "long_term_memories_created_at_idx",
+				columns: [{ expression: "created_at", isExpression: false }],
+				isUnique: false,
+			},
+		});
+	});
+
+	it("declares no additional constraints", () => {
+		expect(longTermMemories.foreignKeys).toEqual({});
+		expect(longTermMemories.compositePrimaryKeys).toEqual({});
+		expect(longTermMemories.uniqueConstraints).toEqual({});
+		expect(longTermMemories.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for the exported `longTermMemories` schema
- verify the complete table identity, column definitions and defaults
- verify compound index ordering, secondary indexes, and empty constraint maps

## Validation

- `bunx vitest run packages/core/src/features/advanced-memory/schemas/long-term-memories.test.ts` — 1 file passed, 4 tests passed
- `bunx biome check --write packages/core/src/features/advanced-memory/schemas/long-term-memories.test.ts` — checked 1 file, no fixes applied
- `cd packages/core && bunx tsc --noEmit` — exited 0 with no output; the new test filename appeared nowhere
- diff is test-only: 1 new test file, 82 insertions, 0 deletions

Hosted CI does not run for fork-contributor pull requests; the local validation above is the available test evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:897b634f449cb17ff09aa620e1000fcb0949a866 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
