### PR TITLE
fix(shared): handle verb-linked cadence negation

### DIFF
--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -355,6 +355,65 @@ describe("TRIGGER create — recurrence wins over sprayed one-shot fields", () =
     expect(result?.text).not.toContain("once at");
   });
 
+  it("keeps maxRuns:1 when the user's words negate the cadence through a verb (#26089)", async () => {
+    // The reachable production failure: the planner sprays a cron AND
+    // maxRuns:1, and trigger.ts drops the one-shot cap whenever the user's
+    // own text states explicit recurrence. A verb-linked negation
+    // ("won't be daily") is NOT a statement of recurrence, so the cap must
+    // survive and the reminder must stay a single fire.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "stretch",
+        displayName: "stretch",
+        triggerType: "cron",
+        cronExpression: "0 8 * * *",
+        maxRuns: 1,
+      },
+      "remind me to stretch tomorrow, it won't be daily",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0].metadata.trigger?.maxRuns).toBe(1);
+  });
+
+  it("keeps maxRuns:1 for a 'don't make it weekly' negation (#26089)", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "water the plants",
+        displayName: "water plants",
+        triggerType: "cron",
+        cronExpression: "0 9 * * 1",
+        maxRuns: 1,
+      },
+      "water the plants on Monday, don't make it weekly",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0].metadata.trigger?.maxRuns).toBe(1);
+  });
+
+  it("still drops a sprayed maxRuns:1 when the user really does state recurrence", async () => {
+    // Guard the other direction: the #26089 fix must not turn genuine
+    // recurrence into a one-shot. "make it daily" has no negation, so the
+    // sprayed one-shot cap is still the planner's echo and must be dropped.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "take vitamins",
+        displayName: "vitamins",
+        triggerType: "cron",
+        cronExpression: "0 8 * * *",
+        maxRuns: 1,
+      },
+      "remind me to take vitamins, make it daily",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0].metadata.trigger?.maxRuns).toBeUndefined();
+  });
+
   it("resolves cronExpression + delay to recurring even without an explicit triggerType", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const result = await create(runtime, {

--- a/packages/shared/src/i18n/recurrence-markers.test.ts
+++ b/packages/shared/src/i18n/recurrence-markers.test.ts
@@ -91,6 +91,31 @@ describe("textStatesExplicitRecurrence", () => {
     }
   });
 
+  it("handles negated cadence with intervening verbs without swallowing positive statements or questions", () => {
+    for (const text of [
+      "won't be daily",
+      "don't make it weekly",
+      "isn't going to be weekly",
+      "doesn't run daily",
+    ]) {
+      expect(textStatesExplicitRecurrence(text)).toBe(false);
+    }
+    for (const text of [
+      "will be daily",
+      "runs daily",
+      "is going to be weekly",
+      "isn't this a daily job?",
+    ]) {
+      expect(textStatesExplicitRecurrence(text)).toBe(true);
+    }
+    expect(
+      textStatesExplicitRecurrence("don't be daily, make it weekly instead"),
+    ).toBe(true);
+    expect(
+      textStatesExplicitRecurrence("weekly, actually don't make it daily"),
+    ).toBe(false);
+  });
+
   it("ignores role-labelled non-user text", () => {
     expect(
       textStatesExplicitRecurrence("assistant: should this be weekly?"),

--- a/packages/shared/src/i18n/recurrence-markers.test.ts
+++ b/packages/shared/src/i18n/recurrence-markers.test.ts
@@ -116,6 +116,36 @@ describe("textStatesExplicitRecurrence", () => {
     ).toBe(false);
   });
 
+  it("treats a verb-linked negation exactly like the bare negation it mirrors", () => {
+    // The bridge must not invent new span semantics: a trailing subordinate
+    // clause is swallowed by a negated cadence today for the bare form, so
+    // the verb-linked form has to agree. Pinning the PAIR (rather than each
+    // string alone) is what keeps the two spellings from drifting apart.
+    const pairs: Array<[string, string]> = [
+      [
+        "not daily because it is already weekly",
+        "doesn't run daily because it is already weekly",
+      ],
+      [
+        "never weekly since monthly is intended",
+        "won't be weekly since monthly is intended",
+      ],
+    ];
+    for (const [bare, verbLinked] of pairs) {
+      expect(textStatesExplicitRecurrence(verbLinked)).toBe(
+        textStatesExplicitRecurrence(bare),
+      );
+    }
+
+    // A contrast marker still terminates the span in both spellings, so a
+    // genuine correction survives as recurrence.
+    expect(
+      textStatesExplicitRecurrence(
+        "don't make it daily, make it weekly instead",
+      ),
+    ).toBe(true);
+  });
+
   it("ignores role-labelled non-user text", () => {
     expect(
       textStatesExplicitRecurrence("assistant: should this be weekly?"),

--- a/packages/shared/src/i18n/recurrence-markers.ts
+++ b/packages/shared/src/i18n/recurrence-markers.ts
@@ -89,6 +89,7 @@ const NAME_LIKE_RECURRENCE_PATTERNS: readonly RegExp[] = [
 const NEGATION_WORD = String.raw`\b(?:not|no|never|isn't|isn’t|aren't|aren’t|won't|won’t|doesn't|doesn’t|don't|don’t)\b`;
 const CADENCE_ADJECTIVE = String.raw`\b(?:daily|weekly|monthly|nightly|hourly|yearly|annually|quarterly|biweekly|fortnightly)\b`;
 const PLURAL_WEEKDAY = String.raw`\bmondays\b|\btuesdays\b|\bwednesdays\b|\bthursdays\b|\bfridays\b|\bsaturdays\b|\bsundays\b|\bweekdays\b|\bweekends\b`;
+const NEGATED_CADENCE_BRIDGE = String.raw`(?:going\s+to\s+be|make\s+it|be|run)`;
 const ONE_SHOT_DIRECTIVE_PATTERNS: readonly RegExp[] = [
   new RegExp(
     `${NEGATION_WORD}\\s+(?:a\\s+)?(?:recurr(?:ing|ence)|repeat(?:ed|ing)?|every|each)\\b(?:(?![,.;!?]|\\b(?:but|rather|instead|actually|make\\s+it)\\b)[\\s\\S])*`,
@@ -98,7 +99,7 @@ const ONE_SHOT_DIRECTIVE_PATTERNS: readonly RegExp[] = [
     // "not weekly" / "never daily on Mondays": a negated cadence adjective
     // (optionally followed by more cadence words) is one authoritative
     // one-shot span that swallows any positive markers it covers.
-    `${NEGATION_WORD}\\s+(?:on\\s+|a\\s+|an\\s+)?(?:${CADENCE_ADJECTIVE}|${PLURAL_WEEKDAY})(?:\\s+(?:or|and)\\s+(?:${CADENCE_ADJECTIVE}|${PLURAL_WEEKDAY}))*(?:(?![,.;!?]|\\b(?:but|rather|instead|actually|make\\s+it)\\b)[\\s\\S])*`,
+    `${NEGATION_WORD}\\s+(?:${NEGATED_CADENCE_BRIDGE}\\s+)?(?:on\\s+|a\\s+|an\\s+)?(?:${CADENCE_ADJECTIVE}|${PLURAL_WEEKDAY})(?:\\s+(?:or|and)\\s+(?:${CADENCE_ADJECTIVE}|${PLURAL_WEEKDAY}))*(?:(?![,.;!?]|\\b(?:but|rather|instead|actually|make\\s+it)\\b)[\\s\\S])*`,
     "i",
   ),
   /\b(?:do\s+not|don't)\s+repeat\b(?:(?![,.;!?]|\b(?:but|rather|instead|actually|make\s+it)\b)[\s\S])*/i,


### PR DESCRIPTION
# Relates to

Closes #26089

- [x] This PR targets `develop` and is based on `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda` with zero conflicts.
- [x] The exact-head shared and agent suites pass; the unrelated package-typecheck blockers are recorded below.
- [x] A reviewer can confirm the classifier behavior and the trigger-path behavior from the head-vs-control run recorded below.

# Sync with develop

- [x] Based on `01f7b5e3e47644e6c6bf67bff27e61d8d0fa1fda` (the live PR base at the time of this update); zero conflicts.
- [x] Exact-head affected tests and formatting pass; the broader typecheck gap is documented below.

# Risks

Low. The change extends one existing direct-negation regex with four bounded verb bridges. It does not alter recurrence vocabulary, correction-clause boundaries, or role-labelled text filtering. The main risk is a false one-shot classification, covered with positive statements, questions, and corrections in both orders, plus a trigger-path guard asserting that genuine recurrence still drops a sprayed `maxRuns: 1`.

# Background

## What does this PR do?

Negated cadence phrases such as “won't be daily” and “don't make it weekly” currently leave the cadence word visible to the positive recurrence matcher. `packages/agent/src/actions/trigger.ts` drops the planner's `maxRuns: 1` cap whenever the user's own text states explicit recurrence, so a “just this once” reminder becomes a routine.

This change recognizes common intervening verb phrases inside the existing negated-cadence span, adds regression controls for negative statements, positive statements, questions, and later corrections, and pins the behavior at the TRIGGER `create` boundary where the cap is dropped.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects existing classifier behavior and is covered by source-level tests.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/trigger.test.ts`, in the three `#26089` cases on the TRIGGER `create` op, then `packages/shared/src/i18n/recurrence-markers.test.ts` and the bounded bridge added beside the existing negation patterns in `recurrence-markers.ts`.

## Detailed testing steps

Run on exact head `d371745005538b2c8903b2f826026d8732b4bb2f`, with `packages/shared/src/i18n/recurrence-markers.ts` reverted to `origin/develop` as the control and everything else identical:

| Suite | this head | control (develop's `recurrence-markers.ts`) |
|---|---|---|
| `packages/agent` `src/actions/trigger.test.ts` | **80 passed** | **2 failed** / 78 passed |
| `packages/shared` `src/i18n/recurrence-markers.test.ts` | **14 passed** | 2 failed / 12 passed |

The two control failures are exactly the #26089 regression:

```text
× keeps maxRuns:1 when the user's words negate the cadence through a verb (#26089)
  AssertionError: expected undefined to be 1
× keeps maxRuns:1 for a 'don't make it weekly' negation (#26089)
  AssertionError: expected undefined to be 1
```

The opposite-direction guard (`"remind me to take vitamins, make it daily"` must still drop the sprayed cap) passes on both head and control, so the fix does not turn genuine recurrence into a one-shot.

- Red-first: the focused shared suite failed because `won't be daily` returned recurring before the production change.
- Scoped Biome: both changed files passed.
- `git diff --check` against the merge base: passed.

# Evidence Gate

<!-- evidence-head:d371745005538b2c8903b2f826026d8732b4bb2f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this backend shared classifier change has no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this backend shared classifier change has no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this backend change has no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] Head-vs-control suite output for `packages/agent/src/actions/trigger.test.ts` and `packages/shared/src/i18n/recurrence-markers.test.ts` is recorded above and in the PR comments on this head.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or network behavior is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, provider, or model behavior is changed. The TRIGGER `create` op is exercised through the action's own entry point against an in-memory runtime double, with no model call.
<!-- evidence-row:domain-artifacts -->
- [x] The trigger record handed to `runtime.createTask` is asserted directly (`metadata.trigger.maxRuns`); this is the action's output object, not a row read back from a live database.
<!-- evidence-row:ocr-review -->
- [x] N/A - the changed TypeScript files have no rendered text to review.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action prompt, provider, or model behavior is changed.

## Backend + frontend logs

The changed classifier and its production consumer are exercised by the automated suites above. `makeRuntime()` in `trigger.test.ts` is an in-memory runtime double, so the trigger object is captured at the `createTask` boundary rather than read back from a live store. No frontend surface is involved.

## Screenshots (before / after) + video walkthrough

N/A - the diff contains only backend TypeScript and its tests.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior is changed.

## Known gaps / failures

The package typecheck cannot establish a clean baseline with the existing offline dependency graph: current develop reports missing `@elizaos/cloud-routing` from `packages/core/src/cloud-routing.ts`, missing `@elizaos/core/edge` from `packages/shared/src/todo-cutover.ts`, and an unrelated mock generic mismatch at `packages/shared/src/registry-host.test.ts:45`. Neither changed file is named. Running the agent suite locally also requires the repo codegen (`packages/shared/scripts/generate-keywords.mjs`) and a built `@elizaos/prompts`; both are ordinary repo build steps, not changes from this PR.

The enumerated bridge set does not cover every sibling verb phrase (`won't happen daily`, `doesn't occur daily`). Those are outside #26089's acceptance criteria and left for a follow-up.

## Maintainer CI exception record

N/A - no exception requested.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-goal-100]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0QP95164PSTY8CBXQYD3CCK","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T16:11:55.814Z","completed_at":"2026-08-23T16:13:19.182Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T16:11:56.718Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ed1a3c6768e7cff75ac182322afc1f0684df6c08c0217c2376e7a16f17b1f17d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c619d15c-8db5-456d-9276-09b3d8f75d94","object_id":"sha256:ed1a3c6768e7cff75ac182322afc1f0684df6c08c0217c2376e7a16f17b1f17d","sha256":"ed1a3c6768e7cff75ac182322afc1f0684df6c08c0217c2376e7a16f17b1f17d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"6mJ4SLe6SRn0eIL57veGr7KOkf9sBKaH66r16U-LBUboS0KP7Y1ikjVVAA4IZ1kY1-oaTcqdCgewhA8z1o0qCw"}} -->

