### PR TITLE
test(core): cover session-summaries

### DIFF
--- a/packages/core/src/features/advanced-memory/schemas/session-summaries.test.ts
+++ b/packages/core/src/features/advanced-memory/schemas/session-summaries.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic unit coverage for the advanced-memory session summary table
+ * definition, including its complete column, index, and constraint contracts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sessionSummaries } from "./session-summaries.ts";
+
+describe("sessionSummaries", () => {
+	it("defines the public session summaries table", () => {
+		expect(sessionSummaries.name).toBe("session_summaries");
+		expect(sessionSummaries.schema).toBe("public");
+	});
+
+	it("defines every required and optional summary column", () => {
+		expect(sessionSummaries.columns).toEqual({
+			id: {
+				name: "id",
+				type: "varchar(36)",
+				primaryKey: true,
+				notNull: true,
+			},
+			agent_id: { name: "agent_id", type: "varchar(36)", notNull: true },
+			room_id: { name: "room_id", type: "varchar(36)", notNull: true },
+			entity_id: { name: "entity_id", type: "varchar(36)" },
+			summary: { name: "summary", type: "text", notNull: true },
+			message_count: { name: "message_count", type: "integer", notNull: true },
+			last_message_offset: {
+				name: "last_message_offset",
+				type: "integer",
+				notNull: true,
+				default: 0,
+			},
+			start_time: { name: "start_time", type: "timestamp", notNull: true },
+			end_time: { name: "end_time", type: "timestamp", notNull: true },
+			topics: { name: "topics", type: "jsonb" },
+			metadata: { name: "metadata", type: "jsonb" },
+			embedding: { name: "embedding", type: "real[]" },
+			created_at: {
+				name: "created_at",
+				type: "timestamp",
+				notNull: true,
+				default: "now()",
+			},
+			updated_at: {
+				name: "updated_at",
+				type: "timestamp",
+				notNull: true,
+				default: "now()",
+			},
+		});
+	});
+
+	it("indexes room lookup first and exposes each secondary lookup", () => {
+		expect(sessionSummaries.indexes).toEqual({
+			session_summaries_agent_room_idx: {
+				name: "session_summaries_agent_room_idx",
+				columns: [
+					{ expression: "agent_id", isExpression: false },
+					{ expression: "room_id", isExpression: false },
+				],
+				isUnique: false,
+			},
+			session_summaries_entity_idx: {
+				name: "session_summaries_entity_idx",
+				columns: [{ expression: "entity_id", isExpression: false }],
+				isUnique: false,
+			},
+			session_summaries_start_time_idx: {
+				name: "session_summaries_start_time_idx",
+				columns: [{ expression: "start_time", isExpression: false }],
+				isUnique: false,
+			},
+		});
+	});
+
+	it("declares no additional constraints", () => {
+		expect(sessionSummaries.foreignKeys).toEqual({});
+		expect(sessionSummaries.compositePrimaryKeys).toEqual({});
+		expect(sessionSummaries.uniqueConstraints).toEqual({});
+		expect(sessionSummaries.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for the exported `sessionSummaries` schema
- assert the complete table, column, default, index-order, and empty-constraint contracts
- touch only the new test file; production behavior is unchanged

## Validation

- `bunx vitest run packages/core/src/features/advanced-memory/schemas/session-summaries.test.ts` — 1 file passed, 4 tests passed
- `bunx biome check --write packages/core/src/features/advanced-memory/schemas/session-summaries.test.ts` — checked 1 file, no fixes applied
- `cd packages/core && bunx tsc --noEmit` — exit 0; the new test file appears nowhere in output

Hosted CI does not run for fork pull requests; the commands above were run locally against the current `origin/develop` base.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f97bc411da37a8f66d23940ef5fdc04c450193b5 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
