### PR TITLE
test(core): cover long-term-memory

### DIFF
--- a/packages/core/src/features/advanced-memory/providers/long-term-memory.test.ts
+++ b/packages/core/src/features/advanced-memory/providers/long-term-memory.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Deterministic unit coverage for the long-term-memory provider's service
+ * gates, category rendering, result metadata, and explicit unavailable state.
+ * Uses the real provider and formatter with an in-memory service boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime.ts";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.ts";
+import type { MemoryService } from "../services/memory-service.ts";
+import { type LongTermMemory, LongTermMemoryCategory } from "../types.ts";
+import { longTermMemoryProvider } from "./long-term-memory.ts";
+
+const agentId = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const entityId = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const roomId = "00000000-0000-0000-0000-0000000000cc" as UUID;
+
+function message(senderId: UUID = entityId): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000dd" as UUID,
+		agentId,
+		entityId: senderId,
+		roomId,
+		content: { text: "What do you remember?" },
+		createdAt: 1,
+	};
+}
+
+function longTermMemory(
+	id: string,
+	category: LongTermMemoryCategory,
+	content: string,
+): LongTermMemory {
+	return {
+		id: id as UUID,
+		agentId,
+		entityId,
+		category,
+		content,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+	};
+}
+
+function runtimeWithService(
+	getLongTermMemories: MemoryService["getLongTermMemories"],
+	reportError: IAgentRuntime["reportError"] = vi.fn(),
+): IAgentRuntime {
+	const memoryService = { getLongTermMemories } as MemoryService;
+	return createMockRuntime({
+		agentId,
+		getService: (name) => (name === "memory" ? memoryService : null),
+		reportError,
+	});
+}
+
+async function get(runtime: IAgentRuntime, input = message()) {
+	return longTermMemoryProvider.get(runtime, input, {} as State);
+}
+
+describe("longTermMemoryProvider", () => {
+	it("declares the turn-scoped general-user provider contract", () => {
+		expect(longTermMemoryProvider).toMatchObject({
+			name: "LONG_TERM_MEMORY",
+			description: "Persistent facts and preferences about the user",
+			position: 50,
+			contexts: ["general"],
+			contextGate: { anyOf: ["general"] },
+			cacheStable: false,
+			cacheScope: "turn",
+			roleGate: { minRole: "USER" },
+		});
+	});
+
+	it("returns an empty contribution when the memory service is unavailable", async () => {
+		const runtime = createMockRuntime({
+			agentId,
+			getService: () => null,
+		});
+
+		await expect(get(runtime)).resolves.toEqual({
+			data: { memoryCount: 0 },
+			values: { longTermMemories: "" },
+			text: "",
+		});
+	});
+
+	it("does not query memories for a message authored by the agent", async () => {
+		const getLongTermMemories = vi.fn(async () => []);
+		const runtime = runtimeWithService(getLongTermMemories);
+
+		await expect(get(runtime, message(agentId))).resolves.toEqual({
+			data: { memoryCount: 0 },
+			values: { longTermMemories: "" },
+			text: "",
+		});
+		expect(getLongTermMemories).not.toHaveBeenCalled();
+	});
+
+	it("returns an empty contribution when the user has no stored memories", async () => {
+		const getLongTermMemories = vi.fn(async () => []);
+		const runtime = runtimeWithService(getLongTermMemories);
+
+		await expect(get(runtime)).resolves.toEqual({
+			data: { memoryCount: 0 },
+			values: { longTermMemories: "" },
+			text: "",
+		});
+		expect(getLongTermMemories).toHaveBeenCalledOnce();
+		expect(getLongTermMemories).toHaveBeenCalledWith(entityId);
+	});
+
+	it("renders every memory and counts repeated categories in first-seen order", async () => {
+		const memories = [
+			longTermMemory(
+				"00000000-0000-0000-0000-000000000001",
+				LongTermMemoryCategory.SEMANTIC,
+				"Prefers concise answers",
+			),
+			longTermMemory(
+				"00000000-0000-0000-0000-000000000002",
+				LongTermMemoryCategory.EPISODIC,
+				"Visited Kyoto in spring",
+			),
+			longTermMemory(
+				"00000000-0000-0000-0000-000000000003",
+				LongTermMemoryCategory.SEMANTIC,
+				"Works in software",
+			),
+		];
+		const runtime = runtimeWithService(vi.fn(async () => memories));
+
+		const result = await get(runtime);
+		const expectedText = [
+			"# What I Know About You",
+			"**Semantic**:",
+			"- Prefers concise answers",
+			"- Works in software",
+			"",
+			"**Episodic**:",
+			"- Visited Kyoto in spring",
+			"",
+		].join("\n");
+
+		expect(result).toEqual({
+			data: {
+				memoryCount: 3,
+				categories: "semantic: 2, episodic: 1",
+				truncated: false,
+			},
+			values: {
+				longTermMemories: expectedText,
+				memoryCategories: "semantic: 2, episodic: 1",
+			},
+			text: expectedText,
+		});
+	});
+
+	it.each([
+		{ failure: new Error("storage offline"), expectedError: "storage offline" },
+		{ failure: "storage offline", expectedError: "storage offline" },
+	])(
+		"reports $failure and returns an explicit unavailable state",
+		async ({ failure, expectedError }) => {
+			const reportError = vi.fn<IAgentRuntime["reportError"]>();
+			const runtime = runtimeWithService(async () => {
+				throw failure;
+			}, reportError);
+
+			await expect(get(runtime)).resolves.toEqual({
+				data: { available: false, error: expectedError },
+				values: { longTermMemoryAvailable: false },
+				text: "Long-term memory is unavailable.",
+			});
+			expect(reportError).toHaveBeenCalledWith(
+				"LongTermMemoryProvider.get",
+				failure,
+				{ roomId },
+			);
+		},
+	);
+});


### PR DESCRIPTION

## Summary

- Add colocated unit coverage for the `LONG_TERM_MEMORY` provider metadata and service gates.
- Exercise real category grouping, repeated-category counts, first-seen ordering, prompt text, and explicit failure degradation.
- Keep the change behavior-preserving: the diff contains only the new test file.

## Validation

- `bunx vitest run packages/core/src/features/advanced-memory/providers/long-term-memory.test.ts` — 1 file passed, 7 tests passed.
- `bunx biome check --write packages/core/src/features/advanced-memory/providers/long-term-memory.test.ts` — checked 1 file successfully after formatting.
- `cd packages/core && bunx tsc --noEmit` — exit 0, zero diagnostics; `long-term-memory.test.ts` appears nowhere in output.
- Diff scope: 1 new test file, 186 insertions, 0 deletions; no production files changed.

Hosted CI does not run for fork-authored pull requests, so no hosted-check result is claimed here.

## Evidence

N/A — test-only coverage with no production behavior or rendered artifact change. The focused local checks above are the complete applicable evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0c314ea961255eb77ae092b585a8e7102918c971 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
