### PR TITLE
test(core): cover chat pre-handler registry

### DIFF
--- a/packages/core/src/runtime/chat-pre-handler-registry.test.ts
+++ b/packages/core/src/runtime/chat-pre-handler-registry.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for ChatPreHandlerRegistry: priority ordering, pass-through and
+ * abort propagation.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+	ChatPreHandler,
+	ChatPreHandlerContext,
+} from "../types/chat-pre-handler.ts";
+import { ChatPreHandlerRegistry } from "./chat-pre-handler-registry.ts";
+
+const ctx = {
+	runtime: {},
+	message: {},
+	appendText: () => {},
+	replaceText: () => {},
+} as unknown as ChatPreHandlerContext;
+
+function handler(
+	id: string,
+	priority: number | undefined,
+	responseText: string | null,
+): ChatPreHandler {
+	return {
+		id,
+		priority,
+		async tryHandle() {
+			return responseText === null ? null : { responseText };
+		},
+	};
+}
+
+describe("ChatPreHandlerRegistry", () => {
+	it("starts empty", () => {
+		const registry = new ChatPreHandlerRegistry();
+		expect(registry.size).toBe(0);
+		expect(registry.list()).toEqual([]);
+	});
+
+	it("registers a single handler and drains it", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.register(handler("a", 0, "resolved"));
+		expect(registry.size).toBe(1);
+		await expect(registry.drain(ctx)).resolves.toEqual({
+			responseText: "resolved",
+		});
+	});
+
+	it("registerMany registers all handlers", () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.registerMany([
+			handler("a", 0, null),
+			handler("b", 1, null),
+			handler("c", undefined, null),
+		]);
+		expect(registry.size).toBe(3);
+	});
+
+	it("re-registering the same id replaces the handler", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.register(handler("a", 0, "first"));
+		registry.register(handler("a", 0, "second"));
+		expect(registry.size).toBe(1);
+		await expect(registry.drain(ctx)).resolves.toEqual({
+			responseText: "second",
+		});
+	});
+
+	it("lists handlers in descending priority order", () => {
+		const registry = new ChatPreHandlerRegistry();
+		const low = handler("low", 1, null);
+		const high = handler("high", 10, null);
+		const none = handler("none", undefined, null);
+		registry.register(low);
+		registry.register(high);
+		registry.register(none);
+		expect(registry.list().map((h) => h.id)).toEqual(["high", "low", "none"]);
+	});
+
+	it("keeps insertion order for equal priorities", () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.register(handler("first", 5, null));
+		registry.register(handler("second", 5, null));
+		expect(registry.list().map((h) => h.id)).toEqual(["first", "second"]);
+	});
+
+	it("returns the first non-null result, skipping null handlers", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		const calls: string[] = [];
+		registry.register({
+			id: "miss",
+			priority: 10,
+			async tryHandle() {
+				calls.push("miss");
+				return null;
+			},
+		});
+		registry.register({
+			id: "hit",
+			priority: 5,
+			async tryHandle() {
+				calls.push("hit");
+				return { responseText: "win" };
+			},
+		});
+		await expect(registry.drain(ctx)).resolves.toEqual({
+			responseText: "win",
+		});
+		expect(calls).toEqual(["miss", "hit"]);
+	});
+
+	it("stops draining after the first non-null result", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		const calls: string[] = [];
+		registry.register({
+			id: "hit",
+			priority: 10,
+			async tryHandle() {
+				calls.push("hit");
+				return { responseText: "win" };
+			},
+		});
+		registry.register({
+			id: "later",
+			priority: 1,
+			async tryHandle() {
+				calls.push("later");
+				return { responseText: "never" };
+			},
+		});
+		await expect(registry.drain(ctx)).resolves.toEqual({
+			responseText: "win",
+		});
+		expect(calls).toEqual(["hit"]);
+	});
+
+	it("returns null when every handler passes through", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.register(handler("a", 0, null));
+		registry.register(handler("b", 0, null));
+		await expect(registry.drain(ctx)).resolves.toBeNull();
+	});
+
+	it("returns null when the registry is empty", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		await expect(registry.drain(ctx)).resolves.toBeNull();
+	});
+
+	it("unregisters by id", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.register(handler("a", 0, "resolved"));
+		registry.unregister("a");
+		expect(registry.size).toBe(0);
+		await expect(registry.drain(ctx)).resolves.toBeNull();
+	});
+
+	it("clears all handlers", () => {
+		const registry = new ChatPreHandlerRegistry();
+		registry.registerMany([handler("a", 0, null), handler("b", 0, null)]);
+		registry.clear();
+		expect(registry.size).toBe(0);
+	});
+
+	it("propagates an aborted signal before invoking a handler", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		const controller = new AbortController();
+		controller.abort();
+		const invoked = {
+			id: "a",
+			priority: 0,
+			async tryHandle() {
+				return { responseText: "should not run" };
+			},
+		};
+		registry.register(invoked);
+		await expect(
+			registry.drain({ ...ctx, abortSignal: controller.signal }),
+		).rejects.toThrow("This operation was aborted");
+	});
+
+	it("propagates an aborted signal between handlers", async () => {
+		const registry = new ChatPreHandlerRegistry();
+		const controller = new AbortController();
+		registry.register({
+			id: "first",
+			priority: 10,
+			async tryHandle() {
+				controller.abort();
+				return null;
+			},
+		});
+		registry.register(handler("second", 1, "never"));
+		await expect(
+			registry.drain({ ...ctx, abortSignal: controller.signal }),
+		).rejects.toThrow("This operation was aborted");
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Coverage: Exercises ChatPreHandlerRegistry: register/registerMany/unregister/clear/size, descending priority ordering with insertion-order ties, first-non-null drain semantics, pass-through to null, and abort-signal propagation before and between handlers.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file alongside the source module exercising
existing exported pure functions. No production code is modified, no runtime
behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: ``npx vitest run chat-pre-handler-registry.test.ts` in isolation: Test Files 1 passed (1), Tests 14 passed (14)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
