### PR TITLE
test(agent): cover music player status fallback

### DIFF
--- a/packages/agent/src/api/music-player-route-fallback.test.ts
+++ b/packages/agent/src/api/music-player-route-fallback.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the `/music-player/status` compatibility fallback used when
+ * plugin-music-player is not loaded.
+ */
+
+import type { ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { tryHandleMusicPlayerStatusFallback } from "./music-player-route-fallback.ts";
+
+function makeRes(): ServerResponse {
+  return {
+    statusCode: 0,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ServerResponse;
+}
+
+function bodyOf(res: ServerResponse): unknown {
+  const endMock = res.end as ReturnType<typeof vi.fn>;
+  const [payload] = endMock.mock.calls[0] as [string];
+  return JSON.parse(payload);
+}
+
+const emptyRuntime = (music?: unknown): unknown => ({
+  getService: vi.fn((name: string) => (name === "music" ? music : undefined)),
+});
+
+describe("tryHandleMusicPlayerStatusFallback", () => {
+  it("ignores non-matching paths and methods", () => {
+    const res = makeRes();
+    const runtime = emptyRuntime();
+    expect(
+      tryHandleMusicPlayerStatusFallback({
+        pathname: "/other",
+        method: "GET",
+        runtime: runtime as never,
+        res,
+      }),
+    ).toBe(false);
+    expect(
+      tryHandleMusicPlayerStatusFallback({
+        pathname: "/music-player/status",
+        method: "POST",
+        runtime: runtime as never,
+        res,
+      }),
+    ).toBe(false);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  it("reports unavailable when no music service is registered", () => {
+    const res = makeRes();
+    const handled = tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime() as never,
+      res,
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "application/json; charset=utf-8",
+    );
+    expect(bodyOf(res)).toEqual({
+      available: false,
+      error: "Music player plugin is not enabled",
+    });
+  });
+
+  it("reports available with no track when the service has no queues", () => {
+    const res = makeRes();
+    const music = { getQueues: vi.fn(() => undefined) };
+    const handled = tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    expect(handled).toBe(true);
+    expect(bodyOf(res)).toEqual({
+      available: true,
+      error: "No track is currently playing",
+    });
+  });
+
+  it("reports available with no track when queues are empty", () => {
+    const res = makeRes();
+    const music = { getQueues: vi.fn(() => new Map()) };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    expect(bodyOf(res)).toEqual({
+      available: true,
+      error: "No track is currently playing",
+    });
+  });
+
+  it("returns the active guild track with a stream url", () => {
+    const res = makeRes();
+    const track = {
+      id: "t1",
+      title: "Song",
+      url: "https://cdn/1.mp3",
+      duration: 120,
+      requestedBy: "user-1",
+      addedAt: 1234,
+    };
+    const music = {
+      getQueues: vi.fn(() => new Map([["guild-1", {}]])),
+      getCurrentTrack: vi.fn(() => track),
+      getIsPaused: vi.fn(() => true),
+    };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    expect(bodyOf(res)).toEqual({
+      available: true,
+      guildId: "guild-1",
+      track,
+      isPaused: true,
+      streamUrl: "/music-player/stream?guildId=guild-1",
+    });
+  });
+
+  it("defaults isPaused to false when the service omits it", () => {
+    const res = makeRes();
+    const music = {
+      getQueues: vi.fn(() => new Map([["guild-1", {}]])),
+      getCurrentTrack: vi.fn(() => ({ title: "Song" })),
+    };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    const body = bodyOf(res) as { isPaused: boolean };
+    expect(body.isPaused).toBe(false);
+  });
+
+  it("skips entries whose guild id is missing or empty", () => {
+    const res = makeRes();
+    const music = {
+      getQueues: vi.fn(
+        () =>
+          new Map([
+            ["", {}],
+            ["guild-2", {}],
+          ]),
+      ),
+      getCurrentTrack: vi.fn(() => ({ title: "Song" })),
+    };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    expect(music.getCurrentTrack).toHaveBeenCalledWith("guild-2");
+    const body = bodyOf(res) as { guildId: string };
+    expect(body.guildId).toBe("guild-2");
+  });
+
+  it("handles iterable queue entries instead of maps", () => {
+    const res = makeRes();
+    const music = {
+      getQueues: vi.fn(() => [["guild-3", {}]]),
+      getCurrentTrack: vi.fn(() => ({ title: "Song" })),
+    };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    const body = bodyOf(res) as { guildId: string };
+    expect(body.guildId).toBe("guild-3");
+  });
+
+  it("encodes the guild id into the stream url", () => {
+    const res = makeRes();
+    const music = {
+      getQueues: vi.fn(() => new Map([["a b&c", {}]])),
+      getCurrentTrack: vi.fn(() => ({ title: "Song" })),
+    };
+    tryHandleMusicPlayerStatusFallback({
+      pathname: "/music-player/status",
+      method: "GET",
+      runtime: emptyRuntime(music) as never,
+      res,
+    });
+    const body = bodyOf(res) as { streamUrl: string };
+    expect(body.streamUrl).toBe("/music-player/stream?guildId=a%20b%26c");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Coverage: Exercises the /music-player/status compatibility fallback: non-matching path/method pass-through, unavailable payload without a music service, available-without-track payloads, active-guild track resolution (Map and iterable queues), skipped invalid guild ids, isPaused default, and stream-url encoding.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file alongside the source module exercising
existing exported pure functions. No production code is modified, no runtime
behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: ``npx vitest run music-player-route-fallback.test.ts` in isolation: Test Files 1 passed (1), Tests 9 passed (9)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
