### PR TITLE
test(cloud): cover referral-invite-url

### DIFF
--- a/packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts
+++ b/packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Coverage for referral-invite-url.
+ */
+import { describe, expect, it } from "vitest";
+import { buildReferralInviteLoginUrl } from "./referral-invite-url.js";
+
+describe("referral-invite-url", () => {
+  it("builds url", () => {
+    expect(buildReferralInviteLoginUrl("https://eliza.app", "abc123")).toBe(
+      "https://eliza.app/login?ref=abc123",
+    );
+  });
+  it("trims trailing slash", () => {
+    expect(buildReferralInviteLoginUrl("https://eliza.app/", "code")).toBe(
+      "https://eliza.app/login?ref=code",
+    );
+  });
+  it("encodes", () => {
+    expect(buildReferralInviteLoginUrl("https://eliza.app", "a b")).toContain("a%20b");
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:1a9ccc4009c4387b691a1e6bf00674e2e2df93c9 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/utils/referral-invite-url.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop (e.g. `registry-host`); verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) → Green (restored)

**Red — proves non-vacuous (imports real export):**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop

 ❯ packages/cloud/shared/src/lib/utils/referral-invite-url.test.ts (3 tests | 3 failed) 4ms
     × builds url 3ms
     × trims trailing slash 0ms
     × encodes 0ms

 Test Files  1 failed (1)
      Tests  3 failed (3)
   Start at  23:16:44
   Duration  91ms (transform 16ms, setup 0ms, import 21ms, tests 4ms, environment 0ms)


```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  23:16:43
   Duration  86ms (transform 17ms, setup 0ms, import 22ms, tests 1ms, environment 0ms)


```

**Biome clean:** `biome check --write` passed.
