### PR TITLE
test(core): cover memory-access-logs

### DIFF
--- a/packages/core/src/features/advanced-memory/schemas/memory-access-logs.test.ts
+++ b/packages/core/src/features/advanced-memory/schemas/memory-access-logs.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Verifies the backend-agnostic memory-access log schema exposes the complete
+ * column, timestamp-default, index, and constraint contract expected by
+ * database adapters.
+ */
+
+import { describe, expect, it } from "vitest";
+import { memoryAccessLogs } from "./memory-access-logs";
+
+describe("memoryAccessLogs", () => {
+	it("identifies the public memory_access_logs table", () => {
+		expect(memoryAccessLogs.name).toBe("memory_access_logs");
+		expect(memoryAccessLogs.schema).toBe("public");
+	});
+
+	it("defines every access-log column with its storage contract", () => {
+		expect(memoryAccessLogs.columns).toEqual({
+			id: {
+				name: "id",
+				type: "varchar(36)",
+				primaryKey: true,
+				notNull: true,
+			},
+			memory_id: {
+				name: "memory_id",
+				type: "varchar(36)",
+				notNull: true,
+			},
+			memory_type: { name: "memory_type", type: "text", notNull: true },
+			agent_id: {
+				name: "agent_id",
+				type: "varchar(36)",
+				notNull: true,
+			},
+			access_type: { name: "access_type", type: "text", notNull: true },
+			accessed_at: {
+				name: "accessed_at",
+				type: "timestamp",
+				notNull: true,
+				default: "now()",
+			},
+		});
+	});
+
+	it("indexes memory, agent, and access time without imposing uniqueness", () => {
+		expect(memoryAccessLogs.indexes).toEqual({
+			memory_access_logs_memory_id_idx: {
+				name: "memory_access_logs_memory_id_idx",
+				columns: [{ expression: "memory_id", isExpression: false }],
+				isUnique: false,
+			},
+			memory_access_logs_agent_id_idx: {
+				name: "memory_access_logs_agent_id_idx",
+				columns: [{ expression: "agent_id", isExpression: false }],
+				isUnique: false,
+			},
+			memory_access_logs_accessed_at_idx: {
+				name: "memory_access_logs_accessed_at_idx",
+				columns: [{ expression: "accessed_at", isExpression: false }],
+				isUnique: false,
+			},
+		});
+	});
+
+	it("declares no additional relational or value constraints", () => {
+		expect(memoryAccessLogs.foreignKeys).toEqual({});
+		expect(memoryAccessLogs.compositePrimaryKeys).toEqual({});
+		expect(memoryAccessLogs.uniqueConstraints).toEqual({});
+		expect(memoryAccessLogs.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for the backend-agnostic `memoryAccessLogs` schema
- verify the complete table and column contract, including the primary key and `accessed_at` default
- verify all memory, agent, and timestamp indexes plus the empty constraint maps

This is a test-only change and does not alter production behavior.

## Validation

- `bunx vitest run packages/core/src/features/advanced-memory/schemas/memory-access-logs.test.ts` — 1 test file passed; 4 tests passed
- `bunx biome check --write packages/core/src/features/advanced-memory/schemas/memory-access-logs.test.ts` — checked 1 file; no fixes applied
- `cd packages/core && bunx tsc --noEmit 2>&1 | grep 'memory-access-logs.test.ts' ; echo "EXIT:$?"` — no diagnostics referenced the new test file (`EXIT:1` from `grep`), so the suite adds zero TypeScript errors
- diff scope — one new test file, 71 insertions, 0 deletions

Hosted CI does not run on fork-contributor pull requests, so no hosted-CI result is claimed here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8212c3a454f4a9c8609f804d784d2f68522bc9b8 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
