### PR TITLE
test(cloud): cover request-timeout

### DIFF
--- a/packages/cloud/shared/src/lib/utils/request-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/utils/request-timeout.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Coverage for request-timeout.
+ */
+import { describe, expect, it } from "vitest";
+import { getRouteTimeoutMs } from "./request-timeout.js";
+
+describe("request-timeout", () => {
+  it("calculates timeout", () => {
+    expect(getRouteTimeoutMs(30)).toBe(20000);
+  });
+  it("respects min", () => {
+    expect(getRouteTimeoutMs(1)).toBe(1000);
+  });
+  it("custom buffer", () => {
+    expect(getRouteTimeoutMs(10, 5000)).toBe(5000);
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:32e6dcc5dfbe47a06cb75d30f95f33df89aadc8a -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/utils/request-timeout.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/utils/request-timeout.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/utils/request-timeout.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/utils/request-timeout.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop (e.g. `registry-host`); verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) → Green (restored)

**Red — proves non-vacuous (imports real export):**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop

 ❯ packages/cloud/shared/src/lib/utils/request-timeout.test.ts (3 tests | 3 failed) 4ms
     × calculates timeout 3ms
     × respects min 0ms
     × custom buffer 0ms

 Test Files  1 failed (1)
      Tests  3 failed (3)
   Start at  23:17:37
   Duration  88ms (transform 16ms, setup 0ms, import 21ms, tests 4ms, environment 0ms)


```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  23:17:36
   Duration  85ms (transform 17ms, setup 0ms, import 22ms, tests 1ms, environment 0ms)


```

**Biome clean:** `biome check --write` passed.
