### PR TITLE
test(core): cover ignore

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/ignore.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/ignore.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Deterministic unit tests for the IGNORE action's routing validation and
+ * response-delivery behavior. The real action runs without a model or database;
+ * only the transport callback is observed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "../../../types/index.ts";
+import { ignoreAction } from "./ignore.ts";
+
+const runtime = {} as IAgentRuntime;
+
+function createMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001",
+		agentId: "00000000-0000-0000-0000-000000000002",
+		entityId: "00000000-0000-0000-0000-000000000003",
+		roomId: "00000000-0000-0000-0000-000000000004",
+		content: { text: "goodbye" },
+	} as Memory;
+}
+
+describe("IGNORE action", () => {
+	it("exposes the canonical action metadata", () => {
+		expect(ignoreAction).toMatchObject({
+			name: "IGNORE",
+			contexts: ["general"],
+			roleGate: { minRole: "USER" },
+			parameters: [],
+		});
+		expect(ignoreAction.similes).toEqual([
+			"STOP_TALKING",
+			"STOP_CHATTING",
+			"STOP_CONVERSATION",
+		]);
+	});
+
+	it("rejects validation when the turn has no routing context", async () => {
+		await expect(
+			ignoreAction.validate?.(runtime, createMessage()),
+		).resolves.toBe(false);
+	});
+
+	it("accepts validation when an explicit turn context activates general routing", async () => {
+		const state = {
+			values: {
+				__contextRouting: { primaryContext: "calendar" },
+			},
+		} as unknown as State;
+
+		await expect(
+			ignoreAction.validate?.(runtime, createMessage(), state),
+		).resolves.toBe(true);
+	});
+
+	it("delivers the first pre-composed response content", async () => {
+		const callback: HandlerCallback = vi.fn(async () => []);
+		const firstContent = { text: "", actions: ["IGNORE"], source: "discord" };
+
+		const result = await ignoreAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			undefined,
+			callback,
+			[
+				{ content: firstContent } as Memory,
+				{ content: { text: "later response" } } as Memory,
+			],
+		);
+
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith(firstContent);
+		expect(result).toEqual({
+			text: "",
+			values: { success: true, ignored: true },
+			data: { actionName: "IGNORE" },
+			success: true,
+		});
+	});
+
+	it.each([
+		["no response queue", undefined],
+		["an empty response queue", []],
+		[
+			"content only after the first response",
+			[{} as Memory, { content: { text: "later response" } } as Memory],
+		],
+	])("does not call back for %s", async (_label, responses) => {
+		const callback: HandlerCallback = vi.fn(async () => []);
+
+		const result = await ignoreAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			undefined,
+			callback,
+			responses,
+		);
+
+		expect(callback).not.toHaveBeenCalled();
+		expect(result?.values).toEqual({ success: true, ignored: true });
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for the real `ignoreAction`
- cover canonical action metadata and routing validation with and without an active turn context
- cover first-response callback delivery plus absent, empty, and later-only response queues

## Validation

- `bunx vitest run packages/core/src/features/basic-capabilities/actions/ignore.test.ts` — 1 test file passed; 7 tests passed
- `bunx biome check --write packages/core/src/features/basic-capabilities/actions/ignore.test.ts` — checked 1 file; no fixes applied
- `(cd packages/core && bunx tsc --noEmit)` — exited 0; `grep 'ignore.test.ts'` produced no output (exit 1)
- diff scope — one new test file only, 108 insertions and 0 deletions; no production behavior changed

## Evidence

- Test-only change; live-model, UI, media, and production behavior evidence are not applicable.
- Hosted CI does not run for this fork-contributor pull request; the local focused checks above are the available validation.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2c03e39d9a7a545eb374f3fc264ccf50666af9f7 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
