### PR TITLE
test(core): cover index.edge

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.edge.test.ts
+++ b/packages/core/src/features/basic-capabilities/index.edge.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Deterministic unit coverage for the Workerd basic-capabilities composition.
+ * The suite exercises the real exported registries and every configuration
+ * branch without booting a runtime or replacing collaborators with mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { EvaluatorService } from "../../services/evaluator.ts";
+import { ignoreAction } from "./actions/ignore.ts";
+import { noneAction } from "./actions/none.ts";
+import { replyAction } from "./actions/reply.ts";
+import { resolveCapabilityConfig as resolveCapabilityConfigDirect } from "./config.ts";
+import {
+	basicActions,
+	basicCapabilities,
+	basicEvaluators,
+	basicProviders,
+	basicServices,
+	type CapabilityConfig,
+	type CapabilitySettingFlags,
+	createBasicCapabilitiesPlugin,
+	default as defaultBasicCapabilities,
+	type ExplicitCapabilityOptions,
+	resolveCapabilityConfig,
+} from "./index.edge.ts";
+import { actionStateProvider } from "./providers/actionState.ts";
+import { actionsProvider } from "./providers/actions.ts";
+import { characterProvider } from "./providers/character.ts";
+import { currentTimeProvider } from "./providers/currentTime.ts";
+import {
+	platformChatContextProvider,
+	platformUserContextProvider,
+} from "./providers/platformContext.ts";
+import { providersProvider } from "./providers/providers.ts";
+import { recentMessagesProvider } from "./providers/recentMessages.ts";
+import { replyContextProvider } from "./providers/replyContext.ts";
+import { runtimeModelContextProvider } from "./providers/runtimeModelContext.ts";
+
+const unsupportedFlags = [
+	"enableExtended",
+	"advancedCapabilities",
+	"enableAutonomy",
+	"enableTrust",
+	"enableSecretsManager",
+	"enablePluginManager",
+] as const satisfies ReadonlyArray<keyof CapabilityConfig>;
+
+describe("Workerd basic-capabilities exports", () => {
+	it("exports the providers in their registration order", () => {
+		expect(basicProviders).toEqual([
+			actionsProvider,
+			actionStateProvider,
+			characterProvider,
+			currentTimeProvider,
+			platformChatContextProvider,
+			platformUserContextProvider,
+			providersProvider,
+			recentMessagesProvider,
+			replyContextProvider,
+			runtimeModelContextProvider,
+		]);
+	});
+
+	it("exports canonically documented actions in registration order", () => {
+		expect(basicActions.map((action) => action.name)).toEqual([
+			replyAction.name,
+			ignoreAction.name,
+			noneAction.name,
+		]);
+		for (const action of basicActions) {
+			expect(action.descriptionCompressed).toEqual(expect.any(String));
+		}
+	});
+
+	it("exports the empty evaluator registry and evaluator service", () => {
+		expect(basicEvaluators).toEqual([]);
+		expect(basicServices).toEqual([EvaluatorService]);
+	});
+
+	it("assembles the named and default capability objects from the registries", () => {
+		expect(basicCapabilities).toEqual({
+			providers: basicProviders,
+			actions: basicActions,
+			evaluators: basicEvaluators,
+			services: basicServices,
+		});
+		expect(defaultBasicCapabilities).toBe(basicCapabilities);
+	});
+
+	it("re-exports the shared configuration types and resolver", () => {
+		const options: ExplicitCapabilityOptions = { disableBasic: true };
+		const settings: CapabilitySettingFlags = {
+			DISABLE_BASIC_CAPABILITIES: false,
+		};
+		const config: CapabilityConfig = resolveCapabilityConfig(options, settings);
+
+		expect(resolveCapabilityConfig).toBe(resolveCapabilityConfigDirect);
+		expect(config.disableBasic).toBe(true);
+	});
+});
+
+describe("createBasicCapabilitiesPlugin", () => {
+	it("returns the complete Workerd composition by default", () => {
+		expect(createBasicCapabilitiesPlugin()).toEqual({
+			name: "basic-capabilities",
+			description: "Workerd conversational core actions and context providers.",
+			actions: basicActions,
+			providers: basicProviders,
+			evaluators: basicEvaluators,
+			services: basicServices,
+		});
+	});
+
+	it("removes only the character provider while preserving provider order", () => {
+		const plugin = createBasicCapabilitiesPlugin({
+			skipCharacterProvider: true,
+		});
+
+		expect(plugin.providers).toEqual(
+			basicProviders.filter((provider) => provider !== characterProvider),
+		);
+		expect(basicProviders).toContain(characterProvider);
+		expect(plugin.actions).toBe(basicActions);
+	});
+
+	it("removes actions and providers when basic capabilities are disabled", () => {
+		const plugin = createBasicCapabilitiesPlugin({
+			disableBasic: true,
+			skipCharacterProvider: true,
+		});
+
+		expect(plugin.actions).toEqual([]);
+		expect(plugin.providers).toEqual([]);
+		expect(plugin.evaluators).toBe(basicEvaluators);
+		expect(plugin.services).toBe(basicServices);
+	});
+
+	it.each(unsupportedFlags)("rejects the unsupported %s flag", (flag) => {
+		expect(() => createBasicCapabilitiesPlugin({ [flag]: true })).toThrow(
+			`Workerd runtime does not support core capability flags: ${flag}`,
+		);
+	});
+
+	it("reports multiple unsupported flags in canonical order", () => {
+		expect(() =>
+			createBasicCapabilitiesPlugin({
+				enablePluginManager: true,
+				enableExtended: true,
+				enableTrust: true,
+			}),
+		).toThrow(
+			"Workerd runtime does not support core capability flags: enableExtended, enableTrust, enablePluginManager",
+		);
+	});
+
+	it("accepts explicitly false unsupported flags", () => {
+		expect(
+			createBasicCapabilitiesPlugin({
+				enableExtended: false,
+				advancedCapabilities: false,
+				enableAutonomy: false,
+				enableTrust: false,
+				enableSecretsManager: false,
+				enablePluginManager: false,
+			}),
+		).toEqual(createBasicCapabilitiesPlugin());
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for the Workerd `index.edge.ts` basic-capabilities entry point
- verify exported provider/action ordering, evaluator/service registries, named/default composition, and configuration re-exports
- exercise default, character-provider filtering, basic-disablement, every unsupported flag, multi-flag error ordering, and explicitly false flags through the real module

## Validation

- `bunx vitest run packages/core/src/features/basic-capabilities/index.edge.test.ts` — 1 file passed, 16 tests passed
- `bunx biome check --write packages/core/src/features/basic-capabilities/index.edge.test.ts` — exit 0; checked and formatted 1 file
- `cd packages/core && bunx tsc --noEmit` — exit 0, 0 diagnostics; `index.edge.test.ts` appeared nowhere in output
- refreshed `origin/develop` immediately before the final Vitest run; branch base was `0242ceed35256bc247ed944932f3ccd49a4a3803`

## Scope

- Diff touches only `packages/core/src/features/basic-capabilities/index.edge.test.ts` (`+168/-0`).
- Test-only change; no production behavior changes.
- Hosted CI does not run for fork-contributor pull requests and is not claimed here.
- Interactive identity evidence is unavailable in this unattended session; the focused test, formatting, typecheck, and exact diff are the applicable evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7f97dd2486d2740e3c49ced24356d0cbe636933d -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
