### PR TITLE
test(core): cover none

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/none.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/none.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Deterministic unit tests for the NONE action's routing validation and no-op
+ * result. The real action runs without model, database, or transport mocks.
+ */
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../../../types/index.ts";
+import { noneAction } from "./none.ts";
+
+const runtime = {} as IAgentRuntime;
+
+function createMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001",
+		agentId: "00000000-0000-0000-0000-000000000002",
+		entityId: "00000000-0000-0000-0000-000000000003",
+		roomId: "00000000-0000-0000-0000-000000000004",
+		content: { text: "continue" },
+	} as Memory;
+}
+
+describe("NONE action", () => {
+	it("exposes the canonical action metadata", () => {
+		expect(noneAction).toMatchObject({
+			name: "NONE",
+			contexts: ["general"],
+			roleGate: { minRole: "USER" },
+			parameters: [],
+		});
+		expect(noneAction.description).toBeTruthy();
+		expect(noneAction.examples).toBeInstanceOf(Array);
+	});
+
+	it("rejects validation when the turn has no routing context", async () => {
+		await expect(noneAction.validate?.(runtime, createMessage())).resolves.toBe(
+			false,
+		);
+	});
+
+	it("accepts validation when an explicit turn context activates general routing", async () => {
+		const state = {
+			values: {
+				__contextRouting: { primaryContext: "general" },
+			},
+		} as unknown as State;
+
+		await expect(
+			noneAction.validate?.(runtime, createMessage(), state),
+		).resolves.toBe(true);
+	});
+
+	it("returns the successful no-op result without side effects", async () => {
+		const result = await noneAction.handler?.(runtime, createMessage());
+
+		expect(result).toEqual({
+			text: "",
+			values: {
+				success: true,
+				actionType: "NONE",
+			},
+			data: {
+				actionName: "NONE",
+				description: "Response without additional action",
+			},
+			success: true,
+		});
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for the real `NONE` basic-capabilities action
- verify canonical metadata, routing validation without and with explicit context, and the exact successful no-op result
- change only `packages/core/src/features/basic-capabilities/actions/none.test.ts` (67 additions, 0 deletions)

## Verification

- `bunx vitest run packages/core/src/features/basic-capabilities/actions/none.test.ts` — 1 test file passed, 4 tests passed
- `bunx biome check --write packages/core/src/features/basic-capabilities/actions/none.test.ts` — checked and formatted 1 file
- `cd packages/core && bunx tsc --noEmit` — exit 0, 0 TypeScript errors, 0 diagnostics mentioning `none.test.ts`

This is a fork contribution, so hosted CI does not run on this pull request.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f1a48f62388093735e14ef92b2275bdaf1b581cc -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
