### PR TITLE
test(core): cover preference-extractor-schema

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for preference extractor schemas and tolerant output parser.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	PreferenceOpSchema,
+	PreferenceTraitEnum,
+	parsePreferenceOutputTolerant,
+} from "./preferenceExtractor.schema.js";
+
+describe("preferenceExtractor.schema", () => {
+	it("validates PreferenceTraitEnum values", () => {
+		expect(PreferenceTraitEnum.safeParse("verbosity").success).toBe(true);
+		expect(PreferenceTraitEnum.safeParse("tone").success).toBe(true);
+		expect(PreferenceTraitEnum.safeParse("formality").success).toBe(true);
+		expect(PreferenceTraitEnum.safeParse("reply_gate").success).toBe(false);
+	});
+
+	it("validates PreferenceOpSchema discriminated union members", () => {
+		const setTraitOp = {
+			op: "set_trait",
+			trait: "verbosity",
+			value: "terse",
+			confidence: 0.9,
+		};
+		expect(PreferenceOpSchema.safeParse(setTraitOp).success).toBe(true);
+
+		const directiveOp = {
+			op: "add_directive",
+			text: "Always provide TypeScript code snippets",
+			confidence: 0.85,
+		};
+		expect(PreferenceOpSchema.safeParse(directiveOp).success).toBe(true);
+
+		const factOp = {
+			op: "add_preference_fact",
+			claim: "User loves dark mode",
+			keywords: ["dark", "mode"],
+			confidence: 0.95,
+		};
+		expect(PreferenceOpSchema.safeParse(factOp).success).toBe(true);
+
+		const retractOp = {
+			op: "retract_trait",
+			trait: "tone",
+			reason: "User requested neutral tone",
+		};
+		expect(PreferenceOpSchema.safeParse(retractOp).success).toBe(true);
+	});
+
+	it("parses extractor output tolerantly dropping invalid operations while preserving valid ones", () => {
+		const mixedPayload = {
+			ops: [
+				{
+					op: "set_trait",
+					trait: "verbosity",
+					value: "terse",
+					confidence: 0.9,
+				},
+				{
+					op: "set_trait",
+					trait: "verbosity",
+					value: "invalid_verbosity_value_xyz", // dropped: not in VERBOSITY_VALUES
+					confidence: 0.9,
+				},
+				{
+					op: "add_directive",
+					text: "Prefer functional programming",
+					confidence: 0.8,
+				},
+				{
+					op: "unknown_operation_xyz",
+				},
+			],
+		};
+
+		const result = parsePreferenceOutputTolerant(mixedPayload);
+		expect(result).not.toBeNull();
+		expect(result?.ops).toHaveLength(2);
+		expect(result?.ops[0].op).toBe("set_trait");
+		expect(result?.ops[1].op).toBe("add_directive");
+
+		// Invalid non-envelope returns null
+		expect(parsePreferenceOutputTolerant(null)).toBeNull();
+		expect(parsePreferenceOutputTolerant({ not_ops: [] })).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `PreferenceTraitEnum` validation and exclusion of unsupported traits.
- `PreferenceOpSchema` discriminated union parsing for `set_trait`, `add_directive`, `add_preference_fact`, and `retract_trait`.
- `parsePreferenceOutputTolerant` tolerant parsing, dropping malformed or non-canonical trait values while retaining valid turn operations.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`0c673e635a`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts:1-88`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:0c673e635ad4a82263d25fe5512fd491869d9475 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested