### PR TITLE
test(core): cover fact-extractor-schema

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for fact extractor Zod schemas and tolerant output parsing.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	CurrentCategoryEnum,
+	DurableCategoryEnum,
+	OpSchema,
+	parseExtractorOutputTolerant,
+	VerificationStatusEnum,
+} from "./factExtractor.schema.js";
+
+describe("factExtractor.schema", () => {
+	it("validates categories and verification statuses", () => {
+		expect(DurableCategoryEnum.safeParse("identity").success).toBe(true);
+		expect(DurableCategoryEnum.safeParse("preference").success).toBe(true);
+		expect(DurableCategoryEnum.safeParse("invalid_category").success).toBe(
+			false,
+		);
+
+		expect(CurrentCategoryEnum.safeParse("feeling").success).toBe(true);
+		expect(CurrentCategoryEnum.safeParse("working_on").success).toBe(true);
+
+		expect(VerificationStatusEnum.safeParse("self_reported").success).toBe(
+			true,
+		);
+		expect(VerificationStatusEnum.safeParse("confirmed").success).toBe(true);
+	});
+
+	it("validates all OpSchema variants", () => {
+		const addDurable = {
+			op: "add_durable",
+			claim: "Lives in San Francisco",
+			category: "identity",
+			keywords: ["san francisco", "home"],
+		};
+		expect(OpSchema.safeParse(addDurable).success).toBe(true);
+
+		const addCurrent = {
+			op: "add_current",
+			claim: "Writing a research paper",
+			category: "working_on",
+			valid_at: new Date().toISOString(),
+		};
+		expect(OpSchema.safeParse(addCurrent).success).toBe(true);
+
+		const strengthen = {
+			op: "strengthen",
+			factId: "fact-123",
+			reason: "User re-confirmed",
+		};
+		expect(OpSchema.safeParse(strengthen).success).toBe(true);
+
+		const decay = {
+			op: "decay",
+			factId: "fact-456",
+		};
+		expect(OpSchema.safeParse(decay).success).toBe(true);
+
+		const contradict = {
+			op: "contradict",
+			factId: "fact-789",
+			proposedText: "Actually moved to New York",
+			reason: "User stated new city",
+		};
+		expect(OpSchema.safeParse(contradict).success).toBe(true);
+	});
+
+	it("tolerantly parses extractor output and handles markdown fenced JSON string input", () => {
+		const markdownOutput = `\`\`\`json
+{
+  "ops": [
+    {
+      "op": "add_durable",
+      "claim": "Speaks Japanese",
+      "category": "identity"
+    },
+    {
+      "op": "contradict",
+      "factId": "fact-1"
+    },
+    {
+      "op": "decay",
+      "factId": "fact-2"
+    }
+  ]
+}
+\`\`\``;
+
+		const result = parseExtractorOutputTolerant(markdownOutput);
+		expect(result).not.toBeNull();
+		// contradict missing reason is dropped, so 2 ops remain
+		expect(result?.ops).toHaveLength(2);
+		expect(result?.ops[0].op).toBe("add_durable");
+		expect(result?.ops[1].op).toBe("decay");
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `DurableCategoryEnum`, `CurrentCategoryEnum`, and `VerificationStatusEnum` schema validation.
- `OpSchema` discriminated union parsing across `add_durable`, `add_current`, `strengthen`, `decay`, and `contradict`.
- `parseExtractorOutputTolerant` coercing markdown-fenced JSON and parsing valid ops while dropping malformed entries.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`668210dae2`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts:1-98`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:668210dae22fbea77ff74ebfbed0acb03135af12 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested