### PR TITLE
test(core): cover persist-character-patch

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for applying and persisting partial character patches.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { Character, IAgentRuntime } from "../../../../../types/index.js";
+import { persistCharacterPatch } from "./persist-character-patch.js";
+
+describe("persist-character-patch", () => {
+	it("returns early when patch is empty", async () => {
+		const runtime = {
+			character: { name: "Eliza" } as Character,
+		} as unknown as IAgentRuntime;
+
+		const result = await persistCharacterPatch(runtime, {});
+		expect(result).toEqual({ success: true });
+		expect(runtime.character.name).toBe("Eliza");
+	});
+
+	it("persists character patch when persistence service is present", async () => {
+		const persistMock = vi.fn().mockResolvedValue({ success: true });
+		const persistenceService = {
+			persistCharacter: persistMock,
+		};
+
+		const runtime = {
+			character: {
+				name: "Eliza",
+				bio: ["Original bio"],
+			} as Character,
+			getService: vi.fn().mockImplementation((name: string) => {
+				if (name === "eliza_character_persistence") return persistenceService;
+				return null;
+			}),
+		} as unknown as IAgentRuntime;
+
+		const patch: Partial<Character> = {
+			bio: ["Updated bio"],
+		};
+
+		const result = await persistCharacterPatch(runtime, patch);
+		expect(result.success).toBe(true);
+		expect(persistMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				character: expect.objectContaining({
+					name: "Eliza",
+					bio: ["Updated bio"],
+				}),
+				previousName: "Eliza",
+				source: "agent",
+			}),
+		);
+		expect(runtime.character.bio).toEqual(["Updated bio"]);
+	});
+
+	it("fails and does not mutate runtime character when persistence fails", async () => {
+		const persistMock = vi
+			.fn()
+			.mockResolvedValue({ success: false, error: "Disk full" });
+		const persistenceService = {
+			persistCharacter: persistMock,
+		};
+
+		const runtime = {
+			character: {
+				name: "Eliza",
+				bio: ["Original bio"],
+			} as Character,
+			getService: vi.fn().mockImplementation((name: string) => {
+				if (name === "eliza_character_persistence") return persistenceService;
+				return null;
+			}),
+		} as unknown as IAgentRuntime;
+
+		const patch: Partial<Character> = {
+			bio: ["Will not be applied"],
+		};
+
+		const result = await persistCharacterPatch(runtime, patch);
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Disk full");
+		expect(runtime.character.bio).toEqual(["Original bio"]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds colocated unit coverage for `packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.ts`, which had no same-named test file in the repository.

This is a test-only change. Production behavior is untouched. The suite imports the real module and tests:
- `persistCharacterPatch` fast path for empty patches.
- Persistence and live `runtime.character` mutation when character persistence service succeeds.
- Non-mutation and error reporting when character persistence service rejects or fails.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`8e6103c11f`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts` | N/A (new test file) | 3 passed (3 tests) |
| `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.test.ts:1-84`

## Risks

Low. Test-only contribution with no changes to production code.

## Attribution

Authored by @byt61.

<!-- evidence-head:8e6103c11f0beb19e3576f39a5010d7ec6aec30a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only; no user flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only; no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only; no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only; no LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation is captured by the PR checks and test commands.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or screenshots.

## Maintainer CI exception record

N/A - no exception requested