### PR TITLE
test(core): cover url-ingest

### DIFF
--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1399,7 +1399,7 @@ export class DocumentService extends Service {
 					normalizedContentType,
 					originalFilename,
 				);
-				documentContentToStore = extractedText;
+				documentContentToStore = content;
 			} else {
 				if (looksLikeBase64(content)) {
 					try {

--- a/packages/core/src/features/documents/url-ingest.test.ts
+++ b/packages/core/src/features/documents/url-ingest.test.ts
@@ -126,12 +126,13 @@ describe("url-ingest", () => {
 
 	it("reports unsuccessful HTTP responses with status details", async () => {
 		__setDocumentUrlFetchImplForTests(
-			async () => new Response("missing", { status: 404, statusText: "Not Found" }),
+			async () =>
+				new Response("missing", { status: 404, statusText: "Not Found" }),
 		);
 
-		await expect(fetchDocumentFromUrl("https://8.8.8.8/missing")).rejects.toThrow(
-			"Failed to fetch URL: 404 Not Found",
-		);
+		await expect(
+			fetchDocumentFromUrl("https://8.8.8.8/missing"),
+		).rejects.toThrow("Failed to fetch URL: 404 Not Found");
 	});
 
 	it.each([
@@ -146,7 +147,9 @@ describe("url-ingest", () => {
 				}),
 		);
 
-		await expect(fetchDocumentFromUrl(url)).resolves.toMatchObject({ filename });
+		await expect(fetchDocumentFromUrl(url)).resolves.toMatchObject({
+			filename,
+		});
 	});
 
 	it("removes raw-text HTML elements and decodes basic entities", async () => {
@@ -177,7 +180,9 @@ describe("url-ingest", () => {
 				}),
 		);
 
-		await expect(fetchDocumentFromUrl("https://8.8.8.8/file.bin")).resolves.toMatchObject({
+		await expect(
+			fetchDocumentFromUrl("https://8.8.8.8/file.bin"),
+		).resolves.toMatchObject({
 			content: "AAEC/w==",
 			contentType: "binary",
 			mimeType,
@@ -206,14 +211,16 @@ describe("url-ingest", () => {
 				}),
 		);
 
-		await expect(fetchDocumentFromUrl("https://8.8.8.8/large.txt")).rejects.toThrow(
+		await expect(
+			fetchDocumentFromUrl("https://8.8.8.8/large.txt"),
+		).rejects.toThrow(
 			`URL content exceeds maximum size of ${maximumBytes} bytes`,
 		);
 	});
 
 	it("rejects YouTube URLs without an eleven-character video id", async () => {
-		await expect(fetchDocumentFromUrl("https://youtu.be/short")).rejects.toThrow(
-			"Invalid YouTube URL: could not extract video ID",
-		);
+		await expect(
+			fetchDocumentFromUrl("https://youtu.be/short"),
+		).rejects.toThrow("Invalid YouTube URL: could not extract video ID");
 	});
 });

--- a/packages/core/src/features/documents/url-ingest.test.ts
+++ b/packages/core/src/features/documents/url-ingest.test.ts
@@ -86,4 +86,134 @@ describe("url-ingest", () => {
 			fetchDocumentFromUrl("https://8.8.8.8/redirect"),
 		).rejects.toThrow("URL redirects are not allowed");
 	});
+
+	it.each([
+		"https://youtube.com/embed/dQw4w9WgXcQ",
+		"http://youtube.com/v/dQw4w9WgXcQ",
+	])("recognizes additional supported YouTube URL forms", (url) => {
+		expect(isYouTubeUrl(url)).toBe(true);
+	});
+
+	it.each([
+		["http://127.0.0.1/secret", 'URL host "127.0.0.1" is blocked'],
+		[
+			"http://metadata.google.internal/latest/meta-data",
+			'URL host "metadata.google.internal" is blocked',
+		],
+	])("blocks unsafe host %s before pinned fetch", async (url, message) => {
+		let fetchCalled = false;
+		__setDocumentUrlFetchImplForTests(async () => {
+			fetchCalled = true;
+			return new Response("unused");
+		});
+
+		await expect(fetchDocumentFromUrl(url)).rejects.toThrow(message);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("pins public literal addresses and translates aborts into timeout errors", async () => {
+		__setDocumentUrlFetchImplForTests(async (input) => {
+			expect(input.target.hostname).toBe("8.8.8.8");
+			expect(input.target.pinnedAddress).toBe("8.8.8.8");
+			expect(input.timeoutMs).toBe(15_000);
+			throw new DOMException("Aborted", "AbortError");
+		});
+
+		await expect(fetchDocumentFromUrl("https://8.8.8.8/doc")).rejects.toThrow(
+			"URL fetch timed out after 15000ms",
+		);
+	});
+
+	it("reports unsuccessful HTTP responses with status details", async () => {
+		__setDocumentUrlFetchImplForTests(
+			async () => new Response("missing", { status: 404, statusText: "Not Found" }),
+		);
+
+		await expect(fetchDocumentFromUrl("https://8.8.8.8/missing")).rejects.toThrow(
+			"Failed to fetch URL: 404 Not Found",
+		);
+	});
+
+	it.each([
+		["https://8.8.8.8/", "document"],
+		["https://8.8.8.8/a%20note.txt", "a note.txt"],
+		["https://8.8.8.8/bad%ZZ.txt", "bad%ZZ.txt"],
+	])("derives the filename for %s", async (url, filename) => {
+		__setDocumentUrlFetchImplForTests(
+			async () =>
+				new Response("text", {
+					headers: { "Content-Type": "text/plain; charset=utf-8" },
+				}),
+		);
+
+		await expect(fetchDocumentFromUrl(url)).resolves.toMatchObject({ filename });
+	});
+
+	it("removes raw-text HTML elements and decodes basic entities", async () => {
+		__setDocumentUrlFetchImplForTests(
+			async () =>
+				new Response(
+					"<h1>Title &amp; More</h1><script>secret()</script><style>.hidden{}</style><p>Hello<br>world</p>",
+					{ headers: { "Content-Type": "text/html" } },
+				),
+		);
+
+		const result = await fetchDocumentFromUrl("https://8.8.8.8/page.html");
+
+		expect(result.content).toBe("Title & More\n Hello\nworld");
+		expect(result.content).not.toContain("secret");
+		expect(result.content).not.toContain("hidden");
+	});
+
+	it.each([
+		"application/msword",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"image/png",
+	])("classifies %s payloads as binary", async (mimeType) => {
+		__setDocumentUrlFetchImplForTests(
+			async () =>
+				new Response(new Uint8Array([0, 1, 2, 255]), {
+					headers: { "Content-Type": mimeType },
+				}),
+		);
+
+		await expect(fetchDocumentFromUrl("https://8.8.8.8/file.bin")).resolves.toMatchObject({
+			content: "AAEC/w==",
+			contentType: "binary",
+			mimeType,
+		});
+	});
+
+	it("defaults missing content types to octet-stream text", async () => {
+		__setDocumentUrlFetchImplForTests(
+			async () => new Response(new TextEncoder().encode("raw text")),
+		);
+
+		await expect(fetchDocumentFromUrl("https://8.8.8.8/raw")).resolves.toEqual({
+			filename: "raw",
+			content: "raw text",
+			contentType: "text",
+			mimeType: "application/octet-stream",
+		});
+	});
+
+	it("rejects declared bodies larger than the import limit", async () => {
+		const maximumBytes = 10 * 1024 * 1024;
+		__setDocumentUrlFetchImplForTests(
+			async () =>
+				new Response("small", {
+					headers: { "Content-Length": String(maximumBytes + 1) },
+				}),
+		);
+
+		await expect(fetchDocumentFromUrl("https://8.8.8.8/large.txt")).rejects.toThrow(
+			`URL content exceeds maximum size of ${maximumBytes} bytes`,
+		);
+	});
+
+	it("rejects YouTube URLs without an eleven-character video id", async () => {
+		await expect(fetchDocumentFromUrl("https://youtu.be/short")).rejects.toThrow(
+			"Invalid YouTube URL: could not extract video ID",
+		);
+	});
 });

--- a/packages/core/src/features/documents/url-ingest.test.ts
+++ b/packages/core/src/features/documents/url-ingest.test.ts
@@ -189,15 +189,15 @@ describe("url-ingest", () => {
 		});
 	});
 
-	it("defaults missing content types to octet-stream text", async () => {
+	it("treats a missing content type as binary octet-stream", async () => {
 		__setDocumentUrlFetchImplForTests(
 			async () => new Response(new TextEncoder().encode("raw text")),
 		);
 
 		await expect(fetchDocumentFromUrl("https://8.8.8.8/raw")).resolves.toEqual({
 			filename: "raw",
-			content: "raw text",
-			contentType: "text",
+			content: "cmF3IHRleHQ=",
+			contentType: "binary",
 			mimeType: "application/octet-stream",
 		});
 	});
@@ -213,6 +213,30 @@ describe("url-ingest", () => {
 
 		await expect(
 			fetchDocumentFromUrl("https://8.8.8.8/large.txt"),
+		).rejects.toThrow(
+			`URL content exceeds maximum size of ${maximumBytes} bytes`,
+		);
+	});
+
+	it("rejects an undeclared streamed body that grows beyond the import limit", async () => {
+		const maximumBytes = 10 * 1024 * 1024;
+		__setDocumentUrlFetchImplForTests(async () => {
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new Uint8Array(maximumBytes));
+					controller.enqueue(new Uint8Array(1));
+					controller.close();
+				},
+			});
+			const response = new Response(body, {
+				headers: { "Content-Type": "text/plain" },
+			});
+			expect(response.headers.has("content-length")).toBe(false);
+			return response;
+		});
+
+		await expect(
+			fetchDocumentFromUrl("https://8.8.8.8/chunked.txt"),
 		).rejects.toThrow(
 			`URL content exceeds maximum size of ${maximumBytes} bytes`,
 		);

--- a/packages/core/src/features/documents/url-ingest.test.ts
+++ b/packages/core/src/features/documents/url-ingest.test.ts
@@ -3,6 +3,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter.js";
+import { AgentRuntime } from "../../runtime.js";
+import type { Character, UUID } from "../../types/index.js";
+import { DocumentService } from "./service.js";
 import {
 	__setDocumentUrlFetchImplForTests,
 	fetchDocumentFromUrl,
@@ -200,6 +204,43 @@ describe("url-ingest", () => {
 			contentType: "binary",
 			mimeType: "application/octet-stream",
 		});
+	});
+
+	it("preserves absent-header binary content through document persistence", async () => {
+		__setDocumentUrlFetchImplForTests(
+			async () => new Response(new TextEncoder().encode("raw text")),
+		);
+		const fetched = await fetchDocumentFromUrl("https://8.8.8.8/raw");
+		const agentId = "00000000-0000-4000-8000-000000026346" as UUID;
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const runtime = new AgentRuntime({
+			agentId,
+			character: {
+				name: "UrlIngestPersistenceTestAgent",
+				bio: "Exercises binary URL ingestion persistence.",
+				settings: {},
+			} as Character,
+			adapter,
+			logLevel: "fatal",
+		});
+		const service = new DocumentService(runtime);
+
+		const added = await service.addDocument({
+			agentId,
+			worldId: agentId,
+			roomId: agentId,
+			entityId: agentId,
+			clientDocumentId: agentId,
+			contentType: fetched.mimeType,
+			originalFilename: fetched.filename,
+			content: fetched.content,
+			metadata: { textBacked: fetched.contentType !== "binary" },
+		});
+		const stored = await runtime.getMemoryById(added.storedDocumentMemoryId);
+
+		expect(stored?.content.text).toBe("cmF3IHRleHQ=");
+		expect(stored?.metadata).toMatchObject({ textBacked: false });
 	});
 
 	it("rejects declared bodies larger than the import limit", async () => {

--- a/packages/core/src/features/documents/url-ingest.ts
+++ b/packages/core/src/features/documents/url-ingest.ts
@@ -501,6 +501,7 @@ export interface FetchDocumentFromUrlOptions {
 function classifyMimeType(mimeType: string): FetchedDocumentUrlKind {
 	const normalized = mimeType.toLowerCase();
 	if (
+		normalized.startsWith("application/octet-stream") ||
 		normalized.startsWith("application/pdf") ||
 		normalized.startsWith("application/msword") ||
 		normalized.startsWith("application/vnd.openxmlformats-officedocument") ||


### PR DESCRIPTION
## Summary

- expand the existing `url-ingest` suite across SSRF rejection, public-IP pinning, timeout translation, response errors, filename derivation, HTML sanitization, binary MIME classification, absent content types, and declared/streamed response-size enforcement
- classify a missing `Content-Type` as binary `application/octet-stream`, preserving the fetched bytes as base64 instead of decoding arbitrary bytes as UTF-8
- preserve base64 binary content in `DocumentService` while continuing to derive searchable fragments from extracted text
- add a persistence regression proving the absent-header payload remains base64 with `textBacked: false`

The current diff is three files: 202 test additions, one URL-ingest production addition, and one binary-persistence production substitution. Production behavior intentionally changes for binary document storage.

## Validation

- `bunx --no-install vitest run /Volumes/thescoho_1TB/Developer/worktrees/pr-26346-repair/packages/core/src/features/documents/url-ingest.test.ts` in a network-denied, read-only Bun 1.3.14 container — 1 file passed, 23 tests passed
- `bunx --no-install biome check packages/core/src/features/documents/service.ts packages/core/src/features/documents/url-ingest.ts packages/core/src/features/documents/url-ingest.test.ts` — checked 3 files; no fixes applied
- `bun run --cwd packages/core typecheck` — passed under Bun 1.3.14 / Node-compatible repository tooling
- `bun run verify` reached all 146 typecheck/lint tasks and verified the packed core contracts; the filtered proof container then stopped in an unrelated plugin build because that partial install did not contain the `tsup` executable
- rebased onto `origin/develop` at `126807701e19a2a88b7f50ce785df4b26506007a` before the final proof run

# Relates to

# Evidence Gate

<!-- evidence-head:5b875b50da23e789690f1422b2763c78eecd7741 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only document ingestion has no rendered user interface surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only document ingestion has no rendered user interface surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the changed path is a backend URL importer with no visual flow.

<!-- evidence-row:backend-logs -->
- [x] Backend output from the credential-free shipped `POST /api/documents/url` route:
<details><summary>Real route output at the current head</summary>

```text
source.url=https://httpbin.org/response-headers?Content-Type=
source.status=200 source.contentTypeHeader=null source.byteLength=87
source.sha256=a668798d6db9b8f6280ba7a5136b0ae476bfc68b8b1c39d7825724e6b827aa04
request.method=POST request.path=/api/documents/url
response.status=200 response.ok=true
response.documentId=32ca8a52-f3fe-5891-927e-a888bcba33a6 response.fragmentCount=1
response.filename=response-headers response.contentType=application/octet-stream
response.isYouTubeTranscript=false
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - the credential-free route was exercised directly and no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - URL import performs no model, prompt, provider, action, or planner call.

<!-- evidence-row:domain-artifacts -->
- [x] Resulting PGLite-backed document memory from the same real route invocation:
<details><summary>Stored document artifact at the current head</summary>

```json
{
  "documentId": "32ca8a52-f3fe-5891-927e-a888bcba33a6",
  "content": "ewogICJDb250ZW50LUxlbmd0aCI6ICI4NyIsIAogICJDb250ZW50LVR5cGUiOiBbCiAgICAiYXBwbGljYXRpb24vanNvbiIsIAogICAgIiIKICBdCn0K",
  "metadata": {
    "url": "https://httpbin.org/response-headers?Content-Type=",
    "source": "url",
    "fileType": "application/octet-stream",
    "contentType": "application/octet-stream",
    "textBacked": false
  }
}
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - this backend-only change has no rendered visual text to inspect.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [repair-pr-26346]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
