### PR TITLE
test(core): cover listInbox

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
@@ -7,7 +7,10 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 
+import type { IAgentRuntime } from "../../../../types/index.ts";
+import { CONTEXT_ROUTING_STATE_KEY } from "../../../../utils/context-routing.ts";
 import { listInboxAction } from "../actions/listInbox.ts";
+import { BaseMessageAdapter } from "../adapters/base.ts";
 import {
 	__resetDefaultMessageRefStoreForTests,
 	getDefaultMessageRefStore,
@@ -29,6 +32,39 @@ function messageRef(overrides: Partial<MessageRef>): MessageRef {
 		isRead: false,
 		...overrides,
 	};
+}
+
+class FixedListAdapter extends BaseMessageAdapter {
+	readonly source = "gmail" as const;
+	readonly seenOptions: Parameters<BaseMessageAdapter["listMessages"]>[1][] =
+		[];
+
+	constructor(
+		private readonly refs: MessageRef[],
+		private readonly failure?: unknown,
+	) {
+		super();
+	}
+
+	isAvailable(): boolean {
+		return true;
+	}
+
+	protected override async listMessagesImpl(
+		_runtime: IAgentRuntime,
+		opts: Parameters<BaseMessageAdapter["listMessages"]>[1],
+	): Promise<MessageRef[]> {
+		this.seenOptions.push(opts);
+		if (this.failure !== undefined) {
+			throw this.failure;
+		}
+		return this.refs;
+	}
+}
+
+async function registerAdapter(adapter: BaseMessageAdapter): Promise<void> {
+	const { getDefaultTriageService } = await import("../triage-service.ts");
+	getDefaultTriageService().register(adapter);
 }
 
 describe("listInboxAction", () => {
@@ -78,5 +114,190 @@ describe("listInboxAction", () => {
 		expect(
 			(messages as Array<{ id: string }>).map((message) => message.id),
 		).toEqual(["gmail-1", "whatsapp-1"]);
+	});
+
+	it("validates messaging contexts and rejects unrelated contexts", async () => {
+		const message = { content: { text: "show inbox" } } as never;
+		const runtime = createFakeRuntime();
+
+		expect(
+			await listInboxAction.validate(runtime, message, {
+				values: {
+					[CONTEXT_ROUTING_STATE_KEY]: { primaryContext: "email" },
+				},
+			} as never),
+		).toBe(true);
+		expect(
+			await listInboxAction.validate(runtime, message, {
+				values: {
+					[CONTEXT_ROUTING_STATE_KEY]: { primaryContext: "wallet" },
+				},
+			} as never),
+		).toBe(false);
+	});
+
+	it("ranks cached messages, preserves equal-score ties, filters read mail, and applies the limit", async () => {
+		getDefaultMessageRefStore().saveMessages([
+			messageRef({
+				id: "read-newest",
+				receivedAtMs: 9_000,
+				isRead: true,
+			}),
+			messageRef({
+				id: "equal-first",
+				receivedAtMs: 5_000,
+			}),
+			messageRef({
+				id: "tie-winner",
+				receivedAtMs: 5_000,
+				subject: "Important relationship",
+				triageScore: {
+					contactWeight: 0.9,
+					userRepliedInThread: true,
+					scoredAt: 5_001,
+				},
+			}),
+			messageRef({
+				id: "equal-second",
+				receivedAtMs: 5_000,
+			}),
+			messageRef({
+				id: "older",
+				receivedAtMs: 4_000,
+			}),
+		]);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{ parameters: { limit: 3 } } as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.text).toBe(
+			"4 unread message(s) across 1 platform(s); details in data.messages.",
+		);
+		expect(result.data).toEqual({
+			total: 4,
+			returned: 3,
+			messages: [
+				{
+					id: "tie-winner",
+					source: "gmail",
+					from: "alice@example.com",
+					subject: "Important relationship",
+					snippet: "hello",
+					receivedAtMs: 5_000,
+					contactWeight: 0.9,
+					userRepliedInThread: true,
+				},
+				{
+					id: "equal-first",
+					source: "gmail",
+					from: "alice@example.com",
+					subject: null,
+					snippet: "hello",
+					receivedAtMs: 5_000,
+					contactWeight: null,
+					userRepliedInThread: null,
+				},
+				{
+					id: "equal-second",
+					source: "gmail",
+					from: "alice@example.com",
+					subject: null,
+					snippet: "hello",
+					receivedAtMs: 5_000,
+					contactWeight: null,
+					userRepliedInThread: null,
+				},
+			],
+		});
+	});
+
+	it("pulls and scores live adapter messages when the cache is empty", async () => {
+		const adapter = new FixedListAdapter([
+			messageRef({
+				id: "live-message",
+				externalId: "live-external",
+				receivedAtMs: 7_000,
+			}),
+		]);
+		await registerAdapter(adapter);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{
+				parameters: { sources: ["gmail"], sinceMs: 6_000, limit: 10 },
+			} as never,
+		);
+
+		expect(adapter.seenOptions).toHaveLength(1);
+		expect(adapter.seenOptions[0]).toMatchObject({
+			sinceMs: 6_000,
+			limit: 10,
+		});
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({
+			total: 1,
+			returned: 1,
+			messages: [
+				{
+					id: "live-message",
+					contactWeight: 0.5,
+					userRepliedInThread: false,
+				},
+			],
+		});
+	});
+
+	it("returns the explicit empty-inbox result when no source has messages", async () => {
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			text: "No unread messages across connected platforms.",
+			data: { total: 0, returned: 0, messages: [] },
+		});
+	});
+
+	it("translates adapter errors into a failed action result", async () => {
+		await registerAdapter(
+			new FixedListAdapter([], new Error("gmail unavailable")),
+		);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+		);
+
+		expect(result).toEqual({
+			success: false,
+			text: "Failed to list inbox: gmail unavailable",
+			error: "gmail unavailable",
+			data: { actionName: "MESSAGE" },
+		});
+	});
+
+	it("stringifies non-Error failures at the action boundary", async () => {
+		await registerAdapter(new FixedListAdapter([], "connector refused"));
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+		);
+
+		expect(result).toEqual({
+			success: false,
+			text: "Failed to list inbox: connector refused",
+			error: "connector refused",
+			data: { actionName: "MESSAGE" },
+		});
 	});
 });


### PR DESCRIPTION

## Summary

- Extend the existing `listInboxAction` unit suite with coverage for context validation, cached ordering and stable ties, unread filtering, limits, live adapter fallback, empty inboxes, and error translation.
- Exercise the real action, triage service, message-ref store, ranking logic, and a deterministic in-process adapter; no production code changes and no mocked return-value assertions.
- The diff touches only `packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts` and is additive (`+221/-0`).

## Validation

- `bunx vitest run packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts` — 1 file passed, 7 tests passed.
- `bunx biome check --write packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts` — checked 1 file; formatting fix applied, with the final file clean.
- `cd packages/core && bunx tsc --noEmit` — exit 0; `list-inbox-action.test.ts` appeared nowhere in the output.
- Re-fetched `origin/develop` immediately before the final Vitest run; the production subject matched current `origin/develop`.

## Evidence

- N/A — test-only change with no production behavior, UI, model trajectory, connector, or generated artifact change.
- Hosted CI does not run for fork-contributor pull requests; the local exact commands and counts above are the available validation.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b58848c7d549e06248edd5a8ffb28a4be0933e38 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
