### PR TITLE
test(core): cover locale-detection

### DIFF
--- a/packages/core/src/runtime/locale-detection.test.ts
+++ b/packages/core/src/runtime/locale-detection.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the owner-locale resolver (`detectLocaleFromText`,
+ * `resolveOwnerLocale`). Deterministic in-line literals — no runtime, model,
+ * or database: every expectation below was observed from the real module.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	detectLocaleFromText,
+	resolveOwnerLocale,
+} from "./locale-detection.ts";
+
+describe("detectLocaleFromText", () => {
+	it("returns null for non-string input", () => {
+		expect(detectLocaleFromText(undefined)).toBeNull();
+		expect(detectLocaleFromText(null)).toBeNull();
+	});
+
+	it("returns null for empty and whitespace-only text", () => {
+		expect(detectLocaleFromText("")).toBeNull();
+		expect(detectLocaleFromText("   \n\t  ")).toBeNull();
+	});
+
+	it("detects Japanese from kana", () => {
+		expect(detectLocaleFromText("こんにちは")).toBe("ja");
+	});
+
+	it("prefers kana over Han characters when both scripts appear", () => {
+		expect(detectLocaleFromText("こんにちは世界")).toBe("ja");
+	});
+
+	it("detects zh-Hans from Han characters without kana", () => {
+		expect(detectLocaleFromText("你好世界")).toBe("zh-Hans");
+	});
+
+	it("detects Spanish from hint words alone", () => {
+		expect(detectLocaleFromText("hola gracias por favor")).toBe("es");
+	});
+
+	it("matches hint words case-insensitively", () => {
+		expect(detectLocaleFromText("HOLA GRACIAS")).toBe("es");
+	});
+
+	it("keeps hyphenated tokens whole so compound hints match", () => {
+		expect(detectLocaleFromText("Rappelle-moi demain matin")).toBe("fr");
+	});
+
+	it("detects French from hint words and diacritics together", () => {
+		expect(detectLocaleFromText("bonjour merci très demain")).toBe("fr");
+	});
+
+	it("scores a Spanish-only diacritic as es", () => {
+		expect(detectLocaleFromText("señor mañana")).toBe("es");
+	});
+
+	it("abstains on a shared diacritic tie (é scores both es and fr)", () => {
+		expect(detectLocaleFromText("café")).toBeNull();
+	});
+
+	it("abstains when hint-word scores tie", () => {
+		expect(detectLocaleFromText("hola merci")).toBeNull();
+	});
+
+	it("returns null when there is no signal at all", () => {
+		expect(detectLocaleFromText("hello world how are you")).toBeNull();
+	});
+});
+
+describe("resolveOwnerLocale", () => {
+	it("prefers a non-empty ownerLocale over detection and default", () => {
+		expect(
+			resolveOwnerLocale({
+				ownerLocale: "fr",
+				recentMessage: "こんにちは",
+				defaultLocale: "es",
+			}),
+		).toBe("fr");
+	});
+
+	it("trims surrounding whitespace from ownerLocale", () => {
+		expect(resolveOwnerLocale({ ownerLocale: "  ja  " })).toBe("ja");
+	});
+
+	it("treats a whitespace-only ownerLocale as absent and falls through to detection", () => {
+		expect(
+			resolveOwnerLocale({ ownerLocale: "   ", recentMessage: "bonjour" }),
+		).toBe("fr");
+	});
+
+	it("falls through to detection on empty or null ownerLocale", () => {
+		expect(resolveOwnerLocale({ ownerLocale: "", recentMessage: "hola" })).toBe(
+			"es",
+		);
+		expect(
+			resolveOwnerLocale({ ownerLocale: null, recentMessage: "你好" }),
+		).toBe("zh-Hans");
+	});
+
+	it("uses defaultLocale when detection has no signal", () => {
+		expect(
+			resolveOwnerLocale({
+				recentMessage: "hello world",
+				defaultLocale: "pt-BR",
+			}),
+		).toBe("pt-BR");
+	});
+
+	it("passes an arbitrary caller default through untouched", () => {
+		expect(resolveOwnerLocale({ defaultLocale: "xx-Latn" })).toBe("xx-Latn");
+	});
+
+	it("falls back to en when defaultLocale is missing, empty, or whitespace", () => {
+		expect(resolveOwnerLocale({})).toBe("en");
+		expect(resolveOwnerLocale({ defaultLocale: "" })).toBe("en");
+		expect(resolveOwnerLocale({ defaultLocale: "   " })).toBe("en");
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/runtime/locale-detection.test.ts` — a new unit suite for the pure owner-locale resolver (`detectLocaleFromText`, `resolveOwnerLocale`) in `@elizaos/core`. Test-only change: no production file is touched (+116/−0, one new file).

Note on target selection: this lane was originally assigned `capability-selection/retrieval.ts`, but `retrieval.test.ts` landed on develop before this PR could be filed, so per the one-suite-per-file rule the next untested module was taken instead.

## Why

`locale-detection.ts` had no same-named or dotted test file anywhere in the repo, yet it drives which localized example catalog the planner keys off. Its behavior has several non-obvious contracts worth pinning:

- kana wins over Han when both scripts appear (ja beats zh-Hans by check order)
- hint-word scores tie → abstain (`null`), including the subtle shared-diacritic tie where `é` scores for both es and fr
- hyphenated tokens stay whole so compound hints like `rappelle-moi` match
- `resolveOwnerLocale` trims and falls through whitespace-only owner/default locales, ending at `"en"`

## Coverage

20 cases across both exported functions:

- non-string / empty / whitespace input → `null`
- script priority: kana → `ja`; kana+Han → `ja`; Han only → `zh-Hans`
- hint-word scoring for es/fr, case-insensitive matching, hyphenated token preservation
- diacritic bonuses, Spanish-only vs shared-tie abstention
- zero-signal English text → `null`
- resolver priority order: ownerLocale > detection > defaultLocale; trim handling; whitespace-only fallthrough; arbitrary caller default passthrough; `"en"` final fallback

## Evidence (fork contributor — hosted CI does not run on this PR)

- `bunx vitest run packages/core/src/runtime/locale-detection.test.ts` on current origin/develop (`0242ceed3525`): **Test Files 1 passed (1), Tests 20 passed (20)**
- `bunx biome check packages/core/src/runtime/locale-detection.test.ts`: "Checked 1 file … No fixes applied" (clean)
- `bunx tsc --noEmit -p ./tsconfig.json` in `packages/core`: exit 0, zero errors; the new test file appears nowhere in output
- Diff touches exactly one new test file; no production behavior changes

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f6805fbdbcb1c2ec954f6cb03b8cdc701269dfbd -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
