### PR TITLE
test(core): cover deferred-send-scheduler

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/deferred-send-scheduler.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/deferred-send-scheduler.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Exercises the runtime-scoped deferred-message scheduler registry with real
+ * registration, lookup, duplicate rejection, disposal, and isolation behavior.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../../../../errors.ts";
+import type { IAgentRuntime } from "../../../../types/index.ts";
+import {
+	type DeferredMessageScheduler,
+	getDeferredMessageScheduler,
+	registerDeferredMessageScheduler,
+} from "../deferred-send-scheduler.ts";
+
+function createRuntime(): IAgentRuntime {
+	return {} as IAgentRuntime;
+}
+
+function createScheduler(): DeferredMessageScheduler {
+	return {
+		schedule: () => Promise.reject(new Error("not exercised by the registry")),
+	};
+}
+
+describe("deferred-message scheduler registration", () => {
+	it("returns null when a runtime has no registered scheduler", () => {
+		expect(getDeferredMessageScheduler(createRuntime())).toBeNull();
+	});
+
+	it("registers and disposes the scheduler for a runtime", () => {
+		const runtime = createRuntime();
+		const scheduler = createScheduler();
+
+		const dispose = registerDeferredMessageScheduler(runtime, scheduler);
+
+		expect(getDeferredMessageScheduler(runtime)).toBe(scheduler);
+		dispose();
+		expect(getDeferredMessageScheduler(runtime)).toBeNull();
+	});
+
+	it("rejects duplicate registration without replacing the first scheduler", () => {
+		const runtime = createRuntime();
+		const first = createScheduler();
+		const dispose = registerDeferredMessageScheduler(runtime, first);
+		let duplicateError: unknown;
+
+		try {
+			registerDeferredMessageScheduler(runtime, createScheduler());
+		} catch (error) {
+			duplicateError = error;
+		}
+
+		expect(duplicateError).toBeInstanceOf(ElizaError);
+		expect(duplicateError).toMatchObject({
+			code: "DEFERRED_MESSAGE_SCHEDULER_DUPLICATE",
+			severity: "fatal",
+		});
+		expect(getDeferredMessageScheduler(runtime)).toBe(first);
+		dispose();
+	});
+
+	it("does not let a stale disposer remove a replacement scheduler", () => {
+		const runtime = createRuntime();
+		const firstDispose = registerDeferredMessageScheduler(
+			runtime,
+			createScheduler(),
+		);
+		firstDispose();
+		const replacement = createScheduler();
+		const replacementDispose = registerDeferredMessageScheduler(
+			runtime,
+			replacement,
+		);
+
+		firstDispose();
+
+		expect(getDeferredMessageScheduler(runtime)).toBe(replacement);
+		replacementDispose();
+	});
+
+	it("keeps registrations isolated between runtimes", () => {
+		const firstRuntime = createRuntime();
+		const secondRuntime = createRuntime();
+		const firstScheduler = createScheduler();
+		const secondScheduler = createScheduler();
+		const disposeFirst = registerDeferredMessageScheduler(
+			firstRuntime,
+			firstScheduler,
+		);
+		const disposeSecond = registerDeferredMessageScheduler(
+			secondRuntime,
+			secondScheduler,
+		);
+
+		expect(getDeferredMessageScheduler(firstRuntime)).toBe(firstScheduler);
+		expect(getDeferredMessageScheduler(secondRuntime)).toBe(secondScheduler);
+
+		disposeFirst();
+		expect(getDeferredMessageScheduler(firstRuntime)).toBeNull();
+		expect(getDeferredMessageScheduler(secondRuntime)).toBe(secondScheduler);
+		disposeSecond();
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for the runtime-scoped deferred-message scheduler registry
- verify empty lookup, registration and disposal, duplicate rejection without replacement, stale-disposer safety, and isolation between runtimes
- keep the change behavior-preserving and limited to one new test file

## Validation

- `bunx vitest run packages/core/src/features/messaging/triage/__tests__/deferred-send-scheduler.test.ts` — 1 file passed, 5 tests passed
- `bunx biome check --write src/features/messaging/triage/__tests__/deferred-send-scheduler.test.ts` from `packages/core` — checked 1 file and applied formatting
- `bunx tsc --noEmit` from `packages/core` — exit 0; the new test filename appeared zero times in output
- diff scope — one new test file, 103 insertions, 0 deletions

Hosted CI does not run for this fork-origin pull request; the local results above are the available validation.

## Evidence

N/A — this test-only pull request changes no production behavior or rendered surface.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:260160339bc653b1426911f2d294a8ef4f955645 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
