### PR TITLE
test(core): cover list

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/list.test.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/list.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Exercises the plugin list handler's unavailable, empty, loaded, installed,
+ * and combined planner-facing results using the real handler implementation.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import { type EjectedPluginInfo, PluginStatus } from "../../types.ts";
+import { runList } from "./list.ts";
+
+const INSTALLED_PLUGINS: EjectedPluginInfo[] = [
+	{
+		name: "@elizaos/plugin-discord",
+		version: "2.1.0",
+		path: "/plugins/discord",
+		upstream: null,
+	},
+	{
+		name: "@elizaos/plugin-telegram",
+		version: "3.0.0",
+		path: "/plugins/telegram",
+		upstream: null,
+	},
+];
+
+function createRuntime({
+	loaded = [],
+	installed = [],
+	available = true,
+}: {
+	loaded?: Array<{ name: string; status: PluginStatus }>;
+	installed?: EjectedPluginInfo[];
+	available?: boolean;
+} = {}): IAgentRuntime {
+	const service = available
+		? {
+				getAllPlugins: () => loaded,
+				listInstalledPlugins: async () => installed,
+			}
+		: null;
+
+	return {
+		getService: (name: string) => (name === "plugin_manager" ? service : null),
+	} as unknown as IAgentRuntime;
+}
+
+describe("runList", () => {
+	it("returns a structured failure without invoking the callback when the service is unavailable", async () => {
+		let callbackCalls = 0;
+
+		const result = await runList({
+			runtime: createRuntime({ available: false }),
+			callback: async () => {
+				callbackCalls += 1;
+				return [];
+			},
+		});
+
+		expect(result).toEqual({
+			success: false,
+			text: "Plugin manager service not available",
+		});
+		expect(callbackCalls).toBe(0);
+	});
+
+	it("reports an empty plugin inventory through the callback and completion metadata", async () => {
+		const replies: unknown[] = [];
+
+		const result = await runList({
+			runtime: createRuntime(),
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		expect(replies).toEqual([{ text: "No plugins are loaded or installed." }]);
+		expect(result).toEqual({
+			success: true,
+			text: "No plugins are loaded or installed.",
+			userFacingText: "No plugins are loaded or installed.",
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list", count: 0 },
+		});
+	});
+
+	it("preserves loaded plugin order and exposes only the public list fields", async () => {
+		const loaded = [
+			{ name: "plugin-second", status: PluginStatus.ERROR },
+			{ name: "plugin-first", status: PluginStatus.LOADED },
+		];
+
+		const result = await runList({ runtime: createRuntime({ loaded }) });
+
+		expect(result.text).toBe(
+			[
+				"Loaded plugins (2):",
+				"  - plugin-second [error]",
+				"  - plugin-first [loaded]",
+			].join("\n"),
+		);
+		expect(result.values).toEqual({
+			mode: "list",
+			loadedCount: 2,
+			installedCount: 0,
+		});
+		expect(result.data).toEqual({ loaded, installed: [] });
+	});
+
+	it("renders installed plugins in source order without a leading separator", async () => {
+		const replies: unknown[] = [];
+
+		const result = await runList({
+			runtime: createRuntime({ installed: INSTALLED_PLUGINS }),
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		const text = [
+			"Installed via registry (2):",
+			"  - @elizaos/plugin-discord (v2.1.0) at /plugins/discord",
+			"  - @elizaos/plugin-telegram (v3.0.0) at /plugins/telegram",
+		].join("\n");
+		expect(result.text).toBe(text);
+		expect(replies).toEqual([{ text }]);
+		expect(result.data).toEqual({
+			loaded: [],
+			installed: INSTALLED_PLUGINS,
+		});
+	});
+
+	it("separates loaded and installed sections and reports both counts", async () => {
+		const loaded = [{ name: "plugin-local", status: PluginStatus.READY }];
+
+		const result = await runList({
+			runtime: createRuntime({
+				loaded,
+				installed: INSTALLED_PLUGINS.slice(0, 1),
+			}),
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			text: [
+				"Loaded plugins (1):",
+				"  - plugin-local [ready]",
+				"",
+				"Installed via registry (1):",
+				"  - @elizaos/plugin-discord (v2.1.0) at /plugins/discord",
+			].join("\n"),
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list", loadedCount: 1, installedCount: 1 },
+		});
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for the real `runList` plugin-manager handler
- cover unavailable and empty inventories, loaded-only and installed-only output, and combined section formatting
- verify source ordering, callback delivery, completion metadata, counts, and structured result data

## Validation

- `bunx vitest run packages/core/src/features/plugin-manager/actions/plugin-handlers/list.test.ts` — 1 file passed, 5 tests passed
- `bunx biome check --write packages/core/src/features/plugin-manager/actions/plugin-handlers/list.test.ts` — checked 1 file successfully
- `cd packages/core && bunx tsc --noEmit` — exited 0 with no output; `list.test.ts` appeared nowhere in compiler output
- diff is additive and touches only `packages/core/src/features/plugin-manager/actions/plugin-handlers/list.test.ts` (159 insertions, 0 deletions)

This is a fork-contributor pull request, so hosted CI does not run on it.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d6ef9e7cec426c9156b938f43fd51b6a3c4b4179 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
