### PR TITLE
test(core): cover revoke-oauth-credential

### DIFF
--- a/packages/core/src/features/oauth/actions/revoke-oauth-credential.test.ts
+++ b/packages/core/src/features/oauth/actions/revoke-oauth-credential.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the REVOKE_OAUTH_CREDENTIAL action's validation and revoke
+ * transition. The deterministic harness supplies only the runtime service
+ * boundary while exercising the real action metadata, parameter parsing,
+ * reason normalization, failure responses, and result shaping.
+ */
+import { describe, expect, test, vi } from "vitest";
+import {
+	OAUTH_INTENTS_CLIENT_SERVICE,
+	type OAuthIntentsClient,
+	type OAuthRevokeResult,
+} from "../types";
+import { revokeOAuthCredentialAction } from "./revoke-oauth-credential";
+
+function createClient(revoke = vi.fn()): OAuthIntentsClient {
+	return {
+		create: vi.fn(),
+		get: vi.fn(),
+		cancel: vi.fn(),
+		bind: vi.fn(),
+		revoke,
+	};
+}
+
+function createRuntime(client: OAuthIntentsClient | null) {
+	return {
+		getService: (name: string) =>
+			name === OAUTH_INTENTS_CLIENT_SERVICE ? client : null,
+	};
+}
+
+function message() {
+	return { entityId: "u1", roomId: "r1", content: { text: "" } };
+}
+
+describe("REVOKE_OAUTH_CREDENTIAL", () => {
+	test("declares the expected action metadata", () => {
+		expect(revokeOAuthCredentialAction.name).toBe("REVOKE_OAUTH_CREDENTIAL");
+		expect(revokeOAuthCredentialAction.suppressPostActionContinuation).toBe(
+			true,
+		);
+		expect(revokeOAuthCredentialAction.similes).toEqual([
+			"REVOKE_OAUTH",
+			"DISCONNECT_OAUTH",
+		]);
+		expect(revokeOAuthCredentialAction.parameters).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "oauthIntentId", required: true }),
+				expect.objectContaining({ name: "reason", required: false }),
+			]),
+		);
+	});
+
+	test("validates nested parameters when the client service is available", async () => {
+		const valid = await revokeOAuthCredentialAction.validate?.(
+			createRuntime(createClient()) as never,
+			message() as never,
+			undefined,
+			{ parameters: { oauthIntentId: "oauth_1" } } as never,
+		);
+
+		expect(valid).toBe(true);
+	});
+
+	test.each([
+		["missing service", null, "oauth_1"],
+		["missing OAuth intent id", createClient(), undefined],
+		["empty OAuth intent id", createClient(), ""],
+		["non-string OAuth intent id", createClient(), 42],
+	])("rejects validation for %s", async (_case, client, oauthIntentId) => {
+		const valid = await revokeOAuthCredentialAction.validate?.(
+			createRuntime(client) as never,
+			message() as never,
+			undefined,
+			{ parameters: { oauthIntentId } } as never,
+		);
+
+		expect(valid).toBe(false);
+	});
+
+	test("returns a structured failure when the client service is unavailable", async () => {
+		const result = await revokeOAuthCredentialAction.handler(
+			createRuntime(null) as never,
+			message() as never,
+			undefined,
+			{ parameters: { oauthIntentId: "oauth_1" } } as never,
+		);
+
+		expect(result).toEqual({
+			success: false,
+			text: "OAuthIntentsClient not available",
+			data: { actionName: "REVOKE_OAUTH_CREDENTIAL" },
+		});
+	});
+
+	test.each([undefined, "", 42, false])(
+		"does not revoke when the OAuth intent id is %s",
+		async (oauthIntentId) => {
+			const revoke = vi.fn();
+			const result = await revokeOAuthCredentialAction.handler(
+				createRuntime(createClient(revoke)) as never,
+				message() as never,
+				undefined,
+				{ parameters: { oauthIntentId } } as never,
+			);
+
+			expect(result).toEqual({
+				success: false,
+				text: "Missing required parameter: oauthIntentId",
+				data: { actionName: "REVOKE_OAUTH_CREDENTIAL" },
+			});
+			expect(revoke).not.toHaveBeenCalled();
+		},
+	);
+
+	test("revokes direct parameters and trims the optional reason", async () => {
+		const revokeResult: OAuthRevokeResult = {
+			oauthIntentId: "oauth_1",
+			provider: "google",
+			revoked: true,
+		};
+		const revoke = vi.fn().mockResolvedValue(revokeResult);
+		const callback = vi.fn();
+
+		const result = await revokeOAuthCredentialAction.handler(
+			createRuntime(createClient(revoke)) as never,
+			message() as never,
+			undefined,
+			{ oauthIntentId: "oauth_1", reason: "  user disconnected  " } as never,
+			callback,
+		);
+
+		expect(revoke).toHaveBeenCalledOnce();
+		expect(revoke).toHaveBeenCalledWith({
+			oauthIntentId: "oauth_1",
+			reason: "user disconnected",
+		});
+		expect(callback).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			success: true,
+			text: "Revoked OAuth credential oauth_1.",
+			data: {
+				actionName: "REVOKE_OAUTH_CREDENTIAL",
+				revoke: revokeResult,
+			},
+		});
+	});
+
+	test.each([undefined, "", "   ", 42])(
+		"omits an unusable reason value of %s",
+		async (reason) => {
+			const revoke = vi.fn().mockResolvedValue({
+				oauthIntentId: "oauth_2",
+				provider: "github",
+				revoked: true,
+			});
+
+			await revokeOAuthCredentialAction.handler(
+				createRuntime(createClient(revoke)) as never,
+				message() as never,
+				undefined,
+				{ parameters: { oauthIntentId: "oauth_2", reason } } as never,
+			);
+
+			expect(revoke).toHaveBeenCalledWith({
+				oauthIntentId: "oauth_2",
+				reason: undefined,
+			});
+		},
+	);
+
+	test("prefers nested parameters over direct option fields", async () => {
+		const revoke = vi.fn().mockResolvedValue({
+			oauthIntentId: "nested-oauth",
+			provider: "slack",
+			revoked: true,
+		});
+
+		await revokeOAuthCredentialAction.handler(
+			createRuntime(createClient(revoke)) as never,
+			message() as never,
+			undefined,
+			{
+				oauthIntentId: "direct-oauth",
+				reason: "direct reason",
+				parameters: {
+					oauthIntentId: "nested-oauth",
+					reason: "nested reason",
+				},
+			} as never,
+		);
+
+		expect(revoke).toHaveBeenCalledWith({
+			oauthIntentId: "nested-oauth",
+			reason: "nested reason",
+		});
+	});
+
+	test.each([
+		[
+			"with a provider error",
+			"token already invalid",
+			"Failed to revoke OAuth credential oauth_3: token already invalid.",
+		],
+		[
+			"without a provider error",
+			undefined,
+			"Failed to revoke OAuth credential oauth_3.",
+		],
+	])("reports a failed revocation %s", async (_case, error, text) => {
+		const revokeResult: OAuthRevokeResult = {
+			oauthIntentId: "oauth_3",
+			provider: "notion",
+			revoked: false,
+			error,
+		};
+		const revoke = vi.fn().mockResolvedValue(revokeResult);
+
+		const result = await revokeOAuthCredentialAction.handler(
+			createRuntime(createClient(revoke)) as never,
+			message() as never,
+			undefined,
+			{ parameters: { oauthIntentId: "oauth_3" } } as never,
+		);
+
+		expect(result).toEqual({
+			success: false,
+			text,
+			data: {
+				actionName: "REVOKE_OAUTH_CREDENTIAL",
+				revoke: revokeResult,
+			},
+		});
+	});
+
+	test("propagates a client revoke rejection", async () => {
+		const failure = new Error("provider revoke failed");
+		const revoke = vi.fn().mockRejectedValue(failure);
+
+		await expect(
+			revokeOAuthCredentialAction.handler(
+				createRuntime(createClient(revoke)) as never,
+				message() as never,
+				undefined,
+				{ parameters: { oauthIntentId: "oauth_1" } } as never,
+			),
+		).rejects.toBe(failure);
+	});
+});


### PR DESCRIPTION

## Summary

- Add a behavior-driven unit suite for `REVOKE_OAUTH_CREDENTIAL`.
- Cover action metadata, service and parameter validation, nested/direct parameter parsing, reason normalization, successful and failed result shaping, callback suppression, and client rejection propagation.
- Keep the change additive and test-only: one new test file, 249 insertions, zero deletions.

## Validation

- `bunx vitest run packages/core/src/features/oauth/actions/revoke-oauth-credential.test.ts` — 1 file passed, 20 tests passed on freshly fetched `origin/develop`.
- `bunx biome check --write packages/core/src/features/oauth/actions/revoke-oauth-credential.test.ts` — checked 1 file and applied the formatter's single fix.
- `cd packages/core && bunx tsc --noEmit` — exit 0; grepping the output for `revoke-oauth-credential.test.ts` returned no matches (`grep` exit 1).
- The production module in the shared checkout had the same SHA-256 as current `origin/develop` at the final Vitest run.
- Hosted CI does not run for this fork contribution; no hosted-CI pass is claimed.

## Evidence

This pull request changes no production behavior. Screenshots, walkthrough video, backend/frontend logs, a live-LLM trajectory, and domain artifacts are N/A because the complete observable change is the deterministic unit-test result quoted above.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:21c5a289b8b8de693c9ad55b13c7d20087f19b24 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
