### PR TITLE
test(core): cover list-ejected

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.test.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Exercises the list-ejected plugin handler's service boundary and complete
+ * user-facing result contract with deterministic in-memory collaborators.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { HandlerCallback } from "../../../../types/components.ts";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import type { EjectedPluginInfo } from "../../types.ts";
+import { runListEjected } from "./list-ejected.ts";
+
+function createRuntime(service: unknown): {
+	runtime: IAgentRuntime;
+	getService: ReturnType<typeof vi.fn>;
+} {
+	const getService = vi.fn(() => service);
+	return {
+		runtime: { getService } as unknown as IAgentRuntime,
+		getService,
+	};
+}
+
+function createCallback(): {
+	callback: HandlerCallback;
+	replies: string[];
+} {
+	const replies: string[] = [];
+	const callback: HandlerCallback = vi.fn(async (content) => {
+		if (typeof content.text === "string") replies.push(content.text);
+		return [];
+	});
+	return { callback, replies };
+}
+
+describe("runListEjected", () => {
+	it("returns a failure and reports it when the plugin manager is unavailable", async () => {
+		const { runtime, getService } = createRuntime(null);
+		const { callback, replies } = createCallback();
+
+		const result = await runListEjected({ runtime, callback });
+
+		expect(getService).toHaveBeenCalledOnce();
+		expect(getService).toHaveBeenCalledWith("plugin_manager");
+		expect(result).toEqual({
+			success: false,
+			text: "Plugin manager service not available",
+		});
+		expect(replies).toEqual(["Plugin manager service not available"]);
+	});
+
+	it("returns the complete empty-state delivery contract", async () => {
+		const listEjectedPlugins = vi.fn(async () => []);
+		const { runtime } = createRuntime({ listEjectedPlugins });
+		const { callback, replies } = createCallback();
+
+		const result = await runListEjected({ runtime, callback });
+
+		expect(listEjectedPlugins).toHaveBeenCalledOnce();
+		expect(result).toEqual({
+			success: true,
+			text: "No ejected plugins found.",
+			userFacingText: "No ejected plugins found.",
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list_ejected", count: 0 },
+		});
+		expect(replies).toEqual(["No ejected plugins found."]);
+	});
+
+	it("formats one ejected plugin and works without a callback", async () => {
+		const plugin: EjectedPluginInfo = {
+			name: "@elizaos/plugin-alpha",
+			version: "1.2.3",
+			path: "/workspace/plugins/plugin-alpha",
+			upstream: null,
+		};
+		const { runtime } = createRuntime({
+			listEjectedPlugins: async () => [plugin],
+		});
+
+		const result = await runListEjected({ runtime });
+
+		const text =
+			"Ejected plugins (1):\n" +
+			"  - @elizaos/plugin-alpha (v1.2.3) at /workspace/plugins/plugin-alpha";
+		expect(result).toEqual({
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list_ejected", count: 1 },
+			data: { plugins: [plugin] },
+		});
+	});
+
+	it("preserves service ordering when versions tie and returns every plugin", async () => {
+		const plugins: EjectedPluginInfo[] = [
+			{
+				name: "plugin-zeta",
+				version: "2.0.0",
+				path: "/ejected/zeta",
+				upstream: null,
+			},
+			{
+				name: "plugin-alpha",
+				version: "2.0.0",
+				path: "/ejected/alpha",
+				upstream: null,
+			},
+		];
+		const { runtime } = createRuntime({
+			listEjectedPlugins: async () => plugins,
+		});
+		const { callback, replies } = createCallback();
+
+		const result = await runListEjected({ runtime, callback });
+
+		const text = [
+			"Ejected plugins (2):",
+			"  - plugin-zeta (v2.0.0) at /ejected/zeta",
+			"  - plugin-alpha (v2.0.0) at /ejected/alpha",
+		].join("\n");
+		expect(result).toEqual({
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "list_ejected", count: 2 },
+			data: { plugins },
+		});
+		expect(replies).toEqual([text]);
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for `runListEjected`
- cover unavailable service, empty results, a single plugin without a callback, and multiple tied-version plugins in service order
- assert the complete callback and `ActionResult` delivery contracts while preserving the service's full plugin records

## Validation

- `bunx vitest run packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.test.ts` — 1 test file passed, 4 tests passed
- `bunx biome check --write packages/core/src/features/plugin-manager/actions/plugin-handlers/list-ejected.test.ts` — checked 1 file; no fixes applied
- `(cd packages/core && bunx tsc --noEmit)` — exited 0; `list-ejected.test.ts` appeared nowhere in output
- diff is test-only: one new test file, 135 insertions, 0 deletions

Hosted CI does not run for this fork contribution. No production behavior changes, UI evidence, live-model trajectory, or proof-run artifact applies to this test-only pull request.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0db4fabe6ed043bdbdc481d8a4a8b1c6aaaed455 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
