### PR TITLE
test(auth): cover PKCE verifier/challenge generation

### DIFF
--- a/packages/auth/src/vendor/pi-oauth/__tests__/pkce.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/__tests__/pkce.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash, randomBytes } from "node:crypto";
+
+// 用 node:crypto 替代 Web Crypto（vitest node 环境）
+const subtle = {
+  digest: async (alg: string, data: Uint8Array) => {
+    const h = createHash("sha256").update(Buffer.from(data)).digest();
+    return new Uint8Array(h);
+  },
+};
+const getRandomValues = (arr: Uint8Array) => {
+  const buf = randomBytes(arr.length);
+  arr.set(buf);
+  return arr;
+};
+
+vi.stubGlobal("crypto", { subtle, getRandomValues });
+
+import { generatePKCE } from "./pkce.ts";
+
+function b64urlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+describe("generatePKCE", () => {
+  it("produces a verifier and challenge", async () => {
+    const { verifier, challenge } = await generatePKCE();
+    expect(verifier).toBeTruthy();
+    expect(challenge).toBeTruthy();
+    expect(verifier).not.toBe(challenge);
+  });
+
+  it("challenge is the SHA-256 of the verifier (base64url)", async () => {
+    const { verifier, challenge } = await generatePKCE();
+    const expected = b64urlEncode(
+      new Uint8Array(createHash("sha256").update(verifier).digest()),
+    );
+    expect(challenge).toBe(expected);
+  });
+
+  it("generates distinct verifiers across calls (randomness)", async () => {
+    const a = await generatePKCE();
+    const b = await generatePKCE();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+
+  it("uses URL-safe base64 without padding", async () => {
+    const { verifier } = await generatePKCE();
+    expect(verifier).not.toMatch(/[+/=]/);
+  });
+});

--- a/packages/auth/src/vendor/pi-oauth/__tests__/pkce.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/__tests__/pkce.test.ts
@@ -16,7 +16,7 @@ const getRandomValues = (arr: Uint8Array) => {
 
 vi.stubGlobal("crypto", { subtle, getRandomValues });
 
-import { generatePKCE } from "./pkce.ts";
+import { generatePKCE } from "../pkce.ts";
 
 function b64urlEncode(bytes: Uint8Array): string {
   return Buffer.from(bytes)


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
