### PR TITLE
test(core): cover core-status

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.test.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Exercises the core-status action handler's planner-facing output for packaged,
+ * ejected, unavailable, and incomplete upstream states using the real handler.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import type {
+	CoreStatus,
+	UpstreamMetadata,
+} from "../../services/coreManagerService.ts";
+import { runCoreStatus } from "./core-status.ts";
+
+const BASE_STATUS: CoreStatus = {
+	ejected: false,
+	ejectedPath: "/state/core",
+	monorepoPath: "/state/core/eliza",
+	corePackagePath: "/state/core/eliza/packages/core",
+	coreDistPath: "/state/core/eliza/packages/core/dist",
+	version: "2.0.0",
+	npmVersion: "2.0.3-beta.7",
+	commitHash: null,
+	localChanges: false,
+	upstream: null,
+};
+
+const UPSTREAM: UpstreamMetadata = {
+	$schema: "eliza-upstream-v1",
+	source: "github:elizaos/eliza",
+	gitUrl: "https://github.com/elizaOS/eliza.git",
+	branch: "develop",
+	commitHash: "upstream-commit",
+	ejectedAt: "2026-08-20T10:00:00.000Z",
+	npmPackage: "@elizaos/core",
+	npmVersion: "2.0.3-beta.7",
+	lastSyncAt: "2026-08-22T12:30:00.000Z",
+	localCommits: 2,
+};
+
+function createRuntime(status: CoreStatus | null): {
+	runtime: IAgentRuntime;
+	serviceNames: string[];
+	statusReads: () => number;
+} {
+	const serviceNames: string[] = [];
+	let reads = 0;
+	const service =
+		status === null
+			? null
+			: {
+					getCoreStatus: async () => {
+						reads += 1;
+						return status;
+					},
+				};
+
+	return {
+		runtime: {
+			getService: (name: string) => {
+				serviceNames.push(name);
+				return service;
+			},
+		} as unknown as IAgentRuntime,
+		serviceNames,
+		statusReads: () => reads,
+	};
+}
+
+describe("runCoreStatus", () => {
+	it("returns a structured failure when the core manager is unavailable", async () => {
+		const { runtime, serviceNames, statusReads } = createRuntime(null);
+		let callbackCalls = 0;
+
+		const result = await runCoreStatus({
+			runtime,
+			callback: async () => {
+				callbackCalls += 1;
+				return [];
+			},
+		});
+
+		expect(result).toEqual({
+			success: false,
+			text: "Core manager service not available",
+		});
+		expect(serviceNames).toEqual(["core_manager"]);
+		expect(statusReads()).toBe(0);
+		expect(callbackCalls).toBe(0);
+	});
+
+	it("reports the packaged npm version and complete status data", async () => {
+		const { runtime, statusReads } = createRuntime(BASE_STATUS);
+
+		const result = await runCoreStatus({ runtime });
+
+		expect(result).toEqual({
+			success: true,
+			text: "Core is using NPM package (v2.0.3-beta.7). Not ejected.",
+			values: { mode: "core_status", ejected: false },
+			data: {
+				ejected: false,
+				ejectedPath: "/state/core",
+				monorepoPath: "/state/core/eliza",
+				corePackagePath: "/state/core/eliza/packages/core",
+				coreDistPath: "/state/core/eliza/packages/core/dist",
+				version: "2.0.0",
+				npmVersion: "2.0.3-beta.7",
+				commitHash: undefined,
+				localChanges: false,
+				upstream: undefined,
+			},
+		});
+		expect(statusReads()).toBe(1);
+	});
+
+	it("renders ejected status fields and upstream metadata in order", async () => {
+		const status: CoreStatus = {
+			...BASE_STATUS,
+			ejected: true,
+			version: "2.1.0-local",
+			commitHash: "abc1234",
+			localChanges: true,
+			upstream: UPSTREAM,
+		};
+		const { runtime } = createRuntime(status);
+
+		const result = await runCoreStatus({ runtime });
+
+		expect(result.text).toBe(
+			[
+				"Core is EJECTED at /state/core",
+				"Version: 2.1.0-local",
+				"Commit: abc1234",
+				"Local changes: yes",
+				"Upstream: https://github.com/elizaOS/eliza.git#develop",
+				"Last sync: 2026-08-22T12:30:00.000Z",
+			].join("\n"),
+		);
+		expect(result.values).toEqual({ mode: "core_status", ejected: true });
+		expect(result.data).toMatchObject({
+			commitHash: "abc1234",
+			localChanges: true,
+			upstream: UPSTREAM,
+		});
+	});
+
+	it("uses fallback labels for a missing commit and never-synced upstream", async () => {
+		const neverSyncedUpstream: UpstreamMetadata = {
+			...UPSTREAM,
+			lastSyncAt: null,
+		};
+		const status: CoreStatus = {
+			...BASE_STATUS,
+			ejected: true,
+			commitHash: null,
+			upstream: neverSyncedUpstream,
+		};
+		const { runtime } = createRuntime(status);
+
+		const result = await runCoreStatus({ runtime });
+
+		expect(result.text).toContain("Commit: unknown");
+		expect(result.text).toContain("Local changes: no");
+		expect(result.text).toContain("Last sync: never");
+		expect(result.data?.commitHash).toBeUndefined();
+		expect(result.data?.upstream).toEqual(neverSyncedUpstream);
+	});
+
+	it("omits upstream lines when an ejected core has no upstream metadata", async () => {
+		const status: CoreStatus = {
+			...BASE_STATUS,
+			ejected: true,
+			commitHash: "detached-head",
+		};
+		const { runtime } = createRuntime(status);
+
+		const result = await runCoreStatus({ runtime });
+
+		expect(result.text).toBe(
+			[
+				"Core is EJECTED at /state/core",
+				"Version: 2.0.0",
+				"Commit: detached-head",
+				"Local changes: no",
+			].join("\n"),
+		);
+		expect(result.text).not.toContain("Upstream:");
+		expect(result.text).not.toContain("Last sync:");
+		expect(result.data?.upstream).toBeUndefined();
+	});
+});


### PR DESCRIPTION

# Relates to

Operator-requested coverage for the core plugin manager's status handler.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run; this test-only PR used the explicitly requested focused Vitest, Biome, and owning-package TypeScript checks.
- [x] A reviewer can confirm the handler contract from the focused test output and assertions below.

# Sync with develop

- [x] Based on the latest `origin/develop`; GitHub compare reported `behind_by: 0` before filing.
- [ ] `bun run verify` was not run; see **Known gaps / failures**.

# Risks

Low. The diff adds one unit-test file and changes no production code. The tests exercise the real `runCoreStatus` handler with deterministic service-boundary status values.

# Background

## What does this PR do?

Adds direct unit coverage for all meaningful `runCoreStatus` branches:

- unavailable `core_manager` service and planner-only callback behavior;
- packaged npm core status;
- ejected core status with ordered upstream details;
- missing commit and never-synced fallbacks;
- ejected status without upstream metadata.

The suite also verifies the `core_manager` service lookup, returned values/data payloads, and that status is read exactly once on the success path.

## What kind of change is this?

Tests only; no production behavior changes.

# Documentation changes needed?

No. This adds coverage for the existing handler contract.

# Testing

## Where should a reviewer start?

`packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.test.ts`

## Detailed testing steps

- `bunx vitest run packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.test.ts`
  - Result after the final `origin/develop` refresh: **1 test file passed, 5 tests passed**.
- `bunx biome check --write packages/core/src/features/plugin-manager/actions/plugin-handlers/core-status.test.ts`
  - Result: **Checked 1 file; no fixes applied**.
- From `packages/core`: `bunx tsc --noEmit`
  - Result: **exit 0, zero diagnostic lines**.
  - `grep 'core-status.test.ts'` over the captured output returned no matches (`exit 1`).
- Remote diff check: **one added test file, 191 additions, 0 deletions**.

Hosted CI does not run for fork-contributor pull requests; no hosted-CI pass is claimed.

# Evidence Gate

Evidence matches commit `baf3c094eea87958c8bf45cd7131885384e8d0db`.
<!-- evidence-head:baf3c094eea87958c8bf45cd7131885384e8d0db -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only TypeScript diff with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only TypeScript diff with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or UI behavior changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/server behavior changed; focused unit-test output is quoted above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, or action production behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or artifact is produced by this test-only change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only coverage; no model call path changed.

## Backend + frontend logs

N/A - test-only coverage; no backend or frontend runtime path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` was intentionally not run under the operator-defined evidence scope for this test-only pull request.
- No receipt or interactive identity trace was created because the unattended session cannot finalize the required OAuth consent.
- Hosted CI is unavailable for fork-contributor pull requests, so no hosted-CI result is claimed.

## Maintainer CI exception record

N/A - no exception requested.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
