### PR TITLE
fix(orchestrator): preserve typed coding failures across ACP

### DIFF
--- a/packages/examples/code/src/acp-terminal-failure.test.ts
+++ b/packages/examples/code/src/acp-terminal-failure.test.ts
@@ -1,0 +1,31 @@
+/** Tests the typed failure receipt exported by the eliza-code ACP boundary. */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { terminalFailureFromAgentClientError } from "./acp-terminal-failure.js";
+
+describe("terminalFailureFromAgentClientError", () => {
+  it("preserves kind, code, retryability, and complete message", () => {
+    const error = new ElizaError("Verification did not complete.", {
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: {
+        failureKind: "coding_mutation_unverified",
+        failureCode: "VERIFY_REQUIRED",
+        transient: false,
+      },
+      severity: "fatal",
+    });
+
+    expect(terminalFailureFromAgentClientError(error)).toEqual({
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Verification did not complete.",
+    });
+  });
+
+  it("does not translate unrelated failures", () => {
+    expect(
+      terminalFailureFromAgentClientError(new Error("transport failed")),
+    ).toBeUndefined();
+  });
+});

--- a/packages/examples/code/src/acp-terminal-failure.ts
+++ b/packages/examples/code/src/acp-terminal-failure.ts
@@ -1,0 +1,41 @@
+/**
+ * Converts the coding runtime's typed failed-turn exception into the ACP
+ * prompt-result extension consumed by the parent orchestrator.
+ */
+import { ElizaError } from "@elizaos/core";
+
+export interface AcpTerminalFailureReceipt {
+  kind: string;
+  code?: string;
+  transient: boolean;
+  message: string;
+}
+
+/** Preserve only the dedicated failed-turn exception; unrelated faults throw. */
+export function terminalFailureFromAgentClientError(
+  error: unknown,
+): AcpTerminalFailureReceipt | undefined {
+  if (
+    !(error instanceof ElizaError) ||
+    error.code !== "ELIZA_CODE_SYNTHETIC_TURN_FAILURE"
+  ) {
+    return undefined;
+  }
+  const context = error.context;
+  if (!context) return undefined;
+  const kind =
+    typeof context.failureKind === "string" && context.failureKind.trim()
+      ? context.failureKind.trim()
+      : undefined;
+  if (!kind || typeof context.transient !== "boolean") return undefined;
+  const code =
+    typeof context.failureCode === "string" && context.failureCode.trim()
+      ? context.failureCode.trim()
+      : undefined;
+  return {
+    kind,
+    ...(code ? { code } : {}),
+    transient: context.transient,
+    message: error.message,
+  };
+}

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -44,6 +44,7 @@ import {
 } from "@elizaos/plugin-coding-tools";
 import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { publishParsedReply } from "./acp-response.js";
+import { terminalFailureFromAgentClientError } from "./acp-terminal-failure.js";
 import { AcpActivePromptRegistry } from "./acp-active-prompts.js";
 import {
   type AcpToolCallUpdate,
@@ -378,21 +379,40 @@ const _connection = new AgentSideConnection(
         publish: (update: Parameters<typeof conn.sessionUpdate>[0]) =>
           conn.sessionUpdate(update),
       };
-      const response = await activePrompts.run(promptContext, (abortSignal) =>
-        getAgentClient().sendMessage({
-          room,
-          text,
-          identity: sessionIdentity,
-          source: "acp",
-          codingMode: true,
-          abortSignal,
-        }),
-      );
-      await publishParsedReply(params.sessionId, response, (update) =>
-        conn.sessionUpdate(update),
-      );
-      log("prompt done", { response: response.length });
-      return { stopReason: "end_turn" };
+      try {
+        const response = await activePrompts.run(promptContext, (abortSignal) =>
+          getAgentClient().sendMessage({
+            room,
+            text,
+            identity: sessionIdentity,
+            source: "acp",
+            codingMode: true,
+            abortSignal,
+          }),
+        );
+        await publishParsedReply(params.sessionId, response, (update) =>
+          conn.sessionUpdate(update),
+        );
+        log("prompt done", { response: response.length });
+        return { stopReason: "end_turn" };
+      } catch (error) {
+        // error-policy:J1 The ACP request boundary converts only the runtime's
+        // authoritative failed-turn receipt. Transport and programming faults
+        // still reject the JSON-RPC request normally.
+        const terminalFailure = terminalFailureFromAgentClientError(error);
+        if (!terminalFailure) throw error;
+        log("prompt terminal failure", {
+          kind: terminalFailure.kind,
+          transient: terminalFailure.transient,
+        });
+        return {
+          // ACP's standard StopReason union has no `error` member. The typed
+          // receipt is authoritative and the orchestrator maps it to its
+          // internal error stop reason without emitting an invalid ACP value.
+          stopReason: "end_turn",
+          _meta: { terminalFailure },
+        };
+      }
     },
     async cancel(params: { sessionId?: string }) {
       const sessionId = params?.sessionId;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -311,6 +311,63 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     await expect(cancelled).resolves.toEqual({ stopReason: "cancelled" });
   });
 
+  it("preserves an authoritative terminal failure from prompt metadata", async () => {
+    const { client, p } = await startClient();
+    const prompted = client.prompt("session-1", "change and verify it");
+    await waitForWrites(p, 2);
+
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        stopReason: "end_turn",
+        _meta: {
+          terminalFailure: {
+            kind: "coding_mutation_unverified",
+            code: "VERIFY_REQUIRED",
+            transient: false,
+            message: "The mutation was not verified.",
+          },
+        },
+      },
+    });
+
+    await expect(prompted).resolves.toEqual({
+      stopReason: "end_turn",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        code: "VERIFY_REQUIRED",
+        transient: false,
+        message: "The mutation was not verified.",
+      },
+    });
+  });
+
+  it("rejects malformed terminal failure metadata instead of dropping it", async () => {
+    const { client, p } = await startClient();
+    const prompted = client.prompt("session-1", "change and verify it");
+    await waitForWrites(p, 2);
+
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        stopReason: "end_turn",
+        _meta: {
+          terminalFailure: {
+            kind: "coding_mutation_unverified",
+            transient: "no",
+            message: "The mutation was not verified.",
+          },
+        },
+      },
+    });
+
+    await expect(prompted).rejects.toThrow(
+      "ACP terminalFailure requires kind, message, transient",
+    );
+  });
+
   it("triggers cancellation when a prompt request times out", async () => {
     vi.useFakeTimers();
     const { client, p } = await startClient({ timeoutMs: 10 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -2109,6 +2109,273 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
+  it("CLI sendPrompt preserves the untyped error-with-deliverable completion heuristic", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-untyped-error-with-output",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "build it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-untyped-error",
+          result: {
+            stopReason: "error",
+            content: [{ type: "text", text: "Verified deliverable." }],
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    closeOk(prompt);
+
+    const result = await sent;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: "Verified deliverable.",
+    });
+    expect(result.error).toBeUndefined();
+    expect(events).toEqual(["task_complete"]);
+    expect((await service.getSession(sessionId))?.status).toBe("ready");
+  });
+
+  it("CLI typed failure suppresses generic auth/crash handling on nonzero exit", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-typed-terminal-failure",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Files changed, but verification did not complete.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-typed-failure",
+          result: {
+            stopReason: "end_turn",
+            content: [{ type: "text", text: terminalFailure.message }],
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    prompt.proc.stderr.emit(
+      "data",
+      Buffer.from("401 Unauthorized token expired"),
+    );
+    prompt.proc.emit("close", 1, null);
+
+    const result = await sent;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: terminalFailure.message,
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect(await service.getSession(sessionId)).toMatchObject({
+      status: "errored",
+      lastError: terminalFailure.message,
+    });
+  });
+
+  it("CLI protocol failure suppresses generic crash persistence on nonzero exit", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-malformed-terminal-failure",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    expect(() =>
+      prompt.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: "req-malformed-failure",
+            result: {
+              stopReason: "end_turn",
+              content: [{ type: "text", text: "Unverified prose." }],
+              _meta: {
+                terminalFailure: {
+                  kind: "coding_mutation_unverified",
+                  transient: "no",
+                  message: "Unverified prose.",
+                },
+              },
+            },
+            sessionId,
+          })}\n`,
+        ),
+      ),
+    ).not.toThrow();
+    prompt.proc.stderr.emit("data", Buffer.from("subprocess crashed"));
+    prompt.proc.emit("close", 2, null);
+
+    const result = await sent;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toMatchObject({
+      failureKind: "protocol_error",
+      stopReason: "error",
+    });
+    expect(await service.getSession(sessionId)).toMatchObject({
+      status: "errored",
+      lastError: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+  });
+
+  it.each([
+    {
+      label: "typed terminal failure",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        transient: false,
+        message: "Typed failure remains authoritative.",
+      },
+      expectedFailureKind: "coding_mutation_unverified",
+      expectedLastError: "Typed failure remains authoritative.",
+    },
+    {
+      label: "malformed terminal receipt",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        transient: "no",
+        message: "Malformed failure receipt.",
+      },
+      expectedFailureKind: "protocol_error",
+      expectedLastError:
+        "ACP terminalFailure requires kind, message, transient",
+    },
+  ])(
+    "keeps $label exactly once across an auth-like nonzero exit",
+    async ({
+      label,
+      terminalFailure,
+      expectedFailureKind,
+      expectedLastError,
+    }) => {
+      const create = nextProc();
+      const service = new AcpService(runtime());
+      const events: Array<{ event: string; payload: unknown }> = [];
+      service.onSessionEvent((_sid, event, payload) => {
+        events.push({ event, payload });
+      });
+      await service.start();
+      const spawned = service.spawnSession({
+        name: `exactly-once-${label.replaceAll(" ", "-")}`,
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+      await waitForSpawn(create);
+      closeOk(create);
+      const { sessionId } = await spawned;
+      events.length = 0;
+
+      const prompt = nextProc();
+      const sent = service.sendPrompt(sessionId, "verify it");
+      await waitForSpawn(prompt);
+      prompt.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: `req-${label}`,
+            result: {
+              stopReason: "end_turn",
+              _meta: { terminalFailure },
+            },
+            sessionId,
+          })}\n`,
+        ),
+      );
+      prompt.proc.stderr.emit(
+        "data",
+        Buffer.from("401 Unauthorized token expired"),
+      );
+      prompt.proc.emit("close", 3, null);
+
+      const result = await sent;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(result.stopReason).toBe("error");
+      expect(events.map(({ event }) => event)).toEqual(["error"]);
+      expect(events[0]?.payload).toMatchObject({
+        failureKind: expectedFailureKind,
+      });
+      expect(await service.getSession(sessionId)).toMatchObject({
+        status: "errored",
+        lastError: expect.stringContaining(expectedLastError),
+      });
+    },
+  );
+
   it("flushes raw stdout before advertising stdoutLogPath on task_complete", async () => {
     const priorTrajDir = process.env.ELIZA_TRAJECTORY_DIR;
     const priorRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
@@ -2346,6 +2613,59 @@ describe("AcpService", () => {
     expect(result.finalText).toBe("Deployed the site to https://x.io");
     // Durable store is NOT flipped to errored — the work succeeded for the user.
     expect((await service.getSession(sessionId))?.status).not.toBe("errored");
+  });
+
+  it("native sendPrompt never promotes a typed terminal failure with prose to task_complete", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-typed-error-with-output",
+      agentType: "elizaos",
+      workdir: "/tmp/acp-test",
+    });
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Files changed, but verification did not complete.",
+    };
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        sessionId: "protocol-session",
+        result: {
+          stopReason: "error",
+          content: [{ type: "text", text: terminalFailure.message }],
+          _meta: { terminalFailure },
+        },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn", terminalFailure };
+    });
+
+    const result = await service.sendPrompt(sessionId, "build it");
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: terminalFailure.message,
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map((event) => event.event)).toContain("error");
+    expect(events.map((event) => event.event)).not.toContain("task_complete");
+    expect(events.find((event) => event.event === "error")?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
   });
 
   // The other half of Fix #2: a true failure (stopReason error AND no captured
@@ -2587,8 +2907,8 @@ describe("AcpService", () => {
     await new Promise((resolve) => setImmediate(resolve));
     const cancelled = service.cancelSession(sessionId);
     resolvePrompt({ stopReason: "cancelled" });
-    await cancelled;
     const result = await sent;
+    await cancelled;
 
     expect(client.cancel).toHaveBeenCalledWith("protocol-session");
     expect(result.stopReason).toBe("cancelled");
@@ -2928,6 +3248,57 @@ describe("AcpService", () => {
     );
   });
 
+  it("cancels a CLI prompt during credential setup without spawning a prompt process", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cancel-during-credentials",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    let markCredentialsStarted: () => void = () => undefined;
+    const credentialsStarted = new Promise<void>((resolve) => {
+      markCredentialsStarted = resolve;
+    });
+    let releaseCredentials: (value: Record<string, string>) => void = () =>
+      undefined;
+    const delayedCredentials = new Promise<Record<string, string>>(
+      (resolve) => {
+        releaseCredentials = resolve;
+      },
+    );
+    const internal = service as unknown as {
+      accountCredentialsForSession(
+        session: unknown,
+      ): Promise<Record<string, string> | undefined>;
+    };
+    vi.spyOn(internal, "accountCredentialsForSession").mockImplementationOnce(
+      async () => {
+        markCredentialsStarted();
+        return delayedCredentials;
+      },
+    );
+    const spawnCountBeforePrompt = spawnMock.mock.calls.length;
+    const sent = service.sendPrompt(sessionId, "start slowly");
+    await credentialsStarted;
+    const cancelled = service.cancelSession(sessionId);
+
+    const [result] = await Promise.all([sent, cancelled.then(() => undefined)]);
+    releaseCredentials({});
+    expect(result).toMatchObject({ stopReason: "cancelled" });
+    expect(spawnMock.mock.calls).toHaveLength(spawnCountBeforePrompt);
+    expect(events).toEqual(["cancelled"]);
+    expect((await service.getSession(sessionId))?.status).toBe("cancelled");
+  });
+
   it("cancelSession sends SIGTERM then SIGKILL after grace", async () => {
     const create = nextProc();
     const service = new AcpService(runtime());
@@ -2982,6 +3353,253 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("cancelled");
     expect(events).toContain("cancelled");
     expect(events).not.toContain("error");
+  });
+
+  it("keeps a typed CLI terminal failure authoritative over a later cancellation", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "typed-failure-cancel-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const internalStore = (
+      service as unknown as {
+        store: {
+          updateStatus(
+            id: string,
+            status: string,
+            error?: string,
+          ): Promise<unknown>;
+        };
+      }
+    ).store;
+    const originalUpdateStatus = internalStore.updateStatus.bind(internalStore);
+    const statusWrites: string[] = [];
+    let releaseDelayedCancelledWrite: () => void = () => undefined;
+    const delayedCancelledWrite = new Promise<void>((resolve) => {
+      releaseDelayedCancelledWrite = resolve;
+    });
+    vi.spyOn(internalStore, "updateStatus").mockImplementation(
+      async (id, status, error) => {
+        statusWrites.push(status);
+        if (status === "cancelled") await delayedCancelledWrite;
+        return originalUpdateStatus(id, status, error);
+      },
+    );
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Verification failed before cancellation arrived.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-typed-cancel-race",
+          result: {
+            stopReason: "end_turn",
+            content: [{ type: "text", text: terminalFailure.message }],
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    prompt.proc.emit("close", 130, "SIGTERM");
+
+    const result = await sent;
+    // If cancelSession started its own durable write, release it only after the
+    // prompt's errored write has landed. The old two-writer implementation then
+    // finished as cancelled and failed the assertions below.
+    releaseDelayedCancelledWrite();
+    await cancelled;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect(statusWrites).not.toContain("cancelled");
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
+  });
+
+  it("keeps prompt ownership after process close until delayed error persistence settles", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "post-close-persistence-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const internalStore = (
+      service as unknown as {
+        store: {
+          updateStatus(
+            id: string,
+            status: string,
+            error?: string,
+          ): Promise<unknown>;
+        };
+      }
+    ).store;
+    const originalUpdateStatus = internalStore.updateStatus.bind(internalStore);
+    const statusWrites: string[] = [];
+    let markErroredWriteStarted: () => void = () => undefined;
+    const erroredWriteStarted = new Promise<void>((resolve) => {
+      markErroredWriteStarted = resolve;
+    });
+    let releaseErroredWrite: () => void = () => undefined;
+    const delayedErroredWrite = new Promise<void>((resolve) => {
+      releaseErroredWrite = resolve;
+    });
+    vi.spyOn(internalStore, "updateStatus").mockImplementation(
+      async (id, status, error) => {
+        statusWrites.push(status);
+        if (status === "errored") {
+          markErroredWriteStarted();
+          await delayedErroredWrite;
+        }
+        return originalUpdateStatus(id, status, error);
+      },
+    );
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      transient: false,
+      message: "The terminal receipt owns settlement.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "finish");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-post-close-race",
+          result: {
+            stopReason: "end_turn",
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    prompt.proc.emit("close", 0, null);
+    await erroredWriteStarted;
+    const spawnCountAtClose = spawnMock.mock.calls.length;
+    const fallbackCancel = nextProc();
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    if (spawnMock.mock.calls.length > spawnCountAtClose)
+      closeOk(fallbackCancel);
+    releaseErroredWrite();
+
+    const [result] = await Promise.all([sent, cancelled.then(() => undefined)]);
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(spawnMock.mock.calls).toHaveLength(spawnCountAtClose);
+    expect(statusWrites).not.toContain("cancelled");
+    expect(events).toEqual(["error"]);
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
+  });
+
+  it("keeps a malformed CLI receipt error authoritative over a later cancellation", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "protocol-error-cancel-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-malformed-cancel-race",
+          result: {
+            stopReason: "end_turn",
+            _meta: {
+              terminalFailure: {
+                kind: "coding_mutation_unverified",
+                transient: "no",
+                message: "Malformed receipt.",
+              },
+            },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    prompt.proc.emit("close", 130, "SIGTERM");
+
+    await cancelled;
+    const result = await sent;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toMatchObject({
+      failureKind: "protocol_error",
+      stopReason: "error",
+    });
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
   });
 
   it("ignores malformed NDJSON without crashing", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -10,7 +10,12 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
-import type { AcpJsonRpcMessage, ApprovalPreset } from "./types.js";
+import {
+  type AcpJsonRpcMessage,
+  type AcpTerminalFailure,
+  type ApprovalPreset,
+  readAcpTerminalFailure,
+} from "./types.js";
 
 export type NativeAcpEventCallback = (
   event: AcpJsonRpcMessage,
@@ -99,6 +104,7 @@ export type NativeAcpSessionClaim = {
 
 export type NativeAcpPromptResult = {
   stopReason: string;
+  terminalFailure?: AcpTerminalFailure;
 };
 
 type JsonRpcId = string | number | null;
@@ -308,8 +314,10 @@ export class NativeAcpClient {
       },
     ).then((value) => {
       const result = asRecord(value);
+      const terminalFailure = readAcpTerminalFailure(result);
       return {
         stopReason: stringValue(result?.stopReason) ?? "end_turn",
+        ...(terminalFailure ? { terminalFailure } : {}),
       };
     });
     this.activePrompts.set(sessionId, prompt);

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -134,11 +134,13 @@ import {
   type AcpCapacity,
   type AcpEventCallback,
   type AcpJsonRpcMessage,
+  type AcpTerminalFailure,
   type AcpToolCall,
   type AgentType,
   type ApprovalPreset,
   type AvailableAgentInfo,
   type PromptResult,
+  readAcpTerminalFailure,
   type SendOptions,
   SessionCapError,
   type SessionEventCallback,
@@ -230,6 +232,8 @@ type RunResult = {
   stderr: string;
   finalText: string;
   stopReason?: string;
+  terminalFailure?: AcpTerminalFailure;
+  protocolError?: string;
   cancelled?: boolean;
   durationMs: number;
 };
@@ -950,7 +954,15 @@ export class AcpService extends Service {
   // the completed turn through the session's next task metadata (#18490).
   private readonly promptTurns = new Map<
     string,
-    { id: string; sessionSnapshot: SessionInfo }
+    {
+      id: string;
+      sessionSnapshot: SessionInfo;
+      settled: Promise<void>;
+      resolveSettled: () => void;
+      cancelRequested: boolean;
+      cancellationRequested: Promise<void>;
+      resolveCancellationRequested: () => void;
+    }
   >();
   private readonly acpCallbacks: AcpEventCallback[] = [];
   private readonly activeProcesses = new Map<string, ProcessRecord>();
@@ -2388,17 +2400,31 @@ export class AcpService extends Service {
     if (this.promptTurns.has(sessionId)) {
       throw new Error(`ACP session is already busy: ${sessionId}`);
     }
+    let resolveSettled: () => void = () => undefined;
+    const settled = new Promise<void>((resolve) => {
+      resolveSettled = resolve;
+    });
+    let resolveCancellationRequested: () => void = () => undefined;
+    const cancellationRequested = new Promise<void>((resolve) => {
+      resolveCancellationRequested = resolve;
+    });
     const turn = {
       id: randomUUID(),
       sessionSnapshot: {
         ...session,
         metadata: session.metadata ? { ...session.metadata } : undefined,
       },
+      settled,
+      resolveSettled,
+      cancelRequested: false,
+      cancellationRequested,
+      resolveCancellationRequested,
     };
     this.promptTurns.set(sessionId, turn);
     try {
       return await this.sendPromptTurn(session, text, opts);
     } finally {
+      turn.resolveSettled();
       if (this.promptTurns.get(sessionId)?.id === turn.id) {
         this.promptTurns.delete(sessionId);
       }
@@ -2412,13 +2438,44 @@ export class AcpService extends Service {
   ): Promise<PromptResult> {
     const sessionId = session.id;
     const transportMode = sessionTransportMode(session, this.transportMode);
+    const startedAt = Date.now();
+    const settlePreProcessCancellation = async (): Promise<PromptResult> => {
+      await this.store.updateStatus(sessionId, "cancelled");
+      this.emitSessionEvent(sessionId, "cancelled", {
+        sessionId,
+        response: "",
+        exitCode: null,
+        signal: null,
+      });
+      return {
+        sessionId,
+        response: "",
+        finalText: "",
+        stopReason: "cancelled",
+        durationMs: Date.now() - startedAt,
+        exitCode: null,
+        signal: null,
+      };
+    };
+    const raceCancellation = async <T>(operation: Promise<T>) => {
+      const turn = this.promptTurns.get(sessionId);
+      if (!turn) return { cancelled: false as const, value: await operation };
+      if (turn.cancelRequested) return { cancelled: true as const };
+      return Promise.race([
+        operation.then((value) => ({ cancelled: false as const, value })),
+        turn.cancellationRequested.then(() => ({ cancelled: true as const })),
+      ]);
+    };
     if (
       transportMode !== "native" &&
       session.acpxSessionId &&
       !this.nativeClients.has(sessionId)
     ) {
-      const exists = await this.hasAcpxSessionState(session.acpxSessionId);
-      if (!exists) {
+      const stateCheck = await raceCancellation(
+        this.hasAcpxSessionState(session.acpxSessionId),
+      );
+      if (stateCheck.cancelled) return settlePreProcessCancellation();
+      if (!stateCheck.value) {
         this.logSubAgentStateLost(session, "send-prompt");
         const message =
           "Sub-agent state was lost (process exited without persisting). No automatic action taken.";
@@ -2430,7 +2487,6 @@ export class AcpService extends Service {
         throw new Error(message);
       }
     }
-    const startedAt = Date.now();
     const promptModel =
       session.agentType === "claude"
         ? normalizeClaudeAcpModelId(opts.model)
@@ -2463,7 +2519,6 @@ export class AcpService extends Service {
       }
     }
     this.turnOutputBuffers.set(sessionId, []);
-    await this.store.updateStatus(sessionId, "busy");
     const args = this.baseArgs({
       workdir: session.workdir,
       approvalPreset: session.approvalPreset,
@@ -2484,16 +2539,32 @@ export class AcpService extends Service {
     // session's selected-account credentials (the native transport keeps the
     // spawn-time client, which already has them) and the per-session git index
     // env that keeps same-repo sessions from sharing one mutable index file.
-    let promptCredentials: Record<string, string> | undefined;
-    try {
-      promptCredentials = await this.accountCredentialsForSession(session);
-    } catch (err) {
+    const credentialResult = await raceCancellation(
+      this.accountCredentialsForSession(session),
+    ).catch((error: unknown) => ({
+      cancelled: false as const,
+      error,
+    }));
+    if (credentialResult.cancelled) return settlePreProcessCancellation();
+    if ("error" in credentialResult) {
       // error-policy:J1 The CLI prompt boundary persists the typed account
       // failure before propagating it; no subprocess may inherit ambient
       // credentials after a session's pinned account pool is exhausted.
-      const message = errorMessage(err);
-      await this.recordAccountCredentialFailure(session, err, message);
-      throw err;
+      const message = errorMessage(credentialResult.error);
+      await this.recordAccountCredentialFailure(
+        session,
+        credentialResult.error,
+        message,
+      );
+      throw credentialResult.error;
+    }
+    const promptCredentials = credentialResult.value;
+    if (this.promptTurns.get(sessionId)?.cancelRequested) {
+      return settlePreProcessCancellation();
+    }
+    await this.store.updateStatus(sessionId, "busy");
+    if (this.promptTurns.get(sessionId)?.cancelRequested) {
+      return settlePreProcessCancellation();
     }
     const promptEnv: Record<string, string> = {
       ...(opts.env ?? {}),
@@ -2519,12 +2590,14 @@ export class AcpService extends Service {
     });
 
     const stopReason =
-      result.stopReason ??
-      (result.cancelled
-        ? "cancelled"
-        : result.code === 0
-          ? "end_turn"
-          : "error");
+      result.terminalFailure || result.protocolError
+        ? "error"
+        : (result.stopReason ??
+          (result.cancelled
+            ? "cancelled"
+            : result.code === 0
+              ? "end_turn"
+              : "error"));
     const promptResult: PromptResult = {
       sessionId,
       response: result.finalText,
@@ -2533,17 +2606,42 @@ export class AcpService extends Service {
       durationMs: result.durationMs || Date.now() - startedAt,
       exitCode: result.code,
       signal: result.signal,
-      ...(result.code !== 0 && !result.cancelled
-        ? { error: this.classifyExitError(result.code, result.stderr) }
-        : {}),
+      ...(result.terminalFailure
+        ? {
+            error: result.terminalFailure.message,
+            terminalFailure: result.terminalFailure,
+          }
+        : result.protocolError
+          ? { error: result.protocolError }
+          : result.code !== 0 && !result.cancelled
+            ? { error: this.classifyExitError(result.code, result.stderr) }
+            : {}),
     };
+
+    if (result.terminalFailure || result.protocolError) {
+      // An authoritative failed-turn receipt or invalid protocol result was
+      // observed before the subprocess closed. It outranks a later cancel race
+      // so the event, durable status, and returned result all remain an error.
+      await this.store.updateStatus(
+        sessionId,
+        "errored",
+        promptResult.error ?? "ACP prompt failed",
+      );
+      return promptResult;
+    }
 
     if (result.cancelled || stopReason === "cancelled") {
       await this.store.updateStatus(sessionId, "cancelled");
       return promptResult;
     }
 
-    if (result.code === 0 && stopReason !== "error") {
+    if (
+      (result.code === 0 || result.code === null) &&
+      (stopReason !== "error" || result.finalText.trim().length > 0)
+    ) {
+      // Preserve the legacy untyped ACP heuristic: an error stop reason after
+      // a captured deliverable remains a completion. Typed and malformed
+      // receipts returned above before they can enter this branch.
       await this.store.update(sessionId, {
         status: "ready",
         lastActivityAt: new Date(),
@@ -2565,6 +2663,32 @@ export class AcpService extends Service {
   }
 
   async cancelSession(sessionId: string): Promise<void> {
+    const ownedPromptTurn = this.promptTurns.get(sessionId);
+    if (
+      ownedPromptTurn &&
+      sessionTransportMode(
+        ownedPromptTurn.sessionSnapshot,
+        this.transportMode,
+      ) !== "native"
+    ) {
+      ownedPromptTurn.cancelRequested = true;
+      ownedPromptTurn.resolveCancellationRequested();
+      const active = this.activeProcesses.get(sessionId);
+      if (active) {
+        active.cancelled = true;
+        this.terminateProcess(sessionId, active);
+      }
+      // Consult prompt ownership before any store lookup or process lookup.
+      // The turn spans setup, child execution, close, and durable settlement,
+      // so no fallback acpx cancel or competing status write may begin here.
+      await ownedPromptTurn.settled;
+      this.workspaceRegistry.markTerminal(
+        ownedPromptTurn.sessionSnapshot.workdir,
+      );
+      void this.revokeModelLease(sessionId, "cancelSession");
+      await this.removeOwnedGitIndex(ownedPromptTurn.sessionSnapshot);
+      return;
+    }
     const session = await this.requireSession(sessionId);
     const transportMode = sessionTransportMode(session, this.transportMode);
     if (transportMode === "native") {
@@ -2608,23 +2732,17 @@ export class AcpService extends Service {
       await this.removeOwnedGitIndex(session);
       return;
     }
-    const active = this.activeProcesses.get(sessionId);
-    if (active) {
-      active.cancelled = true;
-      this.terminateProcess(sessionId, active);
-    } else {
-      const args = this.agentCommandArgs(session.agentType, [
-        "cancel",
-        "-s",
-        session.name ?? session.id,
-      ]);
-      await this.runAcpx({
-        sessionId,
-        agentType: session.agentType,
-        workdir: session.workdir,
-        args,
-      });
-    }
+    const args = this.agentCommandArgs(session.agentType, [
+      "cancel",
+      "-s",
+      session.name ?? session.id,
+    ]);
+    await this.runAcpx({
+      sessionId,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      args,
+    });
     await this.store.updateStatus(sessionId, "cancelled");
     this.workspaceRegistry.markTerminal(session.workdir);
     void this.revokeModelLease(sessionId, "cancelSession");
@@ -3587,29 +3705,39 @@ export class AcpService extends Service {
         : cancelled
           ? "cancelled"
           : stopReason;
+      const terminalFailure = result.terminalFailure;
+      const effectiveStopReason = terminalFailure ? "error" : finalStopReason;
       const promptResult: PromptResult = {
         sessionId: session.id,
         response: finalText,
         finalText,
-        stopReason: finalStopReason,
+        stopReason: effectiveStopReason,
         durationMs: Date.now() - startedAt,
         exitCode: 0,
         signal: null,
-        ...(finalStopReason === "error" && !finalText?.trim()
-          ? { error: "ACP prompt ended with stopReason error" }
-          : {}),
+        ...(terminalFailure
+          ? { error: terminalFailure.message, terminalFailure }
+          : effectiveStopReason === "error" && !finalText?.trim()
+            ? { error: "ACP prompt ended with stopReason error" }
+            : {}),
       };
-      if (stopped) {
+      if (terminalFailure) {
+        await this.store.updateStatus(
+          session.id,
+          "errored",
+          terminalFailure.message,
+        );
+        void this.revokeModelLease(session.id, "native_prompt:error");
+      } else if (stopped) {
         await this.store.updateStatus(session.id, "stopped");
         void this.revokeModelLease(session.id, "native_prompt:stopped");
       } else if (cancelled) {
         await this.store.updateStatus(session.id, "cancelled");
         void this.revokeModelLease(session.id, "native_prompt:cancelled");
-      } else if (finalStopReason === "error" && !finalText?.trim()) {
-        // Mirror the handleAcpEvent guard: a stopReason-error session that still
-        // captured a real deliverable is relayed as a completion, so don't mark
-        // it errored in the durable store — that would show a false-failed task
-        // in history/providers while the user actually got the result.
+      } else if (effectiveStopReason === "error" && !finalText?.trim()) {
+        // Untyped errors with a captured deliverable retain the legacy
+        // completion heuristic. An authoritative terminalFailure never reaches
+        // this branch and is always persisted as errored above.
         await this.store.updateStatus(
           session.id,
           "errored",
@@ -3949,7 +4077,23 @@ export class AcpService extends Service {
     const startedAt = Date.now();
     let finalText = "";
     let stopReason: string | undefined;
+    let terminalFailure: AcpTerminalFailure | undefined;
+    let protocolError: string | undefined;
     const capturedToolOutputs = new Set<string>();
+    const promptTurn = opts.sessionId
+      ? this.promptTurns.get(opts.sessionId)
+      : undefined;
+    if (opts.activeForSession && promptTurn?.cancelRequested) {
+      return Promise.resolve({
+        code: null,
+        signal: null,
+        stderr: "",
+        finalText: "",
+        stopReason: "cancelled",
+        cancelled: true,
+        durationMs: Date.now() - startedAt,
+      });
+    }
     const missingCliMessage = this.missingCliMessage();
     if (missingCliMessage) {
       if (opts.sessionId) {
@@ -3996,6 +4140,48 @@ export class AcpService extends Service {
       };
       if (opts.activeForSession && opts.sessionId)
         this.activeProcesses.set(opts.sessionId, record);
+      if (opts.activeForSession && promptTurn?.cancelRequested) {
+        record.cancelled = true;
+        this.terminateProcess(opts.sessionId ?? "", record);
+      }
+
+      const consumeAcpEvent = (parsed: AcpJsonRpcMessage): void => {
+        if (protocolError) return;
+        try {
+          const handled = this.handleAcpEvent(
+            parsed,
+            opts.sessionId,
+            finalText,
+            startedAt,
+            opts.activeForSession === true,
+            capturedToolOutputs,
+            opts.activeForSession === true,
+          );
+          finalText = handled.finalText;
+          stopReason = handled.stopReason ?? stopReason;
+          terminalFailure = handled.terminalFailure ?? terminalFailure;
+        } catch (err) {
+          // error-policy:J1 The CLI stdout boundary contains an invalid typed
+          // receipt and converts it to a structured failed prompt. Throwing
+          // from EventEmitter's data listener would crash the host process.
+          protocolError = errorMessage(err);
+          stopReason = "error";
+          record.stderr = capStderr(
+            `${record.stderr}\nACP protocol error: ${protocolError}`,
+          );
+          this.log("warn", "invalid acpx prompt result", {
+            sessionId: opts.sessionId,
+            error: protocolError,
+          });
+          if (opts.sessionId) {
+            this.emitSessionEvent(opts.sessionId, "error", {
+              message: protocolError,
+              failureKind: "protocol_error",
+              stopReason: "error",
+            });
+          }
+        }
+      };
 
       proc.stdout.on("data", (chunk: Buffer) => {
         const rawChunk = chunk.toString("utf8");
@@ -4007,19 +4193,7 @@ export class AcpService extends Service {
           record.stdoutBuffer = record.stdoutBuffer.slice(newlineIndex + 1);
           if (line) {
             const parsed = this.parseNdjson(line, opts.sessionId);
-            if (parsed) {
-              const handled = this.handleAcpEvent(
-                parsed,
-                opts.sessionId,
-                finalText,
-                startedAt,
-                opts.activeForSession === true,
-                capturedToolOutputs,
-                opts.activeForSession === true,
-              );
-              finalText = handled.finalText;
-              stopReason = handled.stopReason ?? stopReason;
-            }
+            if (parsed) consumeAcpEvent(parsed);
           }
           newlineIndex = record.stdoutBuffer.indexOf("\n");
         }
@@ -4049,19 +4223,7 @@ export class AcpService extends Service {
             record.stdoutBuffer.trim(),
             opts.sessionId,
           );
-          if (parsed) {
-            const handled = this.handleAcpEvent(
-              parsed,
-              opts.sessionId,
-              finalText,
-              startedAt,
-              opts.activeForSession === true,
-              capturedToolOutputs,
-              opts.activeForSession === true,
-            );
-            finalText = handled.finalText;
-            stopReason = handled.stopReason ?? stopReason;
-          }
+          if (parsed) consumeAcpEvent(parsed);
         }
         if (
           opts.sessionId &&
@@ -4073,6 +4235,8 @@ export class AcpService extends Service {
         if (
           opts.sessionId &&
           !record.cancelled &&
+          !terminalFailure &&
+          !protocolError &&
           code !== 0 &&
           // Emit for a 401/unauthorized auth failure OR an explicit token-expiry
           // exit (isAuthText alone misses a bare "token expired"), so a run that
@@ -4087,6 +4251,8 @@ export class AcpService extends Service {
         if (
           opts.sessionId &&
           !record.cancelled &&
+          !terminalFailure &&
+          !protocolError &&
           code !== 0 &&
           code !== null
         ) {
@@ -4137,7 +4303,19 @@ export class AcpService extends Service {
             (code === 0 || code === null) &&
             finalText.trim().length > 0 &&
             !isIncompletePromptStopReason(stopReason);
-          if (record.cancelled) {
+          if (terminalFailure) {
+            this.emitSessionEvent(opts.sessionId, "error", {
+              message: terminalFailure.message,
+              failureKind: terminalFailure.kind,
+              ...(terminalFailure.code
+                ? { failureCode: terminalFailure.code }
+                : {}),
+              transient: terminalFailure.transient,
+              stopReason: "error",
+            });
+          } else if (protocolError) {
+            // The data-listener boundary already emitted the structured error.
+          } else if (record.cancelled) {
             this.emitSessionEvent(opts.sessionId, "cancelled", {
               sessionId: opts.sessionId,
               response: finalText,
@@ -4175,7 +4353,14 @@ export class AcpService extends Service {
           signal,
           stderr: record.stderr,
           finalText,
-          stopReason: record.cancelled ? "cancelled" : stopReason,
+          stopReason:
+            terminalFailure || protocolError
+              ? "error"
+              : record.cancelled
+                ? "cancelled"
+                : stopReason,
+          ...(terminalFailure ? { terminalFailure } : {}),
+          ...(protocolError ? { protocolError } : {}),
           cancelled: record.cancelled,
           durationMs: Date.now() - startedAt,
         });
@@ -4214,7 +4399,11 @@ export class AcpService extends Service {
     emitPromptTerminalEvents: boolean,
     capturedToolOutputs: Set<string>,
     deferPromptTerminalEvent = false,
-  ): { finalText: string; stopReason?: string } {
+  ): {
+    finalText: string;
+    stopReason?: string;
+    terminalFailure?: AcpTerminalFailure;
+  } {
     const protocolSessionId = extractSessionId(event);
     const sessionId = localSessionId ?? protocolSessionId;
     if (
@@ -4473,7 +4662,8 @@ export class AcpService extends Service {
     }
 
     if (sessionId && result && typeof result.stopReason === "string") {
-      stopReason = result.stopReason;
+      const terminalFailure = readAcpTerminalFailure(result);
+      stopReason = terminalFailure ? "error" : result.stopReason;
       if (emitPromptTerminalEvents) {
         // Per-turn token usage rides on the terminal result (claude-agent-acp
         // reports it under `result.usage` / `result._meta.usage`). Emit it once
@@ -4505,9 +4695,19 @@ export class AcpService extends Service {
         // NO captured output is a true, user-facing failure — otherwise the user
         // gets a false "hit a snag" for a build that actually succeeded.
         if (deferPromptTerminalEvent) {
-          return { finalText, stopReason };
+          return { finalText, stopReason, terminalFailure };
         }
-        if (!isIncompletePromptStopReason(stopReason)) {
+        if (terminalFailure) {
+          this.emitSessionEvent(sessionId, "error", {
+            message: terminalFailure.message,
+            failureKind: terminalFailure.kind,
+            ...(terminalFailure.code
+              ? { failureCode: terminalFailure.code }
+              : {}),
+            transient: terminalFailure.transient,
+            stopReason,
+          });
+        } else if (!isIncompletePromptStopReason(stopReason)) {
           if (stopReason === "cancelled") {
             this.emitSessionEvent(sessionId, "cancelled", {
               response: finalText,

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -4406,6 +4406,7 @@ export class AcpService extends Service {
   } {
     const protocolSessionId = extractSessionId(event);
     const sessionId = localSessionId ?? protocolSessionId;
+    let terminalFailure: AcpTerminalFailure | undefined;
     if (
       localSessionId &&
       protocolSessionId &&
@@ -4662,7 +4663,7 @@ export class AcpService extends Service {
     }
 
     if (sessionId && result && typeof result.stopReason === "string") {
-      const terminalFailure = readAcpTerminalFailure(result);
+      terminalFailure = readAcpTerminalFailure(result);
       stopReason = terminalFailure ? "error" : result.stopReason;
       if (emitPromptTerminalEvents) {
         // Per-turn token usage rides on the terminal result (claude-agent-acp
@@ -4744,7 +4745,7 @@ export class AcpService extends Service {
       this.emitSessionEvent(sessionId, "error", { message });
     }
 
-    return { finalText, stopReason };
+    return { finalText, stopReason, terminalFailure };
   }
 
   emitSessionEvent(

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -295,6 +295,71 @@ export interface SendOptions {
   model?: string;
 }
 
+/** Authoritative failed-turn receipt carried by an ACP prompt result. */
+export interface AcpTerminalFailure {
+  kind: string;
+  code?: string;
+  transient: boolean;
+  message: string;
+}
+
+/**
+ * Read the elizaOS terminal-failure extension from an ACP prompt result.
+ * Presence is authoritative: malformed receipts fail the protocol boundary
+ * instead of being dropped and allowing surrounding prose to imply success.
+ */
+export function readAcpTerminalFailure(
+  promptResult: unknown,
+): AcpTerminalFailure | undefined {
+  if (
+    !promptResult ||
+    typeof promptResult !== "object" ||
+    Array.isArray(promptResult)
+  ) {
+    return undefined;
+  }
+  const metadata = (promptResult as Record<string, unknown>)._meta;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const candidate = (metadata as Record<string, unknown>).terminalFailure;
+  if (candidate === undefined) return undefined;
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new TypeError("ACP terminalFailure must be an object");
+  }
+  const record = candidate as Record<string, unknown>;
+  const kind =
+    typeof record.kind === "string" && record.kind.trim()
+      ? record.kind.trim()
+      : undefined;
+  const message =
+    typeof record.message === "string" && record.message.trim()
+      ? record.message
+      : undefined;
+  const code =
+    record.code === undefined
+      ? undefined
+      : typeof record.code === "string" && record.code.trim()
+        ? record.code.trim()
+        : null;
+  if (
+    !kind ||
+    !message ||
+    typeof record.transient !== "boolean" ||
+    code === null
+  ) {
+    throw new TypeError(
+      "ACP terminalFailure requires kind, message, transient, and an optional non-empty code",
+    );
+  }
+  return {
+    kind,
+    ...(code ? { code } : {}),
+    transient: record.transient,
+    message,
+  };
+}
+
 export interface PromptResult {
   sessionId: string;
   response: string;
@@ -304,6 +369,7 @@ export interface PromptResult {
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
   error?: string;
+  terminalFailure?: AcpTerminalFailure;
 }
 
 export interface AvailableAgentInfo {


### PR DESCRIPTION
Closes #24870

## Summary
- preserves authoritative coding terminal-failure receipts across Eliza Code ACP, native transport, and CLI-backed ACP sessions
- makes typed failure override surrounding prose, wire `end_turn`, cancellation races, and generic auth/crash heuristics
- rejects malformed typed receipts and keeps untyped partial-deliverable behavior unchanged

## Exact-head local evidence
- `bunx vitest run --config vitest.config.ts __tests__/unit/acp-service.test.ts __tests__/unit/acp-native-transport.test.ts --maxWorkers=1` — 122/122 passed
- `bun test --conditions=eliza-source src/acp-terminal-failure.test.ts` — 2/2 passed
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — passed after building required workspace packages
- Biome on all changed orchestrator and example files — passed
- `git diff --check origin/develop...HEAD` — passed

Independent adversarial review found and verified the final CLI return-path repair. No shared checkout files were modified.