### PR TITLE
test(shared): cover discord dm authorization policy

### DIFF
--- a/packages/shared/src/__tests__/discord-dm-policy.test.ts
+++ b/packages/shared/src/__tests__/discord-dm-policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isDiscordDmSenderAllowed } from "./discord-dm-policy.ts";
+
+describe("isDiscordDmSenderAllowed", () => {
+  it("allows everyone when the policy is open (default)", () => {
+    expect(isDiscordDmSenderAllowed({}, "anyone")).toBe(true);
+    expect(isDiscordDmSenderAllowed({ dmPolicy: "open" }, "stranger")).toBe(
+      true,
+    );
+  });
+
+  it("denies everyone when disabled", () => {
+    expect(isDiscordDmSenderAllowed({ dmPolicy: "disabled" }, "owner-1")).toBe(
+      false,
+    );
+  });
+
+  it("allowlist admits listed ids and owner ids", () => {
+    const meta = {
+      dmPolicy: "allowlist" as const,
+      dmAllowFrom: ["friend-1"],
+      ownerDiscordUserId: "owner-1",
+    };
+    expect(isDiscordDmSenderAllowed(meta, "friend-1")).toBe(true);
+    expect(isDiscordDmSenderAllowed(meta, "owner-1")).toBe(true);
+    expect(isDiscordDmSenderAllowed(meta, "stranger")).toBe(false);
+  });
+
+  it("pairing admits only owner ids (no external allowlist)", () => {
+    const meta = {
+      dmPolicy: "pairing" as const,
+      ownerDiscordUserId: "owner-1",
+      dmAllowFrom: ["friend-1"],
+    };
+    expect(isDiscordDmSenderAllowed(meta, "owner-1")).toBe(true);
+    // pairing 不读 dmAllowFrom
+    expect(isDiscordDmSenderAllowed(meta, "friend-1")).toBe(false);
+  });
+
+  it("supports ownerDiscordUserIds array", () => {
+    const meta = {
+      dmPolicy: "pairing" as const,
+      ownerDiscordUserIds: ["a", "b"],
+    };
+    expect(isDiscordDmSenderAllowed(meta, "a")).toBe(true);
+    expect(isDiscordDmSenderAllowed(meta, "b")).toBe(true);
+    expect(isDiscordDmSenderAllowed(meta, "c")).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 5 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
