### PR TITLE
test(core): cover reply-gate

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-reply-gate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-reply-gate.test.ts
@@ -54,6 +54,16 @@ describe("resolveEffectiveReplyGate", () => {
 		const result = resolveEffectiveReplyGate(userSlot(), globalSlot());
 		expect(result).toEqual({ mode: null, scope: null });
 	});
+
+	test("treats missing slots like unset gates", () => {
+		expect(resolveEffectiveReplyGate(undefined, undefined)).toEqual({
+			mode: null,
+			scope: null,
+		});
+		expect(
+			resolveEffectiveReplyGate(null, globalSlot({ reply_gate: "on_mention" })),
+		).toEqual({ mode: "on_mention", scope: "global" });
+	});
 });
 
 describe("decideReplyGate", () => {
@@ -168,6 +178,52 @@ describe("decideReplyGate", () => {
 			expect(decision.scope).toBe("global");
 		}
 	});
+
+	test("on_mention deny from global scope carries the full deny shape", () => {
+		const decision = decideReplyGate({
+			userSlot: userSlot(),
+			globalSlot: globalSlot({ reply_gate: "on_mention" }),
+			messageText: "room chatter",
+			explicitlyAddressesAgent: false,
+		});
+		expect(decision).toEqual({
+			allow: false,
+			reason: "on_mention_not_addressed",
+			gateMode: "on_mention",
+			scope: "global",
+		});
+	});
+
+	test("never_until_lift suppresses missing or empty message text", () => {
+		for (const messageText of [undefined, ""]) {
+			const decision = decideReplyGate({
+				userSlot: userSlot({ reply_gate: "never_until_lift" }),
+				globalSlot: globalSlot(),
+				messageText,
+				explicitlyAddressesAgent: false,
+			});
+			expect(decision.allow).toBe(false);
+			if (!decision.allow) {
+				expect(decision.reason).toBe("never_until_lift");
+			}
+		}
+	});
+
+	test("never_until_lift keeps suppressing a textless turn even when addressed", () => {
+		// Observed ordering: messageContainsLiftSignal checks for empty text
+		// before its explicit-address short-circuit, so a textless addressed
+		// turn does not lift the gate at ingress.
+		const decision = decideReplyGate({
+			userSlot: userSlot({ reply_gate: "never_until_lift" }),
+			globalSlot: globalSlot(),
+			messageText: undefined,
+			explicitlyAddressesAgent: true,
+		});
+		expect(decision.allow).toBe(false);
+		if (!decision.allow) {
+			expect(decision.reason).toBe("never_until_lift");
+		}
+	});
 });
 
 describe("messageContainsLiftSignal", () => {
@@ -192,5 +248,59 @@ describe("messageContainsLiftSignal", () => {
 
 	test("addressed-to-agent always counts as a lift", () => {
 		expect(messageContainsLiftSignal("anything", true)).toBe(true);
+	});
+
+	test("matches 'you can talk' family", () => {
+		expect(messageContainsLiftSignal("you can talk now", false)).toBe(true);
+		expect(messageContainsLiftSignal("you can talk again please", false)).toBe(
+			true,
+		);
+	});
+
+	test("matches lift/cancel/clear/remove mute phrases", () => {
+		expect(messageContainsLiftSignal("lift the mute", false)).toBe(true);
+		expect(messageContainsLiftSignal("cancel the shut up", false)).toBe(true);
+		expect(messageContainsLiftSignal("clear silence", false)).toBe(true);
+		expect(messageContainsLiftSignal("remove the gag", false)).toBe(true);
+	});
+
+	test("matches 'come back' / 'wake up' with the literal space", () => {
+		expect(messageContainsLiftSignal("wake up", false)).toBe(true);
+		expect(messageContainsLiftSignal("come back to us", false)).toBe(true);
+		expect(messageContainsLiftSignal("wakeup time", false)).toBe(false);
+	});
+
+	test("matches 'start/begin ...ing again'", () => {
+		expect(messageContainsLiftSignal("start responding again", false)).toBe(
+			true,
+		);
+		expect(messageContainsLiftSignal("begin talking again!", false)).toBe(true);
+		expect(messageContainsLiftSignal("stop responding again", false)).toBe(
+			false,
+		);
+	});
+
+	test("is case-insensitive and tolerates leading whitespace", () => {
+		expect(messageContainsLiftSignal("WAKE UP", false)).toBe(true);
+		expect(messageContainsLiftSignal("  okay you can talk", false)).toBe(true);
+	});
+
+	test("ignores lift phrases that do not start the message", () => {
+		expect(
+			messageContainsLiftSignal("he said wake up earlier today", false),
+		).toBe(false);
+		expect(
+			messageContainsLiftSignal(
+				"the agent should start responding again",
+				false,
+			),
+		).toBe(false);
+		expect(messageContainsLiftSignal("ok talkative folks", false)).toBe(false);
+	});
+
+	test("missing or empty text never lifts, even when addressed", () => {
+		expect(messageContainsLiftSignal(undefined, false)).toBe(false);
+		expect(messageContainsLiftSignal("", false)).toBe(false);
+		expect(messageContainsLiftSignal(undefined, true)).toBe(false);
 	});
 });


### PR DESCRIPTION

Adds real unit coverage for `packages/core/src/features/advanced-capabilities/personality/reply-gate.ts` by extending the module's existing suite `__tests__/personality-reply-gate.test.ts`. An earlier target snapshot listed this module as untested, but current develop already carries a suite for it, so this PR only ADDS cases (+110/−0, no line deleted) covering branches develop's suite does not reach.

Newly covered behavior (all asserted against the real module, no mocks):

- The remaining lift-phrase families: "you can talk (again)", "lift/cancel/clear/remove … silence/mute/shut up/gag", "come back"/"wake up", "start/begin responding|talking|replying again".
- Case-insensitivity and leading-whitespace tolerance of the lift matchers.
- Anchor-at-start semantics, including the word boundary ("ok talkative folks" stays muted) and the literal space requirement ("wakeup time" stays muted).
- The missing/empty `messageText` guard in `messageContainsLiftSignal`, including its observed ordering versus `explicitlyAddressesAgent`: a textless addressed turn does not lift a `never_until_lift` gate at ingress (documented as observed behavior in-test).
- `resolveEffectiveReplyGate` with `undefined`/`null` slots.
- The complete deny shape (`reason`, `gateMode`, `scope`) for a global-scope `on_mention` suppression.

Evidence (fork contributor: hosted CI does not run on this PR; local verification below):

- Tests: `bunx vitest run packages/core/src/features/advanced-capabilities/personality/__tests__/personality-reply-gate.test.ts` on current origin/develop (`0242ceed3525`, re-fetched and re-run immediately before filing): **Test Files 1 passed (1), Tests 27 passed (27)** (16 pre-existing + 11 new).
- Lint: `bunx biome check --write <file>` clean (biome.json/tsconfig.json verified present; checkout is not sparse).
- Types: `bunx tsc --noEmit` in `packages/core` produces zero output mentioning `personality-reply-gate.test.ts`.
- Diff: one test file, +110/−0; test-only change, no production behavior modified.

Note: open #26339 adds a separate colocated `reply-gate.test.ts`; this PR touches only the existing `__tests__/personality-reply-gate.test.ts` suite and deletes nothing from any existing test.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8e4efb05ade1e362941097ada6759d0c4347b684 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
