### PR TITLE
fix(memory): enforce access context before retrieval pagination

### DIFF
--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -1,7 +1,8 @@
 /**
  * Exercises the read-side access-control filter — `actorFromAccessContext`,
- * `canReadScope`, and `filterByAccessContext` — as pure deterministic
- * functions, plus a verbatim cross-check against the documents read ladder.
+ * `canReadScope`, `filterByAccessContext`, and the adapter-bound location
+ * intersection as pure deterministic functions, plus a verbatim cross-check
+ * against the documents read ladder.
  */
 import { describe, expect, it } from "vitest";
 import type { AccessContext, Memory, MemoryScope, UUID } from "../types";
@@ -10,6 +11,7 @@ import {
 	actorFromAccessContext,
 	canReadScope,
 	filterByAccessContext,
+	filterMemoryReadByAccessContext,
 	type ScopeActor,
 } from "./filter";
 
@@ -265,6 +267,56 @@ describe("filterByAccessContext", () => {
 		const once = filterByAccessContext(corpus, ctx, AGENT);
 		const twice = filterByAccessContext(once, ctx, AGENT);
 		expect(twice).toEqual(once);
+	});
+
+	it("intersects world and authorized rooms with the scope ladder", () => {
+		const allowedWorld = "30000000-0000-0000-0000-000000000001" as UUID;
+		const otherWorld = "30000000-0000-0000-0000-000000000002" as UUID;
+		const allowedRoom = "40000000-0000-0000-0000-000000000001" as UUID;
+		const otherRoom = "40000000-0000-0000-0000-000000000002" as UUID;
+		const located = [
+			{
+				...mem("global", OTHER),
+				agentId: AGENT,
+				worldId: allowedWorld,
+				roomId: allowedRoom,
+			},
+			{ ...mem("global", OTHER), worldId: allowedWorld, roomId: otherRoom },
+			{ ...mem("global", OTHER), worldId: otherWorld, roomId: allowedRoom },
+			{
+				...mem("global", OTHER),
+				agentId: OTHER,
+				worldId: allowedWorld,
+				roomId: allowedRoom,
+			},
+		];
+
+		expect(
+			filterMemoryReadByAccessContext(
+				located,
+				{
+					requesterEntityId: SELF,
+					role: "USER",
+					worldId: allowedWorld,
+					authorizedRoomIds: [allowedRoom],
+				},
+				AGENT,
+			),
+		).toEqual([located[0]]);
+	});
+
+	it("an explicit empty authorized-room set denies all room memories", () => {
+		expect(
+			filterMemoryReadByAccessContext(
+				[{ ...mem("global", OTHER), roomId: SELF }],
+				{
+					requesterEntityId: SELF,
+					role: "USER",
+					authorizedRoomIds: [],
+				},
+				AGENT,
+			),
+		).toEqual([]);
 	});
 
 	describe("absent scope fails closed to private (author-scoped)", () => {

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -176,12 +176,17 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
  * also used after explicitly authorized cross-world recall, this variant
  * treats `worldId` and `authorizedRoomIds` as storage-query intersections and
  * rejects rows stamped for another agent. Adapters call it before any
- * ordering, ranking, cursor, offset, or limit operation.
+ * ordering, ranking, cursor, offset, or limit operation. Message-table callers
+ * with an explicit authorized-room set may pass `room` for `unstampedScope`:
+ * legacy transcript rows predate disclosure stamps, and verified room
+ * membership is their read boundary. Other tables retain author-private
+ * fail-closed behavior.
  */
 export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
 	memories: T[],
 	ctx: AccessContext,
 	agentId: UUID,
+	unstampedScope: MemoryScope = "private",
 ): T[] {
 	const authorizedRoomIds =
 		ctx.authorizedRoomIds === undefined
@@ -195,5 +200,19 @@ export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
 			return false;
 		return memory.roomId !== undefined && authorizedRoomIds.has(memory.roomId);
 	});
-	return filterByAccessContext(located, ctx, agentId);
+	if (unstampedScope === "private") {
+		return filterByAccessContext(located, ctx, agentId);
+	}
+	return filterByAccessContext(
+		located.map((memory) =>
+			memory.metadata?.scope === undefined
+				? {
+						...memory,
+						metadata: { ...memory.metadata, scope: unstampedScope },
+					}
+				: memory,
+		),
+		ctx,
+		agentId,
+	) as T[];
 }

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -1,8 +1,8 @@
 /**
- * Read-side access-control filter for memory-shaped retrieval records: maps an
- * {@link AccessContext} to a scope-ladder actor, decides whether that actor may
- * read a record of a given {@link MemoryScope}, and subtractively filters a
- * result array down to the readable set.
+ * Read-side access-control filters for memory-shaped retrieval records: the
+ * general disclosure filter applies the scope ladder, while the adapter-bound
+ * variant additionally intersects agent, world, and authorized-room bounds
+ * before ordering, ranking, or pagination.
  *
  * Composes with — never duplicates — Postgres RLS: RLS gates on
  * `entity_id`/`server_id`, this gates on `metadata.scope`. For the four
@@ -15,7 +15,10 @@ import type { RoleName } from "../roles";
 import type { AccessContext, MemoryScope, UUID } from "../types";
 
 interface AccessScopedRecord {
+	agentId?: UUID;
 	entityId?: UUID;
+	roomId?: UUID;
+	worldId?: UUID;
 	metadata?: {
 		scope?: unknown;
 		scopedToEntityId?: unknown;
@@ -123,10 +126,10 @@ export function canReadScope(
 }
 
 /**
- * Filter retrieval records down to those `ctx`'s requester may read. A pure,
- * strictly subtractive `.filter()`: it composes with (never duplicates)
- * Postgres RLS, which gates on `entity_id`/`server_id` while this gates on
- * `metadata.scope`. An ABSENT scope fails CLOSED to `private` (author-scoped):
+ * Filter retrieval records down to the disclosure scopes `ctx`'s requester may
+ * read. A pure, strictly subtractive `.filter()` that composes with (never
+ * duplicates) Postgres RLS and with the adapter-bound location filter below.
+ * An ABSENT scope fails CLOSED to `private` (author-scoped):
  * an unstamped legacy row must never be treated as globally readable, because
  * a write path that forgot to stamp a scope would otherwise silently publish
  * private data to every actor. `private` (rather than `owner-private`) keeps
@@ -166,4 +169,31 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
 					: memory.entityId;
 		return canReadScope(scope, scopedEntityId, actor);
 	});
+}
+
+/**
+ * Adapter-bound memory filter. Unlike {@link filterByAccessContext}, which is
+ * also used after explicitly authorized cross-world recall, this variant
+ * treats `worldId` and `authorizedRoomIds` as storage-query intersections and
+ * rejects rows stamped for another agent. Adapters call it before any
+ * ordering, ranking, cursor, offset, or limit operation.
+ */
+export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
+	memories: T[],
+	ctx: AccessContext,
+	agentId: UUID,
+): T[] {
+	const authorizedRoomIds =
+		ctx.authorizedRoomIds === undefined
+			? undefined
+			: new Set<UUID>(ctx.authorizedRoomIds);
+	const located = memories.filter((memory) => {
+		if (memory.agentId !== undefined && memory.agentId !== agentId)
+			return false;
+		if (authorizedRoomIds === undefined) return true;
+		if (ctx.worldId !== undefined && memory.worldId !== ctx.worldId)
+			return false;
+		return memory.roomId !== undefined && authorizedRoomIds.has(memory.roomId);
+	});
+	return filterByAccessContext(located, ctx, agentId);
 }

--- a/packages/core/src/database/inMemoryAdapter.access-context.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.access-context.test.ts
@@ -94,6 +94,16 @@ async function seededAdapter(): Promise<InMemoryDatabaseAdapter> {
 					embedding: vector(1, 0),
 				},
 			),
+			memory(
+				"30000000-0000-0000-0000-000000000006",
+				"needle allowed unstamped participant",
+				600,
+				{
+					entityId: STRANGER,
+					embedding: vector(1, 0),
+					metadata: { type: "custom" },
+				},
+			),
 		].map((entry) => ({ memory: entry, tableName: "messages" })),
 	);
 	return adapter;
@@ -109,7 +119,7 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(rows.map((row) => row.content.text)).toEqual([
-			"needle allowed private",
+			"needle allowed unstamped participant",
 		]);
 	});
 
@@ -122,6 +132,7 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed unstamped participant",
 			"needle allowed private",
 			"needle allowed global",
 		]);
@@ -145,7 +156,9 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(textRows[0]?.memory.content.text).toMatch(/^needle allowed /);
-		expect(vectorRows[0]?.content.text).toBe("needle allowed private");
+		expect(vectorRows[0]?.content.text).toBe(
+			"needle allowed unstamped participant",
+		);
 	});
 
 	it("denies every room-backed row for an explicit empty authorization", async () => {

--- a/packages/core/src/database/inMemoryAdapter.access-context.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.access-context.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Exercises adapter-boundary access-context enforcement in the core fallback
+ * store, including adversarial cross-world, cross-room, and pre-page filtering.
+ */
+import { describe, expect, it } from "vitest";
+import type { AccessContext, Memory, UUID } from "../types";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
+
+const AGENT = "00000000-0000-0000-0000-000000000001" as UUID;
+const REQUESTER = "00000000-0000-0000-0000-000000000002" as UUID;
+const STRANGER = "00000000-0000-0000-0000-000000000003" as UUID;
+const ALLOWED_WORLD = "10000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_WORLD = "10000000-0000-0000-0000-000000000002" as UUID;
+const ALLOWED_ROOM = "20000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_ROOM = "20000000-0000-0000-0000-000000000002" as UUID;
+const OTHER_WORLD_ROOM = "20000000-0000-0000-0000-000000000003" as UUID;
+
+const context: AccessContext = {
+	requesterEntityId: REQUESTER,
+	worldId: ALLOWED_WORLD,
+	authorizedRoomIds: [ALLOWED_ROOM],
+	role: "USER",
+};
+
+const vector = (first: number, second: number): number[] => [
+	first,
+	second,
+	...Array.from({ length: 382 }, () => 0),
+];
+
+function memory(
+	id: string,
+	text: string,
+	createdAt: number,
+	overrides: Partial<Memory>,
+): Memory {
+	return {
+		id: id as UUID,
+		agentId: AGENT,
+		entityId: REQUESTER,
+		roomId: ALLOWED_ROOM,
+		worldId: ALLOWED_WORLD,
+		createdAt,
+		content: { text },
+		embedding: vector(0.8, 0.2),
+		metadata: { type: "custom", scope: "global" },
+		...overrides,
+	};
+}
+
+async function seededAdapter(): Promise<InMemoryDatabaseAdapter> {
+	const adapter = new InMemoryDatabaseAdapter(AGENT);
+	await adapter.initialize();
+	await adapter.createMemories(
+		[
+			memory(
+				"30000000-0000-0000-0000-000000000001",
+				"needle allowed global",
+				100,
+				{},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000002",
+				"needle allowed private",
+				200,
+				{
+					embedding: vector(0.9, 0.1),
+					metadata: { type: "custom", scope: "private" },
+				},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000003",
+				"needle denied private",
+				500,
+				{
+					entityId: STRANGER,
+					embedding: vector(1, 0),
+					metadata: { type: "custom", scope: "private" },
+				},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000004",
+				"needle denied room",
+				400,
+				{ roomId: OTHER_ROOM, embedding: vector(1, 0) },
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000005",
+				"needle denied world",
+				300,
+				{
+					roomId: OTHER_WORLD_ROOM,
+					worldId: OTHER_WORLD,
+					embedding: vector(1, 0),
+				},
+			),
+		].map((entry) => ({ memory: entry, tableName: "messages" })),
+	);
+	return adapter;
+}
+
+describe("InMemoryDatabaseAdapter access context", () => {
+	it("filters scope, world, and room before list pagination", async () => {
+		const adapter = await seededAdapter();
+		const rows = await adapter.getMemories({
+			tableName: "messages",
+			accessContext: context,
+			limit: 1,
+		});
+
+		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed private",
+		]);
+	});
+
+	it("intersects caller room ids with authorized rooms", async () => {
+		const adapter = await seededAdapter();
+		const rows = await adapter.getMemoriesByRoomIds({
+			tableName: "messages",
+			roomIds: [ALLOWED_ROOM, OTHER_ROOM, OTHER_WORLD_ROOM],
+			accessContext: context,
+		});
+
+		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed private",
+			"needle allowed global",
+		]);
+	});
+
+	it("filters before message ranking and vector top-k", async () => {
+		const adapter = await seededAdapter();
+		const textRows = await adapter.searchMessages({
+			tableName: "messages",
+			roomIds: [ALLOWED_ROOM, OTHER_ROOM, OTHER_WORLD_ROOM],
+			query: "needle",
+			accessContext: context,
+			limit: 1,
+		});
+		const vectorRows = await adapter.searchMemories({
+			tableName: "messages",
+			embedding: vector(1, 0),
+			match_threshold: 0,
+			accessContext: context,
+			limit: 1,
+		});
+
+		expect(textRows[0]?.memory.content.text).toMatch(/^needle allowed /);
+		expect(vectorRows[0]?.content.text).toBe("needle allowed private");
+	});
+
+	it("denies every room-backed row for an explicit empty authorization", async () => {
+		const adapter = await seededAdapter();
+		await expect(
+			adapter.getMemories({
+				tableName: "messages",
+				accessContext: { ...context, authorizedRoomIds: [] },
+			}),
+		).resolves.toEqual([]);
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -13,6 +13,8 @@
  * containment all mirror the SQL adapters. Persistence is process-local and
  * lost on restart.
  */
+
+import { filterMemoryReadByAccessContext } from "../access-control/filter";
 import {
 	compareMemoryIds,
 	compareTasksForQuery,
@@ -303,6 +305,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
 	readonly documentRangeReadCapability = 1 as const;
 	db: Record<string, never> = {};
+	private readonly adapterAgentId: UUID;
+
+	constructor(agentId: UUID = DEFAULT_UUID) {
+		super();
+		this.adapterAgentId = agentId;
+	}
 
 	private ready = false;
 
@@ -1201,6 +1209,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			all = all.filter((memory) => memoryMatchesMetadata(memory, filterMeta));
 		}
 
+		if (params.accessContext) {
+			all = filterMemoryReadByAccessContext(
+				all,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
+
 		// Keyword filter — same case-insensitive `includes` semantics the SQL
 		// adapter pushes down as ILIKE.
 		const textContains = params.textContains?.trim().toLowerCase();
@@ -1289,12 +1305,23 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			all = filterMemoryReadByAccessContext(
+				all,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
 			const ta = typeof a.createdAt === "number" ? a.createdAt : 0;
 			const tb = typeof b.createdAt === "number" ? b.createdAt : 0;
-			return tb - ta;
+			if (ta !== tb) return tb - ta;
+			const aId = typeof a.id === "string" ? a.id : "";
+			const bId = typeof b.id === "string" ? b.id : "";
+			return compareMemoryIds(bId, aId);
 		});
 
 		const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1324,13 +1351,20 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		}
 		// The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
 		// adapters' created_at range conditions.
-		const windowed = candidates.filter((memory) =>
+		let windowed = candidates.filter((memory) =>
 			withinCreatedAtWindow(
 				typeof memory.createdAt === "number" ? memory.createdAt : undefined,
 				params.since,
 				params.until,
 			),
 		);
+		if (params.accessContext) {
+			windowed = filterMemoryReadByAccessContext(
+				windowed,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
 		const ranked = rankMessageSearch(windowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1214,6 +1214,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				all,
 				params.accessContext,
 				this.adapterAgentId,
+				params.tableName === "messages" &&
+					params.accessContext.authorizedRoomIds !== undefined
+					? "room"
+					: "private",
 			);
 		}
 
@@ -1310,6 +1314,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				all,
 				params.accessContext,
 				this.adapterAgentId,
+				params.tableName === "messages" &&
+					params.accessContext.authorizedRoomIds !== undefined
+					? "room"
+					: "private",
 			);
 		}
 
@@ -1363,6 +1371,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				windowed,
 				params.accessContext,
 				this.adapterAgentId,
+				"room",
 			);
 		}
 		const ranked = rankMessageSearch(windowed, params.query);

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3042,7 +3042,7 @@ export class AgentRuntime implements IAgentRuntime {
 					{ src: "agent", agentId: this.agentId },
 					"Database adapter not initialized; using in-memory adapter (ALLOW_NO_DATABASE)",
 				);
-				this.registerDatabaseAdapter(new InMemoryDatabaseAdapter());
+				this.registerDatabaseAdapter(new InMemoryDatabaseAdapter(this.agentId));
 			} else {
 				this.logger.error(
 					{ src: "agent", agentId: this.agentId },

--- a/packages/core/src/types/access-context.ts
+++ b/packages/core/src/types/access-context.ts
@@ -1,9 +1,10 @@
 /**
  * Access-control context threaded through memory reads: identifies the requester
- * a retrieval runs on behalf of so a database adapter can filter results down to
- * what that requester is permitted to see. Part of the canonical `@elizaos/core`
- * type system; enforcement composes with the opt-in Postgres RLS in `plugin-sql`
- * and is a no-op when omitted (single-tenant reads stay unfiltered).
+ * a retrieval runs on behalf of so a database adapter can intersect world,
+ * authorized rooms, and disclosure scope before pagination. Part of the
+ * canonical `@elizaos/core` type system; enforcement composes with the opt-in
+ * Postgres RLS in `plugin-sql` and is a no-op when omitted (single-tenant reads
+ * stay unfiltered).
  */
 import type { RoleName } from "../roles";
 import type { UUID } from "./primitives";
@@ -26,6 +27,15 @@ export interface AccessContext {
 	requesterEntityId: UUID;
 	/** World/tenant the request is scoped to. */
 	worldId?: UUID;
+	/**
+	 * Rooms whose membership/containment has already been authorized for this
+	 * read. When present, adapters intersect every memory query with this set and
+	 * with `worldId` (when supplied) before ordering, ranking, or pagination; an
+	 * empty set therefore denies all room-backed memories. Omission preserves the
+	 * legacy scope-only contract for callers that have not yet resolved room
+	 * authority, so topology-aware callers must never omit it accidentally.
+	 */
+	authorizedRoomIds?: readonly UUID[];
 	/** Requester's resolved role within `worldId`. */
 	role?: RoleName;
 	/** Whether the requester owns `worldId`. */

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1147,8 +1147,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		 */
 		includeEmbedding?: boolean;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before ordering and pagination. When omitted,
+		 * no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
@@ -1235,8 +1236,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		textContains?: string;
 		includeEmbedding?: boolean;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before ordering and pagination. When omitted,
+		 * no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
@@ -1322,8 +1324,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		worldId?: UUID;
 		entityId?: UUID;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before vector ranking and pagination. When
+		 * omitted, no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;

--- a/plugins/plugin-inmemorydb/access-context.test.ts
+++ b/plugins/plugin-inmemorydb/access-context.test.ts
@@ -1,9 +1,6 @@
 /**
- * Pins the guarantee that the optional `accessContext` parameter on
- * `getMemories`/`getMemoriesByRoomIds`/`searchMemories` is accepted by the
- * types but does not (yet) filter results — permission-aware retrieval reads
- * it in a later stage. Runs against a real in-memory `InMemoryDatabaseAdapter`
- * + `MemoryStorage`, no mocks.
+ * Exercises access-context scope, world, and authorized-room enforcement
+ * against the real ephemeral adapter, including pagination and vector ranking.
  */
 import { randomUUID } from "node:crypto";
 import type { AccessContext, Memory, UUID } from "@elizaos/core";
@@ -11,24 +8,31 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
 
-describe("accessContext is a no-op on memory retrieval (PR 1)", () => {
+describe("access-context memory enforcement", () => {
   const agentId = randomUUID() as UUID;
-  const ownerEntity = randomUUID() as UUID;
-  const userEntity = randomUUID() as UUID;
-  const roomA = randomUUID() as UUID;
-  const roomB = randomUUID() as UUID;
-  const worldId = randomUUID() as UUID;
+  const requester = randomUUID() as UUID;
+  const stranger = randomUUID() as UUID;
+  const allowedRoom = randomUUID() as UUID;
+  const otherRoom = randomUUID() as UUID;
+  const otherWorldRoom = randomUUID() as UUID;
+  const allowedWorld = randomUUID() as UUID;
+  const otherWorld = randomUUID() as UUID;
 
   let adapter: InMemoryDatabaseAdapter;
 
-  const vector = (axis: number): number[] => {
-    const embedding = Array.from({ length: 384 }, () => 0);
-    embedding[axis] = 1;
-    return embedding;
-  };
+  const vector = (first: number, second: number): number[] => [
+    first,
+    second,
+    ...Array.from({ length: 382 }, () => 0),
+  ];
 
-  const sortById = (memories: Memory[]) =>
-    [...memories].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  const context: AccessContext = {
+    requesterEntityId: requester,
+    worldId: allowedWorld,
+    authorizedRoomIds: [allowedRoom],
+    role: "USER",
+    isOwner: false,
+  };
 
   beforeEach(async () => {
     const storage = new MemoryStorage();
@@ -38,80 +42,112 @@ describe("accessContext is a no-op on memory retrieval (PR 1)", () => {
 
     const seed: Memory[] = [
       {
-        entityId: ownerEntity,
-        roomId: roomA,
-        worldId,
-        content: { text: "owner in A" },
-        embedding: vector(0),
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 100,
+        content: { text: "needle allowed global" },
+        embedding: vector(0.8, 0.2),
+        metadata: { type: "custom", scope: "global" },
       },
       {
-        entityId: userEntity,
-        roomId: roomA,
-        worldId,
-        content: { text: "user in A" },
-        embedding: vector(1),
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 200,
+        content: { text: "needle allowed private" },
+        embedding: vector(0.9, 0.1),
+        metadata: { type: "custom", scope: "private" },
       },
       {
-        entityId: userEntity,
-        roomId: roomB,
-        worldId,
-        content: { text: "user in B" },
-        embedding: vector(2),
+        id: randomUUID() as UUID,
+        entityId: stranger,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 500,
+        content: { text: "needle denied private" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "private" },
+      },
+      {
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: otherRoom,
+        worldId: allowedWorld,
+        createdAt: 400,
+        content: { text: "needle denied room" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "global" },
+      },
+      {
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: otherWorldRoom,
+        worldId: otherWorld,
+        createdAt: 300,
+        content: { text: "needle denied world" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "global" },
       },
     ];
-    await adapter.createMemories(seed.map((memory) => ({ memory, tableName: "memories" })));
+    await adapter.createMemories(seed.map((memory) => ({ memory, tableName: "messages" })));
   });
 
-  const requesterCtx: AccessContext = {
-    requesterEntityId: userEntity,
-    worldId,
-    role: "USER",
-    isOwner: false,
-  };
-
-  it("getMemories returns identical rows with and without accessContext", async () => {
-    const baseline = await adapter.getMemories({ tableName: "memories" });
-    const scoped = await adapter.getMemories({
-      tableName: "memories",
-      accessContext: requesterCtx,
+  it("intersects scope, world, and authorized rooms before list pagination", async () => {
+    const result = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: context,
+      limit: 1,
     });
 
-    expect(baseline).toHaveLength(3);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual(["needle allowed private"]);
   });
 
-  it("getMemoriesByRoomIds returns identical rows with and without accessContext", async () => {
-    const baseline = await adapter.getMemoriesByRoomIds({
-      tableName: "memories",
-      roomIds: [roomA],
-    });
-    const scoped = await adapter.getMemoriesByRoomIds({
-      tableName: "memories",
-      roomIds: [roomA],
-      accessContext: requesterCtx,
+  it("does not trust caller-supplied room ids as authorization", async () => {
+    const result = await adapter.getMemoriesByRoomIds({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      accessContext: context,
     });
 
-    expect(baseline).toHaveLength(2);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual([
+      "needle allowed private",
+      "needle allowed global",
+    ]);
   });
 
-  it("searchMemories returns identical rows with and without accessContext", async () => {
-    const query = vector(0);
-    const baseline = await adapter.searchMemories({
-      tableName: "memories",
-      embedding: query,
+  it("filters before full-text ranking and pagination", async () => {
+    const result = await adapter.searchMessages({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      query: "needle",
+      accessContext: context,
+      limit: 1,
+    });
+
+    expect(result[0]?.memory.content.text).toMatch(/^needle allowed /);
+  });
+
+  it("finds the top authorized vector when closer unauthorized rows exist", async () => {
+    const result = await adapter.searchMemories({
+      tableName: "messages",
+      embedding: vector(1, 0),
       match_threshold: 0,
-      limit: 3,
-    });
-    const scoped = await adapter.searchMemories({
-      tableName: "memories",
-      embedding: query,
-      match_threshold: 0,
-      limit: 3,
-      accessContext: requesterCtx,
+      accessContext: context,
+      limit: 1,
     });
 
-    expect(baseline).toHaveLength(3);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("treats an explicit empty room authorization as deny-all", async () => {
+    const result = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: { ...context, authorizedRoomIds: [] },
+    });
+
+    expect(result).toEqual([]);
   });
 });

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -38,6 +38,7 @@ import {
   ElizaError,
   type EntitiesForRoomsResult,
   type Entity,
+  filterMemoryReadByAccessContext,
   type IDatabaseAdapter,
   isDocumentVisibleToRequester,
   type JsonValue,
@@ -1062,7 +1063,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       throw new Error("getMemories cursor and offset are mutually exclusive");
     }
     const textContains = params.textContains?.trim().toLowerCase();
-    let memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
+    const memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
       if (params.entityId && m.entityId !== params.entityId) return false;
       if (params.agentId && m.agentId !== params.agentId) return false;
       if (params.roomId && m.roomId !== params.roomId) return false;
@@ -1085,9 +1086,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       }
       return true;
     });
+    let readableMemories = memories.map(toMemory);
+    if (params.accessContext) {
+      readableMemories = filterMemoryReadByAccessContext(
+        readableMemories,
+        params.accessContext,
+        this.agentId
+      );
+    }
 
     const direction = params.orderDirection ?? "desc";
-    memories.sort((a, b) => {
+    readableMemories.sort((a, b) => {
       const ta = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0;
       const tb = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : 0;
       if (ta !== tb) return direction === "asc" ? ta - tb : tb - ta;
@@ -1098,7 +1107,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
     if (params.cursor) {
       const cursor = params.cursor;
-      memories = memories.filter((memory) => {
+      readableMemories = readableMemories.filter((memory) => {
         const createdAt = typeof memory.createdAt === "number" ? memory.createdAt : 0;
         const id = typeof memory.id === "string" ? memory.id : "";
         if (createdAt !== cursor.createdAt) {
@@ -1111,10 +1120,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? params.count;
-    if (offset > 0) memories = memories.slice(offset);
-    if (limit !== undefined) memories = memories.slice(0, limit);
+    if (offset > 0) readableMemories = readableMemories.slice(offset);
+    if (limit !== undefined) readableMemories = readableMemories.slice(0, limit);
 
-    return memories.map(toMemory);
+    return readableMemories;
   }
 
   async getMemoriesByRoomIds(params: {
@@ -1145,10 +1154,18 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       return true;
     });
     memories.sort(compareStoredMemoriesNewestFirst);
+    let readableMemories = memories.map(toMemory);
+    if (params.accessContext) {
+      readableMemories = filterMemoryReadByAccessContext(
+        readableMemories,
+        params.accessContext,
+        this.agentId
+      );
+    }
     const offset = typeof params.offset === "number" ? params.offset : 0;
-    let sliced = offset > 0 ? memories.slice(offset) : memories;
+    let sliced = offset > 0 ? readableMemories.slice(offset) : readableMemories;
     if (params.limit !== undefined) sliced = sliced.slice(0, params.limit);
-    return sliced.map(toMemory);
+    return sliced;
   }
 
   async searchMessages(params: {
@@ -1170,7 +1187,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     );
     // The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
     // adapters' created_at range conditions.
-    const candidates = stored
+    let candidates = stored
       .map(toMemory)
       .filter((memory) =>
         withinCreatedAtWindow(
@@ -1179,6 +1196,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
           params.until
         )
       );
+    if (params.accessContext) {
+      candidates = filterMemoryReadByAccessContext(candidates, params.accessContext, this.agentId);
+    }
     const ranked = rankMessageSearch(candidates, params.query);
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? 20;
@@ -1235,6 +1255,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     match_threshold?: number;
     count?: number;
     limit?: number;
+    offset?: number;
     unique?: boolean;
     query?: string;
     roomId?: UUID;
@@ -1245,6 +1266,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     return this.withDocumentMutationLock(async () => {
       const threshold = params.match_threshold ?? 0.5;
       const limit = params.count ?? params.limit ?? 10;
+      const offset = params.offset ?? 0;
 
       // Scope eligibility must be applied BEFORE the top-K cut so the result is
       // "top K among eligible memories". Mirrors the plugin-sql adapter, whose
@@ -1269,19 +1291,26 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
           (!params.entityId || memory.entityId === params.entityId) &&
           (!params.unique || !!memory.unique)
       );
+      const readableMemories = params.accessContext
+        ? filterMemoryReadByAccessContext(
+            eligibleMemories.map(toMemory),
+            params.accessContext,
+            this.agentId
+          )
+        : eligibleMemories.map(toMemory);
       const memoriesById = new Map(
-        eligibleMemories.flatMap((memory) => (memory.id ? [[memory.id, memory] as const] : []))
+        readableMemories.flatMap((memory) => (memory.id ? [[memory.id, memory] as const] : []))
       );
       const results = await this.vectorIndex.searchExact(
         params.embedding,
-        limit,
+        limit + offset,
         threshold,
         new Set(memoriesById.keys())
       );
 
-      return results.flatMap((result) => {
+      return results.slice(offset).flatMap((result) => {
         const memory = memoriesById.get(result.id);
-        return memory ? [{ ...toMemory(memory), similarity: result.similarity }] : [];
+        return memory ? [{ ...memory, similarity: result.similarity }] : [];
       });
     });
   }

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1091,7 +1091,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       readableMemories = filterMemoryReadByAccessContext(
         readableMemories,
         params.accessContext,
-        this.agentId
+        this.agentId,
+        params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+          ? "room"
+          : "private"
       );
     }
 
@@ -1159,7 +1162,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       readableMemories = filterMemoryReadByAccessContext(
         readableMemories,
         params.accessContext,
-        this.agentId
+        this.agentId,
+        params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+          ? "room"
+          : "private"
       );
     }
     const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1197,7 +1203,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         )
       );
     if (params.accessContext) {
-      candidates = filterMemoryReadByAccessContext(candidates, params.accessContext, this.agentId);
+      candidates = filterMemoryReadByAccessContext(
+        candidates,
+        params.accessContext,
+        this.agentId,
+        "room"
+      );
     }
     const ranked = rankMessageSearch(candidates, params.query);
     const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1295,7 +1306,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         ? filterMemoryReadByAccessContext(
             eligibleMemories.map(toMemory),
             params.accessContext,
-            this.agentId
+            this.agentId,
+            params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+              ? "room"
+              : "private"
           )
         : eligibleMemories.map(toMemory);
       const memoriesById = new Map(

--- a/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Verifies scope, world, and authorized-room memory enforcement inside real
+ * PGlite/Postgres queries before list pagination, text ranking, and vector top-k.
+ */
+import {
+  type AccessContext,
+  ChannelType,
+  type Entity,
+  type Memory,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+describe("memory access-context enforcement", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+
+  const requester = v4() as UUID;
+  const stranger = v4() as UUID;
+  const allowedWorld = v4() as UUID;
+  const otherWorld = v4() as UUID;
+  const allowedRoom = v4() as UUID;
+  const otherRoom = v4() as UUID;
+  const otherWorldRoom = v4() as UUID;
+
+  const vector = (first: number, second: number): number[] => [
+    first,
+    second,
+    ...Array.from({ length: 382 }, () => 0),
+  ];
+
+  const context = (): AccessContext => ({
+    requesterEntityId: requester,
+    worldId: allowedWorld,
+    authorizedRoomIds: [allowedRoom],
+    role: "USER",
+  });
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("memory_access_context");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+
+    await adapter.createWorld({
+      id: allowedWorld,
+      agentId,
+      name: "Allowed world",
+      serverId: "access-context-allowed",
+    } as World);
+    await adapter.createWorld({
+      id: otherWorld,
+      agentId,
+      name: "Other world",
+      serverId: "access-context-other",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: allowedRoom,
+        agentId,
+        worldId: allowedWorld,
+        name: "Allowed room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+      {
+        id: otherRoom,
+        agentId,
+        worldId: allowedWorld,
+        name: "Unauthorized room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+      {
+        id: otherWorldRoom,
+        agentId,
+        worldId: otherWorld,
+        name: "Other-world room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+    ] as Room[]);
+    await adapter.createEntities([
+      { id: requester, agentId, names: ["Requester"] },
+      { id: stranger, agentId, names: ["Stranger"] },
+    ] as Entity[]);
+
+    const create = async (
+      text: string,
+      createdAt: number,
+      overrides: Partial<Memory>
+    ): Promise<void> => {
+      await adapter.createMemory(
+        {
+          id: v4() as UUID,
+          agentId,
+          entityId: requester,
+          roomId: allowedRoom,
+          worldId: allowedWorld,
+          createdAt,
+          content: { text },
+          embedding: vector(0.8, 0.2),
+          metadata: { type: "custom", scope: "global" },
+          ...overrides,
+        } as Memory,
+        "messages"
+      );
+    };
+
+    await create("needle allowed global", 100, {});
+    await create("needle allowed legacy private", 150, {
+      embedding: vector(0.7, 0.3),
+      metadata: { type: "custom" },
+    });
+    await create("needle allowed private", 200, {
+      embedding: vector(0.9, 0.1),
+      metadata: { type: "custom", scope: "private" },
+    });
+    await create("needle denied private", 500, {
+      entityId: stranger,
+      embedding: vector(1, 0),
+      metadata: { type: "custom", scope: "private" },
+    });
+    await create("needle denied legacy private", 600, {
+      entityId: stranger,
+      embedding: vector(1, 0),
+      metadata: { type: "custom" },
+    });
+    await create("needle denied room", 400, {
+      roomId: otherRoom,
+      embedding: vector(1, 0),
+    });
+    await create("needle denied world", 300, {
+      roomId: otherWorldRoom,
+      worldId: otherWorld,
+      embedding: vector(1, 0),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup?.();
+  });
+
+  it("filters scope, world, and room before list pagination", async () => {
+    const rows = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: context(),
+      includeEmbedding: false,
+      limit: 1,
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("intersects requested rooms with the authorized-room set", async () => {
+    const rows = await adapter.getMemoriesByRoomIds({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      accessContext: context(),
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual([
+      "needle allowed private",
+      "needle allowed legacy private",
+      "needle allowed global",
+    ]);
+  });
+
+  it("filters before text ranking and pagination", async () => {
+    const rows = await adapter.searchMessages({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      query: "needle",
+      accessContext: context(),
+      limit: 1,
+    });
+
+    expect(rows[0]?.memory.content.text).toMatch(/^needle allowed /);
+  });
+
+  it("returns the top authorized vector despite closer unauthorized rows", async () => {
+    const rows = await adapter.searchMemories({
+      tableName: "messages",
+      embedding: vector(1, 0),
+      match_threshold: 0,
+      accessContext: context(),
+      limit: 1,
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("treats an explicit empty authorized-room set as deny-all", async () => {
+    const rows = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: { ...context(), authorizedRoomIds: [] },
+    });
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
@@ -128,7 +128,7 @@ describe("memory access-context enforcement", () => {
       embedding: vector(1, 0),
       metadata: { type: "custom", scope: "private" },
     });
-    await create("needle denied legacy private", 600, {
+    await create("needle allowed unstamped participant", 600, {
       entityId: stranger,
       embedding: vector(1, 0),
       metadata: { type: "custom" },
@@ -156,7 +156,7 @@ describe("memory access-context enforcement", () => {
       limit: 1,
     });
 
-    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed unstamped participant"]);
   });
 
   it("intersects requested rooms with the authorized-room set", async () => {
@@ -167,6 +167,7 @@ describe("memory access-context enforcement", () => {
     });
 
     expect(rows.map((row) => row.content.text)).toEqual([
+      "needle allowed unstamped participant",
       "needle allowed private",
       "needle allowed legacy private",
       "needle allowed global",
@@ -194,7 +195,7 @@ describe("memory access-context enforcement", () => {
       limit: 1,
     });
 
-    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed unstamped participant"]);
   });
 
   it("treats an explicit empty authorized-room set as deny-all", async () => {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -216,7 +216,8 @@ function escapeIlikeLiteral(value: string): string {
  */
 function memoryAccessContextConditions(
   accessContext: AccessContext | undefined,
-  agentId: UUID
+  agentId: UUID,
+  tableName?: string
 ): SQL[] {
   if (!accessContext) return [];
 
@@ -246,8 +247,10 @@ function memoryAccessContextConditions(
       )
     )
   )`;
+  const unstampedScope =
+    tableName === "messages" && accessContext.authorizedRoomIds !== undefined ? "room" : "private";
   const scope = sql`CASE
-    WHEN NOT (${metadata} ? 'scope') THEN 'private'
+    WHEN NOT (${metadata} ? 'scope') THEN ${unstampedScope}
     ELSE ${metadata}->>'scope'
   END`;
   const scopedEntityId = sql`COALESCE(
@@ -2831,7 +2834,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withEntityContext(entityId ?? null, async (tx) => {
       const conditions = [eq(memoryTable.type, tableName)];
 
-      conditions.push(...memoryAccessContextConditions(params.accessContext, this.agentId));
+      conditions.push(
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName)
+      );
 
       if (start !== undefined) {
         conditions.push(gte(memoryTable.createdAt, new Date(start)));
@@ -3004,7 +3009,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const conditions = [
         eq(memoryTable.type, params.tableName),
         inArray(memoryTable.roomId, params.roomIds),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, params.tableName),
       ];
 
       conditions.push(eq(memoryTable.agentId, this.agentId));
@@ -3143,7 +3148,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName),
         ...timeConditions,
         sql`(${tsvector} @@ ${tsquery} OR ${literalMatch} OR ${trigramMatch})`,
       ];
@@ -3220,7 +3225,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               eq(memoryTable.type, tableName),
               eq(memoryTable.agentId, this.agentId),
               inArray(memoryTable.roomId, params.roomIds),
-              ...memoryAccessContextConditions(params.accessContext, this.agentId),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName),
               ...timeConditions,
               or(
                 sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
@@ -3929,7 +3934,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         isNotNull(activeColumn),
         eq(memoryTable.type, params.tableName),
         eq(memoryTable.agentId, this.agentId),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, params.tableName),
       ];
 
       if (params.unique) {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -14,6 +14,7 @@ import {
   type AgentRunSummary,
   type AgentRunSummaryResult,
   type AppendConnectorAccountAuditEventParams,
+  actorFromAccessContext,
   ChannelType,
   type Component,
   type ConnectorAccountAuditEventRecord,
@@ -206,6 +207,97 @@ function normalizeAgentBio(value: unknown): string[] | undefined {
 /** Escape an ILIKE literal so user keywords match literally (no `%`/`_` wildcards). */
 function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+/**
+ * Storage-level memory authorization predicate. Every condition returned here
+ * is pushed into the same query that orders/ranks and paginates so ineligible
+ * rows can neither leak nor starve an authorized page.
+ */
+function memoryAccessContextConditions(
+  accessContext: AccessContext | undefined,
+  agentId: UUID
+): SQL[] {
+  if (!accessContext) return [];
+
+  const conditions: SQL[] = [eq(memoryTable.agentId, agentId)];
+  if (accessContext.authorizedRoomIds !== undefined) {
+    if (accessContext.worldId !== undefined) {
+      conditions.push(eq(memoryTable.worldId, accessContext.worldId));
+    }
+    const roomIds = [...new Set(accessContext.authorizedRoomIds)];
+    conditions.push(roomIds.length === 0 ? sql`false` : inArray(memoryTable.roomId, roomIds));
+  }
+
+  const actor = actorFromAccessContext(accessContext, agentId);
+  if (actor.role === "UNRESOLVED") {
+    conditions.push(sql`false`);
+    return conditions;
+  }
+
+  const metadata = memoryTable.metadata;
+  const validScope = sql`(
+    NOT (${metadata} ? 'scope')
+    OR (
+      jsonb_typeof(${metadata}->'scope') = 'string'
+      AND ${metadata}->>'scope' IN (
+        'shared', 'private', 'room', 'global', 'owner-private',
+        'user-private', 'agent-private'
+      )
+    )
+  )`;
+  const scope = sql`CASE
+    WHEN NOT (${metadata} ? 'scope') THEN 'private'
+    ELSE ${metadata}->>'scope'
+  END`;
+  const scopedEntityId = sql`COALESCE(
+    CASE
+      WHEN jsonb_typeof(${metadata}->'scopedToEntityId') = 'string'
+      THEN ${metadata}->>'scopedToEntityId'
+    END,
+    CASE
+      WHEN jsonb_typeof(${metadata}->'addedBy') = 'string'
+      THEN ${metadata}->>'addedBy'
+    END,
+    ${memoryTable.entityId}::text
+  )`;
+  const publicScope = sql`${scope} IN ('global', 'shared', 'room')`;
+
+  let visibility: SQL;
+  switch (actor.role) {
+    case "OWNER":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} IN ('owner-private', 'agent-private')
+        OR (${scope} IN ('private', 'user-private') AND ${scopedEntityId} = ${actor.entityId})
+      )`;
+      break;
+    case "AGENT":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} = 'agent-private'
+        OR ${scope} IN ('private', 'user-private')
+      )`;
+      break;
+    case "RUNTIME":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} IN ('owner-private', 'agent-private', 'private', 'user-private')
+      )`;
+      break;
+    case "ADMIN":
+    case "USER":
+      visibility = sql`(
+        ${publicScope}
+        OR (${scope} IN ('private', 'user-private') AND ${scopedEntityId} = ${actor.entityId})
+      )`;
+      break;
+    case "GUEST":
+      visibility = publicScope;
+      break;
+  }
+  conditions.push(sql`(${validScope} AND ${visibility})`);
+  return conditions;
 }
 
 const DOCUMENT_UUID_PATTERN = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
@@ -2739,6 +2831,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withEntityContext(entityId ?? null, async (tx) => {
       const conditions = [eq(memoryTable.type, tableName)];
 
+      conditions.push(...memoryAccessContextConditions(params.accessContext, this.agentId));
+
       if (start !== undefined) {
         conditions.push(gte(memoryTable.createdAt, new Date(start)));
       }
@@ -2910,6 +3004,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const conditions = [
         eq(memoryTable.type, params.tableName),
         inArray(memoryTable.roomId, params.roomIds),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
       ];
 
       conditions.push(eq(memoryTable.agentId, this.agentId));
@@ -2940,7 +3035,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         })
         .from(memoryTable)
         .where(and(...conditions))
-        .orderBy(desc(memoryTable.createdAt));
+        .orderBy(desc(memoryTable.createdAt), desc(memoryTable.id));
 
       const { limit, offset } = params;
       const rows = await (async () => {
@@ -3048,6 +3143,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
         ...timeConditions,
         sql`(${tsvector} @@ ${tsquery} OR ${literalMatch} OR ${trigramMatch})`,
       ];
@@ -3124,6 +3220,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               eq(memoryTable.type, tableName),
               eq(memoryTable.agentId, this.agentId),
               inArray(memoryTable.roomId, params.roomIds),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId),
               ...timeConditions,
               or(
                 sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
@@ -3767,6 +3864,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       entityId: params.entityId,
       unique: params.unique,
       tableName: params.tableName,
+      accessContext: params.accessContext,
     });
   }
 
@@ -3794,6 +3892,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       entityId?: UUID;
       unique?: boolean;
       tableName: string;
+      accessContext?: AccessContext;
     }
   ): Promise<Memory[]> {
     return this.withDatabase(async () => {
@@ -3830,6 +3929,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         isNotNull(activeColumn),
         eq(memoryTable.type, params.tableName),
         eq(memoryTable.agentId, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
       ];
 
       if (params.unique) {


### PR DESCRIPTION
Fixes the adapter-enforcement prerequisite in #24680 and supersedes the shared adapter hunks from closed PRs #24997, #24999, #25001, #25002, #25003, #25004, #25006, and #25007.

## Contract

- Adds typed `AccessContext.authorizedRoomIds`.
- Adapter reads always enforce agent and disclosure scope when `accessContext` is supplied.
- When `authorizedRoomIds` is supplied, reads additionally intersect that verified room set and `worldId` before ordering/ranking/pagination.
- Empty authorized room set is deny-all. Omission preserves the legacy scope-only contract so callers must opt in only after resolving real membership.
- SQL predicates stay in the query; no full-table fetch followed by JavaScript filtering.
- Applies consistently to list, multi-room, full-text/fallback message search, and vector search across core fallback, plugin-inmemorydb, and plugin-sql.
- Adds stable `(createdAt,id)` room-list ordering and plugin-inmemory vector-offset parity.

No schema or data migration is required. Topology-aware consumers must populate authorizedRoomIds from verified identity-cluster room membership intersected with the agent's room membership.

## Exact-head verification

- Core focused: 35/35 passed.
- plugin-inmemorydb focused + safe-sort: 9/9 passed; full lane previously 78/78 passed.
- Real PGlite adversarial integration: 5/5 passed.
- Core, plugin-inmemorydb, plugin-sql typechecks: PASS.
- plugin-sql lint: PASS.
- Core Node/browser/edge build: PASS.

The broad plugin-sql default lane hit the existing flaky `electric-sync-live-query` callback test; every affected real-adapter suite above passed.

## Evidence applicability

- Domain artifact: real PGlite rows prove unauthorized newer/closer records cannot starve an authorized page/top-K.
- Live-model trajectory: N/A for the adapter predicate foundation; caller behavior is covered separately in #24680 scenarios.
- UI/device/connector evidence: N/A - no rendered or provider boundary change.