### PR TITLE
fix(core): reject non-finite memory similarities

### DIFF
--- a/packages/core/src/features/advanced-memory/services/memory-service.test.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.test.ts
@@ -235,4 +235,103 @@ describe("MemoryService searchLongTermMemories similarity comparator", () => {
 		expect(results[1]?.id).toBe("00000000-0000-0000-0000-000000000002");
 		expect(results[2]?.id).toBe("00000000-0000-0000-0000-000000000003");
 	});
+
+	it("withholds NaN and infinite scores after the result set reaches its limit", async () => {
+		const candidates = [
+			{
+				id: "00000000-0000-0000-0000-000000000011" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "exact",
+				embedding: [1, 0],
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+			{
+				id: "00000000-0000-0000-0000-000000000012" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "finite",
+				embedding: [0.8, 0.6],
+				createdAt: 2000,
+				updatedAt: 2000,
+			},
+			{
+				id: "00000000-0000-0000-0000-000000000013" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "nan",
+				embedding: [Number.NaN, 1],
+				createdAt: 3000,
+				updatedAt: 3000,
+			},
+			{
+				id: "00000000-0000-0000-0000-000000000014" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "infinite",
+				embedding: [Number.POSITIVE_INFINITY, 1],
+				createdAt: 4000,
+				updatedAt: 4000,
+			},
+		];
+		const mockStorage = {
+			storeLongTermMemory: vi.fn(),
+			storeSessionSummary: vi.fn(),
+			getLongTermMemories: vi.fn(async () => candidates),
+		};
+		const reportError = vi.fn();
+		const runtime = createMockRuntime({
+			getSetting: vi.fn((key: string) =>
+				key === "MEMORY_LONG_TERM_VECTOR_SEARCH_ENABLED" ||
+				key === "MEMORY_VECTOR_SEARCH_ENABLED"
+					? "true"
+					: undefined,
+			),
+			hasService: (name: string) => name === "memoryStorage",
+			getService: (name: string) =>
+				name === "memoryStorage" ? mockStorage : null,
+			getServiceLoadPromise: vi.fn(async () => mockStorage),
+			reportError,
+		});
+		const service = new MemoryService(runtime);
+		await service.initialize(runtime);
+		(
+			service as unknown as {
+				memoryConfig: { longTermVectorSearchEnabled: boolean };
+			}
+		).memoryConfig.longTermVectorSearchEnabled = true;
+
+		const results = await service.searchLongTermMemories(
+			ENTITY_ID,
+			[1, 0],
+			2,
+			0,
+		);
+
+		expect(results.map((result) => result.id)).toEqual([
+			"00000000-0000-0000-0000-000000000011",
+			"00000000-0000-0000-0000-000000000012",
+		]);
+		expect(results.every((result) => Number.isFinite(result.similarity))).toBe(
+			true,
+		);
+		expect(reportError).toHaveBeenCalledOnce();
+		expect(reportError).toHaveBeenCalledWith(
+			"MemoryService.vectorSearch.invalidSimilarity",
+			expect.objectContaining({
+				code: "MEMORY_VECTOR_SIMILARITY_NON_FINITE",
+			}),
+			expect.objectContaining({
+				memoryIds: expect.arrayContaining([
+					"00000000-0000-0000-0000-000000000013",
+					"00000000-0000-0000-0000-000000000014",
+				]),
+			}),
+		);
+	});
 });

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -20,6 +20,7 @@
  * that renders memories as a category-grouped markdown block.
  */
 
+import { ElizaError } from "../../../errors.ts";
 import {
 	getRelatedEntityIds,
 	resolvePrimaryEntityId,
@@ -425,12 +426,17 @@ export class MemoryService extends Service {
 				200,
 			);
 			const scored: Array<{ memory: LongTermMemory; similarity: number }> = [];
+			const invalidSimilarityMemoryIds: string[] = [];
 			for (const memory of candidates) {
 				if ((memory.embedding?.length ?? 0) === 0) continue;
 				const similarity = cosineSimilarity(
 					memory.embedding ?? [],
 					queryEmbedding,
 				);
+				if (!Number.isFinite(similarity)) {
+					invalidSimilarityMemoryIds.push(memory.id);
+					continue;
+				}
 				if (similarity < matchThreshold) continue;
 				if (scored.length < limit) {
 					scored.push({ memory, similarity });
@@ -450,6 +456,22 @@ export class MemoryService extends Service {
 				if (scored.length > limit) {
 					scored.pop();
 				}
+			}
+			if (invalidSimilarityMemoryIds.length > 0) {
+				this.runtime.reportError(
+					"MemoryService.vectorSearch.invalidSimilarity",
+					new ElizaError(
+						"Long-term memory vector search produced non-finite similarity",
+						{
+							code: "MEMORY_VECTOR_SIMILARITY_NON_FINITE",
+							context: {
+								entityId,
+								memoryIds: invalidSimilarityMemoryIds,
+							},
+						},
+					),
+					{ entityId, memoryIds: invalidSimilarityMemoryIds },
+				);
 			}
 			return scored.map((x) => ({
 				...x.memory,


### PR DESCRIPTION
Fixes #26365 and completes the incomplete edge case left by #25132.

## Root cause

#25132 normalized non-finite values only inside the initial sort comparator. Once top-K was full, a NaN comparison bypassed both the threshold and tail guards, inserted at index zero, evicted a valid candidate, and reached model-facing recall. Its zero-vector test produced finite `0`, so it never exercised NaN/Infinity.

## Change

- Reject non-finite cosine results immediately after scoring, before threshold/top-K logic.
- Aggregate invalid memory IDs and report a typed `MEMORY_VECTOR_SIMILARITY_NON_FINITE` diagnostic.
- Add a real NaN + Infinity regression after the result set is full; assert only finite valid candidates survive.

## Verification

- Advanced-memory MemoryService: 13/13 passed.
- Core typecheck: PASS.
- Biome touched files: PASS.

## Evidence applicability

- Domain artifact: exact returned top-K and diagnostic payload asserted.
- Live-model/UI/connector/device evidence: N/A - deterministic pre-model ranking boundary.