### PR TITLE
test(core): cover pluginConfigurationService

### DIFF
--- a/packages/core/src/features/plugin-manager/services/pluginConfigurationService.test.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginConfigurationService.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Exercises plugin configuration readiness through the real service methods,
+ * with process environment changes isolated to test-only key names.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Plugin } from "../../../types/plugin.ts";
+import type { IAgentRuntime } from "../../../types/runtime.ts";
+import { PluginManagerServiceType } from "../types.ts";
+import { PluginConfigurationService } from "./pluginConfigurationService.ts";
+
+const configuredKey = "ELIZA_TEST_PLUGIN_CONFIGURATION_CONFIGURED";
+const emptyKey = "ELIZA_TEST_PLUGIN_CONFIGURATION_EMPTY";
+
+function createPlugin(config?: Plugin["config"]): Plugin {
+	return {
+		name: "test-plugin",
+		description: "Plugin configuration service test fixture",
+		...(config === undefined ? {} : { config }),
+	};
+}
+
+function createService(): PluginConfigurationService {
+	return new PluginConfigurationService({} as IAgentRuntime);
+}
+
+afterEach(() => {
+	delete process.env[configuredKey];
+	delete process.env[emptyKey];
+});
+
+describe("PluginConfigurationService", () => {
+	it("starts and stops with the plugin configuration service contract", async () => {
+		const service = await PluginConfigurationService.start({} as IAgentRuntime);
+
+		expect(service).toBeInstanceOf(PluginConfigurationService);
+		expect(PluginConfigurationService.serviceType).toBe(
+			PluginManagerServiceType.PLUGIN_CONFIGURATION,
+		);
+		expect(service.capabilityDescription).toBe(
+			"Checks plugin configuration status against runtime settings",
+		);
+		await expect(service.stop()).resolves.toBeUndefined();
+	});
+
+	it("reports a plugin without a config schema as configured", () => {
+		const service = createService();
+		const plugin = createPlugin();
+
+		expect(service.getMissingConfigKeys(plugin)).toEqual([]);
+		expect(service.getPluginConfigStatus(plugin)).toEqual({
+			configured: true,
+			missingKeys: [],
+			totalKeys: 0,
+		});
+	});
+
+	it("reports an empty config schema as configured", () => {
+		const service = createService();
+		const plugin = createPlugin({});
+
+		expect(service.getPluginConfigStatus(plugin)).toEqual({
+			configured: true,
+			missingKeys: [],
+			totalKeys: 0,
+		});
+	});
+
+	it("preserves declaration order for missing null and empty-string defaults", () => {
+		const service = createService();
+		const plugin = createPlugin({
+			FIRST_REQUIRED: null,
+			OPTIONAL_STRING: "fallback",
+			SECOND_REQUIRED: "",
+			OPTIONAL_NUMBER: 0,
+			OPTIONAL_BOOLEAN: false,
+		});
+
+		expect(service.getMissingConfigKeys(plugin)).toEqual([
+			"FIRST_REQUIRED",
+			"SECOND_REQUIRED",
+		]);
+		expect(service.getPluginConfigStatus(plugin)).toEqual({
+			configured: false,
+			missingKeys: ["FIRST_REQUIRED", "SECOND_REQUIRED"],
+			totalKeys: 5,
+		});
+	});
+
+	it("accepts a non-empty environment value but rejects an empty one", () => {
+		process.env[configuredKey] = "available";
+		process.env[emptyKey] = "";
+		const service = createService();
+		const plugin = createPlugin({
+			[configuredKey]: null,
+			[emptyKey]: null,
+		});
+
+		expect(service.getPluginConfigStatus(plugin)).toEqual({
+			configured: false,
+			missingKeys: [emptyKey],
+			totalKeys: 2,
+		});
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for `PluginConfigurationService`
- verify lifecycle metadata, absent and empty schemas, primitive defaults, missing-key order, environment resolution, and aggregate status counts
- keep the change behavior-preserving and limited to one new test file

## Verification

- `bunx vitest run packages/core/src/features/plugin-manager/services/pluginConfigurationService.test.ts` — 1 file passed, 5 tests passed (rerun after fetching current `origin/develop`)
- `bunx biome check --write packages/core/src/features/plugin-manager/services/pluginConfigurationService.test.ts` — checked 1 file, no fixes applied
- `cd packages/core && bunx tsc --noEmit` — exit 0, zero diagnostics; `pluginConfigurationService.test.ts` appeared nowhere in output
- diff: 1 new test file, 106 insertions, 0 deletions; no production files changed

Hosted CI does not run for pull requests from this fork; the local commands above are the available verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6e8c5e9f3a3687242112a8a739771312b352a18f -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
