### PR TITLE
test(core): cover reward-service

### DIFF
--- a/packages/core/src/features/trajectories/reward-service.test.ts
+++ b/packages/core/src/features/trajectories/reward-service.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Deterministic unit coverage for trajectory heuristic rewards and group
+ * normalization, including optional signals, clamping, ties, and empty inputs.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	createRewardService,
+	RewardService,
+	scoreTrajectory,
+	scoreTrajectoryGroup,
+} from "./reward-service";
+import type { Trajectory } from "./types";
+
+function makeTrajectory(
+	overrides: {
+		finalPnL?: number;
+		successRate?: number;
+		finalStatus?: Trajectory["metrics"]["finalStatus"];
+		environmentReward?: number;
+	} = {},
+): Trajectory {
+	return {
+		trajectoryId: "10000000-0000-0000-0000-000000000001",
+		agentId: "20000000-0000-0000-0000-000000000002",
+		startTime: 1,
+		steps: [],
+		totalReward: 0,
+		rewardComponents: {
+			environmentReward: overrides.environmentReward ?? 0,
+		},
+		metrics: {
+			episodeLength: 0,
+			finalStatus: overrides.finalStatus ?? "completed",
+			...(overrides.finalPnL === undefined
+				? {}
+				: { finalPnL: overrides.finalPnL }),
+			...(overrides.successRate === undefined
+				? {}
+				: { successRate: overrides.successRate }),
+		},
+		metadata: {},
+	};
+}
+
+describe("RewardService", () => {
+	it("combines every heuristic signal using the documented weights", async () => {
+		const trajectory = makeTrajectory({
+			finalPnL: 0,
+			successRate: 0.75,
+			finalStatus: "completed",
+			environmentReward: 0.5,
+		});
+
+		await expect(
+			new RewardService().scoreTrajectory(trajectory),
+		).resolves.toBeCloseTo(0.4);
+	});
+
+	it("renormalizes over only the signals that are present", async () => {
+		const trajectory = makeTrajectory();
+		delete (trajectory.rewardComponents as { environmentReward?: number })
+			.environmentReward;
+
+		await expect(new RewardService().scoreTrajectory(trajectory)).resolves.toBe(
+			1,
+		);
+	});
+
+	it("uses the non-completed penalty and clamps environment rewards", async () => {
+		await expect(
+			new RewardService().scoreTrajectory(
+				makeTrajectory({ finalStatus: "error", environmentReward: -20 }),
+			),
+		).resolves.toBeCloseTo(-2 / 3);
+	});
+
+	it("normalizes profit and loss asymptotically", async () => {
+		const service = new RewardService();
+
+		await expect(
+			service.scoreTrajectory(
+				makeTrajectory({ finalPnL: Number.POSITIVE_INFINITY }),
+			),
+		).resolves.toBeCloseTo(6 / 7);
+		await expect(
+			service.scoreTrajectory(
+				makeTrajectory({ finalPnL: Number.NEGATIVE_INFINITY }),
+			),
+		).resolves.toBeCloseTo(-2 / 7);
+	});
+
+	it("clamps out-of-range aggregate scores", async () => {
+		const service = new RewardService();
+
+		await expect(
+			service.scoreTrajectory(
+				makeTrajectory({ successRate: 10, environmentReward: 1 }),
+			),
+		).resolves.toBe(1);
+		await expect(
+			service.scoreTrajectory(
+				makeTrajectory({
+					successRate: -10,
+					finalStatus: "terminated",
+					environmentReward: -1,
+				}),
+			),
+		).resolves.toBe(-1);
+	});
+
+	it("uses the current heuristic implementation when heuristics are disabled", async () => {
+		const trajectory = makeTrajectory({ finalPnL: 250, successRate: 0.25 });
+		const enabled = new RewardService({ useHeuristics: true });
+		const disabled = new RewardService({ useHeuristics: false });
+
+		expect(await disabled.scoreTrajectory(trajectory)).toBe(
+			await enabled.scoreTrajectory(trajectory),
+		);
+	});
+
+	it("returns an empty result for empty and sparse single-item groups", async () => {
+		const service = new RewardService();
+		const sparse = new Array<Trajectory>(1);
+
+		await expect(service.scoreTrajectoryGroup([])).resolves.toEqual([]);
+		await expect(service.scoreTrajectoryGroup(sparse)).resolves.toEqual([]);
+	});
+
+	it("maps a single raw score from -1..1 into 0..1", async () => {
+		const trajectory = makeTrajectory({
+			finalPnL: 0,
+			successRate: 0.75,
+			environmentReward: 0.5,
+		});
+
+		await expect(
+			new RewardService().scoreTrajectoryGroup([trajectory]),
+		).resolves.toEqual([0.7]);
+	});
+
+	it("normalizes a group relative to its extrema without reordering it", async () => {
+		const highest = makeTrajectory({ environmentReward: 1 });
+		const lowest = makeTrajectory({
+			finalStatus: "error",
+			environmentReward: -1,
+		});
+		const middle = makeTrajectory({
+			finalStatus: "error",
+			environmentReward: 1,
+		});
+
+		const scores = await new RewardService().scoreTrajectoryGroup([
+			highest,
+			lowest,
+			middle,
+		]);
+
+		expect(scores[0]).toBe(1);
+		expect(scores[1]).toBe(0);
+		expect(scores[2]).toBeCloseTo(0.4);
+	});
+
+	it("assigns the neutral midpoint to tied group scores", async () => {
+		const first = makeTrajectory({ finalPnL: 100 });
+		const second = makeTrajectory({ finalPnL: 100 });
+
+		await expect(
+			new RewardService().scoreTrajectoryGroup([first, second]),
+		).resolves.toEqual([0.5, 0.5]);
+	});
+});
+
+describe("reward-service convenience exports", () => {
+	it("creates configured services and delegates scoring through real instances", async () => {
+		const trajectory = makeTrajectory({ environmentReward: 1 });
+		const service = createRewardService({ archetype: "trader" });
+
+		expect(service).toBeInstanceOf(RewardService);
+		await expect(scoreTrajectory(trajectory)).resolves.toBe(1);
+		await expect(
+			scoreTrajectoryGroup([trajectory, trajectory]),
+		).resolves.toEqual([0.5, 0.5]);
+	});
+});


### PR DESCRIPTION

## Summary

- add deterministic unit coverage for the real `RewardService` runtime surface and convenience exports
- cover weighted heuristic scoring, missing optional signals, completion penalties, P&L normalization, and score clamping
- cover empty, sparse, single-item, ordered multi-item, and tied trajectory groups

## Validation

- `bunx vitest run packages/core/src/features/trajectories/reward-service.test.ts` — 1 test file passed, 11 tests passed
- `bunx biome check --write packages/core/src/features/trajectories/reward-service.test.ts` — checked 1 file successfully and formatted it
- `cd packages/core && bunx tsc --noEmit` — exit 0 with zero output; `reward-service.test.ts` appeared nowhere in compiler output
- diff is one new test file only: 184 insertions, 0 deletions; production behavior is unchanged

Hosted CI does not run on pull requests from this fork.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ca16bc831b8864fc37d695d6da4ae0a7a3caaeb4 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
