### PR TITLE
test(core): cover hasTrustEngine

### DIFF
--- a/packages/core/src/features/trust/actions/hasTrustEngine.test.ts
+++ b/packages/core/src/features/trust/actions/hasTrustEngine.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Verifies TRUST action availability against the real runtime service registry,
+ * including exact service-name matching and registration transitions.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentRuntime } from "../../../runtime.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import { Service } from "../../../types/service.ts";
+import { hasTrustEngine } from "./hasTrustEngine.ts";
+
+class CoreTrustEngineService extends Service {
+	static override serviceType = "trust-engine:core";
+	capabilityDescription = "core trust engine test service";
+
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<CoreTrustEngineService> {
+		return new CoreTrustEngineService(runtime);
+	}
+
+	async stop(): Promise<void> {}
+}
+
+class TrustEngineService extends Service {
+	static override serviceType = "trust-engine";
+	capabilityDescription = "trust engine test service";
+
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<TrustEngineService> {
+		return new TrustEngineService(runtime);
+	}
+
+	async stop(): Promise<void> {}
+}
+
+const activeRuntimes: AgentRuntime[] = [];
+
+async function makeRuntime(): Promise<AgentRuntime> {
+	const runtime = new AgentRuntime({ logLevel: "fatal" });
+	await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+	activeRuntimes.push(runtime);
+	return runtime;
+}
+
+describe("hasTrustEngine", () => {
+	afterEach(async () => {
+		await Promise.all(
+			activeRuntimes.splice(0).map((runtime) => runtime.stop()),
+		);
+	});
+
+	it("returns false when the trust-engine service is not registered", async () => {
+		const runtime = await makeRuntime();
+
+		expect(hasTrustEngine(runtime)).toBe(false);
+	});
+
+	it("requires the exact trust-engine service name", async () => {
+		const runtime = await makeRuntime();
+		await runtime.registerService(CoreTrustEngineService);
+		await runtime.getServiceLoadPromise(CoreTrustEngineService.serviceType);
+
+		expect(hasTrustEngine(runtime)).toBe(false);
+	});
+
+	it("returns true after the trust-engine service is registered", async () => {
+		const runtime = await makeRuntime();
+		await runtime.registerService(TrustEngineService);
+		await runtime.getServiceLoadPromise(TrustEngineService.serviceType);
+
+		expect(hasTrustEngine(runtime)).toBe(true);
+	});
+});


### PR DESCRIPTION

## Summary

- add direct unit coverage for `hasTrustEngine`
- exercise the real `AgentRuntime` service registry rather than mocking `getService`
- verify the absent-service branch, exact service-name matching, and the registered-service branch

## Validation

- `bunx vitest run packages/core/src/features/trust/actions/hasTrustEngine.test.ts` — 1 test file passed, 3 tests passed
- `bunx biome check --write packages/core/src/features/trust/actions/hasTrustEngine.test.ts` — checked 1 file and exited 0
- `(cd packages/core && bunx tsc --noEmit)` — exited 0; `hasTrustEngine.test.ts` appeared nowhere in the output
- diff is additive and touches only `packages/core/src/features/trust/actions/hasTrustEngine.test.ts` (+75/-0)

Hosted CI does not run for this fork contribution; the local results above are the available validation.

## Evidence

N/A — test-only change with no production behavior or user-facing surface changed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1cecb6b21f7b628846e33c1bf25a7f9dec59075b -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
