### PR TITLE
test(core): cover ambient-context

### DIFF
--- a/packages/core/src/ambient-context.test.ts
+++ b/packages/core/src/ambient-context.test.ts
@@ -1,56 +1,61 @@
 /**
- * Unit coverage for the ambient-context singleton: `getAmbientSingleton` builds
- * a value once and caches it on a shared `globalThis` slot keyed by symbol so
- * duplicate module copies agree, `setAmbientSingleton` overrides it everywhere,
- * and `peekAmbientSingleton` reads without creating. Pure deterministic test —
- * no model or database.
+ * Coverage for ambient-context.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
-
+import { describe, expect, it } from "vitest";
 import {
 	getAmbientSingleton,
 	peekAmbientSingleton,
 	setAmbientSingleton,
-} from "./ambient-context";
+} from "./ambient-context.js";
 
-const KEY = Symbol.for("elizaos.test.ambient-context.singleton");
-
-afterEach(() => {
-	delete (globalThis as Record<PropertyKey, unknown>)[KEY];
-});
-
-describe("ambient-context singleton", () => {
-	it("creates the value once and reuses it across calls", () => {
-		const factory = vi.fn(() => ({ id: "first" }));
-
-		const a = getAmbientSingleton(KEY, factory);
-		const b = getAmbientSingleton(KEY, factory);
-
-		expect(a).toBe(b);
-		expect(factory).toHaveBeenCalledTimes(1);
+describe("ambient-context", () => {
+	it("returns undefined for an unset singleton", () => {
+		const key = Symbol("unset");
+		expect(peekAmbientSingleton(key)).toBeUndefined();
 	});
 
-	it("stores the value on the shared global slot so duplicate copies agree", () => {
-		const value = { id: "shared" };
-		getAmbientSingleton(KEY, () => value);
-
-		expect((globalThis as Record<PropertyKey, unknown>)[KEY]).toBe(value);
-		expect(peekAmbientSingleton(KEY)).toBe(value);
+	it("returns the value after set", () => {
+		const key = Symbol("set");
+		const value = { n: 1 };
+		setAmbientSingleton(key, value);
+		expect(getAmbientSingleton(key, () => ({ n: 0 }))).toBe(value);
+		expect(peekAmbientSingleton(key)).toBe(value);
 	});
 
-	it("setAmbientSingleton overrides the value everywhere immediately", () => {
-		getAmbientSingleton(KEY, () => ({ id: "original" }));
-		const override = { id: "override" };
-
-		setAmbientSingleton(KEY, override);
-
-		// A subsequent get returns the override, never re-running the factory.
-		const factory = vi.fn(() => ({ id: "unused" }));
-		expect(getAmbientSingleton(KEY, factory)).toBe(override);
-		expect(factory).not.toHaveBeenCalled();
+	it("does not call the factory when the singleton already exists", () => {
+		const key = Symbol("existing");
+		const value = { n: 2 };
+		setAmbientSingleton(key, value);
+		let factoryCalls = 0;
+		const got = getAmbientSingleton(key, () => {
+			factoryCalls += 1;
+			return { n: 3 };
+		});
+		expect(got).toBe(value);
+		expect(factoryCalls).toBe(0);
 	});
 
-	it("peek returns undefined before anything is stored", () => {
-		expect(peekAmbientSingleton(KEY)).toBeUndefined();
+	it("calls the factory exactly once on first get", () => {
+		const key = Symbol("factory");
+		let factoryCalls = 0;
+		const first = getAmbientSingleton(key, () => {
+			factoryCalls += 1;
+			return { n: 4 };
+		});
+		const second = getAmbientSingleton(key, () => {
+			factoryCalls += 1;
+			return { n: 5 };
+		});
+		expect(first).toBe(second);
+		expect(factoryCalls).toBe(1);
+	});
+
+	it("keeps keys isolated", () => {
+		const a = Symbol("a");
+		const b = Symbol("b");
+		setAmbientSingleton(a, { tag: "a" });
+		setAmbientSingleton(b, { tag: "b" });
+		expect(peekAmbientSingleton(a)?.tag).toBe("a");
+		expect(peekAmbientSingleton(b)?.tag).toBe("b");
 	});
 });


### PR DESCRIPTION
## What

Behavioral coverage for `ambient-context.ts`: singleton get/set/peek semantics, factory-once behavior, key isolation, and unset returns undefined.

## Tests

```text
$ bunx vitest run ambient-context
5 passed (real module, not a stub)
```

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->