### PR TITLE
test(core): cover provenance-envelope

### DIFF
--- a/packages/core/src/access-control/provenance-envelope.test.ts
+++ b/packages/core/src/access-control/provenance-envelope.test.ts
@@ -201,3 +201,468 @@ describe("buildCanonicalRecall", () => {
 		expect(result.withheld[0].code).toBe("invalid_provenance");
 	});
 });
+
+/**
+ * Additive branch coverage: readString coercion and trim semantics,
+ * connector-source normalization and key validation, nested identity lookup
+ * under the canonical source key, display-name precedence, passthrough
+ * fields, timestamp and scope validation, secondary message-id agreement, v2
+ * tuple structure, recall ordering / tie-breaking / cross-room and scope
+ * withholding, aggregate identifier-free withheld entries, empty candidate
+ * sets, and the fail-closed unbound-delivery-turn behavior of
+ * searchCanonicalConversationMemories.
+ */
+
+function discordMeta(platformMessageId: string) {
+	return {
+		provider: "discord",
+		accountId: "acc-1",
+		platformMessageId,
+		scope: "shared",
+		discord: { userId: "discord-user-1", name: "Alice" },
+	};
+}
+
+describe("deriveCanonicalProvenance field coercion and normalization", () => {
+	it("coerces numeric telegram-style identifiers to strings", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "telegram",
+				accountId: 987654321,
+				platformMessageId: 42,
+				scope: "room",
+				chatType: "group",
+				telegram: { userId: 555000111, name: "Bob" },
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.source).toBe("telegram");
+			expect(result.provenance.accountId).toBe("987654321");
+			expect(result.provenance.platformMessageId).toBe("42");
+			expect(result.provenance.senderPlatformId).toBe("555000111");
+			expect(result.provenance.senderDisplayName).toBe("Bob");
+			expect(result.provenance.trust).toBe("sender-stamped");
+			expect(result.provenance.chatType).toBe("group");
+			expect(result.provenance.scope).toBe("room");
+		}
+	});
+
+	it("treats whitespace-only strings as missing required fields", () => {
+		const blankProvider = makeMemory({
+			metadata: {
+				provider: "   ",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+			},
+		});
+		const providerResult = deriveCanonicalProvenance(blankProvider, AGENT_ID);
+		expect(providerResult.valid).toBe(false);
+		if (!providerResult.valid) {
+			expect(providerResult.reason).toContain("missing a valid source");
+		}
+
+		const blankAccount = makeMemory({
+			metadata: {
+				provider: "discord",
+				accountId: "   ",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+			},
+		});
+		const accountResult = deriveCanonicalProvenance(blankAccount, AGENT_ID);
+		expect(accountResult.valid).toBe(false);
+		if (!accountResult.valid) {
+			expect(accountResult.reason).toContain(
+				"missing a connector account id",
+			);
+		}
+	});
+
+	it("normalizes source casing and resolves nested identity under the canonical key", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "Discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+				discord: { userId: "u-1" },
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.rawSource).toBe("Discord");
+			expect(result.provenance.source).toBe("discord");
+			expect(result.provenance.senderPlatformId).toBe("u-1");
+			expect(result.provenance.trust).toBe("sender-stamped");
+		}
+	});
+
+	it("treats differently-cased duplicate source paths as one surface, not a conflict", () => {
+		const memory = makeMemory({
+			content: { text: "hi", source: "DISCORD" },
+			metadata: {
+				provider: "discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.source).toBe("discord");
+		}
+	});
+
+	it("rejects sources that are not valid registry keys", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "not a source!",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.code).toBe("invalid_provenance");
+			expect(result.reason).toContain("missing a valid source");
+		}
+	});
+
+	it("prefers metadata.sender.name over nested identity names", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+				sender: { name: "Carol" },
+				discord: { userId: "u-1", name: "NestedName" },
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.senderDisplayName).toBe("Carol");
+		}
+	});
+
+	it("falls back to sender.username then metadata.entityName for display name", () => {
+		const usernameOnly = makeMemory({
+			metadata: {
+				provider: "discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+				sender: { username: "carol_un" },
+				discord: { userId: "u-1" },
+			},
+		});
+		const usernameResult = deriveCanonicalProvenance(usernameOnly, AGENT_ID);
+		expect(usernameResult.valid).toBe(true);
+		if (usernameResult.valid) {
+			expect(usernameResult.provenance.senderDisplayName).toBe("carol_un");
+		}
+
+		const entityNameOnly = makeMemory({
+			metadata: {
+				provider: "discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "shared",
+				entityName: "Entity Fallback",
+				discord: { userId: "u-1" },
+			},
+		});
+		const entityResult = deriveCanonicalProvenance(entityNameOnly, AGENT_ID);
+		expect(entityResult.valid).toBe(true);
+		if (entityResult.valid) {
+			expect(entityResult.provenance.senderDisplayName).toBe(
+				"Entity Fallback",
+			);
+		}
+	});
+
+	it("passes worldId through from the stored memory", () => {
+		const worldId = "33333333-3333-3333-3333-333333333333" as UUID;
+		const result = deriveCanonicalProvenance(
+			makeMemory({ worldId }),
+			AGENT_ID,
+		);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.worldId).toBe(worldId);
+		}
+	});
+
+	it("rejects non-positive, non-finite, and non-numeric timestamps", () => {
+		const badTimestamps: unknown[] = [0, -50, Number.NaN, "1000"];
+		for (const createdAt of badTimestamps) {
+			const result = deriveCanonicalProvenance(
+				makeMemory({ createdAt: createdAt as number }),
+				AGENT_ID,
+			);
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.reason).toContain("missing a valid timestamp");
+			}
+		}
+	});
+
+	it("rejects scope strings outside the canonical MemoryScope set", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "discord",
+				accountId: "acc-1",
+				platformMessageId: "pmi-1",
+				scope: "workspace",
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.code).toBe("invalid_provenance");
+			expect(result.reason).toContain("missing a valid scope");
+		}
+	});
+
+	it("accepts agreeing secondary message-id paths without a top-level id", () => {
+		const memory = makeMemory({
+			metadata: {
+				provider: "telegram",
+				accountId: "bot-1",
+				messageIdFull: "777",
+				scope: "shared",
+				telegram: { messageId: "777" },
+			},
+		});
+		const result = deriveCanonicalProvenance(memory, AGENT_ID);
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.provenance.platformMessageId).toBe("777");
+		}
+	});
+});
+
+describe("canonicalDedupeKey v2 tuple structure", () => {
+	it("round-trips delimiter-bearing identifiers through the versioned JSON tuple", () => {
+		const roomId = "44444444-4444-4444-4444-444444444444" as UUID;
+		const provenance: CanonicalProvenance = {
+			source: "slack",
+			accountId: "team:channel:acct",
+			roomId,
+			senderId: USER_ID,
+			timestampMs: 1000,
+			trust: "sender-stamped",
+			platformMessageId: "msg:42:tail",
+			scope: "shared",
+		};
+
+		const key = canonicalDedupeKey(provenance);
+		expect(key.startsWith("v2|")).toBe(true);
+		expect(JSON.parse(key.slice(3))).toEqual([
+			"slack",
+			"team:channel:acct",
+			roomId,
+			"msg:42:tail",
+		]);
+	});
+});
+
+describe("buildCanonicalRecall ordering, withholding, and aggregation", () => {
+	it("returns items sorted ascending by creation timestamp", () => {
+		const result = buildCanonicalRecall({
+			candidates: [
+				makeMemory({
+					id: "mem-c" as UUID,
+					createdAt: 3000,
+					metadata: discordMeta("pmi-3"),
+				}),
+				makeMemory({
+					id: "mem-a" as UUID,
+					createdAt: 1000,
+					metadata: discordMeta("pmi-1"),
+				}),
+				makeMemory({
+					id: "mem-b" as UUID,
+					createdAt: 2000,
+					metadata: discordMeta("pmi-2"),
+				}),
+			],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items.map((item) => item.memory.id)).toEqual([
+			"mem-a",
+			"mem-b",
+			"mem-c",
+		]);
+	});
+
+	it("keeps the first-seen candidate when timestamps tie within one dedupe group", () => {
+		const firstSeen = makeMemory({
+			id: "mem-tie-first" as UUID,
+			createdAt: 500,
+			metadata: discordMeta("tie-pmi"),
+		});
+		const secondSeen = makeMemory({
+			id: "mem-tie-second" as UUID,
+			createdAt: 500,
+			metadata: discordMeta("tie-pmi"),
+		});
+		const result = buildCanonicalRecall({
+			candidates: [firstSeen, secondSeen],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0].memory.id).toBe("mem-tie-first");
+	});
+
+	it("withholds candidates from a different room under the disabled cross-room gate", () => {
+		const otherRoomId = "55555555-5555-5555-5555-555555555555" as UUID;
+		const sameRoom = makeMemory({
+			id: "mem-same" as UUID,
+			metadata: discordMeta("pmi-same"),
+		});
+		const otherRoom = makeMemory({
+			id: "mem-other" as UUID,
+			roomId: otherRoomId,
+			metadata: discordMeta("pmi-other"),
+		});
+		const result = buildCanonicalRecall({
+			candidates: [sameRoom, otherRoom],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items.map((item) => item.memory.id)).toEqual(["mem-same"]);
+		expect(result.withheld).toHaveLength(1);
+		expect(result.withheld[0].code).toBe("cross_room_denied");
+		expect(result.withheld[0].reason).toContain("cross-room recall is disabled");
+	});
+
+	it("withholds owner-private candidates from a non-owner but admits the owner", () => {
+		const privateMemory = makeMemory({
+			id: "mem-owner-private" as UUID,
+			metadata: { ...discordMeta("pmi-private"), scope: "owner-private" },
+		});
+
+		const asUser = buildCanonicalRecall({
+			candidates: [privateMemory],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+		expect(asUser.items).toHaveLength(0);
+		expect(asUser.withheld).toHaveLength(1);
+		expect(asUser.withheld[0].code).toBe("scope_denied");
+
+		const asOwner = buildCanonicalRecall({
+			candidates: [privateMemory],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, isOwner: true },
+			destinationRoomId: ROOM_ID,
+		});
+		expect(asOwner.items).toHaveLength(1);
+		expect(asOwner.withheld).toHaveLength(0);
+	});
+
+	it("aggregates repeated deny codes into one identifier-free withheld entry", () => {
+		const missingAccount = makeMemory({
+			id: "mem-no-acct" as UUID,
+			metadata: {
+				provider: "discord",
+				platformMessageId: "p-1",
+				scope: "shared",
+			},
+		});
+		const badTimestamp = makeMemory({
+			id: "mem-bad-ts" as UUID,
+			createdAt: -7,
+			metadata: discordMeta("p-2"),
+		});
+		const valid = makeMemory({
+			id: "mem-valid" as UUID,
+			metadata: discordMeta("p-ok"),
+		});
+
+		const result = buildCanonicalRecall({
+			candidates: [missingAccount, badTimestamp, valid],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items.map((item) => item.memory.id)).toEqual(["mem-valid"]);
+		expect(result.withheld).toHaveLength(1);
+		expect(result.withheld[0].code).toBe("invalid_provenance");
+		expect(result.withheld[0].reason).not.toContain("acc-1");
+		expect(result.withheld[0].reason).not.toContain("p-1");
+		expect(result.withheld[0].reason).not.toContain("p-2");
+	});
+
+	it("returns an empty result for an empty candidate set", () => {
+		const result = buildCanonicalRecall({
+			candidates: [],
+			agentId: AGENT_ID,
+			requester: { requesterEntityId: USER_ID, role: "USER" },
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items).toEqual([]);
+		expect(result.withheld).toEqual([]);
+	});
+});
+
+describe("searchCanonicalConversationMemories fail-closed delivery binding", () => {
+	it("returns unavailable without querying the adapter when the delivery turn is not runtime-bound", async () => {
+		const { searchCanonicalConversationMemories } = await import(
+			"./provenance-envelope.js"
+		);
+		let searchCalls = 0;
+		const runtime = {
+			agentId: AGENT_ID,
+			searchMemories: async () => {
+				searchCalls += 1;
+				return [];
+			},
+		} as unknown as Parameters<
+			typeof searchCanonicalConversationMemories
+		>[0]["runtime"];
+
+		const result = await searchCanonicalConversationMemories({
+			runtime,
+			embedding: [0.1, 0.2],
+			count: 5,
+			deliveryMessage: makeMemory(),
+		});
+
+		expect(result).toEqual({
+			items: [],
+			withheld: [],
+			availability: "unavailable",
+			candidateWindowComplete: false,
+		});
+		expect(searchCalls).toBe(0);
+	});
+});

--- a/packages/core/src/access-control/provenance-envelope.test.ts
+++ b/packages/core/src/access-control/provenance-envelope.test.ts
@@ -202,467 +202,211 @@ describe("buildCanonicalRecall", () => {
 	});
 });
 
-/**
- * Additive branch coverage: readString coercion and trim semantics,
- * connector-source normalization and key validation, nested identity lookup
- * under the canonical source key, display-name precedence, passthrough
- * fields, timestamp and scope validation, secondary message-id agreement, v2
- * tuple structure, recall ordering / tie-breaking / cross-room and scope
- * withholding, aggregate identifier-free withheld entries, empty candidate
- * sets, and the fail-closed unbound-delivery-turn behavior of
- * searchCanonicalConversationMemories.
- */
-
-function discordMeta(platformMessageId: string) {
-	return {
-		provider: "discord",
-		accountId: "acc-1",
-		platformMessageId,
-		scope: "shared",
-		discord: { userId: "discord-user-1", name: "Alice" },
-	};
-}
-
-describe("deriveCanonicalProvenance field coercion and normalization", () => {
-	it("coerces numeric telegram-style identifiers to strings", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "telegram",
-				accountId: 987654321,
-				platformMessageId: 42,
-				scope: "room",
-				chatType: "group",
-				telegram: { userId: 555000111, name: "Bob" },
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.source).toBe("telegram");
-			expect(result.provenance.accountId).toBe("987654321");
-			expect(result.provenance.platformMessageId).toBe("42");
-			expect(result.provenance.senderPlatformId).toBe("555000111");
-			expect(result.provenance.senderDisplayName).toBe("Bob");
-			expect(result.provenance.trust).toBe("sender-stamped");
-			expect(result.provenance.chatType).toBe("group");
-			expect(result.provenance.scope).toBe("room");
-		}
-	});
-
-	it("treats whitespace-only strings as missing required fields", () => {
-		const blankProvider = makeMemory({
-			metadata: {
-				provider: "   ",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-			},
-		});
-		const providerResult = deriveCanonicalProvenance(blankProvider, AGENT_ID);
-		expect(providerResult.valid).toBe(false);
-		if (!providerResult.valid) {
-			expect(providerResult.reason).toContain("missing a valid source");
-		}
-
-		const blankAccount = makeMemory({
-			metadata: {
-				provider: "discord",
-				accountId: "   ",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-			},
-		});
-		const accountResult = deriveCanonicalProvenance(blankAccount, AGENT_ID);
-		expect(accountResult.valid).toBe(false);
-		if (!accountResult.valid) {
-			expect(accountResult.reason).toContain(
-				"missing a connector account id",
-			);
-		}
-	});
-
-	it("normalizes source casing and resolves nested identity under the canonical key", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "Discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-				discord: { userId: "u-1" },
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.rawSource).toBe("Discord");
-			expect(result.provenance.source).toBe("discord");
-			expect(result.provenance.senderPlatformId).toBe("u-1");
-			expect(result.provenance.trust).toBe("sender-stamped");
-		}
-	});
-
-	it("treats differently-cased duplicate source paths as one surface, not a conflict", () => {
-		const memory = makeMemory({
-			content: { text: "hi", source: "DISCORD" },
-			metadata: {
-				provider: "discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.source).toBe("discord");
-		}
-	});
-
-	it("rejects sources that are not valid registry keys", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "not a source!",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(false);
-		if (!result.valid) {
-			expect(result.code).toBe("invalid_provenance");
-			expect(result.reason).toContain("missing a valid source");
-		}
-	});
-
-	it("prefers metadata.sender.name over nested identity names", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-				sender: { name: "Carol" },
-				discord: { userId: "u-1", name: "NestedName" },
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.senderDisplayName).toBe("Carol");
-		}
-	});
-
-	it("falls back to sender.username then metadata.entityName for display name", () => {
-		const usernameOnly = makeMemory({
-			metadata: {
-				provider: "discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-				sender: { username: "carol_un" },
-				discord: { userId: "u-1" },
-			},
-		});
-		const usernameResult = deriveCanonicalProvenance(usernameOnly, AGENT_ID);
-		expect(usernameResult.valid).toBe(true);
-		if (usernameResult.valid) {
-			expect(usernameResult.provenance.senderDisplayName).toBe("carol_un");
-		}
-
-		const entityNameOnly = makeMemory({
-			metadata: {
-				provider: "discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "shared",
-				entityName: "Entity Fallback",
-				discord: { userId: "u-1" },
-			},
-		});
-		const entityResult = deriveCanonicalProvenance(entityNameOnly, AGENT_ID);
-		expect(entityResult.valid).toBe(true);
-		if (entityResult.valid) {
-			expect(entityResult.provenance.senderDisplayName).toBe(
-				"Entity Fallback",
-			);
-		}
-	});
-
-	it("passes worldId through from the stored memory", () => {
-		const worldId = "33333333-3333-3333-3333-333333333333" as UUID;
-		const result = deriveCanonicalProvenance(
-			makeMemory({ worldId }),
+describe("deriveCanonicalProvenance additive branches", () => {
+	it("falls back to content and base sources while reading nested identities", () => {
+		const fromContent = deriveCanonicalProvenance(
+			makeMemory({
+				content: { text: "from content", source: "telegram" },
+				metadata: {
+					accountId: "bot-1",
+					platformMessageId: "41",
+					scope: "room",
+					telegram: { id: 12345, username: "telegram-user" },
+				},
+			}),
 			AGENT_ID,
 		);
 
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.worldId).toBe(worldId);
-		}
+		expect(fromContent).toMatchObject({
+			valid: true,
+			provenance: {
+				source: "telegram",
+				rawSource: "telegram",
+				senderPlatformId: "12345",
+				senderDisplayName: "telegram-user",
+			},
+		});
+
+		const fromBase = deriveCanonicalProvenance(
+			makeMemory({
+				metadata: {
+					accountId: "bot-2",
+					platformMessageId: "42",
+					base: { source: "telegram", scope: "shared" },
+				},
+			}),
+			AGENT_ID,
+		);
+
+		expect(fromBase).toMatchObject({
+			valid: true,
+			provenance: {
+				source: "telegram",
+				rawSource: "telegram",
+				scope: "shared",
+			},
+		});
 	});
 
-	it("rejects non-positive, non-finite, and non-numeric timestamps", () => {
-		const badTimestamps: unknown[] = [0, -50, Number.NaN, "1000"];
-		for (const createdAt of badTimestamps) {
+	it("rejects non-positive and non-finite timestamps", () => {
+		for (const createdAt of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
 			const result = deriveCanonicalProvenance(
-				makeMemory({ createdAt: createdAt as number }),
+				makeMemory({ createdAt }),
 				AGENT_ID,
 			);
-			expect(result.valid).toBe(false);
-			if (!result.valid) {
-				expect(result.reason).toContain("missing a valid timestamp");
-			}
+			expect(result).toEqual({
+				valid: false,
+				code: "invalid_provenance",
+				source: "discord",
+				reason: "stored memory is missing a valid timestamp",
+			});
 		}
 	});
 
-	it("rejects scope strings outside the canonical MemoryScope set", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "discord",
-				accountId: "acc-1",
-				platformMessageId: "pmi-1",
-				scope: "workspace",
-			},
-		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(false);
-		if (!result.valid) {
-			expect(result.code).toBe("invalid_provenance");
-			expect(result.reason).toContain("missing a valid scope");
+	it("accepts every declared scope and rejects an unknown scope", () => {
+		for (const scope of [
+			"shared",
+			"private",
+			"room",
+			"global",
+			"owner-private",
+			"user-private",
+			"agent-private",
+		] as const) {
+			const result = deriveCanonicalProvenance(
+				makeMemory({
+					metadata: {
+						provider: "discord",
+						accountId: "acc-1",
+						platformMessageId: `scope-${scope}`,
+						scope,
+					},
+				}),
+				AGENT_ID,
+			);
+			expect(result).toMatchObject({ valid: true, provenance: { scope } });
 		}
-	});
 
-	it("accepts agreeing secondary message-id paths without a top-level id", () => {
-		const memory = makeMemory({
-			metadata: {
-				provider: "telegram",
-				accountId: "bot-1",
-				messageIdFull: "777",
-				scope: "shared",
-				telegram: { messageId: "777" },
-			},
+		const unknown = deriveCanonicalProvenance(
+			makeMemory({
+				metadata: {
+					provider: "discord",
+					accountId: "acc-1",
+					platformMessageId: "unknown-scope",
+					scope: "team-private",
+				},
+			}),
+			AGENT_ID,
+		);
+		expect(unknown).toMatchObject({
+			valid: false,
+			code: "invalid_provenance",
+			reason: "stored memory is missing a valid scope",
 		});
-		const result = deriveCanonicalProvenance(memory, AGENT_ID);
-
-		expect(result.valid).toBe(true);
-		if (result.valid) {
-			expect(result.provenance.platformMessageId).toBe("777");
-		}
 	});
 });
 
-describe("canonicalDedupeKey v2 tuple structure", () => {
-	it("round-trips delimiter-bearing identifiers through the versioned JSON tuple", () => {
-		const roomId = "44444444-4444-4444-4444-444444444444" as UUID;
-		const provenance: CanonicalProvenance = {
-			source: "slack",
-			accountId: "team:channel:acct",
-			roomId,
-			senderId: USER_ID,
-			timestampMs: 1000,
-			trust: "sender-stamped",
-			platformMessageId: "msg:42:tail",
+function recallMemory(
+	id: string,
+	createdAt: number,
+	platformMessageId: string,
+	overrides: Partial<Memory> = {},
+): Memory {
+	return makeMemory({
+		id: id as UUID,
+		createdAt,
+		metadata: {
+			provider: "discord",
+			accountId: "acc-1",
+			platformMessageId,
 			scope: "shared",
-		};
-
-		const key = canonicalDedupeKey(provenance);
-		expect(key.startsWith("v2|")).toBe(true);
-		expect(JSON.parse(key.slice(3))).toEqual([
-			"slack",
-			"team:channel:acct",
-			roomId,
-			"msg:42:tail",
-		]);
+			discord: { userId: "discord-user-1" },
+		},
+		...overrides,
 	});
-});
+}
 
-describe("buildCanonicalRecall ordering, withholding, and aggregation", () => {
-	it("returns items sorted ascending by creation timestamp", () => {
+describe("buildCanonicalRecall additive branches", () => {
+	const requester = { requesterEntityId: USER_ID, role: "USER" as const };
+
+	it("returns empty arrays for an empty candidate queue", () => {
 		const result = buildCanonicalRecall({
-			candidates: [
-				makeMemory({
-					id: "mem-c" as UUID,
-					createdAt: 3000,
-					metadata: discordMeta("pmi-3"),
-				}),
-				makeMemory({
-					id: "mem-a" as UUID,
-					createdAt: 1000,
-					metadata: discordMeta("pmi-1"),
-				}),
-				makeMemory({
-					id: "mem-b" as UUID,
-					createdAt: 2000,
-					metadata: discordMeta("pmi-2"),
-				}),
-			],
+			candidates: [],
 			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
+			requester,
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result).toEqual({ items: [], withheld: [] });
+	});
+
+	it("sorts records chronologically and keeps the first encounter on a timestamp tie", () => {
+		const later = recallMemory("later", 30, "later");
+		const firstTie = recallMemory("first-tie", 20, "tie");
+		const earlier = recallMemory("earlier", 10, "earlier");
+		const secondTie = recallMemory("second-tie", 20, "tie", {
+			content: { text: "second encounter" },
+		});
+
+		const result = buildCanonicalRecall({
+			candidates: [later, firstTie, earlier, secondTie],
+			agentId: AGENT_ID,
+			requester,
 			destinationRoomId: ROOM_ID,
 		});
 
 		expect(result.items.map((item) => item.memory.id)).toEqual([
-			"mem-a",
-			"mem-b",
-			"mem-c",
+			"earlier",
+			"first-tie",
+			"later",
 		]);
+		expect(result.withheld).toEqual([]);
 	});
 
-	it("keeps the first-seen candidate when timestamps tie within one dedupe group", () => {
-		const firstSeen = makeMemory({
-			id: "mem-tie-first" as UUID,
-			createdAt: 500,
-			metadata: discordMeta("tie-pmi"),
-		});
-		const secondSeen = makeMemory({
-			id: "mem-tie-second" as UUID,
-			createdAt: 500,
-			metadata: discordMeta("tie-pmi"),
-		});
-		const result = buildCanonicalRecall({
-			candidates: [firstSeen, secondSeen],
-			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
-			destinationRoomId: ROOM_ID,
-		});
-
-		expect(result.items).toHaveLength(1);
-		expect(result.items[0].memory.id).toBe("mem-tie-first");
-	});
-
-	it("withholds candidates from a different room under the disabled cross-room gate", () => {
-		const otherRoomId = "55555555-5555-5555-5555-555555555555" as UUID;
-		const sameRoom = makeMemory({
-			id: "mem-same" as UUID,
-			metadata: discordMeta("pmi-same"),
-		});
-		const otherRoom = makeMemory({
-			id: "mem-other" as UUID,
-			roomId: otherRoomId,
-			metadata: discordMeta("pmi-other"),
-		});
-		const result = buildCanonicalRecall({
-			candidates: [sameRoom, otherRoom],
-			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
-			destinationRoomId: ROOM_ID,
-		});
-
-		expect(result.items.map((item) => item.memory.id)).toEqual(["mem-same"]);
-		expect(result.withheld).toHaveLength(1);
-		expect(result.withheld[0].code).toBe("cross_room_denied");
-		expect(result.withheld[0].reason).toContain("cross-room recall is disabled");
-	});
-
-	it("withholds owner-private candidates from a non-owner but admits the owner", () => {
-		const privateMemory = makeMemory({
-			id: "mem-owner-private" as UUID,
-			metadata: { ...discordMeta("pmi-private"), scope: "owner-private" },
-		});
-
-		const asUser = buildCanonicalRecall({
-			candidates: [privateMemory],
-			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
-			destinationRoomId: ROOM_ID,
-		});
-		expect(asUser.items).toHaveLength(0);
-		expect(asUser.withheld).toHaveLength(1);
-		expect(asUser.withheld[0].code).toBe("scope_denied");
-
-		const asOwner = buildCanonicalRecall({
-			candidates: [privateMemory],
-			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, isOwner: true },
-			destinationRoomId: ROOM_ID,
-		});
-		expect(asOwner.items).toHaveLength(1);
-		expect(asOwner.withheld).toHaveLength(0);
-	});
-
-	it("aggregates repeated deny codes into one identifier-free withheld entry", () => {
-		const missingAccount = makeMemory({
-			id: "mem-no-acct" as UUID,
+	it("aggregates denial codes without leaking withheld identifiers", () => {
+		const invalidOne = recallMemory("invalid-one", 1, "secret-message-one", {
 			metadata: {
 				provider: "discord",
-				platformMessageId: "p-1",
+				platformMessageId: "secret-message-one",
 				scope: "shared",
 			},
 		});
-		const badTimestamp = makeMemory({
-			id: "mem-bad-ts" as UUID,
-			createdAt: -7,
-			metadata: discordMeta("p-2"),
+		const invalidTwo = recallMemory("invalid-two", 2, "secret-message-two", {
+			metadata: {
+				provider: "discord",
+				platformMessageId: "secret-message-two",
+				scope: "shared",
+			},
 		});
-		const valid = makeMemory({
-			id: "mem-valid" as UUID,
-			metadata: discordMeta("p-ok"),
+		const privateOther = recallMemory("private-other", 3, "private-record", {
+			entityId: "33333333-3333-3333-3333-333333333333" as UUID,
+			metadata: {
+				provider: "discord",
+				accountId: "secret-account",
+				platformMessageId: "private-record",
+				scope: "user-private",
+			},
+		});
+		const crossRoom = recallMemory("cross-room", 4, "cross-room-record", {
+			roomId: "44444444-4444-4444-4444-444444444444" as UUID,
 		});
 
 		const result = buildCanonicalRecall({
-			candidates: [missingAccount, badTimestamp, valid],
+			candidates: [invalidOne, invalidTwo, privateOther, crossRoom],
 			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
-			destinationRoomId: ROOM_ID,
-		});
-
-		expect(result.items.map((item) => item.memory.id)).toEqual(["mem-valid"]);
-		expect(result.withheld).toHaveLength(1);
-		expect(result.withheld[0].code).toBe("invalid_provenance");
-		expect(result.withheld[0].reason).not.toContain("acc-1");
-		expect(result.withheld[0].reason).not.toContain("p-1");
-		expect(result.withheld[0].reason).not.toContain("p-2");
-	});
-
-	it("returns an empty result for an empty candidate set", () => {
-		const result = buildCanonicalRecall({
-			candidates: [],
-			agentId: AGENT_ID,
-			requester: { requesterEntityId: USER_ID, role: "USER" },
+			requester,
 			destinationRoomId: ROOM_ID,
 		});
 
 		expect(result.items).toEqual([]);
-		expect(result.withheld).toEqual([]);
-	});
-});
-
-describe("searchCanonicalConversationMemories fail-closed delivery binding", () => {
-	it("returns unavailable without querying the adapter when the delivery turn is not runtime-bound", async () => {
-		const { searchCanonicalConversationMemories } = await import(
-			"./provenance-envelope.js"
-		);
-		let searchCalls = 0;
-		const runtime = {
-			agentId: AGENT_ID,
-			searchMemories: async () => {
-				searchCalls += 1;
-				return [];
-			},
-		} as unknown as Parameters<
-			typeof searchCanonicalConversationMemories
-		>[0]["runtime"];
-
-		const result = await searchCanonicalConversationMemories({
-			runtime,
-			embedding: [0.1, 0.2],
-			count: 5,
-			deliveryMessage: makeMemory(),
-		});
-
-		expect(result).toEqual({
-			items: [],
-			withheld: [],
-			availability: "unavailable",
-			candidateWindowComplete: false,
-		});
-		expect(searchCalls).toBe(0);
+		expect(result.withheld.map((item) => item.code)).toEqual([
+			"invalid_provenance",
+			"scope_denied",
+			"cross_room_denied",
+		]);
+		expect(result.withheld).toHaveLength(3);
+		const serialized = JSON.stringify(result.withheld);
+		expect(serialized).not.toContain("secret-message");
+		expect(serialized).not.toContain("secret-account");
 	});
 });


### PR DESCRIPTION
## Summary

Extends the colocated runtime unit suite for `packages/core/src/access-control/provenance-envelope.ts` with six additive cases. Production code is unchanged.

The new coverage drives the real module without mocks and verifies:

- content/base source fallback and numeric nested connector identities;
- non-positive and non-finite timestamp rejection;
- every declared memory scope plus unknown-scope rejection;
- empty recall, chronological ordering, and first-encounter retention on timestamp ties;
- aggregation of invalid-provenance, scope, and cross-room denials without leaking withheld identifiers.

## Verification

- `bunx vitest run packages/core/src/access-control/provenance-envelope.test.ts` — 1 file passed, 14 tests passed (current `origin/develop`, rerun immediately before filing).
- `bunx biome check --write packages/core/src/access-control/provenance-envelope.test.ts` — checked 1 file; no fixes applied.
- `cd packages/core && bunx tsc --noEmit` — exit 0 with zero output; `provenance-envelope.test.ts` appears nowhere in diagnostics.
- Diff against current `origin/develop`: one test file only, 209 additions and 0 deletions.

## Risk

Low. This changes no production behavior and uses no mocks or type-level-only assertions.

## Hosted CI

This is a fork contribution, so hosted CI has not run for this PR. The local exact-head checks above are the available verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c66d069f37d249d22580922b9937f837a93d9e0d -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
