### PR TITLE
fix(cloud): truncate the Discord bot nickname without splitting a surrogate pair

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -408,7 +408,7 @@ class DiscordAutomationService {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          nick: trimmed.slice(0, 32),
+          nick: truncateWellFormed(toWellFormedUnicode(trimmed), 32),
         }),
       });
 


### PR DESCRIPTION
# Relates to

Follow-up to #25425, which merged with this site left as it was. No separate issue — the defect and its consequence are described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Single-line change; the exact before/after is quoted below.
- [x] A reviewer can confirm the behaviour from the evidence below without reading the code.

# Sync with develop

- [x] Built on `origin/develop@0242ceed`; zero conflicts.
- [x] One file differs from `develop`, and only the lines quoted below.

# Risks

Minimal. The change is confined to one expression. Every value that resolves correctly today resolves identically after.

# Background

## What does this PR do?

`setBotNickname` sends `nick` in the body of `PATCH /guilds/{id}/members/@me`. On `develop` the value is cut with a bare slice:

```ts
body: JSON.stringify({
  nick: trimmed.slice(0, 32),
}),
```

If the 32nd and 33rd code units are one astral character, the cut lands inside the surrogate pair and the request carries a lone high surrogate. Bot nicknames are user-supplied and routinely contain emoji, so this is an ordinary input, not a crafted one.

#25425 converted the three `logger.warn` call sites in this same file and left this one — the only truncation here whose output leaves the process. The other three produce log lines; this one produces an HTTP request body.

## What is the fix?

Apply the same sanitise-then-truncate composition already used three times in this file. The imports are present at line 9, so this is a one-line change.

```diff
-  nick: trimmed.slice(0, 32),
+  nick: truncateWellFormed(toWellFormedUnicode(trimmed), 32),
```

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes.

# Testing

## Where should a reviewer start?

The evidence block below — it shows the exact value produced before and after.

## Detailed testing steps

Reproduced with a 33-code-unit nickname whose emoji straddles the boundary:

| | `isWellFormed()` | JSON tail |
| --- | --- | --- |
| `develop` — `.slice(0, 32)` | **false** | `aaaaaaaa\ud83d"}` |
| this PR — `truncateWellFormed` | true | `aaaaaaaaaaaaaa"}` |

And what reaches Discord after the body is UTF-8 encoded:

```
Discord receives nick = U+61 U+61 U+D83D
```

A lone high surrogate in a JSON request body.

| Gate | Result |
| --- | --- |
| every truncation site in the file enumerated at `develop` | 3 converted (186, 420, 519), 1 bare (411) |
| after this PR | 4 converted, 0 bare |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| diff vs `develop` | `+1/-1`, one file, one line |

# Evidence Gate

<!-- evidence-head:5600e55e4ea272e4993790320b535d2ea8cc4577 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend string handling; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend string handling; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the produced string, quoted directly above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the expression is exercised directly`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the string shown above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found while reviewing #25425; raised there before it merged.
- Diagnosis, reproduction, and fix by Claude Code (`claude-opus-5`).

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Attribution status: self-reported
