### PR TITLE
test(cloud): cover database-adapter-config

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Coverage for database-adapter-config.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  getRuntimeDatabaseBackend,
+  resolveRuntimeDatabaseAdapterConfig,
+} from "./database-adapter-config.js";
+
+describe("database-adapter-config", () => {
+  it("resolves backend", () => {
+    expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "pglite" })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "postgresql" })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "postgres" })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({})).toBe("postgresql");
+  });
+  it("throws on unsupported", () => {
+    expect(() => getRuntimeDatabaseBackend({ DATABASE_ENGINE: "bad" })).toThrow();
+  });
+  it("resolves pglite config", () => {
+    const c = resolveRuntimeDatabaseAdapterConfig({ DATABASE_ENGINE: "pglite" });
+    expect(c.dataDir).toBeTruthy();
+  });
+  it("throws without postgres url", () => {
+    expect(() => resolveRuntimeDatabaseAdapterConfig({ DATABASE_ENGINE: "postgresql" })).toThrow();
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:ab39468ead5961e29e5e71c923f75e9f1cdd92c1 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/eliza/database-adapter-config.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop; verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) -> Green (restored)

**Red — proves non-vacuous (imports real export):**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop

 ❯ packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts (4 tests | 1 failed) 4ms
     × resolves backend 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts > database-adapter-config > resolves backend
AssertionError: expected 'bad' to be 'postgresql' // Object.is equality

Expected: "postgresql"
Received: "bad"

 ❯ packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts:13:74
     11|   it("resolves backend", () => {
     12|     expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "pglite" })).t…
     13|     expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "postgresql" }…
       |                                                                          ^
     14|     expect(getRuntimeDatabaseBackend({ DATABASE_ENGINE: "postgres" }))…
     15|     expect(getRuntimeDatabaseBackend({})).toBe("postgresql");

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
   Start at  00:28:42
   Duration  93ms (transform 19ms, setup 0ms, import 24ms, tests 4ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  00:28:41
   Duration  83ms (transform 17ms, setup 0ms, import 22ms, tests 2ms, environment 0ms)
```

**Biome clean:** `biome check --write` passed.

**Dedup checks:**
- Open PR file collision: `gh pr list --state open --json headRefName | grep test/cloud-cover-database-adapter-config3` (none)
- Develop still missing: `git ls-tree origin/develop -- packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts` (no output = still missing)
- Closed PR search: no prior ruling on this module

**Rebase:** `git fetch origin && git rebase origin/develop` zero conflicts, `git diff --check` clean.

