### PR TITLE
test(core): cover prompt-batcher config

### DIFF
--- a/packages/core/src/utils/prompt-batcher/config.test.ts
+++ b/packages/core/src/utils/prompt-batcher/config.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Verifies strict resolution of the documented prompt-batcher environment
+ * settings at one boundary: explicit values must be finite decimals in the
+ * domain their consumers require, absent or blank values retain defaults, and
+ * invalid values throw a fatal ElizaError.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ElizaError } from "../../errors";
+import { resolvePromptBatcherSettings } from "./config";
+
+const envRead = vi.fn();
+
+vi.mock("../environment", () => ({
+	getEnv: (...args: unknown[]) => envRead(...args),
+}));
+
+describe("resolvePromptBatcherSettings", () => {
+	afterEach(() => {
+		envRead.mockReset();
+	});
+
+	it("returns documented defaults when every variable is unset", () => {
+		envRead.mockReturnValue(undefined);
+		const { dispatcher, batcher } = resolvePromptBatcherSettings();
+
+		expect(batcher.batchSize).toBe(8);
+		expect(batcher.maxDrainIntervalMs).toBe(30_000);
+		expect(batcher.maxSectionsPerCall).toBe(8);
+		expect(batcher.packingDensity).toBe(0.85);
+		expect(batcher.maxTokensPerCall).toBe(24_000);
+		expect(batcher.maxParallelCalls).toBe(2);
+		expect(batcher.modelSeparation).toBe(1);
+
+		expect(dispatcher).toEqual({
+			packingDensity: 0.85,
+			maxTokensPerCall: 24_000,
+			maxParallelCalls: 2,
+			modelSeparation: 1,
+			maxSectionsPerCall: 8,
+		});
+	});
+
+	it("honors explicit valid integer settings", () => {
+		envRead.mockImplementation((key: string) => {
+			if (key === "PROMPT_BATCHER_BATCH_SIZE") return "16";
+			if (key === "PROMPT_BATCHER_MAX_PARALLEL_CALLS") return "4";
+			return undefined;
+		});
+		const { batcher } = resolvePromptBatcherSettings();
+		expect(batcher.batchSize).toBe(16);
+		expect(batcher.maxParallelCalls).toBe(4);
+		expect(batcher.maxSectionsPerCall).toBe(8);
+	});
+
+	it("honors explicit unit-interval settings", () => {
+		envRead.mockImplementation((key: string) => {
+			if (key === "PROMPT_BATCHER_PACKING_DENSITY") return "0.5";
+			if (key === "PROMPT_BATCHER_MODEL_SEPARATION") return "1";
+			return undefined;
+		});
+		const { batcher } = resolvePromptBatcherSettings();
+		expect(batcher.packingDensity).toBe(0.5);
+		expect(batcher.modelSeparation).toBe(1);
+	});
+
+	it("trims surrounding whitespace before parsing", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_BATCH_SIZE" ? "  16  " : undefined,
+		);
+		expect(resolvePromptBatcherSettings().batcher.batchSize).toBe(16);
+	});
+
+	it("retains defaults for blank values", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_BATCH_SIZE" ? "   " : undefined,
+		);
+		expect(resolvePromptBatcherSettings().batcher.batchSize).toBe(8);
+	});
+
+	it("accepts scientific notation that lands on a valid integer", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_MAX_TOKENS_PER_CALL" ? "1e3" : undefined,
+		);
+		expect(resolvePromptBatcherSettings().batcher.maxTokensPerCall).toBe(1000);
+	});
+
+	it("rejects non-numeric garbage for a positive-integer setting", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_BATCH_SIZE" ? "abc" : undefined,
+		);
+		expect(() => resolvePromptBatcherSettings()).toThrow(ElizaError);
+	});
+
+	it("rejects zero and negative values for positive-integer settings", () => {
+		for (const bad of ["0", "-3"]) {
+			envRead.mockReset();
+			envRead.mockImplementation((key: string) =>
+				key === "PROMPT_BATCHER_BATCH_SIZE" ? bad : undefined,
+			);
+			expect(() => resolvePromptBatcherSettings()).toThrow(
+				/PROMPT_BATCHER_BATCH_SIZE/,
+			);
+		}
+	});
+
+	it("rejects fractional values for positive-integer settings", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_BATCH_SIZE" ? "8.5" : undefined,
+		);
+		expect(() => resolvePromptBatcherSettings()).toThrow(ElizaError);
+	});
+
+	it("rejects values outside the unit interval", () => {
+		for (const bad of ["1.5", "-0.1", "2"]) {
+			envRead.mockReset();
+			envRead.mockImplementation((key: string) =>
+				key === "PROMPT_BATCHER_PACKING_DENSITY" ? bad : undefined,
+			);
+			expect(() => resolvePromptBatcherSettings()).toThrow(
+				/PROMPT_BATCHER_PACKING_DENSITY/,
+			);
+		}
+	});
+
+	it("names the offending setting in the fatal error", () => {
+		envRead.mockImplementation((key: string) =>
+			key === "PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS" ? "soon" : undefined,
+		);
+		try {
+			resolvePromptBatcherSettings();
+			expect.unreachable("expected a throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("PROMPT_BATCHER_CONFIG_INVALID");
+			expect((error as ElizaError).message).toContain(
+				"PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS",
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Relates to

Behavior coverage for the prompt-batcher environment-settings boundary in `packages/core/src/utils/prompt-batcher/config.ts` (`resolvePromptBatcherSettings`; no existing unit coverage).

## Background

`config.ts` resolves the documented `PROMPT_BATCHER_*` environment settings at one strict boundary: explicit values must be finite decimal numbers in the domain their consumers require (positive integers, or unit-interval for density/separation), absent or blank values retain defaults, and invalid values throw a fatal `ElizaError` (`PROMPT_BATCHER_CONFIG_INVALID`). This suite pins the default table, valid-value handling, whitespace trimming, scientific notation, and every rejection path.

## Testing

- `bun x vitest run src/utils/prompt-batcher/config.test.ts` — **11/11 passed** (341ms)
- `bun x biome check src/utils/prompt-batcher/config.test.ts` — clean
- No source changes; test-only PR.

<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A (unit test coverage PR)
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A (unit test coverage PR)
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A (unit test coverage PR)
<!-- evidence-row:backend-logs -->
- [ ] backend-logs: N/A
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: vitest run output in PR description above (11/11 passed)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
