### PR TITLE
[cloud-shared] Validate configured app origin scheme

### DIFF
--- a/packages/cloud/shared/src/lib/utils/app-url.test.ts
+++ b/packages/cloud/shared/src/lib/utils/app-url.test.ts
@@ -1,4 +1,6 @@
 // Exercises app url behavior with deterministic cloud-shared lib fixtures.
+
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, test } from "vitest";
 import { getAppHost, getAppUrl } from "./app-url";
 
@@ -27,6 +29,43 @@ describe("getAppUrl", () => {
 
   test("prepends https:// when the configured value has no scheme", () => {
     expect(getAppUrl({ NEXT_PUBLIC_APP_URL: "app.eliza.how" })).toBe("https://app.eliza.how");
+    expect(getAppUrl({ NEXT_PUBLIC_APP_URL: "app.eliza.how/auth" })).toBe(
+      "https://app.eliza.how/auth",
+    );
+  });
+
+  test("trims configuration and canonicalizes case-insensitive HTTP schemes", () => {
+    expect(getAppUrl({ NEXT_PUBLIC_APP_URL: " HTTPS://APP.ELIZA.HOW/ " })).toBe(
+      "https://app.eliza.how",
+    );
+    expect(getAppUrl({ NEXT_PUBLIC_APP_URL: "HTTP://LOCALHOST:8787/" })).toBe(
+      "http://localhost:8787",
+    );
+    expect(getAppUrl({ NEXT_PUBLIC_APP_URL: "   " })).toBe("http://localhost:3000");
+  });
+
+  test.each([
+    ["httpx://example.invalid", "unsupported-or-ambiguous-scheme"],
+    ["ftp://example.invalid", "unsupported-or-ambiguous-scheme"],
+    ["//example.invalid", "unsupported-or-ambiguous-scheme"],
+    ["not a url", "malformed-url"],
+    ["https://", "malformed-url"],
+    ["https://user:secret@example.invalid", "embedded-credentials"],
+  ])("rejects invalid configured application URL %s", (configured, reason) => {
+    let thrown: unknown;
+    try {
+      getAppUrl({ NEXT_PUBLIC_APP_URL: configured });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      code: "INVALID_APP_URL",
+      context: { reason },
+      severity: "fatal",
+    });
+    expect(JSON.stringify(thrown)).not.toContain("secret");
   });
 });
 
@@ -36,5 +75,6 @@ describe("getAppHost", () => {
     expect(getAppHost({ NEXT_PUBLIC_APP_URL: "https://app.eliza.how:8080/path" })).toBe(
       "app.eliza.how:8080",
     );
+    expect(getAppHost({ NEXT_PUBLIC_APP_URL: " HTTPS://APP.ELIZA.HOW/ " })).toBe("app.eliza.how");
   });
 });

--- a/packages/cloud/shared/src/lib/utils/app-url.test.ts
+++ b/packages/cloud/shared/src/lib/utils/app-url.test.ts
@@ -34,6 +34,18 @@ describe("getAppUrl", () => {
     );
   });
 
+  test.each([
+    ["localhost:3000", "https://localhost:3000", "localhost:3000"],
+    ["app.eliza.how:443/path", "https://app.eliza.how/path", "app.eliza.how"],
+  ])(
+    "preserves scheme-less host and port configuration %s",
+    (configured, expectedUrl, expectedHost) => {
+      const env = { NEXT_PUBLIC_APP_URL: configured };
+      expect(getAppUrl(env)).toBe(expectedUrl);
+      expect(getAppHost(env)).toBe(expectedHost);
+    },
+  );
+
   test("trims configuration and canonicalizes case-insensitive HTTP schemes", () => {
     expect(getAppUrl({ NEXT_PUBLIC_APP_URL: " HTTPS://APP.ELIZA.HOW/ " })).toBe(
       "https://app.eliza.how",

--- a/packages/cloud/shared/src/lib/utils/app-url.ts
+++ b/packages/cloud/shared/src/lib/utils/app-url.ts
@@ -9,17 +9,59 @@
  * appropriate for the browser bundle (Vite replaces `process.env.NEXT_PUBLIC_*`
  * at build time) and Node tests.
  */
+import { ElizaError } from "@elizaos/core";
+
 interface AppUrlEnv {
   NEXT_PUBLIC_APP_URL?: unknown;
   [key: string]: unknown;
 }
 
+const DEFAULT_APP_URL = "http://localhost:3000";
+const EXPLICIT_SCHEME_PATTERN = /^([A-Za-z][A-Za-z\d+.-]*):/;
+const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
+
+function invalidAppUrl(configured: string, reason: string): never {
+  const explicitScheme = EXPLICIT_SCHEME_PATTERN.exec(configured)?.[1]?.toLowerCase();
+  throw new ElizaError("NEXT_PUBLIC_APP_URL must identify a valid HTTP(S) application URL", {
+    code: "INVALID_APP_URL",
+    context: {
+      reason,
+      configuredLength: configured.length,
+      explicitScheme: explicitScheme ?? null,
+    },
+    severity: "fatal",
+  });
+}
+
 export function getAppUrl(env: AppUrlEnv = process.env): string {
   const configuredUrl =
-    typeof env.NEXT_PUBLIC_APP_URL === "string" ? env.NEXT_PUBLIC_APP_URL : undefined;
-  const url = configuredUrl || "http://localhost:3000";
-  const base = url.startsWith("http") ? url : `https://${url}`;
-  return base.replace(/\/$/, "");
+    typeof env.NEXT_PUBLIC_APP_URL === "string" ? env.NEXT_PUBLIC_APP_URL.trim() : "";
+  const value = configuredUrl || DEFAULT_APP_URL;
+  const explicitScheme = EXPLICIT_SCHEME_PATTERN.test(value);
+
+  if ((explicitScheme && !HTTP_SCHEME_PATTERN.test(value)) || value.startsWith("//")) {
+    return invalidAppUrl(value, "unsupported-or-ambiguous-scheme");
+  }
+
+  const candidate = HTTP_SCHEME_PATTERN.test(value) ? value : `https://${value}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    // error-policy:J3 Invalid operator configuration fails closed without
+    // retaining a parser error that can echo embedded credentials.
+    return invalidAppUrl(value, "malformed-url");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return invalidAppUrl(value, "unsupported-scheme");
+  }
+  if (!parsed.hostname) return invalidAppUrl(value, "missing-hostname");
+  if (parsed.username || parsed.password) {
+    return invalidAppUrl(value, "embedded-credentials");
+  }
+
+  return parsed.href.replace(/\/$/, "");
 }
 
 export function getAppHost(env: AppUrlEnv = process.env): string {

--- a/packages/cloud/shared/src/lib/utils/app-url.ts
+++ b/packages/cloud/shared/src/lib/utils/app-url.ts
@@ -17,7 +17,7 @@ interface AppUrlEnv {
 }
 
 const DEFAULT_APP_URL = "http://localhost:3000";
-const EXPLICIT_SCHEME_PATTERN = /^([A-Za-z][A-Za-z\d+.-]*):/;
+const EXPLICIT_SCHEME_PATTERN = /^([A-Za-z][A-Za-z\d+.-]*):\/\//;
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
 
 function invalidAppUrl(configured: string, reason: string): never {


### PR DESCRIPTION
# Relates to

Closes #26494

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto latest `origin/develop` (`0242ceed35256bc247ed944932f3ccd49a4a3803`) with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; exact unrelated failures are recorded below.
- [x] A reviewer can confirm the change from the focused configuration-boundary tests and output below.

# Sync with develop

- [x] Rebasing onto latest `origin/develop` reported the branch up to date with zero conflicts.
- [x] `bun run verify` was run post-sync; exact unrelated blockers are documented under **Known gaps / failures**.

# Risks

Low. The change tightens operator configuration parsing for the canonical Cloud app URL. Existing valid lowercase HTTP(S), localhost, and scheme-less host values retain their behavior. Explicit unsupported/ambiguous schemes, malformed URLs, and embedded credentials now fail fast with typed `INVALID_APP_URL` errors.

# Background

## What does this PR do?

- Replaces the `startsWith("http")` shortcut with URL parsing and explicit HTTP(S) validation.
- Trims configuration, handles HTTP(S) schemes case-insensitively, and preserves scheme-less-host compatibility.
- Rejects unsupported or ambiguous schemes, malformed URLs, missing hosts, and embedded credentials without retaining secret-bearing parser errors.
- Adds focused coverage for valid, invalid, adversarial, and compatibility cases.

## What kind of change is this?

Bug fix (non-breaking configuration validation hardening).

# Documentation changes needed?

No. This enforces the helper's existing documented contract: `NEXT_PUBLIC_APP_URL` identifies the canonical HTTP(S) app URL.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/app-url.ts` and `app-url.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/cloud/shared test -- src/lib/utils/app-url.test.ts
bunx @biomejs/biome check \
  packages/cloud/shared/src/lib/utils/app-url.ts \
  packages/cloud/shared/src/lib/utils/app-url.test.ts
bun run --cwd packages/cloud/shared typecheck
```

Exact-head result at `fee4ab575a8964540e09104d33d12c2dfc402d17`:

```text
11 pass, 0 fail, 31 assertions
Checked 2 files in 6ms. No fixes applied.
cloud-shared typecheck: exit 0
```

# Evidence Gate

<!-- evidence-head:dacebba0edf48fe91a1ad9441e58c8ba4495524c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side configuration helper with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side configuration helper with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic configuration parsing has no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no long-running backend service changed; the canonical helper path is exercised directly by the focused 11-test run.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; canonical URLs, hosts, and typed failures are asserted inline by the focused tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the changed boundary is a pure configuration resolver. The focused suite directly exercises both exported functions and validates canonical output plus typed failure context.

## Screenshots (before / after) + video walkthrough

N/A - backend-only configuration parsing.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- Package-wide `lint:check` fails on existing formatting drift in untouched `jwt-lifetime.test.ts`, `invoice-ids.test.ts`, and `ai-json-parse.test.ts`. The two touched files pass Biome.
- Package-wide tests stop in batch 1/299 on existing unrelated failures: the gateway workflow test still expects a `branches: [develop]` trigger that the current workflow no longer has, the dormant restore boundary assertion fails, and a plugin-sql `@elizaos/core` module-resolution error occurs. The affected helper suite passes 11/11.
- `bun run verify` reaches workspace lint/typecheck and fails on existing missing translation keys and formatting drift in untouched packages, including plugin-calendar. Cloud-shared typecheck and affected-file lint pass.
- A direct multi-file Cloud API probe passed the wallet-attach consumer tests but encountered existing Bun/source-export resolution errors in SIWE/SIWS nonce suites; no integration-pass claim is made from that probe.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [mysteryjax-issue-fix-2]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0QTW3EGYB4RMG4MY8R2MFR3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T17:32:11.089Z","completed_at":"2026-08-23T17:42:01.685Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEASLwS0eshLeA4cpT_vbS3lnzrnGRmGrX8f03fEtMmqdA","device_key_id":"3d2067bc23a0d32e00b5dcb579c70fa9f982894b17fdb1dfe2497057f9d99324","device_signature":"bWAOqJ0bmzA-vmMel_nY-f_2C_bMlQNy2xUfOIYTxcywUhjbCCHUDjwMSPpkLvPvuydu3PdY9IHsYWN5xVAeBQ"}} -->

