### PR TITLE
test(core): cover search

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/search.test.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/search.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Exercises the plugin search handler through its real implementation: the
+ * unavailable-service and empty-query failures, the empty-result completion
+ * shape, ranked rendering of registry hits with optional fields and zero
+ * scores, and neutral-reference fallbacks for unshaped queries.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import { runSearch } from "./search.ts";
+
+interface RegistryResult {
+	name: string;
+	score?: number;
+	description?: string;
+	tags?: string[];
+	version?: string;
+}
+
+function createRuntime({
+	available = true,
+	results = [],
+	queries,
+}: {
+	available?: boolean;
+	results?: RegistryResult[];
+	queries?: string[];
+} = {}): IAgentRuntime {
+	const service = available
+		? {
+				searchRegistry: async (query: string) => {
+					queries?.push(query);
+					return results;
+				},
+			}
+		: null;
+
+	return {
+		getService: (name: string) => (name === "plugin_manager" ? service : null),
+	} as unknown as IAgentRuntime;
+}
+
+describe("runSearch", () => {
+	it("returns a structured failure through the callback when the service is unavailable", async () => {
+		const replies: unknown[] = [];
+
+		const result = await runSearch({
+			runtime: createRuntime({ available: false }),
+			query: "blockchain",
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		expect(result).toEqual({
+			success: false,
+			text: "Plugin manager service not available",
+		});
+		expect(replies).toEqual([{ text: "Plugin manager service not available" }]);
+	});
+
+	it("rejects an empty query before touching the registry", async () => {
+		const replies: unknown[] = [];
+		const queries: string[] = [];
+
+		const result = await runSearch({
+			runtime: createRuntime({ queries }),
+			query: "",
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		expect(result).toEqual({
+			success: false,
+			text: 'Specify a search query (e.g. "plugins for blockchain transactions").',
+		});
+		expect(replies).toEqual([
+			{
+				text: 'Specify a search query (e.g. "plugins for blockchain transactions").',
+			},
+		]);
+		expect(queries).toEqual([]);
+	});
+
+	it("reports an empty registry result as the complete verified answer", async () => {
+		const replies: unknown[] = [];
+		const queries: string[] = [];
+
+		const result = await runSearch({
+			runtime: createRuntime({ results: [], queries }),
+			query: "voice agents",
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		expect(queries).toEqual(["voice agents"]);
+		expect(replies).toEqual([
+			{
+				text: 'No plugins found matching "voice agents". Try keywords like database, twitter, solana, voice.',
+			},
+		]);
+		expect(result).toEqual({
+			success: true,
+			text: 'No plugins found matching "voice agents". Try keywords like database, twitter, solana, voice.',
+			userFacingText:
+				'No plugins found matching "voice agents". Try keywords like database, twitter, solana, voice.',
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { mode: "search", count: 0 },
+		});
+		expect("data" in result).toBe(false);
+	});
+
+	it("renders every registry hit in service order with scores, descriptions, tags, and versions", async () => {
+		const replies: unknown[] = [];
+		const results: RegistryResult[] = [
+			{
+				name: "@elizaos/plugin-web3",
+				score: 0.924,
+				description: "Ethereum wallet helpers",
+				tags: ["ethereum", "wallet"],
+				version: "1.4.2",
+			},
+			{ name: "@elizaos/plugin-solana", score: 0 },
+			{
+				name: "@elizaos/plugin-voice",
+				score: 0.5,
+				description: "Speech utilities",
+				tags: ["a", "b", "c", "d", "e", "f"],
+				version: "0.9.0",
+			},
+		];
+
+		const result = await runSearch({
+			runtime: createRuntime({ results }),
+			query: "blockchain",
+			callback: async (content) => {
+				replies.push(content);
+				return [];
+			},
+		});
+
+		const expectedText = [
+			'Found 3 plugin(s) matching "blockchain":',
+			"",
+			"1. @elizaos/plugin-web3 (match: 92%)",
+			"   Ethereum wallet helpers",
+			"   tags: ethereum, wallet",
+			"   version: 1.4.2",
+			"2. @elizaos/plugin-solana",
+			"3. @elizaos/plugin-voice (match: 50%)",
+			"   Speech utilities",
+			"   tags: a, b, c, d, e",
+			"   version: 0.9.0",
+		].join("\n");
+
+		expect(result.text).toBe(expectedText);
+		expect(result.userFacingText).toBe(expectedText);
+		expect(replies).toEqual([{ text: expectedText }]);
+		expect(result.values).toEqual({
+			mode: "search",
+			count: 3,
+			query: "blockchain",
+		});
+		expect(result.data).toEqual({ results });
+	});
+
+	it("uses the neutral reference noun for unshaped queries while collapsing them in metadata", async () => {
+		const result = await runSearch({
+			runtime: createRuntime({
+				results: [{ name: "@elizaos/plugin-solana", score: 0.5 }],
+			}),
+			query: "solana\ntransfer indexer",
+		});
+
+		expect(result.text).toBe(
+			[
+				"Found 1 plugin(s) matching that request:",
+				"",
+				"1. @elizaos/plugin-solana (match: 50%)",
+			].join("\n"),
+		);
+		expect(result.values).toEqual({
+			mode: "search",
+			count: 1,
+			query: "solana transfer indexer",
+		});
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the plugin-manager search handler:
`packages/core/src/features/plugin-manager/actions/plugin-handlers/search.test.ts`
(new file, +194/-0; no production code is touched).

The module had no same-named test file on `origin/develop` at filing time
(verified via `git ls-tree -r --name-only origin/develop`).

## Coverage

`runSearch` is driven through its real implementation with only the
`IAgentRuntime` collaborator stubbed (same pattern as the sibling
`list.test.ts`). Five cases cover every branch of the handler:

- unavailable `plugin_manager` service: structured `{ success: false }`
  failure, callback still invoked once with the exact failure text;
- empty query: rejected before the registry is queried (asserted by
  observing zero `searchRegistry` calls), exact hint text through the
  callback and result;
- empty result set: complete verified answer shape
  (`verifiedUserFacing`, `turnComplete`, `values.count === 0`) with no
  `data` field;
- populated registry: service-order rendering with score percentages
  (`0.924 -> 92%`), falsy-score omission (`score: 0` renders no match
  suffix), description/tags/version lines, six tags rendering only the
  first five, `values.query` echo, and `data.results` pass-through;
- unshaped (multi-line) query: neutral reference noun `"that request"`
  in user-facing text while metadata collapses whitespace
  (`"solana\ntransfer indexer" -> "solana transfer indexer"`).

## Verification

Fork contributor: hosted CI does not run on this PR. All checks were run
locally against this exact head.

- `bunx vitest run src/features/plugin-manager/actions/plugin-handlers/search.test.ts`
  (in `packages/core`, re-run immediately before filing):
  **Test Files 1 passed (1), Tests 5 passed (5)**.
- `bunx biome check --write packages/core/src/features/plugin-manager/actions/plugin-handlers/search.test.ts`
  from the repo root: **clean** ("Checked 1 file", no fixes applied).
- `bunx tsc --noEmit` in `packages/core`: the string `search.test.ts`
  appears nowhere in the output (zero new type errors from this diff).
- The diff touches only the new test file (+194/-0).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ae55fcc180a100bc5fd06598055bdcb869214a50 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
