### PR TITLE
test(core): cover autonomy providers

### DIFF
--- a/packages/core/src/features/autonomy/providers.test.ts
+++ b/packages/core/src/features/autonomy/providers.test.ts
@@ -1,0 +1,629 @@
+/**
+ * Unit tests for the autonomy feature's two providers. Drives the real
+ * `adminChatProvider.get` and `autonomyStatusProvider.get` implementations
+ * against a mocked `IAgentRuntime` plus a stub `AutonomyService`, asserting the
+ * observable provider contracts: availability gates, admin-history query shape,
+ * rendering order and sender roles, the three-message admin recency window,
+ * one-hour activity detection, interval rounding/clamping, and the J4
+ * error-translation paths. Deterministic harness: no model, database, network,
+ * or real runtime involvement.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, UUID } from "../../types";
+import { stringToUuid } from "../../utils";
+import { adminChatProvider, autonomyStatusProvider } from "./providers";
+import type { AutonomyService } from "./service";
+import { AUTONOMY_SERVICE_TYPE } from "./service";
+
+const agentId = stringToUuid("providers-test-agent") as UUID;
+const adminUserId = "admin-user";
+const adminUUID = stringToUuid(adminUserId) as UUID;
+const otherUUID = stringToUuid("other-entity") as UUID;
+const autonomousRoomId = stringToUuid("providers-test-autonomous-room") as UUID;
+const otherRoomId = stringToUuid("providers-test-other-room") as UUID;
+
+let sequence = 0;
+
+function memory(
+	roomId: UUID,
+	entityId: UUID,
+	text: string,
+	createdAt?: number,
+): Memory {
+	sequence += 1;
+	return {
+		id: stringToUuid(`providers-test-memory-${sequence}`) as UUID,
+		entityId,
+		roomId,
+		...(createdAt === undefined ? {} : { createdAt }),
+		content: { text },
+	};
+}
+
+type ServiceStub = Pick<
+	AutonomyService,
+	"getAutonomousRoomId" | "isLoopRunning" | "getLoopInterval"
+>;
+
+function buildRuntime(parts: {
+	service?: ServiceStub | null;
+	settings?: Record<string, string>;
+	memories?: () => Promise<Memory[] | null>;
+	enableAutonomy?: boolean;
+}) {
+	const service =
+		parts.service === undefined
+			? ({
+					getAutonomousRoomId: () => autonomousRoomId,
+					isLoopRunning: () => false,
+					getLoopInterval: () => 30_000,
+				} satisfies ServiceStub)
+			: parts.service;
+	const runtime = {
+		agentId,
+		enableAutonomy: parts.enableAutonomy ?? false,
+		getService: vi.fn((serviceType: string) =>
+			serviceType === AUTONOMY_SERVICE_TYPE ? service : null,
+		),
+		getSetting: vi.fn((key: string) => parts.settings?.[key]),
+		getMemories: vi.fn(parts.memories ?? (async () => [])),
+		reportError: vi.fn(),
+	} as unknown as IAgentRuntime & {
+		getMemories: ReturnType<typeof vi.fn>;
+		reportError: ReturnType<typeof vi.fn>;
+	};
+	return runtime;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("adminChatProvider", () => {
+	it("returns autonomy_service_unavailable when the service is absent", async () => {
+		const runtime = buildRuntime({ service: null });
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toBe("");
+		expect(result.data).toEqual({
+			available: false,
+			reason: "autonomy_service_unavailable",
+		});
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
+
+	it("returns not_autonomous_room when the service has no autonomous room", async () => {
+		const runtime = buildRuntime({
+			service: {
+				getAutonomousRoomId: () => null,
+				isLoopRunning: () => false,
+				getLoopInterval: () => 30_000,
+			},
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "hello"),
+		);
+		expect(result.data).toEqual({
+			available: false,
+			reason: "not_autonomous_room",
+		});
+		expect(runtime.getSetting).not.toHaveBeenCalled();
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
+
+	it("returns not_autonomous_room outside the autonomous room", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				memory(autonomousRoomId, adminUUID, "should not load"),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(otherRoomId, adminUUID, "hello"),
+		);
+		expect(result.data).toEqual({
+			available: false,
+			reason: "not_autonomous_room",
+		});
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
+
+	it("reports an unconfigured admin without touching memory", async () => {
+		const runtime = buildRuntime({ settings: {} });
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("No admin user configured");
+		expect(result.text).toContain("[ADMIN_CHAT_HISTORY]");
+		expect(result.data).toMatchObject({
+			adminConfigured: false,
+			messageCount: 0,
+		});
+		expect(result.values).toEqual({
+			adminConfigured: false,
+			adminHistoryCount: 0,
+		});
+		expect(runtime.getMemories).not.toHaveBeenCalled();
+	});
+
+	it("reports an empty admin history as configured but silent", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("No recent messages found with admin user.");
+		expect(result.data).toMatchObject({
+			adminConfigured: true,
+			messageCount: 0,
+			adminUserId,
+		});
+		expect(result.values).toEqual({
+			adminConfigured: true,
+			adminHistoryCount: 0,
+		});
+	});
+
+	it("tolerates a null memory lookup like an empty one", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => null,
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("No recent messages found with admin user.");
+		expect(result.values).toEqual({
+			adminConfigured: true,
+			adminHistoryCount: 0,
+		});
+	});
+
+	it("queries admin memories with the canonical window parameters", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [],
+		});
+		await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(runtime.getMemories).toHaveBeenCalledTimes(1);
+		expect(runtime.getMemories).toHaveBeenCalledWith({
+			entityId: adminUUID,
+			limit: 15,
+			unique: false,
+			tableName: "memories",
+		});
+	});
+
+	it("renders history in ascending creation order with sender roles", async () => {
+		const early = memory(autonomousRoomId, adminUUID, "first", 1_000);
+		const middle = memory(autonomousRoomId, agentId, "second", 2_000);
+		const late = memory(autonomousRoomId, otherUUID, "third", 3_000);
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [late, early, middle],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("(3 total messages)");
+		const lines = [
+			`${new Date(1_000).toLocaleTimeString()} Admin: first`,
+			`${new Date(2_000).toLocaleTimeString()} Agent: second`,
+			`${new Date(3_000).toLocaleTimeString()} Other: third`,
+		];
+		const history = lines.join("\n");
+		expect(result.text).toContain(history);
+		expect(result.data).toMatchObject({
+			messageCount: 3,
+			historyWindowCount: 3,
+			recentMessageCount: 1,
+			lastAdminMessage: "first",
+		});
+		expect(result.values).toEqual({
+			adminConfigured: true,
+			adminHistoryCount: 3,
+			adminHistoryWindowCount: 3,
+		});
+	});
+
+	it("substitutes a placeholder for blank message text", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [memory(autonomousRoomId, adminUUID, "", 1_000)],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain(`Admin: [No text content]`);
+		expect(result.data).toMatchObject({
+			lastAdminMessage: "",
+		});
+		expect(result.text).toContain('Last admin message: "N/A"');
+	});
+
+	it("sanitizes lone surrogates in history and the last admin message", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				memory(autonomousRoomId, adminUUID, "bad\uD800line", 1_000),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("Admin: bad\uFFFDline");
+		expect(result.data).toMatchObject({ lastAdminMessage: "bad\uFFFDline" });
+		expect(result.text).toContain('Last admin message: "bad\uFFFDline"');
+	});
+
+	it("limits the admin recency window to the newest three admin messages", async () => {
+		const admin = (text: string, createdAt: number) =>
+			memory(autonomousRoomId, adminUUID, text, createdAt);
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				admin("a1", 1_000),
+				memory(autonomousRoomId, otherUUID, "noise", 1_500),
+				admin("a2", 2_000),
+				admin("a3", 3_000),
+				admin("a4", 4_000),
+				admin("a5", 5_000),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.data).toMatchObject({
+			recentMessageCount: 3,
+			lastAdminMessage: "a5",
+		});
+		expect(result.text).toContain('Last admin message: "a5"');
+		expect(result.text).not.toContain('"a1"');
+		expect(result.text).not.toContain('"a2"');
+	});
+
+	it("reports zero admin context when no history is admin-authored", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				memory(autonomousRoomId, otherUUID, "from other", 1_000),
+				memory(autonomousRoomId, agentId, "from agent", 2_000),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.text).toContain("No recent admin messages");
+		expect(result.data).toMatchObject({
+			recentMessageCount: 0,
+			lastAdminMessage: "",
+		});
+	});
+
+	it("marks the conversation active strictly inside the one-hour window", async () => {
+		const now = 1_700_000_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(now);
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				memory(autonomousRoomId, adminUUID, "recent", now - 3_599_999),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.data).toMatchObject({ conversationActive: true });
+	});
+
+	it("keeps the conversation inactive at and beyond the one-hour boundary", async () => {
+		const now = 1_700_000_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(now);
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => [
+				memory(
+					autonomousRoomId,
+					adminUUID,
+					"exactly one hour",
+					now - 3_600_000,
+				),
+				memory(autonomousRoomId, otherUUID, "no timestamp"),
+			],
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.data).toMatchObject({ conversationActive: false });
+	});
+
+	it("translates failures into an explicitly unavailable history result", async () => {
+		const failure = new Error("memory store down");
+		const roomId = autonomousRoomId;
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => {
+				throw failure;
+			},
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(roomId, otherUUID, "hello"),
+		);
+		expect(result.text).toBe("Admin conversation history is unavailable.");
+		expect(result.data).toMatchObject({
+			available: false,
+			reason: "admin_history_unavailable",
+			error: "memory store down",
+		});
+		expect(result.values).toEqual({ adminHistoryAvailable: false });
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"AdminChatHistoryProvider.get",
+			failure,
+			{ roomId },
+		);
+	});
+
+	it("stringifies non-Error failures", async () => {
+		const runtime = buildRuntime({
+			settings: { ADMIN_USER_ID: adminUserId },
+			memories: async () => {
+				throw "storage string failure";
+			},
+		});
+		const result = await adminChatProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "hello"),
+		);
+		expect(result.data).toMatchObject({
+			reason: "admin_history_unavailable",
+			error: "storage string failure",
+		});
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"AdminChatHistoryProvider.get",
+			"storage string failure",
+			{ roomId: autonomousRoomId },
+		);
+	});
+});
+
+describe("autonomyStatusProvider", () => {
+	it("returns autonomy_service_unavailable when the service is absent", async () => {
+		const runtime = buildRuntime({ service: null });
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toBe("");
+		expect(result.data).toEqual({
+			available: false,
+			reason: "autonomy_service_unavailable",
+		});
+	});
+
+	it("suppresses status inside the autonomous room", async () => {
+		const runtime = buildRuntime({
+			enableAutonomy: true,
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => true,
+				getLoopInterval: () => 30_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toBe("");
+		expect(result.data).toEqual({
+			available: false,
+			reason: "autonomous_room",
+		});
+	});
+
+	it("shows status when the service has no autonomous room", async () => {
+		const runtime = buildRuntime({
+			service: {
+				getAutonomousRoomId: () => null,
+				isLoopRunning: () => false,
+				getLoopInterval: () => 30_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(autonomousRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toContain("[AUTONOMY_STATUS]");
+		expect(result.text).toContain("🔕 autonomy disabled");
+		expect(result.text).toContain("Thinking interval: 30 seconds");
+		expect(result.data).toMatchObject({ status: "disabled" });
+	});
+
+	it("reports a running loop with the robot icon", async () => {
+		const runtime = buildRuntime({
+			enableAutonomy: true,
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => true,
+				getLoopInterval: () => 45_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toContain("🤖 running autonomously");
+		expect(result.text).toContain("Thinking interval: 45 seconds");
+		expect(result.data).toMatchObject({
+			status: "running",
+			serviceRunning: true,
+			autonomyEnabled: true,
+			interval: 45_000,
+			intervalSeconds: 45,
+		});
+		expect(result.values).toEqual({
+			autonomyEnabled: true,
+			autonomyRunning: true,
+			autonomyIntervalSeconds: 45,
+		});
+	});
+
+	it("reports enabled-but-stopped autonomy with the pause icon", async () => {
+		const runtime = buildRuntime({
+			enableAutonomy: true,
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => false,
+				getLoopInterval: () => 120_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toContain("⏸️ autonomy enabled but not running");
+		expect(result.text).toContain("Thinking interval: 2 minutes");
+		expect(result.data).toMatchObject({ status: "enabled" });
+	});
+
+	it("keeps running status precedence over a disabled flag", async () => {
+		const runtime = buildRuntime({
+			enableAutonomy: false,
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => true,
+				getLoopInterval: () => 30_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toContain("🤖 running autonomously");
+		expect(result.data).toMatchObject({
+			status: "running",
+			serviceRunning: true,
+			autonomyEnabled: false,
+		});
+		expect(result.values).toEqual({
+			autonomyEnabled: false,
+			autonomyRunning: true,
+			autonomyIntervalSeconds: 30,
+		});
+	});
+
+	it.each([
+		[30_000, "30 seconds"],
+		[59_499, "59 seconds"],
+		[59_500, "1 minutes"],
+		[60_000, "1 minutes"],
+		[90_000, "2 minutes"],
+	] as const)(
+		"formats a %s ms interval as %s",
+		async (intervalMs, expectedUnit) => {
+			const runtime = buildRuntime({
+				service: {
+					getAutonomousRoomId: () => autonomousRoomId,
+					isLoopRunning: () => false,
+					getLoopInterval: () => intervalMs,
+				},
+			});
+			const result = await autonomyStatusProvider.get(
+				runtime,
+				memory(otherRoomId, otherUUID, "status?"),
+			);
+			expect(result.text).toContain(`Thinking interval: ${expectedUnit}`);
+			expect(result.data).toMatchObject({
+				interval: intervalMs,
+				intervalSeconds: Math.round(intervalMs / 1000),
+			});
+		},
+	);
+
+	it("clamps intervals beyond twenty-four hours", async () => {
+		const runtime = buildRuntime({
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => false,
+				getLoopInterval: () => 100_000_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.text).toContain("Thinking interval: 1440 minutes");
+		expect(result.data).toMatchObject({
+			interval: 86_400_000,
+			intervalSeconds: 86_400,
+		});
+	});
+
+	it("translates service failures into an explicitly unavailable status", async () => {
+		const failure = new Error("loop probe failed");
+		const roomId = otherRoomId;
+		const runtime = buildRuntime({
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => {
+					throw failure;
+				},
+				getLoopInterval: () => 30_000,
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(roomId, otherUUID, "status?"),
+		);
+		expect(result.text).toBe("Autonomy status is unavailable.");
+		expect(result.data).toMatchObject({
+			available: false,
+			reason: "autonomy_status_unavailable",
+			error: "loop probe failed",
+		});
+		expect(result.values).toEqual({ autonomyStatusAvailable: false });
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"AutonomyStatusProvider.get",
+			failure,
+			{ roomId },
+		);
+	});
+
+	it("stringifies non-Error service failures", async () => {
+		const runtime = buildRuntime({
+			service: {
+				getAutonomousRoomId: () => autonomousRoomId,
+				isLoopRunning: () => false,
+				getLoopInterval: () => {
+					throw 7;
+				},
+			},
+		});
+		const result = await autonomyStatusProvider.get(
+			runtime,
+			memory(otherRoomId, otherUUID, "status?"),
+		);
+		expect(result.data).toMatchObject({
+			reason: "autonomy_status_unavailable",
+			error: "7",
+		});
+	});
+});


### PR DESCRIPTION

# Relates to

N/A - additive test-coverage only; no behavioural change and no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      Branch cut directly from `origin/develop` @ `0242ceed35256bc247ed944932f3ccd49a4a3803`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Recorded honestly: the full `bun run verify` gate was not executed for
      this test-only diff (unattended volume lane); the scoped gates quoted in
      **Testing** below were run at the exact head. See Known gaps / failures.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Branched from `origin/develop` @ `0242ceed3525`; diff is one NEW file,
      +629/-0, zero deletions.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The diff adds exactly one new test file,
`packages/core/src/features/autonomy/providers.test.ts`, and touches no
production module. No exports, routes, events, env vars, or public surfaces
change. Existing suites are untouched (no deletions against `origin/develop`).

# Background

## What does this PR do?

Adds the first unit suite for the autonomy feature's providers module
(`packages/core/src/features/autonomy/providers.ts`), which had no same-named
test anywhere on `develop`. 30 cases drive the real `adminChatProvider.get`
and `autonomyStatusProvider.get` implementations against a stubbed runtime and
autonomy service, asserting observable contracts:

- availability gates (`autonomy_service_unavailable`, `not_autonomous_room`,
  `autonomous_room`) including the nullish-room-id short-circuit;
- the admin memory query shape (`entityId` derived via `stringToUuid`,
  `limit: 15`, `unique: false`, `tableName: "memories"`);
- unconfigured-admin and empty/null history contracts (`values` included);
- ascending `createdAt` ordering, Admin/Agent/Other sender roles, the
  `[No text content]` placeholder, and lone-surrogate sanitisation through
  `toWellFormedUnicode` in both rendered history and `lastAdminMessage`;
- the newest-three admin recency window (interleaved non-admin messages
  excluded), empty-text `N/A` mood line vs empty `data.lastAdminMessage`;
- strict `< 1 hour` activity detection (boundary at exactly 3,600,000 ms is
  inactive; missing `createdAt` sorts as epoch and stays inactive);
- interval formatting and rounding boundaries (59,499 ms -> "59 seconds";
  59,500 ms -> rounded 60 s -> "1 minutes"), the 24-hour clamp
  (86,400,000 ms -> "1440 minutes"), and running/enabled/disabled precedence
  including running-loop-over-disabled-flag;
- both J4 error-translation paths: `runtime.reportError(scope, error,
  { roomId })` plus the explicitly-unavailable result contract, for `Error`
  and non-`Error` thrown values alike.

## What kind of change is this?

Improvements (misc. changes to existing features) - tests only; non-breaking,
no production behaviour change.

## Why are we doing this? Any context or related work?

The module currently ships with zero direct unit coverage while its sibling
files (`service.ts`, `action.ts`) are covered. This closes that gap with
behaviour-recording assertions only: every expectation was written from the
observed implementation, and no production code was modified to make a test
pass.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/autonomy/providers.test.ts`

## Detailed testing steps

```bash
bun run --cwd packages/core exec vitest run src/features/autonomy/providers.test.ts
```

Observed at head `5dc803f390ba66318e34655537754892c8659384`:

```
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

(vitest v4.1.5; re-run against current `origin/develop` immediately before
filing - base `0242ceed3525` unchanged since branch creation.)

None: automated tests are acceptable.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5dc803f390ba66318e34655537754892c8659384 -->

This is a backend-free, UI-free test-only diff; every capture-dependent row is
marked N/A with its reason. Scoped command evidence is quoted inline above and
below.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only diff; no UI surface exists to screenshot.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only diff; no UI surface exists to screenshot.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed; vitest invocation quoted inline.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic vitest output quoted inline in Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model call involved; providers exercised against a stubbed
      runtime/service, no live-model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, tasks, or generated artifacts produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behaviour changed; this PR only
adds unit tests that mock the runtime boundary.

## Backend + frontend logs

N/A - see the vitest summary quoted in **Testing**
(`Test Files 1 passed (1)` / `Tests 30 passed (30)`).

Additional scoped checks at the same head:

- `bunx biome check --write src/features/autonomy/providers.test.ts`
  -> `Checked 1 file in 236ms. Fixed 1 file.` (formatting auto-applied;
  subsequent runs clean).
- `bunx tsc --noEmit` in `packages/core`, grep for `providers.test.ts` ->
  no matches (exit 1): the new file introduces zero TypeScript diagnostics.
  Note `packages/core/tsconfig.json` excludes `src/**/*.test.ts`; vitest
  executes the suite directly.
- No `expectTypeOf` and no `vi.hoisted` anywhere in the new file; the owning
  package's runner is vitest (`packages/core` test script), so the quoted
  counts come from `bunx vitest run`.

## Screenshots (before / after) + video walkthrough

N/A - test-only diff with no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no user-facing flow changed.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT/omnivoice change.

## Known gaps / failures

- This pull request is filed from a fork, so hosted CI does NOT run on it.
  All quoted results were produced locally at the exact head SHA; nothing in
  this body implies hosted-CI execution.
- Full `bun run verify` was not run for this test-only diff (unattended
  volume lane, time-boxed). Not a blocker: the diff is one new test file,
  +629/-0, touching no production module, and every gate relevant to a
  test-only change (suite, formatter, type-diagnostics grep) is quoted at the
  exact reviewed head.
- Locale-coupled rendering (`toLocaleTimeString()` in history lines) is
  asserted by computing the identical expression in the test on the same
  host, so the ordering/sender assertions stay deterministic across locales.

## Maintainer CI exception record

N/A - no exception requested.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
