### PR TITLE
test(core): cover plugin install handler

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/install.test.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/install.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Exercises the install handler's validation, failure reporting, success
+ * delivery contract, and the PLUGIN_MANAGER_LOCAL_CLONE scoping that a
+ * git-source install applies for the duration of one service call only,
+ * using the real handler implementation.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { HandlerCallback } from "../../../../types/components.ts";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import { runInstall } from "./install.ts";
+
+function createHarness({
+	result,
+	available = true,
+}: {
+	result?: unknown;
+	available?: boolean;
+} = {}): {
+	runtime: IAgentRuntime;
+	serviceNames: string[];
+	installedNames: string[];
+	observedEnvValues: (string | undefined)[];
+	progressReporters: ((progress: unknown) => void)[];
+} {
+	const serviceNames: string[] = [];
+	const installedNames: string[] = [];
+	const observedEnvValues: (string | undefined)[] = [];
+	const progressReporters: ((progress: unknown) => void)[] = [];
+	const service = available
+		? {
+				installPlugin: async (
+					name: string,
+					onProgress?: (progress: unknown) => void,
+				) => {
+					installedNames.push(name);
+					observedEnvValues.push(process.env.PLUGIN_MANAGER_LOCAL_CLONE);
+					if (onProgress) progressReporters.push(onProgress);
+					return result;
+				},
+			}
+		: null;
+
+	return {
+		runtime: {
+			getService: (name: string) => {
+				serviceNames.push(name);
+				return service;
+			},
+		} as unknown as IAgentRuntime,
+		serviceNames,
+		installedNames,
+		observedEnvValues,
+		progressReporters,
+	};
+}
+
+function createCallback(): {
+	callback: HandlerCallback;
+	replies: unknown[];
+} {
+	const replies: unknown[] = [];
+	return {
+		callback: async (content) => {
+			replies.push(content);
+			return [];
+		},
+		replies,
+	};
+}
+
+afterEach(() => {
+	delete process.env.PLUGIN_MANAGER_LOCAL_CLONE;
+});
+
+describe("runInstall", () => {
+	it("returns and delivers a failure when the plugin manager is unavailable", async () => {
+		const { runtime, serviceNames, installedNames } = createHarness({
+			available: false,
+		});
+		const { callback, replies } = createCallback();
+
+		const result = await runInstall({
+			runtime,
+			name: "@elizaos/plugin-example",
+			callback,
+		});
+
+		expect(serviceNames).toEqual(["plugin_manager"]);
+		expect(installedNames).toEqual([]);
+		expect(result).toEqual({
+			success: false,
+			text: "Plugin manager service not available",
+		});
+		expect(replies).toEqual([{ text: "Plugin manager service not available" }]);
+	});
+
+	it("rejects an empty plugin name without calling the install service", async () => {
+		const { runtime, installedNames } = createHarness();
+		const { callback, replies } = createCallback();
+
+		const result = await runInstall({ runtime, name: "", callback });
+
+		expect(installedNames).toEqual([]);
+		expect(result).toEqual({
+			success: false,
+			text: "Specify a plugin name to install (e.g. @elizaos/plugin-discord).",
+		});
+		expect(replies).toEqual([
+			{
+				text: "Specify a plugin name to install (e.g. @elizaos/plugin-discord).",
+			},
+		]);
+	});
+
+	it("preserves the requested name and service error in a failed result", async () => {
+		const requestedName = "@elizaos/plugin-example@next";
+		const { runtime, installedNames } = createHarness({
+			result: {
+				success: false,
+				pluginName: "@elizaos/plugin-example",
+				requiresRestart: false,
+				error: "npm install exited with code 1",
+			},
+		});
+		const { callback, replies } = createCallback();
+
+		const result = await runInstall({
+			runtime,
+			name: requestedName,
+			callback,
+		});
+
+		expect(installedNames).toEqual([requestedName]);
+		expect(result).toEqual({
+			success: false,
+			text: `Failed to install ${requestedName}: npm install exited with code 1`,
+		});
+		expect(replies).toEqual([
+			{
+				text: `Failed to install ${requestedName}: npm install exited with code 1`,
+			},
+		]);
+	});
+
+	it("uses the unknown-error fallback when a failed result omits its error", async () => {
+		const { runtime, installedNames } = createHarness({
+			result: {
+				success: false,
+				pluginName: "plugin-example",
+				requiresRestart: false,
+			},
+		});
+
+		const result = await runInstall({ runtime, name: "plugin-example" });
+
+		expect(installedNames).toEqual(["plugin-example"]);
+		expect(result).toEqual({
+			success: false,
+			text: "Failed to install plugin-example: unknown error",
+		});
+	});
+
+	it("returns complete install data without restart wording", async () => {
+		const installPath = "/state/plugins/installed/@elizaos_plugin-example";
+		const { runtime, installedNames } = createHarness({
+			result: {
+				success: true,
+				pluginName: "@elizaos/plugin-example",
+				version: "2.0.0",
+				installPath,
+				requiresRestart: false,
+			},
+		});
+		const { callback, replies } = createCallback();
+
+		const result = await runInstall({
+			runtime,
+			name: "@elizaos/plugin-example",
+			callback,
+		});
+
+		const text = "Installed @elizaos/plugin-example (v2.0.0).";
+		expect(installedNames).toEqual(["@elizaos/plugin-example"]);
+		expect(result).toEqual({
+			success: true,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: {
+				mode: "install",
+				name: "@elizaos/plugin-example",
+				version: "2.0.0",
+				installPath,
+			},
+			data: {
+				success: true,
+				pluginName: "@elizaos/plugin-example",
+				version: "2.0.0",
+				installPath,
+				requiresRestart: false,
+			},
+		});
+		expect(replies).toEqual([{ text }]);
+		expect(text).not.toContain(installPath);
+	});
+
+	it("adds restart guidance to the exact result and callback text", async () => {
+		const { runtime } = createHarness({
+			result: {
+				success: true,
+				pluginName: "plugin-example",
+				version: "1.2.3",
+				installPath: "/state/plugins/installed/plugin-example",
+				requiresRestart: true,
+			},
+		});
+		const { callback, replies } = createCallback();
+
+		const result = await runInstall({
+			runtime,
+			name: "plugin-example",
+			callback,
+		});
+
+		const text =
+			"Installed plugin-example (v1.2.3). A restart is needed before it's active.";
+		expect(result.text).toBe(text);
+		expect(result.userFacingText).toBe(text);
+		expect(result.values).toEqual({
+			mode: "install",
+			name: "plugin-example",
+			version: "1.2.3",
+			installPath: "/state/plugins/installed/plugin-example",
+		});
+		expect(replies).toEqual([{ text }]);
+	});
+
+	it("passes a progress reporter through to the service call", async () => {
+		const { runtime, progressReporters } = createHarness({
+			result: {
+				success: true,
+				pluginName: "plugin-example",
+				version: "1.0.0",
+				installPath: "/state/plugins/installed/plugin-example",
+				requiresRestart: false,
+			},
+		});
+
+		await runInstall({ runtime, name: "plugin-example" });
+
+		expect(progressReporters.length).toBe(1);
+		expect(() =>
+			progressReporters[0]?.({ phase: "resolving", message: "looking up" }),
+		).not.toThrow();
+	});
+
+	it("sets PLUGIN_MANAGER_LOCAL_CLONE during a git-source call and deletes it afterwards when previously unset", async () => {
+		const { runtime, observedEnvValues } = createHarness({
+			result: {
+				success: true,
+				pluginName: "plugin-example",
+				version: "1.0.0",
+				installPath: "/state/plugins/installed/plugin-example",
+				requiresRestart: false,
+			},
+		});
+		delete process.env.PLUGIN_MANAGER_LOCAL_CLONE;
+
+		const result = await runInstall({
+			runtime,
+			name: "plugin-example",
+			source: "git",
+		});
+
+		expect(observedEnvValues).toEqual(["true"]);
+		expect(result.success).toBe(true);
+		expect(process.env.PLUGIN_MANAGER_LOCAL_CLONE).toBeUndefined();
+	});
+
+	it("restores the previous PLUGIN_MANAGER_LOCAL_CLONE value after a git-source call", async () => {
+		const { runtime, observedEnvValues } = createHarness({
+			result: {
+				success: true,
+				pluginName: "plugin-example",
+				version: "1.0.0",
+				installPath: "/state/plugins/installed/plugin-example",
+				requiresRestart: false,
+			},
+		});
+		process.env.PLUGIN_MANAGER_LOCAL_CLONE = "false";
+
+		await runInstall({
+			runtime,
+			name: "plugin-example",
+			source: "git",
+		});
+
+		expect(observedEnvValues).toEqual(["true"]);
+		expect(process.env.PLUGIN_MANAGER_LOCAL_CLONE).toBe("false");
+	});
+
+	it("keeps the local-clone override active after a failed git-source call until restoration", async () => {
+		const { runtime, observedEnvValues } = createHarness({
+			result: {
+				success: false,
+				pluginName: "plugin-example",
+				requiresRestart: false,
+				error: "clone failed",
+			},
+		});
+		process.env.PLUGIN_MANAGER_LOCAL_CLONE = "keep-me";
+
+		const result = await runInstall({
+			runtime,
+			name: "plugin-example",
+			source: "git",
+		});
+
+		expect(observedEnvValues).toEqual(["true"]);
+		expect(result.success).toBe(false);
+		expect(process.env.PLUGIN_MANAGER_LOCAL_CLONE).toBe("keep-me");
+	});
+
+	it("leaves PLUGIN_MANAGER_LOCAL_CLONE untouched for npm installs", async () => {
+		const { runtime, observedEnvValues } = createHarness({
+			result: {
+				success: true,
+				pluginName: "plugin-example",
+				version: "1.0.0",
+				installPath: "/state/plugins/installed/plugin-example",
+				requiresRestart: false,
+			},
+		});
+		process.env.PLUGIN_MANAGER_LOCAL_CLONE = "false";
+
+		await runInstall({ runtime, name: "plugin-example" });
+
+		expect(observedEnvValues).toEqual(["false"]);
+		expect(process.env.PLUGIN_MANAGER_LOCAL_CLONE).toBe("false");
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/plugin-manager/actions/plugin-handlers/install.test.ts`, a new vitest unit suite for `runInstall` in `packages/core/src/features/plugin-manager/actions/plugin-handlers/install.ts`. The module previously had no same-named test anywhere in the repository. This is a test-only change: no production code is touched.

## Coverage

The suite drives the real handler and asserts observed behavior over every branch:

- plugin-manager service unavailable → failure result plus callback delivery, service never invoked;
- empty `name` → guidance text without calling the install service;
- failed install result → requested name and service error preserved in text and callback;
- failed install result omitting `error` → `"unknown error"` fallback;
- successful install → exact result shape (`text`, `userFacingText`, `verifiedUserFacing`, `turnComplete`, `values`, full `data`) with no restart wording and no raw filesystem path in user-facing text;
- `requiresRestart: true` → restart guidance appended to the exact result and callback text;
- a progress reporter is passed through to the service call;
- `source: "git"` env scoping: `PLUGIN_MANAGER_LOCAL_CLONE` becomes `"true"` for the duration of the service call, is deleted afterwards when previously unset, restores a pre-existing value, restores even when the install fails, and is left untouched entirely for npm installs.

No mocks of the module under test: collaborator stubs only supply inputs and record calls; all asserted strings, shapes, and env transitions are produced by the real `runInstall`.

## Verification

Fork contribution — hosted CI does not run on this PR; the following were executed locally at head `a048e7d20dba` (base `origin/develop` @ `0242ceed3525`):

- `bunx vitest run packages/core/src/features/plugin-manager/actions/plugin-handlers/install.test.ts` → **Test Files 1 passed (1); Tests 11 passed (11)**, re-run against current `origin/develop` immediately before filing;
- `bunx biome check --write <file>` → clean ("Checked 1 file ... No fixes applied" on re-check);
- `bunx tsc --noEmit` in `packages/core` → the new test file appears nowhere in the output (zero errors introduced);
- `git diff origin/develop HEAD` → exactly one new file, **343 insertions, 0 deletions**.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a048e7d20dbaca3adf47377a4f2193d73d2dd152 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
