### PR TITLE
test(core): cover choice provider

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/choice.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the CHOICE pending-task picker provider, driving
+ * choiceProvider.get against a deterministic mock runtime. Pins the task-store
+ * query contract, both "no pending choices" guards, and the exact numbered
+ * rendering of legacy string options alongside typed option objects.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	createMockRuntime,
+	MOCK_AGENT_ID,
+} from "../../../testing/mock-runtime";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	Task,
+	TaskMetadata,
+	UUID,
+} from "../../../types/index.ts";
+import choiceProviderDefault, { choiceProvider } from "./choice.ts";
+
+const roomId = "00000000-0000-0000-0000-0000000000bb" as UUID;
+
+const message = {
+	agentId: MOCK_AGENT_ID,
+	entityId: "00000000-0000-0000-0000-0000000000cc",
+	roomId,
+	content: { text: "What are my choices?" },
+} as unknown as Memory;
+
+const state: State = { values: {}, data: {}, text: "" };
+
+function taskWith(name: string, metadata?: TaskMetadata): Task {
+	return { name, roomId, metadata };
+}
+
+describe("CHOICE provider contract", () => {
+	it("exposes the generated provider contract with turn scope and USER gate", () => {
+		expect(choiceProvider).toMatchObject({
+			name: "CHOICE",
+			contexts: ["general"],
+			contextGate: { anyOf: ["general"] },
+			cacheStable: false,
+			cacheScope: "turn",
+			roleGate: { minRole: "USER" },
+		});
+		expect(typeof choiceProvider.description).toBe("string");
+	});
+
+	it("is also the default export", () => {
+		expect(choiceProviderDefault).toBe(choiceProvider);
+	});
+});
+
+describe("CHOICE provider.get", () => {
+	it("queries the task store for this room, agent, and the AWAITING_CHOICE tag", async () => {
+		const calls: Parameters<IAgentRuntime["getTasks"]>[0][] = [];
+		const runtime = createMockRuntime({
+			getTasks: async (params) => {
+				calls.push(params);
+				return [];
+			},
+		});
+
+		await choiceProvider.get(runtime, message, state);
+
+		expect(calls).toEqual([
+			{ roomId, tags: ["AWAITING_CHOICE"], agentIds: [MOCK_AGENT_ID] },
+		]);
+	});
+
+	it("renders the placeholder when the task store returns nothing", async () => {
+		const runtime = createMockRuntime({
+			getTasks: async () => [] as unknown as Task[],
+		});
+		const result = await choiceProvider.get(runtime, message, state);
+
+		expect(result).toEqual({
+			data: { tasks: [] },
+			values: { tasks: "No pending choices for the moment." },
+			text: "No pending choices for the moment.",
+		});
+	});
+
+	it("renders the placeholder when the store reports no pending tasks at all", async () => {
+		const runtime = createMockRuntime({
+			getTasks: async () => null as unknown as Task[],
+		});
+		const result = await choiceProvider.get(runtime, message, state);
+
+		expect(result.text).toBe("No pending choices for the moment.");
+		expect(result.data.tasks).toEqual([]);
+	});
+
+	it("renders the placeholder when awaiting tasks carry no options field at all", async () => {
+		const runtime = createMockRuntime({
+			getTasks: async () => [taskWith("NO_OPTIONS")],
+		});
+		const result = await choiceProvider.get(runtime, message, state);
+
+		expect(result.text).toBe("No pending choices for the moment.");
+		expect(result.data.tasks).toEqual([]);
+	});
+
+	it("still lists a task whose options array is empty, with an empty Options block", async () => {
+		const emptyOptions = taskWith("EMPTY_OPTIONS", { options: [] });
+		const runtime = createMockRuntime({
+			getTasks: async () => [emptyOptions],
+		});
+		const result = await choiceProvider.get(runtime, message, state);
+
+		expect(result.text).toBe(
+			"# Pending Tasks\n\n" +
+				"The following tasks are awaiting your selection:\n\n" +
+				"1. **EMPTY_OPTIONS**\n" +
+				"   Options:\n" +
+				"\n" +
+				"To select an option, reply with the option name (e.g., 'post' or 'cancel').\n",
+		);
+		expect(result.data.tasks).toEqual([emptyOptions]);
+	});
+
+	it("renders only options-bearing tasks with their full numbered selection list", async () => {
+		const pickColor = taskWith("PICK_COLOR", {
+			options: ["red", { name: "blue", description: "The blue one" }],
+		} as unknown as TaskMetadata);
+		const confirmLaunch = {
+			name: "CONFIRM_LAUNCH",
+			roomId,
+			description: "Confirm the launch.",
+			metadata: {
+				options: [
+					{ name: "yes", description: "affirm" },
+					{ name: "no", description: "" },
+				],
+			},
+		};
+		const ignored = taskWith("NOT_A_CHOICE");
+		const runtime = createMockRuntime({
+			getTasks: async () => [pickColor, ignored, confirmLaunch],
+		});
+
+		const result = await choiceProvider.get(runtime, message, state);
+
+		const rendered =
+			"# Pending Tasks\n\n" +
+			"The following tasks are awaiting your selection:\n\n" +
+			"1. **PICK_COLOR**\n" +
+			"   Options:\n" +
+			"   - `red` \n" +
+			"   - `blue` - The blue one\n" +
+			"\n" +
+			"2. **CONFIRM_LAUNCH**\n" +
+			"   Confirm the launch.\n" +
+			"   Options:\n" +
+			"   - `yes` - affirm\n" +
+			"   - `no` \n" +
+			"\n" +
+			"To select an option, reply with the option name (e.g., 'post' or 'cancel').\n";
+		expect(result.text).toBe(rendered);
+		expect(result.values.tasks).toBe(rendered);
+		expect(result.data.tasks).toEqual([pickColor, confirmLaunch]);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/basic-capabilities/providers/choice.test.ts`, a new unit suite for the CHOICE pending-task picker provider (`providers/choice.ts`), which had no same-named suite anywhere in the repository. The diff is a single new test file: +164/-0, no production code touched.

## Coverage

The suite drives the real `choiceProvider.get` through `createMockRuntime` (the package's typed unit-test fixture) and pins observed behavior:

- provider contract: generated `CHOICE` spec name, `contexts: ["general"]`, `contextGate`, `cacheStable: false`, `cacheScope: "turn"`, `roleGate.minRole: "USER"`; default export identity.
- task-store query contract: `getTasks` receives exactly `{ roomId, tags: ["AWAITING_CHOICE"], agentIds: [runtime.agentId] }`.
- both empty-state guards return the exact `"No pending choices for the moment."` result shape: empty array and a null store response.
- presence-based options filter: a task without an `options` field is filtered out of text and `data.tasks`; a task with an *empty* options array still renders, with an empty Options block (documented as-is).
- full exact-string rendering: numbered bold task names, indented descriptions, legacy string options alongside typed option objects, the string-option description lookup over mixed arrays, falsy-description suppression of the `- desc` suffix, and the reply-instruction footer.

## Evidence (test-only change)

- `bunx vitest run packages/core/src/features/basic-capabilities/providers/choice.test.ts` → **Test Files 1 passed (1), Tests 8 passed (8)**, re-run against current `origin/develop` immediately before filing.
- `bunx biome check --write` on the file → clean (config verified present at repo root; worktree is not sparse).
- `bunx tsc --noEmit` in `packages/core` → zero diagnostics mentioning `choice.test.ts`.
- Diff touches only the one new test file; no production behavior changes.

This is a fork contribution: hosted CI does not run on this pull request; the counts above are local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:270996699999a57910f7a6d482f399b1b8fed78c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
