### PR TITLE
test(core): cover mcp-server-config

### DIFF
--- a/packages/core/src/security/mcp-server-config.test.ts
+++ b/packages/core/src/security/mcp-server-config.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Exercises `validateMcpServerConfig`, the GHSA-54rx-pcr9-hg9x gate shared by
+ * the agent API and the MCP spawn path: config-type and command allowlists,
+ * per-family argument denylists (interpreters, package runners, containers,
+ * deno), SSRF guards on remote URLs, env-injection rejection, and scalar field
+ * validation. Deterministic: every case short-circuits before DNS, so the
+ * suite never touches the network.
+ */
+
+import { describe, expect, test } from "vitest";
+import { validateMcpServerConfig } from "./mcp-server-config";
+
+describe("validateMcpServerConfig", () => {
+	test("rejects a missing config type with the allowlist message", async () => {
+		expect(await validateMcpServerConfig({})).toBe(
+			"Invalid config type. Must be one of: stdio, http, streamable-http, sse",
+		);
+	});
+
+	test.each([["websocket"], [42], [null], [undefined]])(
+		"rejects config type %p",
+		async (configType) => {
+			expect(await validateMcpServerConfig({ type: configType })).toBe(
+				"Invalid config type. Must be one of: stdio, http, streamable-http, sse",
+			);
+		},
+	);
+
+	test.each(["http", "streamable-http", "sse"])(
+		"requires a URL for remote transport %s",
+		async (type) => {
+			expect(await validateMcpServerConfig({ type })).toBe(
+				"URL is required for remote servers",
+			);
+			expect(await validateMcpServerConfig({ type, url: "   " })).toBe(
+				"URL is required for remote servers",
+			);
+		},
+	);
+
+	describe("stdio command gating", () => {
+		test("requires a command for stdio servers", async () => {
+			expect(await validateMcpServerConfig({ type: "stdio" })).toBe(
+				"Command is required for stdio servers",
+			);
+		});
+
+		test("treats a whitespace-only command as missing", async () => {
+			expect(
+				await validateMcpServerConfig({ type: "stdio", command: "   " }),
+			).toBe("Command is required for stdio servers");
+		});
+
+		test.each(["/usr/bin/node", "..\\node.exe", "a b"])(
+			"rejects command %p that is not a bare executable name",
+			async (command) => {
+				expect(await validateMcpServerConfig({ type: "stdio", command })).toBe(
+					"Command must be a bare executable name without path separators",
+				);
+			},
+		);
+
+		test("rejects an unlisted command and lists the allowed commands", async () => {
+			expect(
+				await validateMcpServerConfig({ type: "stdio", command: "curl" }),
+			).toBe(
+				'Command "curl" is not allowed. Allowed commands: npx, node, bun, bunx, deno, python, python3, uvx, uv, docker, podman',
+			);
+		});
+
+		test("normalizes case and Windows executable suffixes before allowlisting", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "BUNX.EXE",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("interpreter argument denylist", () => {
+		test("blocks -e for node", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					args: ["-e", "process.exit(1)"],
+				}),
+			).toBe('Flag "-e" is not allowed for node MCP servers');
+		});
+
+		test("blocks --eval for bun", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "bun",
+					args: ["--eval", "1"],
+				}),
+			).toBe('Flag "--eval" is not allowed for bun MCP servers');
+		});
+
+		test("blocks a combined single-token interpreter flag like -eVALUE", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					args: ["-econsole.log(1)"],
+				}),
+			).toBe('Flag "-e" is not allowed for node MCP servers');
+		});
+
+		test("blocks --import for python3", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "python3",
+					args: ["--import", "os"],
+				}),
+			).toBe('Flag "--import" is not allowed for python3 MCP servers');
+		});
+
+		test("ignores flags from other families for interpreters", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					args: ["--privileged"],
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("package runner argument denylist", () => {
+		test("blocks --index-url for uvx", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "uvx",
+					args: ["--index-url", "https://evil.example"],
+				}),
+			).toBe('Flag "--index-url" is not allowed for uvx MCP servers');
+		});
+
+		test("blocks -c for npx", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "npx",
+					args: ["-c", "console.log(1)"],
+				}),
+			).toBe('Flag "-c" is not allowed for npx MCP servers');
+		});
+	});
+
+	describe("container argument denylist", () => {
+		test("blocks --privileged for docker", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "docker",
+					args: ["run", "--privileged"],
+				}),
+			).toBe('Flag "--privileged" is not allowed for docker MCP servers');
+		});
+
+		test("blocks bind mounts for podman", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "podman",
+					args: ["-v", "/:/host"],
+				}),
+			).toBe('Flag "-v" is not allowed for podman MCP servers');
+		});
+	});
+
+	describe("deno capability gating", () => {
+		test("blocks the eval subcommand", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "deno",
+					args: ["eval", "code"],
+				}),
+			).toBe('Subcommand "eval" is not allowed for deno MCP servers');
+		});
+
+		test("blocks all-permissions shorthand -A", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "deno",
+					args: ["-A"],
+				}),
+			).toBe('Flag "-A" is not allowed for deno MCP servers');
+		});
+
+		test("blocks granular permission grants like --allow-net", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "deno",
+					args: ["--allow-net"],
+				}),
+			).toBe('Flag "--allow-net" is not allowed for deno MCP servers');
+		});
+
+		test("blocks the --unstable flag family by prefix", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "deno",
+					args: ["--unstable-kv"],
+				}),
+			).toBe('Flag "--unstable" is not allowed for deno MCP servers');
+		});
+
+		test("routes remote script URLs through the SSRF host guard", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "deno",
+					args: ["run", "https://127.0.0.1/x.ts"],
+				}),
+			).toBe('URL host "127.0.0.1" is blocked for security reasons');
+		});
+	});
+
+	describe("remote URL SSRF guard", () => {
+		test("rejects a string that is not an absolute URL", async () => {
+			expect(
+				await validateMcpServerConfig({ type: "sse", url: "not a url" }),
+			).toBe("URL must be a valid absolute URL");
+		});
+
+		test("rejects non-http protocols before any network work", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "http",
+					url: "ftp://example.com/files",
+				}),
+			).toBe("URL must use http:// or https://");
+		});
+
+		test.each([
+			"http://localhost:8080/mcp",
+			"https://metadata.google.internal/computeMetadata",
+			"http://api.localhost/mcp",
+			"http://printer.local/mcp",
+		])("blocks literal internal host %s without DNS", async (url) => {
+			const hostname = new URL(url).hostname;
+			expect(await validateMcpServerConfig({ type: "http", url })).toBe(
+				`URL host "${hostname.replace(/^\[/, "").replace(/\]$/, "")}" is blocked for security reasons`,
+			);
+		});
+
+		test("blocks a loopback IPv4 literal", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "http",
+					url: "http://127.0.0.1/",
+				}),
+			).toBe('URL host "127.0.0.1" is blocked for security reasons');
+		});
+
+		test("blocks a hex-encoded loopback literal after URL canonicalization", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "http",
+					url: "http://0x7f.0.0.1/",
+				}),
+			).toBe('URL host "127.0.0.1" is blocked for security reasons');
+		});
+
+		test("blocks a bracketed IPv6 loopback literal", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "streamable-http",
+					url: "http://[::1]:3000/mcp",
+				}),
+			).toBe('URL host "::1" is blocked for security reasons');
+		});
+
+		test("accepts a public IP-literal URL without touching DNS", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "http",
+					url: "http://93.184.216.34/mcp",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("args shape validation", () => {
+		test("rejects non-array args", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					args: "server.js",
+				}),
+			).toBe("args must be an array of strings");
+		});
+
+		test("rejects non-string entries inside args", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					args: ["server.js", 42],
+				}),
+			).toBe("Each arg must be a string");
+		});
+	});
+
+	describe("env validation", () => {
+		function stdioWithEnv(env: unknown) {
+			return { type: "stdio", command: "node", args: ["server.js"], env };
+		}
+
+		test.each([
+			["a string", "PATH=/usr/bin"],
+			["an array", ["A=1"]],
+			["null", null],
+		])("rejects env that is %s", async (_label, env) => {
+			expect(await validateMcpServerConfig(stdioWithEnv(env))).toBe(
+				"env must be a plain object of string key-value pairs",
+			);
+		});
+
+		test("rejects a non-string env value", async () => {
+			expect(await validateMcpServerConfig(stdioWithEnv({ RETRIES: 3 }))).toBe(
+				"env.RETRIES must be a string",
+			);
+		});
+
+		test.each(["__proto__", "constructor", "prototype", "$include"])(
+			"blocks the dangerous object key env.%s",
+			async (key) => {
+				expect(
+					await validateMcpServerConfig(stdioWithEnv({ [key]: "x" })),
+				).toBe(`env key "${key}" is blocked for security reasons`);
+			},
+		);
+
+		test("blocks denylisted env keys case-insensitively", async () => {
+			expect(
+				await validateMcpServerConfig(stdioWithEnv({ ld_preload: "/evil.so" })),
+			).toBe('env variable "ld_preload" is not allowed for security reasons');
+		});
+
+		test("blocks env keys matching a denylisted prefix", async () => {
+			expect(
+				await validateMcpServerConfig(
+					stdioWithEnv({ NPM_CONFIG_REGISTRY: "https://evil.example" }),
+				),
+			).toBe(
+				'env variable "NPM_CONFIG_REGISTRY" matches blocked prefix NPM_CONFIG_ and is not allowed',
+			);
+		});
+
+		test("blocks env values containing a null byte", async () => {
+			expect(
+				await validateMcpServerConfig(stdioWithEnv({ SAFE: "a\u0000b" })),
+			).toBe('env variable "SAFE" contains a null byte and is not allowed');
+		});
+
+		test("accepts benign env values", async () => {
+			expect(
+				await validateMcpServerConfig(
+					stdioWithEnv({ LOG_LEVEL: "info", MAX_CONNECTIONS: "10" }),
+				),
+			).toBeNull();
+		});
+	});
+
+	describe("scalar fields and precedence", () => {
+		test("rejects a non-string cwd", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					cwd: 7,
+				}),
+			).toBe("cwd must be a string");
+		});
+
+		test.each([
+			["a negative number", -1],
+			["Infinity", Number.POSITIVE_INFINITY],
+			["NaN", Number.NaN],
+			["a string", "5000"],
+		])("rejects timeoutInMillis that is %s", async (_label, value) => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "node",
+					timeoutInMillis: value as number,
+				}),
+			).toBe("timeoutInMillis must be a non-negative number");
+		});
+
+		test("reports the config type before inspecting env", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "carrier-pigeon",
+					env: { LD_PRELOAD: "/evil.so" },
+				}),
+			).toBe(
+				"Invalid config type. Must be one of: stdio, http, streamable-http, sse",
+			);
+		});
+
+		test("accepts a fully valid stdio config", async () => {
+			expect(
+				await validateMcpServerConfig({
+					type: "stdio",
+					command: "bunx",
+					args: ["@modelcontextprotocol/server-filesystem", "/tmp"],
+					env: { LOG_LEVEL: "debug" },
+					cwd: "/workspace",
+					timeoutInMillis: 30_000,
+				}),
+			).toBeNull();
+		});
+
+		test("accepts a minimal stdio config with no optional fields", async () => {
+			expect(
+				await validateMcpServerConfig({ type: "stdio", command: "uvx" }),
+			).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION

## Summary

Adds a deterministic unit suite for `packages/core/src/security/mcp-server-config.ts`, the GHSA-54rx-pcr9-hg9x MCP server config validator shared by the agent API and the `@elizaos/plugin-mcp` spawn path. The module previously had no same-named test file anywhere on `develop`.

The suite drives the real exported `validateMcpServerConfig` function end to end — no handler, model, DNS, or network stubs anywhere. Every asserted rejection short-circuits before DNS, so the run is fully offline-deterministic.

## What is covered

- **Config-type gate:** unknown / missing / non-string types rejected with the exact allowlist message; type checked before env content.
- **stdio command gating:** required command, whitespace-only treated as missing, path separators rejected, unlisted commands rejected with the allowed-command list, and Windows-style normalization (`BUNX.EXE` accepted as `bunx`).
- **Per-family argument denylists:** interpreters (`node -e`, combined single-token `-eVALUE`, `bun --eval`, `python3 --import`), package runners (`npx -c`, `uvx --index-url`), containers (`docker --privileged`, `podman -v`), including that container flags do not trip interpreter configs.
- **Deno capability gating:** `eval` subcommand, `-A`, granular `--allow-*` grants, `--unstable-*` prefix family, and remote script URLs routed through the SSRF host guard.
- **Remote URL SSRF guard:** invalid URLs, non-http(s) protocols, literal internal hosts (`localhost`, `*.localhost`, `*.local`, `metadata.google.internal`) blocked without DNS, loopback IPv4 literals, bracketed IPv6 loopback, and a hex-encoded loopback (`http://0x7f.0.0.1/`) which WHATWG URL parsing canonicalizes to `127.0.0.1` before the guard rejects it. A public IP-literal URL is accepted with zero DNS traffic.
- **args shape:** non-array args and non-string entries rejected.
- **env injection:** non-object/array/null shapes, non-string values, prototype-pollution keys (`__proto__`, `constructor`, `prototype`, `$include`), case-insensitive denylisted keys (`ld_preload`), denylisted prefixes (`NPM_CONFIG_`), null bytes in values, plus benign-env acceptance.
- **Scalar fields & precedence:** non-string `cwd`; negative / infinite / NaN / string `timeoutInMillis`; and fully-valid minimal and complete stdio configs returning `null`.

## Verification

Fork contributor: hosted CI does not run on this PR. All checks below were run locally against base `3624a59ccb823312f73b42334d5a4daf23251c54` (current `origin/develop` at filing time), re-fetched immediately before filing.

| Check | Command | Result |
| --- | --- | --- |
| Unit suite | `bunx vitest run packages/core/src/security/mcp-server-config.test.ts` | **1 file, 61 passed / 61 failed 0** (~0.3s) |
| Lint/format | `bunx biome check packages/core/src/security/mcp-server-config.test.ts` | Clean (`Checked 1 file … No fixes applied`) |
| Types | `bunx tsc --noEmit` in `packages/core`, grepped for the new file | No output — the new test file introduces zero TypeScript diagnostics |

The diff is additive: exactly one new file, `packages/core/src/security/mcp-server-config.test.ts`, +N/−0. No production code is touched.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3624a59ccb823312f73b42334d5a4daf23251c54 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
