### PR TITLE
fix(ui): flatten nested card surfaces

### DIFF
--- a/packages/scripts/design-doctor-baseline.json
+++ b/packages/scripts/design-doctor-baseline.json
@@ -11,7 +11,6 @@
   "no-inline-exhaustive-style": 1,
   "no-invisible-focus-control": 2,
   "no-layout-shifting-interaction-state": 2,
-  "no-nested-card-surface": 26,
   "no-pure-black-background": 47,
   "no-symmetric-text-button-padding": 2
 }

--- a/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
+++ b/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
@@ -375,7 +375,7 @@ export function ApiRouteExplorerClient({
               <div className="py-5 border-b border-border">
                 <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
                   {/* Auth */}
-                  <div className="p-4 bg-bg border border-border rounded-sm">
+                  <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <Lock
                         aria-hidden="true"
@@ -403,7 +403,7 @@ export function ApiRouteExplorerClient({
                   </div>
 
                   {/* Rate Limit */}
-                  <div className="p-4 bg-bg border border-border rounded-sm">
+                  <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <Zap
                         aria-hidden="true"
@@ -420,7 +420,7 @@ export function ApiRouteExplorerClient({
                   </div>
 
                   {/* Category */}
-                  <div className="p-4 bg-bg border border-border rounded-sm">
+                  <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <Tag
                         aria-hidden="true"
@@ -438,7 +438,7 @@ export function ApiRouteExplorerClient({
                   </div>
 
                   {/* Pricing */}
-                  <div className="p-4 bg-bg border border-border rounded-sm">
+                  <div className="p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <DollarSign
                         aria-hidden="true"

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -416,7 +416,7 @@ export function AppSettings({ app }: AppSettingsProps) {
         </h3>
 
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-4 bg-surface rounded-sm border border-red-500/10">
+          <div className="flex items-center justify-between border-l-2 border-red-500/40 bg-red-500/5 p-4">
             <div className="min-w-0 flex-1 mr-3">
               <p className="text-sm font-medium text-txt">
                 {t("cloud.appSettings.regenerateApiKey", {
@@ -479,7 +479,7 @@ export function AppSettings({ app }: AppSettingsProps) {
             </AlertDialog>
           </div>
 
-          <div className="flex items-center justify-between p-4 bg-surface rounded-sm border border-red-500/10">
+          <div className="flex items-center justify-between border-l-2 border-red-500/40 bg-red-500/5 p-4">
             <div className="min-w-0 flex-1 mr-3">
               <p className="text-sm font-medium text-txt">
                 {t("cloud.appSettings.deleteApp", {

--- a/packages/ui/src/cloud/mcps/McpsView.tsx
+++ b/packages/ui/src/cloud/mcps/McpsView.tsx
@@ -324,7 +324,7 @@ const BuiltinCard = memo(function BuiltinCard({
   };
 
   return (
-    <div className="rounded-sm border border-border bg-card p-4">
+    <div className="border-b border-border p-4 last:border-b-0">
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-3 min-w-0">
           <div className="p-2 rounded-sm border border-border bg-bg-elevated shrink-0">

--- a/packages/ui/src/components/accounts/AccountList.tsx
+++ b/packages/ui/src/components/accounts/AccountList.tsx
@@ -169,7 +169,7 @@ export function AccountList({ providerId }: AccountListProps) {
       </div>
 
       {sorted.length === 0 ? (
-        <div className="rounded-sm border border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted">
+        <div className="border-y border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted">
           {t("accounts.empty", {
             defaultValue:
               "No accounts yet — add one to start using this provider.",

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
@@ -400,7 +400,7 @@ export function BrowserSessionPolicyPanel({
             {intercepted.length > 0 ? (
               <div
                 data-testid={`browser-session-${session.id}-intercepted`}
-                className="rounded-sm border border-accent/40 bg-accent/10 px-3 py-2 text-xs"
+                className="border-l-2 border-accent/60 bg-accent/10 px-3 py-2 text-xs"
               >
                 <span className="font-medium">Held for confirmation:</span>{" "}
                 {intercepted.map((action) => action.label).join(", ")}

--- a/packages/ui/src/components/chat/AccountConnectBlock.tsx
+++ b/packages/ui/src/components/chat/AccountConnectBlock.tsx
@@ -115,7 +115,7 @@ export function AccountConnectBlock({
             <div
               key={providerId}
               data-testid={`account-connect-row-${providerId}`}
-              className="flex items-center justify-between gap-3 rounded-sm border border-border/40 bg-bg-accent/40 px-3 py-2"
+              className="flex items-center justify-between gap-3 border-b border-border/40 px-3 py-2 last:border-b-0"
             >
               <div className="min-w-0">
                 <div className="truncate font-medium">

--- a/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
+++ b/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
@@ -410,7 +410,7 @@ export function DiscordLocalConnectorPanel() {
                     })}
                   </div>
                 ) : channels.length > 0 ? (
-                  <div className="max-h-56 space-y-2 overflow-y-auto rounded-sm border border-border/30 bg-bg/40 p-2">
+                  <div className="max-h-56 space-y-2 overflow-y-auto border-y border-border/30 py-2">
                     {channels.map((channel) => {
                       const checked = selectedChannelIds.includes(channel.id);
                       return (

--- a/packages/ui/src/components/release-center/sections.tsx
+++ b/packages/ui/src/components/release-center/sections.tsx
@@ -12,7 +12,7 @@ import { useAppSelector } from "../../state";
 import { formatDateTime } from "../../utils/format";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-import { DefinitionRow, StatusPill } from "./shared";
+import { DefinitionList, DefinitionRow, StatusPill } from "./shared";
 import { partitionDescription } from "./shared.helpers";
 import type {
   AppReleaseStatus,
@@ -95,7 +95,7 @@ export function ReleaseStatusSection({
         ) : null}
       </div>
 
-      <div className="mb-4 flex items-start justify-between gap-4">
+      <div className="mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row">
         <div>
           <h3 className="text-sm font-semibold text-txt">
             {tr(t, "releasecenter.ReleaseStatus", "Release Status")}
@@ -132,33 +132,35 @@ export function ReleaseStatusSection({
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
-        <div className="p-3">
+        <div className="bg-bg/40 p-3">
           <div className="text-xs font-semibold text-txt">
             {tr(t, "releasecenter.AppReleaseService", "App Release Service")}
           </div>
-          <DefinitionRow
-            label={tr(t, "releasecenter.CurrentVersion", "Current version")}
-            value={updateStatus?.currentVersion}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.LatestVersion", "Latest version")}
-            value={updateStatus?.latestVersion ?? currentLabel}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenterview.Channel", "Channel")}
-            value={updateStatus?.channel}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.LastChecked", "Last checked")}
-            value={
-              updateStatus?.lastCheckAt
-                ? new Date(updateStatus.lastCheckAt).toLocaleString("en-US")
-                : tr(t, "releasecenter.NotYet", "Not yet")
-            }
-          />
+          <DefinitionList className="mt-1">
+            <DefinitionRow
+              label={tr(t, "releasecenter.CurrentVersion", "Current version")}
+              value={updateStatus?.currentVersion}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.LatestVersion", "Latest version")}
+              value={updateStatus?.latestVersion ?? currentLabel}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenterview.Channel", "Channel")}
+              value={updateStatus?.channel}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.LastChecked", "Last checked")}
+              value={
+                updateStatus?.lastCheckAt
+                  ? new Date(updateStatus.lastCheckAt).toLocaleString("en-US")
+                  : tr(t, "releasecenter.NotYet", "Not yet")
+              }
+            />
+          </DefinitionList>
         </div>
 
-        <div className="p-3">
+        <div className="bg-bg/40 p-3">
           <div className="mb-3 text-xs font-semibold text-txt">
             {tr(
               t,
@@ -166,33 +168,36 @@ export function ReleaseStatusSection({
               "Native Electrobun Updater",
             )}
           </div>
-          <DefinitionRow
-            label={tr(t, "releasecenter.CurrentVersion", "Current version")}
-            value={nativeUpdater?.currentVersion}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.LatestVersion", "Latest version")}
-            value={nativeUpdater?.latestVersion ?? currentLabel}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.AppBundle", "App bundle")}
-            value={
-              nativeUpdater?.appBundlePath ?? tr(t, "common.unknown", "Unknown")
-            }
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.LastStatus", "Last status")}
-            value={
-              nativeUpdater?.lastStatus?.message ??
-              tr(t, "releasecenterview.Idle", "Idle")
-            }
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.StatusTime", "Status time")}
-            value={formatDateTime(nativeUpdater?.lastStatus?.timestamp, {
-              fallback: tr(t, "releasecenter.NotYet", "Not yet"),
-            })}
-          />
+          <DefinitionList>
+            <DefinitionRow
+              label={tr(t, "releasecenter.CurrentVersion", "Current version")}
+              value={nativeUpdater?.currentVersion}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.LatestVersion", "Latest version")}
+              value={nativeUpdater?.latestVersion ?? currentLabel}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.AppBundle", "App bundle")}
+              value={
+                nativeUpdater?.appBundlePath ??
+                tr(t, "common.unknown", "Unknown")
+              }
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.LastStatus", "Last status")}
+              value={
+                nativeUpdater?.lastStatus?.message ??
+                tr(t, "releasecenterview.Idle", "Idle")
+              }
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.StatusTime", "Status time")}
+              value={formatDateTime(nativeUpdater?.lastStatus?.timestamp, {
+                fallback: tr(t, "releasecenter.NotYet", "Not yet"),
+              })}
+            />
+          </DefinitionList>
           {autoUpdateDisabled && nativeUpdater?.autoUpdateDisabledReason ? (
             <div className="mt-3 border-l-2 border-warning/60 bg-warning/10 px-3 py-2 text-xs text-warning">
               {nativeUpdater.autoUpdateDisabledReason}
@@ -303,7 +308,7 @@ export function ReleaseNotesSection({
         </div>
 
         {releaseNotesWindow ? (
-          <div className="border-y border-border py-3 text-xs text-txt">
+          <DefinitionList className="text-xs text-txt">
             <DefinitionRow
               label={tr(t, "releasecenter.WindowId", "Window ID")}
               value={releaseNotesWindow.windowId}
@@ -316,9 +321,9 @@ export function ReleaseNotesSection({
               label={tr(t, "appsview.URL", "URL")}
               value={releaseNotesWindow.url}
             />
-          </div>
+          </DefinitionList>
         ) : (
-          <div className="border-y border-border py-3 text-xs text-muted">
+          <div className="border-b border-border/60 py-3 text-xs text-muted">
             {tr(t, "releasecenter.UsingUpdaterUrl", "Using updater URL:")}{" "}
             {nativeUpdater?.baseUrl ?? defaultReleaseNotesUrl}
           </div>
@@ -364,47 +369,49 @@ export function BuildRuntimeSection({
         </p>
       </div>
 
-      <div className="border-y border-border py-3">
-        <DefinitionRow
-          label={tr(t, "releasecenter.Platform", "Platform")}
-          value={buildInfo?.platform}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.Architecture", "Architecture")}
-          value={buildInfo?.arch}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.DefaultRenderer", "Default renderer")}
-          value={buildInfo?.defaultRenderer}
-        />
-        <DefinitionRow
-          label={tr(
-            t,
-            "releasecenter.AvailableRenderers",
-            "Available renderers",
-          )}
-          value={buildInfo?.availableRenderers.join(", ")}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.BunVersion", "Bun version")}
-          value={buildInfo?.bunVersion}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.CefVersion", "CEF version")}
-          value={buildInfo?.cefVersion}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.UpdaterBaseUrl", "Updater base URL")}
-          value={nativeUpdater?.baseUrl ?? defaultReleaseNotesUrl}
-        />
-        <DefinitionRow
-          label={tr(t, "releasecenter.DockIconVisible", "Dock icon visible")}
-          value={
-            buildInfo?.platform === "darwin"
-              ? String(dockVisible)
-              : tr(t, "releasecenter.MacOsOnly", "macOS only")
-          }
-        />
+      <div>
+        <DefinitionList>
+          <DefinitionRow
+            label={tr(t, "releasecenter.Platform", "Platform")}
+            value={buildInfo?.platform}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.Architecture", "Architecture")}
+            value={buildInfo?.arch}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.DefaultRenderer", "Default renderer")}
+            value={buildInfo?.defaultRenderer}
+          />
+          <DefinitionRow
+            label={tr(
+              t,
+              "releasecenter.AvailableRenderers",
+              "Available renderers",
+            )}
+            value={buildInfo?.availableRenderers.join(", ")}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.BunVersion", "Bun version")}
+            value={buildInfo?.bunVersion}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.CefVersion", "CEF version")}
+            value={buildInfo?.cefVersion}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.UpdaterBaseUrl", "Updater base URL")}
+            value={nativeUpdater?.baseUrl ?? defaultReleaseNotesUrl}
+          />
+          <DefinitionRow
+            label={tr(t, "releasecenter.DockIconVisible", "Dock icon visible")}
+            value={
+              buildInfo?.platform === "darwin"
+                ? String(dockVisible)
+                : tr(t, "releasecenter.MacOsOnly", "macOS only")
+            }
+          />
+        </DefinitionList>
         <div className="mt-3 flex flex-wrap gap-2">
           <Button
             size="sm"
@@ -455,14 +462,11 @@ export function SessionControlsSection({
         </p>
       </div>
 
-      <div className="space-y-3">
+      <div className="divide-y divide-border/60">
         {SESSION_PARTITIONS.map(({ label, partition }) => {
           const snapshot = sessionSnapshots[partition];
           return (
-            <div
-              key={partition}
-              className="border-b border-border py-3 last:border-b-0"
-            >
+            <div key={partition} className="py-3">
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <div className="text-xs font-semibold text-txt">{label}</div>
@@ -490,7 +494,7 @@ export function SessionControlsSection({
                 </div>
               </div>
 
-              <div className="mt-3">
+              <DefinitionList className="mt-3">
                 <DefinitionRow
                   label={tr(t, "releasecenter.Partition", "Partition")}
                   value={snapshot?.partition ?? partition}
@@ -503,7 +507,7 @@ export function SessionControlsSection({
                   label={tr(t, "releasecenter.CookieCount", "Cookie count")}
                   value={snapshot?.cookieCount}
                 />
-              </div>
+              </DefinitionList>
 
               {snapshot?.cookies.length ? (
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -632,7 +636,7 @@ export function WgpuSurfaceSection({
           </div>
         </div>
 
-        <div className="border-y border-border py-3">
+        <div className="bg-bg/40 p-3">
           <div className="mb-3 text-xs font-semibold text-txt">
             {tr(
               t,
@@ -647,33 +651,35 @@ export function WgpuSurfaceSection({
               "This reports whether the desktop webview is expected to expose WebGPU for the WGPU preview above. It is not overall app health: companion and avatar already fall back to WebGL when WebGPU is missing.",
             )}
           </p>
-          <DefinitionRow
-            label={tr(
-              t,
-              "releasecenter.InlineSurfaceReady",
-              "Inline surface ready",
-            )}
-            value={String(wgpuReady)}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.RendererSupport", "Renderer support")}
-            value={
-              webGpuStatus?.available
-                ? tr(t, "releasecenter.Available", "Available")
-                : tr(t, "releasecenter.NotAvailable", "Not available")
-            }
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.RendererType", "Renderer type")}
-            value={webGpuStatus?.renderer}
-          />
-          <DefinitionRow
-            label={tr(t, "releasecenter.ChromeBeta", "Chrome Beta")}
-            value={
-              webGpuStatus?.chromeBetaPath ??
-              tr(t, "releasecenter.NotDetected", "Not detected")
-            }
-          />
+          <DefinitionList>
+            <DefinitionRow
+              label={tr(
+                t,
+                "releasecenter.InlineSurfaceReady",
+                "Inline surface ready",
+              )}
+              value={String(wgpuReady)}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.RendererSupport", "Renderer support")}
+              value={
+                webGpuStatus?.available
+                  ? tr(t, "releasecenter.Available", "Available")
+                  : tr(t, "releasecenter.NotAvailable", "Not available")
+              }
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.RendererType", "Renderer type")}
+              value={webGpuStatus?.renderer}
+            />
+            <DefinitionRow
+              label={tr(t, "releasecenter.ChromeBeta", "Chrome Beta")}
+              value={
+                webGpuStatus?.chromeBetaPath ??
+                tr(t, "releasecenter.NotDetected", "Not detected")
+              }
+            />
+          </DefinitionList>
           <div className="mt-3 border-l-2 border-border bg-bg-accent px-3 py-2 text-xs text-muted">
             {webGpuStatus?.reason ??
               tr(

--- a/packages/ui/src/components/release-center/sections.tsx
+++ b/packages/ui/src/components/release-center/sections.tsx
@@ -132,7 +132,7 @@ export function ReleaseStatusSection({
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
-        <div className="rounded-sm border border-border bg-bg p-3">
+        <div className="p-3">
           <div className="text-xs font-semibold text-txt">
             {tr(t, "releasecenter.AppReleaseService", "App Release Service")}
           </div>
@@ -158,7 +158,7 @@ export function ReleaseStatusSection({
           />
         </div>
 
-        <div className="rounded-sm border border-border bg-bg p-3">
+        <div className="p-3">
           <div className="mb-3 text-xs font-semibold text-txt">
             {tr(
               t,
@@ -194,7 +194,7 @@ export function ReleaseStatusSection({
             })}
           />
           {autoUpdateDisabled && nativeUpdater?.autoUpdateDisabledReason ? (
-            <div className="mt-3 rounded-sm border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+            <div className="mt-3 border-l-2 border-warning/60 bg-warning/10 px-3 py-2 text-xs text-warning">
               {nativeUpdater.autoUpdateDisabledReason}
             </div>
           ) : null}
@@ -303,7 +303,7 @@ export function ReleaseNotesSection({
         </div>
 
         {releaseNotesWindow ? (
-          <div className="rounded-sm border border-border bg-bg p-3 text-xs text-txt">
+          <div className="border-y border-border py-3 text-xs text-txt">
             <DefinitionRow
               label={tr(t, "releasecenter.WindowId", "Window ID")}
               value={releaseNotesWindow.windowId}
@@ -318,7 +318,7 @@ export function ReleaseNotesSection({
             />
           </div>
         ) : (
-          <div className="rounded-sm border border-border bg-bg p-3 text-xs text-muted">
+          <div className="border-y border-border py-3 text-xs text-muted">
             {tr(t, "releasecenter.UsingUpdaterUrl", "Using updater URL:")}{" "}
             {nativeUpdater?.baseUrl ?? defaultReleaseNotesUrl}
           </div>
@@ -364,7 +364,7 @@ export function BuildRuntimeSection({
         </p>
       </div>
 
-      <div className="rounded-sm border border-border bg-bg p-3">
+      <div className="border-y border-border py-3">
         <DefinitionRow
           label={tr(t, "releasecenter.Platform", "Platform")}
           value={buildInfo?.platform}
@@ -461,7 +461,7 @@ export function SessionControlsSection({
           return (
             <div
               key={partition}
-              className="rounded-sm border border-border bg-bg p-3"
+              className="border-b border-border py-3 last:border-b-0"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
@@ -586,7 +586,7 @@ export function WgpuSurfaceSection({
               })}
             </div>
           ) : (
-            <div className="rounded-sm border border-dashed border-border px-4 py-12 text-center text-sm text-muted">
+            <div className="border-y border-dashed border-border px-4 py-12 text-center text-sm text-muted">
               {tr(
                 t,
                 "releasecenter.WgpuCustomElementUnavailable",
@@ -632,7 +632,7 @@ export function WgpuSurfaceSection({
           </div>
         </div>
 
-        <div className="rounded-sm border border-border bg-bg p-3">
+        <div className="border-y border-border py-3">
           <div className="mb-3 text-xs font-semibold text-txt">
             {tr(
               t,
@@ -674,7 +674,7 @@ export function WgpuSurfaceSection({
               tr(t, "releasecenter.NotDetected", "Not detected")
             }
           />
-          <div className="mt-3 rounded-sm border border-border bg-bg-accent px-3 py-2 text-xs text-muted">
+          <div className="mt-3 border-l-2 border-border bg-bg-accent px-3 py-2 text-xs text-muted">
             {webGpuStatus?.reason ??
               tr(
                 t,

--- a/packages/ui/src/components/release-center/shared.stories.tsx
+++ b/packages/ui/src/components/release-center/shared.stories.tsx
@@ -2,7 +2,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { MockAppProvider } from "../../storybook/mock-providers";
-import { DefinitionRow, StatusPill } from "./shared";
+import { DefinitionList, DefinitionRow, StatusPill } from "./shared";
 
 const meta = {
   title: "ReleaseCenter/Shared",
@@ -48,7 +48,9 @@ export const DefinitionRowDefault: DefinitionRowStory = {
   render: (args) => (
     <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
-        <DefinitionRow {...args} />
+        <DefinitionList>
+          <DefinitionRow {...args} />
+        </DefinitionList>
       </div>
     </MockAppProvider>
   ),
@@ -62,7 +64,9 @@ export const DefinitionRowNumeric: DefinitionRowStory = {
   render: (args) => (
     <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
-        <DefinitionRow {...args} />
+        <DefinitionList>
+          <DefinitionRow {...args} />
+        </DefinitionList>
       </div>
     </MockAppProvider>
   ),
@@ -76,7 +80,9 @@ export const DefinitionRowEmptyFallback: DefinitionRowStory = {
   render: (args) => (
     <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
-        <DefinitionRow {...args} />
+        <DefinitionList>
+          <DefinitionRow {...args} />
+        </DefinitionList>
       </div>
     </MockAppProvider>
   ),
@@ -91,7 +97,9 @@ export const DefinitionRowUnavailable: DefinitionRowStory = {
   render: (args) => (
     <MockAppProvider>
       <div className="w-80 rounded-md border border-border bg-surface p-3">
-        <DefinitionRow {...args} />
+        <DefinitionList>
+          <DefinitionRow {...args} />
+        </DefinitionList>
       </div>
     </MockAppProvider>
   ),

--- a/packages/ui/src/components/release-center/shared.test.tsx
+++ b/packages/ui/src/components/release-center/shared.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Verifies the Release Center's semantic metadata-list contract with the real
+ * React components under the deterministic application provider.
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MockAppProvider } from "../../storybook/mock-providers";
+import { DefinitionList, DefinitionRow } from "./shared";
+
+describe("DefinitionList", () => {
+  it("renders metadata as a definition list with quiet row separators", () => {
+    const { container } = render(
+      <MockAppProvider>
+        <DefinitionList>
+          <DefinitionRow label="Platform" value="darwin" />
+          <DefinitionRow label="Architecture" value="arm64" />
+        </DefinitionList>
+      </MockAppProvider>,
+    );
+
+    const list = container.querySelector("dl");
+    expect(list?.className).toContain("divide-y");
+    expect(list?.className).toContain("divide-border/60");
+    expect(screen.getByText("Platform").tagName).toBe("DT");
+    expect(screen.getByText("darwin").tagName).toBe("DD");
+    expect(screen.getByText("Architecture").tagName).toBe("DT");
+    expect(screen.getByText("arm64").tagName).toBe("DD");
+  });
+
+  it("renders the explicit fallback instead of a healthy-looking empty value", () => {
+    render(
+      <MockAppProvider>
+        <DefinitionList>
+          <DefinitionRow
+            label="Release notes"
+            value={null}
+            emptyFallback="Not provided"
+          />
+        </DefinitionList>
+      </MockAppProvider>,
+    );
+
+    expect(screen.getByText("Not provided").textContent).toBe("Not provided");
+  });
+});

--- a/packages/ui/src/components/release-center/shared.tsx
+++ b/packages/ui/src/components/release-center/shared.tsx
@@ -1,11 +1,13 @@
 /**
  * Small presentational primitives shared across the Release Center sections: a
  * `StatusPill` mapping a neutral/good/warning tone onto the `StatusBadge`
- * variants, and a `DefinitionRow` (label + value with an "Unavailable"
- * fallback).
+ * variants, and semantic definition-list primitives. `DefinitionList` owns
+ * the quiet row separators so metadata is not boxed into nested cards.
  */
 
+import type { ReactNode } from "react";
 import { useAppSelector } from "../../state";
+import { cn } from "../../utils";
 import { StatusBadge, type StatusVariant } from "../ui/status-badge";
 
 const PILL_TONE_MAP: Record<string, StatusVariant> = {
@@ -30,6 +32,18 @@ export function StatusPill({
   );
 }
 
+export function DefinitionList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <dl className={cn("divide-y divide-border/60", className)}>{children}</dl>
+  );
+}
+
 export function DefinitionRow({
   emptyFallback,
   label,
@@ -41,13 +55,13 @@ export function DefinitionRow({
 }) {
   const t = useAppSelector((s) => s.t);
   return (
-    <div className="flex items-start justify-between gap-4 py-2">
-      <div className="text-xs text-muted">{label}</div>
-      <div className="text-right text-xs text-txt break-all">
+    <div className="grid grid-cols-[minmax(8rem,1fr)_minmax(0,2fr)] items-start gap-4 py-2.5">
+      <dt className="text-xs text-muted">{label}</dt>
+      <dd className="min-w-0 break-words text-right text-xs text-txt">
         {value ??
           emptyFallback ??
           t("common.unavailable", { defaultValue: "Unavailable" })}
-      </div>
+      </dd>
     </div>
   );
 }

--- a/packages/ui/src/components/settings/DevicesRuntimesSection.tsx
+++ b/packages/ui/src/components/settings/DevicesRuntimesSection.tsx
@@ -176,7 +176,7 @@ function LinuxTargetPanel({
         {confirmingRevoke ? (
           <div
             role="alert"
-            className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-2"
+            className="mt-3 flex flex-wrap items-center gap-2 border-l-2 border-destructive/50 bg-destructive/5 p-2"
           >
             <span className="mr-auto text-xs text-txt-strong">
               Revoke this host in Cloud, stop its relay, and remove local host
@@ -213,7 +213,7 @@ function LinuxTargetPanel({
         {target.enrolled && onActivate ? (
           <div className="mt-4 grid gap-4 border-t border-border pt-4">
             {localPairing ? (
-              <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-accent/30 bg-accent/5 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-l-2 border-accent/50 bg-accent/5 p-3">
                 <div>
                   <p className="text-sm font-medium text-txt-strong">
                     Pair {localPairing.hostLabel} on this computer

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -833,7 +833,7 @@ export function InstallSheet({
       )}
 
       {done && !error && (
-        <div className="flex items-center justify-between gap-2 rounded-sm border border-ok/30 bg-ok/10 px-2 py-1.5 text-xs text-ok">
+        <div className="flex items-center justify-between gap-2 border-l-2 border-ok/50 bg-ok/10 px-2 py-1.5 text-xs text-ok">
           <span className="flex items-center gap-1.5">
             <CheckCircle2 className="size-3.5" aria-hidden />
             {t("vault.install.complete", { defaultValue: "Install complete." })}
@@ -852,7 +852,7 @@ export function InstallSheet({
       )}
 
       {error && (
-        <div className="rounded-sm border border-danger/40 bg-danger/10 px-2 py-1.5 text-xs text-danger">
+        <div className="border-l-2 border-danger/60 bg-danger/10 px-2 py-1.5 text-xs text-danger">
           {error}
         </div>
       )}
@@ -1215,7 +1215,7 @@ export function SigninSheet({
       </div>
 
       {error && (
-        <div className="rounded-sm border border-danger/40 bg-danger/10 px-2 py-1.5 text-xs text-danger">
+        <div className="border-l-2 border-danger/60 bg-danger/10 px-2 py-1.5 text-xs text-danger">
           {error}
         </div>
       )}


### PR DESCRIPTION
## Summary

- remove all 26 `no-nested-card-surface` findings left after #26414 without treating every nested region as the same information pattern
- codify key/value metadata as a semantic `DefinitionList` whose rows use quiet 1px `border-border/60` separators
- retain subtle grouped surfaces for independent operational peers such as release services and WGPU status, and retain record-level grouping for actionable session partitions
- preserve semantic callouts for destructive, warning, success, error, and confirmation states
- ratchet the design-doctor baseline from 26 findings to zero

## Verification

- `bun run audit:design` — pass, zero design-rule regression
- `bun run --cwd packages/ui typecheck` — pass
- `bunx vitest run src/components/release-center/shared.test.tsx` — 2/2 pass; verifies semantic `dl`/`dt`/`dd` structure and the shared separator contract
- original focused UI regression set — 7 files, 45 tests passed
- Biome on all revised Release Center files — pass
- package-wide UI lint — blocked by two unrelated existing formatting errors in `src/__tests__/regression-truncation.test.ts`; also reports seven existing warnings
- `ELIZA_NODE_PATH=/opt/homebrew/bin/node bun run --cwd packages/app audit:app` — 226/227 capture tests passed, zero broken views; strict aggregate gate still reports the existing Settings chat-overlay overlap at mobile and iPad portrait
- `bun run verify` — blocked by a pre-existing Biome formatting failure in `plugins/plugin-calendar`, outside this diff

## Visual evidence

Each desktop pair is **the original surface on the left** and **the revised structured surface on the right**. Mobile captures show the revised responsive state. The complete ten-image bundle is [26518-structured-metadata-visuals.zip](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-structured-metadata-visuals.zip).

### Release status

Independent release systems retain subtle grouped surfaces; their metadata now reads as aligned rows with quiet separators.

![Release status before and after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-status-before-after-v2.jpg)

![Release status revised mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-status-mobile-v2.jpg)

### Release notes BrowserView

Window metadata becomes a semantic definition list instead of a nested card or a bordered strip.

![Release notes before and after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-notes-before-after-v2.jpg)

![Release notes revised mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-notes-mobile-v2.jpg)

### Build configuration and shell runtime

Runtime metadata becomes a single responsive definition list with 1px separators between rows.

![Build runtime before and after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-build-runtime-before-after-v2.jpg)

![Build runtime revised mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-build-runtime-mobile-v2.jpg)

### Session and cookie controls

Each actionable partition remains a distinct record; metadata rows use the shared definition-list treatment and partitions are separated once at record level.

![Session controls before and after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-session-controls-before-after-v2.jpg)

![Session controls revised mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-session-controls-mobile-v2.jpg)

### Browser WGPU status

The status companion remains visually distinct from the preview while its key/value metadata uses the same row contract.

![WGPU status before and after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-wgpu-before-after-v2.jpg)

![WGPU status revised mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26518-release-wgpu-mobile-v2.jpg)

## Evidence applicability

- Backend logs: `N/A — frontend-only presentation and semantic markup changes; no server path fires`
- Frontend console/network logs: `N/A — no runtime request behavior changed`
- Live-model trajectory: `N/A — no agent, model, prompt, provider, or action behavior changed`

## Scope

Follow-up to merged #26414. This PR does not amend or update that merged branch.
