### PR TITLE
test(core): cover channel-participant

### DIFF
--- a/packages/core/src/schemas/channel-participant.test.ts
+++ b/packages/core/src/schemas/channel-participant.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the canonical `channelParticipantSchema` table definition —
+ * the pure data contract for the channel_participants join table that
+ * `buildBaseTables` assembles and adapters materialize. Deterministic unit
+ * harness over the real exported `SchemaTable`; no database or mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { channelParticipantSchema } from "./channel-participant";
+
+describe("channelParticipantSchema", () => {
+	it("declares the channel_participants join table in the default schema", () => {
+		expect(channelParticipantSchema.name).toBe("channel_participants");
+		expect(channelParticipantSchema.schema).toBe("");
+	});
+
+	it("requires both participant columns as non-null text", () => {
+		const columns = channelParticipantSchema.columns;
+		expect(Object.keys(columns)).toEqual(["channel_id", "entity_id"]);
+		for (const key of ["channel_id", "entity_id"] as const) {
+			expect(columns[key].name).toBe(key);
+			expect(columns[key].type).toBe("text");
+			expect(columns[key].notNull).toBe(true);
+			// Primary-key semantics belong to the composite key below; no
+			// column-level flag may duplicate them.
+			expect(columns[key].primaryKey).toBeUndefined();
+			expect(columns[key].isUnique).toBeUndefined();
+		}
+	});
+
+	it("expresses exactly one composite primary key over (channel_id, entity_id)", () => {
+		const pks = channelParticipantSchema.compositePrimaryKeys;
+		expect(Object.keys(pks)).toEqual(["channel_participants_pk"]);
+		expect(pks.channel_participants_pk.name).toBe("channel_participants_pk");
+		expect(pks.channel_participants_pk.columns).toEqual([
+			"channel_id",
+			"entity_id",
+		]);
+	});
+
+	it("indexes entity_id alone for reverse entity-to-channels lookups", () => {
+		const indexes = channelParticipantSchema.indexes;
+		expect(Object.keys(indexes)).toEqual(["idx_cp_entity"]);
+		expect(indexes.idx_cp_entity.isUnique).toBe(false);
+		expect(indexes.idx_cp_entity.columns).toEqual([
+			{ expression: "entity_id", isExpression: false },
+		]);
+	});
+
+	it("cascades channel deletion through a single FK to channels.id", () => {
+		const fks = channelParticipantSchema.foreignKeys;
+		expect(Object.keys(fks)).toEqual(["fk_channel_participant_channel"]);
+		const fk = fks.fk_channel_participant_channel;
+		expect(fk.tableFrom).toBe("channel_participants");
+		expect(fk.tableTo).toBe("channels");
+		expect(fk.columnsFrom).toEqual(["channel_id"]);
+		expect(fk.columnsTo).toEqual(["id"]);
+		expect(fk.onDelete).toBe("cascade");
+		expect(fk.schemaTo).toBe("");
+	});
+
+	it("declares no unique or check constraints beyond the composite PK", () => {
+		expect(channelParticipantSchema.uniqueConstraints).toEqual({});
+		expect(channelParticipantSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/schemas/channel-participant.test.ts` — a new unit suite for the canonical `channelParticipantSchema` table definition, the pure `SchemaTable` data contract that `buildBaseTables` assembles and the SQL adapters materialize. The suite drives the real exported module (no mocks) and locks the contract reviewers rely on when touching the join table:

- exactly two non-null text columns (`channel_id`, `entity_id`) with no per-column `primaryKey`/`isUnique` duplication of the composite key;
- one composite primary key over `(channel_id, entity_id)` in that order;
- the non-unique reverse index on `entity_id` alone (the "which channels is this entity in?" lookup);
- a single FK to `channels.id` with `onDelete: cascade`;
- no extra unique or check constraints.

## Why

The module had no same-named test file anywhere in the repo. These are behavior-preserving additions only — no production file is touched.

## Evidence

Test-only change; diff is exactly one NEW file (+65/−0), so no behavioural-fix evidence applies. Fork contributor note: hosted CI does not run on this PR; results below were produced locally against current `origin/develop` at `3624a59`:

- `bunx vitest run packages/core/src/schemas/channel-participant.test.ts` → Test Files **1 passed (1)**, Tests **6 passed (6)**, 0 failed.
- `bunx biome check --write packages/core/src/schemas/channel-participant.test.ts` → clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/core` → zero diagnostics mentioning `channel-participant.test.ts`; zero new errors versus base.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0d988a15eae7583b9a9c121c7d3a062315d4b757 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
