### PR TITLE
test(core): cover pairing-allowlist

### DIFF
--- a/packages/core/src/schemas/pairing-allowlist.test.ts
+++ b/packages/core/src/schemas/pairing-allowlist.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Verifies the pairing allowlist table schema: table identity, column
+ * types and nullability defaults, the unique sender/channel/agent index,
+ * the non-unique channel/agent lookup index, and the cascading agent
+ * foreign key.
+ */
+
+import { describe, expect, it } from "vitest";
+import { pairingAllowlistSchema } from "./pairing-allowlist";
+
+describe("pairing allowlist schema", () => {
+	it("names the pairing_allowlist table with an empty schema qualifier", () => {
+		expect(pairingAllowlistSchema.name).toBe("pairing_allowlist");
+		expect(pairingAllowlistSchema.schema).toBe("");
+	});
+
+	it("declares a generated uuid primary key", () => {
+		const id = pairingAllowlistSchema.columns.id;
+		expect(id?.type).toBe("uuid");
+		expect(id?.primaryKey).toBe(true);
+		expect(id?.notNull).toBe(true);
+		expect(id?.default).toBe("defaultRandom()");
+	});
+
+	it("requires every approved pair to carry channel, sender, and agent attribution", () => {
+		expect(pairingAllowlistSchema.columns.channel?.type).toBe("text");
+		expect(pairingAllowlistSchema.columns.channel?.notNull).toBe(true);
+		expect(pairingAllowlistSchema.columns.sender_id?.type).toBe("text");
+		expect(pairingAllowlistSchema.columns.sender_id?.notNull).toBe(true);
+		expect(pairingAllowlistSchema.columns.agent_id?.type).toBe("uuid");
+		expect(pairingAllowlistSchema.columns.agent_id?.notNull).toBe(true);
+	});
+
+	it("timestamps rows at creation and keeps metadata optional jsonb", () => {
+		expect(pairingAllowlistSchema.columns.created_at?.type).toBe("timestamp");
+		expect(pairingAllowlistSchema.columns.created_at?.notNull).toBe(true);
+		expect(pairingAllowlistSchema.columns.created_at?.default).toBe("now()");
+		expect(pairingAllowlistSchema.columns.metadata?.type).toBe("jsonb");
+		expect(pairingAllowlistSchema.columns.metadata?.notNull).toBeUndefined();
+		expect(pairingAllowlistSchema.columns.metadata?.default).toBe("{}");
+	});
+
+	it("keeps the channel/agent lookup index non-unique in declared order", () => {
+		const lookup =
+			pairingAllowlistSchema.indexes.pairing_allowlist_channel_agent_idx;
+		expect(lookup?.isUnique).toBe(false);
+		expect(lookup?.columns.map((column) => column.expression)).toEqual([
+			"channel",
+			"agent_id",
+		]);
+		expect(
+			lookup?.columns.every((column) => column.isExpression === false),
+		).toBe(true);
+	});
+
+	it("uniquely constrains one approval per sender, channel, and agent", () => {
+		const unique =
+			pairingAllowlistSchema.indexes.pairing_allowlist_sender_channel_agent_idx;
+		expect(unique?.isUnique).toBe(true);
+		expect(unique?.columns.map((column) => column.expression)).toEqual([
+			"sender_id",
+			"channel",
+			"agent_id",
+		]);
+	});
+
+	it("cascades row deletion when the owning agent is removed", () => {
+		const fk = pairingAllowlistSchema.foreignKeys.fk_pairing_allowlist_agent;
+		expect(fk?.tableFrom).toBe("pairing_allowlist");
+		expect(fk?.tableTo).toBe("agents");
+		expect(fk?.columnsFrom).toEqual(["agent_id"]);
+		expect(fk?.columnsTo).toEqual(["id"]);
+		expect(fk?.onDelete).toBe("cascade");
+		expect(fk?.schemaTo).toBe("");
+	});
+
+	it("carries no composite primary keys, unique constraints, or checks", () => {
+		expect(pairingAllowlistSchema.compositePrimaryKeys).toEqual({});
+		expect(pairingAllowlistSchema.uniqueConstraints).toEqual({});
+		expect(pairingAllowlistSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/core/src/schemas/pairing-allowlist.ts` — the Drizzle-style schema table backing the runtime pairing service's approved (channel, sender) allowlist. The module had no same-named test file anywhere on `develop`.

The suite drives the real exported `pairingAllowlistSchema` object (no mocks) and covers:

- table identity (`pairing_allowlist`, empty schema qualifier)
- generated uuid primary key (`defaultRandom()`)
- required attribution columns: `channel` (text), `sender_id` (text), `agent_id` (uuid), all notNull
- creation timestamp default (`now()`) and optional jsonb `metadata` defaulting to `"{}"`
- the non-unique `channel + agent_id` lookup index, including exact column order and no expression columns
- the unique `sender_id + channel + agent_id` constraint index with exact column order
- the cascading foreign key `fk_pairing_allowlist_agent` from `pairing_allowlist.agent_id` to `agents.id`
- empty `compositePrimaryKeys` / `uniqueConstraints` / `checkConstraints`

## Evidence

Test-only change; the diff touches exactly one NEW file (`packages/core/src/schemas/pairing-allowlist.test.ts`, +N/-0). No production behaviour is changed, so this PR carries only the lightweight test-only evidence set:

- `bunx vitest run packages/core/src/schemas/pairing-allowlist.test.ts` against current `develop` (3624a59ccb823312f73b42334d5a4daf23251c54): **1 test file passed, 8/8 tests passed**.
- `bunx biome check --write packages/core/src/schemas/pairing-allowlist.test.ts`: clean ("Checked 1 file… No fixes applied"), with repo config present (`biome.json`) and sparse-checkout disabled.
- `bunx tsc --noEmit` in `packages/core`: grepping the output for `pairing-allowlist.test` returns nothing — zero type errors introduced by this file.
- Diff contains only the single new test file; no existing lines removed anywhere.

This is a fork contribution, so hosted CI does not run on this pull request; all checks above were executed locally against the pushed head commit and are quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8831fc6a047375398e3ecf288141e979b13465fa -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
