### PR TITLE
test(core): cover message-server

### DIFF
--- a/packages/core/src/schemas/message-server.test.ts
+++ b/packages/core/src/schemas/message-server.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Verifies the portable `message_servers` table descriptor keeps the
+ * find-or-create keying contract: deterministic self-named columns, a
+ * non-unique (source_type, source_id) lookup index, server-local defaults,
+ * and no relational escape hatches. Pure data assertions against the real
+ * exported descriptor — no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { messageServerSchema } from "./message-server";
+
+describe("message_servers table descriptor", () => {
+	it("keeps the portable table identity and find-or-create lookup index", () => {
+		expect(messageServerSchema.name).toBe("message_servers");
+		expect(messageServerSchema.schema).toBe("");
+		const lookup = messageServerSchema.indexes.idx_ms_source;
+		expect(lookup?.name).toBe("idx_ms_source");
+		expect(lookup?.isUnique).toBe(false);
+		expect(lookup?.columns).toEqual([
+			{ expression: "source_type", isExpression: false },
+			{ expression: "source_id", isExpression: false },
+		]);
+	});
+
+	it("declares the complete column contract with explicit nullability", () => {
+		const { columns } = messageServerSchema;
+		expect(columns.id).toMatchObject({
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+		});
+		expect(columns.name).toMatchObject({ type: "text", notNull: true });
+		expect(columns.source_type).toMatchObject({
+			type: "text",
+			notNull: true,
+		});
+		expect(columns.source_id?.notNull).toBeUndefined();
+		expect(columns.metadata).toMatchObject({ type: "jsonb" });
+		expect(columns.metadata?.notNull).toBeUndefined();
+	});
+
+	it("defaults both audit timestamps to now() and requires them", () => {
+		for (const key of ["created_at", "updated_at"] as const) {
+			const column = messageServerSchema.columns[key];
+			expect(column?.type).toBe("timestamp");
+			expect(column?.notNull).toBe(true);
+			expect(column?.default).toBe("now()");
+		}
+	});
+
+	it("mirrors every column key into its declared name", () => {
+		for (const [key, column] of Object.entries(messageServerSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+
+	it("stays a standalone container with no relations or extra constraints", () => {
+		expect(messageServerSchema.foreignKeys).toEqual({});
+		expect(messageServerSchema.compositePrimaryKeys).toEqual({});
+		expect(messageServerSchema.uniqueConstraints).toEqual({});
+		expect(messageServerSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

Adds the first unit test suite for `packages/core/src/schemas/message-server.ts` — the portable `message_servers` table descriptor that `buildBaseTables` assembles and the plugin-sql / localdb adapters materialize. The module previously had no same-named test file anywhere on `develop`.

Test-only change: one new file, no production behavior modified.

## What is covered

Five deterministic cases against the real exported descriptor (no mocks):

- **Find-or-create keying:** table identity (`name`, empty portable `schema`) and the `idx_ms_source` index — non-unique, covering exactly the ordered `(source_type, source_id)` pair documented for `findOrCreateMessageServer`.
- **Column contract:** explicit types and nullability for all seven columns — `id` (uuid PK, notNull), `name`/`source_type` (text, notNull), nullable `source_id` and `metadata` (jsonb).
- **Audit timestamps:** `created_at` / `updated_at` are notNull timestamps defaulting to `now()`.
- **Self-naming invariant:** every column's declared `name` mirrors its object key (additive-safe).
- **Standalone container:** empty `foreignKeys`, `compositePrimaryKeys`, `uniqueConstraints`, and `checkConstraints`.

## Verification

Fork contributor — hosted CI does not run on this PR; all checks were executed locally against current `develop` (`3624a59ccb82`):

- `bunx vitest run src/schemas/message-server.test.ts` (in `packages/core`): **Test Files 1 passed (1), Tests 5 passed (5)**
- `bunx biome check --write packages/core/src/schemas/message-server.test.ts`: clean — "Checked 1 file in 24ms. No fixes applied."
- `bunx tsc --noEmit` (in `packages/core`): zero diagnostics referencing `message-server.test.ts`
- Diff is exactly one new test file, +64/−0

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ccd319abe86b23c6361a70160141319dfd745334 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
