### PR TITLE
test(core): cover log

### DIFF
--- a/packages/core/src/schemas/log.test.ts
+++ b/packages/core/src/schemas/log.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the `logs` table descriptor (`logSchema`) the runtime writes
+ * typed event records into and `getLogs` / `getAgentRunSummaries` read back.
+ * Pure declarative-shape assertions over the real exported object — no mocks,
+ * no DB: the descriptor itself is the contract adapters materialize. Covers
+ * table identity, the full column set with nullability and defaults, the three
+ * indexes including the covering index column order, both cascading foreign
+ * keys, and the empty constraint maps.
+ */
+import { describe, expect, it } from "vitest";
+import { logSchema } from "./log";
+
+describe("logSchema table identity", () => {
+	it("names the logs table in the default schema", () => {
+		expect(logSchema.name).toBe("logs");
+		expect(logSchema.schema).toBe("");
+	});
+});
+
+describe("logSchema columns", () => {
+	it("declares exactly the six log columns", () => {
+		expect(Object.keys(logSchema.columns).sort()).toEqual([
+			"body",
+			"created_at",
+			"entity_id",
+			"id",
+			"room_id",
+			"type",
+		]);
+	});
+
+	it("keeps every column key consistent with its own name field", () => {
+		for (const [key, column] of Object.entries(logSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+
+	it("types id as a non-null uuid defaulting to defaultRandom()", () => {
+		expect(logSchema.columns.id).toEqual({
+			name: "id",
+			type: "uuid",
+			notNull: true,
+			default: "defaultRandom()",
+		});
+	});
+
+	it("types created_at as a non-null timestamp defaulting to now()", () => {
+		expect(logSchema.columns.created_at).toEqual({
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+	});
+
+	it("leaves entity_id, body, type, and room_id without defaults", () => {
+		expect(logSchema.columns.entity_id.default).toBeUndefined();
+		expect(logSchema.columns.body.default).toBeUndefined();
+		expect(logSchema.columns.type.default).toBeUndefined();
+		expect(logSchema.columns.room_id.default).toBeUndefined();
+	});
+
+	it("marks entity_id and room_id as non-null uuid scoping columns", () => {
+		expect(logSchema.columns.entity_id.type).toBe("uuid");
+		expect(logSchema.columns.entity_id.notNull).toBe(true);
+		expect(logSchema.columns.room_id.type).toBe("uuid");
+		expect(logSchema.columns.room_id.notNull).toBe(true);
+	});
+
+	it("stores body as non-null jsonb and type as non-null text", () => {
+		expect(logSchema.columns.body.type).toBe("jsonb");
+		expect(logSchema.columns.body.notNull).toBe(true);
+		expect(logSchema.columns.type.type).toBe("text");
+		expect(logSchema.columns.type.notNull).toBe(true);
+	});
+});
+
+describe("logSchema indexes", () => {
+	it("declares exactly three indexes", () => {
+		expect(Object.keys(logSchema.indexes).sort()).toEqual([
+			"idx_logs_entity_type",
+			"idx_logs_room_type_created",
+			"idx_logs_type",
+		]);
+	});
+
+	it("covers getLogs filtering with room_id, type, created_at in order", () => {
+		const index = logSchema.indexes.idx_logs_room_type_created;
+		expect(index.name).toBe("idx_logs_room_type_created");
+		expect(index.isUnique).toBe(false);
+		expect(index.columns.map((column) => column.expression)).toEqual([
+			"room_id",
+			"type",
+			"created_at",
+		]);
+		expect(index.columns.every((column) => column.isExpression === false)).toBe(
+			true,
+		);
+	});
+
+	it("supports the optional entity_id + type filter", () => {
+		const index = logSchema.indexes.idx_logs_entity_type;
+		expect(index.isUnique).toBe(false);
+		expect(index.columns.map((column) => column.expression)).toEqual([
+			"entity_id",
+			"type",
+		]);
+	});
+
+	it("supports agent-wide run aggregation by type alone", () => {
+		const index = logSchema.indexes.idx_logs_type;
+		expect(index.isUnique).toBe(false);
+		expect(index.columns.map((column) => column.expression)).toEqual(["type"]);
+	});
+
+	it("references only columns that exist on the table", () => {
+		for (const index of Object.values(logSchema.indexes)) {
+			for (const column of index.columns) {
+				expect(logSchema.columns[column.expression]).toBeDefined();
+			}
+		}
+	});
+});
+
+describe("logSchema foreignKeys", () => {
+	it("cascades room deletion through fk_room to rooms.id", () => {
+		expect(logSchema.foreignKeys.fk_room).toEqual({
+			name: "fk_room",
+			tableFrom: "logs",
+			tableTo: "rooms",
+			columnsFrom: ["room_id"],
+			columnsTo: ["id"],
+			onDelete: "cascade",
+			schemaTo: "",
+		});
+	});
+
+	it("cascades entity deletion through fk_user to entities.id", () => {
+		expect(logSchema.foreignKeys.fk_user).toEqual({
+			name: "fk_user",
+			tableFrom: "logs",
+			tableTo: "entities",
+			columnsFrom: ["entity_id"],
+			columnsTo: ["id"],
+			onDelete: "cascade",
+			schemaTo: "",
+		});
+	});
+
+	it("declares no foreign keys beyond the two cascade links", () => {
+		expect(Object.keys(logSchema.foreignKeys).sort()).toEqual([
+			"fk_room",
+			"fk_user",
+		]);
+	});
+});
+
+describe("logSchema constraint maps", () => {
+	it("uses the uuid default as implicit primary key — no composite keys", () => {
+		expect(logSchema.compositePrimaryKeys).toEqual({});
+	});
+
+	it("declares no unique constraints or check constraints", () => {
+		expect(logSchema.uniqueConstraints).toEqual({});
+		expect(logSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/core/src/schemas/log.ts` (`logSchema`, the `logs` table descriptor that `getLogs` and `getAgentRunSummaries` read back), colocated as `packages/core/src/schemas/log.test.ts` following the existing sibling convention in that directory. **Test-only:** no production file is touched, diff is a single new file at +167/-0.

## Coverage

Pure declarative-shape assertions driving the real exported object (no mocks):

- table identity: `name === "logs"` in the default schema
- columns: exact six-column key set; every column key consistent with its own `name` field; `id` uuid/notNull/`defaultRandom()`; `created_at` timestamp/notNull/`now()`; `entity_id`/`room_id` non-null uuids; `body` jsonb and `type` text both non-null with no defaults
- indexes: exactly three; `idx_logs_room_type_created` covers `room_id → type → created_at` in order (the covering scan for `getLogs` ordering) with all entries as plain columns; `idx_logs_entity_type`; `idx_logs_type`; every index references only columns that exist on the table; all non-unique
- foreign keys: `fk_room` → `rooms.id` and `fk_user` → `entities.id`, both `onDelete: cascade` with exact column pairs; no additional keys
- constraint maps: `compositePrimaryKeys`, `uniqueConstraints`, `checkConstraints` empty (implicit uuid primary key)

## Verification

Fork contributor — hosted CI does not run on this PR; local results quoted below.

- `bunx vitest run packages/core/src/schemas/log.test.ts` → **Test Files 1 passed (1); Tests 18 passed (18)** — re-fetched and re-run against current `origin/develop` immediately before filing; same counts.
- `bunx biome check packages/core/src/schemas/log.test.ts` → clean (`Checked 1 file … No fixes applied`).
- `bunx tsc --noEmit` in `packages/core` → zero mentions of `log.test.ts` in output.
- Diff touches only the new test file (+167/-0); no deletions anywhere.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:653f1fd753d0d299361204f7b9a0accd84d8c2f1 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
