### PR TITLE
test(core): cover participant

### DIFF
--- a/packages/core/src/schemas/participant.test.ts
+++ b/packages/core/src/schemas/participant.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Verifies the participants table descriptor keeps its one-membership-per-room
+ * unique index, per-foreign-key lookup indexes, cascade delete bindings, and
+ * the nullable membership columns the sql/localdb adapters materialize.
+ */
+
+import { describe, expect, it } from "vitest";
+import { participantSchema } from "./participant";
+
+describe("participants table schema", () => {
+	it("declares the portable participants table", () => {
+		expect(participantSchema.name).toBe("participants");
+		expect(participantSchema.schema).toBe("");
+	});
+
+	it("makes id the sole primary key column with a database-side uuid default", () => {
+		const primaryColumns = Object.entries(participantSchema.columns)
+			.filter(([, column]) => column.primaryKey)
+			.map(([key]) => key);
+		expect(primaryColumns).toEqual(["id"]);
+		expect(participantSchema.columns.id).toMatchObject({
+			type: "uuid",
+			notNull: true,
+			default: "gen_random_uuid()",
+		});
+	});
+
+	it("keeps every membership reference nullable and non-primary", () => {
+		for (const key of ["entity_id", "room_id", "agent_id"]) {
+			const column = participantSchema.columns[key];
+			expect(column?.type).toBe("uuid");
+			expect(column?.primaryKey).toBeUndefined();
+			expect(column?.notNull).toBeUndefined();
+		}
+	});
+
+	it("defaults created_at to now() and types room_state as free text", () => {
+		expect(participantSchema.columns.created_at).toMatchObject({
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+		expect(participantSchema.columns.room_state).toMatchObject({
+			type: "text",
+		});
+		expect(participantSchema.columns.room_state?.notNull).toBeUndefined();
+	});
+
+	it("defines exactly the six documented columns in declaration order", () => {
+		expect(Object.keys(participantSchema.columns)).toEqual([
+			"id",
+			"created_at",
+			"entity_id",
+			"room_id",
+			"agent_id",
+			"room_state",
+		]);
+	});
+
+	it("indexes each foreign-key column alone for its lookup scans", () => {
+		expect(Object.keys(participantSchema.indexes)).toEqual([
+			"idx_participants_user",
+			"idx_participants_room",
+			"idx_participants_entity_room",
+			"idx_participants_agent",
+		]);
+		expect(participantSchema.indexes.idx_participants_user).toMatchObject({
+			isUnique: false,
+			columns: [{ expression: "entity_id", isExpression: false }],
+		});
+		expect(participantSchema.indexes.idx_participants_room).toMatchObject({
+			isUnique: false,
+			columns: [{ expression: "room_id", isExpression: false }],
+		});
+		expect(participantSchema.indexes.idx_participants_agent).toMatchObject({
+			isUnique: false,
+			columns: [{ expression: "agent_id", isExpression: false }],
+		});
+	});
+
+	it("enforces one-membership-per-room through a unique (entity_id, room_id) index", () => {
+		const index = participantSchema.indexes.idx_participants_entity_room;
+		expect(index?.isUnique).toBe(true);
+		expect(index?.name).toBe("idx_participants_entity_room");
+		expect(index?.columns).toEqual([
+			{ expression: "entity_id", isExpression: false },
+			{ expression: "room_id", isExpression: false },
+		]);
+	});
+
+	it("cascades room deletion down to participant rows", () => {
+		const foreignKey = participantSchema.foreignKeys.fk_room;
+		expect(foreignKey?.tableFrom).toBe("participants");
+		expect(foreignKey?.tableTo).toBe("rooms");
+		expect(foreignKey?.columnsFrom).toEqual(["room_id"]);
+		expect(foreignKey?.columnsTo).toEqual(["id"]);
+		expect(foreignKey?.onDelete).toBe("cascade");
+		expect(foreignKey?.schemaTo).toBe("");
+	});
+
+	it("cascades entity deletion down to participant rows through fk_user", () => {
+		const foreignKey = participantSchema.foreignKeys.fk_user;
+		expect(foreignKey?.tableFrom).toBe("participants");
+		expect(foreignKey?.tableTo).toBe("entities");
+		expect(foreignKey?.columnsFrom).toEqual(["entity_id"]);
+		expect(foreignKey?.columnsTo).toEqual(["id"]);
+		expect(foreignKey?.onDelete).toBe("cascade");
+		expect(foreignKey?.schemaTo).toBe("");
+	});
+
+	it("defines no additional foreign keys beyond the two documented joins", () => {
+		expect(Object.keys(participantSchema.foreignKeys)).toEqual([
+			"fk_room",
+			"fk_user",
+		]);
+	});
+
+	it("mirrors every declared column name on its own descriptor", () => {
+		for (const [key, column] of Object.entries(participantSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+
+	it("carries no competing key or check machinery", () => {
+		expect(participantSchema.compositePrimaryKeys).toEqual({});
+		expect(participantSchema.uniqueConstraints).toEqual({});
+		expect(participantSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for `packages/core/src/schemas/participant.ts`, which had no same-named test file anywhere in the repository. Test-only change: no production code is touched (`+129/-0`, one new file).

## What the suite covers

Drives the real `participantSchema` table descriptor (no mocks):

- declares the portable `participants` table (`name`/`schema`)
- `id` as sole primary key column with uuid type, `notNull`, and `gen_random_uuid()` default
- `entity_id`/`room_id`/`agent_id` kept nullable and non-primary
- `created_at` defaulting to `now()`, `room_state` typed text and nullable
- exact six-column set in declaration order
- per-column lookup indexes (`idx_participants_user`, `idx_participants_room`, `idx_participants_agent`) with their exact column expressions
- the unique `(entity_id, room_id)` index that enforces one membership per room
- both cascade foreign keys (`fk_room` → rooms, `fk_user` → entities)
- mirrored column descriptors and empty `compositePrimaryKeys`/`uniqueConstraints`/`checkConstraints`

## Verification (test-only PR)

- `bunx vitest run packages/core/src/schemas/participant.test.ts` — **Test Files 1 passed (1), Tests 12 passed (12)**; re-fetched and re-run immediately before filing against current `origin/develop`: **12 passed (12)**, and `schemas/participant.ts` shows zero drift between my base and current develop
- `bunx biome check packages/core/src/schemas/participant.test.ts` — clean ("Checked 1 file", no findings), verified against the repo-root `biome.json` (worktree is not sparse)
- `bunx tsc --noEmit` in `packages/core` — the new test file appears nowhere in the output (zero errors introduced by this diff)
- Diff touches only the new test file

Note: filed from a fork, so hosted CI does not run on this pull request; the local counts above are the actual observed results.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a49d3d5c794808397320bceb5762eb88d97c0184 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
