### PR TITLE
test(core): cover relationship

### DIFF
--- a/packages/core/src/schemas/relationship.test.ts
+++ b/packages/core/src/schemas/relationship.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the `relationships` table definition (`relationshipSchema`) —
+ * the directed, agent-scoped edge schema the relationships service reads and
+ * writes and SQL adapters materialize. Pure data-object assertions over the
+ * exported `SchemaTable`; deterministic, no database, no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { relationshipSchema } from "./relationship";
+
+describe("relationshipSchema table identity", () => {
+	it("is the relationships table in the default schema", () => {
+		expect(relationshipSchema.name).toBe("relationships");
+		expect(relationshipSchema.schema).toBe("");
+	});
+
+	it("exposes exactly the seven edge columns in declaration order", () => {
+		expect(Object.keys(relationshipSchema.columns)).toEqual([
+			"id",
+			"created_at",
+			"source_entity_id",
+			"target_entity_id",
+			"agent_id",
+			"tags",
+			"metadata",
+		]);
+	});
+
+	it("mirrors every column key into its own name field", () => {
+		for (const [key, column] of Object.entries(relationshipSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+});
+
+describe("relationshipSchema columns", () => {
+	it("makes id the sole primary key with a server-generated uuid default", () => {
+		const primaryKeys = Object.entries(relationshipSchema.columns).filter(
+			([, column]) => column.primaryKey,
+		);
+		expect(primaryKeys.map(([key]) => key)).toEqual(["id"]);
+		expect(relationshipSchema.columns.id).toMatchObject({
+			type: "uuid",
+			notNull: true,
+			default: "gen_random_uuid()",
+		});
+	});
+
+	it("stamps created_at server-side", () => {
+		expect(relationshipSchema.columns.created_at).toMatchObject({
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+	});
+
+	it("requires both endpoints and the owning agent as uuids", () => {
+		for (const key of [
+			"source_entity_id",
+			"target_entity_id",
+			"agent_id",
+		] as const) {
+			expect(relationshipSchema.columns[key]).toMatchObject({
+				type: "uuid",
+				notNull: true,
+			});
+			expect(relationshipSchema.columns[key].primaryKey).toBeUndefined();
+		}
+	});
+
+	it("keeps tags and metadata as nullable free-form payloads", () => {
+		expect(relationshipSchema.columns.tags?.type).toBe("text[]");
+		expect(relationshipSchema.columns.tags?.notNull).toBeUndefined();
+		expect(relationshipSchema.columns.metadata?.type).toBe("jsonb");
+		expect(relationshipSchema.columns.metadata?.notNull).toBeUndefined();
+	});
+});
+
+describe("relationshipSchema indexes", () => {
+	it("declares exactly the pair-lookup and reverse-target indexes, neither unique", () => {
+		expect(Object.keys(relationshipSchema.indexes)).toEqual([
+			"idx_relationships_users",
+			"idx_relationships_target",
+		]);
+		for (const index of Object.values(relationshipSchema.indexes)) {
+			expect(index.isUnique).toBe(false);
+		}
+	});
+
+	it("orders idx_relationships_users source-first then target", () => {
+		const users = relationshipSchema.indexes.idx_relationships_users;
+		expect(users.name).toBe("idx_relationships_users");
+		expect(
+			users.columns.map((column) => ({
+				expression: column.expression,
+				isExpression: column.isExpression,
+			})),
+		).toEqual([
+			{ expression: "source_entity_id", isExpression: false },
+			{ expression: "target_entity_id", isExpression: false },
+		]);
+	});
+
+	it("gives target-only lookups their own single-column index", () => {
+		const target = relationshipSchema.indexes.idx_relationships_target;
+		expect(target.name).toBe("idx_relationships_target");
+		expect(target.columns.map((column) => column.expression)).toEqual([
+			"target_entity_id",
+		]);
+		expect(target.columns[0]?.isExpression).toBe(false);
+	});
+});
+
+describe("relationshipSchema foreignKeys", () => {
+	it("cascades deletion from each entity endpoint to its own column", () => {
+		expect(relationshipSchema.foreignKeys.fk_user_a).toMatchObject({
+			tableFrom: "relationships",
+			tableTo: "entities",
+			onDelete: "cascade",
+			schemaTo: "",
+			columnsFrom: ["source_entity_id"],
+			columnsTo: ["id"],
+		});
+		expect(relationshipSchema.foreignKeys.fk_user_b).toMatchObject({
+			tableFrom: "relationships",
+			tableTo: "entities",
+			onDelete: "cascade",
+			schemaTo: "",
+			columnsFrom: ["target_entity_id"],
+			columnsTo: ["id"],
+		});
+	});
+
+	it("binds the edge to its owning agent by cascade", () => {
+		expect(relationshipSchema.foreignKeys.fk_relationship_agent).toMatchObject({
+			tableFrom: "relationships",
+			tableTo: "agents",
+			onDelete: "cascade",
+			schemaTo: "",
+			columnsFrom: ["agent_id"],
+			columnsTo: ["id"],
+		});
+	});
+});
+
+describe("relationshipSchema uniqueConstraints", () => {
+	it("enforces one edge per (source, target, agent) triple", () => {
+		expect(Object.keys(relationshipSchema.uniqueConstraints)).toEqual([
+			"unique_relationship",
+		]);
+		expect(relationshipSchema.uniqueConstraints.unique_relationship).toEqual({
+			name: "unique_relationship",
+			columns: ["source_entity_id", "target_entity_id", "agent_id"],
+		});
+	});
+
+	it("constrains only required endpoint columns", () => {
+		const unique =
+			relationshipSchema.uniqueConstraints.unique_relationship.columns;
+		for (const column of unique) {
+			expect(relationshipSchema.columns[column]?.notNull).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the `relationships` table definition in
`packages/core/src/schemas/relationship.ts` (`relationshipSchema`), which had
no same-named test file anywhere in the repository on current `develop`.

The suite drives the real exported module (no mocks) and locks down every
branch of its data surface:

- table identity: name/schema and the exact seven-column declaration order,
  with each column key mirrored into its `name` field;
- columns: `id` as the sole primary key with the `gen_random_uuid()` default,
  server-side `created_at` (`now()`), both endpoints plus `agent_id` as
  required uuids, and `tags`/`metadata` as nullable `text[]`/`jsonb` payloads;
- indexes: exactly `idx_relationships_users` (ordered source→target) and the
  single-column `idx_relationships_target` that exists so OR-lookups on the
  target endpoint stay indexed — neither unique;
- foreign keys: cascade deletion from each entity endpoint to its own column
  and from the edge to its owning agent;
- unique constraint: one edge per `(source_entity_id, target_entity_id,
  agent_id)` triple, constrained only over required columns.

## Test-only change

This diff adds one new test file and changes no production behaviour:
+163/−0, a single new file at `packages/core/src/schemas/relationship.test.ts`.

## Evidence

- `bunx vitest run src/schemas/relationship.test.ts` from `packages/core`
  (the vitest lane that owns this package): **1 file passed, 14/14 tests
  passed**, re-run immediately before filing against current `origin/develop`
  (`3624a59ccb82`, module byte-identical to the working tree).
- `bunx biome check --write packages/core/src/schemas/relationship.test.ts`:
  clean ("Checked 1 file... No fixes applied") against the repository
  `biome.json` (checkout verified non-sparse).
- `bunx tsc --noEmit` in `packages/core`: grep for
  `relationship.test.ts` returns nothing — zero new type errors introduced by
  this diff.
- Hosted CI does not run on fork PRs, so the counts above are quoted from
  local runs rather than implied from checks.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4c491f3a89d6b2a64ed296ca0651551e95d54652 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
