### PR TITLE
test(core): cover message-server-agent

### DIFF
--- a/packages/core/src/schemas/message-server-agent.test.ts
+++ b/packages/core/src/schemas/message-server-agent.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the `message_server_agents` junction-table descriptor
+ * (`messageServerAgentSchema`) — a pure portable `SchemaTable` constant, so the
+ * suite drives the real exported data with no mocks or database. Covers the
+ * junction columns, composite-PK ordering, cascade FKs into the real `agents`
+ * and `message_servers` descriptors, and the agent_id-only lookup index.
+ */
+import { describe, expect, it } from "vitest";
+import { agentSchema } from "./agent";
+import { messageServerSchema } from "./message-server";
+import { messageServerAgentSchema } from "./message-server-agent";
+
+describe("messageServerAgentSchema", () => {
+	const schema = messageServerAgentSchema;
+
+	it("describes the message_server_agents table", () => {
+		expect(schema.name).toBe("message_server_agents");
+		expect(schema.schema).toBe("");
+	});
+
+	it("has exactly the two junction columns, both non-null uuids", () => {
+		expect(Object.keys(schema.columns).sort()).toEqual([
+			"agent_id",
+			"message_server_id",
+		]);
+		for (const key of ["message_server_id", "agent_id"] as const) {
+			const column = schema.columns[key];
+			expect(column.name).toBe(key);
+			expect(column.type).toBe("uuid");
+			expect(column.notNull).toBe(true);
+		}
+	});
+
+	it("keys rows by the composite PK (message_server_id, agent_id) in that order", () => {
+		const pks = Object.values(schema.compositePrimaryKeys);
+		expect(pks).toHaveLength(1);
+		expect(pks[0].name).toBe("message_server_agents_pk");
+		expect(pks[0].columns).toEqual(["message_server_id", "agent_id"]);
+	});
+
+	it("cascades deletion from either parent down to the junction row", () => {
+		const serverFk = schema.foreignKeys.fk_message_server_agent_server;
+		const agentFk = schema.foreignKeys.fk_message_server_agent_agent;
+
+		expect(serverFk.tableTo).toBe("message_servers");
+		expect(serverFk.columnsFrom).toEqual(["message_server_id"]);
+		expect(serverFk.columnsTo).toEqual(["id"]);
+		expect(serverFk.onDelete).toBe("cascade");
+
+		expect(agentFk.tableTo).toBe("agents");
+		expect(agentFk.columnsFrom).toEqual(["agent_id"]);
+		expect(agentFk.columnsTo).toEqual(["id"]);
+		expect(agentFk.onDelete).toBe("cascade");
+
+		for (const fk of Object.values(schema.foreignKeys)) {
+			expect(fk.tableFrom).toBe("message_server_agents");
+			expect(fk.schemaTo).toBe("");
+			expect(fk.columnsFrom).toHaveLength(fk.columnsTo.length);
+		}
+	});
+
+	it("points each FK at an existing uuid primary key on its parent table", () => {
+		for (const [fkName, parent] of [
+			["fk_message_server_agent_server", messageServerSchema],
+			["fk_message_server_agent_agent", agentSchema],
+		] as const) {
+			const fk = schema.foreignKeys[fkName];
+			expect(parent.name).toBe(fk.tableTo);
+			const targetColumn = parent.columns[fk.columnsTo[0]];
+			expect(targetColumn).toBeDefined();
+			expect(targetColumn.type).toBe("uuid");
+			expect(targetColumn.primaryKey).toBe(true);
+			expect(targetColumn.notNull).toBe(true);
+		}
+	});
+
+	it("indexes agent_id alone as a plain column for getMessageServers lookups", () => {
+		expect(Object.keys(schema.indexes)).toEqual(["idx_msa_agent"]);
+		const index = schema.indexes.idx_msa_agent;
+		expect(index.name).toBe("idx_msa_agent");
+		expect(index.isUnique).toBe(false);
+		expect(index.columns).toHaveLength(1);
+		expect(index.columns[0]).toEqual({
+			expression: "agent_id",
+			isExpression: false,
+		});
+	});
+
+	it("declares no unique or check constraints beyond the composite PK", () => {
+		expect(schema.uniqueConstraints).toEqual({});
+		expect(schema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

Adds the first unit-test suite for `packages/core/src/schemas/message-server-agent.ts`, the portable `SchemaTable` descriptor for the `message_server_agents` junction table (message servers ↔ agents, keyed by the composite PK). The module previously had no same-named test file anywhere in the repo.

The suite drives the real exported constant — no mocks, no database:

- table identity (`message_server_agents`, empty portable schema)
- exactly two junction columns (`message_server_id`, `agent_id`), both non-null uuids
- composite primary key `message_server_agents_pk` covering both columns in PK order
- both foreign keys cascade on delete into `message_servers.id` / `agents.id`
- FK targets cross-checked against the real `agentsSchema` / `messageServerSchema` descriptors (existing uuid primary keys)
- the `idx_msa_agent` index on `agent_id` alone as a plain column (the `getMessageServers` lookup path that cannot use the composite-PK order)
- no unique or check constraints beyond the composite PK

## Evidence

Test-only diff: one new file, +93/-0. No production behaviour changed. This is a fork contribution, so hosted CI does not run on this PR; local verification on the exact head:

- `bunx vitest run src/schemas/message-server-agent.test.ts` (packages/core): **1 file passed, 7 tests passed / 7**, re-run against a tree whose copy of `message-server-agent.ts` is byte-identical to current `origin/develop` (blob `0bb6a2d9`)
- `bunx biome check --write packages/core/src/schemas/message-server-agent.test.ts`: clean ("No fixes applied" on re-check)
- `bunx tsc --noEmit` in `packages/core`: zero occurrences of the new test file in output

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a71722911b113b995939f4c9d7d087ec188a0d21 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
