### PR TITLE
test(core): cover bip39-wordlist

### DIFF
--- a/packages/core/src/security/bip39-wordlist.test.ts
+++ b/packages/core/src/security/bip39-wordlist.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The BIP-39 wordlist module backs the seed-phrase detector: a candidate must
+ * be all-BIP-39 words AND pass the trailing SHA-256 checksum, so an ordinary
+ * English sentence of common words is rejected. These tests pin the canonical
+ * list invariants (2048 sorted unique words), the real checksum vectors for
+ * every validation branch (word-count gate, unknown word, checksum mismatch,
+ * normalization), and the non-overlapping sliding-window finder including its
+ * whitespace-adjacency guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	BIP39_WORD_INDEX,
+	BIP39_WORD_SET,
+	BIP39_WORDLIST,
+	findAllMnemonicPhrases,
+	findMnemonicPhrase,
+	mnemonicValid,
+} from "./bip39-wordlist.ts";
+
+const CANONICAL_ZERO_ENTROPY =
+	"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const ALL_ZOO = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong";
+const MIXED_WORDS =
+	"fog spot notable regret pizza coffee harvest ensure fog spot notable reflect";
+const FIFTEEN_WORDS =
+	"drastic bamboo mountain loyal category cancel animal embark drastic bamboo mountain loyal category cancel apart";
+
+describe("BIP39_WORDLIST", () => {
+	it("contains exactly 2048 words", () => {
+		expect(BIP39_WORDLIST).toHaveLength(2048);
+	});
+
+	it("is in canonical strictly ascending alphabetical order", () => {
+		for (let i = 1; i < BIP39_WORDLIST.length; i += 1) {
+			if (!(BIP39_WORDLIST[i - 1] < BIP39_WORDLIST[i])) {
+				throw new Error(
+					`not strictly ascending at ${i}: ${BIP39_WORDLIST[i - 1]} !< ${BIP39_WORDLIST[i]}`,
+				);
+			}
+		}
+	});
+
+	it("starts and ends with the known boundary words", () => {
+		expect(BIP39_WORDLIST[0]).toBe("abandon");
+		expect(BIP39_WORDLIST[2047]).toBe("zoo");
+	});
+});
+
+describe("BIP39_WORD_SET", () => {
+	it("holds every wordlist entry without duplicates", () => {
+		expect(BIP39_WORD_SET.size).toBe(2048);
+	});
+
+	it("membership matches the wordlist for known words and rejects near-misses", () => {
+		expect(BIP39_WORD_SET.has("about")).toBe(true);
+		expect(BIP39_WORD_SET.has("zoo")).toBe(true);
+		expect(BIP39_WORD_SET.has("abduct")).toBe(false);
+		expect(BIP39_WORD_SET.has("ABOUT")).toBe(false);
+		expect(BIP39_WORD_SET.has("")).toBe(false);
+	});
+});
+
+describe("BIP39_WORD_INDEX", () => {
+	it("maps every word to its canonical position", () => {
+		expect(BIP39_WORD_INDEX.size).toBe(2048);
+		expect(BIP39_WORD_INDEX.get("abandon")).toBe(0);
+		expect(BIP39_WORD_INDEX.get("about")).toBe(3);
+		expect(BIP39_WORD_INDEX.get("zoo")).toBe(2047);
+	});
+});
+
+describe("mnemonicValid", () => {
+	it.each([
+		["canonical zero-entropy 12-word vector", CANONICAL_ZERO_ENTROPY],
+		["12-word vector from all-0xff entropy", ALL_ZOO],
+		["12-word vector from mixed entropy", MIXED_WORDS],
+		["15-word vector (160-bit entropy)", FIFTEEN_WORDS],
+	])("accepts $title", (_title, phrase) => {
+		expect(mnemonicValid(phrase)).toBe(true);
+	});
+
+	it("normalizes casing, leading/trailing whitespace, and runs of spaces", () => {
+		expect(mnemonicValid(CANONICAL_ZERO_ENTROPY.toUpperCase())).toBe(true);
+		expect(mnemonicValid(`  ${CANONICAL_ZERO_ENTROPY}  `)).toBe(true);
+		expect(mnemonicValid(CANONICAL_ZERO_ENTROPY.split(" ").join("\t "))).toBe(
+			true,
+		);
+	});
+
+	it("rejects an in-wordlist phrase whose checksum bits do not match", () => {
+		const badChecksum = `${CANONICAL_ZERO_ENTROPY.split(" ").slice(0, 11).join(" ")} abandon`;
+		expect(badChecksum.split(" ").every((w) => BIP39_WORD_SET.has(w))).toBe(
+			true,
+		);
+		expect(mnemonicValid(badChecksum)).toBe(false);
+	});
+
+	it("rejects a phrase containing a word outside the wordlist", () => {
+		const unknownWord = CANONICAL_ZERO_ENTROPY.replace("about", "abduct");
+		expect(BIP39_WORD_SET.has("abduct")).toBe(false);
+		expect(mnemonicValid(unknownWord)).toBe(false);
+	});
+
+	it.each([
+		["11 words", CANONICAL_ZERO_ENTROPY.split(" ").slice(0, 11).join(" ")],
+		["13 words", `${CANONICAL_ZERO_ENTROPY} zoo`],
+		["empty string", ""],
+		["single word", "abandon"],
+		["whitespace-only", "   "],
+	])("rejects invalid word count: $title", (_title, phrase) => {
+		expect(mnemonicValid(phrase)).toBe(false);
+	});
+});
+
+describe("findAllMnemonicPhrases", () => {
+	it("returns an empty array for empty or mnemonic-free text", () => {
+		expect(findAllMnemonicPhrases("")).toEqual([]);
+		expect(findAllMnemonicPhrases("nothing to see here at all")).toEqual([]);
+	});
+
+	it("locates one embedded phrase with its exact substring bounds", () => {
+		const text = `my seed: ${CANONICAL_ZERO_ENTROPY} please keep safe`;
+		expect(findAllMnemonicPhrases(text)).toEqual([
+			{ value: CANONICAL_ZERO_ENTROPY, start: 9, end: 102 },
+		]);
+	});
+
+	it("finds two adjacent phrases in one token run without overlap", () => {
+		const text = `${ALL_ZOO} ${CANONICAL_ZERO_ENTROPY}`;
+		expect(findAllMnemonicPhrases(text)).toEqual([
+			{ value: ALL_ZOO, start: 0, end: 49 },
+			{ value: CANONICAL_ZERO_ENTROPY, start: 50, end: 143 },
+		]);
+	});
+
+	it("does not bridge words separated by punctuation instead of whitespace", () => {
+		expect(
+			findAllMnemonicPhrases(CANONICAL_ZERO_ENTROPY.split(" ").join("-")),
+		).toEqual([]);
+	});
+});
+
+describe("findMnemonicPhrase", () => {
+	it("returns the first detected phrase value", () => {
+		expect(findMnemonicPhrase(`seed is ${CANONICAL_ZERO_ENTROPY} ok`)).toBe(
+			CANONICAL_ZERO_ENTROPY,
+		);
+		expect(
+			findMnemonicPhrase(`${ALL_ZOO} then ${CANONICAL_ZERO_ENTROPY}`),
+		).toBe(ALL_ZOO);
+	});
+
+	it("returns null when no valid phrase exists", () => {
+		expect(findMnemonicPhrase("")).toBeNull();
+		expect(
+			findMnemonicPhrase(
+				CANONICAL_ZERO_ENTROPY.split(" ").slice(0, 6).join(" "),
+			),
+		).toBeNull();
+	});
+});


### PR DESCRIPTION

## Summary

Adds a colocated unit suite for `packages/core/src/security/bip39-wordlist.ts`, which had no same-named test file on develop. Test-only change; no production behavior is modified.

## What is covered

- **`BIP39_WORDLIST`**: exactly 2048 entries in canonical strictly ascending order (`abandon` … `zoo`) — the ordering invariant the index-based checksum encoding depends on.
- **`BIP39_WORD_SET` / `BIP39_WORD_INDEX`**: full-population membership (size 2048), canonical positions (`abandon`→0, `about`→3, `zoo`→2047), and rejection of near-misses and case variants.
- **`mnemonicValid()`**, driven through real SHA-256 checksums (no mocks):
  - accepts real vectors derived from known entropy: the canonical zero-entropy 12-word phrase (`abandon ×11 about`), an all-`0xff` entropy vector (`zoo ×11 wrong`), a mixed entropy vector, and a 15-word (160-bit) vector;
  - normalizes casing, leading/trailing whitespace, and multi-space separators;
  - rejects an all-in-wordlist phrase whose trailing checksum bits do not match (all-abandon variant);
  - rejects a phrase containing a word outside the list (`abduct`);
  - rejects invalid word counts: 11 words, 13 words, empty string, single word, whitespace-only.
- **`findAllMnemonicPhrases()`**:
  - returns `[]` for empty and mnemonic-free text;
  - locates one embedded phrase with exact substring bounds (`{value, start: 9, end: 102}`) preserving surrounding text;
  - finds two adjacent phrases in one token run without overlap, advancing past each accepted window (spans `[0,49]` and `[50,143]`);
  - does not bridge words joined by punctuation instead of whitespace (adjacency guard).
- **`findMnemonicPhrase()`**: returns the first span value, and `null` when nothing matches.

All expectations were observed by driving the real module before being written into assertions — including the exact span offsets above.

## Evidence (test-only diff)

- `bunx vitest run packages/core/src/security/bip39-wordlist.test.ts` → **Test Files 1 passed (1), Tests 24 passed (24)** (re-fetched origin/develop and re-ran immediately before filing).
- `bunx biome check packages/core/src/security/bip39-wordlist.test.ts` → clean ("Checked 1 file … No fixes applied" after `--write`).
- `bunx tsc --noEmit` in `packages/core`: grep for `bip39-wordlist.test` over the full output matched nothing — zero new type errors introduced.
- The diff touches only `packages/core/src/security/bip39-wordlist.test.ts` (+162/−0, new file).

Note: as a fork contributor, hosted CI does not run on this PR; the counts above are quoted from local runs of the pinned toolchain.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:77649b6473a25c5336622f80a514319ad9707c2c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
