### PR TITLE
test(core): cover world schema

### DIFF
--- a/packages/core/src/schemas/world.test.ts
+++ b/packages/core/src/schemas/world.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the `worlds` table descriptor (`worldSchema`) that groups
+ * rooms under agent-owned server/guild worlds. Pure declarative-shape
+ * assertions over the real exported object — no mocks, no DB: the descriptor
+ * itself is the contract adapters materialize. Covers table identity, the
+ * full column set with nullability and defaults, the agent-scoping index,
+ * the cascading agent foreign key, and the empty constraint maps.
+ */
+import { describe, expect, it } from "vitest";
+import { worldSchema } from "./world";
+
+describe("worldSchema table identity", () => {
+	it("names the worlds table in the default schema", () => {
+		expect(worldSchema.name).toBe("worlds");
+		expect(worldSchema.schema).toBe("");
+	});
+});
+
+describe("worldSchema columns", () => {
+	it("declares exactly the six world columns", () => {
+		expect(Object.keys(worldSchema.columns).sort()).toEqual([
+			"agent_id",
+			"created_at",
+			"id",
+			"message_server_id",
+			"metadata",
+			"name",
+		]);
+	});
+
+	it("keeps every column key consistent with its own name field", () => {
+		for (const [key, column] of Object.entries(worldSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+
+	it("types id as a non-null primary-key uuid defaulting to gen_random_uuid()", () => {
+		expect(worldSchema.columns.id).toEqual({
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "gen_random_uuid()",
+		});
+	});
+
+	it("types created_at as a non-null timestamp defaulting to now()", () => {
+		expect(worldSchema.columns.created_at).toEqual({
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+	});
+
+	it("marks agent_id as a non-null uuid without a default", () => {
+		expect(worldSchema.columns.agent_id.type).toBe("uuid");
+		expect(worldSchema.columns.agent_id.notNull).toBe(true);
+		expect(worldSchema.columns.agent_id.default).toBeUndefined();
+	});
+
+	it("marks name as non-null text without a default", () => {
+		expect(worldSchema.columns.name.type).toBe("text");
+		expect(worldSchema.columns.name.notNull).toBe(true);
+		expect(worldSchema.columns.name.default).toBeUndefined();
+	});
+
+	it("leaves metadata jsonb and message_server_id uuid nullable", () => {
+		expect(worldSchema.columns.metadata.type).toBe("jsonb");
+		expect(worldSchema.columns.metadata.notNull).toBeUndefined();
+		expect(worldSchema.columns.message_server_id.type).toBe("uuid");
+		expect(worldSchema.columns.message_server_id.notNull).toBeUndefined();
+	});
+
+	it("declares no defaults beyond id and created_at", () => {
+		for (const [key, column] of Object.entries(worldSchema.columns)) {
+			if (key !== "id" && key !== "created_at") {
+				expect(column.default).toBeUndefined();
+			}
+		}
+	});
+});
+
+describe("worldSchema indexes", () => {
+	it("declares exactly one index", () => {
+		expect(Object.keys(worldSchema.indexes)).toEqual(["idx_worlds_agent"]);
+	});
+
+	it("covers getWorlds agent filtering with a plain single-column agent_id index", () => {
+		const index = worldSchema.indexes.idx_worlds_agent;
+		expect(index.name).toBe("idx_worlds_agent");
+		expect(index.isUnique).toBe(false);
+		expect(index.columns.map((column) => column.expression)).toEqual([
+			"agent_id",
+		]);
+		expect(index.columns.every((column) => column.isExpression === false)).toBe(
+			true,
+		);
+	});
+
+	it("references only columns that exist on the table", () => {
+		for (const index of Object.values(worldSchema.indexes)) {
+			for (const column of index.columns) {
+				expect(worldSchema.columns[column.expression]).toBeDefined();
+			}
+		}
+	});
+});
+
+describe("worldSchema foreignKeys", () => {
+	it("cascades agent deletion through fk_world_agent to agents.id", () => {
+		expect(worldSchema.foreignKeys.fk_world_agent).toEqual({
+			name: "fk_world_agent",
+			tableFrom: "worlds",
+			tableTo: "agents",
+			columnsFrom: ["agent_id"],
+			columnsTo: ["id"],
+			onDelete: "cascade",
+			schemaTo: "",
+		});
+	});
+
+	it("declares no foreign keys beyond the agent cascade link", () => {
+		expect(Object.keys(worldSchema.foreignKeys)).toEqual(["fk_world_agent"]);
+	});
+});
+
+describe("worldSchema constraint maps", () => {
+	it("uses the explicit uuid primary key — no composite keys", () => {
+		expect(worldSchema.compositePrimaryKeys).toEqual({});
+	});
+
+	it("declares no unique constraints or check constraints", () => {
+		expect(worldSchema.uniqueConstraints).toEqual({});
+		expect(worldSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit test suite for the `worlds` table descriptor: `packages/core/src/schemas/world.test.ts` (+137/-0, one new file, no other paths touched).

The module under test exports one runtime symbol, `worldSchema` (a Drizzle-style `SchemaTable` const). The suite drives the real exported object — no mocks — and covers every declarative branch it has:

- **Table identity:** `name: "worlds"` in the default schema (`schema: ""`).
- **Columns:** exactly the six declared columns; every key matches its own `name` field.
- **id:** full-shape equality — uuid primary key, non-null, defaulting to `gen_random_uuid()`.
- **created_at:** full-shape equality — timestamp, non-null, defaulting to `now()`.
- **agent_id / name:** required (non-null) uuid/text columns with no defaults.
- **metadata / message_server_id:** nullable jsonb/uuid columns (no `notNull`, no default).
- **Defaults invariant:** no column other than `id` and `created_at` carries a default.
- **Indexes:** exactly one index, `idx_worlds_agent`; non-unique; plain single-column `agent_id` (`isExpression: false`); index references only columns that exist on the table. This is the index behind `getWorldsByIds`/`getWorlds` agent filtering.
- **Foreign keys:** exactly one, `fk_world_agent` — full-shape equality: `worlds.agent_id -> agents.id`, `onDelete: "cascade"`, `schemaTo: ""`.
- **Constraint maps:** empty `compositePrimaryKeys`, `uniqueConstraints`, and `checkConstraints`.

## Why

`packages/core/src/schemas/world.ts` had no same-named test file anywhere on `develop`. The descriptor itself is the contract that adapters materialize into DDL, so locking its shape catches accidental column/index/FK drift in review. The suite follows the existing sibling convention in this directory (see `log.test.ts`): pure declarative-shape assertions over the real module.

## Evidence (fork contributor — hosted CI does not run on this PR)

All commands were run against this exact head on current `develop` (`3624a59c`):

- `bunx vitest run packages/core/src/schemas/world.test.ts` → **Test Files 1 passed (1), Tests 16 passed (16)** (300ms).
- `bunx biome check --write packages/core/src/schemas/world.test.ts` → "Checked 1 file… No fixes applied." Config verified present (`biome.json`, `tsconfig.json`; checkout is not sparse).
- `bunx tsc --noEmit` in `packages/core` → zero errors mentioning `world.test.ts` (in fact 0 TS errors package-wide).
- The diff touches only the new test file; no production code changed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:423006335e3ee4cf42ff5f2d044b3312d07253d1 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
