### PR TITLE
feat(registry): add @bridgenode/plugin-x402 third-party entry

### DIFF
--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -1,0 +1,9 @@
+{
+  "package": "@bridgenode/plugin-x402",
+  "repository": "github:bridgenode-ai/elizaos-plugin-x402",
+  "kind": "plugin",
+  "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
+  "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
+  "version": "0.1.0",
+  "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
+}


### PR DESCRIPTION
Adds the @bridgenode/plugin-x402 third-party registry entry.

**What:** Pay-per-request LLM inference for ElizaOS agents via x402 on Solana USDC — no API keys, no accounts, gas sponsored by BridgeNode (https://bridgenode.cc/v1).

**Entry:** `packages/registry/entries/third-party/bridgenode__plugin-x402.json` with package/repository/kind=plugin/description/homepage/version=0.1.0/tags. Validated against `registry-entry.schema.json` (required fields package/repository/kind present, kind=plugin valid, tags array).

**Package:** https://www.npmjs.com/package/@bridgenode/plugin-x402 (MIT-0, keyword `elizaos` for auto-discovery)