### PR TITLE
test(core): cover fallback-reply

### DIFF
--- a/packages/core/src/services/message/fallback-reply.test.ts
+++ b/packages/core/src/services/message/fallback-reply.test.ts
@@ -125,4 +125,353 @@ describe("fallback-reply", () => {
 			expect(stripReasoningBlocks(rawWithNoThink)).toBe("Final text");
 		});
 	});
+
+	describe("describeModelCallError unwrapping and serialization", () => {
+		it("unwraps the AI SDK retry envelope carried on lastError", () => {
+			expect(
+				describeModelCallError({
+					lastError: { statusCode: 503, error: { message: "upstream down" } },
+				}),
+			).toBe("HTTP 503: upstream down");
+		});
+
+		it("unwraps the last entry of an errors array envelope", () => {
+			expect(
+				describeModelCallError({
+					errors: [
+						{ statusCode: 500, error: { message: "first attempt" } },
+						{ statusCode: 502, error: { message: "final attempt" } },
+					],
+				}),
+			).toBe("HTTP 502: final attempt");
+		});
+
+		it("prefers the unwrapped status over the outer envelope status", () => {
+			const outerThrottled = {
+				statusCode: 429,
+				lastError: { statusCode: 402 },
+			};
+			expect(describeModelCallError(outerThrottled)).toBe("HTTP 402");
+		});
+
+		it("falls back to the original error's message when the unwrap carries none", () => {
+			expect(
+				describeModelCallError({
+					lastError: { statusCode: 500 },
+					error: { message: "outer provider context" },
+				}),
+			).toBe("HTTP 500: outer provider context");
+		});
+
+		it("renders a status-only failure without a message", () => {
+			expect(describeModelCallError({ statusCode: 429 })).toBe("HTTP 429");
+		});
+
+		it("serializes a bare payload that has no status or message", () => {
+			expect(describeModelCallError({ code: "ECONNRESET" })).toBe(
+				'{"code":"ECONNRESET"}',
+			);
+		});
+
+		it("never stringifies an empty object as the diagnostic line", () => {
+			expect(describeModelCallError({})).toBe("[object Object]");
+			expect(describeModelCallError(new Error(""))).toBe("Error");
+		});
+
+		it("survives a non-serializable circular payload via String()", () => {
+			const circular: Record<string, unknown> = {};
+			circular.self = circular;
+			expect(describeModelCallError(circular)).toBe("[object Object]");
+		});
+	});
+
+	describe("rate-limit classification edge inputs", () => {
+		it("reads the structured 429 through the retry envelope and legacy .status duck type", () => {
+			expect(isRateLimitError({ lastError: { statusCode: 429 } })).toBe(true);
+			expect(isRateLimitError({ status: 429 })).toBe(true);
+		});
+
+		it("matches credit-exhaustion session phrases as rate limits", () => {
+			expect(isRateLimitError(new Error("you've hit your usage limit"))).toBe(
+				true,
+			);
+			expect(isRateLimitError(new Error("Session limit reached"))).toBe(true);
+			expect(
+				isRateLimitError(new Error("provider is overloaded, slow down")),
+			).toBe(true);
+		});
+
+		it("matches bare status tokens in message text", () => {
+			expect(isRateLimitError(new Error("request failed with HTTP 429"))).toBe(
+				true,
+			);
+			expect(isRateLimitError(new Error("anthropic returned a 529"))).toBe(
+				true,
+			);
+		});
+
+		it("does not classify non-Error values even when they mention rate limits", () => {
+			expect(
+				isRateLimitError({ code: "X", message: "rate limit exceeded" }),
+			).toBe(false);
+			expect(isRateLimitError("rate limit exceeded")).toBe(false);
+		});
+	});
+
+	describe("insufficient-credits classification edge inputs", () => {
+		it("classifies plain strings through the same message scanner", () => {
+			expect(isInsufficientCreditsError("out of credits")).toBe(true);
+			expect(isInsufficientCreditsError("max usage reached")).toBe(true);
+			expect(isInsufficientCreditsError("payment required by provider")).toBe(
+				true,
+			);
+			expect(isInsufficientCreditsError("rate limit exceeded")).toBe(false);
+		});
+
+		it("reads an insufficient-credits code from the structured error body", () => {
+			expect(
+				isInsufficientCreditsError({ error: { code: "insufficient_quota" } }),
+			).toBe(true);
+			expect(
+				isInsufficientCreditsError({ error: { code: "insufficient_funds" } }),
+			).toBe(true);
+		});
+
+		it("treats a throttled 429 with billing context as credit exhaustion but a bare one as rate limiting", () => {
+			const billingThrottle = new Error(
+				"quota exceeded while throttled",
+			) as Error & {
+				statusCode?: number;
+			};
+			billingThrottle.statusCode = 429;
+			expect(isInsufficientCreditsError(billingThrottle)).toBe(true);
+
+			const plainThrottle = new Error("too many requests") as Error & {
+				statusCode?: number;
+			};
+			plainThrottle.statusCode = 429;
+			expect(isInsufficientCreditsError(plainThrottle)).toBe(false);
+			expect(isRateLimitError(plainThrottle)).toBe(true);
+		});
+	});
+
+	describe("auth-error classification edge inputs", () => {
+		it("reads 401/403 through the retry envelope", () => {
+			expect(isAuthError({ lastError: { statusCode: 401 } })).toBe(true);
+			expect(isAuthError({ lastError: { statusCode: 403 } })).toBe(true);
+		});
+
+		it("matches auth substrings and bare status tokens in message text", () => {
+			expect(isAuthError(new Error("authentication failed for key"))).toBe(
+				true,
+			);
+			expect(isAuthError(new Error("expired api key"))).toBe(true);
+			expect(
+				isAuthError(new Error("authentication_required by provider")),
+			).toBe(true);
+			expect(isAuthError(new Error("request rejected with 403"))).toBe(true);
+		});
+
+		it("does not classify other statuses as auth failures", () => {
+			expect(isAuthError({ statusCode: 402 })).toBe(false);
+			expect(isAuthError({ statusCode: 500 })).toBe(false);
+		});
+	});
+
+	describe("model-provider fallback edge inputs", () => {
+		it("fails over on the typed local-inference capability error", () => {
+			expect(
+				isModelProviderFallbackError({ code: "LOCAL_INFERENCE_UNAVAILABLE" }),
+			).toBe(true);
+			// The TTS gate runs before any classifier, so TTS never rotates.
+			expect(
+				isModelProviderFallbackError(
+					{ code: "LOCAL_INFERENCE_UNAVAILABLE" },
+					ModelType.TEXT_TO_SPEECH,
+				),
+			).toBe(false);
+		});
+
+		it("fails over on structural 529 and inherited rate limits", () => {
+			expect(isModelProviderFallbackError({ statusCode: 529 })).toBe(true);
+			expect(isModelProviderFallbackError({ statusCode: 429 })).toBe(true);
+		});
+
+		it("matches transient infrastructure substrings on real Errors only", () => {
+			expect(isModelProviderFallbackError(new Error("socket hang up"))).toBe(
+				true,
+			);
+			expect(isModelProviderFallbackError(new Error("request timed out"))).toBe(
+				true,
+			);
+			// Non-Error values get no substring scan at all.
+			expect(isModelProviderFallbackError("timed out")).toBe(false);
+			expect(isModelProviderFallbackError({ statusCode: 400 })).toBe(false);
+		});
+	});
+
+	describe("structured-failure cause classification edges", () => {
+		it("surfaces repeated_failures provenance when the tool failure carried it", () => {
+			const repeatedWithHandler = new TrajectoryLimitExceeded({
+				kind: "repeated_failures",
+				max: 3,
+				observed: 3,
+				failureProvenance: {
+					kind: "handler_error",
+					boundary: "handler",
+					code: "ACTION_FAILED",
+					retryable: true,
+				},
+			});
+			expect(classifyStructuredFailureCause(repeatedWithHandler)).toBe(
+				"handler_error",
+			);
+		});
+
+		it("classifies provenance-less repeated failures and budget kinds as planner exhaustion", () => {
+			expect(
+				classifyStructuredFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: "repeated_failures",
+						max: 2,
+						observed: 2,
+					}),
+				),
+			).toBe("planner_exhaustion");
+			expect(
+				classifyStructuredFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: "trajectory_token_budget",
+						max: 1000,
+						observed: 1001,
+					}),
+				),
+			).toBe("planner_exhaustion");
+			expect(
+				classifyStructuredFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: "terminal_only_continuations",
+						max: 2,
+						observed: 3,
+					}),
+				),
+			).toBe("planner_exhaustion");
+			expect(
+				classifyStructuredFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: "tool_calls",
+						max: 10,
+						observed: 11,
+					}),
+				),
+			).toBe("planner_exhaustion");
+		});
+
+		it("reads action-failure provenance attached under an error context", () => {
+			const persistenceLike = {
+				context: {
+					failureProvenance: {
+						kind: "persistence_error",
+						boundary: "persistence",
+						code: "WRITE_FAILED",
+						retryable: true,
+					},
+				},
+			};
+			expect(classifyStructuredFailureCause(persistenceLike)).toBe(
+				"persistence_error",
+			);
+		});
+
+		it("fails closed to transient on malformed thrown provenance", () => {
+			expect(
+				classifyStructuredFailureCause({
+					failureProvenance: { kind: "nonsense" },
+				}),
+			).toBe("transient");
+		});
+	});
+
+	describe("buildFailureReplyPrompt per-cause shaping", () => {
+		it("defaults to the transient cause and its retry rule", () => {
+			const prompt = buildFailureReplyPrompt("User: hi");
+			expect(prompt).toContain("You hit a transient model error");
+			expect(prompt).toContain(
+				"- Acknowledge that something went wrong and suggest a retry.",
+			);
+		});
+
+		it("shapes each distinguishable cause with its own line and retry rule", () => {
+			const handlerPrompt = buildFailureReplyPrompt("c", "handler_error");
+			expect(handlerPrompt).toContain(
+				"An action failed while carrying out the user's request",
+			);
+
+			const persistencePrompt = buildFailureReplyPrompt(
+				"c",
+				"persistence_error",
+			);
+			expect(persistencePrompt).toContain(
+				"The requested change reached its persistence boundary but could not be saved",
+			);
+			expect(persistencePrompt).toContain("suggest a retry.");
+
+			const exhaustionPrompt = buildFailureReplyPrompt(
+				"c",
+				"planner_exhaustion",
+			);
+			expect(exhaustionPrompt).toContain(
+				"You ran out of attempts while working on the user's request",
+			);
+		});
+
+		it("orders the cause lines before the conversation and trailing Reply marker", () => {
+			const prompt = buildFailureReplyPrompt(
+				"User: hello",
+				"missing_capability",
+			);
+			expect(prompt.trim().endsWith("Reply:")).toBe(true);
+			expect(prompt.indexOf("capability which is not available")).toBeLessThan(
+				prompt.indexOf("Recent Conversation:"),
+			);
+			expect(prompt.indexOf("Recent Conversation:")).toBeLessThan(
+				prompt.indexOf("User: hello"),
+			);
+			expect(prompt).toContain("do not emit answer-shaped tokens");
+		});
+	});
+
+	describe("stripReasoningBlocks residue shapes", () => {
+		it("truncates an unclosed reasoning block to the pre-tag text", () => {
+			expect(stripReasoningBlocks("Answer here <think>leaked chain")).toBe(
+				"Answer here",
+			);
+		});
+
+		it("discards leading close-only residue left by a repair pass", () => {
+			expect(stripReasoningBlocks("None</think> Final answer")).toBe(
+				"Final answer",
+			);
+		});
+
+		it("strips every reasoning tag family case-insensitively", () => {
+			expect(
+				stripReasoningBlocks("<thinking>private</thinking>Visible reply"),
+			).toBe("Visible reply");
+			expect(stripReasoningBlocks("<THINK>x</think>Ok")).toBe("Ok");
+		});
+
+		it("collapses nested same-family tags to the nearest pairing then drops the residue", () => {
+			expect(stripReasoningBlocks("<think>a<think>b</think>c</think>d")).toBe(
+				"d",
+			);
+		});
+
+		it("removes no_think markers including a leading slash but respects word boundaries", () => {
+			expect(stripReasoningBlocks("/no_think Result")).toBe("Result");
+			expect(stripReasoningBlocks("no_thinkReady stays")).toBe(
+				"no_thinkReady stays",
+			);
+		});
+	});
 });


### PR DESCRIPTION

## Summary

Adds behavior-preserving unit coverage for `packages/core/src/services/message/fallback-reply.ts` by **extending the existing colocated suite additively** (+349/−0 — no existing case is modified or removed). The module classifies provider model-call failures and shapes the user-facing fallback reply; the new cases pin branches the suite did not yet exercise:

- `describeModelCallError`: retry-envelope unwrapping (`lastError`, `errors[]` tail wins), unwrapped-status precedence over the outer envelope, message fallback to the original error when the unwrap carries none, status-only rendering, JSON serialization of bare payloads, the `{}` / non-serializable (circular) fallbacks.
- `isRateLimitError`: 429 via `lastError` envelope and legacy `.status` duck type, credit-exhaustion session phrases ("usage limit", "session limit", "overloaded", "slow down"), bare `\b429\b` / `\b529\b` tokens in message text, and the fact that non-`Error` values get no substring scan.
- `isInsufficientCreditsError`: plain-string routing through the message scanner, structured body `error.code` matching, and the documented 429-with-billing-context vs bare-429 discrimination pair.
- `isAuthError`: 401/403 through the retry envelope, auth substrings and bare status tokens, negative cases for other statuses.
- `isModelProviderFallbackError`: `LOCAL_INFERENCE_UNAVAILABLE` typed failover, TTS gate running before every classifier, structural 529, inherited rate limits, transient infrastructure substrings on real `Error`s only.
- `classifyStructuredFailureCause`: `repeated_failures` surfacing attached `failureProvenance` kind vs defaulting to planner exhaustion, all budget-kind mappings, provenance read from `error.context`, and fail-closed-to-transient on malformed thrown provenance.
- `buildFailureReplyPrompt`: transient default cause, per-cause line/retry-rule shaping for handler/persistence/exhaustion causes, and cause-line → conversation → `Reply:` ordering.
- `stripReasoningBlocks`: unclosed-block truncation, leading close-only residue discard, multi-family/case-insensitive stripping, nested same-family collapse composition, and `no_think` removal honoring word boundaries.

All expectations record observed behavior of the current implementation; no mocks are involved (pure functions driven directly).

## Evidence

- `bunx vitest run src/services/message/fallback-reply.test.ts` (packages/core): **1 file passed, 41/41 tests passed** (8 pre-existing + 33 new), re-run against current origin/develop immediately before filing.
- `bunx biome check --write packages/core/src/services/message/fallback-reply.test.ts`: clean (`Checked 1 file ... Fixed 1 file`, exit 0).
- `bunx tsc --noEmit` in `packages/core`: zero occurrences of `fallback-reply.test` in output.
- Diff touches only `packages/core/src/services/message/fallback-reply.test.ts`, +349/−0.

## Notes

- Test-only pull request: no production behavior changes.
- This is a fork contribution — hosted CI does not run on this PR; the counts above are quoted from local runs against the pinned toolchain (Bun 1.3.14 / vitest 4.1.5).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6e3feefecf27462aeef1c31b465090e4ed92b1e5 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
