### PR TITLE
feat(registry): add @bridgenode/plugin-x402 third-party entry

### DIFF
--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -1,0 +1,9 @@
+{
+  "package": "@bridgenode/plugin-x402",
+  "repository": "github:bridgenode-ai/elizaos-plugin-x402",
+  "kind": "plugin",
+  "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
+  "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
+  "version": "0.1.0",
+  "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
+}

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,6 +4,13 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.4",
-  "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
+  "version": "0.1.5",
+  "tags": [
+    "x402",
+    "solana",
+    "usdc",
+    "llm",
+    "inference",
+    "payment"
+  ]
 }

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
 }

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
 }

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
 }

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "tags": [
     "x402",
     "solana",

--- a/packages/registry/entries/third-party/bridgenode__plugin-x402.json
+++ b/packages/registry/entries/third-party/bridgenode__plugin-x402.json
@@ -4,6 +4,6 @@
   "kind": "plugin",
   "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
   "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "tags": ["x402", "solana", "usdc", "llm", "inference", "payment"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.4"
+        "v2": "0.1.5"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.1.1"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.2"
+        "v2": "0.1.3"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.5"
+        "v2": "0.1.6"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.3"
+        "v2": "0.1.4"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -138,6 +138,52 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@bridgenode/plugin-x402": {
+      "git": {
+        "repo": "bridgenode-ai/elizaos-plugin-x402",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@bridgenode/plugin-x402",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Pay-per-request LLM inference via x402 on Solana USDC — no API keys, no accounts, gas sponsored",
+      "homepage": "https://github.com/bridgenode-ai/elizaos-plugin-x402",
+      "topics": [
+        "x402",
+        "solana",
+        "usdc",
+        "llm",
+        "inference",
+        "payment"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@davyjones0x/plugin-peer-cash": {
       "git": {
         "repo": "ADWilkinson/plugin-peer-cash",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -155,7 +155,7 @@
         "repo": "@bridgenode/plugin-x402",
         "v0": null,
         "v1": null,
-        "v2": "0.1.1"
+        "v2": "0.1.2"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
> **Integration issue:** #29009 — maintainer-facing acceptance gate (spending model + evidence options), filed per reviewer guidance

## @bridgenode/plugin-x402 — third-party registry entry

Adds the BridgeNode plugin (x402 pay-per-request LLM inference on Solana USDC) to the Eliza third-party registry.

- **Source entry:** `packages/registry/entries/third-party/bridgenode__plugin-x402.json`
- **Generated:** `packages/registry/generated-registry.json` (regenerated via `bun run --cwd packages/registry generate`, 50 third-party entries)
- **npm:** `@bridgenode/plugin-x402@0.1.6` (gitHead `bdb232a` — publishing as part of this listing)

### Payment safety pins (fail-closed, 0.1.5)

The plugin refuses to sign anything that is not exactly what BridgeNode advertises:

- **Asset pin (USDC only)** — a `PaymentPolicy` validates every payment requirement before signing: only Solana-mainnet USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) is accepted. The other `@x402/svm` mainnet default assets (USDT, USDG, PYUSD, CASH) are rejected with an error — nothing is signed.
- **Recipient pin** — payments are only ever made to `BRIDGENODE_PAY_TO` (default: the BridgeNode USDC wallet). A challenge offering any other recipient is rejected.
- **Origin pin** — `BRIDGENODE_BASE_URL` must be HTTPS on exactly `bridgenode.cc` (subdomains and other hosts are rejected). Validation runs at config load, before any fetch is created.

All three pins throw at the point of violation, so a malicious or misconfigured endpoint can never cause an unintended payment.

### Action-path origin pin (0.1.6)

Addressing the static review gap: `GET_PRICE_ESTIMATE` now validates `BRIDGENODE_BASE_URL` through the same `validateBaseUrl` as the payment path — HTTPS on exactly `bridgenode.cc` — **before any fetch is created**, and throws a typed error (fail-closed) instead of degrading into narrated prose. Also in 0.1.6: `peerDependencies` widened to `^1.0.0 || ^2.0.0` (API surface resolves on `develop` 2.0.3-beta.7).

### Spend-cap safety (fail-closed, 0.1.4)

`BRIDGENODE_MAX_USDC_PER_TX` is validated fail-closed in `getX402Config()` (`parseMaxUsdcPerTx`):

- unset / blank → default $1 (cap stays ON)
- **only the exact, untrimmed string `"0"` disables the cap** — whitespace/tab/newline/NBSP-wrapped zeros (`" 0 "`, `"\t0"`, `"\u00A00"`) are NOT the canonical `"0"` and are rejected (`parsed <= 0` → throw), so a config typo can never silently disable the payment limit
- non-numeric / `NaN` / `Infinity` → throws
- negative → throws
- non-canonical zeros (`-0`, `+0`, `00`, `0.0`, `0e999`, `0x0`, `1e-324`) → throws (rejected via `parsed <= 0`, so JS `-0 < 0` quirk and underflow-to-zero cannot disable controls)

Tests in `__tests__/x402.test.ts` cover blank, whitespace, non-numeric, NaN, Infinity, negative, non-canonical zeros, valid values, canonical `0`, the wrapped-zero regression cases from review, plus the pins: non-USDC asset rejection (against the real `@x402/svm` mainnet default mints — USDT, USDG, PYUSD, CASH), wrong recipient, mixed offers, `http://` same-host, subdomains and alternate hosts.

### Verification

- Plugin repo: `bridgenode-ai/elizaos-plugin-x402` (public) — CI green on `main` (`npm run typecheck`, `npm run build`, `npm test`)
- Registry entry + `generated-registry.json` regenerated against the current generator (50 third-party entries)
- Branch: both touched files (`packages/registry/entries/third-party/bridgenode__plugin-x402.json`, `packages/registry/generated-registry.json`) are byte-unchanged on `develop` between merge base `8ab1c484` and current head; regenerated against the current generator (50 third-party entries)


