### PR TITLE
test(core): cover side-effect-claims

### DIFF
--- a/packages/core/src/services/message/side-effect-claims.test.ts
+++ b/packages/core/src/services/message/side-effect-claims.test.ts
@@ -95,6 +95,179 @@ describe("side-effect-claims", () => {
 
 		it("returns false on empty string", () => {
 			expect(replyClaimsEmptyTrackedWorkState("")).toBe(false);
+			expect(replyClaimsEmptyTrackedWorkState("   ")).toBe(false);
+		});
+	});
+});
+
+describe("side-effect-claims — extended branch coverage", () => {
+	describe("replyClaimsCompletedSideEffect", () => {
+		it("detects perfective auxiliaries beyond the contraction form", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"I have scheduled your appointment for Tuesday.",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"I just added a reminder to your calendar.",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("I've updated your calendar settings."),
+			).toBe(true);
+		});
+
+		it("keeps denials from reading as completed claims", () => {
+			expect(
+				replyClaimsCompletedSideEffect("I have not set any reminders yet."),
+			).toBe(false);
+		});
+
+		it("fires on tag questions but not leading subordinators", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"I've set your reminder — anything else?",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Once I've set the reminder, I will let you know.",
+				),
+			).toBe(false);
+		});
+
+		it("separates bare-past reports from offers built on the same verb", () => {
+			expect(replyClaimsCompletedSideEffect("I set a reminder for 9am.")).toBe(
+				true,
+			);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Before I set the alarm, let me check your calendar.",
+				),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"I set reminders every morning — should I keep that?",
+				),
+			).toBe(false);
+		});
+
+		it("reads state-of-the-world completions without a first-person subject", () => {
+			expect(replyClaimsCompletedSideEffect("Your reminders are set.")).toBe(
+				true,
+			);
+			expect(replyClaimsCompletedSideEffect("It's all set for tomorrow.")).toBe(
+				false,
+			);
+			expect(
+				replyClaimsCompletedSideEffect("It's all set on your calendar."),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Saved! Your book report plan is now set up as reminders.",
+				),
+			).toBe(true);
+		});
+
+		it("does not misread congratulations or read-only navigation as writes", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Well done — that's every task cleared.",
+				),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect("Done — your notes are loaded."),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Done — your notes are loaded and I archived the old ones.",
+				),
+			).toBe(true);
+		});
+
+		it("anchors subjectless headline reports to sentence boundaries", () => {
+			expect(
+				replyClaimsCompletedSideEffect("Deleted the reminder as requested."),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("Added todo: sand the shelf?"),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Set a reminder on your phone to confirm.",
+				),
+			).toBe(false);
+		});
+
+		it("requires terminal punctuation on noun-first headlines", () => {
+			expect(replyClaimsCompletedSideEffect("Reminder set: 9am.")).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"The reminder set by the old app still works.",
+				),
+			).toBe(false);
+		});
+
+		it("extends completion detection across the shipped locale tiers", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"Mình đã đặt lời nhắc cho buổi họp rồi.",
+				),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect("Naitakda ko na ang paalala."),
+			).toBe(true);
+			expect(
+				replyClaimsCompletedSideEffect(
+					"He creado tus recordatorios — ¿algo más?",
+				),
+			).toBe(true);
+		});
+
+		it("rejects non-assertive locale shapes (negation, conditionals, second person, questions)", () => {
+			expect(
+				replyClaimsCompletedSideEffect(
+					"No he guardado todavía el recordatorio.",
+				),
+			).toBe(false);
+			expect(
+				replyClaimsCompletedSideEffect("알림을 설정했으면 바로 알려주세요."),
+			).toBe(false);
+			expect(replyClaimsCompletedSideEffect("你已经把提醒设置好了。")).toBe(
+				false,
+			);
+			expect(replyClaimsCompletedSideEffect("提醒已经保存了吗？")).toBe(false);
+		});
+	});
+
+	describe("replyClaimsEmptyTrackedWorkState", () => {
+		it("covers the remaining empty-state shapes", () => {
+			expect(
+				replyClaimsEmptyTrackedWorkState("Nothing logged today so far."),
+			).toBe(true);
+			expect(replyClaimsEmptyTrackedWorkState("Your day is wide open!")).toBe(
+				true,
+			);
+			expect(
+				replyClaimsEmptyTrackedWorkState("Zero reminders on file right now."),
+			).toBe(true);
+			expect(
+				replyClaimsEmptyTrackedWorkState("I don't have your task list handy."),
+			).toBe(true);
+		});
+
+		it("passes through conditionals and ordinary chat about absence", () => {
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"Whenever your schedule looks clear, tell me.",
+				),
+			).toBe(false);
+			expect(
+				replyClaimsEmptyTrackedWorkState(
+					"No messages from Bob in this thread.",
+				),
+			).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION

## Summary

Adds real unit test coverage for `packages/core/src/services/message/side-effect-claims.ts` — the leaf detector module that flags fabricated completion claims ("I've set…", "Done — your reminders are set") and fabricated empty tracked-work assertions ("your task list is empty") before they reach users.

This is a **test-only, additive** change: +173/-0 in a single file, no production code touched.

## What is covered

The suite already on develop covered 7 cases. This PR appends 12 new cases (`side-effect-claims — extended branch coverage`) driving the real module with no mocks:

- **Perfective auxiliaries** beyond the contraction form ("I have scheduled", "I just added", "I've updated").
- **Negation adjacency**: "I have not set any reminders yet." stays false.
- **Tag question vs leading subordinator**: "I've set your reminder — anything else?" fires; "Once I've set…" does not.
- **Bare-past vs offer collision**: "I set a reminder for 9am." fires; "Before I set…" and the question-gated "…should I keep that?" do not.
- **State-of-the-world shapes** ("Your reminders are set.", "It's all set on your calendar.", the #16941 "Saved!" opener) plus the tracked-work noun gate observed on "It's all set for tomorrow." (false — no schedulable noun).
- **Read-navigation exemption (#22609)**: "Done — your notes are loaded." stays false while a committed write in the same sentence ("…and I archived the old ones.") overrides it.
- **Subjectless headline anchoring** (sentence-start "Deleted the reminder…" fires; advisory imperative "Set a reminder…" and the question-form headline stay false).
- **Noun-first headlines** requiring terminal punctuation ("Reminder set: 9am." vs descriptive "the reminder set by the old app…").
- **Locale tiers**: Vietnamese perfective, Tagalog completed aspect, Spanish courtesy tag ("— ¿algo más?"), and non-assertive rejections across Spanish negation, Korean conditional tail (-면), Chinese second-person subject, and the 吗 particle question.
- **Empty-state patterns**: "Nothing logged today so far.", "Your day is wide open!", "Zero reminders on file right now.", "I don't have your task list handy.", plus pass-through for conditionals and ordinary chat ("No messages from Bob in this thread.").

All expectations record behavior **observed by running the real module**, including two shapes where my initial guess was wrong and the assertion was corrected to match reality ("It's all set for tomorrow." → false; bare "is all set" without it's/that's → no match).

## Verification

- `bunx vitest run packages/core/src/services/message/side-effect-claims.test.ts` — **Test Files 1 passed (1), Tests 19 passed (19)** (7 pre-existing + 12 new), re-run against current origin/develop (`3624a59`) immediately before filing.
- `bunx biome check --write` on the touched file — clean, no fixes needed after formatting.
- `bunx tsc --noEmit` in `packages/core` — zero mentions of `side-effect-claims.test.ts` in output.
- `git diff origin/develop` — exactly one file changed, +173/-0, purely additive; no existing test line removed or rewritten.
- No `expectTypeOf`, no `vi.hoisted`, no mocks standing in for the system under test.

Note: this is a fork contribution, so hosted CI does not run on this PR — the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5b8460afc7d11a58b716a0e30cfb63b2b57224bb -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
