### PR TITLE
test(core): cover stage1-prompt-tier

### DIFF
--- a/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
+++ b/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
@@ -367,3 +367,65 @@ describe("Stage-1 complete prompt rendering", () => {
 		expect(unaddressed.systemContent).toBe(addressed.systemContent);
 	});
 });
+
+describe("isUnaddressedTextGroupTurn structural edges", () => {
+	it("rejects always-respond sources matched case-insensitively as substrings", () => {
+		expect(
+			isUnaddressedTextGroupTurn(
+				makeMessage({
+					channelType: String(ChannelType.GROUP),
+					source: "Trigger-Prompt",
+				}),
+				false,
+			),
+		).toBe(false);
+		expect(
+			isUnaddressedTextGroupTurn(
+				makeMessage({
+					channelType: String(ChannelType.GROUP),
+					source: "webhook-client_chat-bridge",
+				}),
+				false,
+			),
+		).toBe(false);
+	});
+
+	it("ignores non-true autonomous and sub-agent flags", () => {
+		expect(
+			isUnaddressedTextGroupTurn(
+				makeMessage({
+					channelType: String(ChannelType.GROUP),
+					contentMetadata: { isAutonomous: false, subAgent: false },
+				}),
+				false,
+			),
+		).toBe(true);
+	});
+
+	it("treats array and null content metadata as absent", () => {
+		const base = makeMessage({ channelType: String(ChannelType.GROUP) });
+		expect(
+			isUnaddressedTextGroupTurn(
+				{ ...base, content: { ...base.content, metadata: [] } },
+				false,
+			),
+		).toBe(true);
+		expect(
+			isUnaddressedTextGroupTurn(
+				{ ...base, content: { ...base.content, metadata: null } },
+				false,
+			),
+		).toBe(true);
+	});
+
+	it("classifies a group turn that carries no source field", () => {
+		const base = makeMessage({ channelType: String(ChannelType.GROUP) });
+		const { source: _discardedSource, ...contentWithoutSource } = base.content;
+		expect(
+			isUnaddressedTextGroupTurn(
+				{ ...base, content: contentWithoutSource },
+				false,
+			),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION

Appends four behavioral edge cases for `isUnaddressedTextGroupTurn` to the existing canonical suite at `packages/core/src/__tests__/message-stage1-prompt-tier.test.ts`, covering branches no current suite asserts:

- always-respond sources (`client_chat`, `trigger-prompt`) are matched case-insensitively and as substrings of `content.source`
- `isAutonomous` / `subAgent` metadata flags only divert a turn when strictly `true`; explicit `false` values still classify as unaddressed
- array and `null` content-metadata containers are treated as absent rather than failing classification
- a turn with no `content.source` field at all still classifies by channel type alone

The diff is purely additive (+62/-0, single test file): every pre-existing case is preserved byte-for-byte. All expectations record observed behavior of the real module — no mocks stand in for the subject under test.

This is a test-only change with no production-behavior delta. As a fork contribution, hosted CI does not run on this PR; verification was run locally at head `0a87a1bafd623461390e28af7b05f26656831a29` against `origin/develop` @ `3624a59ccb823312f73b42334d5a4daf23251c54`:

- `bunx vitest run packages/core/src/__tests__/message-stage1-prompt-tier.test.ts` — 1 file, 19 passed (15 pre-existing + 4 new)
- `bunx biome check --write` on the touched file — clean
- `bunx tsc --noEmit` in `packages/core` — zero diagnostics referencing the touched file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0a87a1bafd623461390e28af7b05f26656831a29 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
