### PR TITLE
test(core): cover setup-state

### DIFF
--- a/packages/core/src/services/setup-state.test.ts
+++ b/packages/core/src/services/setup-state.test.ts
@@ -129,3 +129,512 @@ describe("setup-state", () => {
 		expect(isSetupComplete(sm.getContext())).toBe(false);
 	});
 });
+
+describe("setup-state additional coverage", () => {
+	const reachAuth = async () => {
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli" });
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		return sm;
+	};
+
+	const reachChannels = async () => {
+		const sm = await reachAuth();
+		await sm.advanceStep({ step: SetupStep.AUTH, data: { skip: true } });
+		return sm;
+	};
+
+	const reachSkills = async () => {
+		const sm = await reachChannels();
+		await sm.advanceStep({
+			step: SetupStep.CHANNELS,
+			data: { channels: [], skip: true },
+		});
+		return sm;
+	};
+
+	it("blocks canAdvance and reports completion once the flow reaches COMPLETE", async () => {
+		const onComplete = vi.fn();
+		const sm = new SetupStateMachine({
+			platform: "cli",
+			mode: "cli",
+			onComplete,
+		});
+
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		await sm.advanceStep({ step: SetupStep.AUTH, data: { skip: true } });
+		await sm.advanceStep({
+			step: SetupStep.CHANNELS,
+			data: { channels: [], skip: true },
+		});
+		const final = await sm.skipStep();
+
+		expect(final.isComplete).toBe(true);
+		expect(final.message).toBe("Setup complete!");
+		expect(sm.getCurrentStep()).toBe(SetupStep.COMPLETE);
+		expect(sm.canAdvance()).toBe(false);
+		expect(isSetupComplete(sm.getContext())).toBe(true);
+		expect(onComplete).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces step statuses, error state, and percentage in getProgress", async () => {
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli" });
+
+		const fresh = sm.getProgress();
+		expect(fresh.totalSteps).toBe(6);
+		expect(fresh.currentStepNumber).toBe(1);
+		expect(fresh.percentage).toBe(0);
+		expect(fresh.steps[0]).toMatchObject({
+			step: SetupStep.WELCOME,
+			status: "current",
+		});
+		expect(fresh.steps[5]?.status).toBe("pending");
+
+		const rejected = await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: false },
+		});
+		expect(rejected.success).toBe(false);
+
+		const mismatch = await sm.advanceStep({
+			step: SetupStep.SKILLS,
+			data: { skills: [] },
+		});
+		expect(mismatch.success).toBe(false);
+
+		const errored = sm.getProgress();
+		expect(errored.steps[0]).toMatchObject({
+			step: SetupStep.WELCOME,
+			status: "error",
+			errorMessage: "Cannot process step SKILLS when current step is WELCOME",
+		});
+
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		const advanced = sm.getProgress();
+		expect(advanced.percentage).toBe(20);
+		expect(advanced.currentStepNumber).toBe(2);
+		expect(advanced.steps[0]).toMatchObject({ status: "completed" });
+		expect(advanced.steps[1]).toMatchObject({
+			step: SetupStep.RISK_ACK,
+			status: "current",
+		});
+	});
+
+	it("returns NOT_ACKNOWLEDGED failures in the result without leaving WELCOME", async () => {
+		const onError = vi.fn();
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli", onError });
+
+		const res = await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: false },
+		});
+
+		expect(res.success).toBe(false);
+		expect(res.error?.code).toBe("NOT_ACKNOWLEDGED");
+		expect(res.newStep).toBe(SetupStep.WELCOME);
+		expect(res.isComplete).toBe(false);
+		expect(sm.getCurrentStep()).toBe(SetupStep.WELCOME);
+		expect(sm.getContext().errors).toHaveLength(0);
+		expect(sm.canAdvance()).toBe(true);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("refuses risk rejection with RISK_NOT_ACCEPTED and stores acceptance settings on accept", async () => {
+		const sm = await reachAuth();
+		expect(sm.getCurrentStep()).toBe(SetupStep.AUTH);
+
+		const rewound = sm.goBack(SetupStep.RISK_ACK);
+		expect(rewound.success).toBe(true);
+
+		const refused = await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: false },
+		});
+		expect(refused.success).toBe(false);
+		expect(refused.error?.code).toBe("RISK_NOT_ACCEPTED");
+		expect(sm.getCurrentStep()).toBe(SetupStep.RISK_ACK);
+
+		const accepted = await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		expect(accepted.success).toBe(true);
+		const settings = sm.getSettings();
+		expect(settings.riskAcknowledged).toBe(true);
+		expect(typeof settings.riskAcknowledgedAt).toBe("number");
+	});
+
+	it("clears recorded errors for a step when it is retried successfully", async () => {
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli" });
+
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: false },
+		});
+		await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		expect(sm.getContext().errors).toHaveLength(1);
+		expect(sm.getContext().errors[0]?.code).toBe("STEP_MISMATCH");
+
+		const ok = await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		expect(ok.success).toBe(true);
+		expect(ok.context.errors).toHaveLength(0);
+		expect(sm.getContext().metadata).toBeUndefined();
+	});
+
+	it("converts throwing handlers into HANDLER_ERROR results without throwing", async () => {
+		const onError = vi.fn();
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli", onError });
+
+		sm.registerHandler(SetupStep.WELCOME, async () => {
+			throw new Error("boom");
+		});
+		const res = await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		expect(res.success).toBe(false);
+		expect(res.error?.code).toBe("HANDLER_ERROR");
+		expect(res.error?.message).toBe("boom");
+		expect(res.newStep).toBe(SetupStep.WELCOME);
+		expect(sm.getContext().errors[0]?.code).toBe("HANDLER_ERROR");
+		expect(onError).toHaveBeenCalledTimes(1);
+
+		sm.registerHandler(SetupStep.WELCOME, async () => {
+			throw "string-failure";
+		});
+		const nonError = await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		expect(nonError.success).toBe(false);
+		expect(nonError.error?.message).toBe("string-failure");
+		expect(nonError.error?.details).toBeUndefined();
+	});
+
+	it("validates auth input variants and persists credentials for valid ones", async () => {
+		const missingMethod = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: {} as unknown as { method: "api_key" },
+		});
+		expect(missingMethod.error?.message).toBe(
+			"Authentication method is required",
+		);
+
+		const missingKey = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "api_key" },
+		});
+		expect(missingKey.success).toBe(false);
+		expect(missingKey.error?.message).toBe("API key is required");
+
+		const shortKey = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "api_key", apiKey: "  short  " },
+		});
+		expect(shortKey.error?.message).toBe("API key appears too short");
+
+		const missingToken = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "setup_token" },
+		});
+		expect(missingToken.error?.message).toBe("Setup token is required");
+
+		const partialOauth = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "oauth", oauthCallback: { code: "c", state: "" } },
+		});
+		expect(partialOauth.error?.message).toBe("OAuth callback data is partial");
+
+		const unknownMethod = await (await reachAuth()).advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "carrier_pigeon" } as unknown as { method: "api_key" },
+		});
+		expect(unknownMethod.error?.message).toBe(
+			"Unknown auth method: carrier_pigeon",
+		);
+
+		const apiKeyMachine = await reachAuth();
+		const stored = await apiKeyMachine.advanceStep({
+			step: SetupStep.AUTH,
+			data: {
+				method: "api_key",
+				provider: "anthropic",
+				apiKey: "sk-test-123456",
+			},
+		});
+		expect(stored.success).toBe(true);
+		expect(stored.newStep).toBe(SetupStep.CHANNELS);
+		expect(apiKeyMachine.getSettings().auth).toEqual({
+			authMethod: "api_key",
+			modelProvider: "anthropic",
+			apiKey: "sk-test-123456",
+		});
+
+		const tokenMachine = await reachAuth();
+		await tokenMachine.advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "setup_token", setupToken: "tok-abcdef" },
+		});
+		expect(tokenMachine.getSettings().auth?.setupToken).toBe("tok-abcdef");
+
+		const oauthMachine = await reachAuth();
+		await oauthMachine.advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "oauth", oauthCallback: { code: "c", state: "s" } },
+		});
+		expect(oauthMachine.getSettings().auth?.oauthTokens?.accessToken).toBe("");
+	});
+
+	it("records only enabled channels plus their configs and stores the DM policy", async () => {
+		const sm = await reachChannels();
+		const res = await sm.advanceStep({
+			step: SetupStep.CHANNELS,
+			data: {
+				channels: [
+					{ type: "discord", enabled: true, credentials: { token: "d" } },
+					{ type: "telegram", enabled: false },
+				],
+				dmPolicy: { requireApproval: true },
+			},
+		});
+
+		expect(res.success).toBe(true);
+		expect(res.message).toBe(
+			"1 channel(s) configured. Now let's set up skills.",
+		);
+		const channels = sm.getSettings().channels;
+		expect(channels?.enabledChannels).toEqual(["discord"]);
+		const discordConfig = channels?.channelConfigs.discord;
+		expect(discordConfig?.type).toBe("discord");
+		expect(discordConfig?.enabled).toBe(true);
+		expect(discordConfig?.credentials).toEqual({ token: "d" });
+		expect(channels?.channelConfigs.telegram).toBeUndefined();
+		expect(channels?.dmPolicy).toEqual({ requireApproval: true });
+
+		const emptyMachine = await reachChannels();
+		const emptyRes = await emptyMachine.advanceStep({
+			step: SetupStep.CHANNELS,
+			data: { channels: [] },
+		});
+		expect(emptyRes.success).toBe(true);
+		expect(emptyRes.message).toBe(
+			"No channels configured. You can add them later.",
+		);
+		expect(emptyMachine.getSettings().channels?.enabledChannels).toEqual([]);
+	});
+
+	it("stores skills preferences; completing steps report the fixed completion message", async () => {
+		const sm = await reachSkills();
+		const res = await sm.advanceStep({
+			step: SetupStep.SKILLS,
+			data: {
+				skills: ["browser"],
+				install: ["scheduling", "health"],
+				preferences: { useHomebrew: true, nodeManager: "bun" },
+			},
+		});
+
+		expect(res.isComplete).toBe(true);
+		expect(res.message).toBe("Setup complete!");
+		const skills = sm.getSettings().skills;
+		expect(skills?.enabledSkills).toEqual(["browser"]);
+		expect(skills?.skillsToInstall).toEqual(["scheduling", "health"]);
+		expect(skills?.useHomebrew).toBe(true);
+		expect(skills?.nodeManager).toBe("bun");
+
+		const bare = await reachSkills();
+		const bareRes = await bare.advanceStep({
+			step: SetupStep.SKILLS,
+			data: { skills: [], install: [] },
+		});
+		expect(bareRes.isComplete).toBe(true);
+		expect(bareRes.message).toBe("Setup complete!");
+	});
+
+	it("refuses skipping unskippable steps with CANNOT_SKIP including COMPLETE", async () => {
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli" });
+		const atWelcome = await sm.skipStep();
+		expect(atWelcome.success).toBe(false);
+		expect(atWelcome.error?.code).toBe("CANNOT_SKIP");
+
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		const atRiskAck = await sm.skipStep();
+		expect(atRiskAck.success).toBe(false);
+		expect(atRiskAck.error?.code).toBe("CANNOT_SKIP");
+		expect(sm.getCurrentStep()).toBe(SetupStep.RISK_ACK);
+
+		await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		await sm.skipStep();
+		await sm.skipStep();
+		const completed = await sm.skipStep();
+		expect(completed.isComplete).toBe(true);
+		const atComplete = await sm.skipStep();
+		expect(atComplete.success).toBe(false);
+		expect(atComplete.error?.code).toBe("CANNOT_SKIP");
+		expect(atComplete.newStep).toBe(SetupStep.COMPLETE);
+	});
+
+	it("enforces goBack targets and prunes completed steps and errors on rewind", async () => {
+		const onStepChange = vi.fn();
+		const sm = new SetupStateMachine({
+			platform: "cli",
+			mode: "cli",
+			onStepChange,
+		});
+
+		const atStart = sm.goBack();
+		expect(atStart.success).toBe(false);
+		expect(atStart.error?.code).toBe("NO_PREVIOUS_STEP");
+
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+		await sm.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		await sm.advanceStep({
+			step: SetupStep.AUTH,
+			data: { method: "api_key", apiKey: "sk-test-123456" },
+		});
+		await sm.advanceStep({ step: SetupStep.SKILLS, data: { skills: [] } });
+		expect(sm.getCurrentStep()).toBe(SetupStep.CHANNELS);
+		expect(sm.getContext().errors).toHaveLength(1);
+
+		const forward = sm.goBack(SetupStep.SKILLS);
+		expect(forward.success).toBe(false);
+		expect(forward.error?.code).toBe("INVALID_TARGET");
+
+		const bogus = sm.goBack("BOGUS" as SetupStep);
+		expect(bogus.success).toBe(false);
+		expect(bogus.error?.code).toBe("INVALID_TARGET");
+
+		const back = sm.goBack(SetupStep.RISK_ACK);
+		expect(back.success).toBe(true);
+		expect(back.message).toBe("Returned to Risk Acknowledgement");
+		expect(sm.getCurrentStep()).toBe(SetupStep.RISK_ACK);
+		expect(sm.getContext().completedSteps).toEqual([SetupStep.WELCOME]);
+		expect(sm.getContext().errors).toEqual([]);
+		expect(onStepChange).toHaveBeenLastCalledWith(
+			SetupStep.CHANNELS,
+			SetupStep.RISK_ACK,
+			expect.anything(),
+		);
+	});
+
+	it("restores from serialized state even when the version differs", async () => {
+		const sm = new SetupStateMachine({
+			platform: "discord",
+			mode: "conversational",
+		});
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true },
+		});
+
+		const serialized = sm.toJSON();
+		expect(serialized.version).toBe(1);
+
+		const restored = SetupStateMachine.fromJSON(
+			{ version: 999, context: serialized.context },
+			{ platform: "discord", mode: "conversational" },
+		);
+		expect(restored.getCurrentStep()).toBe(SetupStep.RISK_ACK);
+		expect(restored.getContext().completedSteps).toEqual([SetupStep.WELCOME]);
+		expect(restored.getContext().platform).toBe("discord");
+		expect(restored.getContext().mode).toBe("conversational");
+	});
+
+	it("reset restores a pristine WELCOME context", async () => {
+		const sm = new SetupStateMachine({ platform: "cli", mode: "cli" });
+		await sm.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true, userName: "Cara" },
+		});
+		const beforeSession = sm.getContext().sessionId;
+
+		sm.reset();
+		const ctx = sm.getContext();
+
+		expect(ctx.currentStep).toBe(SetupStep.WELCOME);
+		expect(ctx.completedSteps).toEqual([]);
+		expect(ctx.settings).toEqual({});
+		expect(ctx.metadata).toBeUndefined();
+		expect(ctx.sessionId).not.toBe(beforeSession);
+	});
+
+	it("returns isolated snapshots for scalar context and settings objects", async () => {
+		const sm = await reachAuth();
+
+		const ctx = sm.getContext();
+		ctx.currentStep = SetupStep.COMPLETE;
+		expect(sm.getCurrentStep()).toBe(SetupStep.AUTH);
+
+		const settings = sm.getSettings();
+		settings.auth = { authMethod: "api_key", apiKey: "leak" };
+		expect(sm.getSettings().auth).toBeUndefined();
+		expect(sm.getContext().settings.riskAcknowledged).toBe(true);
+	});
+
+	it("defaults conversational mode and renders completed/error sections in summaries", async () => {
+		const conversational = createSetupStateMachine({ platform: "chat" });
+		expect(conversational.getContext().mode).toBe("conversational");
+
+		const errored = new SetupStateMachine({
+			platform: "chat",
+			mode: "conversational",
+		});
+		await errored.advanceStep({
+			step: SetupStep.RISK_ACK,
+			data: { accepted: true },
+		});
+		const errorSummary = getSetupSummary(errored.getContext());
+		expect(errorSummary).toContain("**Errors:**");
+		expect(errorSummary).toContain(
+			"- [WELCOME] Cannot process step RISK_ACK when current step is WELCOME",
+		);
+
+		const progressing = new SetupStateMachine({
+			platform: "chat",
+			mode: "conversational",
+		});
+		await progressing.advanceStep({
+			step: SetupStep.WELCOME,
+			data: { acknowledged: true, userName: "Dana" },
+		});
+		const progressSummary = getSetupSummary(progressing.getContext());
+		expect(progressSummary).toContain("## Setup Progress: 20%");
+		expect(progressSummary).toContain("**Completed Steps:**");
+		expect(progressSummary).toContain("- Welcome");
+		expect(progressSummary).toContain("**Current Step:** Risk Acknowledgement");
+	});
+});


### PR DESCRIPTION

## What

Additive unit-test coverage only for `packages/core/src/services/setup-state.ts`. The suite on develop (#26265) covered the happy path, one STEP_MISMATCH case, a single goBack, JSON roundtrip, and basic summary rendering. This PR appends 15 cases (+509/-0) in a new `describe("setup-state additional coverage")` block — no existing line is touched.

## Newly covered behaviour (all driven through the real `SetupStateMachine`, no mocks standing in for the subject)

- Completion boundary: `canAdvance()` flips to false and `isSetupComplete()` to true at COMPLETE; skip-chain to COMPLETE fires `onComplete` once.
- `getProgress()`: totalSteps/currentStepNumber/percentage math (0% → 20%), completed/current/pending statuses, and the "error" status + `errorMessage` surfacing after a recorded STEP_MISMATCH.
- Handler-validation failures (`NOT_ACKNOWLEDGED`) are result-only: they do not push into `context.errors`, do not call `onError`, and leave the machine at WELCOME while retry stays permitted.
- `RISK_NOT_ACCEPTED` refusal, and acceptance persisting `riskAcknowledged`/`riskAcknowledgedAt`.
- Retry semantics: a recorded STEP_MISMATCH is cleared from `context.errors` when its step advances successfully; welcome without userName leaves `metadata` unset.
- `HANDLER_ERROR` boundary: throwing custom handlers convert to failure results for both Error and non-Error throws, record the error, and fire `onError` exactly once per failure.
- AUTH validation matrix: missing method, missing/whitespace API key, too-short key, missing setup token, partial OAuth callback, unknown method; plus credential persistence for api_key/setup_token/oauth paths.
- CHANNELS: enabled-only channel configs, DM policy storage, count vs empty messages.
- SKILLS: preference and install-queue persistence; completing steps return the fixed `"Setup complete!"` message regardless of handler-composed text.
- `skipStep()` guards: CANNOT_SKIP at WELCOME, RISK_ACK and COMPLETE (the last via the SKILLS skip branch, which was previously unexercised).
- `goBack()` edges: NO_PREVIOUS_STEP at start, INVALID_TARGET for forward and unknown targets, pruning of completedSteps/errors to strictly-before the target, and the synchronous onStepChange call args.
- Serialization: version-mismatched restores still succeed; restored platform/mode/completedSteps preserved.
- `reset()` returns a pristine WELCOME context with a fresh sessionId.
- Snapshot isolation of scalar context fields and settings objects returned by getContext/getSettings.
- `createSetupStateMachine` default mode, and summary rendering of Completed/Errors sections.

Two behaviours are asserted exactly as observed (not as one might wish them): handler-returned validation errors live only in the result payload, and any step that completes returns `"Setup complete!"`. If either contract should change, that belongs in a separate production PR.

## Verification (test-only diff; no production behaviour changed)

- `bunx vitest run src/services/setup-state.test.ts` in `packages/core`: **1 file passed, 20 passed (20)** — 5 pre-existing + 15 new.
- `bunx biome check --write src/services/setup-state.test.ts`: clean (config verified present; checkout is not sparse).
- `bunx tsc --noEmit -p ./tsconfig.json` in `packages/core`: zero mentions of `setup-state.test.ts` in output.
- Diff is a single file, +509/-0 against current origin/develop (`3624a59ccb82`).

Note: we are fork contributors, so hosted CI does not run on this pull request; the local runs above are the verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3ce3d61cbc9af2f59f7a07acc1ccc671f4e0b09d -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
