### PR TITLE
test(core): cover trajectory-types

### DIFF
--- a/packages/core/src/services/trajectory-types.test.ts
+++ b/packages/core/src/services/trajectory-types.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Coverage for the trajectory subsystem's canonical constant surface in
+ * `services/trajectory-types.ts`. Deterministic unit harness: it drives the
+ * real module with no mocks and pins the two runtime bindings plus the
+ * export-row shape they feed.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	ELIZA_NATIVE_MODEL_BOUNDARIES,
+	ELIZA_NATIVE_TRAJECTORY_FORMAT,
+	type ElizaNativeTrajectoryRow,
+} from "./trajectory-types.ts";
+
+describe("trajectory-types canonical constants", () => {
+	it("exports the eliza-native format tag verbatim", () => {
+		expect(ELIZA_NATIVE_TRAJECTORY_FORMAT).toBe("eliza_native_v1");
+		expect(typeof ELIZA_NATIVE_TRAJECTORY_FORMAT).toBe("string");
+	});
+
+	it("lists the model boundaries in canonical order without duplicates", () => {
+		expect(ELIZA_NATIVE_MODEL_BOUNDARIES).toEqual([
+			"vercel_ai_sdk.generateText",
+			"vercel_ai_sdk.streamText",
+		]);
+		expect(new Set(ELIZA_NATIVE_MODEL_BOUNDARIES).size).toBe(
+			ELIZA_NATIVE_MODEL_BOUNDARIES.length,
+		);
+	});
+
+	it("exposes exactly the two runtime bindings from the module", async () => {
+		const mod = await import("./trajectory-types.ts");
+		expect(Object.keys(mod).sort()).toEqual([
+			"ELIZA_NATIVE_MODEL_BOUNDARIES",
+			"ELIZA_NATIVE_TRAJECTORY_FORMAT",
+		]);
+		expect(mod.ELIZA_NATIVE_TRAJECTORY_FORMAT).toBe(
+			ELIZA_NATIVE_TRAJECTORY_FORMAT,
+		);
+		expect(mod.ELIZA_NATIVE_MODEL_BOUNDARIES).toBe(
+			ELIZA_NATIVE_MODEL_BOUNDARIES,
+		);
+	});
+
+	it("binds both constants into an eliza-native export row", () => {
+		const row: ElizaNativeTrajectoryRow = {
+			trajectoryId: "traj-1",
+			agentId: "agent-1",
+			status: "completed",
+			stepId: "step-1",
+			callId: "call-1",
+			stepIndex: 0,
+			callIndex: 0,
+			timestamp: 1_700_000_000_000,
+			tags: [],
+			format: ELIZA_NATIVE_TRAJECTORY_FORMAT,
+			schemaVersion: 1,
+			boundary: ELIZA_NATIVE_MODEL_BOUNDARIES[0],
+			request: { prompt: "hello" },
+			response: { text: "hi" },
+			metadata: {},
+			trajectoryTotals: {
+				stepCount: 1,
+				llmCallCount: 1,
+				providerAccessCount: 0,
+				promptTokens: 10,
+				completionTokens: 5,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+			},
+			cacheStats: {
+				totalInputTokens: 10,
+				promptTokens: 10,
+				completionTokens: 5,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+				cachedCallCount: 0,
+				cacheReadCallCount: 0,
+				cacheWriteCallCount: 0,
+				tokenUsageEstimatedCallCount: 0,
+			},
+		};
+
+		expect(row.format).toBe(ELIZA_NATIVE_TRAJECTORY_FORMAT);
+		expect(row.schemaVersion).toBe(1);
+		expect(ELIZA_NATIVE_MODEL_BOUNDARIES).toContain(row.boundary);
+		expect(row.trajectoryTotals.llmCallCount).toBe(1);
+		expect(row.cacheStats.totalInputTokens).toBe(
+			row.trajectoryTotals.promptTokens,
+		);
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for `packages/core/src/services/trajectory-types.ts`, which previously had no same-named test file anywhere in the repository. This is a test-only change: no production code is touched and no runtime behavior is modified.

## What the module actually exports

The module's entire runtime surface is two exported constants; everything else it declares (the trajectory record/summary/detail shapes, the export option/result types, and the re-exported retrieval-funnel shapes) is compile-time only:

- `ELIZA_NATIVE_TRAJECTORY_FORMAT` — the `"eliza_native_v1"` format tag embedded in every eliza-native export row.
- `ELIZA_NATIVE_MODEL_BOUNDARIES` — the ordered boundary list `["vercel_ai_sdk.generateText", "vercel_ai_sdk.streamText"]` recorded on those rows.

## What the suite covers

Four deterministic cases drive the real module with no mocks:

1. The format tag equals `"eliza_native_v1"` verbatim and is a string at runtime.
2. `ELIZA_NATIVE_MODEL_BOUNDARIES` equals the two-element list in canonical order, with no duplicate entries.
3. A dynamic import of the module exposes exactly the two runtime bindings (`Object.keys`), confirming the remaining exports are type-only, and both bindings are reference-identical to the static imports.
4. An `ElizaNativeTrajectoryRow` built from the module's own types binds both constants correctly (`format` === `ELIZA_NATIVE_TRAJECTORY_FORMAT`, `schemaVersion` 1, `boundary` contained in `ELIZA_NATIVE_MODEL_BOUNDARIES`) with consistent usage-totals/cache-stats numbers.

No `expectTypeOf` / type-level assertions are used, and no mocks substitute for the module under test.

## Verification (observed on current `origin/develop` @ 3624a59ccb82)

- `bunx vitest run src/services/trajectory-types.test.ts` (in `packages/core`): **Test Files 1 passed (1), Tests 4 passed (4)**. Re-fetched and re-run immediately before filing; develop had not moved.
- `bunx biome check --write src/services/trajectory-types.test.ts`: clean ("Checked 1 file... No fixes applied").
- `bunx tsc --noEmit` in `packages/core`: zero occurrences of `trajectory-types.test` in the output.
- `git diff --stat` versus base: one new file only, +N/-0. No existing test file was rewritten or deleted.

## Notes

- As a fork contributor, hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3624a59ccb823312f73b42334d5a4daf23251c54 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
