### PR TITLE
fix(plugin-finances): keep genuinely distinct identical CSV charges (#26540)

### DIFF
--- a/plugins/plugin-finances/src/db/finances-repository.ts
+++ b/plugins/plugin-finances/src/db/finances-repository.ts
@@ -953,6 +953,7 @@ export class FinancesRepository {
 
   async insertPaymentTransaction(
     transaction: LifeOpsPaymentTransaction,
+    options?: { migrateLegacyContentRow?: boolean },
   ): Promise<boolean> {
     const externalId = transaction.externalId;
     if (externalId) {
@@ -968,10 +969,31 @@ export class FinancesRepository {
           throw new Error("Payment transaction source does not exist.");
         }
         // Match on the external id (the normal idempotency key) OR the row's
-        // deterministic primary-key id. The id fallback replaces a legacy row
-        // that predates external ids on this row (e.g. a CSV row imported when
-        // external_id was still NULL) so the immediately following INSERT of
-        // the same deterministic id does not raise a primary-key violation.
+        // deterministic primary-key id. The id fallback covers a row already
+        // stored under this exact deterministic id, so the immediately
+        // following INSERT does not raise a primary-key violation.
+        //
+        // A legacy CSV row imported before this fix carries a NULL external_id
+        // and a primary-key id derived from a different (now-abandoned) hash
+        // formula, so neither key above can reach it. `migrateLegacyContentRow`
+        // — set only for the occurrence-0 fallback row of an import — adds a
+        // content match that migrates that single legacy survivor in place.
+        // The partial `legacy_tuple_unique` index guarantees at most one
+        // NULL-external row per (agent, source, posted_at, amount, merchant),
+        // and folding `direction` into the match keeps a same-amount opposite-
+        // direction charge from being deleted as a false migration target.
+        const legacyContentMatch = options?.migrateLegacyContentRow
+          ? `
+                OR (
+                  external_id IS NULL
+                  AND posted_at = ${sqlQuote(transaction.postedAt)}
+                  AND amount_usd = ${sqlNumber(transaction.amountUsd)}
+                  AND direction = ${sqlQuote(transaction.direction)}
+                  AND merchant_normalized = ${sqlQuote(
+                    transaction.merchantNormalized,
+                  )}
+                )`
+          : "";
         const existing = await executeRawSqlTx(
           tx,
           `DELETE FROM ${FINANCE_TABLES.paymentTransactions}
@@ -979,7 +1001,7 @@ export class FinancesRepository {
               AND source_id = ${sqlQuote(transaction.sourceId)}
               AND (
                 external_id = ${sqlQuote(externalId)}
-                OR id = ${sqlQuote(transaction.id)}
+                OR id = ${sqlQuote(transaction.id)}${legacyContentMatch}
               )
             RETURNING id`,
         );

--- a/plugins/plugin-finances/src/db/finances-repository.ts
+++ b/plugins/plugin-finances/src/db/finances-repository.ts
@@ -967,12 +967,20 @@ export class FinancesRepository {
         if (source.length === 0) {
           throw new Error("Payment transaction source does not exist.");
         }
+        // Match on the external id (the normal idempotency key) OR the row's
+        // deterministic primary-key id. The id fallback replaces a legacy row
+        // that predates external ids on this row (e.g. a CSV row imported when
+        // external_id was still NULL) so the immediately following INSERT of
+        // the same deterministic id does not raise a primary-key violation.
         const existing = await executeRawSqlTx(
           tx,
           `DELETE FROM ${FINANCE_TABLES.paymentTransactions}
             WHERE agent_id = ${sqlQuote(transaction.agentId)}
               AND source_id = ${sqlQuote(transaction.sourceId)}
-              AND external_id = ${sqlQuote(externalId)}
+              AND (
+                external_id = ${sqlQuote(externalId)}
+                OR id = ${sqlQuote(transaction.id)}
+              )
             RETURNING id`,
         );
         await executeRawSqlTx(tx, paymentTransactionInsertSql(transaction));

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -358,8 +358,9 @@ function buildTransactionId(args: {
   //
   // The Nth genuinely-identical (posted_at, amount, direction, merchant) row
   // gets occurrence index N. Occurrence 0 reuses the bare content-tuple hash
-  // so a pre-fix row (imported when its external id was still NULL) keeps its
-  // deterministic primary key and migrates in place instead of duplicating.
+  // as its deterministic base identity; a pre-fix row (imported when its
+  // external id was still NULL) hashed a different, now-abandoned tuple and is
+  // therefore migrated by content in `insertPaymentTransaction`, not by id.
   // Because reordering cannot distinguish two byte-identical rows, an
   // overlapping export (prepended, trimmed, or reordered) maps each existing
   // charge back onto the same key and stays idempotent, while two distinct
@@ -736,7 +737,12 @@ export class FinancesService {
         metadata: { sourceRowIndex: txn.rowIndex },
         createdAt: new Date().toISOString(),
       };
-      const didInsert = await this.repository.insertPaymentTransaction(record);
+      // Only the occurrence-0 fallback row of a source-external-id-less import
+      // can correspond to a pre-fix NULL-external legacy survivor, so it alone
+      // asks the repository to migrate that legacy content row in place.
+      const didInsert = await this.repository.insertPaymentTransaction(record, {
+        migrateLegacyContentRow: !hasExternalId && occurrenceIndex === 0,
+      });
       if (didInsert) {
         inserted += 1;
       } else {

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -54,6 +54,7 @@ import type {
   AddPaymentSourceRequest,
   ImportTransactionsCsvRequest,
   ImportTransactionsCsvResult,
+  LifeOpsPaymentDirection,
   LifeOpsPaymentSource,
   LifeOpsPaymentSourceKind,
   LifeOpsPaymentsDashboard,
@@ -336,6 +337,7 @@ function buildTransactionId(args: {
   externalId?: string | null;
   postedAt: string;
   amountUsd: number;
+  direction: LifeOpsPaymentDirection;
   merchantNormalized: string;
   occurrenceIndex: number;
 }): string {
@@ -345,9 +347,18 @@ function buildTransactionId(args: {
   // identity so identity depends on WHAT the row is and HOW MANY identical
   // rows precede it in the import — never on the absolute CSV row index.
   //
-  // The Nth genuinely-identical (posted_at, amount, merchant) row gets
-  // occurrence index N. Occurrence 0 reuses the bare content-tuple hash so a
-  // pre-fix row (imported when its external id was still NULL) keeps its
+  // The content tuple carries the normalized debit/credit direction because
+  // parsing stores an absolute `amountUsd` separately from `direction`: a
+  // $4.50 debit and a $4.50 refund otherwise share the same date/amount/
+  // merchant tuple, collapse into one occurrence bucket, and a later trimmed
+  // overlap containing only the refund would map onto occurrence 0 and
+  // overwrite the debit's identity while the debit's charge lingers — losing
+  // the debit and duplicating the credit. Folding direction in keeps the two
+  // sides on independent occurrence sequences with distinct durable ids.
+  //
+  // The Nth genuinely-identical (posted_at, amount, direction, merchant) row
+  // gets occurrence index N. Occurrence 0 reuses the bare content-tuple hash
+  // so a pre-fix row (imported when its external id was still NULL) keeps its
   // deterministic primary key and migrates in place instead of duplicating.
   // Because reordering cannot distinguish two byte-identical rows, an
   // overlapping export (prepended, trimmed, or reordered) maps each existing
@@ -360,6 +371,7 @@ function buildTransactionId(args: {
     args.sourceId,
     args.postedAt,
     args.amountUsd.toFixed(2),
+    args.direction,
     args.merchantNormalized,
   ];
   const key = hasExternalId
@@ -663,12 +675,16 @@ export class FinancesService {
     });
     let inserted = 0;
     let skipped = 0;
-    // Count how many identical (posted_at, amount, merchant) rows have already
-    // been seen in THIS import so each gets a stable per-content occurrence
-    // index. Position-based counting is deliberately avoided so that adding,
-    // removing, or reordering rows around an existing charge does not shift its
-    // identity. Only rows without a source external id use this fallback; a
-    // provided external id is already the row's stable identity.
+    // Count how many identical (posted_at, amount, direction, merchant) rows
+    // have already been seen in THIS import so each gets a stable per-content
+    // occurrence index. Direction is part of the bucket key because a debit and
+    // a same-amount refund must occupy independent occurrence sequences;
+    // otherwise a trimmed overlap containing only the refund would collapse
+    // onto the debit's occurrence 0 and overwrite it. Position-based counting is
+    // deliberately avoided so that adding, removing, or reordering rows around
+    // an existing charge does not shift its identity. Only rows without a
+    // source external id use this fallback; a provided external id is already
+    // the row's stable identity.
     const occurrenceByContent = new Map<string, number>();
     for (const txn of parsed.transactions) {
       const merchantNormalized =
@@ -681,6 +697,7 @@ export class FinancesService {
         const contentKey = [
           txn.postedAt,
           amountUsd.toFixed(2),
+          txn.direction,
           merchantNormalized,
         ].join("|");
         occurrenceIndex = occurrenceByContent.get(contentKey) ?? 0;
@@ -692,6 +709,7 @@ export class FinancesService {
         externalId: txn.externalId,
         postedAt: txn.postedAt,
         amountUsd,
+        direction: txn.direction,
         merchantNormalized,
         occurrenceIndex,
       });

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -338,8 +338,10 @@ function buildTransactionId(args: {
   sourceId: string;
   parsed: ParsedCsvTransaction;
 }): string {
-  // Deterministic id so re-importing the same CSV is idempotent under the
-  // unique (agent, source, posted_at, amount, merchant) constraint.
+  // Deterministic per-row id (and, via `csv:<id>`, the row's external id) so
+  // re-importing the same CSV replays onto the same keys and stays idempotent,
+  // while two genuinely distinct same-day/same-amount/same-merchant rows get
+  // distinct ids through `rowIndex` instead of colliding on the content tuple.
   const key = [
     args.agentId,
     args.sourceId,
@@ -644,15 +646,23 @@ export class FinancesService {
     let inserted = 0;
     let skipped = 0;
     for (const txn of parsed.transactions) {
-      const record: LifeOpsPaymentTransaction = {
-        id: buildTransactionId({
-          agentId: this.agentId(),
-          sourceId,
-          parsed: txn,
-        }),
+      const transactionId = buildTransactionId({
         agentId: this.agentId(),
         sourceId,
-        externalId: txn.externalId,
+        parsed: txn,
+      });
+      const record: LifeOpsPaymentTransaction = {
+        id: transactionId,
+        agentId: this.agentId(),
+        sourceId,
+        // Give every CSV row a stable, per-row-unique external id (the
+        // deterministic hash folds in rowIndex). Two genuinely distinct
+        // same-day/same-amount/same-merchant charges then get distinct keys
+        // and are both stored, while re-importing the identical CSV replays
+        // onto the same external id and stays idempotent. Without a non-null
+        // external id the row falls into the content-only legacy tuple index
+        // and the second real charge is silently dropped.
+        externalId: txn.externalId ?? `csv:${transactionId}`,
         postedAt: txn.postedAt,
         amountUsd: Number(txn.amountUsd.toFixed(2)),
         direction: txn.direction,

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -45,10 +45,7 @@ import {
   requireAgentId,
   requireNonEmptyString,
 } from "./finance-normalize.ts";
-import {
-  type ParsedCsvTransaction,
-  parseTransactionsCsv,
-} from "./payment-csv-import.ts";
+import { parseTransactionsCsv } from "./payment-csv-import.ts";
 import {
   detectRecurringCharges,
   normalizeMerchant,
@@ -336,20 +333,41 @@ function normalizeSourceKind(value: unknown): LifeOpsPaymentSourceKind {
 function buildTransactionId(args: {
   agentId: string;
   sourceId: string;
-  parsed: ParsedCsvTransaction;
+  externalId?: string | null;
+  postedAt: string;
+  amountUsd: number;
+  merchantNormalized: string;
+  occurrenceIndex: number;
 }): string {
-  // Deterministic per-row id (and, via `csv:<id>`, the row's external id) so
-  // re-importing the same CSV replays onto the same keys and stays idempotent,
-  // while two genuinely distinct same-day/same-amount/same-merchant rows get
-  // distinct ids through `rowIndex` instead of colliding on the content tuple.
-  const key = [
+  // A source-provided external id is the lossless, position-independent
+  // identity, so hash it directly: prepending, trimming, or reordering the
+  // export never moves that row. Without one, derive a per-content occurrence
+  // identity so identity depends on WHAT the row is and HOW MANY identical
+  // rows precede it in the import — never on the absolute CSV row index.
+  //
+  // The Nth genuinely-identical (posted_at, amount, merchant) row gets
+  // occurrence index N. Occurrence 0 reuses the bare content-tuple hash so a
+  // pre-fix row (imported when its external id was still NULL) keeps its
+  // deterministic primary key and migrates in place instead of duplicating.
+  // Because reordering cannot distinguish two byte-identical rows, an
+  // overlapping export (prepended, trimmed, or reordered) maps each existing
+  // charge back onto the same key and stays idempotent, while two distinct
+  // same-day/same-amount/same-merchant charges still receive distinct ids.
+  const hasExternalId =
+    typeof args.externalId === "string" && args.externalId.length > 0;
+  const contentKey = [
     args.agentId,
     args.sourceId,
-    args.parsed.postedAt,
-    args.parsed.amountUsd.toFixed(2),
-    args.parsed.merchantNormalized,
-    args.parsed.rowIndex,
-  ].join("|");
+    args.postedAt,
+    args.amountUsd.toFixed(2),
+    args.merchantNormalized,
+  ];
+  const key = hasExternalId
+    ? [args.agentId, args.sourceId, "ext", args.externalId].join("|")
+    : (args.occurrenceIndex === 0
+        ? contentKey
+        : [...contentKey, args.occurrenceIndex]
+      ).join("|");
   return crypto.createHash("sha1").update(key).digest("hex").slice(0, 32);
 }
 
@@ -645,30 +663,55 @@ export class FinancesService {
     });
     let inserted = 0;
     let skipped = 0;
+    // Count how many identical (posted_at, amount, merchant) rows have already
+    // been seen in THIS import so each gets a stable per-content occurrence
+    // index. Position-based counting is deliberately avoided so that adding,
+    // removing, or reordering rows around an existing charge does not shift its
+    // identity. Only rows without a source external id use this fallback; a
+    // provided external id is already the row's stable identity.
+    const occurrenceByContent = new Map<string, number>();
     for (const txn of parsed.transactions) {
+      const merchantNormalized =
+        txn.merchantNormalized || normalizeMerchant(txn.merchantRaw);
+      const amountUsd = Number(txn.amountUsd.toFixed(2));
+      const hasExternalId =
+        typeof txn.externalId === "string" && txn.externalId.length > 0;
+      let occurrenceIndex = 0;
+      if (!hasExternalId) {
+        const contentKey = [
+          txn.postedAt,
+          amountUsd.toFixed(2),
+          merchantNormalized,
+        ].join("|");
+        occurrenceIndex = occurrenceByContent.get(contentKey) ?? 0;
+        occurrenceByContent.set(contentKey, occurrenceIndex + 1);
+      }
       const transactionId = buildTransactionId({
         agentId: this.agentId(),
         sourceId,
-        parsed: txn,
+        externalId: txn.externalId,
+        postedAt: txn.postedAt,
+        amountUsd,
+        merchantNormalized,
+        occurrenceIndex,
       });
       const record: LifeOpsPaymentTransaction = {
         id: transactionId,
         agentId: this.agentId(),
         sourceId,
-        // Give every CSV row a stable, per-row-unique external id (the
-        // deterministic hash folds in rowIndex). Two genuinely distinct
-        // same-day/same-amount/same-merchant charges then get distinct keys
-        // and are both stored, while re-importing the identical CSV replays
-        // onto the same external id and stays idempotent. Without a non-null
-        // external id the row falls into the content-only legacy tuple index
-        // and the second real charge is silently dropped.
+        // Give every CSV row a stable, non-null external id so it never falls
+        // into the content-only legacy tuple index that silently dropped a
+        // second identical charge. A source-provided id is used as-is; rows
+        // without one get a synthetic key derived from the per-content
+        // occurrence identity, which is stable across re-imports regardless of
+        // row order, so overlapping exports replay in place instead of
+        // duplicating.
         externalId: txn.externalId ?? `csv:${transactionId}`,
         postedAt: txn.postedAt,
-        amountUsd: Number(txn.amountUsd.toFixed(2)),
+        amountUsd,
         direction: txn.direction,
         merchantRaw: txn.merchantRaw,
-        merchantNormalized:
-          txn.merchantNormalized || normalizeMerchant(txn.merchantRaw),
+        merchantNormalized,
         description: txn.description,
         category: txn.category,
         currency: txn.currency,

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -1196,6 +1196,127 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
       expect(replayData.receipt).toBeUndefined();
     });
 
+    it("records two genuinely distinct identical charges instead of dropping the second (regression #26540)", async () => {
+      const source = await service.addPaymentSource({
+        kind: "csv",
+        label: "Duplicate-charge account",
+      });
+      // Two real purchases that happen to share date, amount, and merchant —
+      // e.g. two identical $4.50 coffees at the same shop on the same day.
+      // The content-only legacy tuple used to collapse these into one row,
+      // silently undercounting the owner's real spend.
+      const recentDate = new Date(Date.now() - 3 * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      const csvText = `Date,Description,Amount\n${recentDate},Blue Bottle Coffee,-4.50\n${recentDate},Blue Bottle Coffee,-4.50\n`;
+
+      const before = await service.getSpendingSummary({ sourceId: source.id });
+      expect(before.totalSpendUsd).toBe(0);
+
+      const result = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText,
+      });
+      // Both legitimate charges are inserted; neither is skipped as a false
+      // content-duplicate.
+      expect(result.rowsRead).toBe(2);
+      expect(result.inserted).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toEqual([]);
+
+      const storedCount = await repository.countPaymentTransactionsForSource(
+        runtime.agentId,
+        source.id,
+      );
+      expect(storedCount).toBe(2);
+
+      // Each stored row carries a distinct, non-null external id derived from
+      // its CSV row index, so both real charges have durable identity.
+      const stored = await repository.listPaymentTransactions(runtime.agentId, {
+        sourceId: source.id,
+      });
+      expect(stored).toHaveLength(2);
+      const externalIds = stored.map((row) => row.externalId);
+      expect(
+        externalIds.every((id) => typeof id === "string" && id.length > 0),
+      ).toBe(true);
+      expect(new Set(externalIds).size).toBe(2);
+
+      // The corrected spend now reflects BOTH purchases ($9.00), not one.
+      const after = await service.getSpendingSummary({ sourceId: source.id });
+      expect(after.transactionCount).toBe(2);
+      expect(after.totalSpendUsd).toBeCloseTo(9.0, 2);
+
+      // Re-importing the identical CSV is idempotent: the same external ids
+      // replay in place, so nothing new is inserted and the totals hold.
+      const replay = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText,
+      });
+      expect(replay.inserted).toBe(0);
+      expect(replay.skipped).toBe(2);
+      const afterReplayCount =
+        await repository.countPaymentTransactionsForSource(
+          runtime.agentId,
+          source.id,
+        );
+      expect(afterReplayCount).toBe(2);
+      const afterReplay = await service.getSpendingSummary({
+        sourceId: source.id,
+      });
+      expect(afterReplay.totalSpendUsd).toBeCloseTo(9.0, 2);
+
+      // Upgrade path: a row imported before this fix carries a NULL external_id
+      // but the same deterministic primary-key id. Only ONE such row can exist
+      // per content tuple (the partial legacy_tuple_unique index forbade the
+      // second — that was the original drop bug), so reconstruct exactly that
+      // survivor: keep the first CSV row with a NULL external_id and remove the
+      // second so the legacy single-row state is reproduced deterministically.
+      const [rowOne, rowTwo] = stored;
+      await repository.deletePaymentTransactionById(runtime.agentId, rowTwo.id);
+      await executeRawSql(
+        runtime,
+        `UPDATE app_finances.life_payment_transactions
+            SET external_id = NULL
+          WHERE agent_id = '${runtime.agentId}'
+            AND id = '${rowOne.id}'`,
+      );
+      const legacyRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(legacyRows).toHaveLength(1);
+      expect(legacyRows[0].externalId).toBeNull();
+
+      // Re-importing the two-row CSV must NOT raise a primary-key violation on
+      // the legacy row (matched by its deterministic id) and must RECOVER the
+      // previously dropped second charge, restoring the true count of two.
+      const upgradeReplay = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText,
+      });
+      expect(upgradeReplay.inserted).toBe(1);
+      expect(upgradeReplay.skipped).toBe(1);
+      const upgradeCount = await repository.countPaymentTransactionsForSource(
+        runtime.agentId,
+        source.id,
+      );
+      expect(upgradeCount).toBe(2);
+      const upgradedRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      // Every row now carries a durable, distinct csv external id.
+      expect(
+        upgradedRows.every(
+          (row) =>
+            typeof row.externalId === "string" &&
+            row.externalId.startsWith("csv:"),
+        ),
+      ).toBe(true);
+      expect(new Set(upgradedRows.map((row) => row.externalId)).size).toBe(2);
+    });
+
     it("balances derives per-source figures with freshness metadata", async () => {
       const source = await service.addPaymentSource({
         kind: "manual",

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -1317,6 +1317,123 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
       expect(new Set(upgradedRows.map((row) => row.externalId)).size).toBe(2);
     });
 
+    it("does not duplicate existing charges when an overlapping export is reordered, prepended, or trimmed (regression #26540)", async () => {
+      const source = await service.addPaymentSource({
+        kind: "csv",
+        label: "Overlapping-export account",
+      });
+      const day = (n: number) =>
+        new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
+      // Three genuinely distinct charges (distinct content tuples).
+      const rowA = `${day(5)},Rent,-1500.00`;
+      const rowB = `${day(4)},Blue Bottle Coffee,-4.50`;
+      const rowC = `${day(3)},Netflix,-12.34`;
+      const csv = (rows: string[]) =>
+        `Date,Description,Amount\n${rows.join("\n")}\n`;
+
+      // Initial export carries two of the charges.
+      const first = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([rowB, rowC]),
+      });
+      expect(first.inserted).toBe(2);
+      expect(first.skipped).toBe(0);
+      const firstRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(firstRows).toHaveLength(2);
+      // Remember each carried-over charge's durable identity.
+      const idByExternalId = new Map(
+        firstRows.map((row) => [row.externalId, row.id]),
+      );
+
+      // Second export PREPENDS a brand-new charge and REORDERS the two
+      // existing ones. Every existing row's absolute CSV row index changes,
+      // yet only the genuinely new charge is inserted; the two overlapping
+      // charges replay in place and are NOT duplicated.
+      const second = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([rowA, rowC, rowB]),
+      });
+      expect(second.inserted).toBe(1);
+      expect(second.skipped).toBe(2);
+      const afterPrepend = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterPrepend).toHaveLength(3);
+      expect(new Set(afterPrepend.map((row) => row.externalId)).size).toBe(3);
+      // The carried-over charges kept their exact primary-key id and external
+      // id despite the reorder/prepend.
+      for (const [externalId, id] of idByExternalId) {
+        const match = afterPrepend.find((row) => row.externalId === externalId);
+        expect(match?.id).toBe(id);
+      }
+
+      // Third export TRIMS the file down to a single overlapping row. Import is
+      // additive and idempotent: the surviving charge replays in place and
+      // nothing is duplicated (the untrimmed rows remain, still distinct).
+      const third = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([rowC]),
+      });
+      expect(third.inserted).toBe(0);
+      expect(third.skipped).toBe(1);
+      const afterTrim = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterTrim).toHaveLength(3);
+      expect(new Set(afterTrim.map((row) => row.externalId)).size).toBe(3);
+    });
+
+    it("keeps genuinely repeated identical rows distinct when an overlapping export shifts their position (regression #26540)", async () => {
+      const source = await service.addPaymentSource({
+        kind: "csv",
+        label: "Repeated-identical account",
+      });
+      const d = new Date(Date.now() - 2 * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      const coffee = `${d},Blue Bottle Coffee,-4.50`;
+      const rent = `${d},Rent,-1500.00`;
+      const csv = (rows: string[]) =>
+        `Date,Description,Amount\n${rows.join("\n")}\n`;
+
+      // Two genuinely distinct but byte-identical coffee charges.
+      const first = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([coffee, coffee]),
+      });
+      expect(first.inserted).toBe(2);
+      const firstRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      const coffeeIdsBefore = new Set(firstRows.map((row) => row.id));
+      expect(coffeeIdsBefore.size).toBe(2);
+
+      // An overlapping export prepends a distinct charge, shifting BOTH
+      // coffees' absolute row index. Both must replay in place: still two
+      // distinct rows, never collapsed into one and never duplicated into four.
+      const second = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([rent, coffee, coffee]),
+      });
+      expect(second.inserted).toBe(1);
+      expect(second.skipped).toBe(2);
+      const afterRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterRows).toHaveLength(3);
+      const coffeeRows = afterRows.filter((row) => row.amountUsd === 4.5);
+      expect(coffeeRows).toHaveLength(2);
+      expect(new Set(coffeeRows.map((row) => row.id))).toEqual(coffeeIdsBefore);
+      expect(new Set(coffeeRows.map((row) => row.externalId)).size).toBe(2);
+    });
+
     it("balances derives per-source figures with freshness metadata", async () => {
       const source = await service.addPaymentSource({
         kind: "manual",

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -1434,6 +1434,116 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
       expect(new Set(coffeeRows.map((row) => row.externalId)).size).toBe(2);
     });
 
+    it("keeps an equal-amount debit and credit distinct across overlapping prepend/trim/reorder/replay imports (regression #26540)", async () => {
+      const source = await service.addPaymentSource({
+        kind: "csv",
+        label: "Opposite-direction account",
+      });
+      const d = new Date(Date.now() - 2 * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      // Same date, same merchant, same $4.50 magnitude, opposite directions:
+      // a debit charge and a same-amount refund. Because parsing stores the
+      // absolute amount separately from direction, these share their entire
+      // (posted_at, amount, merchant) content tuple and only differ by
+      // debit/credit. `-4.50` parses as a debit; `4.50` parses as a credit.
+      const debit = `${d},Blue Bottle Coffee,-4.50`;
+      const credit = `${d},Blue Bottle Coffee,4.50`;
+      const rent = `${d},Rent,-1500.00`;
+      const csv = (rows: string[]) =>
+        `Date,Description,Amount\n${rows.join("\n")}\n`;
+
+      // Import both sides. They must be stored as two distinct rows, never
+      // collapsed into one occurrence bucket.
+      const first = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([debit, credit]),
+      });
+      expect(first.inserted).toBe(2);
+      expect(first.skipped).toBe(0);
+      const firstRows = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(firstRows).toHaveLength(2);
+      const debitRow = firstRows.find((row) => row.direction === "debit");
+      const creditRow = firstRows.find((row) => row.direction === "credit");
+      expect(debitRow).toBeDefined();
+      expect(creditRow).toBeDefined();
+      expect(debitRow?.id).not.toBe(creditRow?.id);
+      expect(new Set(firstRows.map((row) => row.externalId)).size).toBe(2);
+      const debitId = debitRow?.id;
+      const debitExternalId = debitRow?.externalId;
+      const creditId = creditRow?.id;
+      const creditExternalId = creditRow?.externalId;
+
+      // TRIM to only the credit (the refund). Under a direction-blind identity
+      // this would map the refund onto the debit's occurrence 0, overwrite the
+      // debit, and leave the original credit behind — losing the debit and
+      // duplicating the credit. With direction in the content key the refund
+      // replays onto its own identity: nothing new, debit untouched.
+      const trimmed = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([credit]),
+      });
+      expect(trimmed.inserted).toBe(0);
+      expect(trimmed.skipped).toBe(1);
+      const afterTrim = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterTrim).toHaveLength(2);
+      const trimDebit = afterTrim.find((row) => row.direction === "debit");
+      const trimCredit = afterTrim.find((row) => row.direction === "credit");
+      // The debit survives with its exact identity; the credit is not
+      // duplicated and keeps its identity.
+      expect(trimDebit?.id).toBe(debitId);
+      expect(trimDebit?.externalId).toBe(debitExternalId);
+      expect(trimCredit?.id).toBe(creditId);
+      expect(trimCredit?.externalId).toBe(creditExternalId);
+      expect(
+        afterTrim.filter((row) => row.direction === "credit"),
+      ).toHaveLength(1);
+
+      // PREPEND a distinct charge and REORDER the two existing sides. Only the
+      // new charge inserts; both opposite-direction charges replay in place
+      // with unchanged durable identity despite the position shuffle.
+      const reordered = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([rent, credit, debit]),
+      });
+      expect(reordered.inserted).toBe(1);
+      expect(reordered.skipped).toBe(2);
+      const afterReorder = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterReorder).toHaveLength(3);
+      expect(new Set(afterReorder.map((row) => row.externalId)).size).toBe(3);
+      const reDebit = afterReorder.find(
+        (row) => row.direction === "debit" && row.amountUsd === 4.5,
+      );
+      const reCredit = afterReorder.find((row) => row.direction === "credit");
+      expect(reDebit?.id).toBe(debitId);
+      expect(reDebit?.externalId).toBe(debitExternalId);
+      expect(reCredit?.id).toBe(creditId);
+      expect(reCredit?.externalId).toBe(creditExternalId);
+
+      // REPLAY the full opposite-direction export: fully idempotent.
+      const replay = await service.importTransactionsCsv({
+        sourceId: source.id,
+        csvText: csv([debit, credit]),
+      });
+      expect(replay.inserted).toBe(0);
+      expect(replay.skipped).toBe(2);
+      const afterReplay = await repository.listPaymentTransactions(
+        runtime.agentId,
+        { sourceId: source.id },
+      );
+      expect(afterReplay).toHaveLength(3);
+      expect(new Set(afterReplay.map((row) => row.externalId)).size).toBe(3);
+    });
+
     it("balances derives per-source figures with freshness metadata", async () => {
       const source = await service.addPaymentSource({
         kind: "manual",

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -14,6 +14,7 @@
  * behavior execute against the real database.
  */
 
+import { createHash } from "node:crypto";
 import type { AgentRuntime, HandlerOptions, Memory } from "@elizaos/core";
 import {
   PlaidManagedClient,
@@ -1267,30 +1268,49 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
       expect(afterReplay.totalSpendUsd).toBeCloseTo(9.0, 2);
 
       // Upgrade path: a row imported before this fix carries a NULL external_id
-      // but the same deterministic primary-key id. Only ONE such row can exist
-      // per content tuple (the partial legacy_tuple_unique index forbade the
-      // second — that was the original drop bug), so reconstruct exactly that
-      // survivor: keep the first CSV row with a NULL external_id and remove the
-      // second so the legacy single-row state is reproduced deterministically.
+      // AND a primary-key id from the abandoned pre-fix formula, which hashed
+      // (agent, source, posted_at, amount, merchant, absoluteRowIndex) — not
+      // the current content tuple. Only ONE such row can exist per content
+      // tuple (the partial legacy_tuple_unique index forbade the second — that
+      // was the original drop bug), so reproduce exactly that survivor: drop
+      // both new-format rows and insert a genuine legacy row whose id is the
+      // real pre-fix SHA-1 (rowIndex=1 for the first data row) with a NULL
+      // external_id. The migration must recover it by CONTENT, since its id can
+      // never be reconstructed from the current formula.
       const [rowOne, rowTwo] = stored;
+      await repository.deletePaymentTransactionById(runtime.agentId, rowOne.id);
       await repository.deletePaymentTransactionById(runtime.agentId, rowTwo.id);
-      await executeRawSql(
-        runtime,
-        `UPDATE app_finances.life_payment_transactions
-            SET external_id = NULL
-          WHERE agent_id = '${runtime.agentId}'
-            AND id = '${rowOne.id}'`,
-      );
+      const legacyId = createHash("sha1")
+        .update(
+          [
+            runtime.agentId,
+            source.id,
+            rowOne.postedAt,
+            rowOne.amountUsd.toFixed(2),
+            rowOne.merchantNormalized,
+            1,
+          ].join("|"),
+        )
+        .digest("hex")
+        .slice(0, 32);
+      expect(legacyId).not.toBe(rowOne.id);
+      const legacyInserted = await repository.insertPaymentTransaction({
+        ...rowOne,
+        id: legacyId,
+        externalId: null,
+      });
+      expect(legacyInserted).toBe(true);
       const legacyRows = await repository.listPaymentTransactions(
         runtime.agentId,
         { sourceId: source.id },
       );
       expect(legacyRows).toHaveLength(1);
+      expect(legacyRows[0].id).toBe(legacyId);
       expect(legacyRows[0].externalId).toBeNull();
 
-      // Re-importing the two-row CSV must NOT raise a primary-key violation on
-      // the legacy row (matched by its deterministic id) and must RECOVER the
-      // previously dropped second charge, restoring the true count of two.
+      // Re-importing the two-row CSV must NOT double-count the legacy survivor:
+      // its content — not its unreconstructable id — is migrated in place, and
+      // the previously dropped second charge is recovered, restoring two rows.
       const upgradeReplay = await service.importTransactionsCsv({
         sourceId: source.id,
         csvText,


### PR DESCRIPTION
# Relates to

Closes #26540

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks were run (see **Known gaps / failures** for the repo-wide `verify` blocker).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** for the pre-existing, unrelated blockers on this machine.

# Risks

Low. The change is bounded to `@elizaos/plugin-finances`. It alters how CSV-imported transactions are keyed (populating a per-row `external_id`) and hardens the shared external-id insert path so a re-import cannot raise a primary-key violation. No schema/migration change (the split-index constraint already landed in #23167); Plaid/PayPal paths are unchanged in behavior (their `id` is a random UUID that never matches the added deterministic-id fallback).

# Background

## What does this PR do?

CSV-imported transactions were persisted with a **NULL `external_id`**, which routes them into the content-only partial unique index `life_payment_transactions_legacy_tuple_unique` on `(agent_id, source_id, posted_at, amount_usd, merchant_normalized)`. Two genuinely distinct charges that happen to share date + amount + merchant — e.g. **two identical $4.50 coffees at the same shop on the same day** — collided on that key, so the second real charge was silently dropped: CSV import reported it as `skipped` and it never entered the DB. This undercounts real spend, transaction counts, spending summaries, and recurring-charge detection — a data-integrity defect in a finance product. The CSV path already builds a per-row-unique primary-key `id` (`buildTransactionId` folds in `rowIndex`), showing the intent was to keep each row distinct; the content-based key defeated that `id`.

The fix makes transaction identity **per-real-transaction** rather than **per-content** for CSV rows:

1. Give every CSV row a stable, non-null `external_id` derived from the deterministic `buildTransactionId` hash (which already includes the CSV `rowIndex`): `csv:<id>`. Distinct rows now get distinct keys and are both stored via the non-unique provider-id index (`life_payment_transactions_provider_id_idx`), while re-importing the identical CSV replays onto the same `external_id` and stays idempotent.
2. Harden the external-id insert path (`FinancesRepository.insertPaymentTransaction`) to also match a row by its deterministic primary-key `id`. Re-importing a CSV whose rows were persisted **before** this fix (`external_id` NULL, same deterministic `id`) then replaces the legacy row in place instead of raising a primary-key violation — and recovers the previously dropped charge. Plaid/PayPal are unaffected because their `id` is a fresh UUID that never matches an existing row.

The Plaid/PayPal `external_id` upsert, `delta.modified` in-place update, and `delta.removed` deletion described in the original issue already landed in #23167; the CSV drop was the remaining reproducible core.

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity issue).

# Documentation changes needed?

No. Behavior is corrected to match the documented per-row import intent; no public API or config surface changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-finances/test/finances.real-db.test.ts` → the new real-PGLite test **"records two genuinely distinct identical charges instead of dropping the second (regression #26540)"**. It boots a real PGLite-backed runtime, registers `financesPlugin` so the SQL plugin materializes `app_finances`, and exercises `FinancesService.importTransactionsCsv` against the live DB.

## Detailed testing steps

```bash
bun install
# regenerate the core i18n keyword artifact on a fresh checkout if needed:
node packages/shared/scripts/generate-keywords.mjs

# failing-before / passing-after (real DB):
bunx --cwd plugins/plugin-finances vitest run --config ./vitest.config.ts \
  test/finances.real-db.test.ts -t "regression #26540"
```

The test asserts, against the real database:
- import CSV with two identical `2024-03-15, Blue Bottle Coffee, -4.50` rows → `inserted=2`, `skipped=0`, stored `count=2`;
- both rows carry distinct, non-null `csv:` external ids;
- corrected `getSpendingSummary().totalSpendUsd` = **$9.00** (was $4.50), `transactionCount=2`;
- re-import the identical CSV → `inserted=0`, `skipped=2`, count stays 2 (idempotent);
- upgrade path: reconstruct a legacy single row with `external_id=NULL` sharing the deterministic id, re-import → **no primary-key violation**, the previously dropped charge is recovered (count=2), every row re-keyed with a durable `csv:` external id.

# Evidence Gate

<!-- evidence-head:5b51a0d46096806d7e1917c95c67bee720ae8512 -->

<!-- evidence-row:before-screenshots -->
- [ ] `N/A - back-end data-integrity fix in @elizaos/plugin-finances; no rendered UI surface changed.`
<!-- evidence-row:after-screenshots -->
- [ ] `N/A - back-end data-integrity fix; no rendered UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - no UI flow; the corrected path is proven by the real-DB regression test and logs below.`
<!-- evidence-row:backend-logs -->
- [x] Real-DB regression test output (structured Vitest run against live PGLite), captured on the current PR head `5b51a0d4` after making the legacy-upgrade path migrate a pre-fix NULL-`external_id` row by CONTENT rather than by an unreconstructable deterministic id: **26 passed (26)**. The upgrade regression now reconstructs the genuine pre-fix SHA-1 id (the abandoned `(agent, source, posted_at, amount, merchant, absoluteRowIndex)` formula, `rowIndex=1`) and was confirmed to FAIL against this head's prior implementation (`expected 2 to be 1` — both new rows inserted beside the surviving legacy row, double-counting the charge) and to pass on the fix.

<details>
<summary>Backend logs — passing-after on PR head `5b51a0d4` (real PGLite), all four #26540 regressions by name</summary>

Command (cwd `plugins/plugin-finances`): `bun run vitest run --config ./vitest.config.ts test/finances.real-db.test.ts -t "regression #26540" --reporter=verbose` — bun 1.3.14 / vitest 4.1.10.

```
 RUN  v4.1.10 /…/plugins/plugin-finances

 ✓ … real PGLite > … (real DB) > records two genuinely distinct identical charges instead of dropping the second (regression #26540) 123ms
 ✓ … real PGLite > … (real DB) > does not duplicate existing charges when an overlapping export is reordered, prepended, or trimmed (regression #26540) 43ms
 ✓ … real PGLite > … (real DB) > keeps genuinely repeated identical rows distinct when an overlapping export shifts their position (regression #26540) 33ms
 ✓ … real PGLite > … (real DB) > keeps an equal-amount debit and credit distinct across overlapping prepend/trim/reorder/replay imports (regression #26540) 56ms

 Test Files  1 passed (1)
      Tests  4 passed | 22 skipped (26)
   Duration  52.79s (transform 36.02s, setup 566ms, import 42.19s, tests 9.66s)
```

Whole-file run (`… test/finances.real-db.test.ts`, no `-t` filter): `Test Files 1 passed (1) / Tests 26 passed (26) / Duration 35.06s`.
</details>

<details>
<summary>Backend logs — failing-before on prior src (rowIndex identity restored, tests kept)</summary>

```
 # Upgrade-path regression fails when only the production fix is reverted
 # (test kept, real pre-fix id reconstructed) — proving it captures the
 # double-count the reviewer reported at head b9051067:
 FAIL  test/finances.real-db.test.ts > ... > records two genuinely distinct identical charges instead of dropping the second (regression #26540)
 AssertionError: expected 2 to be 1 // Object.is equality
 1318|       expect(upgradeReplay.inserted).toBe(1);
      |                                     ^
   (both new csv: rows inserted beside the surviving legacy NULL-external row)

 Test Files  1 failed (1)
      Tests  1 failed | 25 skipped (26)
```

Original #26540 drop bug (src fully reverted on `origin/develop`, test kept):

```
 FAIL  test/finances.real-db.test.ts > ... > records two genuinely distinct identical charges instead of dropping the second (regression #26540)
 AssertionError: expected 1 to be 2 // Object.is equality
 1223|       expect(result.inserted).toBe(2);
      |                               ^
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/action/provider/prompt/model behavior changed; this is a repository/DB persistence fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: DB-backed transaction counts, distinct external ids, and before/after spending-summary totals asserted against the real database.

<details>
<summary>Domain artifacts — printed live-DB round-trip on head `5b51a0d4` (real PGLite)</summary>

Values below are printed directly from the live database (insert → read-back) by driving `FinancesService.importTransactionsCsv` + `FinancesRepository` against the real `app_finances` tables — the same numbers the `regression #26540` test asserts.

```
=== PR #26554 / issue #26540 — real PGLite domain artifact ===
Input CSV: two identical rows  Blue Bottle Coffee, -4.50 (same date)

[before import]  totalSpendUsd=0  transactionCount=0

[initial import (real DB)]
  rowsRead=2  inserted=2  skipped=0  errors=[]
  stored rows=2
  distinct external ids=2 -> ["csv:be4cf5a4eb53ef82a67b61c250eeb79f","csv:135a6cafc1cf736951133c5d872d7bf7"]
  corrected totalSpendUsd=9  transactionCount=2

[re-import identical CSV (idempotent)]
  inserted=0  skipped=2  storedCount=2

[legacy state reconstructed]  rows=1  external_id=[null]  id=<genuine pre-fix SHA-1, rowIndex=1>

[legacy upgrade re-import (NULL external_id migrated by content, not id)]
  inserted=1  skipped=1  -> legacy survivor migrated in place, no double count
  recovered storedCount=2
  durable external ids=["csv:be4cf5a4eb53ef82a67b61c250eeb79f","csv:135a6cafc1cf736951133c5d872d7bf7"]
```

Before the fix the second identical $4.50 charge was silently dropped (`inserted=1, skipped=1, totalSpendUsd=4.50, count=1`); after the fix both genuine charges persist with distinct `csv:` external ids (`totalSpendUsd=9.00, count=2`), re-import is idempotent, and the legacy NULL-`external_id` upgrade path recovers the dropped charge by matching the survivor on its content tuple (including normalized direction) — the pre-fix id is unreconstructable from the current formula, so a content match, not an id match, is what migrates it in place.
</details>

<!-- evidence-row:ocr-review -->
- [ ] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed.`

## Backend + frontend logs

Backend (real PGLite): the same new regression test **fails on `origin/develop` and passes with this fix**.

<details>
<summary>Failing before (src reverted to origin/develop, new test kept) — <code>expected 1 to be 2</code></summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-26540/plugins/plugin-finances

 ❯ test/finances.real-db.test.ts (23 tests | 1 failed | 22 skipped) 7617ms
       × records two genuinely distinct identical charges instead of dropping the second (regression #26540) 64ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > records two genuinely distinct identical charges instead of dropping the second (regression #26540)
AssertionError: expected 1 to be 2 // Object.is equality

- Expected
+ Received

- 2
+ 1

 ❯ test/finances.real-db.test.ts:1223:31
    1221|       // content-duplicate.
    1222|       expect(result.rowsRead).toBe(2);
    1223|       expect(result.inserted).toBe(2);
       |                               ^
    1224|       expect(result.skipped).toBe(0);
    1225|       expect(result.errors).toEqual([]);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 22 skipped (23)
   Start at  21:03:09
   Duration  31.35s (transform 19.40s, setup 191ms, import 23.31s, tests 7.62s, environment 0ms)
```
</details>

<details>
<summary>Passing after (with the fix) — regression #26540 + existing import_csv idempotency</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-26540/plugins/plugin-finances

 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > creates a payment source and reads it back via the repository
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > rejects generic Plaid metadata before it can persist a local secret
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > startup credential sweep scrubs dormant Plaid tokens in the real database
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > persists only an opaque Plaid connection and revokes it before deletion
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > revokes the Cloud connection when local source persistence fails
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > drains Plaid pagination beyond the former 20-page ceiling
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > rejects a Plaid cursor cycle without advancing state or persisting a partial delta
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > scrubs dormant legacy Plaid secrets during startup migration without API access
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > keeps distinct Plaid ids even when every legacy uniqueness field matches
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > preserves typed relink errors and persists a visible needs-attention state
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > restarts mutation-during-pagination and atomically applies added, modified, and removed rows
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > serializes concurrent cursor windows and replays the stale caller
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > rolls back every Plaid sync write when a later transaction insert fails
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > inserts transactions and lists / spending round-trips against the real DB
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > detects a recurring charge from real monthly transactions
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > deletePaymentSource cascades transaction deletion in the real DB
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > upsertBillFromEmail is idempotent by source message id (real DB)
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > add_source and remove_source return internal-write receipts
 ✓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > import_csv issues a receipt only when rows were actually inserted 81ms
 ✓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > records two genuinely distinct identical charges instead of dropping the second (regression #26540) 107ms
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > balances derives per-source figures with freshness metadata
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > budget_status rejects a missing budget and evaluates a supplied one
 ↓ test/finances.real-db.test.ts > FinancesService + FinancesRepository — real PGLite > normalized capability subactions via runPaymentsHandler (real DB) > anomalies flags a real duplicate charge and subscriptions handles empty data

 Test Files  1 passed (1)
      Tests  2 passed | 21 skipped (23)
   Start at  21:04:02
   Duration  31.21s (transform 19.24s, setup 192ms, import 23.18s, tests 7.63s, environment 0ms)
```
</details>

Frontend: `N/A - no frontend surface in this change.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no rendered UI surface changed.`

### After

`N/A - no rendered UI surface changed.`

### Walkthrough video

`N/A - back-end data-integrity fix; the corrected persistence is proven by the real-DB test above.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface in this change.`

## Known gaps / failures

- `bun run verify` (repo-wide) was not run to completion on this machine:
  - `bun run --cwd plugins/plugin-finances typecheck` reports errors only in **unrelated, unbuilt workspace packages** (`@elizaos/vault`, `@elizaos/cloud-routing`, `@elizaos/plugin-google-workspace` module resolution and downstream `any` in `gmail-seam.ts`); **none are in the files this PR changes**. My changed files (`finances-service.ts`, `finances-repository.ts`, the test) produce zero type errors.
  - `bun run --cwd plugins/plugin-finances test` has **4 pre-existing failures** in `src/components/finances/format-minor.test.ts` and `FinancesView.test.tsx` caused by an ICU/`Intl` currency-symbol difference on this environment (`US$`/`JP¥` vs `$`/`¥`). They fail identically on the untouched `origin/develop` tree (verified by stashing this PR's changes) and are unrelated to this fix. All 23 tests in the touched `test/finances.real-db.test.ts` suite pass, and `test/plaid-lifecycle.real-db.test.ts` (which shares `insertPaymentTransaction`) passes (38/38 together).
  - Fresh checkouts need `node packages/shared/scripts/generate-keywords.mjs` to materialize the generated core i18n artifact before running the suite.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@b9051067e8cb43972bf09fcfddc15a055f9c9138:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@b9051067e8cb43972bf09fcfddc15a055f9c9138:packages/skills/skills/contribute-to-eliza"} -->



