### PR TITLE
test(core): cover retry

### DIFF
--- a/packages/core/src/utils/retry.backoff.test.ts
+++ b/packages/core/src/utils/retry.backoff.test.ts
@@ -5,6 +5,12 @@
  */
 import { describe, expect, it } from "vitest";
 import { type BackoffPolicy, computeBackoff, sleepWithAbort } from "./retry";
+import {
+	type RetryInfo,
+	resolveRetryConfig,
+	retryAsync,
+	sleep,
+} from "./retry.js";
 
 const noJitter: BackoffPolicy = {
 	initialMs: 100,
@@ -66,5 +72,297 @@ describe("sleepWithAbort abort signal listener cleanup", () => {
 		const promise = sleepWithAbort(1000, controller.signal);
 		controller.abort();
 		await expect(promise).rejects.toThrow("aborted");
+	});
+});
+
+describe("sleep", () => {
+	it("resolves after waiting at least the requested duration", async () => {
+		const started = Date.now();
+		await sleep(10);
+		expect(Date.now() - started).toBeGreaterThanOrEqual(9);
+	});
+});
+
+describe("sleepWithAbort zero-duration edge", () => {
+	it("resolves immediately for ms <= 0 even when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(sleepWithAbort(0, controller.signal)).resolves.toBeUndefined();
+	});
+});
+
+describe("resolveRetryConfig", () => {
+	it("returns the built-in defaults when overrides are omitted", () => {
+		expect(resolveRetryConfig()).toEqual({
+			attempts: 3,
+			minDelayMs: 300,
+			maxDelayMs: 30_000,
+			jitter: 0,
+		});
+	});
+
+	it("honors custom defaults when no overrides are given", () => {
+		expect(
+			resolveRetryConfig({
+				attempts: 5,
+				minDelayMs: 10,
+				maxDelayMs: 100,
+				jitter: 0.5,
+			}),
+		).toEqual({ attempts: 5, minDelayMs: 10, maxDelayMs: 100, jitter: 0.5 });
+	});
+
+	it("rounds fractional attempt counts and floors them at one", () => {
+		expect(resolveRetryConfig(undefined, { attempts: 2.6 }).attempts).toBe(3);
+		expect(resolveRetryConfig(undefined, { attempts: 0 }).attempts).toBe(1);
+		expect(resolveRetryConfig(undefined, { attempts: -5 }).attempts).toBe(1);
+	});
+
+	it("falls back to default attempts for non-finite overrides", () => {
+		const custom = { attempts: 7 };
+		expect(resolveRetryConfig(custom, { attempts: Number.NaN }).attempts).toBe(
+			7,
+		);
+		expect(
+			resolveRetryConfig(custom, { attempts: Number.POSITIVE_INFINITY })
+				.attempts,
+		).toBe(7);
+	});
+
+	it("clamps negative minDelayMs to zero", () => {
+		expect(resolveRetryConfig(undefined, { minDelayMs: -50 }).minDelayMs).toBe(
+			0,
+		);
+	});
+
+	it("raises maxDelayMs to minDelayMs when it would be lower", () => {
+		expect(
+			resolveRetryConfig(undefined, { minDelayMs: 200, maxDelayMs: 50 })
+				.maxDelayMs,
+		).toBe(200);
+	});
+
+	it("clamps jitter into [0, 1]", () => {
+		expect(resolveRetryConfig(undefined, { jitter: 1.5 }).jitter).toBe(1);
+		expect(resolveRetryConfig(undefined, { jitter: -0.2 }).jitter).toBe(0);
+	});
+});
+
+describe("retryAsync numeric-attempts style", () => {
+	it("resolves on the first success without retrying", async () => {
+		let calls = 0;
+		const result = await retryAsync(async () => {
+			calls += 1;
+			return "ok";
+		}, 3);
+		expect(result).toBe("ok");
+		expect(calls).toBe(1);
+	});
+
+	it("retries failed attempts until the function succeeds", async () => {
+		let calls = 0;
+		const result = await retryAsync(
+			async () => {
+				calls += 1;
+				if (calls < 3) {
+					throw new Error(`boom ${calls}`);
+				}
+				return "recovered";
+			},
+			5,
+			1,
+		);
+		expect(result).toBe("recovered");
+		expect(calls).toBe(3);
+	});
+
+	it("throws the last error once attempts are exhausted", async () => {
+		let calls = 0;
+		const failures = [new Error("first"), new Error("second")];
+		await expect(
+			retryAsync(
+				async () => {
+					const err = failures[Math.min(calls, failures.length - 1)];
+					calls += 1;
+					throw err;
+				},
+				2,
+				1,
+			),
+		).rejects.toBe(failures[1]);
+		expect(calls).toBe(2);
+	});
+
+	it("treats an attempt count below one as a single attempt", async () => {
+		let calls = 0;
+		await expect(
+			retryAsync(
+				async () => {
+					calls += 1;
+					throw new Error("always fails");
+				},
+				0,
+				1,
+			),
+		).rejects.toThrow("always fails");
+		expect(calls).toBe(1);
+	});
+
+	it("waits exponentially longer between attempts", async () => {
+		let calls = 0;
+		const started = Date.now();
+		await retryAsync(
+			async () => {
+				calls += 1;
+				if (calls < 3) {
+					throw new Error("flaky");
+				}
+				return "done";
+			},
+			3,
+			20,
+		);
+		expect(Date.now() - started).toBeGreaterThanOrEqual(60); // 20ms + 40ms
+		expect(calls).toBe(3);
+	});
+
+	it('reports "Retry failed" when every attempt throws a non-Error value', async () => {
+		const throwsUndefined = async (): Promise<never> => {
+			throw undefined;
+		};
+		await expect(retryAsync(throwsUndefined, 2, 1)).rejects.toThrow(
+			"Retry failed",
+		);
+	});
+});
+
+describe("retryAsync options style", () => {
+	it("does not invoke onRetry when the first attempt succeeds", async () => {
+		const retries: RetryInfo[] = [];
+		const result = await retryAsync(async () => "ok", {
+			attempts: 4,
+			minDelayMs: 1,
+			onRetry: (info) => retries.push(info),
+		});
+		expect(result).toBe("ok");
+		expect(retries).toEqual([]);
+	});
+
+	it("reports ascending attempts, exact delays, errors, and label through onRetry", async () => {
+		const errA = new Error("A");
+		const errB = new Error("B");
+		let calls = 0;
+		const retries: RetryInfo[] = [];
+		const result = await retryAsync(
+			async () => {
+				calls += 1;
+				if (calls === 1) {
+					throw errA;
+				}
+				if (calls === 2) {
+					throw errB;
+				}
+				return "ok";
+			},
+			{
+				attempts: 4,
+				minDelayMs: 10,
+				label: "unit-test",
+				onRetry: (info) => retries.push(info),
+			},
+		);
+		expect(result).toBe("ok");
+		expect(calls).toBe(3);
+		expect(retries).toEqual([
+			{
+				attempt: 1,
+				maxAttempts: 4,
+				delayMs: 10,
+				err: errA,
+				label: "unit-test",
+			},
+			{
+				attempt: 2,
+				maxAttempts: 4,
+				delayMs: 20,
+				err: errB,
+				label: "unit-test",
+			},
+		]);
+	});
+
+	it("stops immediately without retrying when shouldRetry returns false", async () => {
+		let calls = 0;
+		const retries: RetryInfo[] = [];
+		const failure = new Error("do not retry");
+		await expect(
+			retryAsync(
+				async () => {
+					calls += 1;
+					throw failure;
+				},
+				{
+					attempts: 5,
+					minDelayMs: 1,
+					shouldRetry: () => false,
+					onRetry: (info) => retries.push(info),
+				},
+			),
+		).rejects.toBe(failure);
+		expect(calls).toBe(1);
+		expect(retries).toEqual([]);
+	});
+
+	it("honors retryAfterMs in place of the exponential schedule", async () => {
+		let calls = 0;
+		const delays: number[] = [];
+		const started = Date.now();
+		await retryAsync(
+			async () => {
+				calls += 1;
+				if (calls < 3) {
+					const err = new Error("rate limited") as Error & {
+						status?: number;
+					};
+					err.status = 429;
+					throw err;
+				}
+				return "ok";
+			},
+			{
+				attempts: 3,
+				minDelayMs: 5,
+				retryAfterMs: (err) =>
+					typeof err === "object" &&
+					err !== null &&
+					(err as { status?: number }).status === 429
+						? 30
+						: undefined,
+				onRetry: (info) => delays.push(info.delayMs),
+			},
+		);
+		expect(delays).toEqual([30, 30]);
+		expect(Date.now() - started).toBeGreaterThanOrEqual(60);
+	});
+
+	it("caps successive delays at maxDelayMs and exhausts all attempts", async () => {
+		let calls = 0;
+		const delays: number[] = [];
+		await expect(
+			retryAsync(
+				async () => {
+					calls += 1;
+					throw new Error(`attempt ${calls} failed`);
+				},
+				{
+					attempts: 4,
+					minDelayMs: 10,
+					maxDelayMs: 15,
+					onRetry: (info) => delays.push(info.delayMs),
+				},
+			),
+		).rejects.toThrow("attempt 4 failed");
+		expect(calls).toBe(4);
+		expect(delays).toEqual([10, 15, 15]);
 	});
 });


### PR DESCRIPTION

## What

Extends `packages/core/src/utils/retry.backoff.test.ts` with **+298/−0** lines. This is the only file in the diff; no production code changes.

The existing suite covered `computeBackoff` math and `sleepWithAbort` listener cleanup. The rest of `packages/core/src/utils/retry.ts` had no coverage, so this adds cases for:

- `sleep` â waits at least the requested duration before resolving.
- `sleepWithAbort` â the `ms <= 0` early-return resolves immediately even when the signal is already aborted (documents observed behavior of the guard running before the aborted check).
- `resolveRetryConfig` â built-in defaults `{ attempts: 3, minDelayMs: 300, maxDelayMs: 30_000, jitter: 0 }`, custom defaults passthrough, fractional attempt rounding with a floor of one, non-finite override fallback, negative `minDelayMs` clamped to zero, `maxDelayMs` raised to `minDelayMs`, and jitter clamped into `[0, 1]`.
- `retryAsync`, numeric style â first-attempt success makes one call; retries until success; exhaustion rethrows the last error by identity; attempt counts below one collapse to a single attempt; delays grow exponentially (`initialDelayMs * 2^i`); a non-Error thrown value surfaces the `"Retry failed"` fallback.
- `retryAsync`, options style â `onRetry` is not called when the first attempt succeeds; retry infos carry ascending attempt numbers, exact deterministic delays (`minDelayMs * 2^(attemptâ1)` with jitter 0), the triggering error and label; `shouldRetry: () => false` stops after one call without invoking `onRetry`; a finite `retryAfterMs` replaces the exponential schedule; delays are capped at `maxDelayMs` across successive retries while all attempts are exhausted.

All expectations were written from observed behavior of the current module; no aspirational behavior is asserted.

## Verification

Test-only change; hosted CI does not run on fork pull requests, so counts are quoted from local runs at head `83350ac94eefdfea5cba0625cd6b42f33452dab2` (base `cd4fb2746e7387982986405451bf38c049747acf`, current `origin/develop`):

1. `bunx vitest run src/utils/retry.backoff.test.ts` (in `packages/core`) â **Test Files: 1 passed (1); Tests: 27 passed (27)** (7 pre-existing + 20 new).
2. `bunx biome check --write src/utils/retry.backoff.test.ts` â clean, "No fixes applied" (config verified present: root `biome.json`; worktree not sparse).
3. `bunx tsc --noEmit` in `packages/core` â zero diagnostics mention `retry.backoff.test`.
4. Diff vs base touches only `packages/core/src/utils/retry.backoff.test.ts` and contains zero removed lines relative to the base version of that file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:83350ac94eefdfea5cba0625cd6b42f33452dab2 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
