### PR TITLE
test(core): cover trajectories

### DIFF
--- a/packages/core/src/services/trajectories.test.ts
+++ b/packages/core/src/services/trajectories.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Drives the trajectories services barrel against its live implementations:
+ * the public class/route surface it publishes, the SQL-service resolution
+ * helpers consumers rely on, and the lifecycle gating branches (ownership,
+ * disablement, synchronous step routing with diagnostic-only rollback) that
+ * are reachable without a database.
+ */
+
+import type { ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { ElizaError } from "../errors";
+import type { IAgentRuntime } from "../types";
+import { Service } from "../types/service";
+import {
+	TrajectoriesService,
+	tryHandleTrajectoryReadRoutes,
+} from "./trajectories";
+
+function makeRuntime(
+	overrides: {
+		agentId?: string;
+		getService?: (type: string) => unknown;
+		getServicesByType?: (type: string) => unknown[];
+	} = {},
+): IAgentRuntime {
+	return {
+		agentId: overrides.agentId ?? "agent-under-test",
+		getService: overrides.getService ?? (() => null),
+		getServicesByType: overrides.getServicesByType ?? (() => []),
+		reportError: vi.fn(),
+	} as unknown as IAgentRuntime;
+}
+
+function makeService(agentId?: string) {
+	const runtime = makeRuntime({ agentId });
+	return new TrajectoriesService(runtime);
+}
+
+describe("services/trajectories public surface", () => {
+	it("publishes the SQL-backed trajectories service under its registered type", () => {
+		expect(TrajectoriesService.serviceType).toBe("trajectories");
+		expect(TrajectoriesService.allowsMultiple).toBe(true);
+		expect(TrajectoriesService).toBeTypeOf("function");
+	});
+
+	it("produces Service instances carrying the trajectory capability", () => {
+		const service = makeService();
+		expect(service).toBeInstanceOf(TrajectoriesService);
+		expect(service).toBeInstanceOf(Service);
+		expect(service.capabilityDescription).toContain("trajector");
+		expect(service.serviceType).toBe("trajectories");
+		expect(service.isEnabled()).toBe(true);
+	});
+
+	it("exposes the trajectory read-route handler through the barrel", () => {
+		expect(tryHandleTrajectoryReadRoutes).toBeTypeOf("function");
+	});
+});
+
+describe("services/trajectories route fall-through", () => {
+	it.each([
+		["POST", "/api/trajectories"],
+		["GET", "/api/messages"],
+	] as const)(
+		"falls through (%s %s) without touching the response",
+		async (method, pathname) => {
+			const res = {} as ServerResponse;
+			await expect(
+				tryHandleTrajectoryReadRoutes({
+					pathname,
+					method,
+					url: new URL(`http://localhost${pathname}`),
+					runtime: makeRuntime(),
+					res,
+				}),
+			).resolves.toBe(false);
+		},
+	);
+
+	it("claims GET /api/trajectories routes and answers on the response", async () => {
+		const res = {
+			setHeader: vi.fn(),
+			end: vi.fn(),
+		} as unknown as ServerResponse;
+		await expect(
+			tryHandleTrajectoryReadRoutes({
+				pathname: "/api/trajectories",
+				method: "GET",
+				url: new URL("http://localhost/api/trajectories"),
+				runtime: null,
+				res,
+			}),
+		).resolves.toBe(true);
+		expect(res.setHeader).toHaveBeenCalledOnce();
+		expect(res.end).toHaveBeenCalledOnce();
+	});
+});
+
+describe("TrajectoriesService.resolveFromRuntime", () => {
+	it("returns the real service when getService already yields it", () => {
+		const service = makeService();
+		const runtime = makeRuntime({ getService: () => service });
+		expect(TrajectoriesService.resolveFromRuntime(runtime)).toBe(service);
+	});
+
+	it("scans past the lightweight fallback to find the real service", () => {
+		const service = makeService();
+		const fallback = {};
+		const runtime = makeRuntime({
+			getService: () => fallback,
+			getServicesByType: () => [fallback, service],
+		});
+		expect(TrajectoriesService.resolveFromRuntime(runtime)).toBe(service);
+	});
+
+	it("returns null when no real service is registered", () => {
+		const fallback = {};
+		const runtime = makeRuntime({
+			getService: () => fallback,
+			getServicesByType: () => [fallback],
+		});
+		expect(TrajectoriesService.resolveFromRuntime(runtime)).toBeNull();
+	});
+
+	it("tolerates runtimes without getServicesByType", () => {
+		const runtime = {
+			agentId: "agent-under-test",
+			getService: () => null,
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+		expect(TrajectoriesService.resolveFromRuntime(runtime)).toBeNull();
+	});
+});
+
+describe("TrajectoriesService.waitForService", () => {
+	it("resolves promptly once the real service is registered", async () => {
+		const service = makeService();
+		const runtime = makeRuntime({
+			getService: () => null,
+			getServicesByType: () => [service],
+		});
+		await expect(
+			TrajectoriesService.waitForService(runtime, 1_000),
+		).resolves.toBe(service);
+	});
+
+	it("gives up with null when the service never registers", async () => {
+		const runtime = makeRuntime();
+		await expect(
+			TrajectoriesService.waitForService(runtime, 120),
+		).resolves.toBeNull();
+	});
+});
+
+describe("TrajectoriesService lifecycle gating", () => {
+	it("rejects a foreign agent before any database work", async () => {
+		const service = makeService("agent-under-test");
+		await expect(
+			service.startTrajectory("agent-somewhere-else"),
+		).rejects.toMatchObject({
+			code: "TRAJECTORY_AGENT_OWNERSHIP_CONFLICT",
+			context: expect.objectContaining({
+				runtimeAgentId: "agent-under-test",
+				requestedAgentId: "agent-somewhere-else",
+			}),
+		});
+	});
+
+	it("mints unpersisted ids for every call once disabled, skipping ownership checks", async () => {
+		const service = makeService("agent-under-test");
+		service.setEnabled(false);
+		expect(service.isEnabled()).toBe(false);
+
+		const first = await service.startTrajectory("agent-somewhere-else");
+		const second = await service.startTrajectory("agent-under-test");
+		for (const id of [first, second]) {
+			expect(id).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+			);
+		}
+		expect(first).not.toBe(second);
+	});
+
+	it("registers the current step synchronously, then rolls routing back when persistence fails diagnostically", async () => {
+		const runtime = makeRuntime() as IAgentRuntime & {
+			reportError: ReturnType<typeof vi.fn>;
+		};
+		const service = new TrajectoriesService(runtime);
+		const trajectoryId = "traj-rollback";
+		const stepId = service.startStep(trajectoryId, { timestamp: 1_000 });
+
+		expect(stepId).toMatch(/^[0-9a-f-]{36}$/i);
+		expect(service.getCurrentStepId(trajectoryId)).toBe(stepId);
+
+		await expect(service.flushWriteQueue(trajectoryId)).rejects.toMatchObject({
+			code: "TRAJECTORY_TRANSACTION_UNAVAILABLE",
+		});
+
+		expect(service.getCurrentStepId(trajectoryId)).toBeNull();
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"TrajectoriesService.detachedWrite",
+			expect.any(ElizaError),
+			expect.objectContaining({
+				trajectoryId,
+				stepId,
+				diagnosticOnly: true,
+			}),
+		);
+	});
+
+	it("stops cleanly even when it was never initialized", async () => {
+		const service = makeService();
+		service.setEnabled(false);
+		await expect(service.stop()).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for `packages/core/src/services/trajectories.ts`, which had no same-named test file anywhere in the repository. The barrel's public surface is exercised against its live implementations — no mocks standing in for the system under test:

- **Public surface**: `TrajectoriesService` is published under the registered `"trajectories"` service type with `allowsMultiple`, produces real `Service` instances, and the barrel exposes `tryHandleTrajectoryReadRoutes`.
- **Route fall-through**: non-GET methods and non-trajectory paths return `false` without touching the response, while `GET /api/trajectories` is claimed and answered on the response object.
- **SQL-service resolution**: `resolveFromRuntime` fast path (service already returned by `getService`), slow path (scans past a lightweight fallback via `getServicesByType`), null when absent, and tolerance for runtimes without `getServicesByType`; `waitForService` resolves promptly once registered and gives up with `null` after its timeout.
- **Lifecycle gating**: a foreign-agent `startTrajectory` rejects with `TRAJECTORY_AGENT_OWNERSHIP_CONFLICT` before any database work; once disabled, ids are minted unpersisted and ownership checks are skipped; `startStep` registers the current step id synchronously and rolls in-memory routing back with a diagnostic-only `reportError` when persistence fails (`TRAJECTORY_TRANSACTION_UNAVAILABLE`); `stop()` resolves cleanly on a never-initialized instance.

The diff touches only this one new test file (`+231/-0` style addition, no production code changed).

## Test plan

- [x] `bunx vitest run src/services/trajectories.test.ts` (in `packages/core`) — **Test Files 1 passed (1), Tests 16 passed (16)**; re-fetched `origin/develop` immediately before filing and re-ran with identical counts.
- [x] `bunx biome check src/services/trajectories.test.ts` — clean ("No fixes applied"), with the repo-root `biome.json` present (checkout verified non-sparse).
- [x] `bunx tsc --noEmit` in `packages/core` — the new test file appears nowhere in the output (zero errors introduced).
- [x] The diff contains exactly one new test file and no deletions.

Note: this is a fork contribution, so hosted CI does not run on this PR — the counts above are quoted from local runs of the pinned toolchain.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2e6ab68e716592e93d8006d07d07df57496a8008 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
