### PR TITLE
test(elizaos): cover memory-tiering

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -68,7 +68,7 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `  SELF:          ${c.SELF}`,
       `  older marker:  ${c.MARKER}`,
       `  dedup dropped: ${plan.summary.duplicatesDropped}`,
-      `  clipped:       ${plan.summary.clipped} (truncated at maxChunkLen)`,
+      `  content lost:  ${plan.summary.clipped} (oversized bodies split losslessly)`,
       "",
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -68,7 +68,6 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `  SELF:          ${c.SELF}`,
       `  older marker:  ${c.MARKER}`,
       `  dedup dropped: ${plan.summary.duplicatesDropped}`,
-      `  content lost:  ${plan.summary.clipped} (oversized bodies split losslessly)`,
       "",
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -48,7 +48,7 @@ export interface MigratePlan {
     hasSecretsDir: boolean;
     /** Cross-tier duplicate memories dropped during tiering. */
     duplicatesDropped: number;
-    /** Memory bodies clipped at maxChunkLen (content truncated). */
+    /** Compatibility counter; zero because oversized bodies split losslessly. */
     clipped: number;
     /** sqlite memory stores detected in the source home. */
     sqliteStores: number;

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -46,9 +46,9 @@ export interface MigratePlan {
     hasUser: boolean;
     firewalled: boolean;
     hasSecretsDir: boolean;
-    /** Cross-tier duplicate memories dropped during tiering. */
+    /** Cross-tier duplicate source bodies dropped during tiering. */
     duplicatesDropped: number;
-    /** Compatibility counter; zero because oversized bodies split losslessly. */
+    /** @deprecated Always zero because oversized bodies split losslessly. */
     clipped: number;
     /** sqlite memory stores detected in the source home. */
     sqliteStores: number;

--- a/packages/elizaos/src/migrate/memory-tiering.test.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.test.ts
@@ -1,7 +1,7 @@
 /**
  * Coverage for the recency-tiered OpenClaw memory seeder: firewall posture,
  * the CURRENT/LONGTERM/SELF/MARKER tiers, window and minimum-length filters,
- * max-length clipping, and tier-priority cross-tier dedup. Drives the real
+ * lossless max-length chunking, and tier-priority cross-tier dedup. Drives the real
  * `tierMemories` over hand-built sources — no mocks, no filesystem.
  */
 
@@ -388,17 +388,44 @@ describe("tierMemories", () => {
     expect(result.counts.CURRENT).toBe(1);
   });
 
-  it("clips oversized bodies at maxChunkLen and reports the loss", () => {
-    const awareness = "x".repeat(200);
-    const clippedResult = tierMemories(
+  it("splits oversized bodies losslessly with an ordered reassembly contract", () => {
+    const awareness = `${"x".repeat(49)}😀${"y".repeat(151)}`;
+    const chunkedResult = tierMemories(
       { ...emptySource(), awareness },
       opts({ maxChunkLen: 50 }),
     );
-    expect(clippedResult.clipped).toBe(1);
-    expect(clippedResult.memories[0].content.text).toBe(
-      `[CURRENT] ${awareness.slice(0, 50)}`,
+    expect(chunkedResult.clipped).toBe(0);
+    expect(chunkedResult.memories).toHaveLength(5);
+    expect(chunkedResult.counts.CURRENT).toBe(5);
+
+    const groupIds = new Set(
+      chunkedResult.memories.map((memory) => memory.metadata.chunkGroupId),
     );
-    expect(clippedResult.memories[0].content.text).toHaveLength(60);
+    expect(groupIds.size).toBe(1);
+    expect(groupIds.has(undefined)).toBe(false);
+    expect(
+      chunkedResult.memories.map((memory) => memory.metadata.chunkIndex),
+    ).toEqual([0, 1, 2, 3, 4]);
+    expect(
+      chunkedResult.memories.every(
+        (memory) => memory.metadata.chunkCount === 5,
+      ),
+    ).toBe(true);
+
+    const reassembled = [...chunkedResult.memories]
+      .sort(
+        (a, b) => (a.metadata.chunkIndex ?? 0) - (b.metadata.chunkIndex ?? 0),
+      )
+      .map((memory) => memory.content.text.replace(/^\[CURRENT\] /, ""))
+      .join("");
+    expect(reassembled).toBe(awareness);
+    expect(
+      chunkedResult.memories.every(
+        (memory) =>
+          Array.from(memory.content.text.replace(/^\[CURRENT\] /, "")).length <=
+          50,
+      ),
+    ).toBe(true);
 
     const intact = tierMemories(
       { ...emptySource(), awareness },
@@ -406,6 +433,17 @@ describe("tierMemories", () => {
     );
     expect(intact.clipped).toBe(0);
     expect(intact.memories[0].content.text).toBe(`[CURRENT] ${awareness}`);
+  });
+
+  it("rejects invalid maxChunkLen values before returning partial memories", () => {
+    for (const maxChunkLen of [0, -1, 1.5]) {
+      expect(() =>
+        tierMemories(
+          { ...emptySource(), awareness: "complete source text" },
+          opts({ maxChunkLen }),
+        ),
+      ).toThrow(/maxChunkLen must be a positive integer/);
+    }
   });
 
   it("assigns unique ids across a full multi-tier run", () => {

--- a/packages/elizaos/src/migrate/memory-tiering.test.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.test.ts
@@ -5,6 +5,7 @@
  * `tierMemories` over hand-built sources — no mocks, no filesystem.
  */
 
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   type MemoryTier,
@@ -473,6 +474,69 @@ describe("tierMemories", () => {
       .map((memory) => memory.content.text.replace(/^\[CURRENT\] /, ""))
       .join("");
     expect(reassembled).toBe(body);
+  });
+
+  it("keeps digest-looking text unrelated to a chunked source body", () => {
+    const longBody = `${"unrelated-long-body-".repeat(8)}collision-tail`;
+    const digestLookingBody = createHash("sha256")
+      .update(longBody)
+      .digest("hex");
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: digestLookingBody,
+        curatedMemory: longBody,
+      },
+      opts({ maxChunkLen: 64 }),
+    );
+
+    const current = tierOf(result, "CURRENT");
+    const longterm = tierOf(result, "LONGTERM");
+    expect(result.duplicatesDropped).toBe(0);
+    expect(result.counts).toEqual({
+      CURRENT: 1,
+      LONGTERM: 3,
+      SELF: 0,
+      MARKER: 0,
+    });
+    expect(current.map((memory) => memory.content.text)).toEqual([
+      `[CURRENT] ${digestLookingBody}`,
+    ]);
+    expect(
+      longterm
+        .sort(
+          (a, b) => (a.metadata.chunkIndex ?? 0) - (b.metadata.chunkIndex ?? 0),
+        )
+        .map((memory) => memory.content.text.replace(/^\[LONGTERM\] /, ""))
+        .join(""),
+    ).toBe(longBody);
+  });
+
+  it("deduplicates normalized-equivalent bodies across the chunk boundary", () => {
+    const compactBody = "normalized body spans the chunk boundary exactly";
+    const expandedBody = compactBody.replaceAll(" ", "     ");
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: compactBody,
+        curatedMemory: expandedBody,
+      },
+      opts({ maxChunkLen: Array.from(compactBody).length }),
+    );
+
+    expect(Array.from(expandedBody).length).toBeGreaterThan(
+      Array.from(compactBody).length,
+    );
+    expect(result.duplicatesDropped).toBe(1);
+    expect(result.counts).toEqual({
+      CURRENT: 1,
+      LONGTERM: 0,
+      SELF: 0,
+      MARKER: 0,
+    });
+    expect(result.memories.map((memory) => memory.content.text)).toEqual([
+      `[CURRENT] ${compactBody}`,
+    ]);
   });
 
   it("rejects invalid maxChunkLen values before returning partial memories", () => {

--- a/packages/elizaos/src/migrate/memory-tiering.test.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.test.ts
@@ -435,6 +435,46 @@ describe("tierMemories", () => {
     expect(intact.memories[0].content.text).toBe(`[CURRENT] ${awareness}`);
   });
 
+  it("deduplicates identical oversized bodies by complete source identity", () => {
+    const body = `${"x".repeat(49)}😀${"y".repeat(76)}`;
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: body,
+        curatedMemory: body,
+      },
+      opts({ maxChunkLen: 25 }),
+    );
+
+    expect(result.duplicatesDropped).toBe(1);
+    expect(result.counts).toEqual({
+      CURRENT: 6,
+      LONGTERM: 0,
+      SELF: 0,
+      MARKER: 0,
+    });
+    expect(result.memories).toHaveLength(6);
+    expect(
+      result.memories.every((memory) => memory.metadata.tier === "CURRENT"),
+    ).toBe(true);
+    expect(
+      new Set(result.memories.map((memory) => memory.metadata.chunkGroupId))
+        .size,
+    ).toBe(1);
+    expect(
+      new Set(result.memories.map((memory) => memory.metadata.sourceBodyDigest))
+        .size,
+    ).toBe(1);
+
+    const reassembled = [...result.memories]
+      .sort(
+        (a, b) => (a.metadata.chunkIndex ?? 0) - (b.metadata.chunkIndex ?? 0),
+      )
+      .map((memory) => memory.content.text.replace(/^\[CURRENT\] /, ""))
+      .join("");
+    expect(reassembled).toBe(body);
+  });
+
   it("rejects invalid maxChunkLen values before returning partial memories", () => {
     for (const maxChunkLen of [0, -1, 1.5]) {
       expect(() =>

--- a/packages/elizaos/src/migrate/memory-tiering.test.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Coverage for the recency-tiered OpenClaw memory seeder: firewall posture,
+ * the CURRENT/LONGTERM/SELF/MARKER tiers, window and minimum-length filters,
+ * max-length clipping, and tier-priority cross-tier dedup. Drives the real
+ * `tierMemories` over hand-built sources — no mocks, no filesystem.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type MemoryTier,
+  type TieringOptions,
+  type TieringResult,
+  tierMemories,
+} from "./memory-tiering.js";
+import type { OcAgentSource } from "./openclaw-reader.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function emptySource(): OcAgentSource {
+  return {
+    agentId: "tester",
+    home: "/unused",
+    dailyLogs: [],
+    namedMemory: [],
+    hasSecretsDir: false,
+    sqliteStores: [],
+    sqliteUningested: false,
+    warnings: [],
+  };
+}
+
+function opts(overrides: Partial<TieringOptions> = {}): TieringOptions {
+  return {
+    memoryDays: 14,
+    roomId: "room-0000-0000",
+    entityId: "entity-0000-000",
+    agentId: "agent-0000-0000",
+    ...overrides,
+  };
+}
+
+/** A source exercising every tier: awareness, fresh + ancient logs, MEMORY.md, journal. */
+function richSource(): OcAgentSource {
+  const now = Date.now();
+  return {
+    ...emptySource(),
+    awareness: "Current open threads live here",
+    curatedMemory: "# Work\ncurated work fact worth keeping",
+    dailyLogs: [
+      {
+        date: "2026-08-20",
+        epochMs: now - 2 * DAY_MS,
+        filename: "2026-08-20.md",
+        text: "fresh daily log entry content",
+      },
+      {
+        date: "2020-01-01",
+        epochMs: now - 400 * DAY_MS,
+        filename: "2020-01-01.md",
+        text: "ancient daily log entry content",
+      },
+    ],
+    namedMemory: [
+      {
+        key: "journal",
+        filename: "journal.md",
+        text: "private becoming notes",
+      },
+    ],
+  };
+}
+
+function tierOf(result: TieringResult, tier: MemoryTier) {
+  return result.memories.filter((m) => m.metadata.tier === tier);
+}
+
+describe("tierMemories", () => {
+  it("returns an empty result for an empty source", () => {
+    const result = tierMemories(emptySource(), opts());
+    expect(result.memories).toEqual([]);
+    expect(result.counts).toEqual({
+      CURRENT: 0,
+      LONGTERM: 0,
+      SELF: 0,
+      MARKER: 0,
+    });
+    expect(result.duplicatesDropped).toBe(0);
+    expect(result.clipped).toBe(0);
+  });
+
+  it("firewall=true seeds only the privacy MARKER out of a rich source", () => {
+    const result = tierMemories(richSource(), opts({ firewall: true }));
+    expect(result.memories).toHaveLength(1);
+    const marker = result.memories[0];
+    expect(marker.metadata.tier).toBe("MARKER");
+    expect(marker.content.text.startsWith("[MARKER] ")).toBe(true);
+    expect(marker.content.text).toContain("firewalled");
+    expect(result.counts).toEqual({
+      CURRENT: 0,
+      LONGTERM: 0,
+      SELF: 0,
+      MARKER: 1,
+    });
+    expect(result.duplicatesDropped).toBe(0);
+    expect(result.clipped).toBe(0);
+  });
+
+  it("defaults firewall to false so the full corpus is seeded", () => {
+    const result = tierMemories(richSource(), opts());
+    expect(result.memories.length).toBeGreaterThan(1);
+    // The 400-day-old log yields exactly one older-history summary marker;
+    // the privacy MARKER path is the only other source and stays silent.
+    expect(tierOf(result, "MARKER")).toHaveLength(1);
+    expect(tierOf(result, "MARKER")[0].content.text).toContain(
+      "(1 daily logs before",
+    );
+    expect(tierOf(result, "CURRENT").length).toBeGreaterThan(0);
+    expect(tierOf(result, "LONGTERM").length).toBeGreaterThan(0);
+    expect(tierOf(result, "SELF").length).toBeGreaterThan(0);
+  });
+
+  it("seeds awareness verbatim as CURRENT with provenance metadata", () => {
+    const before = Date.now();
+    const seeded = tierMemories(
+      { ...emptySource(), awareness: "  Live awareness body  " },
+      opts(),
+    );
+    const after = Date.now();
+    expect(seeded.memories).toHaveLength(1);
+    const mem = seeded.memories[0];
+    expect(mem.content.text).toBe("[CURRENT] Live awareness body");
+    expect(mem.metadata).toEqual({
+      type: "custom",
+      source: "openclaw-migration",
+      tier: "CURRENT",
+    });
+    expect(mem.unique).toBe(true);
+    expect(mem.entityId).toBe("entity-0000-000");
+    expect(mem.agentId).toBe("agent-0000-0000");
+    expect(mem.roomId).toBe("room-0000-0000");
+    expect(mem.createdAt).toBeGreaterThanOrEqual(before);
+    expect(mem.createdAt).toBeLessThanOrEqual(after);
+
+    // Whitespace-only awareness is treated as absent.
+    const blank = tierMemories(
+      { ...emptySource(), awareness: "   \n\t  " },
+      opts(),
+    );
+    expect(blank.memories).toEqual([]);
+  });
+
+  it("seeds only in-window daily logs as CURRENT and summarizes the rest", () => {
+    const now = Date.now();
+    const recentA = now - 2 * DAY_MS;
+    const recentB = now - 3 * DAY_MS;
+    const ancient = now - 40 * DAY_MS;
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: "anchor for internal-now timestamps",
+        dailyLogs: [
+          {
+            date: "2026-08-22",
+            epochMs: recentA,
+            filename: "2026-08-22.md",
+            text: "newest daily log body here",
+          },
+          {
+            date: "2026-08-21",
+            epochMs: recentB,
+            filename: "2026-08-21.md",
+            text: "older-but-still-recent log body",
+          },
+          {
+            date: "2020-06-01",
+            epochMs: ancient,
+            filename: "2020-06-01.md",
+            text: "ancient daily log body kept out",
+          },
+        ],
+      },
+      opts(),
+    );
+
+    const current = tierOf(result, "CURRENT");
+    expect(current.map((m) => m.content.text)).toEqual([
+      "[CURRENT] anchor for internal-now timestamps",
+      "[CURRENT] daily log 2026-08-22\nnewest daily log body here",
+      "[CURRENT] daily log 2026-08-21\nolder-but-still-recent log body",
+    ]);
+    // In-window memories carry their own log timestamp, not seed time.
+    expect(current[1].createdAt).toBe(recentA);
+    expect(current[2].createdAt).toBe(recentB);
+
+    // One summary marker instead of flat-seeding stale logs; anchored at the
+    // window edge minus 1ms relative to the awareness seed time.
+    const markers = tierOf(result, "MARKER");
+    expect(markers).toHaveLength(1);
+    expect(markers[0].content.text).toContain("(1 daily logs before");
+    expect(markers[0].content.text).toContain("back to 2020-06-01");
+    const internalNow = current[0].createdAt;
+    expect(markers[0].createdAt).toBe(
+      internalNow - opts().memoryDays * DAY_MS - 1,
+    );
+    expect(result.counts).toEqual({
+      CURRENT: 3,
+      LONGTERM: 0,
+      SELF: 0,
+      MARKER: 1,
+    });
+  });
+
+  it("skips in-window daily logs below minChunkLen entirely", () => {
+    const now = Date.now();
+    const source: OcAgentSource = {
+      ...emptySource(),
+      dailyLogs: [
+        {
+          date: "2026-08-22",
+          epochMs: now - 1 * DAY_MS,
+          filename: "2026-08-22.md",
+          text: "small entry",
+        },
+      ],
+    };
+    const strict = tierMemories(source, opts());
+    expect(strict.memories).toEqual([]);
+    expect(Object.values(strict.counts).every((n) => n === 0)).toBe(true);
+
+    const lenient = tierMemories(source, opts({ minChunkLen: 5 }));
+    expect(tierOf(lenient, "CURRENT")).toHaveLength(1);
+    expect(lenient.counts.CURRENT).toBe(1);
+    expect(lenient.counts.MARKER).toBe(0);
+  });
+
+  it("counts unparseable-timestamp logs as older history", () => {
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        dailyLogs: [
+          { date: null, epochMs: 0, filename: "unknown-date.md", text: "" },
+        ],
+      },
+      opts(),
+    );
+    expect(result.memories).toHaveLength(1);
+    const marker = result.memories[0];
+    expect(marker.metadata.tier).toBe("MARKER");
+    expect(marker.content.text).toContain("(1 daily logs before");
+    expect(marker.content.text).toContain("back to earlier");
+    expect(result.counts.MARKER).toBe(1);
+    expect(result.counts.CURRENT).toBe(0);
+    // Anchored just below the window edge, not at seed time.
+    expect(
+      Math.abs(marker.createdAt - (Date.now() - 14 * DAY_MS)),
+    ).toBeLessThan(60_000);
+  });
+
+  it("chunks curated MEMORY.md by top-level headings into LONGTERM", () => {
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: "time anchor",
+        curatedMemory: [
+          "# Work",
+          "first curated section body here",
+          "",
+          "## Projects",
+          "second curated section body",
+          "",
+          "## Tiny",
+          "no",
+        ].join("\n"),
+      },
+      opts(),
+    );
+
+    const longterm = tierOf(result, "LONGTERM");
+    // The too-small "Tiny" section is dropped by minChunkLen.
+    expect(longterm.map((m) => m.content.text)).toEqual([
+      "[LONGTERM] # Work\nfirst curated section body here",
+      "[LONGTERM] ## Projects\nsecond curated section body",
+    ]);
+    const internalNow = tierOf(result, "CURRENT")[0].createdAt;
+    for (const mem of longterm) {
+      expect(mem.createdAt).toBe(internalNow - 1);
+    }
+    expect(result.counts.LONGTERM).toBe(2);
+  });
+
+  it("does not split chunks on deeper ### sub-headings", () => {
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        curatedMemory: "intro paragraph line\n### deep\ndeep body text here",
+      },
+      opts({ minChunkLen: 5 }),
+    );
+    const longterm = tierOf(result, "LONGTERM");
+    expect(longterm).toHaveLength(1);
+    expect(longterm[0].content.text).toBe(
+      "[LONGTERM] intro paragraph line\n### deep\ndeep body text here",
+    );
+  });
+
+  it("seeds SELF journals verbatim and ignores non-self named memory", () => {
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: "time anchor",
+        namedMemory: [
+          {
+            key: "conversation-playbook",
+            filename: "conversation-playbook.md",
+            text: "long playbook text that is not a journal",
+          },
+          {
+            key: "thoughts",
+            filename: "thoughts.md",
+            text: "tiny",
+          },
+          {
+            key: "inner-state",
+            filename: "inner-state.md",
+            text: "becoming journal prose here",
+          },
+        ],
+      },
+      opts(),
+    );
+
+    const self = tierOf(result, "SELF");
+    expect(self).toHaveLength(1);
+    expect(self[0].content.text).toBe(
+      "[SELF] inner-state\nbecoming journal prose here",
+    );
+    const internalNow = tierOf(result, "CURRENT")[0].createdAt;
+    expect(self[0].createdAt).toBe(internalNow - 2);
+    expect(result.counts.SELF).toBe(1);
+    expect(result.counts.CURRENT).toBe(1);
+  });
+
+  it("keeps the highest-priority copy when a fact spans tiers", () => {
+    const result = tierMemories(
+      {
+        ...emptySource(),
+        awareness: "Standup   moved to THURSDAYS",
+        curatedMemory:
+          "standup moved to thursdays\n# Personal\nunrelated personal note",
+      },
+      opts(),
+    );
+
+    // The CURRENT copy survives verbatim; the LONGTERM duplicate is dropped
+    // while the unrelated section survives.
+    expect(result.duplicatesDropped).toBe(1);
+    expect(result.memories.map((m) => m.content.text)).toEqual([
+      "[CURRENT] Standup   moved to THURSDAYS",
+      "[LONGTERM] # Personal\nunrelated personal note",
+    ]);
+    expect(result.counts).toEqual({
+      CURRENT: 1,
+      LONGTERM: 1,
+      SELF: 0,
+      MARKER: 0,
+    });
+  });
+
+  it("keeps the first copy when one tier repeats the same fact", () => {
+    const now = Date.now();
+    const row = {
+      date: "2026-08-21",
+      epochMs: now - 2 * DAY_MS,
+      filename: "2026-08-21.md",
+      text: "repeated identical entry here today",
+    };
+    // Duplicate rows occur when markdown and sqlite ingestion overlap.
+    const result = tierMemories(
+      { ...emptySource(), dailyLogs: [row, { ...row }] },
+      opts(),
+    );
+    expect(result.memories).toHaveLength(1);
+    expect(result.memories[0].metadata.tier).toBe("CURRENT");
+    expect(result.memories[0].content.text).toBe(
+      "[CURRENT] daily log 2026-08-21\nrepeated identical entry here today",
+    );
+    expect(result.duplicatesDropped).toBe(1);
+    expect(result.counts.CURRENT).toBe(1);
+  });
+
+  it("clips oversized bodies at maxChunkLen and reports the loss", () => {
+    const awareness = "x".repeat(200);
+    const clippedResult = tierMemories(
+      { ...emptySource(), awareness },
+      opts({ maxChunkLen: 50 }),
+    );
+    expect(clippedResult.clipped).toBe(1);
+    expect(clippedResult.memories[0].content.text).toBe(
+      `[CURRENT] ${awareness.slice(0, 50)}`,
+    );
+    expect(clippedResult.memories[0].content.text).toHaveLength(60);
+
+    const intact = tierMemories(
+      { ...emptySource(), awareness },
+      opts({ maxChunkLen: 6000 }),
+    );
+    expect(intact.clipped).toBe(0);
+    expect(intact.memories[0].content.text).toBe(`[CURRENT] ${awareness}`);
+  });
+
+  it("assigns unique ids across a full multi-tier run", () => {
+    const result = tierMemories(richSource(), opts());
+    const ids = new Set(result.memories.map((m) => m.id));
+    expect(ids.size).toBe(result.memories.length);
+  });
+});

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -293,11 +293,15 @@ function dedupeByTierPriority(
   memories: Memory[],
   counts: Record<MemoryTier, number>,
 ): { deduped: Memory[]; duplicatesDropped: number } {
-  const dedupKey = (memory: Memory): string =>
-    memory.metadata.sourceBodyDigest ??
-    (memory.metadata.chunkGroupId
-      ? `${memory.metadata.chunkGroupId}:${memory.metadata.chunkIndex}`
-      : normalizeForDedup(memory.content.text));
+  const dedupKey = (memory: Memory): string => {
+    if (memory.metadata.sourceBodyDigest) {
+      return `sha256:${memory.metadata.sourceBodyDigest}`;
+    }
+    const normalized = normalizeForDedup(memory.content.text);
+    return normalized
+      ? `sha256:${createHash("sha256").update(normalized).digest("hex")}`
+      : "";
+  };
   const sourceId = (memory: Memory): string =>
     memory.metadata.chunkGroupId ?? memory.id;
 

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -29,7 +29,7 @@ export interface TieringOptions {
   agentId: UUID;
   /** Minimum chunk length to bother seeding. Default 20 chars. */
   minChunkLen?: number;
-  /** Max chars per memory (longer chunks are clipped). Default 6000. */
+  /** Target characters per lossless memory chunk. Default 6000. */
   maxChunkLen?: number;
   /**
    * When true, the personal corpus (daily logs, awareness, curated MEMORY.md,
@@ -48,7 +48,7 @@ export interface TieringResult {
   counts: Record<MemoryTier, number>;
   /** How many memories were dropped as cross-tier duplicates. */
   duplicatesDropped: number;
-  /** How many memory bodies were clipped at maxChunkLen (content lost). */
+  /** Compatibility counter; always zero because oversized bodies split losslessly. */
   clipped: number;
 }
 
@@ -72,23 +72,45 @@ function normalizeForDedup(text: string): string {
     .toLowerCase();
 }
 
-/** Mutable counter passed through mkMemory so we can tally clips. */
-interface ClipCounter {
-  n: number;
+/** Typed configuration failure raised before any partial memories are returned. */
+export class MemoryTieringConfigError extends Error {
+  readonly code = "MEMORY_TIERING_CONFIG_INVALID";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryTieringConfigError";
+  }
 }
 
-function mkMemory(
+/** Split by Unicode code point and preserve the exact ordered source text. */
+function splitLosslessly(text: string, maxChunkLen: number): string[] {
+  if (!Number.isInteger(maxChunkLen) || maxChunkLen <= 0) {
+    throw new MemoryTieringConfigError(
+      "maxChunkLen must be a positive integer so memory can be split losslessly.",
+    );
+  }
+
+  const characters = Array.from(text);
+  if (characters.length <= maxChunkLen) return [text];
+
+  const chunks: string[] = [];
+  for (let offset = 0; offset < characters.length; offset += maxChunkLen) {
+    chunks.push(characters.slice(offset, offset + maxChunkLen).join(""));
+  }
+  return chunks;
+}
+
+function mkMemories(
   text: string,
   tier: MemoryTier,
   opts: TieringOptions,
   createdAt: number,
-  clipCounter?: ClipCounter,
-): Memory {
+): Memory[] {
   const max = opts.maxChunkLen ?? 6000;
-  const wasClipped = text.length > max;
-  if (wasClipped && clipCounter) clipCounter.n++;
-  const body = wasClipped ? text.slice(0, max) : text;
-  return {
+  const chunks = splitLosslessly(text, max);
+  const chunkGroupId = chunks.length > 1 ? (randomUUID() as UUID) : undefined;
+
+  return chunks.map((body, chunkIndex) => ({
     id: randomUUID() as UUID,
     entityId: opts.entityId,
     agentId: opts.agentId,
@@ -100,9 +122,25 @@ function mkMemory(
       // Provenance for downstream filtering / debugging.
       source: "openclaw-migration",
       tier,
-    } as Memory["metadata"],
+      ...(chunkGroupId
+        ? { chunkGroupId, chunkIndex, chunkCount: chunks.length }
+        : {}),
+    },
     unique: true,
-  };
+  }));
+}
+
+function appendMemories(
+  memories: Memory[],
+  counts: Record<MemoryTier, number>,
+  text: string,
+  tier: MemoryTier,
+  opts: TieringOptions,
+  createdAt: number,
+): void {
+  const added = mkMemories(text, tier, opts, createdAt);
+  memories.push(...added);
+  counts[tier] += added.length;
 }
 
 /** Split a markdown doc into section chunks by top-level "## " / "# " headings. */
@@ -141,7 +179,6 @@ export function tierMemories(
   };
   const now = Date.now();
   const cutoff = now - opts.memoryDays * DAY_MS;
-  const clip: ClipCounter = { n: 0 };
 
   // ---- FIREWALL: a portable archive carries the persona, NOT the personal corpus ----
   // Daily logs, <agent>-awareness.md, curated MEMORY.md, and SELF journals all
@@ -149,41 +186,43 @@ export function tierMemories(
   // -- only a marker -- so a shared archive cannot leak personal context (#10283).
   // The sovereign-local path passes firewall=false to seed the full corpus.
   if (firewall) {
-    memories.push(
-      mkMemory(
-        "Personal memory (daily logs, journals, awareness, and curated long-term " +
-          "memory) was firewalled out of this portable archive for privacy. Re-seed " +
-          "it from a sovereign-local export on the owner's own machine if you need it.",
-        "MARKER",
-        opts,
-        now,
-        clip,
-      ),
+    appendMemories(
+      memories,
+      counts,
+      "Personal memory (daily logs, journals, awareness, and curated long-term " +
+        "memory) was firewalled out of this portable archive for privacy. Re-seed " +
+        "it from a sovereign-local export on the owner's own machine if you need it.",
+      "MARKER",
+      opts,
+      now,
     );
-    counts.MARKER++;
-    return { memories, counts, duplicatesDropped: 0, clipped: clip.n };
+    return { memories, counts, duplicatesDropped: 0, clipped: 0 };
   }
 
   // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
   if (src.awareness?.trim()) {
-    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now, clip));
-    counts.CURRENT++;
+    appendMemories(
+      memories,
+      counts,
+      src.awareness.trim(),
+      "CURRENT",
+      opts,
+      now,
+    );
   }
   let olderCount = 0;
   for (const log of src.dailyLogs) {
     const ts = log.epochMs || 0;
     if (ts >= cutoff) {
       if (log.text.trim().length >= minLen) {
-        memories.push(
-          mkMemory(
-            `daily log ${log.date ?? log.filename}\n${log.text.trim()}`,
-            "CURRENT",
-            opts,
-            ts || now,
-            clip,
-          ),
+        appendMemories(
+          memories,
+          counts,
+          `daily log ${log.date ?? log.filename}\n${log.text.trim()}`,
+          "CURRENT",
+          opts,
+          ts || now,
         );
-        counts.CURRENT++;
       }
     } else {
       olderCount++;
@@ -193,8 +232,7 @@ export function tierMemories(
   // ---- T2 LONGTERM: curated MEMORY.md, chunked by section ----
   if (src.curatedMemory?.trim()) {
     for (const chunk of chunkBySection(src.curatedMemory, minLen)) {
-      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1, clip));
-      counts.LONGTERM++;
+      appendMemories(memories, counts, chunk, "LONGTERM", opts, now - 1);
     }
   }
 
@@ -202,26 +240,29 @@ export function tierMemories(
   for (const m of src.namedMemory) {
     if (!isSelfMemory(m.key)) continue;
     if (m.text.trim().length < minLen) continue;
-    memories.push(
-      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2, clip),
+    appendMemories(
+      memories,
+      counts,
+      `${m.key}\n${m.text.trim()}`,
+      "SELF",
+      opts,
+      now - 2,
     );
-    counts.SELF++;
   }
 
   // ---- T4 OLDER: NOT flat-seeded. One marker so the agent knows history exists. ----
   if (olderCount > 0) {
     const oldest = src.dailyLogs[src.dailyLogs.length - 1]?.date ?? "earlier";
-    memories.push(
-      mkMemory(
-        `Older history (${olderCount} daily logs before the last ${opts.memoryDays} days, ` +
-          `back to ${oldest}) is summarized and NOT seeded verbatim to avoid resurfacing ` +
-          `stale threads. Ask the owner if you need detail from a specific older date.`,
-        "MARKER",
-        opts,
-        cutoff - 1,
-      ),
+    appendMemories(
+      memories,
+      counts,
+      `Older history (${olderCount} daily logs before the last ${opts.memoryDays} days, ` +
+        `back to ${oldest}) is summarized and NOT seeded verbatim to avoid resurfacing ` +
+        `stale threads. Ask the owner if you need detail from a specific older date.`,
+      "MARKER",
+      opts,
+      cutoff - 1,
     );
-    counts.MARKER++;
   }
 
   // ---- Cross-tier dedup: the same fact can appear in MEMORY.md AND a daily log
@@ -229,7 +270,7 @@ export function tierMemories(
   // Hermes's normalize_text + seen-set dedup, but tier-priority-aware.) ----
   const { deduped, duplicatesDropped } = dedupeByTierPriority(memories, counts);
 
-  return { memories: deduped, counts, duplicatesDropped, clipped: clip.n };
+  return { memories: deduped, counts, duplicatesDropped, clipped: 0 };
 }
 
 /**
@@ -244,7 +285,9 @@ function dedupeByTierPriority(
   // First pass: for each normalized body, find the winning (highest-priority) id.
   const winnerByKey = new Map<string, { id: string; prio: number }>();
   for (const m of memories) {
-    const key = normalizeForDedup(m.content.text);
+    const key = m.metadata.chunkGroupId
+      ? `${m.metadata.chunkGroupId}:${m.metadata.chunkIndex}`
+      : normalizeForDedup(m.content.text);
     if (!key) continue;
     const prio = TIER_PRIORITY[m.metadata.tier as MemoryTier] ?? 0;
     const cur = winnerByKey.get(key);
@@ -255,7 +298,9 @@ function dedupeByTierPriority(
   let duplicatesDropped = 0;
   const kept = new Set<string>();
   for (const m of memories) {
-    const key = normalizeForDedup(m.content.text);
+    const key = m.metadata.chunkGroupId
+      ? `${m.metadata.chunkGroupId}:${m.metadata.chunkIndex}`
+      : normalizeForDedup(m.content.text);
     if (!key) {
       deduped.push(m);
       continue;

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -12,7 +12,7 @@
  * time. Each Memory is content-only with a tier tag in metadata + a text prefix.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { isSelfMemory, type OcAgentSource } from "./openclaw-reader.js";
 import type { MigratedMemory as Memory, UUID } from "./types.js";
 
@@ -46,9 +46,9 @@ export interface TieringOptions {
 export interface TieringResult {
   memories: Memory[];
   counts: Record<MemoryTier, number>;
-  /** How many memories were dropped as cross-tier duplicates. */
+  /** How many complete source bodies were dropped as cross-tier duplicates. */
   duplicatesDropped: number;
-  /** Compatibility counter; always zero because oversized bodies split losslessly. */
+  /** @deprecated Always zero because oversized bodies split losslessly. */
   clipped: number;
 }
 
@@ -109,6 +109,11 @@ function mkMemories(
   const max = opts.maxChunkLen ?? 6000;
   const chunks = splitLosslessly(text, max);
   const chunkGroupId = chunks.length > 1 ? (randomUUID() as UUID) : undefined;
+  const sourceBodyDigest = chunkGroupId
+    ? createHash("sha256")
+        .update(normalizeForDedup(`[${tier}] ${text}`))
+        .digest("hex")
+    : undefined;
 
   return chunks.map((body, chunkIndex) => ({
     id: randomUUID() as UUID,
@@ -123,7 +128,12 @@ function mkMemories(
       source: "openclaw-migration",
       tier,
       ...(chunkGroupId
-        ? { chunkGroupId, chunkIndex, chunkCount: chunks.length }
+        ? {
+            chunkGroupId,
+            chunkIndex,
+            chunkCount: chunks.length,
+            sourceBodyDigest,
+          }
         : {}),
     },
     unique: true,
@@ -274,46 +284,54 @@ export function tierMemories(
 }
 
 /**
- * Drop cross-tier duplicate memories (by normalized text), keeping the
- * highest-priority tier's copy. Decrements `counts` for dropped entries so the
- * reported tier counts stay accurate. Order-stable for the survivors.
+ * Drop cross-tier duplicate source bodies (by normalized complete text),
+ * keeping the highest-priority tier's copy. Decrements `counts` for every
+ * dropped chunk while counting one duplicate per discarded source body.
+ * Order-stable for the survivors.
  */
 function dedupeByTierPriority(
   memories: Memory[],
   counts: Record<MemoryTier, number>,
 ): { deduped: Memory[]; duplicatesDropped: number } {
-  // First pass: for each normalized body, find the winning (highest-priority) id.
-  const winnerByKey = new Map<string, { id: string; prio: number }>();
+  const dedupKey = (memory: Memory): string =>
+    memory.metadata.sourceBodyDigest ??
+    (memory.metadata.chunkGroupId
+      ? `${memory.metadata.chunkGroupId}:${memory.metadata.chunkIndex}`
+      : normalizeForDedup(memory.content.text));
+  const sourceId = (memory: Memory): string =>
+    memory.metadata.chunkGroupId ?? memory.id;
+
+  // First pass: for each complete normalized body, find the winning source.
+  const winnerByKey = new Map<string, { sourceId: string; prio: number }>();
   for (const m of memories) {
-    const key = m.metadata.chunkGroupId
-      ? `${m.metadata.chunkGroupId}:${m.metadata.chunkIndex}`
-      : normalizeForDedup(m.content.text);
+    const key = dedupKey(m);
     if (!key) continue;
     const prio = TIER_PRIORITY[m.metadata.tier as MemoryTier] ?? 0;
     const cur = winnerByKey.get(key);
-    if (!cur || prio > cur.prio) winnerByKey.set(key, { id: m.id, prio });
+    if (!cur || prio > cur.prio) {
+      winnerByKey.set(key, { sourceId: sourceId(m), prio });
+    }
   }
-  // Second pass: keep only the winner for each key (and any keyless memory).
+
+  // Second pass: keep every chunk from the winning source and drop every chunk
+  // from losing sources, counting each discarded source body once.
   const deduped: Memory[] = [];
-  let duplicatesDropped = 0;
-  const kept = new Set<string>();
+  const droppedSources = new Set<string>();
   for (const m of memories) {
-    const key = m.metadata.chunkGroupId
-      ? `${m.metadata.chunkGroupId}:${m.metadata.chunkIndex}`
-      : normalizeForDedup(m.content.text);
+    const key = dedupKey(m);
     if (!key) {
       deduped.push(m);
       continue;
     }
     const winner = winnerByKey.get(key);
-    if (winner && winner.id === m.id && !kept.has(key)) {
+    const currentSourceId = sourceId(m);
+    if (winner?.sourceId === currentSourceId) {
       deduped.push(m);
-      kept.add(key);
     } else {
-      duplicatesDropped++;
+      droppedSources.add(currentSourceId);
       const tier = m.metadata.tier as MemoryTier;
       if (counts[tier] > 0) counts[tier]--;
     }
   }
-  return { deduped, duplicatesDropped };
+  return { deduped, duplicatesDropped: droppedSources.size };
 }

--- a/packages/elizaos/src/migrate/types.ts
+++ b/packages/elizaos/src/migrate/types.ts
@@ -43,6 +43,8 @@ export interface MigratedMemory {
     chunkIndex?: number;
     /** Total chunks required to reconstruct the complete source body. */
     chunkCount?: number;
+    /** SHA-256 of the normalized complete source body for cross-tier dedup. */
+    sourceBodyDigest?: string;
   };
   unique: boolean;
 }

--- a/packages/elizaos/src/migrate/types.ts
+++ b/packages/elizaos/src/migrate/types.ts
@@ -33,7 +33,17 @@ export interface MigratedMemory {
   roomId: UUID;
   createdAt: number;
   content: { text: string };
-  metadata: { type: "custom"; source: string; tier: string };
+  metadata: {
+    type: "custom";
+    source: string;
+    tier: string;
+    /** Shared identifier for losslessly ordered chunks of one source body. */
+    chunkGroupId?: UUID;
+    /** Zero-based position within a losslessly chunked source body. */
+    chunkIndex?: number;
+    /** Total chunks required to reconstruct the complete source body. */
+    chunkCount?: number;
+  };
   unique: boolean;
 }
 


### PR DESCRIPTION
## Summary

Repairs the OpenClaw memory migration so oversized bodies are split into lossless, Unicode-safe chunks and cross-tier deduplication compares every complete normalized body in one namespaced SHA-256 key domain.

This is a five-file production migration change with regression coverage, not a test-only coverage change. It updates CLI reporting, migration result documentation, migrated-memory chunk metadata, tiering behavior, and the colocated 18-test suite.

## Production behavior

- Replaces `maxChunkLen` clipping with ordered, lossless Unicode code-point chunks.
- Adds chunk group, index, count, and complete-body digest metadata for reassembly and deduplication.
- Keeps random group IDs for reassembly while using stable normalized complete-body identity for deduplication.
- Namespaces both chunked and unchunked identities as `sha256:<digest>`, preventing literal digest-looking text from colliding with a different chunked body.
- Deduplicates normalized-equivalent bodies even when whitespace expansion puts only one representation over `maxChunkLen`.
- Keeps tier counts coherent, counts one dropped source body in `duplicatesDropped`, deprecates the permanently-zero `clipped` counter, and removes the dead CLI `clipped` output row.
- Rejects invalid `maxChunkLen` before returning partial memories.

## Regression coverage

The 18-case suite drives the real `tierMemories` implementation without mocks. In addition to firewall, tiering, time-window, minimum-length, ordering, Unicode chunking, metadata, and invalid-configuration behavior, it now covers:

- identical oversized CURRENT and LONGTERM bodies, retaining every CURRENT chunk and reassembling byte-exactly;
- a short body whose literal text is the SHA-256 digest of an unrelated chunked body, preserving both complete bodies with zero duplicates; and
- normalized-equivalent bodies that straddle `maxChunkLen`, retaining only the higher-priority complete body and reporting one duplicate.

## Verification

Evidence head: `0430e5ca78a1a5bcaf89047bdae7c2432b2a6c21`

```text
RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/repair-pr-26561

✓ packages/elizaos/src/migrate/memory-tiering.test.ts (18 tests) 14ms

Test Files  1 passed (1)
Tests       18 passed (18)
Start at    21:29:06
Duration    194ms (transform 92ms, setup 0ms, import 105ms, tests 14ms, environment 0ms)
```

- `bunx @biomejs/biome check packages/elizaos/src/migrate/memory-tiering.ts packages/elizaos/src/migrate/memory-tiering.test.ts` — passed, no fixes.
- `bun run --cwd packages/elizaos typecheck` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Root `bun run verify` advanced into workspace linting but is blocked by pre-existing `noExplicitAny` violations in `plugins/plugin-agent-skills` outside this PR diff.

# Relates to

# Evidence Gate

- Before screenshots: N/A - no rendered UI changes.
- After screenshots: N/A - no rendered UI changes.
- Walkthrough video: N/A - no rendered UI flow changes.
- Backend logs: N/A - this is an offline CLI migration/domain transformation.
- Frontend logs: N/A - no frontend changes.
- Real-LLM trajectory: N/A - no model, prompt, provider, action, or agent-loop behavior.
- Domain artifacts: focused production-code regressions reassemble every surviving chunked body exactly and verify coherent tier counts and duplicate totals; exact output is above.

<!-- evidence-head:0430e5ca78a1a5bcaf89047bdae7c2432b2a6c21 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [repair-pr-26561]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
