### PR TITLE
test(cloud): cover agent-token minting and JWKS

### DIFF
--- a/packages/cloud/shared/src/lib/auth/agent-token.test.ts
+++ b/packages/cloud/shared/src/lib/auth/agent-token.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Covers agent token minting and the published JWKS.
+ *
+ * The property that matters most is negative: `getAgentTokenPublicJwk` exports
+ * the signing key and must strip every private RSA parameter before publishing
+ * it. Leaking `d` (or any CRT factor) from the JWKS endpoint would hand out the
+ * key that mints agent tokens, so that stripping is asserted explicitly rather
+ * than assumed.
+ *
+ * Beyond that: TTL is clamped to its documented window, agent ids are
+ * validated before they reach the subject claim, and a minted token actually
+ * verifies against the published JWK with the expected issuer/audience.
+ *
+ * Uses a real RSA keypair generated per suite — no stubbed crypto.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { exportJWK, importJWK, jwtVerify } from "jose";
+
+import {
+  getAgentTokenJWKS,
+  getAgentTokenKeyId,
+  getAgentTokenPublicJwk,
+  isAgentTokenSigningConfigured,
+  mintAgentToken,
+  normalizeAgentTokenTtl,
+} from "./agent-token";
+
+const PEM_ENV = "AGENT_TOKEN_PRIVATE_KEY_PEM";
+const KID_ENV = "AGENT_TOKEN_KEY_ID";
+const PRIVATE_PARAMS = ["d", "p", "q", "dp", "dq", "qi", "oth"] as const;
+
+let previousPem: string | undefined;
+let previousKid: string | undefined;
+
+beforeAll(() => {
+  previousPem = process.env[PEM_ENV];
+  previousKid = process.env[KID_ENV];
+  delete process.env[KID_ENV];
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  process.env[PEM_ENV] = privateKey as string;
+});
+
+afterAll(() => {
+  if (previousPem === undefined) delete process.env[PEM_ENV];
+  else process.env[PEM_ENV] = previousPem;
+  if (previousKid === undefined) delete process.env[KID_ENV];
+  else process.env[KID_ENV] = previousKid;
+});
+
+describe("normalizeAgentTokenTtl", () => {
+  test("defaults to 15 minutes when no usable value is given", () => {
+    for (const value of [undefined, null, "900", Number.NaN, Number.POSITIVE_INFINITY, {}]) {
+      expect(normalizeAgentTokenTtl(value)).toBe(900);
+    }
+  });
+
+  test("clamps to the documented 60s..3600s window", () => {
+    expect(normalizeAgentTokenTtl(1)).toBe(60);
+    expect(normalizeAgentTokenTtl(0)).toBe(60);
+    expect(normalizeAgentTokenTtl(-9999)).toBe(60);
+    expect(normalizeAgentTokenTtl(99_999)).toBe(3600);
+    expect(normalizeAgentTokenTtl(60)).toBe(60);
+    expect(normalizeAgentTokenTtl(3600)).toBe(3600);
+  });
+
+  test("floors a fractional TTL rather than rounding up", () => {
+    expect(normalizeAgentTokenTtl(120.9)).toBe(120);
+  });
+});
+
+describe("published JWKS", () => {
+  test("reports signing as configured when a key is present", () => {
+    expect(isAgentTokenSigningConfigured()).toBe(true);
+  });
+
+  test("never publishes private RSA parameters", async () => {
+    const jwk = await getAgentTokenPublicJwk();
+    for (const param of PRIVATE_PARAMS) {
+      expect(jwk).not.toHaveProperty(param);
+    }
+    // Belt and braces: nothing private survives serialization either.
+    const serialized = JSON.stringify(jwk);
+    for (const param of PRIVATE_PARAMS) {
+      expect(serialized).not.toContain(`"${param}":`);
+    }
+    expect(jwk.kty).toBe("RSA");
+  });
+
+  test("publishes the algorithm, use, and key id", async () => {
+    const jwk = await getAgentTokenPublicJwk();
+    expect(jwk.alg).toBe("RS256");
+    expect(jwk.use).toBe("sig");
+    expect(jwk.kid).toBe(await getAgentTokenKeyId());
+  });
+
+  test("derives a stable 16-character key id from the key itself", async () => {
+    const first = await getAgentTokenKeyId();
+    const second = await getAgentTokenKeyId();
+    expect(first).toBe(second);
+    expect(first).toHaveLength(16);
+  });
+
+  test("wraps the public key in a single-entry JWKS", async () => {
+    const jwks = await getAgentTokenJWKS();
+    expect(jwks.keys).toHaveLength(1);
+    expect(jwks.keys[0]).toEqual(await getAgentTokenPublicJwk());
+  });
+});
+
+describe("mintAgentToken", () => {
+  test("mints a token that verifies against the published JWK", async () => {
+    const { token } = await mintAgentToken("agent-1");
+    const jwk = await getAgentTokenPublicJwk();
+    const key = await importJWK(jwk, "RS256");
+    const { payload, protectedHeader } = await jwtVerify(token, key, {
+      issuer: "eliza-cloud",
+      audience: "steward",
+    });
+    expect(protectedHeader.alg).toBe("RS256");
+    expect(protectedHeader.kid).toBe(await getAgentTokenKeyId());
+    expect(payload.sub).toBe("agent:agent-1");
+    expect(payload.agent_id).toBe("agent-1");
+    expect(payload.scope).toBe("agent");
+    expect(payload.scopes).toEqual(["trade:order"]);
+  });
+
+  test("honours the clamped TTL in both exp and the reported expiry", async () => {
+    const { token, expiresAt } = await mintAgentToken("agent-1", 60);
+    const key = await importJWK(await getAgentTokenPublicJwk(), "RS256");
+    const { payload } = await jwtVerify(token, key);
+    expect((payload.exp ?? 0) - (payload.iat ?? 0)).toBe(60);
+    expect(new Date(expiresAt).getTime()).toBe((payload.exp ?? 0) * 1000);
+  });
+
+  test("sets notBefore to the issue time", async () => {
+    const key = await importJWK(await getAgentTokenPublicJwk(), "RS256");
+    const { payload } = await jwtVerify((await mintAgentToken("agent-1")).token, key);
+    expect(payload.nbf).toBe(payload.iat);
+  });
+
+  test("rejects an agent id outside the permitted character set", async () => {
+    for (const agentId of ["", "   ", "bad id", "bad/id", "bad\nid", "a".repeat(129)]) {
+      expect(mintAgentToken(agentId)).rejects.toThrow("invalid agentId");
+    }
+  });
+
+  test("accepts the documented id characters and trims surrounding space", async () => {
+    const key = await importJWK(await getAgentTokenPublicJwk(), "RS256");
+    const { payload } = await jwtVerify((await mintAgentToken("  Agent_1.2:3-4  ")).token, key);
+    expect(payload.agent_id).toBe("Agent_1.2:3-4");
+  });
+
+  test("does not verify against an unrelated key", async () => {
+    const { token } = await mintAgentToken("agent-1");
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const foreign = await importJWK(await exportJWK(publicKey), "RS256");
+    expect(jwtVerify(token, foreign)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/shared/src/lib/auth/agent-token.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The suite generates a real RSA keypair and exercises the real jose sign/verify path — no stubbed crypto. The key-leak case asserts both structural absence and absence from the serialized JSON, and the verification case is paired with a negative control (an unrelated key must NOT verify), so it cannot pass by accepting everything.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/auth/agent-token.ts` mints the RS256 tokens Steward accepts and publishes the JWKS they are verified against. It had **no dedicated test file**.

The property pinned most deliberately is negative:

| Area | Contract pinned |
|---|---|
| **key material** | `getAgentTokenPublicJwk` exports the signing key, so it must strip every private RSA parameter before publishing. Leaking `d` or any CRT factor from the JWKS endpoint would hand out the key that mints agent tokens. Each of `d`/`p`/`q`/`dp`/`dq`/`qi`/`oth` is asserted absent, and the serialized form is re-checked. |
| token validity | a minted token verifies against the published JWK with the expected issuer, audience, subject, `agent_id`, and scope claims; the header carries the published `kid` |
| negative control | the same token does **not** verify against an unrelated RSA key |
| TTL clamping | clamped to the documented 60s..3600s window; defaults to 900s for undefined/string/NaN/Infinity/object; floors a fractional value rather than rounding up |
| expiry agreement | the reported `expiresAt` matches the token's own `exp`, and `nbf` equals `iat` |
| key id | stable across calls, 16 characters, and reused as the JWKS `kid` |
| id validation | empty, whitespace-only, spaced, slashed, newline-bearing, and >128-char agent ids are rejected before reaching the subject claim; documented characters are accepted and trimmed |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/auth/agent-token.test.ts`, the "never publishes private RSA parameters" case.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/auth/agent-token.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ec878211cd25619e3b17ad53ca05f5bfa42fffe9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ bun test src/lib/auth/agent-token.test.ts
 14 pass
 0 fail
 53 expect() calls
Ran 14 tests across 1 file.
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 14/14 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is the paired negative control on verification and the serialized-form check on key stripping.
- The suite sets `AGENT_TOKEN_PRIVATE_KEY_PEM` for its own run and restores the prior value in `afterAll`; it does not read or require any real deployment key.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
