### PR TITLE
fix(cloud): return finite, non-negative safe-area insets

### DIFF
--- a/packages/cloud/shared/src/lib/utils/platform.test.ts
+++ b/packages/cloud/shared/src/lib/utils/platform.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Covers platform detection and the safe-area inset reader.
+ *
+ * Every helper is expected to be safe on the server (no `window`), and the
+ * inset reader is expected to return numbers callers can do layout math with.
+ * `parseInt` returns NaN for a non-numeric custom property — and `--sat` is
+ * conventionally declared as `env(safe-area-inset-top)`, which is exactly the
+ * shape `parseInt` cannot read — so the reader is pinned to finite output.
+ *
+ * Browser cases install minimal globals and remove them afterwards.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getPlatform,
+  getPlatformConfig,
+  getSafeAreaInsets,
+  getUserAgentInfo,
+  isAndroid,
+  isBrowser,
+  isIOS,
+  isMobileApp,
+  isTouchDevice,
+  isWebView,
+} from "./platform";
+
+const g = globalThis as Record<string, unknown>;
+
+function installBrowser(options: {
+  userAgent?: string;
+  vendor?: string;
+  maxTouchPoints?: number;
+  cssVars?: Record<string, string>;
+  touchEvents?: boolean;
+}): void {
+  const vars = options.cssVars ?? {};
+  g.window = {
+    ...(options.touchEvents ? { ontouchstart: null } : {}),
+    Notification: class {},
+  };
+  g.navigator = {
+    userAgent: options.userAgent ?? "",
+    vendor: options.vendor ?? "",
+    platform: "test",
+    language: "en-US",
+    cookieEnabled: true,
+    onLine: true,
+    maxTouchPoints: options.maxTouchPoints ?? 0,
+    vibrate: () => true,
+  };
+  g.document = { documentElement: {} };
+  g.getComputedStyle = () => ({
+    getPropertyValue: (name: string) => vars[name] ?? "",
+  });
+}
+
+afterEach(() => {
+  for (const key of ["window", "navigator", "document", "getComputedStyle"]) {
+    delete g[key];
+  }
+});
+
+describe("server environment", () => {
+  test("reports no browser and an unknown platform", () => {
+    expect(isBrowser()).toBe(false);
+    expect(getPlatform()).toBe("unknown");
+  });
+
+  test("every capability probe answers false rather than throwing", () => {
+    for (const probe of [isMobileApp, isIOS, isAndroid, isWebView, isTouchDevice]) {
+      expect(probe()).toBe(false);
+    }
+  });
+
+  test("returns zeroed insets and a server marker", () => {
+    expect(getSafeAreaInsets()).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+    expect(getUserAgentInfo()).toEqual({ environment: "server" });
+  });
+
+  test("reports a non-mobile, non-touch config", () => {
+    expect(getPlatformConfig()).toEqual({
+      platform: "unknown",
+      isMobile: false,
+      isTouch: false,
+      supportsNotifications: false,
+      supportsHaptics: false,
+    });
+  });
+});
+
+describe("platform detection", () => {
+  test("detects iOS from the user agent", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0) Safari" });
+    expect(isIOS()).toBe(true);
+    expect(isAndroid()).toBe(false);
+    expect(getPlatform()).toBe("ios");
+  });
+
+  test("detects Android from the user agent", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (Linux; Android 14) Chrome" });
+    expect(isAndroid()).toBe(true);
+    expect(getPlatform()).toBe("android");
+  });
+
+  test("falls back to web for a desktop user agent", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (Macintosh) Safari" });
+    expect(getPlatform()).toBe("web");
+    expect(isMobileApp()).toBe(false);
+  });
+
+  test("falls back to navigator.vendor when userAgent is empty", () => {
+    installBrowser({ userAgent: "", vendor: "iPad" });
+    expect(isIOS()).toBe(true);
+  });
+});
+
+describe("webview detection", () => {
+  test("flags an Android WebView marker", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (Linux; Android 14; wv) Chrome" });
+    expect(isWebView()).toBe(true);
+  });
+
+  test("flags iOS without Safari, but not Safari itself", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (iPhone) CriOS" });
+    expect(isWebView()).toBe(true);
+    installBrowser({ userAgent: "Mozilla/5.0 (iPhone) Safari" });
+    expect(isWebView()).toBe(false);
+  });
+});
+
+describe("touch and capability config", () => {
+  test("detects touch from ontouchstart or maxTouchPoints", () => {
+    installBrowser({ touchEvents: true });
+    expect(isTouchDevice()).toBe(true);
+    installBrowser({ maxTouchPoints: 5 });
+    expect(isTouchDevice()).toBe(true);
+    installBrowser({});
+    expect(isTouchDevice()).toBe(false);
+  });
+
+  test("reports mobile only for ios/android", () => {
+    installBrowser({ userAgent: "Mozilla/5.0 (iPhone) Safari" });
+    expect(getPlatformConfig().isMobile).toBe(true);
+    installBrowser({ userAgent: "Mozilla/5.0 (Macintosh) Safari" });
+    expect(getPlatformConfig().isMobile).toBe(false);
+  });
+});
+
+describe("getSafeAreaInsets", () => {
+  test("reads pixel values from the custom properties", () => {
+    installBrowser({
+      cssVars: { "--sat": "44px", "--sar": "0px", "--sab": "34px", "--sal": "1px" },
+    });
+    expect(getSafeAreaInsets()).toEqual({ top: 44, right: 0, bottom: 34, left: 1 });
+  });
+
+  test("treats an unset custom property as zero", () => {
+    installBrowser({ cssVars: {} });
+    expect(getSafeAreaInsets()).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+  });
+
+  test("returns finite numbers for an unresolved env() custom property", () => {
+    // `--sat: env(safe-area-inset-top)` is the conventional declaration, and
+    // parseInt cannot read it. Callers do layout arithmetic with these values,
+    // so a NaN inset silently poisons every computed offset.
+    installBrowser({
+      cssVars: {
+        "--sat": "env(safe-area-inset-top)",
+        "--sar": "calc(1px + 2px)",
+        "--sab": "auto",
+        "--sal": "",
+      },
+    });
+    const insets = getSafeAreaInsets();
+    for (const [edge, value] of Object.entries(insets)) {
+      expect(Number.isFinite(value), `${edge} must be finite`).toBe(true);
+    }
+    expect(insets).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+  });
+
+  test("ignores a negative inset rather than shrinking the layout", () => {
+    installBrowser({ cssVars: { "--sat": "-10px" } });
+    expect(getSafeAreaInsets().top).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/platform.ts
+++ b/packages/cloud/shared/src/lib/utils/platform.ts
@@ -99,11 +99,29 @@ export function getSafeAreaInsets(): {
   const computedStyle = getComputedStyle(document.documentElement);
 
   return {
-    top: parseInt(computedStyle.getPropertyValue("--sat") || "0", 10),
-    right: parseInt(computedStyle.getPropertyValue("--sar") || "0", 10),
-    bottom: parseInt(computedStyle.getPropertyValue("--sab") || "0", 10),
-    left: parseInt(computedStyle.getPropertyValue("--sal") || "0", 10),
+    top: readInsetPx(computedStyle, "--sat"),
+    right: readInsetPx(computedStyle, "--sar"),
+    bottom: readInsetPx(computedStyle, "--sab"),
+    left: readInsetPx(computedStyle, "--sal"),
   };
+}
+
+/**
+ * One safe-area edge as a usable pixel count.
+ *
+ * `parseInt` returns NaN for any custom property it cannot read as a leading
+ * number, and these variables are conventionally declared as
+ * `--sat: env(safe-area-inset-top)` — a token stream `parseInt` cannot parse.
+ * `calc(...)`, `auto`, and an unset property behave the same way. Callers do
+ * layout arithmetic with these values, so one NaN edge silently poisons every
+ * offset derived from it. A negative inset is equally unusable: an inset is
+ * physical padding, and a negative one would shrink the layout instead of
+ * protecting it. Both collapse to 0, which is what the previous `|| "0"`
+ * default already meant for the unset case.
+ */
+function readInsetPx(computedStyle: CSSStyleDeclaration, name: string): number {
+  const parsed = Number.parseInt(computedStyle.getPropertyValue(name), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
 /**


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/cloud/shared/src/lib/utils/platform.ts`. Same non-finite-value class as merged #25988 and #26041.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

@@RISKS@@

# Background

## What does this PR do?

`getSafeAreaInsets` read each edge with:

```ts
parseInt(computedStyle.getPropertyValue("--sat") || "0", 10)
```

The `|| "0"` default only covers an **unset** property. It does not cover a property that is set to something `parseInt` cannot read — and that is the conventional declaration for these variables:

```css
--sat: env(safe-area-inset-top);
```

`calc(1px + 2px)` and `auto` behave identically. In every one of those cases `parseInt` returns `NaN`, and the function hands `NaN` back as a pixel count. Callers do layout arithmetic with these values, so a single NaN edge does not produce a wrong inset — it produces an unusable one that propagates into every offset derived from it.

A **negative** inset was also passed through unchanged. An inset is physical padding meant to protect content from a notch or home indicator; a negative one shrinks the layout instead of protecting it.

Adds `readInsetPx`, which collapses both non-finite and negative values to `0` — exactly what the previous `|| "0"` default already meant for the unset case.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/platform.test.ts`, the `getSafeAreaInsets` block. The module had no test file at all, so the suite also covers server-side safety for every probe, platform detection, WebView detection, and touch detection.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/utils/platform.test.ts
```

To confirm the suite is not vacuous, revert `platform.ts` (keep the test) and re-run — 2 of 16 fail, and they are exactly the two defects above. The other 14 are controls covering detection and server-side safety, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:4c5c03edbf71814c7dc49628507e244ce883807b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface in this diff; this changes a pure value reader.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface in this diff; this changes a pure value reader.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is the pixel values returned for safe-area insets, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no component or network call is touched; the suite exercises the real reader against stubbed browser globals.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > returns finite numbers for an unresolved env() custom property
 FAIL > ignores a negative inset rather than shrinking the layout

 14 pass
 2 fail
```

### Green — with the fix, at this exact head

```
$ bun test src/lib/utils/platform.test.ts
 16 pass
 0 fail
```

## Domain artifacts

Values returned by the real reader for each declared custom property:

| `--sat` declaration | before | after |
|---|---|---|
| `44px` | `44` | `44` (unchanged) |
| unset | `0` | `0` (unchanged) |
| `env(safe-area-inset-top)` | **`NaN`** | `0` |
| `calc(1px + 2px)` | **`NaN`** | `0` |
| `auto` | **`NaN`** | `0` |
| `-10px` | **`-10`** | `0` |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 16/16 passing at this exact head; the module previously had no test file.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
