### PR TITLE
test(ui): cover relationships-utils

### DIFF
--- a/packages/ui/src/components/pages/relationships/relationships-utils.test.ts
+++ b/packages/ui/src/components/pages/relationships/relationships-utils.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Covers the pure derivation helpers behind the Relationships view.
+ *
+ * `sortPeople` is the load-bearing one: it is a four-level comparator (owner
+ * first, then recency, then relationship count, then name) whose recency key is
+ * an ISO string from an adapter row, so an absent or unparseable date must not
+ * be able to reorder the people around it. The remaining helpers are display
+ * derivations where the failure mode is a silently wrong label rather than a
+ * crash, so each is pinned to its exact output.
+ *
+ * No React, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  RelationshipsGraphSnapshot,
+  RelationshipsMergeCandidate,
+  RelationshipsPersonDetail,
+  RelationshipsPersonSummary,
+} from "../../../api/client-types-relationships";
+import {
+  buildRelationshipsGraphQuery,
+  evidenceSummary,
+  personLabel,
+  platformOptions,
+  profilePrimaryValue,
+  profileSourceLabel,
+  sortPeople,
+  summarizeHandles,
+  topContacts,
+} from "./relationships-utils.ts";
+
+function person(
+  overrides: Partial<RelationshipsPersonSummary> = {},
+): RelationshipsPersonSummary {
+  return {
+    displayName: "Person",
+    isOwner: false,
+    relationshipCount: 0,
+    platforms: [],
+    identities: [],
+    memberEntityIds: [],
+    ...overrides,
+  } as RelationshipsPersonSummary;
+}
+
+const names = (people: RelationshipsPersonSummary[]) =>
+  people.map((entry) => entry.displayName);
+
+describe("buildRelationshipsGraphQuery", () => {
+  it("trims the search term and drops an empty one", () => {
+    expect(buildRelationshipsGraphQuery("  ada  ", "all")).toEqual({
+      search: "ada",
+      platform: undefined,
+      limit: 200,
+    });
+    expect(buildRelationshipsGraphQuery("   ", "all").search).toBeUndefined();
+  });
+
+  it("treats the 'all' platform as no platform filter", () => {
+    expect(buildRelationshipsGraphQuery("", "all").platform).toBeUndefined();
+    expect(buildRelationshipsGraphQuery("", "discord").platform).toBe(
+      "discord",
+    );
+  });
+
+  it("honours an explicit limit", () => {
+    expect(buildRelationshipsGraphQuery("", "all", 25).limit).toBe(25);
+  });
+});
+
+describe("sortPeople", () => {
+  it("puts the owner first regardless of other keys", () => {
+    const sorted = sortPeople([
+      person({
+        displayName: "recent",
+        lastInteractionAt: "2026-05-01T00:00:00Z",
+      }),
+      person({ displayName: "owner", isOwner: true }),
+    ]);
+    expect(names(sorted)[0]).toBe("owner");
+  });
+
+  it("orders by most recent interaction next", () => {
+    expect(
+      names(
+        sortPeople([
+          person({
+            displayName: "old",
+            lastInteractionAt: "2026-01-01T00:00:00Z",
+          }),
+          person({
+            displayName: "new",
+            lastInteractionAt: "2026-05-01T00:00:00Z",
+          }),
+        ]),
+      ),
+    ).toEqual(["new", "old"]);
+  });
+
+  it("does not let an unparseable or absent date reorder the rest", () => {
+    const sorted = names(
+      sortPeople([
+        person({ displayName: "bad", lastInteractionAt: "not-a-date" }),
+        person({
+          displayName: "new",
+          lastInteractionAt: "2026-05-01T00:00:00Z",
+        }),
+        person({ displayName: "absent" }),
+        person({
+          displayName: "old",
+          lastInteractionAt: "2026-01-01T00:00:00Z",
+        }),
+      ]),
+    );
+    expect(sorted.filter((n) => n === "new" || n === "old")).toEqual([
+      "new",
+      "old",
+    ]);
+    expect(sorted).toHaveLength(4);
+  });
+
+  it("breaks a recency tie on relationship count, then on name", () => {
+    expect(
+      names(
+        sortPeople([
+          person({ displayName: "b", relationshipCount: 1 }),
+          person({ displayName: "a", relationshipCount: 1 }),
+          person({ displayName: "c", relationshipCount: 5 }),
+        ]),
+      ),
+    ).toEqual(["c", "a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [person({ displayName: "b" }), person({ displayName: "a" })];
+    sortPeople(input);
+    expect(names(input)).toEqual(["b", "a"]);
+  });
+});
+
+describe("summarizeHandles", () => {
+  it("prefixes handles and caps the summary at three", () => {
+    const summary = summarizeHandles(
+      person({
+        identities: [
+          { handles: [{ handle: "one" }, { handle: "two" }] },
+          { handles: [{ handle: "three" }, { handle: "four" }] },
+        ],
+      } as Partial<RelationshipsPersonSummary>),
+    );
+    expect(summary).toBe("@one, @two, @three");
+  });
+
+  it("returns an empty string when there are no handles", () => {
+    expect(summarizeHandles(person({ identities: [] }))).toBe("");
+  });
+});
+
+describe("platformOptions", () => {
+  it("returns an empty list for a missing snapshot", () => {
+    expect(platformOptions(null)).toEqual([]);
+  });
+
+  it("de-duplicates, drops blanks, and sorts", () => {
+    const snapshot = {
+      people: [
+        person({ platforms: ["discord", "  ", "telegram"] }),
+        person({ platforms: ["discord", "apple"] }),
+      ],
+    } as RelationshipsGraphSnapshot;
+    expect(platformOptions(snapshot)).toEqual(["apple", "discord", "telegram"]);
+  });
+});
+
+describe("topContacts", () => {
+  it("emits only the populated rows, in a fixed order", () => {
+    const detail = {
+      emails: ["a@example.test"],
+      phones: [],
+      websites: ["https://example.test"],
+      preferredCommunicationChannel: "email",
+    } as unknown as RelationshipsPersonDetail;
+    expect(topContacts(detail)).toEqual([
+      { label: "Email", value: "a@example.test" },
+      { label: "Website", value: "https://example.test" },
+      { label: "Preferred channel", value: "email" },
+    ]);
+  });
+
+  it("returns nothing when the person has no contact details", () => {
+    expect(
+      topContacts({
+        emails: [],
+        phones: [],
+        websites: [],
+      } as unknown as RelationshipsPersonDetail),
+    ).toEqual([]);
+  });
+});
+
+describe("profileSourceLabel", () => {
+  it("maps the known sources to their display names", () => {
+    expect(profileSourceLabel("client_chat")).toBe("App chat");
+    expect(profileSourceLabel("elizacloud")).toBe("Eliza Cloud");
+    expect(profileSourceLabel("twitter")).toBe("X / Twitter");
+  });
+
+  it("title-cases an unknown source and expands underscores", () => {
+    expect(profileSourceLabel("google_workspace")).toBe("Google Workspace");
+    expect(profileSourceLabel("discord")).toBe("Discord");
+  });
+});
+
+describe("profilePrimaryValue", () => {
+  const detail = (profiles: unknown[]) =>
+    ({
+      profiles,
+      displayName: "Fallback",
+    }) as unknown as RelationshipsPersonDetail;
+
+  it("returns null when the source has no profile", () => {
+    expect(profilePrimaryValue(detail([]), "discord")).toBeNull();
+  });
+
+  it("prefers displayName, then handle, then userId, then the person name", () => {
+    expect(
+      profilePrimaryValue(
+        detail([{ source: "d", displayName: "D", handle: "h" }]),
+        "d",
+      ),
+    ).toBe("D");
+    expect(
+      profilePrimaryValue(detail([{ source: "d", handle: "h" }]), "d"),
+    ).toBe("h");
+    expect(
+      profilePrimaryValue(detail([{ source: "d", userId: "u" }]), "d"),
+    ).toBe("u");
+    expect(profilePrimaryValue(detail([{ source: "d" }]), "d")).toBe(
+      "Fallback",
+    );
+  });
+});
+
+describe("personLabel", () => {
+  it("falls back to the raw entity id without a graph or a match", () => {
+    expect(personLabel(null, "e1")).toBe("e1");
+    expect(
+      personLabel(
+        { people: [] } as unknown as RelationshipsGraphSnapshot,
+        "e1",
+      ),
+    ).toBe("e1");
+  });
+
+  it("resolves the display name of the person owning the entity", () => {
+    const graph = {
+      people: [person({ displayName: "Ada", memberEntityIds: ["e1", "e2"] })],
+    } as RelationshipsGraphSnapshot;
+    expect(personLabel(graph, "e2")).toBe("Ada");
+  });
+});
+
+describe("evidenceSummary", () => {
+  const candidate = (evidence: Record<string, unknown>) =>
+    ({ evidence }) as unknown as RelationshipsMergeCandidate;
+
+  it("joins platform, handle, notes, and identity count", () => {
+    expect(
+      evidenceSummary(
+        candidate({
+          platform: "discord",
+          handle: "ada",
+          notes: "same email",
+          identityIds: ["a", "b"],
+        }),
+      ),
+    ).toBe("discord:ada · same email · 2 identities");
+  });
+
+  it("emits the platform alone when there is no handle", () => {
+    expect(evidenceSummary(candidate({ platform: "discord" }))).toBe("discord");
+  });
+
+  it("falls back to an explicit no-evidence label", () => {
+    expect(evidenceSummary(candidate({}))).toBe("No evidence");
+    expect(evidenceSummary(candidate({ identityIds: [] }))).toBe("No evidence");
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/components/pages/relationships/relationships-utils.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Display helpers are asserted against exact output strings and exact arrays rather than truthiness, so a silently wrong label fails. The sort cases assert each tie-break level independently, and the malformed-date case checks the surrounding people keep their relative order rather than only that the call returned.

# Background

## What does this PR do?

`packages/ui/src/components/pages/relationships/relationships-utils.ts` owns every derivation the Relationships view renders. It had **no dedicated test file**.

`sortPeople` is the load-bearing one — a four-level comparator (owner, recency, relationship count, name) whose recency key is an ISO string from an adapter row:

| Area | Contract pinned |
|---|---|
| owner precedence | the owner sorts first regardless of every other key |
| recency | most recent interaction next |
| malformed dates | an absent or unparseable `lastInteractionAt` does not reorder the people around it |
| tie-breaks | relationship count, then name, each asserted independently |
| purity | the input array is not mutated |

The display derivations are pinned to exact output, because their failure mode is a silently wrong label rather than a crash: `buildRelationshipsGraphQuery` (trim, empty-search, "all" platform), `summarizeHandles` (`@` prefix, flatten across identities, cap at three), `platformOptions` (de-dupe, drop blanks, sort, null snapshot), `topContacts` (only populated rows, fixed order), `profileSourceLabel` (three known sources plus underscore-expanding title case), `profilePrimaryValue` (displayName -> handle -> userId -> person name, null with no profile), `personLabel` (resolve via `memberEntityIds`, fall back to the raw id), and `evidenceSummary` (joined parts, "No evidence" fallback).

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/relationships/relationships-utils.test.ts`, the `sortPeople` block.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/pages/relationships/relationships-utils.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:0bf4cf3d4167be9b1f6bdf65067fc32e9d6d87e0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/pages/relationships/relationships-utils.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 23/23 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is exact-output assertions and independently-asserted tie-break levels.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
