### PR TITLE
test(ui): cover chat-source helpers

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-source.helpers.test.ts
+++ b/packages/ui/src/components/composites/chat/chat-source.helpers.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Covers chat message provenance helpers: the pluggable source-meta registry,
+ * source-key normalization, the reaction-emoji renderer seam, and voice-speaker
+ * label resolution.
+ *
+ * The registry is injected by the host app, so the contract that matters is
+ * that lookups are normalization-insensitive (a source arriving as `"iMessage "`
+ * from a connector must hit an entry registered as `"imessage"`) and that an
+ * unregistered source still degrades to a readable label rather than an empty
+ * badge.
+ *
+ * The registry is module-level state, so each test registers its own keys and
+ * the renderer seam is reset afterwards.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type ChatSourceMeta,
+  getChatSourceMeta,
+  hasChatSourceMeta,
+  normalizeChatSourceKey,
+  registerChatReactionEmojiRenderer,
+  registerChatSourceMetaEntries,
+  renderChatReactionEmoji,
+  resolveChatVoiceSpeakerLabel,
+} from "./chat-source.helpers.ts";
+import type { ChatVoiceSpeaker } from "./chat-types";
+
+const meta = (label: string): ChatSourceMeta =>
+  ({
+    badgeClassName: "badge",
+    borderClassName: "border",
+    iconClassName: "icon",
+    Icon: () => null,
+    label,
+  }) as ChatSourceMeta;
+
+afterEach(() => {
+  registerChatReactionEmojiRenderer(null);
+});
+
+describe("normalizeChatSourceKey", () => {
+  it("trims and lowercases a usable key", () => {
+    expect(normalizeChatSourceKey("  iMessage  ")).toBe("imessage");
+    expect(normalizeChatSourceKey("TELEGRAM")).toBe("telegram");
+  });
+
+  it("returns null for blank or non-string input", () => {
+    for (const value of ["", "   ", null, undefined, 42, {}, []]) {
+      expect(
+        normalizeChatSourceKey(value as string | null | undefined),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("source meta registry", () => {
+  it("registers under the normalized key and looks up case-insensitively", () => {
+    registerChatSourceMetaEntries({ "  RegTest_One  ": meta("Reg One") });
+    expect(hasChatSourceMeta("regtest_one")).toBe(true);
+    expect(hasChatSourceMeta("  REGTEST_ONE ")).toBe(true);
+    expect(getChatSourceMeta("RegTest_One").label).toBe("Reg One");
+  });
+
+  it("skips entries whose key normalizes to nothing", () => {
+    expect(() =>
+      registerChatSourceMetaEntries({ "   ": meta("blank") }),
+    ).not.toThrow();
+    expect(hasChatSourceMeta("   ")).toBe(false);
+  });
+
+  it("lets a later registration replace an earlier one", () => {
+    registerChatSourceMetaEntries({ regtesttwo: meta("first") });
+    registerChatSourceMetaEntries({ RegTestTwo: meta("second") });
+    expect(getChatSourceMeta("regtesttwo").label).toBe("second");
+  });
+
+  it("reports no meta for an unregistered source", () => {
+    expect(hasChatSourceMeta("regtest-never-registered")).toBe(false);
+  });
+});
+
+describe("getChatSourceMeta fallback", () => {
+  it("title-cases an unregistered source instead of leaving it blank", () => {
+    expect(getChatSourceMeta("google_workspace").label).toBe(
+      "Google Workspace",
+    );
+    expect(getChatSourceMeta("bluebubbles").label).toBe("Bluebubbles");
+    expect(getChatSourceMeta("some-mixed_source name").label).toBe(
+      "Some Mixed Source Name",
+    );
+  });
+
+  it("still returns a complete meta shape for an unregistered source", () => {
+    const fallback = getChatSourceMeta("regtest-unknown-source");
+    expect(fallback.badgeClassName).toBeTruthy();
+    expect(fallback.borderClassName).toBeTruthy();
+    expect(fallback.iconClassName).toBeTruthy();
+    expect(fallback.Icon).toBeTruthy();
+  });
+
+  it("yields an empty label for a blank source rather than throwing", () => {
+    expect(getChatSourceMeta("   ").label).toBe("");
+  });
+});
+
+describe("reaction emoji renderer seam", () => {
+  it("returns null when no renderer is installed", () => {
+    expect(renderChatReactionEmoji("thumbsup")).toBeNull();
+  });
+
+  it("delegates to an installed renderer", () => {
+    const seen: string[] = [];
+    registerChatReactionEmojiRenderer((emoji) => {
+      seen.push(emoji);
+      return `rendered:${emoji}` as unknown as null;
+    });
+    expect(renderChatReactionEmoji("heart")).toBe(
+      "rendered:heart" as unknown as null,
+    );
+    expect(seen).toEqual(["heart"]);
+  });
+
+  it("normalizes a renderer returning null or undefined to null", () => {
+    registerChatReactionEmojiRenderer(() => null);
+    expect(renderChatReactionEmoji("x")).toBeNull();
+    registerChatReactionEmojiRenderer(() => undefined as unknown as null);
+    expect(renderChatReactionEmoji("x")).toBeNull();
+  });
+
+  it("can be uninstalled again", () => {
+    registerChatReactionEmojiRenderer(() => "x" as unknown as null);
+    registerChatReactionEmojiRenderer(null);
+    expect(renderChatReactionEmoji("x")).toBeNull();
+  });
+});
+
+describe("resolveChatVoiceSpeakerLabel", () => {
+  const speaker = (value: Partial<ChatVoiceSpeaker>) =>
+    value as ChatVoiceSpeaker;
+
+  it("returns null when there is no speaker block", () => {
+    expect(resolveChatVoiceSpeakerLabel(null)).toBeNull();
+    expect(resolveChatVoiceSpeakerLabel(undefined)).toBeNull();
+  });
+
+  it("prefers the name, then the userName", () => {
+    expect(
+      resolveChatVoiceSpeakerLabel(speaker({ name: "Ada", userName: "ada99" })),
+    ).toBe("Ada");
+    expect(resolveChatVoiceSpeakerLabel(speaker({ userName: "ada99" }))).toBe(
+      "ada99",
+    );
+  });
+
+  it("treats a whitespace-only value as absent and falls through", () => {
+    expect(
+      resolveChatVoiceSpeakerLabel(speaker({ name: "   ", userName: "ada99" })),
+    ).toBe("ada99");
+    expect(
+      resolveChatVoiceSpeakerLabel(speaker({ name: "   ", userName: "  " })),
+    ).toBeNull();
+  });
+
+  it("trims the value it returns", () => {
+    expect(resolveChatVoiceSpeakerLabel(speaker({ name: "  Ada  " }))).toBe(
+      "Ada",
+    );
+  });
+
+  it("ignores non-string label fields", () => {
+    expect(
+      resolveChatVoiceSpeakerLabel(speaker({ name: 42 as unknown as string })),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/components/composites/chat/chat-source.helpers.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Cases drive the real exported registry rather than a local copy. Each test registers its own uniquely-named keys so the module-level registry is not shared between cases, and the renderer seam is reset in `afterEach`. Fallback labels are asserted as exact strings, so a regression to an empty badge fails.

# Background

## What does this PR do?

`packages/ui/src/components/composites/chat/chat-source.helpers.ts` owns chat message provenance — the pluggable source-meta registry, source-key normalization, the reaction-emoji renderer seam, and voice-speaker label resolution. It had **no dedicated test file**.

The registry is injected by the host app, so the pinned contracts are the ones that make that seam safe:

| Area | Contract pinned |
|---|---|
| normalization-insensitive lookup | a source arriving as `"iMessage "` from a connector hits an entry registered as `"imessage"`; registration normalizes keys the same way |
| blank keys | a key that normalizes to nothing is skipped rather than registered |
| re-registration | a later entry replaces an earlier one for the same normalized key |
| graceful fallback | an unregistered source degrades to a readable title-cased label (`google_workspace` -> `Google Workspace`, `some-mixed_source name` -> `Some Mixed Source Name`) with a complete meta shape, not an empty badge |
| renderer seam | returns null with no renderer installed, delegates when one is, normalizes a renderer returning `null`/`undefined` to `null`, and can be uninstalled |
| speaker labels | name preferred over userName; a whitespace-only value is treated as absent and falls through; the returned value is trimmed; non-string fields are ignored |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/composites/chat/chat-source.helpers.test.ts`, the `source meta registry` and `getChatSourceMeta fallback` blocks.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/composites/chat/chat-source.helpers.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:86db540e13c147b9f68624365a192924691c3a00 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/composites/chat/chat-source.helpers.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 18/18 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is exact-string fallback assertions plus per-test key isolation on the shared registry.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
