### PR TITLE
fix(cloud): honour an explicit maxSize of 0 in audio upload validation

### DIFF
--- a/packages/cloud/shared/src/lib/utils/audio.test.ts
+++ b/packages/cloud/shared/src/lib/utils/audio.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Covers the audio helpers: upload validation, MediaRecorder capability probes,
+ * MIME negotiation, and container normalization.
+ *
+ * `validateAudioFile` is the gate an upload passes through, so its limits must
+ * mean what the caller said. A caller that passes `maxSize: 0` is disabling
+ * uploads; resolving that through `||` would silently restore the 25MB default
+ * and admit everything under it.
+ *
+ * Browser-dependent probes install minimal globals and remove them afterwards.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  ensureAudioFormat,
+  getSupportedMimeType,
+  supportsGetUserMedia,
+  supportsMediaRecorder,
+  validateAudioFile,
+} from "./audio";
+
+const g = globalThis as Record<string, unknown>;
+
+const file = (size: number, type: string): File => ({ size, type, name: "clip" }) as File;
+
+afterEach(() => {
+  for (const key of ["window", "navigator", "MediaRecorder"]) delete g[key];
+});
+
+describe("validateAudioFile", () => {
+  test("accepts a supported type inside the default size limit", () => {
+    expect(validateAudioFile(file(1024, "audio/wav"))).toEqual({ valid: true });
+  });
+
+  test("accepts every documented default type", () => {
+    for (const type of [
+      "audio/mp3",
+      "audio/mpeg",
+      "audio/mp4",
+      "audio/m4a",
+      "audio/wav",
+      "audio/webm",
+      "audio/ogg",
+    ]) {
+      expect(validateAudioFile(file(10, type)).valid).toBe(true);
+    }
+  });
+
+  test("rejects an unsupported type and names it", () => {
+    const result = validateAudioFile(file(10, "video/mp4"));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("video/mp4");
+  });
+
+  test("rejects a file over the default limit", () => {
+    const result = validateAudioFile(file(25 * 1024 * 1024 + 1, "audio/wav"));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("25MB");
+  });
+
+  test("treats a file exactly at the limit as acceptable", () => {
+    expect(validateAudioFile(file(25 * 1024 * 1024, "audio/wav")).valid).toBe(true);
+  });
+
+  test("honours a custom size limit", () => {
+    expect(validateAudioFile(file(2048, "audio/wav"), { maxSize: 1024 }).valid).toBe(false);
+    expect(validateAudioFile(file(512, "audio/wav"), { maxSize: 1024 }).valid).toBe(true);
+  });
+
+  test("honours a caller that disables uploads with maxSize 0", () => {
+    // 0 is a real limit meaning "reject everything", not an absent option.
+    const result = validateAudioFile(file(1, "audio/wav"), { maxSize: 0 });
+    expect(result.valid).toBe(false);
+  });
+
+  test("honours a custom allowlist", () => {
+    expect(validateAudioFile(file(10, "audio/wav"), { allowedTypes: ["audio/ogg"] }).valid).toBe(
+      false,
+    );
+    expect(validateAudioFile(file(10, "audio/ogg"), { allowedTypes: ["audio/ogg"] }).valid).toBe(
+      true,
+    );
+  });
+
+  test("an empty allowlist rejects every type", () => {
+    expect(validateAudioFile(file(10, "audio/wav"), { allowedTypes: [] }).valid).toBe(false);
+  });
+
+  test("checks size before type, so an oversized bad type reports size", () => {
+    const result = validateAudioFile(file(99 * 1024 * 1024, "video/mp4"));
+    expect(result.error).toContain("too large");
+  });
+});
+
+describe("capability probes", () => {
+  test("report false with no browser globals", () => {
+    expect(supportsMediaRecorder()).toBe(false);
+    expect(supportsGetUserMedia()).toBe(false);
+  });
+
+  test("detect MediaRecorder when present", () => {
+    g.window = { MediaRecorder: class {} };
+    expect(supportsMediaRecorder()).toBe(true);
+  });
+
+  test("detect getUserMedia only when the method exists", () => {
+    g.window = {};
+    g.navigator = { mediaDevices: {} };
+    expect(supportsGetUserMedia()).toBe(false);
+    g.navigator = { mediaDevices: { getUserMedia: () => {} } };
+    expect(supportsGetUserMedia()).toBe(true);
+  });
+});
+
+describe("getSupportedMimeType", () => {
+  test("prefers opus-in-webm when everything is supported", () => {
+    g.MediaRecorder = { isTypeSupported: () => true };
+    expect(getSupportedMimeType()).toBe("audio/webm;codecs=opus");
+  });
+
+  test("falls through the priority list in order", () => {
+    g.MediaRecorder = {
+      isTypeSupported: (type: string) => type === "audio/mp4" || type === "audio/wav",
+    };
+    expect(getSupportedMimeType()).toBe("audio/mp4");
+  });
+
+  test("returns an empty string when nothing is supported", () => {
+    g.MediaRecorder = { isTypeSupported: () => false };
+    expect(getSupportedMimeType()).toBe("");
+  });
+
+  test("never offers a video container", () => {
+    g.MediaRecorder = { isTypeSupported: () => true };
+    expect(getSupportedMimeType().startsWith("video/")).toBe(false);
+  });
+});
+
+describe("ensureAudioFormat", () => {
+  test("passes an audio blob through unchanged", async () => {
+    const blob = new Blob(["x"], { type: "audio/webm" });
+    expect(await ensureAudioFormat(blob)).toBe(blob);
+  });
+
+  test("rewrites a video/webm container to audio/webm", async () => {
+    const rewritten = await ensureAudioFormat(new Blob(["x"], { type: "video/webm" }));
+    expect(rewritten.type).toBe("audio/webm");
+  });
+
+  test("preserves the payload while rewriting the container", async () => {
+    const rewritten = await ensureAudioFormat(new Blob(["payload"], { type: "video/webm" }));
+    expect(await rewritten.text()).toBe("payload");
+  });
+
+  test("leaves an unrelated type alone", async () => {
+    const blob = new Blob(["x"], { type: "application/octet-stream" });
+    expect(await ensureAudioFormat(blob)).toBe(blob);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/audio.ts
+++ b/packages/cloud/shared/src/lib/utils/audio.ts
@@ -49,7 +49,12 @@ export function validateAudioFile(
     allowedTypes?: string[];
   },
 ): { valid: boolean; error?: string } {
-  const maxSize = options?.maxSize || 25 * 1024 * 1024; // 25MB default
+  // `??`, not `||`: 0 is a real limit meaning "reject everything", and `||`
+  // would treat it as an absent option and silently restore the 25MB
+  // default — admitting every file under it through a gate the caller
+  // had closed. (`allowedTypes` below is unaffected: `[]` is truthy, so an
+  // empty allowlist already rejects every type.)
+  const maxSize = options?.maxSize ?? 25 * 1024 * 1024; // 25MB default
   const allowedTypes = options?.allowedTypes || [
     "audio/mp3",
     "audio/mpeg",


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/cloud/shared/src/lib/utils/audio.ts`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

@@RISKS@@

# Background

## What does this PR do?

`validateAudioFile` is the gate an audio upload passes through. It resolved its size limit with:

```ts
const maxSize = options?.maxSize || 25 * 1024 * 1024;
```

`||` treats `0` as absent. A caller passing `maxSize: 0` — which means *reject everything* — silently got the 25MB default instead, and every file under that limit was admitted through a gate the caller had closed. The limit could not be tightened to zero at all.

Switches to `??`, which distinguishes an absent option from an explicit `0`.

`allowedTypes` on the very next line does **not** have this problem and is deliberately left alone: `[]` is truthy, so `||` already returns the empty allowlist and every type is rejected. A test pins that so it stays true.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/audio.test.ts`, the "honours a caller that disables uploads with maxSize 0" case. The module had no test file at all, so the suite also covers the default allowlist, the size boundary, capability probes, MIME negotiation, and container normalization.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/utils/audio.test.ts
```

To confirm the suite is not vacuous, revert `audio.ts` (keep the test) and re-run — 1 of 21 fails, and it is exactly the defect above. The other 20 are controls, including one asserting that an empty `allowedTypes` still rejects everything, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f1787487d7800ec9b8098df89c14a5d9ea459c90 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a pure validation helper.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a pure validation helper.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is whether an audio upload is accepted, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no component or network call is touched; the suite exercises the real validator and stubbed browser globals directly.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 (fail) validateAudioFile > honours a caller that disables uploads with maxSize 0

 20 pass
 1 fail
```

### Green — with the fix, at this exact head

```
$ bun test src/lib/utils/audio.test.ts
 21 pass
 0 fail
```

## Domain artifacts

Result of the real validator for a 1-byte `audio/wav` file:

| options | before | after |
|---|---|---|
| `{}` (absent) | accepted (25MB default) | accepted (unchanged) |
| `{ maxSize: 1024 }` | accepted | accepted (unchanged) |
| `{ maxSize: 0 }` | **accepted** — default silently restored | rejected |
| `{ allowedTypes: [] }` | rejected | rejected (unchanged) |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 21/21 passing at this exact head; the module previously had no test file.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
