### PR TITLE
fix(ui): make vector-browser PCA projection deterministic

### DIFF
--- a/packages/ui/src/components/pages/vector-browser-utils.test.ts
+++ b/packages/ui/src/components/pages/vector-browser-utils.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Covers the vector-browser derivations: content parsing, embedding parsing
+ * across storage formats, database-row normalization, and the 2D graph layout.
+ *
+ * `parseEmbedding` and `rowToMemory` read straight off database rows, so the
+ * contracts that matter are the tolerant ones — pgvector text, JSON arrays, and
+ * typed arrays must all resolve, column aliases must all be honoured, and
+ * anything unparseable must become an explicit `null` rather than a partially
+ * filled vector that would silently distort the projection.
+ *
+ * Pure functions — no React, no database, no canvas.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildVectorGraph2DLayout,
+  DIM_COLUMNS,
+  hasEmbedding,
+  type MemoryRecord,
+  parseContent,
+  parseEmbedding,
+  projectTo2D,
+  projectTo3D,
+  rowToMemory,
+  toVectorGraph2DScreenX,
+  toVectorGraph2DScreenY,
+  VECTOR_GRAPH_2D_PALETTE,
+} from "./vector-browser-utils.ts";
+
+const memory = (embedding: number[] | null, type = "message"): MemoryRecord =>
+  ({
+    id: "m",
+    content: "c",
+    roomId: "r",
+    entityId: "e",
+    type,
+    createdAt: "",
+    unique: false,
+    embedding,
+    raw: {},
+  }) as MemoryRecord;
+
+describe("parseContent", () => {
+  it("returns a plain string unchanged", () => {
+    expect(parseContent("hello")).toBe("hello");
+  });
+
+  it("extracts text or content from a JSON string", () => {
+    expect(parseContent('{"text":"hi"}')).toBe("hi");
+    expect(parseContent('{"content":"body"}')).toBe("body");
+  });
+
+  it("returns the raw string when the JSON is malformed", () => {
+    expect(parseContent('{"text":')).toBe('{"text":');
+  });
+
+  it("returns the raw string when the JSON has neither field", () => {
+    expect(parseContent('{"other":1}')).toBe('{"other":1}');
+  });
+
+  it("extracts text or content from an object", () => {
+    expect(parseContent({ text: "hi" })).toBe("hi");
+    expect(parseContent({ content: "body" })).toBe("body");
+  });
+
+  it("pretty-prints an object with neither field", () => {
+    expect(parseContent({ a: 1 })).toBe(JSON.stringify({ a: 1 }, null, 2));
+  });
+
+  it("renders null and undefined as an empty string", () => {
+    expect(parseContent(null)).toBe("");
+    expect(parseContent(undefined)).toBe("");
+  });
+
+  it("stringifies a non-string primitive", () => {
+    expect(parseContent(42)).toBe("42");
+  });
+});
+
+describe("parseEmbedding", () => {
+  it("passes an array through", () => {
+    expect(parseEmbedding([0.1, 0.2])).toEqual([0.1, 0.2]);
+  });
+
+  it("converts a typed array", () => {
+    expect(parseEmbedding(new Float32Array([1, 2]))).toEqual([1, 2]);
+    expect(parseEmbedding(new Float64Array([1.5, 2.5]))).toEqual([1.5, 2.5]);
+  });
+
+  it("parses pgvector bracket text", () => {
+    expect(parseEmbedding("[0.1,0.2,0.3]")).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it("parses bare comma-separated text", () => {
+    expect(parseEmbedding("0.1,0.2")).toEqual([0.1, 0.2]);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseEmbedding("  [1,2]  ")).toEqual([1, 2]);
+  });
+
+  it("returns null rather than a partial vector when a component is unparseable", () => {
+    // A half-parsed embedding would silently distort every projection.
+    expect(parseEmbedding("[0.1,oops,0.3]")).toBeNull();
+  });
+
+  it("returns null for falsy, non-vector, and too-short input", () => {
+    for (const value of [null, undefined, 0, "", "[]", "[1]", 42, {}]) {
+      expect(parseEmbedding(value)).toBeNull();
+    }
+  });
+});
+
+describe("rowToMemory", () => {
+  it("honours every documented id, room, and entity alias", () => {
+    expect(rowToMemory({ ID: "x" }).id).toBe("x");
+    expect(rowToMemory({ memory_id: "y" }).id).toBe("y");
+    expect(rowToMemory({ room_id: "r" }).roomId).toBe("r");
+    expect(rowToMemory({ roomID: "r2" }).roomId).toBe("r2");
+    expect(rowToMemory({ entity_id: "e" }).entityId).toBe("e");
+    expect(rowToMemory({ user_id: "u" }).entityId).toBe("u");
+  });
+
+  it("defaults missing fields to an empty string rather than 'undefined'", () => {
+    const record = rowToMemory({});
+    expect(record.id).toBe("");
+    expect(record.roomId).toBe("");
+    expect(record.entityId).toBe("");
+    expect(record.type).toBe("");
+    expect(record.createdAt).toBe("");
+  });
+
+  it("coerces the unique flag from each accepted representation", () => {
+    expect(rowToMemory({ unique: true }).unique).toBe(true);
+    expect(rowToMemory({ unique: 1 }).unique).toBe(true);
+    expect(rowToMemory({ isUnique: true }).unique).toBe(true);
+    expect(rowToMemory({ unique: 0 }).unique).toBe(false);
+    expect(rowToMemory({}).unique).toBe(false);
+  });
+
+  it("falls back to an elizaOS dim_* column when no explicit embedding exists", () => {
+    for (const dim of DIM_COLUMNS) {
+      expect(rowToMemory({ [dim]: "[1,2]" }).embedding).toEqual([1, 2]);
+    }
+  });
+
+  it("prefers an explicit embedding column over a dim_* column", () => {
+    expect(
+      rowToMemory({ embedding: "[9,9]", dim_384: "[1,1]" }).embedding,
+    ).toEqual([9, 9]);
+  });
+
+  it("preserves the original row", () => {
+    const row = { id: "a", extra: true };
+    expect(rowToMemory(row).raw).toBe(row);
+  });
+});
+
+describe("hasEmbedding", () => {
+  it("narrows on a present embedding", () => {
+    expect(hasEmbedding(memory([1, 2]))).toBe(true);
+    expect(hasEmbedding(memory(null))).toBe(false);
+  });
+});
+
+describe("buildVectorGraph2DLayout", () => {
+  it("returns null when fewer than two memories carry embeddings", () => {
+    expect(buildVectorGraph2DLayout([])).toBeNull();
+    expect(buildVectorGraph2DLayout([memory([1, 2])])).toBeNull();
+    expect(buildVectorGraph2DLayout([memory([1, 2]), memory(null)])).toBeNull();
+  });
+
+  it("projects only the memories that carry embeddings", () => {
+    const layout = buildVectorGraph2DLayout([
+      memory([1, 0]),
+      memory(null),
+      memory([0, 1]),
+      memory([1, 1]),
+    ]);
+    expect(layout?.withEmbeddings).toHaveLength(3);
+    expect(layout?.points).toHaveLength(3);
+  });
+
+  it("never reports a zero range, so screen mapping cannot divide by zero", () => {
+    const layout = buildVectorGraph2DLayout([
+      memory([1, 1]),
+      memory([1, 1]),
+      memory([1, 1]),
+    ]);
+    expect(layout?.bounds.rangeX).not.toBe(0);
+    expect(layout?.bounds.rangeY).not.toBe(0);
+  });
+
+  it("assigns one palette colour per type and cycles the palette", () => {
+    const many = Array.from(
+      { length: VECTOR_GRAPH_2D_PALETTE.length + 2 },
+      (_, i) => memory([i, i + 1], `type-${i}`),
+    );
+    const layout = buildVectorGraph2DLayout(many);
+    const colors = Object.values(layout?.typeColors ?? {});
+    expect(Object.keys(layout?.typeColors ?? {})).toHaveLength(many.length);
+    for (const color of colors) {
+      expect(VECTOR_GRAPH_2D_PALETTE).toContain(color);
+    }
+    expect(layout?.typeColors["type-0"]).toBe(
+      layout?.typeColors[`type-${VECTOR_GRAPH_2D_PALETTE.length}`],
+    );
+  });
+});
+
+describe("screen mapping", () => {
+  const bounds = { minX: 0, minY: 0, rangeX: 10, rangeY: 10 };
+
+  it("maps the minimum onto the padding edge", () => {
+    expect(toVectorGraph2DScreenX(0, 100, 10, bounds)).toBe(10);
+    expect(toVectorGraph2DScreenY(0, 100, 10, bounds)).toBe(10);
+  });
+
+  it("maps the maximum onto the far padded edge", () => {
+    expect(toVectorGraph2DScreenX(10, 100, 10, bounds)).toBe(90);
+    expect(toVectorGraph2DScreenY(10, 100, 10, bounds)).toBe(90);
+  });
+
+  it("maps the midpoint to the centre", () => {
+    expect(toVectorGraph2DScreenX(5, 100, 10, bounds)).toBe(50);
+  });
+});
+
+describe("projections", () => {
+  const vectors = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+    [1, 1, 1],
+  ];
+
+  it("projects to two dimensions, one point per input", () => {
+    const points = projectTo2D(vectors);
+    expect(points).toHaveLength(vectors.length);
+    for (const point of points) {
+      expect(point).toHaveLength(2);
+      expect(point.every((value) => Number.isFinite(value))).toBe(true);
+    }
+  });
+
+  it("projects to three dimensions, one point per input", () => {
+    const points = projectTo3D(vectors);
+    expect(points).toHaveLength(vectors.length);
+    for (const point of points) {
+      expect(point).toHaveLength(3);
+      expect(point.every((value) => Number.isFinite(value))).toBe(true);
+    }
+  });
+
+  it("is deterministic across repeated calls", () => {
+    // The vector browser re-projects on every render; a random seed made the
+    // same memories land somewhere different each time.
+    expect(projectTo2D(vectors)).toEqual(projectTo2D(vectors));
+    expect(projectTo3D(vectors)).toEqual(projectTo3D(vectors));
+  });
+
+  it("does not mirror between runs over identical data", () => {
+    // Power iteration converges to +v or -v depending on where it started.
+    const [first] = projectTo2D(vectors);
+    const [again] = projectTo2D(vectors);
+    expect(Math.sign(first[0])).toBe(Math.sign(again[0]));
+  });
+});

--- a/packages/ui/src/components/pages/vector-browser-utils.ts
+++ b/packages/ui/src/components/pages/vector-browser-utils.ts
@@ -217,14 +217,53 @@ function dot(a: number[], b: Float64Array | number[]): number {
   return s;
 }
 
+/**
+ * Small deterministic PRNG (mulberry32). Power iteration needs a spread-out
+ * starting vector — a uniform one can sit exactly orthogonal to the dominant
+ * eigenvector on symmetric input and converge badly — but it must not need an
+ * UNPREDICTABLE one.
+ */
+function seededRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const POWER_ITERATION_SEED = 0x5eed;
+
+/**
+ * Pin the eigenvector's arbitrary sign. Power iteration converges to either
+ * `+v` or `-v` depending on where it started, so without this the whole plot
+ * can mirror between two runs over identical data. Canonicalizing on the
+ * largest-magnitude component is the usual convention.
+ */
+function canonicalizeSign(v: Float64Array): void {
+  let maxIndex = 0;
+  for (let i = 1; i < v.length; i++) {
+    if (Math.abs(v[i]) > Math.abs(v[maxIndex])) maxIndex = i;
+  }
+  if (v[maxIndex] < 0) {
+    for (let i = 0; i < v.length; i++) v[i] = -v[i];
+  }
+}
+
 function powerIteration(
   data: number[][],
   dims: number,
   iters = 30,
 ): Float64Array {
   const v = new Float64Array(dims);
-  // Random init
-  for (let d = 0; d < dims; d++) v[d] = Math.random() - 0.5;
+  // Deterministic init: the vector browser re-projects on every render, and a
+  // Math.random() seed made the same memories land somewhere different each
+  // time — nodes jumped and the plot could mirror. Seeded by `dims` so the
+  // starting vector still varies with the embedding width.
+  const random = seededRandom(POWER_ITERATION_SEED + dims);
+  for (let d = 0; d < dims; d++) v[d] = random() - 0.5;
   normalize(v);
 
   for (let iter = 0; iter < iters; iter++) {
@@ -236,6 +275,7 @@ function powerIteration(
     normalize(w);
     for (let d = 0; d < dims; d++) v[d] = w[d];
   }
+  canonicalizeSign(v);
   return v;
 }
 


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/ui/src/components/pages/vector-browser-utils.ts`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `cd4fb2746e7387982986405451bf38c049747acf`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

@@RISKS@@

# Background

## What does this PR do?

`powerIteration` seeded its starting vector with `Math.random() - 0.5`:

```ts
// Random init
for (let d = 0; d < dims; d++) v[d] = Math.random() - 0.5;
```

The vector browser re-projects on every render, so the same memories landed somewhere different each time — nodes moved between renders with nothing about the data having changed.

Power iteration also converges to `+v` or `-v` depending on where it started, so the whole plot could **mirror** between two runs over identical data.

Two changes:

1. the starting vector now comes from a small seeded PRNG (mulberry32) keyed on the embedding width;
2. the converged eigenvector's sign is canonicalized on its largest-magnitude component — the usual PCA convention (the same thing scikit-learn's `svd_flip` does) — so the projection cannot mirror.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/pages/vector-browser-utils.test.ts`, the `projections` block. The module had no test file at all, so the suite also covers content parsing, embedding parsing, row normalization, layout, and screen mapping.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/pages/vector-browser-utils.test.ts
```

To confirm the suite is not vacuous, revert `vector-browser-utils.ts` (keep the test) and re-run — the "is deterministic across repeated calls" case fails every time.

One honesty note: the companion "does not mirror between runs" case is inherently a coin flip against the old code (the old sign was random, so it passed roughly half the time). It is included because it pins the sign convention going forward, not because it reliably reds. The determinism case is the reliable red.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:62ce88ca33d884b64a445a060f8c874e1e327f43 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - the change affects layout coordinates in the vector graph, but produces no new rendered element or style; the deliverable is the projection values asserted in the suite.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - the change affects layout coordinates in the vector graph, but produces no new rendered element or style; the deliverable is the projection values asserted in the suite.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is where projected memory nodes are placed, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no network call or component render is touched; the projection functions are pure and exercised directly.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > projections > is deterministic across repeated calls

 Tests  1 failed | 32 passed (33)
```

### Green — with the fix, at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/pages/vector-browser-utils.test.ts
 Test Files  1 passed (1)
      Tests  33 passed (33)
```

## Domain artifacts

Behavior of the real exported projection over one fixed input:

| call | before | after |
|---|---|---|
| `projectTo2D(v)` twice | two different point sets | identical point sets |
| `projectTo3D(v)` twice | two different point sets | identical point sets |
| sign of the first component | varies run to run (plot mirrors) | pinned by the largest-magnitude convention |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 33/33 passing at this exact head; the module previously had no test file.
- The mirror case is a 50/50 red against the old random sign, as noted above; it is a forward-looking pin rather than a reliable regression detector.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
