### PR TITLE
test(ui): cover custom-action form model

### DIFF
--- a/packages/ui/src/components/custom-actions/custom-action-form.test.ts
+++ b/packages/ui/src/components/custom-actions/custom-action-form.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Covers the pure form model behind the custom-action editor: the
+ * name/alias/parameter/method normalizers, the parsers that coerce a
+ * loosely-typed generated payload, and parameter validation.
+ *
+ * These run over model-generated output, so the contracts that matter are the
+ * coercion ones: an action name must always come out as a legal identifier, a
+ * duplicate parameter must be rejected rather than silently shadowing an
+ * earlier one, and an unrecognized HTTP method must fall back rather than
+ * reaching the request builder.
+ *
+ * No React, no network.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  HTTP_METHODS,
+  normalizeActionName,
+  normalizeAlias,
+  normalizeMethod,
+  normalizeParamName,
+  type ParamDef,
+  parseGeneratedAction,
+  parseHeaders,
+  parseParameters,
+  parseSimiles,
+  parseSimilesInput,
+  toNonEmptyString,
+  validateParameters,
+} from "./custom-action-form.ts";
+
+describe("toNonEmptyString", () => {
+  it("trims a usable string and rejects everything else", () => {
+    expect(toNonEmptyString("  hi  ")).toBe("hi");
+    for (const value of ["", "   ", null, undefined, 42, {}, []]) {
+      expect(toNonEmptyString(value)).toBeUndefined();
+    }
+  });
+});
+
+describe("normalizeActionName / normalizeAlias", () => {
+  it("upper-cases and converts separators to single underscores", () => {
+    expect(normalizeActionName("  send message  ")).toBe("SEND_MESSAGE");
+    expect(normalizeActionName("send--message")).toBe("SEND_MESSAGE");
+    expect(normalizeActionName("send.message/now")).toBe("SEND_MESSAGE_NOW");
+  });
+
+  it("strips leading and trailing underscores", () => {
+    expect(normalizeActionName("__send__")).toBe("SEND");
+    expect(normalizeActionName("!!!send!!!")).toBe("SEND");
+  });
+
+  it("keeps digits and collapses to empty for punctuation-only input", () => {
+    expect(normalizeActionName("action 2")).toBe("ACTION_2");
+    expect(normalizeActionName("!!!")).toBe("");
+    expect(normalizeActionName("")).toBe("");
+  });
+
+  it("treats an alias exactly like an action name", () => {
+    expect(normalizeAlias("send message")).toBe(
+      normalizeActionName("send message"),
+    );
+  });
+});
+
+describe("normalizeParamName", () => {
+  it("preserves case, unlike the action-name normalizer", () => {
+    expect(normalizeParamName("  userId  ")).toBe("userId");
+  });
+
+  it("converts separators and trims underscores", () => {
+    expect(normalizeParamName("user-id")).toBe("user_id");
+    expect(normalizeParamName("__user id__")).toBe("user_id");
+    expect(normalizeParamName("!!!")).toBe("");
+  });
+});
+
+describe("normalizeMethod", () => {
+  it("accepts every documented method, case-insensitively", () => {
+    for (const method of HTTP_METHODS) {
+      expect(normalizeMethod(method)).toBe(method);
+      expect(normalizeMethod(method.toLowerCase())).toBe(method);
+    }
+  });
+
+  it("falls back to GET for anything unrecognized", () => {
+    for (const value of ["TRACE", "", "   ", null, undefined, 42, {}]) {
+      expect(normalizeMethod(value)).toBe("GET");
+    }
+  });
+});
+
+describe("parseHeaders", () => {
+  it("returns an empty list for non-record input", () => {
+    for (const value of [null, undefined, "x", 42, ["a"]]) {
+      expect(parseHeaders(value)).toEqual([]);
+    }
+  });
+
+  it("keeps string-valued headers and drops the rest", () => {
+    expect(
+      parseHeaders({ Accept: "application/json", Retries: 3, Blank: null }),
+    ).toEqual([{ key: "Accept", value: "application/json" }]);
+  });
+
+  it("drops a header whose name normalizes to nothing", () => {
+    expect(parseHeaders({ "!!!": "value" })).toEqual([]);
+  });
+});
+
+describe("parseParameters", () => {
+  it("returns an empty list for non-array input", () => {
+    expect(parseParameters(null)).toEqual([]);
+    expect(parseParameters({ name: "a" })).toEqual([]);
+  });
+
+  it("normalizes names and defaults the description to the name", () => {
+    expect(parseParameters([{ name: " user-id " }])).toEqual([
+      { name: "user_id", description: "user_id", required: false },
+    ]);
+  });
+
+  it("treats required as strictly true", () => {
+    expect(parseParameters([{ name: "a", required: true }])[0]?.required).toBe(
+      true,
+    );
+    expect(parseParameters([{ name: "a", required: "yes" }])[0]?.required).toBe(
+      false,
+    );
+    expect(parseParameters([{ name: "a", required: 1 }])[0]?.required).toBe(
+      false,
+    );
+  });
+
+  it("drops entries with no usable name", () => {
+    expect(
+      parseParameters([{ name: "!!!" }, { name: "" }, null, 42, { x: 1 }]),
+    ).toEqual([]);
+  });
+
+  it("keeps only the first of two names colliding case-insensitively", () => {
+    const parsed = parseParameters([
+      { name: "userId", description: "first" },
+      { name: "USERID", description: "second" },
+    ]);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.description).toBe("first");
+  });
+});
+
+describe("parseSimiles / parseSimilesInput", () => {
+  it("normalizes, drops blanks, and de-duplicates case-insensitively", () => {
+    expect(
+      parseSimiles(["send message", "SEND-MESSAGE", "  ", null, "reply"]),
+    ).toEqual(["SEND_MESSAGE", "REPLY"]);
+  });
+
+  it("returns an empty list for non-array input", () => {
+    expect(parseSimiles("send")).toEqual([]);
+  });
+
+  it("splits a comma-separated editor field and normalizes each entry", () => {
+    expect(parseSimilesInput("send message, reply ,, ")).toEqual([
+      "SEND_MESSAGE",
+      "REPLY",
+    ]);
+  });
+
+  it("returns an empty list for an empty editor field", () => {
+    expect(parseSimilesInput("")).toEqual([]);
+    expect(parseSimilesInput(" , , ")).toEqual([]);
+  });
+});
+
+describe("validateParameters", () => {
+  it("accepts a clean list and normalizes names in place", () => {
+    const items: ParamDef[] = [
+      { name: " user-id ", description: "d", required: false },
+    ];
+    expect(validateParameters(items)).toBeNull();
+    // Documented side effect: the editor relies on the rows being normalized.
+    expect(items[0]?.name).toBe("user_id");
+  });
+
+  it("rejects a parameter whose name normalizes to nothing", () => {
+    expect(
+      validateParameters([{ name: "!!!", description: "d", required: false }]),
+    ).toBe("Each parameter needs a non-empty name.");
+  });
+
+  it("rejects a duplicate name, naming it, and matches case-insensitively", () => {
+    const message = validateParameters([
+      { name: "userId", description: "d", required: false },
+      { name: "USERID", description: "d", required: false },
+    ]);
+    expect(message).toContain("Duplicate parameter name");
+    expect(message).toContain("USERID");
+  });
+
+  it("accepts an empty list", () => {
+    expect(validateParameters([])).toBeNull();
+  });
+});
+
+describe("parseGeneratedAction", () => {
+  it("rejects a non-object payload with an explicit error", () => {
+    for (const payload of [null, undefined, "x", 42, ["a"]]) {
+      const result = parseGeneratedAction(payload);
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain(
+        "Generation returned an invalid payload.",
+      );
+      expect(result.action).toBeUndefined();
+    }
+  });
+
+  it("reports errors rather than throwing on a structurally empty object", () => {
+    const result = parseGeneratedAction({});
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.action).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/components/custom-actions/custom-action-form.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `ae1d111a92658da45366b6c063f5075f6e80fa25`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Normalizers are asserted against exact output strings, not shape. The de-duplication cases assert **which** entry survives (the first) rather than just the resulting length, and `required` is checked against `"yes"` and `1` so a truthy-coercion regression fails. The failure paths assert that no partial `action` is returned alongside the errors.

# Background

## What does this PR do?

`packages/ui/src/components/custom-actions/custom-action-form.ts` normalizes every field the custom-action editor submits and coerces model-generated payloads into a validated shape. It had **no dedicated test file**.

Because the input is model-generated, the pinned contracts are the coercion ones:

| Helper | Contract pinned |
|---|---|
| `normalizeActionName` | always yields a legal identifier — upper-cased, separators collapsed to single underscores, leading/trailing underscores stripped, punctuation-only input collapsing to `""` |
| `normalizeParamName` | preserves case where the action-name normalizer does not — the difference the editor depends on |
| `normalizeMethod` | falls back to `GET` for anything outside the documented list, so an unrecognized method never reaches the request builder |
| `parseParameters` | drops unusable entries; keeps only the **first** of two names colliding case-insensitively, so a duplicate cannot silently shadow an earlier parameter; treats `required` as strictly `true`, not truthy |
| `parseHeaders` | keeps only string-valued headers; drops one whose name normalizes to nothing |
| `parseSimiles` / `parseSimilesInput` | normalize, drop blanks, de-duplicate case-insensitively |
| `validateParameters` | names the duplicate it rejects; its documented **in-place** normalization of rows is pinned because the editor relies on it |
| `parseGeneratedAction` | reports errors rather than throwing for a non-object or structurally empty payload, and never returns a partial action alongside a failure |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/custom-actions/custom-action-form.test.ts`, the `parseParameters` and `validateParameters` blocks.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/custom-actions/custom-action-form.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a2b325632bc917b6826e37b4457330f88ad37436 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/custom-actions/custom-action-form.test.ts
 Test Files  1 passed (1)
      Tests  27 passed (27)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 27/27 passing at this exact head.
- `parseGeneratedAction`'s three per-handler branches (http/shell/code) are covered only at the guard level here — the invalid-payload and empty-object paths. Exercising each handler branch fully would need the `CustomActionHandler` fixtures from `@elizaos/shared` and is left to a follow-up rather than stubbed.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is exact-output normalizer assertions and which-entry-survives de-duplication checks.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
