### PR TITLE
fix(core,agent): recap deliverability, forget-scope salvage, envelope-aware vocatives (evidence-run fixes for #25356)

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -503,6 +503,47 @@ describe("MEMORY op:delete by query", () => {
     expect(rows[0].memory.content.text).toBe("nubs lives on a boat");
   });
 
+  it("ignores a malformed entityId when the requester's own id already scopes the delete", async () => {
+    // Live 2026-08-23: "forget my dogs name" hard-failed because the model
+    // copied the redacted placeholder it sees in context into entityId. The
+    // requester always wins below, so the param cannot widen scope — ignore
+    // it and disclose rather than failing a legitimate forget.
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "the user's dog is named biscuit",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "dog",
+      entityId: "[REDACTED:ELIZA_ADMIN_ENTITY_ID]",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("ignored invalid entityId");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("still fails on a malformed roomId, which has no requester fallback", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "the user's dog is named biscuit",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "dog",
+      roomId: "not-a-uuid",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(rows).toHaveLength(1);
+  });
+
   it("scopes delete-by-query to the requesting user's identity cluster", async () => {
     // Multi-user room: another entity holds a fact with the exact same text.
     // "Forget that I play guitar" from USER_ID must remove only USER_ID's

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -614,8 +614,19 @@ async function doDeleteByQuery(
 ): Promise<ActionResult> {
   const type =
     params.type && MEMORY_TYPES.includes(params.type) ? params.type : undefined;
+  // A malformed entityId cannot widen this delete's scope when the message
+  // carries its own entity: the requester always wins below, and the param is
+  // only consulted for entity-less internal invocations. Hard-failing on it
+  // therefore breaks a legitimate forget for no safety gain — live 2026-08-23,
+  // "forget my dogs name" failed because the model copied the redacted
+  // placeholder it sees in context ("[REDACTED:…]") into entityId. Ignore it
+  // and disclose; keep the hard fail where it would actually set the scope.
   const entityParam = parseUuidParam(params.entityId, "entityId");
-  if (!entityParam.ok) return entityParam.result;
+  const ignoredEntityId =
+    !entityParam.ok && message.entityId ? params.entityId?.trim() : undefined;
+  if (!entityParam.ok && !ignoredEntityId) return entityParam.result;
+  // A malformed roomId has no requester fallback — ignoring it would widen the
+  // scan across rooms, so it stays fatal.
   const roomParam = parseUuidParam(params.roomId, "roomId");
   if (!roomParam.ok) return roomParam.result;
 
@@ -623,7 +634,8 @@ async function doDeleteByQuery(
   // text and could name another user, reopening the cross-user match this
   // scope exists to close. The parsed param is a fallback only for messages
   // that carry no entity (internal maintenance invocations).
-  const scopeEntityId = message.entityId ?? entityParam.id;
+  const scopeEntityId =
+    message.entityId ?? (entityParam.ok ? entityParam.id : undefined);
 
   const limit = clampLimit(params.limit, 50);
   const strongMatches = (scan: CandidateScan) =>
@@ -645,7 +657,9 @@ async function doDeleteByQuery(
     complete: true,
   });
   let matched = strongMatches(scan);
-  let widenedNote = "";
+  let widenedNote = ignoredEntityId
+    ? ` (ignored invalid entityId "${ignoredEntityId}"; scoped to the requester)`
+    : "";
 
   // The table is an implementation detail the caller routinely guesses wrong
   // (live 2026-08-23: "forget my dog's name" arrived as type=memories while
@@ -675,7 +689,7 @@ async function doDeleteByQuery(
       // The delete loop removes EVERY matched row, and identical normalized
       // text can exist in more than one table — name them all.
       const matchedTables = [...new Set(matched.map((c) => c.type))];
-      widenedNote = ` (no match in the requested "${type}" table; found in ${matchedTables.join(", ")}).`;
+      widenedNote += ` (no match in the requested "${type}" table; found in ${matchedTables.join(", ")}).`;
     }
   }
 

--- a/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
@@ -46,6 +46,18 @@ export const CHANNEL_RECAP_DEFAULT_COUNT = 50;
  */
 export const CHANNEL_RECAP_MAX_FETCH = 500;
 
+/**
+ * Deliverable-size bound on the rendered transcript, in characters. The row
+ * bound above cannot express this: 500 short messages fit any model window
+ * while 500 long ones do not (live 2026-08-23: a complete 500-message
+ * transcript rendered ~202K tokens against a 131K-token provider limit and
+ * killed the turn, so the caller received nothing at all). A transcript that
+ * cannot be delivered is not a completeness win, so an over-size range is
+ * REJECTED before dispatch with an actionable count — never sliced, never
+ * partially served.
+ */
+export const CHANNEL_RECAP_DELIVERABLE_CHARS = 60_000;
+
 function resolveRequestedCount(options?: HandlerOptions): number | undefined {
 	const raw =
 		options?.parameters && typeof options.parameters === "object"
@@ -241,6 +253,39 @@ export const channelRecapAction: Action = {
 			dialogue,
 		);
 		const transcript = formatMessages({ messages: dialogue, entities });
+		// A single message larger than the bound has no smaller range to
+		// suggest, and slicing it is the violation this action exists to avoid,
+		// so it is served complete; rejection applies only when a smaller
+		// deliverable range genuinely exists.
+		if (
+			dialogue.length > 1 &&
+			transcript.length > CHANNEL_RECAP_DELIVERABLE_CHARS
+		) {
+			// Proportional suggestion: the caller asked for a range whose rendered
+			// size exceeds what one model call can carry, so name a count that
+			// fits rather than returning any part of it.
+			const deliverableCount = Math.max(
+				1,
+				Math.floor(
+					(dialogue.length * CHANNEL_RECAP_DELIVERABLE_CHARS) /
+						transcript.length,
+				),
+			);
+			return {
+				success: false,
+				text: `CHANNEL_RECAP range renders ${transcript.length} characters, over the ${CHANNEL_RECAP_DELIVERABLE_CHARS}-character deliverable bound for one call; request at most ${deliverableCount} message(s), or page older history with offset=${offset + deliverableCount}.`,
+				values: { success: false },
+				data: {
+					actionName: "CHANNEL_RECAP",
+					error: "CHANNEL_RECAP_RANGE_NOT_DELIVERABLE",
+					roomId,
+					renderedChars: transcript.length,
+					deliverableChars: CHANNEL_RECAP_DELIVERABLE_CHARS,
+					deliverableCount,
+					nextOffset: offset + deliverableCount,
+				},
+			};
+		}
 
 		// Store-exhaustion is measured against the full fetch depth
 		// (count + offset): with a nonzero offset the store can satisfy

--- a/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
@@ -253,27 +253,36 @@ export const channelRecapAction: Action = {
 			dialogue,
 		);
 		const transcript = formatMessages({ messages: dialogue, entities });
-		// A single message larger than the bound has no smaller range to
-		// suggest, and slicing it is the violation this action exists to avoid,
-		// so it is served complete; rejection applies only when a smaller
-		// deliverable range genuinely exists.
-		if (
-			dialogue.length > 1 &&
-			transcript.length > CHANNEL_RECAP_DELIVERABLE_CHARS
-		) {
-			// Proportional suggestion: the caller asked for a range whose rendered
-			// size exceeds what one model call can carry, so name a count that
-			// fits rather than returning any part of it.
-			const deliverableCount = Math.max(
-				1,
-				Math.floor(
-					(dialogue.length * CHANNEL_RECAP_DELIVERABLE_CHARS) /
-						transcript.length,
-				),
-			);
+		if (transcript.length > CHANNEL_RECAP_DELIVERABLE_CHARS) {
+			// Find the largest newest-message range that actually fits by rendering
+			// and measuring each binary-search candidate through the same formatter
+			// and bound. A proportional estimate is unsafe when message sizes are
+			// uneven: one giant newest message can make even count=1 undeliverable.
+			let low = 1;
+			let high = dialogue.length - 1;
+			let deliverableCount: number | undefined;
+			while (low <= high) {
+				const candidateCount = Math.floor((low + high) / 2);
+				const candidateTranscript = formatMessages({
+					messages: dialogue.slice(0, candidateCount),
+					entities,
+				});
+				if (candidateTranscript.length <= CHANNEL_RECAP_DELIVERABLE_CHARS) {
+					deliverableCount = candidateCount;
+					low = candidateCount + 1;
+				} else {
+					high = candidateCount - 1;
+				}
+			}
+			const nextOffset =
+				offset + (deliverableCount === undefined ? 1 : deliverableCount);
+			const guidance =
+				deliverableCount === undefined
+					? `no complete newest message fits the bound; skip that oversized message and retry with offset=${nextOffset}`
+					: `request at most ${deliverableCount} message(s), or page older history with offset=${nextOffset}`;
 			return {
 				success: false,
-				text: `CHANNEL_RECAP range renders ${transcript.length} characters, over the ${CHANNEL_RECAP_DELIVERABLE_CHARS}-character deliverable bound for one call; request at most ${deliverableCount} message(s), or page older history with offset=${offset + deliverableCount}.`,
+				text: `CHANNEL_RECAP range renders ${transcript.length} characters, over the ${CHANNEL_RECAP_DELIVERABLE_CHARS}-character deliverable bound for one call; ${guidance}.`,
 				values: { success: false },
 				data: {
 					actionName: "CHANNEL_RECAP",
@@ -281,8 +290,8 @@ export const channelRecapAction: Action = {
 					roomId,
 					renderedChars: transcript.length,
 					deliverableChars: CHANNEL_RECAP_DELIVERABLE_CHARS,
-					deliverableCount,
-					nextOffset: offset + deliverableCount,
+					deliverableCount: deliverableCount ?? null,
+					nextOffset,
 				},
 			};
 		}

--- a/packages/core/src/features/basic-capabilities/channel-recap.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-recap.test.ts
@@ -13,6 +13,7 @@ import { filterByContextGate } from "../../runtime/context-gates.ts";
 import type { IAgentRuntime, Memory, UUID } from "../../types/index.ts";
 import { searchMessagesAction } from "../messaging/triage/actions/searchMessages.ts";
 import {
+	CHANNEL_RECAP_DELIVERABLE_CHARS,
 	CHANNEL_RECAP_MAX_FETCH,
 	channelRecapAction,
 } from "./actions/channel-recap.ts";
@@ -349,8 +350,11 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 	const ROOM = "00000000-0000-4000-8000-00000000f1f1" as UUID;
 
 	it("serves the entire requested range even when it is large", async () => {
+		// Large but deliverable: every requested message renders complete. An
+		// UNdeliverable range is rejected outright (see the deliverable-size
+		// describe below) — never sliced.
 		const rows = Array.from({ length: 20 }, (_, i) =>
-			makeMessage(ROOM, 1_000 + i, `M${i}-${"x".repeat(9_000)}`),
+			makeMessage(ROOM, 1_000 + i, `M${i}-${"x".repeat(2_000)}`),
 		);
 		const { runtime } = makeRuntime({ [ROOM]: rows });
 		const result = (await channelRecapAction.handler(
@@ -363,7 +367,7 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 		const scope = (result.data as { scope: Record<string, unknown> }).scope;
 		expect(scope.renderedCount).toBe(20);
 		for (let i = 0; i < 20; i++) {
-			expect(result.text).toContain(`M${i}-${"x".repeat(9_000)}`);
+			expect(result.text).toContain(`M${i}-${"x".repeat(2_000)}`);
 		}
 	});
 
@@ -387,7 +391,25 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 		expect(result.text).toContain("messages 5–8 back");
 	});
 
-	it("serves every requested message complete without a text-fit slice", async () => {
+	it("serves an oversized single message complete — never a text-fit slice", async () => {
+		// No smaller range exists to suggest, and slicing a message is the
+		// violation this action exists to avoid, so it is served whole.
+		const giant = "G".repeat(65_000);
+		const rows = [makeMessage(ROOM, 2_000, giant)];
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 1 } },
+		)) as ActionResult;
+		expect(result.success).toBe(true);
+		expect(result.text).toContain(giant);
+		const scope = (result.data as { scope: Record<string, unknown> }).scope;
+		expect(scope.renderedCount).toBe(1);
+	});
+
+	it("rejects a multi-message range that cannot be delivered, suggesting one that can", async () => {
 		const giant = "G".repeat(65_000);
 		const rows = [
 			makeMessage(ROOM, 1_000, "older small"),
@@ -400,10 +422,55 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 			undefined,
 			{ parameters: { count: 2 } },
 		)) as ActionResult;
+		expect(result.success).toBe(false);
+		expect((result.data as Record<string, unknown>).error).toBe(
+			"CHANNEL_RECAP_RANGE_NOT_DELIVERABLE",
+		);
+		expect(result.text).not.toContain(giant);
+		expect(result.text).not.toContain("older small");
+	});
+});
+
+describe("CHANNEL_RECAP deliverable-size rejection", () => {
+	const ROOM = "00000000-0000-4000-8000-0000000000d1" as UUID;
+
+	it("rejects an over-size range with an actionable count and no partial payload", async () => {
+		// Live 2026-08-23: a complete 500-message transcript rendered ~202K
+		// tokens against a 131K-token provider limit and killed the turn.
+		const rows = Array.from({ length: 30 }, (_, i) =>
+			makeMessage(ROOM, 1_000 + i, `M${i}-${"x".repeat(4_000)}`),
+		);
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 30 } },
+		)) as ActionResult;
+		expect(result.success).toBe(false);
+		const data = result.data as Record<string, unknown>;
+		expect(data.error).toBe("CHANNEL_RECAP_RANGE_NOT_DELIVERABLE");
+		// No transcript content leaks into the rejection.
+		expect(result.text).not.toContain("xxxx");
+		const suggested = data.deliverableCount as number;
+		expect(suggested).toBeGreaterThan(0);
+		expect(suggested).toBeLessThan(30);
+		expect(result.text).toContain(`at most ${suggested}`);
+	});
+
+	it("serves a range that fits, complete", async () => {
+		const rows = Array.from({ length: 5 }, (_, i) =>
+			makeMessage(ROOM, 2_000 + i, `fits-${i}`),
+		);
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 5 } },
+		)) as ActionResult;
 		expect(result.success).toBe(true);
-		expect(result.text).toContain(giant);
-		const scope = (result.data as { scope: Record<string, unknown> }).scope;
-		expect(scope.renderedCount).toBe(2);
-		expect(result.text).toContain("older small");
+		for (let i = 0; i < 5; i++) expect(result.text).toContain(`fits-${i}`);
+		expect(result.text.length).toBeLessThan(CHANNEL_RECAP_DELIVERABLE_CHARS);
 	});
 });

--- a/packages/core/src/features/basic-capabilities/channel-recap.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-recap.test.ts
@@ -391,9 +391,7 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 		expect(result.text).toContain("messages 5–8 back");
 	});
 
-	it("serves an oversized single message complete — never a text-fit slice", async () => {
-		// No smaller range exists to suggest, and slicing a message is the
-		// violation this action exists to avoid, so it is served whole.
+	it("rejects an oversized single message before dispatch without slicing it", async () => {
 		const giant = "G".repeat(65_000);
 		const rows = [makeMessage(ROOM, 2_000, giant)];
 		const { runtime } = makeRuntime({ [ROOM]: rows });
@@ -403,13 +401,16 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 			undefined,
 			{ parameters: { count: 1 } },
 		)) as ActionResult;
-		expect(result.success).toBe(true);
-		expect(result.text).toContain(giant);
-		const scope = (result.data as { scope: Record<string, unknown> }).scope;
-		expect(scope.renderedCount).toBe(1);
+		expect(result.success).toBe(false);
+		const data = result.data as Record<string, unknown>;
+		expect(data.error).toBe("CHANNEL_RECAP_RANGE_NOT_DELIVERABLE");
+		expect(data.deliverableCount).toBeNull();
+		expect(data.nextOffset).toBe(1);
+		expect(result.text).not.toContain(giant);
+		expect(result.text).toContain("no complete newest message fits");
 	});
 
-	it("rejects a multi-message range that cannot be delivered, suggesting one that can", async () => {
+	it("skips a newest giant message instead of proposing an undeliverable count", async () => {
 		const giant = "G".repeat(65_000);
 		const rows = [
 			makeMessage(ROOM, 1_000, "older small"),
@@ -426,8 +427,22 @@ describe("CHANNEL_RECAP complete transcript and offset paging", () => {
 		expect((result.data as Record<string, unknown>).error).toBe(
 			"CHANNEL_RECAP_RANGE_NOT_DELIVERABLE",
 		);
+		expect(
+			(result.data as Record<string, unknown>).deliverableCount,
+		).toBeNull();
+		expect((result.data as Record<string, unknown>).nextOffset).toBe(1);
 		expect(result.text).not.toContain(giant);
 		expect(result.text).not.toContain("older small");
+
+		const retry = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 1, offset: 1 } },
+		)) as ActionResult;
+		expect(retry.success).toBe(true);
+		expect(retry.text).toContain("older small");
+		expect(retry.text).not.toContain(giant);
 	});
 });
 
@@ -456,6 +471,15 @@ describe("CHANNEL_RECAP deliverable-size rejection", () => {
 		expect(suggested).toBeGreaterThan(0);
 		expect(suggested).toBeLessThan(30);
 		expect(result.text).toContain(`at most ${suggested}`);
+
+		const retry = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: suggested } },
+		)) as ActionResult;
+		expect(retry.success).toBe(true);
+		expect(retry.text.length).toBeLessThan(CHANNEL_RECAP_DELIVERABLE_CHARS);
 	});
 
 	it("serves a range that fits, complete", async () => {

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -10,6 +10,7 @@
  * and its entity lookup are vi-mocked; no model or database.
  */
 import { describe, expect, it, vi } from "vitest";
+import { hardenIncomingUserMessage } from "../../security/incoming-message-security.ts";
 import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
 import {
 	classifyLeadingVocative,
@@ -633,5 +634,67 @@ describe("classifyLeadingVocative (identity notice classifier)", () => {
 				})
 			).kind,
 		).toBe("none");
+	});
+});
+
+describe("envelope-wrapped (external/bot-authored) messages", () => {
+	// hardenIncomingUserMessage replaces content.text with the security
+	// envelope; the ^-anchored vocative shapes must read the retained payload
+	// (live 2026-08-23: every webhook-authored "hey eliza" classified none
+	// because the text began "SECURITY NOTICE:").
+	const room = (): Partial<IAgentRuntime> =>
+		({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, names: ["remilio nubilio"] },
+				{ id: OTHER_BOT, names: ["Eliza"] },
+				{ id: SENDER_ID, names: ["nubs"] },
+			]),
+		}) as unknown as Partial<IAgentRuntime>;
+	const nubilio = (): IAgentRuntime =>
+		makeRuntime({
+			character: { name: "remilio nubilio" },
+			...room(),
+		} as Partial<IAgentRuntime>);
+	const enveloped = (text: string): Memory => {
+		const memory = makeMessage(undefined, undefined, text);
+		hardenIncomingUserMessage(memory);
+		expect(memory.content.text).toContain("SECURITY NOTICE");
+		return memory;
+	};
+
+	it("classifies the retained payload, not the envelope", async () => {
+		// This room HAS an Eliza — resolving her proves the classifier read
+		// the inner payload (the envelope contains no participant names).
+		expect(
+			await classifyLeadingVocative({
+				runtime: nubilio(),
+				message: enveloped("hey eliza"),
+			}),
+		).toEqual({ kind: "participant", name: "eliza" });
+	});
+
+	it("wrapped vocative of an unknown name classifies unresolved", async () => {
+		const noEliza = makeRuntime({
+			character: { name: "remilio nubilio" },
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, names: ["remilio nubilio"] },
+				{ id: SENDER_ID, names: ["nubs"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await classifyLeadingVocative({
+				runtime: noEliza,
+				message: enveloped("hey eliza"),
+			}),
+		).toEqual({ kind: "unresolved", name: "eliza" });
+	});
+
+	it("suppression matcher gates a wrapped vocative of a real participant", async () => {
+		expect(
+			await messageVocativelyAddressesOtherParticipant({
+				runtime: nubilio(),
+				message: enveloped("hey Eliza can you take this"),
+			}),
+		).toBe(true);
 	});
 });

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -5,6 +5,8 @@
  * agent is merely overhearing and should not act on it). All name/id resolution
  * runs against the room's entity list, without an LLM call.
  */
+
+import { unwrapUserMessageText } from "../security/incoming-message-security.ts";
 import type { Entity, UUID } from "../types/index";
 import type { Memory } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";
@@ -388,8 +390,7 @@ export async function messageVocativelyAddressesOtherParticipant(args: {
 	message: Memory;
 }): Promise<boolean> {
 	const { runtime, message } = args;
-	const text =
-		typeof message.content?.text === "string" ? message.content.text : "";
+	const text = unwrapUserMessageText(message);
 	if (!text.trim()) return false;
 
 	const participants = await runtime.getEntitiesForRoom(message.roomId);
@@ -413,8 +414,14 @@ function vocativelyAddressesOtherParticipant(args: {
 	self: ReadonlySet<string>;
 }): boolean {
 	const { runtime, message, participants, self } = args;
-	const text =
-		typeof message.content?.text === "string" ? message.content.text : "";
+	// Enveloped (external/bot-authored) messages carry a security wrapper as
+	// content.text; the ^-anchored vocative shapes must read the retained
+	// user payload, not the envelope (live 2026-08-23: every webhook-authored
+	// "hey eliza" fell through because the text began "SECURITY NOTICE:").
+	// Strict unwrap on purpose — a positive here silences the turn and the
+	// classifier variant echoes the name into a prompt instruction, so armor
+	// debris must collapse to "" and fail open.
+	const text = unwrapUserMessageText(message);
 	if (!text.trim()) return false;
 
 	const lead = text;
@@ -502,8 +509,8 @@ export async function classifyLeadingVocative(args: {
 	message: Memory;
 }): Promise<LeadingVocativeClass> {
 	const { runtime, message } = args;
-	const text =
-		typeof message.content?.text === "string" ? message.content.text : "";
+	// Same unwrap contract as the suppression matcher above.
+	const text = unwrapUserMessageText(message);
 	const match = VOCATIVE_TOKEN_RE.exec(text);
 	const raw = match?.[1];
 	if (!raw) return { kind: "none" };


### PR DESCRIPTION
Targets `codex/review-25283-repair` so #25356's head advances with the three defects found while capturing its required live evidence (full trajectory detail in the #25356 comments):

1. **Recap deliverability** — at the reviewed tip, the planner clamps its own request to the row bound, so the count guard never fires; a complete 500-message transcript then rendered ~202K tokens against the provider's 131K limit and the turn died with zero delivery. The rendered transcript is now measured against a documented deliverable-character bound and an undeliverable range is rejected before dispatch with an actionable count + continuation offset (a single over-bound message is rejected before dispatch; the response provides an offset that skips it, without slicing or compacting the message).
2. **Forget scope salvage** — the model copies the redaction placeholder it sees in context into `entityId`, hard-failing a legitimate forget the requester's own identity already scopes. Malformed `entityId` is ignored + disclosed in delete-by-query; malformed `roomId` (no requester fallback) stays fatal.
3. **Envelope unwrap** — the `^`-anchored vocative matchers ran against the security envelope for every external/bot-authored message and silently fell through. All three sites now use the strict `unwrapUserMessageText`, per that helper's own contract (a positive silences the turn; the classifier echoes the extracted name into a prompt instruction, so armor debris must collapse to empty and fail open).

Suites at this tip: channel-recap 21/21, memories 38/38, addressed-to 44/44; core typecheck clean; Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:bfe6305a29b0e1ed661603157b12e66ca2d49509 -->
<!-- evidence-base:88036c79f577592d328e1681dc34a30097998ae6 -->