### PR TITLE
test(cloud): cover MCP action naming

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/utils/action-naming.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/utils/action-naming.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Covers MCP action-name derivation: server/tool to action name, the simile
+ * set, parsing back out, collision detection, and uniquification.
+ *
+ * Action names are the registry keys an agent dispatches on, so the contracts
+ * that matter are the identity ones: two tools that normalize to the same name
+ * must be reported as colliding, `makeUniqueActionName` must never hand back a
+ * name already in the set, and the simile list must never contain the action's
+ * own name (which would register an alias pointing at itself).
+ *
+ * Pure functions — no runtime, no MCP transport.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  actionNamesCollide,
+  generateSimiles,
+  makeUniqueActionName,
+  parseActionName,
+  toActionName,
+} from "./action-naming";
+
+describe("toActionName", () => {
+  test("upper-cases and joins server and tool", () => {
+    expect(toActionName("github", "create issue")).toBe("GITHUB_CREATE_ISSUE");
+  });
+
+  test("collapses runs of separators to a single underscore", () => {
+    expect(toActionName("my--server", "do..thing")).toBe("MY_SERVER_DO_THING");
+  });
+
+  test("strips leading and trailing separators", () => {
+    expect(toActionName("__github__", "--create--")).toBe("GITHUB_CREATE");
+  });
+
+  test("does not double the server prefix when the tool already carries it", () => {
+    expect(toActionName("github", "github_create")).toBe("GITHUB_CREATE");
+    expect(toActionName("github", "GitHub Create")).toBe("GITHUB_CREATE");
+  });
+
+  test("still prefixes when the tool merely starts with similar text", () => {
+    // "GITHUBBER" is not the "GITHUB_" prefix, so it must not be treated as one.
+    expect(toActionName("github", "githubber")).toBe("GITHUB_GITHUBBER");
+  });
+
+  test("degrades predictably when a side is unusable", () => {
+    expect(toActionName("", "create")).toBe("CREATE");
+    expect(toActionName("!!!", "create")).toBe("CREATE");
+    expect(toActionName("github", "!!!")).toBe("GITHUB_");
+    expect(toActionName("", "")).toBe("_");
+  });
+});
+
+describe("generateSimiles", () => {
+  test("never includes the action's own name", () => {
+    const fullName = toActionName("github", "create_issue");
+    expect(generateSimiles("github", "create_issue")).not.toContain(fullName);
+  });
+
+  test("contains no duplicates", () => {
+    const similes = generateSimiles("github", "create_issue");
+    expect(new Set(similes).size).toBe(similes.length);
+  });
+
+  test("includes the bare tool name and both slash forms", () => {
+    const similes = generateSimiles("GitHub", "create_issue");
+    expect(similes).toContain("CREATE_ISSUE");
+    expect(similes).toContain("GitHub/create_issue");
+    expect(similes).toContain("github/create_issue");
+  });
+
+  test("includes an MCP-prefixed alias", () => {
+    expect(generateSimiles("github", "create_issue")).toContain(
+      `MCP_${toActionName("github", "create_issue")}`,
+    );
+  });
+
+  test("adds the reversed form only for a two-part tool name", () => {
+    expect(generateSimiles("github", "create_issue")).toContain("ISSUE_CREATE");
+    expect(generateSimiles("github", "createissue")).not.toContain("ISSUE_CREATE");
+    expect(generateSimiles("github", "a_b_c")).not.toContain("B_A");
+  });
+
+  test("does not add a reversed form that equals the tool name", () => {
+    const similes = generateSimiles("srv", "same_same");
+    expect(similes.filter((s) => s === "SAME_SAME")).toHaveLength(1);
+  });
+});
+
+describe("parseActionName", () => {
+  test("splits at the first underscore and lower-cases both halves", () => {
+    expect(parseActionName("GITHUB_CREATE_ISSUE")).toEqual({
+      serverName: "github",
+      toolName: "create_issue",
+    });
+  });
+
+  test("returns null when there is no separator", () => {
+    expect(parseActionName("GITHUB")).toBeNull();
+    expect(parseActionName("")).toBeNull();
+    expect(parseActionName("!!!")).toBeNull();
+  });
+
+  test("normalizes before splitting, so raw input parses too", () => {
+    expect(parseActionName("github create issue")).toEqual({
+      serverName: "github",
+      toolName: "create_issue",
+    });
+  });
+
+  test("round-trips a single-token server through toActionName", () => {
+    const parsed = parseActionName(toActionName("github", "create issue"));
+    expect(parsed).toEqual({ serverName: "github", toolName: "create_issue" });
+  });
+});
+
+describe("actionNamesCollide", () => {
+  test("reports names that differ only by case or separators as colliding", () => {
+    expect(actionNamesCollide("GITHUB_CREATE", "github-create")).toBe(true);
+    expect(actionNamesCollide("github create", "__GITHUB__CREATE__")).toBe(true);
+  });
+
+  test("reports genuinely different names as distinct", () => {
+    expect(actionNamesCollide("GITHUB_CREATE", "GITHUB_DELETE")).toBe(false);
+  });
+});
+
+describe("makeUniqueActionName", () => {
+  test("returns the plain name when it is free", () => {
+    expect(makeUniqueActionName("github", "create", new Set())).toBe("GITHUB_CREATE");
+  });
+
+  test("suffixes from 2 when the plain name is taken", () => {
+    expect(makeUniqueActionName("github", "create", new Set(["GITHUB_CREATE"]))).toBe(
+      "GITHUB_CREATE_2",
+    );
+  });
+
+  test("skips over every suffix already in use", () => {
+    const existing = new Set(["GITHUB_CREATE", "GITHUB_CREATE_2", "GITHUB_CREATE_3"]);
+    expect(makeUniqueActionName("github", "create", existing)).toBe("GITHUB_CREATE_4");
+  });
+
+  test("never returns a name already present in the set", () => {
+    const existing = new Set(["GITHUB_CREATE", "GITHUB_CREATE_2"]);
+    const name = makeUniqueActionName("github", "create", existing);
+    expect(existing.has(name)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/shared/src/lib/eliza/plugin-mcp/utils/action-naming.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `ae1d111a92658da45366b6c063f5075f6e80fa25`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Assertions are exact strings, and the uniquification case asserts the invariant directly (`existing.has(result) === false`) rather than only the expected suffix, so it holds even if the suffix scheme changes. The prefix-dedup case is paired with a near-miss (`githubber`) so it cannot pass by always skipping the prefix.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/eliza/plugin-mcp/utils/action-naming.ts` derives the registry keys an agent dispatches MCP tools on. It had **no dedicated test file**.

| Area | Contract pinned |
|---|---|
| uniquification | `makeUniqueActionName` never returns a name already in the set, and skips over every suffix in use rather than stopping at the first gap |
| simile safety | `generateSimiles` never contains the action's own name — that would register an alias pointing at itself — and contains no duplicates |
| collision detection | names differing only by case or separators collide, which is what makes uniquification meaningful |
| prefix dedup | the server prefix is not doubled when the tool already carries it, but `githubber` (a near-miss, not the `GITHUB_` prefix) is still prefixed |
| degraded forms | unusable server -> tool alone; unusable tool -> `SERVER_`; both unusable -> `_` |
| reversed simile | added only for a two-part tool name, and never when it would equal the tool name |
| parsing | splits at the first underscore, normalizes first, returns null with no separator, and round-trips a single-token server |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/eliza/plugin-mcp/utils/action-naming.test.ts`, the `makeUniqueActionName` and `generateSimiles` blocks.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/eliza/plugin-mcp/utils/action-naming.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:61958c1e00b2fd34c7076cea057040e03ec22eaf -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ bun test src/lib/eliza/plugin-mcp/utils/action-naming.test.ts
 22 pass
 0 fail
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 22/22 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is invariant-level assertions plus a paired near-miss on prefix dedup.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
