### PR TITLE
test(ui): cover chat conversation guards

### DIFF
--- a/packages/ui/src/state/chat-conversation-guards.test.ts
+++ b/packages/ui/src/state/chat-conversation-guards.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Covers the predicates that decide which conversations reach the main chat
+ * transcript list.
+ *
+ * The load-bearing case is the legacy page-chat heuristic. A scope-less
+ * conversation whose title is one of a reserved set is treated as a legacy page
+ * chat and hidden from every list — which is why renaming a chat to "wallet"
+ * once made it vanish with no recovery path. `isReservedLegacyChatTitle` is the
+ * guard that rename validation uses to refuse those titles, so the two must
+ * agree exactly: any title the guard rejects must be a title the filter would
+ * have hidden.
+ *
+ * Pure predicates — no React, no API.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Conversation } from "../api";
+import {
+  filterMainChatConversations,
+  isConversationRecord,
+  isMainChatConversation,
+  isReservedLegacyChatTitle,
+  normalizeConversationList,
+} from "./chat-conversation-guards.ts";
+
+const RESERVED = [
+  "browser",
+  "character",
+  "automations",
+  "apps",
+  "phone",
+  "settings",
+  "wallet",
+];
+
+const conversation = (overrides: Partial<Conversation> = {}): Conversation =>
+  ({
+    id: "c1",
+    title: "A chat",
+    roomId: "r1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }) as Conversation;
+
+describe("isReservedLegacyChatTitle", () => {
+  it("rejects every reserved title, case- and whitespace-insensitively", () => {
+    for (const title of RESERVED) {
+      expect(isReservedLegacyChatTitle(title)).toBe(true);
+      expect(isReservedLegacyChatTitle(title.toUpperCase())).toBe(true);
+      expect(isReservedLegacyChatTitle(`  ${title}  `)).toBe(true);
+    }
+  });
+
+  it("allows ordinary titles, including ones merely containing a reserved word", () => {
+    for (const title of [
+      "my wallet",
+      "wallet stuff",
+      "settings for x",
+      "",
+      "notes",
+    ]) {
+      expect(isReservedLegacyChatTitle(title)).toBe(false);
+    }
+  });
+
+  it("agrees with the filter: every rejected title would have been hidden", () => {
+    // This is the invariant that keeps rename validation and the list filter
+    // from drifting apart.
+    for (const title of RESERVED) {
+      expect(isReservedLegacyChatTitle(title)).toBe(true);
+      expect(isMainChatConversation({ title, metadata: undefined })).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("isMainChatConversation", () => {
+  it("keeps an ordinary scope-less conversation", () => {
+    expect(
+      isMainChatConversation({ title: "My chat", metadata: undefined }),
+    ).toBe(true);
+  });
+
+  it("keeps a conversation with no title at all", () => {
+    expect(isMainChatConversation({ title: "", metadata: undefined })).toBe(
+      true,
+    );
+    expect(isMainChatConversation({ metadata: undefined } as never)).toBe(true);
+  });
+
+  it("hides a scope-less conversation whose title collides with a page name", () => {
+    expect(
+      isMainChatConversation({ title: "Wallet", metadata: undefined }),
+    ).toBe(false);
+  });
+
+  it("keeps a reserved title once the conversation carries an explicit scope", () => {
+    // New conversations are stamped scope:"general" at creation, which is what
+    // makes the title heuristic apply only to the pre-stamp backlog.
+    expect(
+      isMainChatConversation({
+        title: "wallet",
+        metadata: { scope: "general" },
+      } as never),
+    ).toBe(true);
+  });
+
+  it("hides every automation scope", () => {
+    for (const scope of [
+      "automation-coordinator",
+      "automation-workflow",
+      "automation-workflow-draft",
+      "automation-draft",
+    ]) {
+      expect(
+        isMainChatConversation({ title: "x", metadata: { scope } } as never),
+      ).toBe(false);
+    }
+  });
+
+  it("hides any page-scoped conversation by prefix", () => {
+    for (const scope of ["page-browser", "page-anything", "page-"]) {
+      expect(
+        isMainChatConversation({ title: "x", metadata: { scope } } as never),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps an unrecognized scope rather than hiding it", () => {
+    expect(
+      isMainChatConversation({
+        title: "x",
+        metadata: { scope: "custom" },
+      } as never),
+    ).toBe(true);
+  });
+
+  it("treats a null or undefined conversation as not hidden", () => {
+    expect(isMainChatConversation(null)).toBe(true);
+    expect(isMainChatConversation(undefined)).toBe(true);
+  });
+});
+
+describe("isConversationRecord", () => {
+  it("accepts a complete record", () => {
+    expect(isConversationRecord(conversation())).toBe(true);
+  });
+
+  it("rejects a record missing any required field", () => {
+    for (const field of ["id", "title", "roomId", "createdAt", "updatedAt"]) {
+      const partial = { ...conversation() } as Record<string, unknown>;
+      delete partial[field];
+      expect(isConversationRecord(partial)).toBe(false);
+    }
+  });
+
+  it("rejects a blank or non-string id", () => {
+    expect(isConversationRecord({ ...conversation(), id: "   " })).toBe(false);
+    expect(isConversationRecord({ ...conversation(), id: 42 })).toBe(false);
+  });
+
+  it("rejects non-objects", () => {
+    for (const value of [null, undefined, "x", 42, []]) {
+      expect(isConversationRecord(value)).toBe(false);
+    }
+  });
+
+  it("accepts an empty title, which is a legal conversation state", () => {
+    expect(isConversationRecord({ ...conversation(), title: "" })).toBe(true);
+  });
+});
+
+describe("filterMainChatConversations / normalizeConversationList", () => {
+  it("filters hidden conversations out of a list", () => {
+    const kept = filterMainChatConversations([
+      conversation({ id: "keep", title: "Real chat" }),
+      conversation({ id: "hide", title: "wallet" }),
+    ]);
+    expect(kept.map((c) => c.id)).toEqual(["keep"]);
+  });
+
+  it("drops malformed entries before filtering", () => {
+    const list = normalizeConversationList([
+      conversation({ id: "keep" }),
+      { id: "broken" },
+      null,
+      "nonsense",
+      conversation({ id: "hidden", title: "settings" }),
+    ]);
+    expect(list.map((c) => c.id)).toEqual(["keep"]);
+  });
+
+  it("returns an empty list for non-array input", () => {
+    for (const value of [null, undefined, {}, "x"]) {
+      expect(normalizeConversationList(value)).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/state/chat-conversation-guards.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `ae1d111a92658da45366b6c063f5075f6e80fa25`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The central case asserts a cross-function invariant (guard rejects <=> filter hides) rather than each function in isolation, so the two cannot drift apart silently. Positive cases are paired with near-misses (`"my wallet"` must stay visible), and the scope cases assert an unrecognized scope is KEPT so the filter cannot pass by hiding everything.

# Background

## What does this PR do?

`packages/ui/src/state/chat-conversation-guards.ts` decides which conversations reach the main chat transcript list. It had **no dedicated test file**.

The load-bearing case is the legacy page-chat heuristic. A scope-less conversation whose title is one of a reserved set (`browser`, `character`, `automations`, `apps`, `phone`, `settings`, `wallet`) is hidden from **every** list — which is why renaming a chat to "wallet" once made it vanish with no recovery path, as the module's own comment records.

`isReservedLegacyChatTitle` is the guard rename validation uses to refuse those titles, so the suite asserts the two **agree exactly**: every title the guard rejects is one the filter would have hidden. That invariant is what keeps rename validation and the list filter from drifting apart.

Also pinned:

| Area | Contract |
|---|---|
| matching | case- and whitespace-insensitive, but a title merely *containing* a reserved word ("my wallet") is allowed |
| scope stamping | a reserved title is kept once the conversation carries an explicit scope — the heuristic only affects the pre-stamp backlog |
| hidden scopes | every automation scope, and any `page-`-prefixed scope |
| unknown scopes | kept rather than hidden |
| `isConversationRecord` | rejects a record missing any required field, a blank or non-string id, and non-objects; accepts an empty title |
| `normalizeConversationList` | drops malformed entries before filtering; empty list for non-array input |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/chat-conversation-guards.test.ts`, the "agrees with the filter: every rejected title would have been hidden" case.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/state/chat-conversation-guards.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:74543b0962e6e3f7ff139300bcf1262fa435ccd9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/state/chat-conversation-guards.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 19/19 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is the cross-function invariant plus paired near-miss cases.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
