### PR TITLE
test(examples): cover filtering-terminal

### DIFF
--- a/packages/examples/code/src/lib/filtering-terminal.test.ts
+++ b/packages/examples/code/src/lib/filtering-terminal.test.ts
@@ -6,8 +6,8 @@
  * each test stubs only the inner terminal's stdio methods at instance level
  * (never real stdin/stdout) and drives the real wrapper logic.
  */
-import { describe, expect, it } from "bun:test";
 import { ProcessTerminal } from "@elizaos/tui";
+import { describe, expect, it } from "vitest";
 import { FilteringTerminal } from "./filtering-terminal.js";
 
 type InnerAccess = { inner: ProcessTerminal };

--- a/packages/examples/code/src/lib/filtering-terminal.test.ts
+++ b/packages/examples/code/src/lib/filtering-terminal.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Covers the `FilteringTerminal` wrapper: the interception gate must swallow
+ * input the app claims before it reaches the TUI host, and every remaining
+ * `Terminal` operation must delegate verbatim to the stdio-backed
+ * {@link ProcessTerminal} instance the wrapper owns. Deterministic harness —
+ * each test stubs only the inner terminal's stdio methods at instance level
+ * (never real stdin/stdout) and drives the real wrapper logic.
+ */
+import { describe, expect, it } from "bun:test";
+import { ProcessTerminal } from "@elizaos/tui";
+import { FilteringTerminal } from "./filtering-terminal.js";
+
+type InnerAccess = { inner: ProcessTerminal };
+
+function innerOf(terminal: FilteringTerminal): ProcessTerminal {
+  return (terminal as unknown as InnerAccess).inner;
+}
+
+/** Records start() wiring without touching process.stdin/stdout. */
+function captureStart(inner: ProcessTerminal) {
+  const captured: {
+    input?: (data: string) => void;
+    resize?: () => void;
+  } = {};
+  inner.start = (onInput, onResize) => {
+    captured.input = onInput;
+    captured.resize = onResize;
+  };
+  return captured;
+}
+
+describe("FilteringTerminal", () => {
+  it("binds a real ProcessTerminal as its inner terminal", () => {
+    const terminal = new FilteringTerminal(() => false);
+    expect(innerOf(terminal)).toBeInstanceOf(ProcessTerminal);
+  });
+
+  it("forwards non-intercepted input to the host handler in order", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const captured = captureStart(innerOf(terminal));
+    const received: string[] = [];
+
+    terminal.start(
+      (data) => received.push(data),
+      () => {},
+    );
+    captured.input?.("a");
+    captured.input?.("b");
+    captured.input?.("c");
+
+    expect(received).toEqual(["a", "b", "c"]);
+  });
+
+  it("swallows intercepted input so it never reaches the host handler", () => {
+    const terminal = new FilteringTerminal(() => true);
+    const captured = captureStart(innerOf(terminal));
+    let received = 0;
+
+    terminal.start(
+      () => received++,
+      () => {},
+    );
+    captured.input?.("x");
+    captured.input?.("\x1b[16~");
+
+    expect(received).toBe(0);
+  });
+
+  it("evaluates the interceptor per chunk, so a mixed stream splits cleanly", () => {
+    const shortcuts = new Set(["\x01", "\x05"]); // Ctrl+A, Ctrl+E
+    const terminal = new FilteringTerminal((data) => shortcuts.has(data));
+    const captured = captureStart(innerOf(terminal));
+    const received: string[] = [];
+
+    terminal.start(
+      (data) => received.push(data),
+      () => {},
+    );
+    captured.input?.("h");
+    captured.input?.("\x01");
+    captured.input?.("i");
+    captured.input?.("\x05");
+    captured.input?.("!"); // not in the set despite the earlier intercept
+
+    expect(received).toEqual(["h", "i", "!"]);
+  });
+
+  it("hands the interceptor the whole paste-sized chunk as one decision", () => {
+    let inspected = "";
+    const terminal = new FilteringTerminal((data) => {
+      inspected = data;
+      return data.length > 3;
+    });
+    const captured = captureStart(innerOf(terminal));
+    const received: string[] = [];
+
+    terminal.start(
+      (data) => received.push(data),
+      () => {},
+    );
+    const paste = "a long pasted sentence";
+    captured.input?.(`\x1b[200~${paste}\x1b[201~`);
+
+    expect(inspected).toBe(`\x1b[200~${paste}\x1b[201~`);
+    expect(received).toEqual([]); // chunk exceeded the limit: swallowed whole
+  });
+
+  it("passes the host resize handler through by reference", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const captured = captureStart(innerOf(terminal));
+    const appResize = () => {};
+
+    terminal.start(() => {}, appResize);
+
+    expect(captured.resize).toBe(appResize);
+  });
+
+  it("keeps instances independent: separate inner terminals and verdicts", () => {
+    const alwaysIntercept = new FilteringTerminal(() => true);
+    const neverIntercept = new FilteringTerminal(() => false);
+    const interceptedStart = captureStart(innerOf(alwaysIntercept));
+    const passthroughStart = captureStart(innerOf(neverIntercept));
+    expect(innerOf(alwaysIntercept)).not.toBe(innerOf(neverIntercept));
+
+    let passthroughReceived = "";
+    let interceptedReceived = "";
+    neverIntercept.start(
+      (data) => {
+        passthroughReceived += data;
+      },
+      () => {},
+    );
+    alwaysIntercept.start(
+      (data) => {
+        interceptedReceived += data;
+      },
+      () => {},
+    );
+
+    interceptedStart.input?.("q");
+    passthroughStart.input?.("q");
+
+    // The intercepting wrapper swallowed its chunk without touching the other.
+    expect(interceptedReceived).toBe("");
+    expect(passthroughReceived).toBe("q");
+  });
+});
+
+describe("FilteringTerminal delegation", () => {
+  it("stop() delegates to the inner terminal exactly once", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    let stops = 0;
+    inner.stop = () => stops++;
+
+    terminal.stop();
+
+    expect(stops).toBe(1);
+  });
+
+  it("drainInput() forwards both timeouts and resolves with the inner result", async () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const seen: Array<number | undefined> = [];
+    inner.drainInput = async (maxMs?: number, idleMs?: number) => {
+      seen.push(maxMs, idleMs);
+    };
+
+    await expect(terminal.drainInput(7, 3)).resolves.toBeUndefined();
+    expect(seen).toEqual([7, 3]);
+  });
+
+  it("drainInput() without arguments forwards no timeouts", async () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const seen: Array<number | undefined> = [];
+    inner.drainInput = async (maxMs?: number, idleMs?: number) => {
+      seen.push(maxMs, idleMs);
+    };
+
+    await terminal.drainInput();
+
+    expect(seen).toEqual([undefined, undefined]);
+  });
+
+  it("write() delegates the payload verbatim", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const written: string[] = [];
+    inner.write = (data) => written.push(data);
+
+    const frame = "\x1b[2J\x1b[Hhello";
+    terminal.write(frame);
+
+    expect(written).toEqual([frame]);
+  });
+
+  it("moveBy() delegates positive and negative line counts unchanged", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const moved: number[] = [];
+    inner.moveBy = (lines) => moved.push(lines);
+
+    terminal.moveBy(4);
+    terminal.moveBy(-2);
+    terminal.moveBy(0);
+
+    expect(moved).toEqual([4, -2, 0]);
+  });
+
+  it("cursor and screen operations each delegate once", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const calls: string[] = [];
+    const record = (method: string) => () => calls.push(method);
+    inner.hideCursor = record("hideCursor");
+    inner.showCursor = record("showCursor");
+    inner.clearLine = record("clearLine");
+    inner.clearFromCursor = record("clearFromCursor");
+    inner.clearScreen = record("clearScreen");
+
+    terminal.hideCursor();
+    terminal.showCursor();
+    terminal.clearLine();
+    terminal.clearFromCursor();
+    terminal.clearScreen();
+
+    expect(calls).toEqual([
+      "hideCursor",
+      "showCursor",
+      "clearLine",
+      "clearFromCursor",
+      "clearScreen",
+    ]);
+  });
+
+  it("setTitle() delegates the title verbatim", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+    const titles: string[] = [];
+    inner.setTitle = (title) => titles.push(title);
+
+    terminal.setTitle("eliza-code — project");
+
+    expect(titles).toEqual(["eliza-code — project"]);
+  });
+
+  it("routes columns, rows and kittyProtocolActive getters to the inner terminal", () => {
+    const terminal = new FilteringTerminal(() => false);
+    const inner = innerOf(terminal);
+
+    // Real initial state of a fresh ProcessTerminal.
+    expect(terminal.kittyProtocolActive).toBe(false);
+
+    Object.defineProperty(inner, "columns", {
+      get: () => 101,
+      configurable: true,
+    });
+    Object.defineProperty(inner, "rows", { get: () => 24, configurable: true });
+    Object.defineProperty(inner, "kittyProtocolActive", {
+      get: () => true,
+      configurable: true,
+    });
+
+    expect(terminal.columns).toBe(101);
+    expect(terminal.rows).toBe(24);
+    expect(terminal.kittyProtocolActive).toBe(true);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/examples/code/src/lib/filtering-terminal.ts` — the `FilteringTerminal` wrapper that lets the app handle global shortcuts before the focused TUI component receives stdin, and delegates every other `Terminal` operation to its stdio-backed `ProcessTerminal`.

**Test-only change:** the diff is one new file, `src/lib/filtering-terminal.test.ts` (+N/−0). No production code, exports, or behavior changed.

## What is covered (15 cases)

- **Interception gate (the wrapper's only non-delegating logic):**
  - non-intercepted input reaches the host handler in order;
  - intercepted chunks are swallowed and never reach the host handler;
  - the interceptor is evaluated per chunk — a mixed stream (`h`, Ctrl+A, `i`, Ctrl+E, `!`) splits cleanly;
  - a paste-sized chunk arrives at the interceptor as one atomic decision and is swallowed whole when claimed.
- **`start()` wiring:** the host resize handler is forwarded by reference.
- **Instance independence:** two wrappers own distinct inner terminals; one instance's interception does not affect the other's stream.
- **Delegation contract:** `stop()` exactly once; `drainInput()` forwards both timeout arguments (and none when called bare) and resolves through; `write()` verbatim; `moveBy()` for positive/negative/zero; each cursor/screen op (`hideCursor`, `showCursor`, `clearLine`, `clearFromCursor`, `clearScreen`) once; `setTitle()` verbatim.
- **Getters route to the inner terminal:** `columns`, `rows`, `kittyProtocolActive`; a fresh `ProcessTerminal` really reports kitty protocol inactive.

## Evidence (test-only scope)

- **Runner:** this package's unit lane runs under `bun test` (`bun test --conditions=eliza-source src` in `packages/examples/code/package.json`), so the suite was run with the owning runner: `bun test --conditions=eliza-source src/lib/filtering-terminal.test.ts` → **15 pass / 0 fail / 22 expect() calls**, re-run immediately before filing against current `origin/develop`.
- **Lint:** `bunx biome check src/lib/filtering-terminal.test.ts` — clean ("Checked 1 file … No fixes applied"); repo-root `biome.json` present and the checkout is not sparse, so the config was real.
- **Types:** `bunx tsc --noEmit` in `packages/examples/code` — the new test file appears nowhere in the output (zero diagnostics attributable to this diff).
- **Harness shape:** deterministic; no real stdin/stdout is touched. Only the owned inner terminal's stdio methods are stubbed at instance level, while all wrapper logic under test executes for real. No `vi.hoisted`, no `expectTypeOf`, assertions are behavioral (data flow through the interception closure), not mock-echoes.
- The suite records observed behavior only; no aspirational expectations.

## CI note

We are a fork contributor: hosted CI does not run on this pull request. All counts above are quoted from local runs of the owning runner on the pushed head.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cd4fb2746e7387982986405451bf38c049747acf -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
