### PR TITLE
test(ui): cover bounded-view LRU sizing and eviction

### DIFF
--- a/packages/ui/src/state/bounded-view-lru.test.ts
+++ b/packages/ui/src/state/bounded-view-lru.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Covers the shared sizing + eviction policy behind every bounded view cache in
+ * the shell.
+ *
+ * Two things are load-bearing. The caps must tighten under EITHER a static
+ * low-memory device hint OR live heap pressure — an engine without either hint
+ * must keep the larger caps rather than defaulting to the conservative tier.
+ * And both eviction planners must never select a pinned or active entry: the
+ * LRU selector excludes exempt ids, and the module planner never evicts an
+ * entry with a live `refCount`, because doing so would tear a module out from
+ * under a mounted view.
+ *
+ * Pure functions with injected clocks; the two capability hints are installed
+ * as globals and removed afterwards.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_KEEP_ALIVE_MAX_VIEWS,
+  DEFAULT_KEEP_ALIVE_TTL_MS,
+  DEFAULT_RETAINED_MODULE_MAX_ENTRIES,
+  DEFAULT_RETAINED_MODULE_TTL_MS,
+  getHeapPressureRatio,
+  getKeepAliveMaxViews,
+  getKeepAliveTtlMs,
+  getRetainedModuleMaxEntries,
+  getRetainedModuleTtlMs,
+  HEAP_PRESSURE_RATIO,
+  isHeapUnderPressure,
+  isLowMemoryDevice,
+  isUnderMemoryPressure,
+  LOW_MEMORY_DEVICE_GB,
+  LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS,
+  LOW_MEMORY_KEEP_ALIVE_TTL_MS,
+  LOW_MEMORY_RETAINED_MODULE_MAX_ENTRIES,
+  LOW_MEMORY_RETAINED_MODULE_TTL_MS,
+  type ModuleCacheEntryLike,
+  planModuleCacheEvictions,
+  resolveDeviceMemoryGb,
+  resolveHeapUsage,
+  selectLruEvictions,
+} from "./bounded-view-lru.ts";
+
+const g = globalThis as Record<string, unknown>;
+
+// `navigator` is a getter-only global in Node, so it has to be redefined
+// rather than assigned, and restored from its original descriptor afterwards.
+const originalNavigator = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+
+function setDeviceMemory(value: unknown): void {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { deviceMemory: value },
+    configurable: true,
+    writable: true,
+  });
+}
+
+function setHeap(used: unknown, limit: unknown): void {
+  (performance as unknown as Record<string, unknown>).memory = {
+    usedJSHeapSize: used,
+    jsHeapSizeLimit: limit,
+  };
+}
+
+afterEach(() => {
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, "navigator", originalNavigator);
+  } else {
+    delete g.navigator;
+  }
+  delete (performance as unknown as Record<string, unknown>).memory;
+});
+
+describe("device memory hint", () => {
+  it("reports null when the hint is absent or unusable", () => {
+    setDeviceMemory(undefined);
+    expect(resolveDeviceMemoryGb()).toBeNull();
+    setDeviceMemory("8");
+    expect(resolveDeviceMemoryGb()).toBeNull();
+    setDeviceMemory(Number.NaN);
+    expect(resolveDeviceMemoryGb()).toBeNull();
+  });
+
+  it("treats an absent hint as NOT low memory, keeping the larger caps", () => {
+    setDeviceMemory(undefined);
+    expect(isLowMemoryDevice()).toBe(false);
+  });
+
+  it("is inclusive at the documented threshold", () => {
+    setDeviceMemory(LOW_MEMORY_DEVICE_GB);
+    expect(isLowMemoryDevice()).toBe(true);
+    setDeviceMemory(LOW_MEMORY_DEVICE_GB + 1);
+    expect(isLowMemoryDevice()).toBe(false);
+  });
+});
+
+describe("heap pressure hint", () => {
+  it("reports null when performance.memory is absent or malformed", () => {
+    expect(resolveHeapUsage()).toBeNull();
+    setHeap("100", 1000);
+    expect(resolveHeapUsage()).toBeNull();
+    setHeap(100, 0);
+    expect(resolveHeapUsage()).toBeNull();
+    setHeap(-1, 1000);
+    expect(resolveHeapUsage()).toBeNull();
+    setHeap(Number.NaN, 1000);
+    expect(resolveHeapUsage()).toBeNull();
+  });
+
+  it("computes the fill ratio and is inclusive at the threshold", () => {
+    setHeap(500, 1000);
+    expect(getHeapPressureRatio()).toBe(0.5);
+    expect(isHeapUnderPressure()).toBe(false);
+    setHeap(HEAP_PRESSURE_RATIO * 1000, 1000);
+    expect(isHeapUnderPressure()).toBe(true);
+  });
+
+  it("reports no pressure when the hint is missing", () => {
+    expect(getHeapPressureRatio()).toBeNull();
+    expect(isHeapUnderPressure()).toBe(false);
+  });
+});
+
+describe("tier selection", () => {
+  it("uses the default tier when neither hint indicates pressure", () => {
+    setDeviceMemory(16);
+    setHeap(100, 1000);
+    expect(isUnderMemoryPressure()).toBe(false);
+    expect(getRetainedModuleTtlMs()).toBe(DEFAULT_RETAINED_MODULE_TTL_MS);
+    expect(getRetainedModuleMaxEntries()).toBe(
+      DEFAULT_RETAINED_MODULE_MAX_ENTRIES,
+    );
+    expect(getKeepAliveMaxViews()).toBe(DEFAULT_KEEP_ALIVE_MAX_VIEWS);
+    expect(getKeepAliveTtlMs()).toBe(DEFAULT_KEEP_ALIVE_TTL_MS);
+  });
+
+  it("tightens on the device hint alone", () => {
+    setDeviceMemory(2);
+    expect(isUnderMemoryPressure()).toBe(true);
+    expect(getRetainedModuleMaxEntries()).toBe(
+      LOW_MEMORY_RETAINED_MODULE_MAX_ENTRIES,
+    );
+    expect(getKeepAliveMaxViews()).toBe(LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS);
+  });
+
+  it("tightens on live heap pressure even on a roomy device", () => {
+    setDeviceMemory(32);
+    setHeap(950, 1000);
+    expect(isUnderMemoryPressure()).toBe(true);
+    expect(getRetainedModuleTtlMs()).toBe(LOW_MEMORY_RETAINED_MODULE_TTL_MS);
+    expect(getKeepAliveTtlMs()).toBe(LOW_MEMORY_KEEP_ALIVE_TTL_MS);
+  });
+
+  it("keeps the larger caps when neither hint exists at all", () => {
+    expect(isUnderMemoryPressure()).toBe(false);
+    expect(getKeepAliveMaxViews()).toBe(DEFAULT_KEEP_ALIVE_MAX_VIEWS);
+  });
+});
+
+describe("selectLruEvictions", () => {
+  const times = (entries: Record<string, number>) =>
+    new Map(Object.entries(entries));
+
+  it("returns nothing when already within the cap", () => {
+    expect(
+      selectLruEvictions(["a", "b"], times({ a: 1, b: 2 }), 2, new Set()),
+    ).toEqual([]);
+  });
+
+  it("evicts the oldest first", () => {
+    expect(
+      selectLruEvictions(
+        ["a", "b", "c"],
+        times({ a: 3, b: 1, c: 2 }),
+        1,
+        new Set(),
+      ),
+    ).toEqual(["b", "c"]);
+  });
+
+  it("never evicts an exempt id, and does not count it against the cap", () => {
+    // The active and pinned views are always rendered, so `max` bounds only the
+    // evictable set.
+    const evicted = selectLruEvictions(
+      ["active", "a", "b"],
+      times({ active: 0, a: 1, b: 2 }),
+      2,
+      new Set(["active"]),
+    );
+    expect(evicted).toEqual([]);
+  });
+
+  it("breaks equal timestamps on id for determinism", () => {
+    expect(
+      selectLruEvictions(
+        ["b", "a", "c"],
+        times({ a: 5, b: 5, c: 5 }),
+        1,
+        new Set(),
+      ),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("treats a missing or non-finite timestamp as oldest", () => {
+    expect(
+      selectLruEvictions(
+        ["fresh", "missing", "bad"],
+        times({ fresh: 100, bad: Number.NaN }),
+        1,
+        new Set(),
+      ).sort(),
+    ).toEqual(["bad", "missing"]);
+  });
+
+  it("does not mutate the input list", () => {
+    const ids = ["b", "a"];
+    selectLruEvictions(ids, times({ a: 1, b: 2 }), 0, new Set());
+    expect(ids).toEqual(["b", "a"]);
+  });
+});
+
+describe("planModuleCacheEvictions", () => {
+  const entry = (
+    refCount: number,
+    lastUsedAt: number,
+  ): ModuleCacheEntryLike => ({
+    refCount,
+    lastUsedAt,
+  });
+
+  it("never selects an entry that is still referenced", () => {
+    // Evicting a live module would tear it out from under a mounted view.
+    const active = entry(1, 0);
+    const plan = planModuleCacheEvictions([active], {
+      now: 1_000_000,
+      ttlMs: 0,
+      maxEntries: 0,
+      force: true,
+      totalSize: 1,
+    });
+    expect(plan).toEqual([]);
+  });
+
+  it("ttl-evicts idle entries past the window, oldest first", () => {
+    const old = entry(0, 0);
+    const recent = entry(0, 9_500);
+    const plan = planModuleCacheEvictions([recent, old], {
+      now: 10_000,
+      ttlMs: 1_000,
+      maxEntries: 10,
+      force: false,
+      totalSize: 2,
+    });
+    expect(plan).toEqual([{ entry: old, phase: "ttl" }]);
+  });
+
+  it("force-evicts every idle entry regardless of ttl", () => {
+    const a = entry(0, 9_999);
+    const b = entry(0, 10_000);
+    const plan = planModuleCacheEvictions([a, b], {
+      now: 10_000,
+      ttlMs: 5_000_000,
+      maxEntries: 10,
+      force: true,
+      totalSize: 2,
+    });
+    expect(plan.map((p) => p.phase)).toEqual(["ttl", "ttl"]);
+  });
+
+  it("lru-evicts the overflow left after the ttl sweep", () => {
+    const a = entry(0, 100);
+    const b = entry(0, 200);
+    const c = entry(0, 300);
+    const plan = planModuleCacheEvictions([a, b, c], {
+      now: 400,
+      ttlMs: 1_000_000,
+      maxEntries: 1,
+      force: false,
+      totalSize: 3,
+    });
+    expect(plan).toEqual([
+      { entry: a, phase: "lru" },
+      { entry: b, phase: "lru" },
+    ]);
+  });
+
+  it("counts ttl evictions against the cap before planning lru", () => {
+    const stale = entry(0, 0);
+    const fresh = entry(0, 1_000);
+    const plan = planModuleCacheEvictions([stale, fresh], {
+      now: 1_000,
+      ttlMs: 500,
+      maxEntries: 1,
+      force: false,
+      totalSize: 2,
+    });
+    // The TTL sweep already brought the cache within the cap.
+    expect(plan).toEqual([{ entry: stale, phase: "ttl" }]);
+  });
+
+  it("never selects the same entry twice", () => {
+    const a = entry(0, 0);
+    const b = entry(0, 1);
+    const plan = planModuleCacheEvictions([a, b], {
+      now: 10_000,
+      ttlMs: 0,
+      maxEntries: 0,
+      force: true,
+      totalSize: 2,
+    });
+    expect(new Set(plan.map((p) => p.entry)).size).toBe(plan.length);
+  });
+
+  it("treats a non-finite lastUsedAt as oldest rather than skipping it", () => {
+    const bad = entry(0, Number.NaN);
+    const plan = planModuleCacheEvictions([bad], {
+      now: 10_000,
+      ttlMs: 1_000,
+      maxEntries: 10,
+      force: false,
+      totalSize: 1,
+    });
+    expect(plan).toEqual([{ entry: bad, phase: "ttl" }]);
+  });
+
+  it("plans nothing for an empty cache", () => {
+    expect(
+      planModuleCacheEvictions([], {
+        now: 0,
+        ttlMs: 0,
+        maxEntries: 0,
+        force: true,
+        totalSize: 0,
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/state/bounded-view-lru.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `ae1d111a92658da45366b6c063f5075f6e80fa25`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Both eviction planners are asserted on their *safety* invariant (never select an exempt id / never select a live `refCount`) under the most aggressive settings available — `force: true` with `maxEntries: 0` — so a regression that widened selection would fail rather than coincidentally pass. Threshold cases assert both sides of the boundary.

# Background

## What does this PR do?

`packages/ui/src/state/bounded-view-lru.ts` owns the cap/TTL tiers and the eviction policy shared by all three bounded view caches (`retained-lazy`, `DynamicViewLoader`, and the keep-alive host). It had **no dedicated test file**.

| Area | Contract pinned |
|---|---|
| tiering | caps tighten under **either** the static low-memory device hint **or** live heap pressure; an engine exposing neither keeps the LARGER caps rather than defaulting conservative |
| thresholds | both are inclusive at their documented boundary (`<= 4GB`, `>= 0.8` fill) |
| hint hygiene | every malformed hint shape — string, `NaN`, negative `usedJSHeapSize`, zero `jsHeapSizeLimit` — resolves to `null` rather than a bogus ratio |
| LRU safety | `selectLruEvictions` never returns an exempt id, and does not count exempt ids against the cap (the active/pinned views are always rendered) |
| module-cache safety | `planModuleCacheEvictions` never selects an entry with a live `refCount`, even under `force: true` with `maxEntries: 0` — evicting a live module would tear it out from under a mounted view |
| ordering | oldest-first, with an id tie-break so eviction is deterministic; a missing or non-finite timestamp sorts as oldest rather than being skipped |
| cap math | TTL evictions count against the cap before the LRU phase runs, so the planner does not over-evict |
| purity | no entry is selected twice; input lists are not mutated |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/bounded-view-lru.test.ts`, the `selectLruEvictions` and `planModuleCacheEvictions` blocks.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/state/bounded-view-lru.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9354136676cfc3ab181187a23e826dd0c41cefb6 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/state/bounded-view-lru.test.ts
 Test Files  1 passed (1)
      Tests  24 passed (24)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 24/24 passing at this exact head.
- The suite redefines the getter-only `navigator` global to install the device-memory hint and restores its original property descriptor in `afterEach`; `performance.memory` is deleted the same way.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is safety-invariant assertions under maximally aggressive eviction settings.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
