### PR TITLE
fix(voice): restore production ingress and remove blocking greeting

### DIFF
--- a/packages/cloud/api/__tests__/redis-transport-config.test.ts
+++ b/packages/cloud/api/__tests__/redis-transport-config.test.ts
@@ -1,4 +1,4 @@
-/** Pins staging-only REST selection while production retains its existing automatic policy. */
+/** Pins REST selection for direct Redis consumers in both Worker environments. */
 
 import { describe, expect, test } from "bun:test";
 
@@ -16,13 +16,13 @@ function environmentVars(name: "staging" | "production"): string {
 }
 
 describe("Worker direct Redis transport config", () => {
-  test("staging selects direct REST without changing either environment's cache policy", () => {
+  test("both environments select direct REST without changing the general cache policy", () => {
     const staging = environmentVars("staging");
     const production = environmentVars("production");
 
     expect(staging).toContain('CACHE_BACKEND = "auto"');
     expect(staging).toContain('DIRECT_REDIS_BACKEND = "redis-rest"');
     expect(production).toContain('CACHE_BACKEND = "auto"');
-    expect(production).not.toContain("DIRECT_REDIS_BACKEND");
+    expect(production).toContain('DIRECT_REDIS_BACKEND = "redis-rest"');
   });
 });

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -29,7 +29,6 @@ import {
 import {
   buildRealtimeVoiceTwiML,
   buildTerminalVoiceTwiML,
-  ELIZA_AI_CALL_DISCLOSURE,
 } from "../lib/twilio-voice-twiml";
 import {
   claimInboundCallOpeningContext,
@@ -393,7 +392,6 @@ app.post("/", async (c) => {
       streamUrl: publicUrl.toString(),
       sessionId: minted.claims.sessionId,
       token: minted.token,
-      disclosure: ELIZA_AI_CALL_DISCLOSURE,
     }),
     {
       headers: { "Content-Type": "text/xml" },

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildRealtimeVoiceTwiML,
   buildTerminalVoiceTwiML,
-  ELIZA_AI_CALL_DISCLOSURE,
 } from "./twilio-voice-twiml";
 
 describe("Twilio voice TwiML", () => {
@@ -13,12 +12,12 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://api.eliza.app/api/v1/twilio/voice/media",
       sessionId: "11111111-1111-4111-8111-111111111111",
       token: "signed",
-      disclosure: ELIZA_AI_CALL_DISCLOSURE,
     });
 
     expect(xml).toContain(
-      `<Response><Say>${ELIZA_AI_CALL_DISCLOSURE}</Say><Connect><Stream url="wss://api.eliza.app/`,
+      '<Response><Connect><Stream url="wss://api.eliza.app/',
     );
+    expect(xml).not.toContain("<Say>");
     expect(xml).toContain(
       'name="sessionId" value="11111111-1111-4111-8111-111111111111"',
     );
@@ -30,11 +29,9 @@ describe("Twilio voice TwiML", () => {
       streamUrl: "wss://example.test/a?x=1&y=<bad>",
       sessionId: '"session"',
       token: "token'one",
-      disclosure: "AI <assistant>",
     });
 
     expect(xml).not.toContain("<bad>");
-    expect(xml).toContain("AI &lt;assistant&gt;");
     expect(xml).toContain("x=1&amp;y=&lt;bad&gt;");
     expect(xml).toContain("&quot;session&quot;");
     expect(xml).toContain("token&apos;one");

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-voice-twiml.ts
@@ -9,9 +9,6 @@ function escapeXml(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-export const ELIZA_AI_CALL_DISCLOSURE =
-  "Hi, this is Eliza, your AI assistant. This call uses an AI-generated voice.";
-
 export function buildTerminalVoiceTwiML(prompt: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(prompt)}</Say></Response>`;
 }
@@ -20,7 +17,6 @@ export function buildRealtimeVoiceTwiML(options: {
   streamUrl: string;
   sessionId: string;
   token: string;
-  disclosure: string;
 }): string {
-  return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(options.disclosure)}</Say><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${escapeXml(options.streamUrl)}"><Parameter name="sessionId" value="${escapeXml(options.sessionId)}"/><Parameter name="token" value="${escapeXml(options.token)}"/></Stream></Connect></Response>`;
 }

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
@@ -8,6 +8,7 @@ import {
   callOpeningPrompt,
   callStartedEvent,
   claimInboundCallOpeningContext,
+  ELIZA_AI_VOICE_DISCLOSURE,
   type InboundCallOpeningClaim,
   prewarmAndRecordVoiceCallStart,
   relativeInteractionAge,
@@ -18,8 +19,12 @@ describe("voice continuity", () => {
   const now = Date.UTC(2026, 7, 15, 12);
 
   test("uses an immediate deterministic greeting while the cold path prewarms", () => {
-    expect(callOpeningGreeting(false)).toBe("Hello? Who's this?");
-    expect(callOpeningGreeting(true)).toBe("Hey, what's up?");
+    expect(callOpeningGreeting(false)).toBe(
+      `Hello? Who's this? ${ELIZA_AI_VOICE_DISCLOSURE}`,
+    );
+    expect(callOpeningGreeting(true)).toBe(
+      `Hey, what's up? ${ELIZA_AI_VOICE_DISCLOSURE}`,
+    );
   });
 
   test("describes first contact without inventing history", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
@@ -6,6 +6,9 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
+export const ELIZA_AI_VOICE_DISCLOSURE =
+  "Just so you know, I'm an AI assistant using an AI-generated voice.";
+
 export interface InboundCallOpeningClaim extends CallContinuityContext {
   id: string;
   receivedAt: Date;
@@ -122,7 +125,8 @@ export function callStartedEvent(
  * through the agent runtime puts its entire cold path before first audio.
  */
 export function callOpeningGreeting(returningCaller: boolean): string {
-  return returningCaller ? "Hey, what's up?" : "Hello? Who's this?";
+  const greeting = returningCaller ? "Hey, what's up?" : "Hello? Who's this?";
+  return `${greeting} ${ELIZA_AI_VOICE_DISCLOSURE}`;
 }
 
 /** Keeps variable history inside the canonical private turn while bounding its spoken output. */

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -858,6 +858,8 @@ describe("voice-session WS lifecycle", () => {
     );
     expect(endOfTurnLog?.[1]).toMatchObject({
       transcriptChars: "hello agent".length,
+      callerResponseTurnIndex: 1,
+      isFirstCallerResponse: true,
       configuredEndTimeoutMs: 640,
       turnActiveMs: expect.any(Number),
       firstTranscriptOffsetMs: expect.any(Number),
@@ -1838,6 +1840,8 @@ describe("voice-session WS lifecycle", () => {
       ([message]) => message === "[voice-session] first-turn latency",
     );
     expect(latencyLog?.[1]).toMatchObject({
+      callerResponseTurnIndex: 1,
+      isFirstCallerResponse: true,
       upstreamAttemptCount: 3,
       prewarmStatus: "not_configured",
       ttsTransportReadyMs: expect.any(Number),

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -262,6 +262,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private turnSttMs = 0;
   private turnTtsChars = 0;
   private firstLlmTextEmitted = false;
+  private callerResponseTurnCount = 0;
 
   // Metering accrual (server-derived): count uplink bytes, convert to seconds.
   private unmeteredUplinkBytes = 0;
@@ -682,6 +683,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         logger.info("[voice-session] end-of-turn latency", {
           traceId: this.currentTraceId,
           transcriptChars: event.transcript?.length ?? 0,
+          callerResponseTurnIndex: event.transcript?.trim()
+            ? this.callerResponseTurnCount + 1
+            : null,
+          isFirstCallerResponse: event.transcript?.trim()
+            ? this.callerResponseTurnCount === 0
+            : null,
           configuredEndTimeoutMs: CARTESIA_INK_TURN_END_TIMEOUT_MILLISECONDS,
           turnActiveMs:
             this.sttTurnStartedAtMs === null
@@ -894,7 +901,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     }
 
     this.state = "thinking";
-    void this.runResponseTurn(transcript, traceId);
+    this.callerResponseTurnCount += 1;
+    void this.runResponseTurn(transcript, traceId, {
+      callerResponseTurnIndex: this.callerResponseTurnCount,
+    });
   }
 
   /** Speak a fixed live opener while the first agent context is warming. */
@@ -1035,6 +1045,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       historyCutoffAt?: number;
       transientInput?: true;
       fallbackGreeting?: string;
+      callerResponseTurnIndex?: number;
     } = {},
   ): Promise<void> {
     const responseStartedAt = this.now();
@@ -1075,6 +1086,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           logger.info("[voice-session] first-turn latency", {
             traceId,
             transcriptChars: transcript.length,
+            callerResponseTurnIndex: options.callerResponseTurnIndex ?? null,
+            isFirstCallerResponse: options.callerResponseTurnIndex === 1,
             firstModelTextMs:
               firstModelTextAt === null
                 ? null

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -199,8 +199,9 @@ storage = "sqlite"
 type = "durable-object"
 storage = "sqlite"
 
-# General API limits and queues may use Railway Redis via REDIS_URL. Inference
-# routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
+# General API limits and queues use the environment's Railway Redis. Worker
+# direct consumers reach it through redis-rest; non-Worker services use
+# REDIS_URL. Inference routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
 # Durable Objects serialize organization/anonymous quotas, and CACHE_KV serves
 # revisioned metadata. Local development can use embedded Wadis when configured.
 
@@ -210,8 +211,9 @@ storage = "sqlite"
 # index_name = "eliza-cloud-embeddings"
 
 # -----------------------------------------------------------------------------
-# Queue: Stripe webhook fan-out runs on Redis (Railway TCP via REDIS_URL in
-# cloud, embedded Wadis locally), not Cloudflare Queues. The webhook route LPUSHes a JSON
+# Queue: Stripe webhook fan-out runs on Redis (redis-rest in Workers, Railway
+# TCP in non-Worker cloud services, embedded Wadis locally), not Cloudflare
+# Queues. The webhook route LPUSHes a JSON
 # envelope; the `* * * * *` cron fires `/api/cron/process-stripe-queue`
 # which drains a bounded batch via the queue helper in
 # `packages/lib/queue/redis-queue.ts`. Failed messages are retried with
@@ -351,7 +353,7 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   DATABASE_URL                       Railway Postgres (Worker reaches it via the HYPERDRIVE binding;
 #       DATABASE_URL is the origin string for the sidecar/scripts — public-proxy DSNs need
 #       ?sslmode=no-verify or DATABASE_SSL_NO_VERIFY=true for direct node-pg consumers)
-#   REDIS_URL                          Railway TCP Redis (primary cache/queue/rate-limit; rediss://...)
+#   REDIS_URL                          Railway TCP Redis for non-Worker consumers (rediss://...)
 #   STEWARD_API_URL                    Optional Steward base URL override;
 #       defaults to NEXT_PUBLIC_STEWARD_API_URL or NEXT_PUBLIC_API_URL + /steward
 #   STEWARD_JWT_SECRET                 Canonical HS256 secret for Steward JWT verify (jose); MUST match Steward host
@@ -390,9 +392,9 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   OXAPAY_MERCHANT_API_KEY            OxaPay crypto checkout + webhook verification
 #   OXAPAY_WEBHOOK_IPS                 Optional OxaPay webhook source IP allowlist
 #   OXAPAY_PAYMENT_REQUESTS_CALLBACK_URL Payment-request settlement callback override
-#   KV_REST_API_URL                    Upstash Redis REST (LEGACY fallback only; primary is REDIS_URL)
-#   KV_REST_API_TOKEN                  Upstash auth (legacy fallback)
-#   KV_REST_API_READ_ONLY_TOKEN        Upstash read-only token (legacy fallback)
+#   KV_REST_API_URL                    Environment-local redis-rest adapter URL for Worker direct consumers
+#   KV_REST_API_TOKEN                  redis-rest bearer token
+#   KV_REST_API_READ_ONLY_TOKEN        Optional read-only token for compatible hosted Redis REST providers
 #   OPENROUTER_API_KEY                 OpenRouter BYOK key (backup for non-native models)
 #   ANTHROPIC_API_KEY                  Claude
 #   OPENAI_API_KEY                     OpenAI direct
@@ -917,6 +919,10 @@ CACHE_ENABLED = "true"
 # auto: Workers prefer CACHE_KV; non-Worker services use REDIS_URL when set.
 # Explicit "redis" / "redis-rest" overrides remain compatibility options.
 CACHE_BACKEND = "auto"
+# Direct Redis consumers (auth nonces, rate limits, voice replay protection,
+# relay state) use the environment-isolated Railway redis-rest proxy. Raw
+# Railway TCP is not reliable from production Workers.
+DIRECT_REDIS_BACKEND = "redis-rest"
 REDIS_RATE_LIMITING = "true"
 # Enables post-provider billing for cache-only Worker admission. Worker cache
 # misses warm and retry instead of joining an authoritative database fallback.

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -20,7 +20,7 @@ config wins — fix this file.
 | `eliza-app` Pages project (homepage, auth, cloud management, and managed agent app) | Cloudflare Pages | `packages/app/` (`build:web`, embedding `packages/homepage`) | `.github/workflows/cloud-cf-deploy.yml` `deploy-app` job | Public: `eliza.app` + `cloud.eliza.app` (staging: `staging.eliza.app` + `cloud-staging.eliza.app`) |
 | `eliza-cloud-api` — REST API, auth, billing, **model gateway**, dedicated-agent proxy, batch voice routes, cron | Cloudflare Worker (`eliza-cloud-api-prod` / `eliza-cloud-api-staging`) | `packages/cloud/api/` | [`wrangler.toml`](../../api/wrangler.toml) via `cloud-cf-deploy.yml` `deploy-api` job (schema-gated on `migrate-db`) | Public: `api.eliza.app`, `x402.eliza.app`, and `*.cloud.eliza.app` (staging uses `*-staging.eliza.app`); legacy elizacloud.ai routes issue 308 redirects |
 | PostgreSQL | **Railway managed Postgres**. Environment-scoped bindings exist, but the repository and current public receipts do not prove an independently isolated staging service, volume, or Hyperdrive origin; follow the identity/recovery gates below | n/a (managed service) | env-scoped `DATABASE_URL` secret in the `staging`/`production` GitHub Environments; the Worker reaches it through the `HYPERDRIVE` binding (`wrangler.toml` `[[env.*.hyperdrive]]`) | Private |
-| Redis | **Railway managed Redis** (TCP, `REDIS_URL`) | n/a (managed service) | `REDIS_URL` Worker secret; in-Worker SocketRedis speaks RESP2 over `cloudflare:sockets` (`wrangler.toml` cache/queue notes). Upstash REST (`KV_REST_API_*`) is a **legacy fallback only** | Private |
+| Redis | **Railway managed Redis** plus environment-local `redis-rest` HTTP adapter | `packages/cloud/services/redis-rest/` (adapter only) | Non-Worker services use `REDIS_URL`. Worker direct consumers use `DIRECT_REDIS_BACKEND=redis-rest` with `KV_REST_API_URL`/`KV_REST_API_TOKEN`; the general Worker cache continues to prefer `CACHE_KV` | Redis private; authenticated adapter public only for Worker reachability |
 | Database migrations | GitHub Actions → Railway Postgres | `packages/cloud/shared/src/db/migrations/` | `cloud-cf-deploy.yml` `migrate-db` job (`bun run db:cloud:migrate`); every deploy job `needs: migrate-db` | n/a |
 | `gateway-discord` (multi-tenant Discord WS gateway) | Railway (Docker) | `packages/cloud/services/gateway-discord/` | Authorized operator upload through `scripts/deploy-railway.sh`; `cloud-gateway-discord.yml` runs tests only and does not deploy | Discord-facing; `/internal/*` shared-secret routes |
 | `gateway-webhook` (Telegram / Blooio / Twilio / WhatsApp) | Railway (Docker) | `packages/cloud/services/gateway-webhook/` | protected `.github/workflows/deploy-gateway-webhook.yml` using `railway.toml` + `Dockerfile` | Public webhook ingress |
@@ -282,9 +282,10 @@ before `/health` goes green.
   `wrangler.toml` marks `NEON_API_KEY` as retired; the migration workflows
   keep `NEON_DATABASE_URL` only as the last fallback name for the env-scoped
   secret.
-- **Upstash Redis as primary** — Railway TCP Redis (`REDIS_URL`) is primary;
-  the Upstash REST path (`KV_REST_API_*`) survives only as a legacy fallback
-  in the Worker cache client.
+- **Upstash-hosted Redis as primary** — Railway remains the authoritative Redis.
+  The Worker-facing `KV_REST_API_*` bindings address an Upstash-compatible HTTP
+  adapter for that same environment-local Railway Redis; they do not select an
+  independently hosted Upstash database.
 - **`packages/cloud-frontend`** — deleted. Both Pages projects build
   `packages/app` (see the `cloud-cf-deploy.yml` header).
 - **AWS EKS gateway deployments** — deleted (terraform + Helm chart + CI

--- a/packages/cloud/services/redis-rest/Dockerfile
+++ b/packages/cloud/services/redis-rest/Dockerfile
@@ -1,0 +1,6 @@
+# Provides the Upstash-compatible HTTP transport used by Worker direct Redis consumers.
+FROM hiett/serverless-redis-http@sha256:5b0bb9239fce53abf87b2018a7a0deb9ec7bd900c5360738fe5fbeeb426f9150
+
+ENV PORT=80
+ENV SRH_PORT=80
+EXPOSE 80

--- a/packages/cloud/services/redis-rest/README.md
+++ b/packages/cloud/services/redis-rest/README.md
@@ -1,0 +1,36 @@
+# redis-rest
+
+This service exposes an Upstash-compatible HTTP interface to each environment's
+authoritative Railway Redis. Cloudflare Worker direct consumers use it because
+raw Railway TCP is not reliable from Workerd. It is a transport adapter, not a
+second Redis database.
+
+The image is digest-pinned in `Dockerfile`. Configure every Railway environment
+with:
+
+- `SRH_MODE=env`
+- `SRH_TOKEN=<rotated random bearer token>`
+- `SRH_CONNECTION_STRING=${{Redis.REDIS_PUBLIC_URL}}`
+- `PORT=80`
+
+The public Railway domain is required so Cloudflare can reach the adapter. The
+adapter still fail-closes without `SRH_TOKEN`; never log or commit that token.
+Set the Worker secrets `KV_REST_API_URL` and `KV_REST_API_TOKEN` to the domain
+and token, and keep `DIRECT_REDIS_BACKEND=redis-rest` in `wrangler.toml`.
+
+Use `REDIS_PUBLIC_URL`, not `REDIS_URL`: the Railway private hostname was not
+reachable from the adapter service during the production recovery on
+2026-08-23. The Redis credential remains encrypted inside the Railway service
+reference and is not exposed to the Worker.
+
+## Deploy
+
+From this directory:
+
+```bash
+railway up . --path-as-root --service redis-rest
+```
+
+After deployment, make an authenticated `PING` through the public adapter and
+verify `GET https://api.eliza.app/api/auth/siwe/nonce` returns HTTP 200 before
+accepting Twilio voice ingress.

--- a/packages/cloud/services/redis-rest/railway.toml
+++ b/packages/cloud/services/redis-rest/railway.toml
@@ -1,0 +1,9 @@
+# Railway deployment contract for the environment-local Redis HTTP adapter.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -528,6 +528,7 @@ async function executeSharedElizaRuntimeTurn(
   let runtimeReporter: IAgentRuntime | undefined;
   const emitTiming = (outcome: SharedRuntimeTimingOutcome): SharedRuntimeTimingReceipt => {
     const receipt = timing.receipt(outcome);
+    logger.info("[shared-eliza-runtime] turn latency", receipt);
     try {
       input.onRuntimeTiming?.(receipt);
     } catch (error) {


### PR DESCRIPTION
## Summary

- remove the blocking Twilio `<Say>` that delayed the media stream and replayed the prerecorded `Hi, this is Eliza` regression
- preserve disclosure inside the immediate Cartesia opener and retain first-contact vs returning-caller continuity
- log first-caller-response latency and the privacy-bounded canonical shared-runtime timing receipt
- route production Worker direct Redis consumers through an environment-local Railway redis-rest adapter, matching staging
- add the digest-pinned Railway adapter definition and update the hosting contract

Closes #22817.
Closes #26585.

## Live production recovery

Before recovery, Twilio error 11200 showed `/api/v1/twilio/voice/inbound` returning HTTP 500 and production `GET /api/auth/siwe/nonce` returned 503 `nonce_storage_unavailable`, while Railway Redis itself returned PONG.

Provisioned the production redis-rest adapter, rotated its token, verified authenticated `PING -> PONG`, installed the Worker REST bindings, and explicitly selected `redis-rest`. The exact production nonce probe now returns HTTP 200. No Twilio or Blooio routing was changed.

## Verification

- 110 focused Twilio/voice WS/shared-runtime/persona tests pass
- production Redis adapter authenticated PING returns PONG
- production SIWE nonce route returns HTTP 200
- cloud API typecheck and production Worker dry-run pass; dry-run shows `DIRECT_REDIS_BACKEND=redis-rest`
- cloud shared typecheck passes
- cloud infra: 93 tests pass
- focused Biome check passes
- `git diff --check` passes

`bun run verify` reaches the workspace Turbo lane but is blocked by pre-existing formatting failures on current `origin/develop` in `packages/shared/src/dev-settings-banner-style.test.ts` and `packages/shared/src/utils/safe-diagnostic-error.test.ts`. Neither file is changed by this PR.

## Remaining acceptance

A real call to +1 808 788 1821 must confirm Twilio ingress, immediate non-prerecorded opener, and the first caller response on the deployed revision.
