### PR TITLE
test(cloud): cover social-media rate-limit retry and wait clamp

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Covers social-platform retry handling and the rate-limit wait clamp.
+ *
+ * The clamp is the load-bearing piece, and its two bounds guard opposite
+ * failures. Without an upper bound a provider's `Retry-After: 86400` parks the
+ * publishing worker for a day per attempt; worse, any wait above 2^31-1 ms is
+ * coerced by `setTimeout` to 1ms, which *inverts* the backoff so the longest
+ * requested pause produces the fastest retry storm. Without a lower bound a
+ * negative header reaches `setTimeout` the same way. A non-finite wait must
+ * therefore clamp to the MAXIMUM, not to zero.
+ *
+ * Retries use `baseDelayMs: 0` so the suite exercises the real ladder without
+ * real waiting.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { SocialPlatform } from "../../types/social-media";
+import {
+  clampRateLimitWaitMs,
+  createRateLimitError,
+  getRateLimitConfig,
+  isRateLimitResponse,
+  MAX_RATE_LIMIT_WAIT_MS,
+  type RateLimitError,
+  withRetry,
+} from "./rate-limit";
+
+const PLATFORM = "twitter" as SocialPlatform;
+const ALL_PLATFORMS = [
+  "twitter",
+  "bluesky",
+  "discord",
+  "telegram",
+  "slack",
+  "reddit",
+  "facebook",
+  "instagram",
+  "tiktok",
+  "linkedin",
+  "mastodon",
+] as SocialPlatform[];
+
+const ok = (body = '{"v":1}') => new Response(body, { status: 200 });
+const limited = (headers: Record<string, string> = {}) =>
+  new Response("", { status: 429, headers });
+const parseJson = async (response: Response) => response.json();
+
+describe("clampRateLimitWaitMs", () => {
+  test("passes an in-range wait through unchanged", () => {
+    expect(clampRateLimitWaitMs(1_000)).toBe(1_000);
+    expect(clampRateLimitWaitMs(0)).toBe(0);
+    expect(clampRateLimitWaitMs(MAX_RATE_LIMIT_WAIT_MS)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+
+  test("caps a very large provider-requested wait", () => {
+    // `Retry-After: 86400` is legal HTTP and would otherwise park one attempt
+    // for a day.
+    expect(clampRateLimitWaitMs(86_400_000)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+
+  test("stays well below the setTimeout coercion threshold", () => {
+    // Anything above 2^31-1 ms is coerced to 1ms, inverting the backoff.
+    expect(clampRateLimitWaitMs(2 ** 31)).toBeLessThan(2 ** 31 - 1);
+    expect(clampRateLimitWaitMs(999_999_999_999)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+
+  test("floors a negative wait at zero rather than passing it to setTimeout", () => {
+    expect(clampRateLimitWaitMs(-1)).toBe(0);
+    expect(clampRateLimitWaitMs(-999_999)).toBe(0);
+  });
+
+  test("clamps a non-finite wait to the MAXIMUM, not to zero", () => {
+    // Clamping down would turn a malformed header into a retry storm.
+    expect(clampRateLimitWaitMs(Number.NaN)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(clampRateLimitWaitMs(Number.POSITIVE_INFINITY)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(clampRateLimitWaitMs(Number.NEGATIVE_INFINITY)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+});
+
+describe("isRateLimitResponse", () => {
+  test("matches 429 and nothing else", () => {
+    expect(isRateLimitResponse(limited())).toBe(true);
+    for (const status of [200, 400, 403, 500, 503]) {
+      expect(isRateLimitResponse(new Response("", { status }))).toBe(false);
+    }
+  });
+});
+
+describe("createRateLimitError", () => {
+  test("carries the typed marker, platform, and retryAfter", () => {
+    const error = createRateLimitError(PLATFORM, 30);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.rateLimited).toBe(true);
+    expect(error.platform).toBe(PLATFORM);
+    expect(error.retryAfter).toBe(30);
+    expect(error.message).toContain(PLATFORM);
+  });
+
+  test("leaves retryAfter undefined when the provider did not say", () => {
+    expect(createRateLimitError(PLATFORM).retryAfter).toBeUndefined();
+  });
+});
+
+describe("getRateLimitConfig", () => {
+  test("returns a usable window for every supported platform", () => {
+    for (const platform of ALL_PLATFORMS) {
+      const config = getRateLimitConfig(platform);
+      expect(config.requestsPerWindow).toBeGreaterThan(0);
+      expect(config.windowMs).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("withRetry", () => {
+  test("returns parsed data on a first-attempt success", async () => {
+    const result = await withRetry(async () => ok(), parseJson, {
+      platform: PLATFORM,
+      baseDelayMs: 0,
+    });
+    expect(result).toEqual({ data: { v: 1 } });
+  });
+
+  test("retries a transient failure and succeeds", async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("network blip");
+        return ok();
+      },
+      parseJson,
+      { platform: PLATFORM, baseDelayMs: 0 },
+    );
+    expect(calls).toBe(2);
+    expect(result.data).toEqual({ v: 1 });
+  });
+
+  test("propagates the last error after exhausting retries", async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls += 1;
+          throw new Error("always down");
+        },
+        parseJson,
+        { platform: PLATFORM, baseDelayMs: 0, maxRetries: 2 },
+      ),
+    ).rejects.toThrow("always down");
+    expect(calls).toBe(3);
+  });
+
+  test("retries a 429 and succeeds once the limit clears", async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls += 1;
+        return calls === 1 ? limited() : ok();
+      },
+      parseJson,
+      { platform: PLATFORM, baseDelayMs: 0 },
+    );
+    expect(calls).toBe(2);
+    expect(result.data).toEqual({ v: 1 });
+  });
+
+  test("throws a typed rate-limit error once retries are exhausted", async () => {
+    const error = (await withRetry(async () => limited({ "retry-after": "30" }), parseJson, {
+      platform: PLATFORM,
+      baseDelayMs: 0,
+      maxRetries: 0,
+    }).catch((e) => e)) as RateLimitError;
+    expect(error.rateLimited).toBe(true);
+    expect(error.platform).toBe(PLATFORM);
+    // Reported verbatim in SECONDS, deliberately unclamped, so callers can
+    // schedule against what the provider actually said.
+    expect(error.retryAfter).toBe(30);
+  });
+
+  test("reports a very large Retry-After verbatim rather than clamped", async () => {
+    const error = (await withRetry(async () => limited({ "retry-after": "86400" }), parseJson, {
+      platform: PLATFORM,
+      baseDelayMs: 0,
+      maxRetries: 0,
+    }).catch((e) => e)) as RateLimitError;
+    expect(error.retryAfter).toBe(86_400);
+  });
+
+  test("does not retry a rate-limit error raised by the caller's parser", async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls += 1;
+          return ok();
+        },
+        async () => {
+          throw createRateLimitError(PLATFORM, 5);
+        },
+        { platform: PLATFORM, baseDelayMs: 0, maxRetries: 3 },
+      ),
+    ).rejects.toMatchObject({ rateLimited: true });
+    expect(calls).toBe(1);
+  });
+
+  test("surfaces a non-ok status with the platform and status in the message", async () => {
+    await expect(
+      withRetry(async () => new Response("boom", { status: 500 }), parseJson, {
+        platform: PLATFORM,
+        baseDelayMs: 0,
+        maxRetries: 0,
+      }),
+    ).rejects.toThrow(/twitter API error 500/);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/shared/src/lib/services/social-media/rate-limit.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. `withRetry` cases drive the real retry ladder (real `Response` objects, real parser, real error paths) with `baseDelayMs: 0`, so the suite exercises the actual control flow without real waiting and asserts exact attempt counts rather than just the final outcome. The clamp cases assert both bounds and the non-finite direction explicitly, since clamping non-finite the wrong way is the failure that turns a bad header into a retry storm.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/services/social-media/rate-limit.ts` owns every outbound social-platform retry. It had **no dedicated test file**.

`clampRateLimitWaitMs` is the load-bearing piece, and its two bounds guard opposite failures — both reachable from a response header we do not control:

| Hazard | Contract pinned |
|---|---|
| unbounded wait | `Retry-After: 86400` would park the publishing worker for a day per attempt |
| `setTimeout` coercion | any wait above 2^31-1 ms is coerced to **1ms**, *inverting* the backoff so the longest requested pause produces the fastest retry storm. The clamp is asserted to stay well below that threshold. |
| negative wait | `Retry-After: -1` reaches `setTimeout` as a negative delay and is coerced the same way |
| non-finite wait | clamps to the **MAXIMUM**, not zero — clamping down would turn a malformed header into a retry storm |

Also pinned for `withRetry`: parsed data on success; retry of a transient failure; propagation of the last error after exhausting the ladder with the exact attempt count; 429 retry then success; a typed rate-limit error when retries run out; **no** retry for a rate-limit error raised by the caller's parser; and a non-ok status surfaced with platform and status in the message.

`retryAfter` is reported verbatim in seconds and deliberately **unclamped** — including for a very large value — so callers can schedule against what the provider actually said.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/social-media/rate-limit.test.ts`, the `clampRateLimitWaitMs` block.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/services/social-media/rate-limit.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c7de88f037512c95c9114ccfb99242186d8b6f4b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ bun test src/lib/services/social-media/rate-limit.test.ts
 17 pass
 0 fail
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 17/17 passing at this exact head. The run prints the module's own retry warnings to stderr; that is the real logger firing, not a failure.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is exact attempt-count assertions and both-direction clamp bounds.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
