### PR TITLE
test(ui): cover gesture recognizers

### DIFF
--- a/packages/ui/src/gestures/recognizers.test.ts
+++ b/packages/ui/src/gestures/recognizers.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Covers the pure gesture recognizers that every pull/pager surface delegates
+ * to, so one dominance/threshold rule governs them all.
+ *
+ * The dominance rule is the load-bearing one: a mostly-vertical scroll must
+ * never register as a horizontal swipe, while a deliberate diagonal must still
+ * commit. The rule is non-strict on purpose (a widened ~51 degree cone), so the
+ * suite asserts both sides of that cone rather than only the easy cases.
+ *
+ * Pure functions — no DOM, no events.
+ */
+import { describe, expect, it } from "vitest";
+
+import { HORIZONTAL_DOMINANCE_RATIO } from "./constants.ts";
+import {
+  commitAxis,
+  resolvePull,
+  resolveSwipe,
+  rubberBand,
+  sqrtRubberBand,
+} from "./recognizers.ts";
+
+describe("resolvePull", () => {
+  it("returns null while under both thresholds", () => {
+    expect(resolvePull(5, 0.1, 50, 1)).toBeNull();
+  });
+
+  it("fires on distance alone, in the direction of travel", () => {
+    expect(resolvePull(60, 0, 50, 1)).toBe("up");
+    expect(resolvePull(-60, 0, 50, 1)).toBe("down");
+  });
+
+  it("fires on velocity alone even when the distance is small", () => {
+    expect(resolvePull(5, 2, 50, 1)).toBe("up");
+    expect(resolvePull(-5, -2, 50, 1)).toBe("down");
+  });
+
+  it("treats each threshold as inclusive", () => {
+    expect(resolvePull(50, 0, 50, 1)).toBe("up");
+    expect(resolvePull(1, 1, 50, 1)).toBe("up");
+  });
+
+  it("resolves an exactly-zero delta as a downward pull once a threshold passes", () => {
+    // `deltaUp > 0` is the only up-condition, so 0 is not "up".
+    expect(resolvePull(0, 5, 50, 1)).toBe("down");
+  });
+});
+
+describe("resolveSwipe", () => {
+  it("rejects a mostly-vertical drag no matter how fast", () => {
+    expect(resolveSwipe(10, 99, 500, 20, 1)).toBeNull();
+  });
+
+  it("fires on a clean horizontal drag, in the direction of travel", () => {
+    expect(resolveSwipe(60, 0, 0, 50, 1)).toBe("left");
+    expect(resolveSwipe(-60, 0, 0, 50, 1)).toBe("right");
+  });
+
+  it("fires on horizontal velocity alone", () => {
+    expect(resolveSwipe(5, 2, 0, 50, 1)).toBe("left");
+  });
+
+  it("accepts a diagonal at exactly the dominance boundary", () => {
+    // Non-strict on purpose: a deliberate diagonal must still commit.
+    const deltaUp = 100;
+    const atBoundary = deltaUp * HORIZONTAL_DOMINANCE_RATIO;
+    expect(resolveSwipe(atBoundary, 0, deltaUp, 1, 999)).toBe("left");
+  });
+
+  it("rejects a diagonal just inside the vertical side of the boundary", () => {
+    const deltaUp = 100;
+    const justUnder = deltaUp * HORIZONTAL_DOMINANCE_RATIO - 0.001;
+    expect(resolveSwipe(justUnder, 0, deltaUp, 1, 999)).toBeNull();
+  });
+
+  it("still requires a threshold once dominance passes", () => {
+    expect(resolveSwipe(5, 0.1, 0, 50, 1)).toBeNull();
+  });
+});
+
+describe("commitAxis", () => {
+  it("stays ambiguous until travel crosses the slop", () => {
+    expect(commitAxis(3, 3, 10, true)).toBeNull();
+    expect(commitAxis(0, 0, 10, false)).toBeNull();
+  });
+
+  it("commits on the larger axis once slop is crossed", () => {
+    expect(commitAxis(50, 5, 10, false)).toBe("x");
+    expect(commitAxis(5, 50, 10, false)).toBe("y");
+  });
+
+  it("uses a strict comparison when swiping is not available", () => {
+    // Vertical-only surface: an exact tie must resolve to the vertical axis.
+    expect(commitAxis(20, 20, 10, false)).toBe("y");
+  });
+
+  it("uses the widened cone when swiping is available", () => {
+    expect(commitAxis(20, 20, 10, true)).toBe("x");
+  });
+
+  it("treats the slop as inclusive on the larger axis", () => {
+    expect(commitAxis(10, 0, 10, false)).toBe("x");
+  });
+
+  it("ignores direction, considering only magnitude", () => {
+    expect(commitAxis(-50, 5, 10, false)).toBe("x");
+    expect(commitAxis(5, -50, 10, false)).toBe("y");
+  });
+});
+
+describe("rubberBand", () => {
+  it("clamps a non-positive travel to zero", () => {
+    expect(rubberBand(0, 100, 0.5)).toBe(0);
+    expect(rubberBand(-50, 100, 0.5)).toBe(0);
+  });
+
+  it("tracks travel one-to-one up to the soft maximum", () => {
+    expect(rubberBand(40, 100, 0.5)).toBe(40);
+    expect(rubberBand(100, 100, 0.5)).toBe(100);
+  });
+
+  it("applies resistance to the overshoot only", () => {
+    expect(rubberBand(200, 100, 0.5)).toBe(150);
+  });
+
+  it("keeps giving a little rather than stopping dead", () => {
+    const near = rubberBand(200, 100, 0.5);
+    const far = rubberBand(400, 100, 0.5);
+    expect(far).toBeGreaterThan(near);
+  });
+
+  it("stops moving entirely at zero resistance", () => {
+    expect(rubberBand(999, 100, 0)).toBe(100);
+  });
+});
+
+describe("sqrtRubberBand", () => {
+  it("is zero at zero overshoot", () => {
+    expect(sqrtRubberBand(0, 10)).toBe(0);
+  });
+
+  it("damps symmetrically on either side of the detent", () => {
+    expect(sqrtRubberBand(100, 1)).toBe(10);
+    expect(sqrtRubberBand(-100, 1)).toBe(-10);
+  });
+
+  it("stiffens progressively — doubling overshoot gives less than double give", () => {
+    const once = sqrtRubberBand(100, 1);
+    const twice = sqrtRubberBand(200, 1);
+    expect(twice).toBeGreaterThan(once);
+    expect(twice).toBeLessThan(once * 2);
+  });
+
+  it("scales linearly with the scale factor", () => {
+    expect(sqrtRubberBand(100, 2)).toBe(sqrtRubberBand(100, 1) * 2);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/gestures/recognizers.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The dominance cases are computed from the real exported `HORIZONTAL_DOMINANCE_RATIO` rather than a hard-coded angle, so they follow the constant if it is retuned instead of silently going stale. Both sides of the boundary are asserted, and the rubber-band cases assert a relationship (progressively stiffening) rather than a magic number, so they survive a scale change.

# Background

## What does this PR do?

`packages/ui/src/gestures/recognizers.ts` is the shared decision core every pull and pager surface delegates to, so one dominance/threshold rule governs them all. It had **no dedicated test file**.

The dominance rule is load-bearing: a mostly-vertical scroll must never register as a horizontal swipe, while a deliberate diagonal must still commit. It is **non-strict on purpose** (a widened cone at `HORIZONTAL_DOMINANCE_RATIO`), so both sides of the boundary are asserted — a diagonal exactly at the ratio commits, one a thousandth inside the vertical side does not.

| Helper | Contract pinned |
|---|---|
| `resolvePull` | fires on distance OR velocity; both thresholds inclusive; an exactly-zero delta resolves **down**, since `deltaUp > 0` is the only up-condition |
| `resolveSwipe` | rejects a mostly-vertical drag no matter how fast; still requires a threshold once dominance passes |
| `commitAxis` | ambiguous below slop; slop inclusive; direction-agnostic; an exact tie resolves **vertical** without swipe and **horizontal** with the widened cone — the difference between the two surfaces |
| `rubberBand` | one-to-one to the soft max; resistance applied to overshoot only; keeps giving as travel grows; stops dead at zero resistance |
| `sqrtRubberBand` | symmetric about the detent; linear in the scale factor; progressively stiffening — doubling overshoot yields strictly less than double the give |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/gestures/recognizers.test.ts`, the `resolveSwipe` dominance-boundary cases.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/gestures/recognizers.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:341d242cc010f8f9d030880aa23b4134291d0604 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/gestures/recognizers.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 26/26 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is boundary cases derived from the real exported constant plus relationship-based assertions on the rubber bands.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
