### PR TITLE
test(core): cover task-clipboard-persistence

### DIFF
--- a/packages/core/src/features/working-memory/taskClipboardPersistence.test.ts
+++ b/packages/core/src/features/working-memory/taskClipboardPersistence.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Behavioral coverage for the ATTACHMENT → task-clipboard persistence bridge:
+ * the clipboard-request flag parsing (boolean and string truthy forms), the
+ * display-title resolution precedence, and the discriminated store result
+ * (including the empty-content and service-failure paths that must never
+ * throw).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	maybeStoreTaskClipboardItem,
+	resolveClipboardTitle,
+	shouldAddToClipboard,
+} from "./taskClipboardPersistence.ts";
+
+const { createTaskClipboardService } = await import(
+	"./taskClipboardService.ts"
+);
+
+vi.mock("./taskClipboardService.ts", () => ({
+	createTaskClipboardService: vi.fn(),
+}));
+
+const mockCreate = vi.mocked(createTaskClipboardService);
+
+function message(
+	content: Record<string, unknown>,
+): Parameters<typeof shouldAddToClipboard>[0] {
+	return {
+		content,
+		roomId: "room-1",
+		entityId: "entity-1",
+		userId: "user-1",
+		agentId: "agent-1",
+	} as never;
+}
+
+describe("shouldAddToClipboard", () => {
+	it("accepts a literal true on any of the three clipboard flags", () => {
+		expect(shouldAddToClipboard(message({ addToClipboard: true }))).toBe(true);
+		expect(shouldAddToClipboard(message({ persistToClipboard: true }))).toBe(
+			true,
+		);
+		expect(shouldAddToClipboard(message({ saveToClipboard: true }))).toBe(true);
+	});
+
+	it("accepts string truthy flag values case-insensitively", () => {
+		for (const flag of [
+			"addToClipboard",
+			"persistToClipboard",
+			"saveToClipboard",
+		]) {
+			for (const value of ["true", "1", "yes", "y", "on", "TRUE", "Yes"]) {
+				expect(shouldAddToClipboard(message({ [flag]: value }))).toBe(true);
+			}
+		}
+	});
+
+	it("rejects falsy, numeric, and unknown flag values", () => {
+		expect(shouldAddToClipboard(message({ addToClipboard: false }))).toBe(
+			false,
+		);
+		expect(shouldAddToClipboard(message({ addToClipboard: 1 }))).toBe(false);
+		expect(shouldAddToClipboard(message({ addToClipboard: "off" }))).toBe(
+			false,
+		);
+		expect(shouldAddToClipboard(message({}))).toBe(false);
+		expect(shouldAddToClipboard(message({ persistToClipboard: "  " }))).toBe(
+			false,
+		);
+	});
+});
+
+describe("resolveClipboardTitle", () => {
+	it("prefers the explicit clipboard title over the generic title", () => {
+		expect(
+			resolveClipboardTitle(
+				message({ clipboardTitle: "  Explicit  ", title: "Generic" }),
+			),
+		).toBe("Explicit");
+	});
+
+	it("falls back to the message title, then the caller fallback", () => {
+		expect(resolveClipboardTitle(message({ title: "  Msg Title " }))).toBe(
+			"Msg Title",
+		);
+		expect(resolveClipboardTitle(message({}), "Fallback Title")).toBe(
+			"Fallback Title",
+		);
+	});
+
+	it("returns undefined when every candidate is blank", () => {
+		expect(
+			resolveClipboardTitle(message({ clipboardTitle: "  " }), "   "),
+		).toBeUndefined();
+		expect(resolveClipboardTitle(message({}))).toBeUndefined();
+	});
+});
+
+describe("maybeStoreTaskClipboardItem", () => {
+	const fakeRuntime = {
+		reportError: vi.fn(),
+	} as never;
+
+	beforeEach(() => {
+		mockCreate.mockReset();
+		fakeRuntime.reportError.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("short-circuits with requested:false when no clipboard flag is set", async () => {
+		const result = await maybeStoreTaskClipboardItem(fakeRuntime, message({}), {
+			content: "some text",
+		} as never);
+		expect(result).toEqual({ requested: false, stored: false });
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("returns an explicit unstored reason for empty content", async () => {
+		const result = await maybeStoreTaskClipboardItem(
+			fakeRuntime,
+			message({ addToClipboard: true }),
+			{ content: "   " } as never,
+		);
+		expect(result).toEqual({
+			requested: true,
+			stored: false,
+			reason: "No stored content was available to save in the clipboard.",
+		});
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("stores the trimmed content and reports the service snapshot", async () => {
+		const item = { id: "item-1", title: "t", content: "payload" } as never;
+		const snapshot = { items: [item] } as never;
+		mockCreate.mockReturnValue({
+			addItem: vi.fn().mockResolvedValue({ item, replaced: false, snapshot }),
+		} as never);
+
+		const result = await maybeStoreTaskClipboardItem(
+			fakeRuntime,
+			message({ addToClipboard: true }),
+			{ content: "  payload  " } as never,
+		);
+
+		expect(result).toEqual({
+			requested: true,
+			stored: true,
+			replaced: false,
+			item,
+			snapshot,
+		});
+		const addItem =
+			mockCreate.mock.calls[0] &&
+			(
+				mockCreate.mock.results[0].value as {
+					addItem: (input: unknown) => unknown;
+				}
+			).addItem;
+		expect(addItem).toHaveBeenCalledWith(
+			expect.objectContaining({ content: "payload" }),
+			"entity-1",
+		);
+	});
+
+	it("translates a service failure into an unstored result and reports it", async () => {
+		mockCreate.mockReturnValue({
+			addItem: vi.fn().mockRejectedValue(new Error("disk full")),
+		} as never);
+
+		const result = await maybeStoreTaskClipboardItem(
+			fakeRuntime,
+			message({ saveToClipboard: true }),
+			{ content: "payload" } as never,
+		);
+
+		expect(result).toEqual({
+			requested: true,
+			stored: false,
+			reason: "disk full",
+		});
+		expect(fakeRuntime.reportError).toHaveBeenCalledWith(
+			"TaskClipboardPersistence.store",
+			expect.any(Error),
+			{ roomId: "room-1" },
+		);
+	});
+});


### PR DESCRIPTION
# test(core): cover task-clipboard-persistence

# Relates to

- No open issue: behavioral test coverage for `packages/core/src/features/working-memory/taskClipboardPersistence.ts`, which currently has no test file.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@HEAD:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.

# Background

## What does this PR do?

`taskClipboardPersistence.ts` bridges the ATTACHMENT action to the task-clipboard service of the working-memory capability. It decides whether a message requested clipboard persistence (`addToClipboard` / `persistToClipboard` / `saveToClipboard` flags, in both boolean and string-truthy forms), resolves a display title with a documented precedence, and stores one item — returning a discriminated result where empty content and service errors surface as `stored:false` with a reason instead of throwing. None of that contract was pinned by tests.

This PR adds behavioral coverage for:

- flag parsing: literal `true` on each of the three flags; string truthy values (`true`/`1`/`yes`/`y`/`on`) case-insensitively; falsy/numeric/unknown values rejected
- title resolution precedence: explicit `clipboardTitle` > message `title` > caller `fallbackTitle`; blank candidates yield `undefined`
- `maybeStoreTaskClipboardItem`: short-circuit `requested:false` without touching the service; explicit unstored reason for blank content; successful store returning the service `item`/`replaced`/`snapshot` with trimmed content and the entity id passed through; service failure translated into `stored:false` plus `runtime.reportError`

## What kind of change is this?

Test coverage only — zero source changes.

# Documentation changes needed?

No user-facing documentation change; test-only PR.

# Testing

## Where should a reviewer start?

- Source under test: `packages/core/src/features/working-memory/taskClipboardPersistence.ts`
- Test file: `packages/core/src/features/working-memory/taskClipboardPersistence.test.ts`

## Tests

```text
$ cd packages/core && bun x vitest run src/features/working-memory/taskClipboardPersistence.test.ts
 ✓ src/features/working-memory/taskClipboardPersistence.test.ts (10 tests) 13ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Biome: `bunx biome check` on the new file — clean, no fixes applied.

## Evidence rows

<!-- evidence-row:before-screenshots -->
N/A - server-side module; no UI surface.

<!-- evidence-row:after-screenshots -->
N/A - server-side module; no UI surface.

<!-- evidence-row:walkthrough-video -->
N/A - deterministic unit coverage below; no interactive flow.

<!-- evidence-row:backend-logs -->
Local run 2026-08-24: `vitest run src/features/working-memory/taskClipboardPersistence.test.ts` → 10 passed (10 tests, 13ms); `bunx biome check` clean.

<!-- evidence-row:frontend-logs -->
N/A - no frontend change.

<!-- evidence-row:llm-trajectory -->
N/A - no live-model path; deterministic unit coverage below.

<!-- evidence-row:domain-artifacts -->
N/A - test-only PR.

# Risks

Low and bounded: adds a single test file; the service dependency is mocked at the module boundary while all pure helpers are tested against the real implementation; no source or dependency changes.

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
