### PR TITLE
fix(ui): do not throw while classifying a null send failure

### DIFF
--- a/packages/ui/src/state/chat-send-failures.test.ts
+++ b/packages/ui/src/state/chat-send-failures.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Covers chat-send failure classification and optimistic-turn reconciliation.
+ *
+ * The notice a user sees has to match what actually went wrong, because each
+ * one prescribes a different action (sign in again / wait / just resend). The
+ * ordering inside `buildSendFailureNotice` is therefore load-bearing: an auth
+ * or throttle status must win over a transport `kind`, and a validation status
+ * must only surface the server's own text when there is real text to surface —
+ * a bare "HTTP 400" would tell the user nothing while displacing the generic
+ * advice.
+ *
+ * Pure policy — no React, no network.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ConversationMessage } from "../api";
+import {
+  buildSendFailureNotice,
+  getSendValidationFailureMessage,
+  resolveAbortRoomId,
+  sentUserTurnPresent,
+  UNDELIVERED_TURN_NOTICE,
+} from "./chat-send-failures.ts";
+
+const httpError = (status: number, message = ""): Error & { status: number } =>
+  Object.assign(new Error(message), { status });
+
+const message = (
+  text: string,
+  timestamp: number,
+  role: "user" | "assistant" = "user",
+): ConversationMessage => ({ role, text, timestamp }) as ConversationMessage;
+
+describe("getSendValidationFailureMessage", () => {
+  it("surfaces the server text for each validation status", () => {
+    for (const status of [400, 413, 415, 422]) {
+      expect(
+        getSendValidationFailureMessage(httpError(status, "Too many parts")),
+      ).toBe("Too many parts");
+    }
+  });
+
+  it("ignores non-validation statuses", () => {
+    for (const status of [401, 403, 429, 500, 503]) {
+      expect(
+        getSendValidationFailureMessage(httpError(status, "nope")),
+      ).toBeNull();
+    }
+  });
+
+  it("ignores a placeholder message that carries no information", () => {
+    // "HTTP 400" would displace the generic advice while saying nothing.
+    expect(
+      getSendValidationFailureMessage(httpError(400, "HTTP 400")),
+    ).toBeNull();
+    expect(
+      getSendValidationFailureMessage(httpError(400, "http 422")),
+    ).toBeNull();
+  });
+
+  it("ignores an empty or whitespace-only message", () => {
+    expect(getSendValidationFailureMessage(httpError(400, ""))).toBeNull();
+    expect(getSendValidationFailureMessage(httpError(400, "   "))).toBeNull();
+  });
+
+  it("trims the surfaced message", () => {
+    expect(
+      getSendValidationFailureMessage(httpError(400, "  bad input  ")),
+    ).toBe("bad input");
+  });
+
+  it("tolerates a non-Error and a status-less value", () => {
+    expect(getSendValidationFailureMessage({ status: 400 })).toBeNull();
+    expect(getSendValidationFailureMessage(null)).toBeNull();
+    expect(getSendValidationFailureMessage("nope")).toBeNull();
+  });
+});
+
+describe("buildSendFailureNotice", () => {
+  it("tells the user to sign in again on an auth failure", () => {
+    for (const status of [401, 403]) {
+      expect(buildSendFailureNotice(httpError(status))).toContain(
+        "sign in again",
+      );
+    }
+  });
+
+  it("tells the user to wait on a throttle", () => {
+    expect(buildSendFailureNotice(httpError(429))).toContain("busy");
+  });
+
+  it("tells the user the agent is waking up on a gateway failure", () => {
+    for (const status of [502, 503]) {
+      expect(buildSendFailureNotice(httpError(status))).toContain("waking up");
+    }
+  });
+
+  it("quotes the server's reason for a validation failure", () => {
+    expect(buildSendFailureNotice(httpError(422, "Attachment too large"))).toBe(
+      "The agent couldn't accept that message: Attachment too large.",
+    );
+  });
+
+  it("prefers an auth or throttle status over a transport kind", () => {
+    // Ordering matters: the actionable advice differs.
+    expect(
+      buildSendFailureNotice(
+        Object.assign(httpError(401), { kind: "network" }),
+      ),
+    ).toContain("sign in again");
+    expect(
+      buildSendFailureNotice(
+        Object.assign(httpError(429), { kind: "timeout" }),
+      ),
+    ).toContain("busy");
+  });
+
+  it("falls back to the transport kind when there is no status", () => {
+    expect(buildSendFailureNotice({ kind: "timeout" })).toContain(
+      "took too long",
+    );
+    expect(buildSendFailureNotice({ kind: "network" })).toContain(
+      "Couldn't reach the agent",
+    );
+  });
+
+  it("falls back to the generic notice for an unrecognized failure", () => {
+    for (const err of [
+      new Error("boom"),
+      httpError(500),
+      {},
+      null,
+      undefined,
+    ]) {
+      expect(buildSendFailureNotice(err)).toBe(
+        "That message didn't go through — please resend.",
+      );
+    }
+  });
+
+  it("falls back to generic when a validation status carries no usable text", () => {
+    expect(buildSendFailureNotice(httpError(400, "HTTP 400"))).toBe(
+      "That message didn't go through — please resend.",
+    );
+  });
+
+  it("always returns a non-empty notice", () => {
+    for (const err of [null, undefined, {}, new Error(""), httpError(418)]) {
+      expect(buildSendFailureNotice(err).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exposes a distinct undelivered-turn notice", () => {
+    expect(UNDELIVERED_TURN_NOTICE).not.toBe(
+      buildSendFailureNotice(new Error("x")),
+    );
+    expect(UNDELIVERED_TURN_NOTICE.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveAbortRoomId", () => {
+  it("prefers the known room id", () => {
+    expect(resolveAbortRoomId("conv", "room", "cached")).toBe("room");
+  });
+
+  it("falls back to the cached id, then to the conversation id", () => {
+    expect(resolveAbortRoomId("conv", null, "cached")).toBe("cached");
+    expect(resolveAbortRoomId("conv", null, null)).toBe("conv");
+    expect(resolveAbortRoomId("conv", undefined, undefined)).toBe("conv");
+  });
+
+  it("treats a whitespace-only id as absent", () => {
+    expect(resolveAbortRoomId("conv", "   ", "cached")).toBe("cached");
+    expect(resolveAbortRoomId("conv", "   ", "   ")).toBe("conv");
+  });
+
+  it("trims the id it returns", () => {
+    expect(resolveAbortRoomId("conv", "  room  ", null)).toBe("room");
+  });
+});
+
+describe("sentUserTurnPresent", () => {
+  const SENT_AT = 1_800_000_000_000;
+
+  it("finds a matching user turn at the send time", () => {
+    expect(
+      sentUserTurnPresent([message("hello", SENT_AT)], "hello", SENT_AT),
+    ).toBe(true);
+  });
+
+  it("matches within the slack window but not before it", () => {
+    expect(
+      sentUserTurnPresent(
+        [message("hello", SENT_AT - 59_000)],
+        "hello",
+        SENT_AT,
+      ),
+    ).toBe(true);
+    expect(
+      sentUserTurnPresent(
+        [message("hello", SENT_AT - 61_000)],
+        "hello",
+        SENT_AT,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores assistant turns with the same text", () => {
+    expect(
+      sentUserTurnPresent(
+        [message("hello", SENT_AT, "assistant")],
+        "hello",
+        SENT_AT,
+      ),
+    ).toBe(false);
+  });
+
+  it("compares trimmed text on both sides", () => {
+    expect(
+      sentUserTurnPresent([message("  hello  ", SENT_AT)], "hello", SENT_AT),
+    ).toBe(true);
+    expect(
+      sentUserTurnPresent([message("hello", SENT_AT)], "  hello  ", SENT_AT),
+    ).toBe(true);
+  });
+
+  it("does not match different text", () => {
+    expect(
+      sentUserTurnPresent([message("hello there", SENT_AT)], "hello", SENT_AT),
+    ).toBe(false);
+  });
+
+  it("reports absent for an empty history", () => {
+    expect(sentUserTurnPresent([], "hello", SENT_AT)).toBe(false);
+  });
+});

--- a/packages/ui/src/state/chat-send-failures.ts
+++ b/packages/ui/src/state/chat-send-failures.ts
@@ -11,7 +11,11 @@ const VALIDATION_FAILURE_STATUSES: ReadonlySet<number> = new Set([
 ]);
 
 export function getSendValidationFailureMessage(err: unknown): string | null {
-  const status = (err as { status?: number }).status;
+  // Optional read: this classifies a rejection value, and a rejection can be
+  // `null`/`undefined` (`throw null`, `Promise.reject()`). A plain property
+  // read throws there, which would replace the user-facing notice with an
+  // unhandled error inside the send path's own failure handler.
+  const status = (err as { status?: number } | null | undefined)?.status;
   if (typeof status !== "number" || !VALIDATION_FAILURE_STATUSES.has(status)) {
     return null;
   }
@@ -21,8 +25,8 @@ export function getSendValidationFailureMessage(err: unknown): string | null {
 }
 
 export function buildSendFailureNotice(err: unknown): string {
-  const status = (err as { status?: number }).status;
-  const kind = (err as { kind?: string }).kind;
+  const status = (err as { status?: number } | null | undefined)?.status;
+  const kind = (err as { kind?: string } | null | undefined)?.kind;
   if (status === 401 || status === 403) {
     return "Your session expired — sign in again and resend your message.";
   }


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/ui/src/state/chat-send-failures.ts`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

@@RISKS@@

# Background

## What does this PR do?

`getSendValidationFailureMessage` and `buildSendFailureNotice` read `(err as { status?: number }).status` directly. Both classify a **rejection value**, and a rejection can legitimately be `null` or `undefined` — `throw null` and a bare `Promise.reject()` both produce one.

A plain property read throws `TypeError: Cannot read properties of null` there. That happens **inside the send path's own failure handler**, so instead of the user seeing *"That message didn't go through — please resend."*, the classifier itself raises and the failure surfaces as an unhandled error — the one place that must not be able to fail.

Both reads are now optional.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/chat-send-failures.test.ts`, the "always returns a non-empty notice" case. The module had no test file at all, so the suite also covers notice ordering, `resolveAbortRoomId`, and `sentUserTurnPresent`.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/state/chat-send-failures.test.ts
```

To confirm the suite is not vacuous, revert `chat-send-failures.ts` (keep the test) and re-run — 3 of 26 fail with `TypeError: Cannot read properties of null`. The other 23 are controls covering notice ordering and turn reconciliation, which must hold either way.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:fd6b71647d7e16a2336eb045b095df0153b2edf2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface in this diff; this changes a pure classifier that produces notice text.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface in this diff; this changes a pure classifier that produces notice text.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is which failure notice the user is shown, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no component or network call is touched; the classifier is pure and exercised directly.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 FAIL > getSendValidationFailureMessage > tolerates a non-Error and a status-less value
   TypeError: Cannot read properties of null (reading 'status')
 FAIL > buildSendFailureNotice > falls back to the generic notice for an unrecognized failure
 FAIL > buildSendFailureNotice > always returns a non-empty notice

 Tests  3 failed | 23 passed (26)
```

### Green — with the fix, at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/state/chat-send-failures.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

## Domain artifacts

Behavior of the real classifier per rejection value:

| rejection value | before | after |
|---|---|---|
| `httpError(401)` | "sign in again" notice | unchanged |
| `{ kind: "timeout" }` | "took too long" notice | unchanged |
| `new Error("boom")` | generic notice | unchanged |
| `null` | **throws TypeError** | generic notice |
| `undefined` | **throws TypeError** | generic notice |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 26/26 passing at this exact head; the module previously had no test file.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
