### PR TITLE
test(cloud): cover provider credential env gate

### DIFF
--- a/packages/cloud/shared/src/lib/providers/provider-env.test.ts
+++ b/packages/cloud/shared/src/lib/providers/provider-env.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Covers the shared provider-credential gate.
+ *
+ * The placeholder rule is the point of the module: a scaffolded `.env` ships
+ * values like `your_openai_key` or `REPLACE_WITH_KEY`, and treating one as a
+ * real credential means the provider is reported as configured and the failure
+ * surfaces later as an opaque 401 from the vendor instead of as "not
+ * configured" here.
+ *
+ * `getProviderKeys` additionally has to merge three sources without emitting a
+ * duplicate, because callers rotate across the list to spread rate-limit
+ * headroom and a repeated key would silently weight one credential.
+ *
+ * Env is set per test and restored afterwards.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getProviderKey,
+  getProviderKeys,
+  getRequiredProviderKey,
+  isPlaceholderProviderKey,
+} from "./provider-env";
+
+const BASE = "TEST_PROVIDER_API_KEY";
+const touched = new Set<string>();
+
+function setEnv(name: string, value: string | undefined): void {
+  touched.add(name);
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+beforeEach(() => {
+  for (const name of Object.keys(process.env)) {
+    if (name.startsWith(BASE)) delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const name of touched) delete process.env[name];
+  touched.clear();
+});
+
+describe("isPlaceholderProviderKey", () => {
+  test("treats absent and blank values as unconfigured", () => {
+    expect(isPlaceholderProviderKey(undefined)).toBe(true);
+    expect(isPlaceholderProviderKey("")).toBe(true);
+    expect(isPlaceholderProviderKey("   ")).toBe(true);
+  });
+
+  test("rejects the scaffolded template values", () => {
+    for (const value of [
+      "placeholder",
+      "PLACEHOLDER",
+      "replace_with_key",
+      "REPLACE_WITH_KEY",
+      "your_openai_key",
+      "your_groq_api_key",
+      "your-api-key",
+      "sk-your_key_here",
+    ]) {
+      expect(isPlaceholderProviderKey(value)).toBe(true);
+    }
+  });
+
+  test("accepts a realistic credential", () => {
+    for (const value of ["sk-proj-abc123", "csk-1234567890", "  sk-with-space  ", "gsk_liveKey"]) {
+      expect(isPlaceholderProviderKey(value)).toBe(false);
+    }
+  });
+});
+
+describe("getProviderKey", () => {
+  test("returns null when the variable is unset", () => {
+    expect(getProviderKey(BASE)).toBeNull();
+  });
+
+  test("returns null for a placeholder value", () => {
+    setEnv(BASE, "your_openai_key");
+    expect(getProviderKey(BASE)).toBeNull();
+  });
+
+  test("returns null for a whitespace-only value", () => {
+    setEnv(BASE, "   ");
+    expect(getProviderKey(BASE)).toBeNull();
+  });
+
+  test("returns the trimmed key when configured", () => {
+    setEnv(BASE, "  sk-real-key  ");
+    expect(getProviderKey(BASE)).toBe("sk-real-key");
+  });
+});
+
+describe("getRequiredProviderKey", () => {
+  test("returns the key when configured", () => {
+    setEnv(BASE, "sk-real-key");
+    expect(getRequiredProviderKey(BASE)).toBe("sk-real-key");
+  });
+
+  test("throws naming the variable when unset or placeholder", () => {
+    expect(() => getRequiredProviderKey(BASE)).toThrow(BASE);
+    setEnv(BASE, "placeholder");
+    expect(() => getRequiredProviderKey(BASE)).toThrow(BASE);
+  });
+});
+
+describe("getProviderKeys", () => {
+  test("returns an empty list when nothing is configured", () => {
+    expect(getProviderKeys(BASE)).toEqual([]);
+  });
+
+  test("reads the singular variable", () => {
+    setEnv(BASE, "k1");
+    expect(getProviderKeys(BASE)).toEqual(["k1"]);
+  });
+
+  test("splits the plural list on commas and whitespace", () => {
+    setEnv(`${BASE}S`, "k1,k2 k3,  k4");
+    expect(getProviderKeys(BASE)).toEqual(["k1", "k2", "k3", "k4"]);
+  });
+
+  test("reads numbered suffixes after the singular", () => {
+    setEnv(BASE, "k1");
+    setEnv(`${BASE}_2`, "k2");
+    setEnv(`${BASE}_3`, "k3");
+    expect(getProviderKeys(BASE)).toEqual(["k1", "k2", "k3"]);
+  });
+
+  test("merges all three sources in the documented order", () => {
+    setEnv(`${BASE}S`, "plural1,plural2");
+    setEnv(BASE, "singular");
+    setEnv(`${BASE}_2`, "numbered");
+    expect(getProviderKeys(BASE)).toEqual(["plural1", "plural2", "singular", "numbered"]);
+  });
+
+  test("never emits a duplicate, so rotation cannot over-weight one credential", () => {
+    setEnv(`${BASE}S`, "dup,dup");
+    setEnv(BASE, "dup");
+    setEnv(`${BASE}_2`, "dup");
+    expect(getProviderKeys(BASE)).toEqual(["dup"]);
+  });
+
+  test("filters placeholders out of every source", () => {
+    setEnv(`${BASE}S`, "placeholder,real1");
+    setEnv(BASE, "your_openai_key");
+    setEnv(`${BASE}_2`, "real2");
+    expect(getProviderKeys(BASE)).toEqual(["real1", "real2"]);
+  });
+
+  test("stops scanning numbered suffixes at the documented cap", () => {
+    setEnv(`${BASE}_16`, "in-range");
+    setEnv(`${BASE}_17`, "out-of-range");
+    const keys = getProviderKeys(BASE);
+    expect(keys).toContain("in-range");
+    expect(keys).not.toContain("out-of-range");
+  });
+
+  test("does not stop at a gap in the numbered sequence", () => {
+    setEnv(`${BASE}_2`, "k2");
+    setEnv(`${BASE}_5`, "k5");
+    expect(getProviderKeys(BASE)).toEqual(["k2", "k5"]);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/shared/src/lib/providers/provider-env.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Every rejection case is paired with an acceptance case (realistic keys like `sk-proj-abc123`, `gsk_liveKey` must NOT be rejected), so a regression that rejected everything would fail rather than look correct. The suite writes only variables prefixed with its own test name and deletes them in `afterEach`; it never reads or depends on a real provider credential.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/providers/provider-env.ts` decides whether a provider counts as configured at all. It had **no dedicated test file**.

The placeholder rule is the point of the module. A scaffolded `.env` ships values like `your_openai_key` or `REPLACE_WITH_KEY`; treating one as a real credential reports the provider as configured and pushes the failure out to an **opaque 401 from the vendor** instead of surfacing it here as "not configured". Every documented template shape is pinned as rejected, case-insensitively, alongside realistic credentials that must be accepted.

`getProviderKeys` merges three sources and callers **rotate across the result** to spread rate-limit headroom, so a duplicate would silently over-weight one credential:

| Area | Contract pinned |
|---|---|
| de-duplication | the merged list never repeats a key, even when the same value appears in all three sources |
| ordering | plural list, then singular, then numbered suffixes — the documented order |
| filtering | placeholders are removed from **every** source, not just the singular |
| numbered cap | the scan reaches `_16` and does not run past it |
| sparse numbering | a gap (`_2`, `_5`) does not stop the scan early |

Also covers `getProviderKey` trimming and null-on-placeholder, and `getRequiredProviderKey` throwing with the variable named.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/providers/provider-env.test.ts`, the `isPlaceholderProviderKey` and `getProviderKeys` blocks.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/providers/provider-env.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f61d224cc33191b3c7f64699bd408ac15dd3da01 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ bun test src/lib/providers/provider-env.test.ts
 18 pass
 0 fail
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 18/18 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is that each rejection case is paired with an acceptance case.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
