### PR TITLE
test(ui): cover app-surface selectors and tone mappers

### DIFF
--- a/packages/ui/src/components/apps/extensions/surface.helpers.test.ts
+++ b/packages/ui/src/components/apps/extensions/surface.helpers.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Covers the pure selectors and tone mappers behind the detail-extension
+ * surfaces.
+ *
+ * `selectLatestRunForApp` decides which run the detail pane describes, and its
+ * ordering key is the newest of two ISO strings that arrive from an API row —
+ * either can be absent or unparseable, so a malformed stamp must not be able to
+ * promote a stale run to the top of the list.
+ *
+ * The tone mappers are ordered checks over free-form status text, so the
+ * precedence between them is a real contract rather than an accident.
+ *
+ * Pure functions — no React, no API.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { AppRunSummary } from "../../../api";
+import {
+  formatDetailTimestamp,
+  selectLatestRunForApp,
+  toneForHealthState,
+  toneForStatusText,
+  toneForViewerAttachment,
+} from "./surface.helpers.ts";
+
+const run = (
+  id: string,
+  appName: string,
+  updatedAt?: string | null,
+  startedAt?: string | null,
+): AppRunSummary => ({ id, appName, updatedAt, startedAt }) as AppRunSummary;
+
+const ids = (runs: AppRunSummary[]) => runs.map((entry) => entry.id);
+
+describe("selectLatestRunForApp", () => {
+  it("returns nothing for absent or non-array input", () => {
+    expect(selectLatestRunForApp("app", null)).toEqual({
+      run: null,
+      matchingRuns: [],
+    });
+    expect(selectLatestRunForApp("app", undefined).run).toBeNull();
+    expect(
+      selectLatestRunForApp("app", "nope" as unknown as AppRunSummary[]).run,
+    ).toBeNull();
+  });
+
+  it("keeps only runs for the requested app", () => {
+    const selected = selectLatestRunForApp("mine", [
+      run("a", "mine", "2026-01-01T00:00:00Z"),
+      run("b", "other", "2026-05-01T00:00:00Z"),
+    ]);
+    expect(ids(selected.matchingRuns)).toEqual(["a"]);
+    expect(selected.run?.id).toBe("a");
+  });
+
+  it("returns null when no run matches", () => {
+    expect(selectLatestRunForApp("mine", [run("b", "other")]).run).toBeNull();
+  });
+
+  it("picks the newest run, newest first", () => {
+    const selected = selectLatestRunForApp("mine", [
+      run("old", "mine", "2026-01-01T00:00:00Z"),
+      run("new", "mine", "2026-05-01T00:00:00Z"),
+      run("mid", "mine", "2026-03-01T00:00:00Z"),
+    ]);
+    expect(selected.run?.id).toBe("new");
+    expect(ids(selected.matchingRuns)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("uses the newer of updatedAt and startedAt", () => {
+    const selected = selectLatestRunForApp("mine", [
+      run("byUpdated", "mine", "2026-05-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+      run("byStarted", "mine", null, "2026-03-01T00:00:00Z"),
+    ]);
+    expect(selected.run?.id).toBe("byUpdated");
+  });
+
+  it("does not let a run with no usable timestamps outrank a dated one", () => {
+    const selected = selectLatestRunForApp("mine", [
+      run("undated", "mine", null, null),
+      run("dated", "mine", "2026-05-01T00:00:00Z"),
+    ]);
+    expect(selected.run?.id).toBe("dated");
+  });
+
+  it("does not let an unparseable timestamp outrank a dated run", () => {
+    const selected = selectLatestRunForApp("mine", [
+      run("bad", "mine", "not-a-date", "also-bad"),
+      run("dated", "mine", "2026-05-01T00:00:00Z"),
+    ]);
+    expect(selected.run?.id).toBe("dated");
+  });
+
+  it("does not mutate the caller's array", () => {
+    const runs = [
+      run("old", "mine", "2026-01-01T00:00:00Z"),
+      run("new", "mine", "2026-05-01T00:00:00Z"),
+    ];
+    selectLatestRunForApp("mine", runs);
+    expect(ids(runs)).toEqual(["old", "new"]);
+  });
+});
+
+describe("formatDetailTimestamp", () => {
+  it("falls back for absent, blank, and unparseable values", () => {
+    for (const value of [
+      null,
+      undefined,
+      "",
+      "   ",
+      "not-a-date",
+      Number.NaN,
+    ]) {
+      expect(formatDetailTimestamp(value)).toBe("Not yet verified");
+    }
+  });
+
+  it("formats a parseable ISO string as something other than the fallback", () => {
+    const formatted = formatDetailTimestamp("2026-05-01T00:00:00.000Z");
+    expect(formatted).not.toBe("Not yet verified");
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+
+  it("formats an epoch number, including 0", () => {
+    expect(formatDetailTimestamp(0)).not.toBe("Not yet verified");
+    expect(formatDetailTimestamp(1_800_000_000_000)).not.toBe(
+      "Not yet verified",
+    );
+  });
+
+  it("agrees between a timestamp and its ISO string", () => {
+    const ms = 1_800_000_000_000;
+    expect(formatDetailTimestamp(ms)).toBe(
+      formatDetailTimestamp(new Date(ms).toISOString()),
+    );
+  });
+});
+
+describe("tone mappers", () => {
+  it("maps each health state, defaulting to neutral", () => {
+    expect(toneForHealthState("healthy")).toBe("success");
+    expect(toneForHealthState("degraded")).toBe("warn");
+    expect(toneForHealthState("offline")).toBe("danger");
+    expect(toneForHealthState(null)).toBe("neutral");
+    expect(toneForHealthState(undefined)).toBe("neutral");
+    expect(toneForHealthState("unknown" as never)).toBe("neutral");
+  });
+
+  it("maps viewer attachment, defaulting to neutral", () => {
+    expect(toneForViewerAttachment("attached")).toBe("success");
+    expect(toneForViewerAttachment("detached")).toBe("warn");
+    expect(toneForViewerAttachment(null)).toBe("neutral");
+    expect(toneForViewerAttachment("other" as never)).toBe("neutral");
+  });
+
+  it("matches status text case-insensitively on a substring", () => {
+    expect(toneForStatusText("RUNNING")).toBe("success");
+    expect(toneForStatusText("container is ready")).toBe("success");
+    expect(toneForStatusText("Waiting for port")).toBe("warn");
+    expect(toneForStatusText("build FAILED")).toBe("danger");
+    expect(toneForStatusText("fatal error")).toBe("danger");
+  });
+
+  it("returns neutral for empty or unrecognized status text", () => {
+    expect(toneForStatusText(null)).toBe("neutral");
+    expect(toneForStatusText(undefined)).toBe("neutral");
+    expect(toneForStatusText("")).toBe("neutral");
+    expect(toneForStatusText("provisioning")).toBe("neutral");
+  });
+
+  it("resolves an overlapping status by the documented check order", () => {
+    // "running"/"ready" is checked first, then warn, then error — so a status
+    // that mentions both reports the earlier tone.
+    expect(toneForStatusText("running with errors")).toBe("success");
+    expect(toneForStatusText("waiting after error")).toBe("warn");
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/components/apps/extensions/surface.helpers.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The timestamp formatter is locale/timezone dependent, so the suite asserts *not the fallback* and cross-checks an epoch number against its own ISO string rather than pinning a rendered string that would break on a different host. Tone precedence is asserted with deliberately overlapping inputs so a reordering fails rather than producing a subtly different badge.

# Background

## What does this PR do?

`packages/ui/src/components/apps/extensions/surface.helpers.ts` chooses which run the detail pane describes and which tone every status badge renders. It had **no dedicated test file**.

| Area | Contract pinned |
|---|---|
| run selection | orders on the **newer** of `updatedAt`/`startedAt`, both ISO strings from an API row |
| malformed stamps | neither an undated run nor one carrying an unparseable stamp can outrank a properly dated run |
| ordering | newest-first across the whole list, not just the head |
| purity | the caller's array is not mutated |
| filtering | only runs for the requested app are kept; no match yields `null` |
| tone precedence | the mappers are ordered substring checks — `running`/`ready` before warn before error. Pinned with overlapping inputs ("running with errors", "waiting after error") so a reordering fails visibly |
| defaults | unknown health state and unknown viewer attachment both fall to `neutral` |
| timestamps | "Not yet verified" for absent, blank, and unparseable input; an epoch number and its ISO string format identically |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/apps/extensions/surface.helpers.test.ts`, the `selectLatestRunForApp` malformed-stamp cases and the tone-precedence case.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/apps/extensions/surface.helpers.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:7a5fb923532041c1de3ec959c4ceb87fa12cfa96 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/apps/extensions/surface.helpers.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 17/17 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is overlapping-input precedence cases and locale-independent timestamp assertions.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
