### PR TITLE
test(core): cover streaming-context propagation and suppression

### DIFF
--- a/packages/core/src/streaming-context.test.ts
+++ b/packages/core/src/streaming-context.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Covers per-turn streaming context propagation, the visible-stream suppression
+ * seam, and the model-stream chunk delivery depth.
+ *
+ * Three properties are load-bearing. Streaming observers must never alter
+ * model/action flow, so a throwing hook is reported and swallowed rather than
+ * propagated. `runWithSuppressedModelStream` must PASS THROUGH when there is no
+ * chunk consumer to detach — installing a discarding callback there would make
+ * a context that merely carries cancellation look like a stream consumer to
+ * `useModel`, moving otherwise non-streaming internal calls onto the streaming
+ * path (#16230). And when it does suppress, the abort signal and structured
+ * hooks must survive, because only the visible token channel is being detached.
+ *
+ * Runs against the real module on the real Node manager; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	emitStreamingHook,
+	getModelStreamChunkDeliveryDepth,
+	getStreamingContext,
+	runInsideModelStreamChunkDelivery,
+	runWithStreamingContext,
+	runWithSuppressedModelStream,
+	type StreamingContext,
+} from "./streaming-context.ts";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("emitStreamingHook", () => {
+	it("is a no-op when the context or the hook is absent", async () => {
+		await expect(
+			emitStreamingHook(undefined, "onToolCall", {} as never),
+		).resolves.toBeUndefined();
+		await expect(
+			emitStreamingHook({} as StreamingContext, "onToolCall", {} as never),
+		).resolves.toBeUndefined();
+	});
+
+	it("delivers the payload to the hook", async () => {
+		const seen: unknown[] = [];
+		const payload = { name: "act" } as never;
+		await emitStreamingHook(
+			{
+				onToolCall: (value: unknown) => void seen.push(value),
+			} as StreamingContext,
+			"onToolCall",
+			payload,
+		);
+		expect(seen).toEqual([payload]);
+	});
+
+	it("awaits an async hook before resolving", async () => {
+		let finished = false;
+		await emitStreamingHook(
+			{
+				onToolCall: async () => {
+					await tick();
+					finished = true;
+				},
+			} as unknown as StreamingContext,
+			"onToolCall",
+			{} as never,
+		);
+		expect(finished).toBe(true);
+	});
+
+	it("swallows a throwing hook so an observer cannot break the turn", async () => {
+		await expect(
+			emitStreamingHook(
+				{
+					onToolCall: () => {
+						throw new Error("observer blew up");
+					},
+				} as unknown as StreamingContext,
+				"onToolCall",
+				{} as never,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("swallows a rejecting async hook too", async () => {
+		await expect(
+			emitStreamingHook(
+				{
+					onToolCall: async () => Promise.reject(new Error("nope")),
+				} as unknown as StreamingContext,
+				"onToolCall",
+				{} as never,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("routes the failure to reportError with the scope and hook name", async () => {
+		const reported: Array<
+			[string, unknown, Record<string, unknown> | undefined]
+		> = [];
+		await emitStreamingHook(
+			{
+				onEvaluation: () => {
+					throw new Error("boom");
+				},
+				reportError: (scope, error, context) =>
+					void reported.push([scope, error, context]),
+			} as unknown as StreamingContext,
+			"onEvaluation",
+			{} as never,
+		);
+		expect(reported).toHaveLength(1);
+		expect(reported[0]?.[0]).toBe("StreamingContext.emitHook");
+		expect(reported[0]?.[2]).toMatchObject({ hook: "onEvaluation" });
+	});
+
+	it("still swallows the failure when no reportError is installed", async () => {
+		await expect(
+			emitStreamingHook(
+				{
+					onToolResult: () => {
+						throw new Error("boom");
+					},
+				} as unknown as StreamingContext,
+				"onToolResult",
+				{} as never,
+			),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("context propagation", () => {
+	const ctx = (overrides: Partial<StreamingContext> = {}): StreamingContext =>
+		({ messageId: "m1", ...overrides }) as StreamingContext;
+
+	it("is undefined outside any scope", () => {
+		expect(getStreamingContext()).toBeUndefined();
+	});
+
+	it("exposes the context inside the scope and clears it afterwards", () => {
+		const seen = runWithStreamingContext(ctx(), () => getStreamingContext());
+		expect(seen?.messageId).toBe("m1");
+		expect(getStreamingContext()).toBeUndefined();
+	});
+
+	it("returns the callback's value", () => {
+		expect(runWithStreamingContext(ctx(), () => 7)).toBe(7);
+	});
+
+	it("survives an await boundary", async () => {
+		const seen = await runWithStreamingContext(ctx(), async () => {
+			await tick();
+			return getStreamingContext()?.messageId;
+		});
+		expect(seen).toBe("m1");
+	});
+
+	it("restores the outer context when a nested scope exits", () => {
+		const observed = runWithStreamingContext(
+			ctx({ messageId: "outer" }),
+			() => {
+				const inner = runWithStreamingContext(
+					ctx({ messageId: "inner" }),
+					() => getStreamingContext()?.messageId,
+				);
+				return { inner, after: getStreamingContext()?.messageId };
+			},
+		);
+		expect(observed).toEqual({ inner: "inner", after: "outer" });
+	});
+
+	it("keeps concurrent turns isolated", async () => {
+		const [a, b] = await Promise.all([
+			runWithStreamingContext(ctx({ messageId: "a" }), async () => {
+				await tick();
+				await tick();
+				return getStreamingContext()?.messageId;
+			}),
+			runWithStreamingContext(ctx({ messageId: "b" }), async () => {
+				await tick();
+				return getStreamingContext()?.messageId;
+			}),
+		]);
+		expect([a, b]).toEqual(["a", "b"]);
+	});
+
+	it("treats an explicitly undefined context as no context", () => {
+		expect(
+			runWithStreamingContext(undefined, () => getStreamingContext()),
+		).toBeUndefined();
+	});
+});
+
+describe("runWithSuppressedModelStream", () => {
+	it("passes through when no streaming context is active", () => {
+		const seen = runWithSuppressedModelStream(() => getStreamingContext());
+		expect(seen).toBeUndefined();
+	});
+
+	it("passes through unchanged when the context has no chunk consumer", () => {
+		// Installing a discarding callback here would make a cancellation-only
+		// context look like a stream consumer to useModel (#16230).
+		const outer = { messageId: "m1" } as StreamingContext;
+		const seen = runWithStreamingContext(outer, () =>
+			runWithSuppressedModelStream(() => getStreamingContext()),
+		);
+		expect(seen).toBe(outer);
+		expect(seen?.onStreamChunk).toBeUndefined();
+	});
+
+	it("detaches the visible chunk channel when there is one", async () => {
+		const chunks: string[] = [];
+		const outer = {
+			messageId: "m1",
+			onStreamChunk: async (chunk: string) => void chunks.push(chunk),
+		} as unknown as StreamingContext;
+
+		await runWithStreamingContext(outer, async () => {
+			await runWithSuppressedModelStream(async () => {
+				await getStreamingContext()?.onStreamChunk?.("suppressed" as never);
+			});
+			await getStreamingContext()?.onStreamChunk?.("visible" as never);
+		});
+
+		expect(chunks).toEqual(["visible"]);
+	});
+
+	it("keeps the abort signal and structured hooks while suppressing", () => {
+		const controller = new AbortController();
+		const onToolCall = () => undefined;
+		const outer = {
+			messageId: "m1",
+			abortSignal: controller.signal,
+			onToolCall,
+			onStreamChunk: async () => undefined,
+		} as unknown as StreamingContext;
+
+		const inner = runWithStreamingContext(outer, () =>
+			runWithSuppressedModelStream(() => getStreamingContext()),
+		);
+		expect(inner?.abortSignal).toBe(controller.signal);
+		expect((inner as unknown as { onToolCall: unknown }).onToolCall).toBe(
+			onToolCall,
+		);
+		expect(inner?.messageId).toBe("m1");
+	});
+
+	it("restores the visible channel after the suppressed scope exits", () => {
+		const onStreamChunk = async () => undefined;
+		const outer = { onStreamChunk } as unknown as StreamingContext;
+		const after = runWithStreamingContext(outer, () => {
+			runWithSuppressedModelStream(() => undefined);
+			return getStreamingContext()?.onStreamChunk;
+		});
+		expect(after).toBe(onStreamChunk);
+	});
+});
+
+describe("model stream chunk delivery depth", () => {
+	it("is zero outside any delivery", () => {
+		expect(getModelStreamChunkDeliveryDepth()).toBe(0);
+	});
+
+	it("is greater than zero inside a delivery", () => {
+		const depth = runInsideModelStreamChunkDelivery(() =>
+			getModelStreamChunkDeliveryDepth(),
+		);
+		expect(depth).toBeGreaterThan(0);
+	});
+
+	it("increments while nested", () => {
+		const depths = runInsideModelStreamChunkDelivery(() => {
+			const outer = getModelStreamChunkDeliveryDepth();
+			const inner = runInsideModelStreamChunkDelivery(() =>
+				getModelStreamChunkDeliveryDepth(),
+			) as number;
+			return { outer, inner };
+		}) as { outer: number; inner: number };
+		expect(depths.inner).toBe(depths.outer + 1);
+	});
+
+	it("returns to zero after the delivery completes", () => {
+		runInsideModelStreamChunkDelivery(() => undefined);
+		expect(getModelStreamChunkDeliveryDepth()).toBe(0);
+	});
+
+	it("survives an await inside the delivery", async () => {
+		const depth = await runInsideModelStreamChunkDelivery(async () => {
+			await tick();
+			return getModelStreamChunkDeliveryDepth();
+		});
+		expect(depth).toBeGreaterThan(0);
+		expect(getModelStreamChunkDeliveryDepth()).toBe(0);
+	});
+
+	it("returns the callback's value", () => {
+		expect(runInsideModelStreamChunkDelivery(() => "v")).toBe("v");
+	});
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/core/src/streaming-context.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `35bb14be4e2389b40648fae724a1333641725d9e`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Runs against the real module on the real Node `AsyncLocalStorage` manager — no injected stack manager. The pass-through case asserts **object identity** (`toBe(outer)`), so a regression that wrapped the context in an equivalent-looking copy would still fail. The suppression case asserts which chunks actually reached the consumer rather than only inspecting the context shape.

# Background

## What does this PR do?

`packages/core/src/streaming-context.ts` propagates per-turn stream callbacks and cancellation through every model and action execution. It had **no dedicated test file**.

| Area | Contract pinned |
|---|---|
| observer isolation | a throwing hook, a rejecting async hook, and a hook failing with **no** `reportError` installed all resolve rather than propagate — streaming observers cannot alter model/action flow |
| failure routing | the failure reaches `reportError` with the `StreamingContext.emitHook` scope and the hook name in context |
| suppression pass-through | `runWithSuppressedModelStream` returns the **same** context object when there is no chunk consumer to detach. Installing a discarding callback there would make a cancellation-only context look like a stream consumer to `useModel`, moving otherwise non-streaming internal calls onto the streaming path (#16230) |
| suppression scope | when it does suppress, `abortSignal`, structured hooks, and `messageId` survive — only the visible token channel is detached — and the original channel is restored once the scope exits |
| chunk routing | a chunk emitted inside the suppressed scope is discarded; one emitted outside still reaches the consumer |
| propagation | context survives `await`, nesting restores the outer context, and concurrent turns stay isolated |
| delivery depth | zero outside a delivery, increments while nested, survives an await, returns to zero afterwards |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/streaming-context.test.ts`, the `runWithSuppressedModelStream` block.

## Detailed testing steps

```bash
cd packages/core && npx vitest run src/streaming-context.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a640f107c63597816cb9e44e99daeab0a5bfa387 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run src/streaming-context.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 25/25 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is object-identity assertions on the pass-through path and chunk-delivery assertions on the suppression path.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
