### PR TITLE
test(scenario-runner): cover calendar-assertions

### DIFF
--- a/packages/scenario-runner/src/scenario-assertions/__tests__/calendar-assertions.test.ts
+++ b/packages/scenario-runner/src/scenario-assertions/__tests__/calendar-assertions.test.ts
@@ -1,0 +1,303 @@
+/** Exercises the real calendar assertion factories against captured CALENDAR calls. */
+
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+import {
+  expectCalendarPayload,
+  expectCalendarResultData,
+} from "../calendar-assertions.ts";
+
+function action(overrides: Partial<CapturedAction> = {}): CapturedAction {
+  return {
+    actionName: "CALENDAR",
+    parameters: {},
+    result: { success: true, data: { ok: 1 } },
+    ...overrides,
+  } as CapturedAction;
+}
+
+function ctx(actions: CapturedAction[]): ScenarioContext {
+  return { actionsCalled: actions } as ScenarioContext;
+}
+
+describe("expectCalendarResultData", () => {
+  it("fails when no action was called at all", () => {
+    const check = expectCalendarResultData({ description: "event created" });
+    const result = check(ctx([]));
+    expect(result).toContain("Expected successful CALENDAR action");
+    expect(result).toContain("(no actions called)");
+  });
+
+  it("fails when only non-CALENDAR actions ran", () => {
+    const check = expectCalendarResultData({ description: "event created" });
+    const result = check(ctx([action({ actionName: "SEND_EMAIL" })]));
+    expect(result).toContain("Expected successful CALENDAR action");
+    expect(result).toContain("SEND_EMAIL(success=true");
+  });
+
+  it("ignores failed CALENDAR calls", () => {
+    const check = expectCalendarResultData({ description: "event created" });
+    const result = check(
+      ctx([
+        action({
+          result: { success: false, data: { title: "Standup" }, text: "ok" },
+        }),
+      ]),
+    );
+    expect(result).toContain("Expected successful CALENDAR action");
+    expect(result).toContain("CALENDAR(success=false");
+  });
+
+  it("ignores synthesized replies", () => {
+    const check = expectCalendarResultData({ description: "event created" });
+    const result = check(
+      ctx([
+        action({
+          result: {
+            success: true,
+            data: { source: "synthesized-reply", title: "Standup" },
+          },
+        }),
+      ]),
+    );
+    expect(result).toContain("Expected successful CALENDAR action");
+  });
+
+  it("passes when successful data satisfies includesAll case-insensitively", () => {
+    const check = expectCalendarResultData({
+      description: "event created",
+      includesAll: ["Event-ID-42"],
+    });
+    expect(
+      check(
+        ctx([
+          action({ result: { success: true, data: { id: "event-id-42" } } }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("tests RegExp patterns against the serialized data", () => {
+    const passing = expectCalendarResultData({
+      description: "event created",
+      includesAll: [/standup-\d+/],
+    });
+    expect(
+      passing(
+        ctx([
+          action({ result: { success: true, data: { title: "Standup-7" } } }),
+        ]),
+      ),
+    ).toBeUndefined();
+
+    const failing = expectCalendarResultData({
+      description: "event created",
+      includesAll: [/weekly-\d{3}/],
+    });
+    expect(
+      failing(
+        ctx([
+          action({ result: { success: true, data: { title: "Standup-7" } } }),
+        ]),
+      ),
+    ).toContain("missing /weekly-\\d{3}/");
+  });
+
+  it("reports the first missing includesAll pattern with the description and payload preview", () => {
+    const check = expectCalendarResultData({
+      description: "event created",
+      includesAll: ["alpha", "beta"],
+    });
+    const result = check(
+      ctx([action({ result: { success: true, data: { note: "alpha" } } })]),
+    );
+    expect(result).toContain("Expected event created: missing beta");
+    expect(result).toContain('"note":"alpha"');
+  });
+
+  it("checks includesAll before includesAny", () => {
+    const check = expectCalendarResultData({
+      description: "event created",
+      includesAll: ["zzz"],
+      includesAny: ["yyy"],
+    });
+    const result = check(
+      ctx([action({ result: { success: true, data: { note: "neither" } } })]),
+    );
+    expect(result).toContain("missing zzz");
+    expect(result).not.toContain("missing any of");
+  });
+
+  it("passes when any includesAny alternative matches", () => {
+    const check = expectCalendarResultData({
+      description: "event created",
+      includesAny: ["nope", "standup"],
+    });
+    expect(
+      check(
+        ctx([
+          action({ result: { success: true, data: { title: "Standup" } } }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("fails when no includesAny alternative matches", () => {
+    const check = expectCalendarResultData({
+      description: "event created",
+      includesAny: ["nope", "nada"],
+    });
+    const result = check(
+      ctx([action({ result: { success: true, data: { title: "Standup" } } })]),
+    );
+    expect(result).toContain("missing any of [nope, nada]");
+    expect(result).toContain('"title":"standup"');
+  });
+
+  it("skips includesAny when it is absent or empty", () => {
+    const empty = expectCalendarResultData({
+      description: "event created",
+      includesAny: [],
+    });
+    expect(
+      empty(ctx([action({ result: { success: true, data: { ok: true } } })])),
+    ).toBeUndefined();
+  });
+
+  it("requires one data-bearing call by default and counts null data as missing", () => {
+    const check = expectCalendarResultData({ description: "event created" });
+    const noData = check(
+      ctx([action({ result: { success: true, text: "done" } })]),
+    );
+    expect(noData).toContain("successful CALENDAR result data, saw 0");
+
+    const nullData = check(
+      ctx([action({ result: { success: true, data: null } })]),
+    );
+    expect(nullData).toContain("saw 0");
+  });
+
+  it("honours an explicit minCount", () => {
+    const strict = expectCalendarResultData({
+      description: "two events",
+      minCount: 2,
+      includesAll: ["standup"],
+    });
+    const single = strict(
+      ctx([action({ result: { success: true, data: { title: "Standup" } } })]),
+    );
+    expect(single).toContain("saw 1");
+
+    const both = strict(
+      ctx([
+        action({ result: { success: true, data: { title: "Standup" } } }),
+        action({ result: { success: true, data: { series: "standup" } } }),
+      ]),
+    );
+    expect(both).toBeUndefined();
+  });
+});
+
+describe("expectCalendarPayload", () => {
+  it("matches tokens found in parameters", () => {
+    const check = expectCalendarPayload({
+      description: "event arguments",
+      includesAll: ["standup"],
+    });
+    expect(
+      check(
+        ctx([
+          action({
+            parameters: { title: "Standup" },
+            result: { success: true },
+          }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("matches tokens found in result text", () => {
+    const check = expectCalendarPayload({
+      description: "event confirmation",
+      includesAll: ["event created"],
+    });
+    expect(
+      check(
+        ctx([
+          action({
+            result: { success: true, text: "Event Created: Standup" },
+          }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("excludes failed calls from the payload blob", () => {
+    const check = expectCalendarPayload({
+      description: "event arguments",
+      includesAll: ["standup"],
+    });
+    const result = check(
+      ctx([
+        action({
+          parameters: { title: "Standup" },
+          result: { success: false },
+        }),
+      ]),
+    );
+    expect(result).toContain("Expected successful CALENDAR action");
+  });
+
+  it("excludes synthesized replies whose parameters carry the token", () => {
+    const check = expectCalendarPayload({
+      description: "event arguments",
+      includesAll: ["standup"],
+    });
+    const result = check(
+      ctx([
+        action({
+          parameters: { title: "Standup" },
+          result: {
+            success: true,
+            data: { source: "synthesized-reply", title: "Standup" },
+          },
+        }),
+      ]),
+    );
+    expect(result).toContain("Expected successful CALENDAR action");
+  });
+
+  it("reports missing patterns with the lowercased payload preview", () => {
+    const check = expectCalendarPayload({
+      description: "event arguments",
+      includesAll: ["gym"],
+    });
+    const result = check(
+      ctx([
+        action({
+          parameters: { title: "Standup" },
+          result: { success: true, data: { id: "E-1" }, text: "Booked" },
+        }),
+      ]),
+    );
+    expect(result).toContain("Expected event arguments: missing gym");
+    expect(result).toContain('"title":"standup"');
+    expect(result).toContain('"text":"booked"');
+  });
+
+  it("renders absent fields as null instead of dropping them", () => {
+    const check = expectCalendarPayload({
+      description: "event arguments",
+      includesAll: ["anything"],
+    });
+    const result = check(
+      ctx([action({ parameters: undefined, result: { success: true } })]),
+    );
+    expect(result).toContain('"parameters":null');
+    expect(result).toContain('"data":null');
+    expect(result).toContain('"text":null');
+  });
+});


### PR DESCRIPTION

Adds a unit suite for `packages/scenario-runner/src/scenario-assertions/calendar-assertions.ts`, which had no same-named test anywhere on `develop`.

**Scope:** test-only. One new file, +303/-0. No production behaviour changes.

## What is covered

`expectCalendarResultData`:

- fails with "Expected successful CALENDAR action" when nothing was called, when only non-CALENDAR actions ran, when the CALENDAR call failed (`success=false`), and when the only call was a synthesized reply
- passes case-insensitively for string `includesAll` patterns against serialized result data
- tests RegExp `includesAll` patterns against the lowercased serialized data (passing and failing)
- reports the first missing `includesAll` pattern with the expectation description and payload preview
- checks `includesAll` before `includesAny`
- passes/fails `includesAny` correctly, including the empty-array no-op branch
- requires one data-bearing successful call by default; counts `undefined` and explicit `null` data as missing ("saw 0")
- honours an explicit `minCount` (2 with one data-bearing call fails "saw 1"; two pass)

`expectCalendarPayload`:

- matches tokens found in `parameters` and in `result.text`
- excludes failed calls from the payload blob (their parameters cannot satisfy the check)
- excludes synthesized replies even when their parameters carry the expected token
- reports missing patterns with the lowercased payload preview containing parameters, data, and text
- renders absent fields as `null` rather than dropping them

## Method

Assertions drive the real module — no mocks of the system under test; contexts are built from real captured-action records exactly like the neighbouring `effect-assertions.test.ts`. Every expectation records observed behaviour (e.g. `String(RegExp)` renders as `/pattern/` in failure messages).

## Verification (fork contributor — hosted CI does not run on this PR)

- `bunx vitest run src/scenario-assertions/__tests__/calendar-assertions.test.ts`: **19 passed (19), 1 file passed**, re-run green against current `origin/develop` immediately before filing
- `bunx biome check --write <file>`: clean (config verified present at repo root)
- `bunx tsc --noEmit` in `packages/scenario-runner`: zero mentions of the new test file
- Diff touches only the new test file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1672730437b27f2588034feb484db07b883cb851 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
