### PR TITLE
test(registry): cover generate

### DIFF
--- a/packages/registry/src/first-party/generate.test.ts
+++ b/packages/registry/src/first-party/generate.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Guards the first-party registry generator's exported collectors: curated-app
+ * definition ordering (order, ties, non-finite fallback), npmName gating,
+ * sorted stable keys, and fail-loud conflict detection across the channel /
+ * short-id / provider maps. Harness is real — the live module runs on
+ * in-memory fixtures; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  collectChannelPluginMap,
+  collectCuratedAppDefinitions,
+  collectProviderPluginMap,
+  collectShortIdPluginMap,
+} from "./generate";
+import type { PluginEntry } from "./schema";
+
+function pluginEntry(
+  id: string,
+  overrides?: Partial<PluginEntry>,
+): PluginEntry {
+  return {
+    id,
+    name: id,
+    source: "bundled",
+    tags: [],
+    config: {},
+    render: {
+      visible: true,
+      pinTo: [],
+      style: "card",
+      group: "models",
+      actions: [],
+    },
+    resources: {},
+    dependsOn: [],
+    channels: [],
+    shortIds: [],
+    kind: "plugin",
+    subtype: "feature",
+    ...overrides,
+  };
+}
+
+function curatedEntry(
+  id: string,
+  npmName: string | undefined,
+  slug: string,
+  order: number,
+  aliases: string[],
+): PluginEntry {
+  return pluginEntry(id, { npmName, curatedApp: { slug, order, aliases } });
+}
+
+describe("collectCuratedAppDefinitions", () => {
+  it("returns no definitions for an empty entry list", () => {
+    expect(collectCuratedAppDefinitions([])).toEqual([]);
+  });
+
+  it("keeps only entries marked as curated apps", () => {
+    const curated = curatedEntry(
+      "marked",
+      "@elizaos/plugin-marked",
+      "marked",
+      1,
+      [],
+    );
+    expect(
+      collectCuratedAppDefinitions([curated, pluginEntry("plain")]),
+    ).toEqual([
+      { slug: "marked", canonicalName: "@elizaos/plugin-marked", aliases: [] },
+    ]);
+  });
+
+  it("orders curated apps by their declared order", () => {
+    const entries = [
+      curatedEntry("late", "@elizaos/plugin-late", "late", 30, []),
+      curatedEntry("first", "@elizaos/plugin-first", "first", 10, []),
+      curatedEntry("middle", "@elizaos/plugin-middle", "middle", 20, []),
+    ];
+    expect(collectCuratedAppDefinitions(entries).map((d) => d.slug)).toEqual([
+      "first",
+      "middle",
+      "late",
+    ]);
+  });
+
+  it("treats a non-finite order as position zero", () => {
+    const infinite = curatedEntry(
+      "infinite",
+      "@elizaos/plugin-infinite",
+      "infinite",
+      Number.POSITIVE_INFINITY,
+      [],
+    );
+    const finite = curatedEntry(
+      "finite",
+      "@elizaos/plugin-finite",
+      "finite",
+      5,
+      [],
+    );
+    expect(
+      collectCuratedAppDefinitions([finite, infinite]).map((d) => d.slug),
+    ).toEqual(["infinite", "finite"]);
+  });
+
+  it("breaks order ties by slug", () => {
+    const entries = [
+      curatedEntry("delta", "@elizaos/plugin-delta", "delta", 2, []),
+      curatedEntry("alpha", "@elizaos/plugin-alpha", "alpha", 2, []),
+    ];
+    expect(collectCuratedAppDefinitions(entries).map((d) => d.slug)).toEqual([
+      "alpha",
+      "delta",
+    ]);
+  });
+
+  it("maps canonicalName from npmName with an empty-string fallback and passes aliases through", () => {
+    const named = curatedEntry("named", "@elizaos/plugin-named", "named", 1, [
+      "nm",
+    ]);
+    const unnamed = curatedEntry("unnamed", undefined, "unnamed", 2, []);
+    expect(collectCuratedAppDefinitions([named, unnamed])).toEqual([
+      {
+        slug: "named",
+        canonicalName: "@elizaos/plugin-named",
+        aliases: ["nm"],
+      },
+      { slug: "unnamed", canonicalName: "", aliases: [] },
+    ]);
+  });
+});
+
+describe("collectChannelPluginMap", () => {
+  it("ignores metadata-only entries that declare channels but ship no package", () => {
+    const orphan = pluginEntry("orphan", { channels: ["orphan"] });
+    expect(collectChannelPluginMap([orphan])).toEqual({});
+  });
+
+  it("maps each claimed channel to its package and sorts the keys", () => {
+    const map = collectChannelPluginMap([
+      pluginEntry("one", {
+        npmName: "@elizaos/plugin-one",
+        channels: ["zeta", "alpha"],
+      }),
+      pluginEntry("two", { npmName: "@elizaos/plugin-two", channels: ["mu"] }),
+    ]);
+    expect(map).toEqual({
+      alpha: "@elizaos/plugin-one",
+      mu: "@elizaos/plugin-two",
+      zeta: "@elizaos/plugin-one",
+    });
+    expect(Object.keys(map)).toEqual(["alpha", "mu", "zeta"]);
+  });
+
+  it("allows one package to re-declare the same channel", () => {
+    expect(
+      collectChannelPluginMap([
+        pluginEntry("same", {
+          npmName: "@elizaos/plugin-same",
+          channels: ["dupe", "dupe"],
+        }),
+      ]),
+    ).toEqual({ dupe: "@elizaos/plugin-same" });
+  });
+
+  it("rejects conflicting channel claims across packages (fail-loud on drift)", () => {
+    expect(() =>
+      collectChannelPluginMap([
+        pluginEntry("one", {
+          npmName: "@elizaos/plugin-one",
+          channels: ["dupe"],
+        }),
+        pluginEntry("two", {
+          npmName: "@elizaos/plugin-two",
+          channels: ["dupe"],
+        }),
+      ]),
+    ).toThrow(
+      'channel "dupe" claimed by both @elizaos/plugin-one and @elizaos/plugin-two',
+    );
+  });
+});
+
+describe("collectShortIdPluginMap", () => {
+  it("derives short ids only from explicit markers and sorts the resulting keys", () => {
+    const map = collectShortIdPluginMap([
+      pluginEntry("aliased", {
+        npmName: "@elizaos/plugin-aliased",
+        shortIds: ["zeta", "alpha"],
+      }),
+      pluginEntry("bare", {
+        npmName: "@elizaos/plugin-bare",
+        shortIds: ["mu"],
+      }),
+    ]);
+    expect(map).toEqual({
+      alpha: "@elizaos/plugin-aliased",
+      mu: "@elizaos/plugin-bare",
+      zeta: "@elizaos/plugin-aliased",
+    });
+    expect(Object.keys(map)).toEqual(["alpha", "mu", "zeta"]);
+  });
+
+  it("ignores entries that claim short ids without shipping a package", () => {
+    const orphan = pluginEntry("orphan", { shortIds: ["orphan"] });
+    expect(collectShortIdPluginMap([orphan])).toEqual({});
+  });
+
+  it("allows one package to re-declare the same short id", () => {
+    expect(
+      collectShortIdPluginMap([
+        pluginEntry("same", {
+          npmName: "@elizaos/plugin-same",
+          shortIds: ["same", "same"],
+        }),
+      ]),
+    ).toEqual({ same: "@elizaos/plugin-same" });
+  });
+
+  it("rejects conflicting short-id claims across packages (fail-loud on drift)", () => {
+    expect(() =>
+      collectShortIdPluginMap([
+        pluginEntry("one", {
+          npmName: "@elizaos/plugin-one",
+          shortIds: ["dupe"],
+        }),
+        pluginEntry("two", {
+          npmName: "@elizaos/plugin-two",
+          shortIds: ["dupe"],
+        }),
+      ]),
+    ).toThrow(
+      'short id "dupe" claimed by both @elizaos/plugin-one and @elizaos/plugin-two',
+    );
+  });
+});
+
+describe("collectProviderPluginMap", () => {
+  it("derives provider env keys only from autoEnableProvider === true markers and sorts them", () => {
+    const map = collectProviderPluginMap([
+      pluginEntry("one", {
+        npmName: "@elizaos/plugin-one",
+        config: {
+          B_KEY: { type: "secret", required: false, autoEnableProvider: true },
+          A_KEY: { type: "secret", required: false, autoEnableProvider: false },
+        },
+      }),
+      pluginEntry("two", {
+        npmName: "@elizaos/plugin-two",
+        config: {
+          C_KEY: { type: "string", required: false, autoEnableProvider: true },
+        },
+      }),
+    ]);
+    expect(map).toEqual({
+      B_KEY: "@elizaos/plugin-one",
+      C_KEY: "@elizaos/plugin-two",
+    });
+    expect(Object.keys(map)).toEqual(["B_KEY", "C_KEY"]);
+  });
+
+  it("ignores metadata-only entries whose config marks autoEnableProvider", () => {
+    const orphan = pluginEntry("orphan", {
+      config: {
+        ORPHAN_API_KEY: {
+          type: "secret",
+          required: false,
+          autoEnableProvider: true,
+        },
+      },
+    });
+    expect(collectProviderPluginMap([orphan])).toEqual({});
+  });
+
+  it("rejects conflicting provider env-key claims across packages (fail-loud on drift)", () => {
+    expect(() =>
+      collectProviderPluginMap([
+        pluginEntry("one", {
+          npmName: "@elizaos/plugin-one",
+          config: {
+            DUPE_API_KEY: {
+              type: "secret",
+              required: false,
+              autoEnableProvider: true,
+            },
+          },
+        }),
+        pluginEntry("two", {
+          npmName: "@elizaos/plugin-two",
+          config: {
+            DUPE_API_KEY: {
+              type: "secret",
+              required: false,
+              autoEnableProvider: true,
+            },
+          },
+        }),
+      ]),
+    ).toThrow(
+      'provider env key "DUPE_API_KEY" claimed by both @elizaos/plugin-one and @elizaos/plugin-two',
+    );
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/registry/src/first-party/generate.test.ts` — a new unit suite for the first-party registry generator's exported collectors. The diff is exactly one new test file (+304/-0); no production code changes.

Covered, against the real module (no mocks, no type-only assertions):

- `collectCuratedAppDefinitions` — empty input; non-curated entries filtered out; ordering by declared `order`; non-finite order treated as position zero; order ties broken by slug; `canonicalName` mapped from `npmName` with an empty-string fallback; alias passthrough.
- `collectChannelPluginMap` — metadata-only entries (no `npmName`) ignored even when they declare channels; channel→package mapping with sorted keys; re-declaration by the same package allowed; conflicting cross-package claims rejected with the exact fail-loud message.
- `collectShortIdPluginMap` — explicit-marker derivation with sorted keys; no-package entries ignored; same-package re-declaration allowed; conflict rejection with exact message.
- `collectProviderPluginMap` — derivation only from `autoEnableProvider === true` markers (explicitly `false` markers ignored); sorted env-key output; metadata-only entries ignored; conflict rejection with exact message.

## Scope note: what was deliberately left out

`collectFirstPartyEntries()` / `generateFirstPartyRegistry()` walk every `plugins/*/registry-entry.json` in the repo and fail loud on schema drift. At current `develop` (`35bb14be4e23`), `plugins/plugin-doordash/registry-entry.json` fails `registryEntrySchema` (`kind: "plugin"` with `subtype: "connector"`, plus a boolean value under `config["features.doordash"]`), so those functions currently throw — the committed `generated.json` predates that entry. A tree-walking assertion would therefore not reproduce for reviewers, so this PR leaves the filesystem-dependent surface untested rather than shipping aspirational expectations. Flagging the doordash entry here in case maintainers want a follow-up fix; happy to split that into its own justified PR.

## Evidence

Fork contributor: hosted CI does **not** run on this PR. Local verification only:

- `vitest run src/first-party/generate.test.ts` (via `node ../scripts/run-vitest.mjs run --config ./vitest.config.ts`, vitest v4.1.10): **Test Files 1 passed (1), Tests 17 passed (17)**.
- `bunx biome check src/first-party/generate.test.ts`: clean — `Checked 1 file in 181ms. No fixes applied.` (after one `--write` pass during authoring).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/registry`: no output (zero errors); `grep 'generate.test.ts'` over its output matches nothing. Note the package's `tsconfig.json` excludes `src/**/*.test.ts`, so tsc does not compile the new file; the suite is exercised by vitest at runtime.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6a67fc9a8e39218adb7a8eaba47af3918c3cce57 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
