### PR TITLE
test(shared): cover entity-types

### DIFF
--- a/packages/shared/src/knowledge-graph/entity-types.test.ts
+++ b/packages/shared/src/knowledge-graph/entity-types.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Entity-type primitives. Built-in types are seeded into every registry,
+ * registration is idempotent per identical metadata but conflicting metadata
+ * throws, listing is sorted, and connector-account normalization trims outer
+ * whitespace only before falling back to the legacy default partition.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BUILT_IN_ENTITY_TYPES,
+  DEFAULT_CONNECTOR_ACCOUNT_ID,
+  defaultEntityTypeRegistry,
+  EntityTypeRegistry,
+  normalizeEntityConnectorAccountId,
+  SELF_ENTITY_ID,
+} from "./entity-types";
+
+describe("module constants", () => {
+  it("exposes exactly the five built-in entity types", () => {
+    expect([...BUILT_IN_ENTITY_TYPES]).toEqual([
+      "person",
+      "organization",
+      "place",
+      "project",
+      "concept",
+    ]);
+  });
+
+  it("uses the reserved self entity id", () => {
+    expect(SELF_ENTITY_ID).toBe("self");
+  });
+
+  it("uses the legacy default connector account partition", () => {
+    expect(DEFAULT_CONNECTOR_ACCOUNT_ID).toBe("default");
+  });
+});
+
+describe("normalizeEntityConnectorAccountId", () => {
+  it("falls back to the default partition for null and undefined", () => {
+    expect(normalizeEntityConnectorAccountId(null)).toBe(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+    expect(normalizeEntityConnectorAccountId(undefined)).toBe(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+  });
+
+  it("falls back to the default partition for empty and blank input", () => {
+    expect(normalizeEntityConnectorAccountId("")).toBe(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+    expect(normalizeEntityConnectorAccountId("   ")).toBe(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+    expect(normalizeEntityConnectorAccountId("\t\n")).toBe(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+  });
+
+  it("returns a non-empty value unchanged", () => {
+    expect(normalizeEntityConnectorAccountId("acct-1")).toBe("acct-1");
+  });
+
+  it("trims surrounding whitespace but keeps interior spacing and case", () => {
+    expect(normalizeEntityConnectorAccountId("  acct 1  ")).toBe("acct 1");
+    expect(normalizeEntityConnectorAccountId(" ACC ")).toBe("ACC");
+    expect(normalizeEntityConnectorAccountId("\tacc\n")).toBe("acc");
+  });
+
+  it("treats ids differing only by case as distinct opaque values", () => {
+    expect(normalizeEntityConnectorAccountId("ACC")).toBe("ACC");
+    expect(normalizeEntityConnectorAccountId("ACC")).not.toBe(
+      normalizeEntityConnectorAccountId("acc"),
+    );
+  });
+});
+
+describe("EntityTypeRegistry", () => {
+  it("seeds every built-in type with itself as label and admin-owner visibility", () => {
+    const registry = new EntityTypeRegistry();
+    for (const type of BUILT_IN_ENTITY_TYPES) {
+      expect(registry.has(type)).toBe(true);
+      expect(registry.metadataFor(type)).toEqual({
+        label: type,
+        defaultVisibility: "owner_agent_admin",
+      });
+    }
+  });
+
+  it("lists all registered types in sorted order", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("vehicle");
+    const listed = registry.list();
+    expect(listed).toEqual([...listed].sort());
+    expect(listed).toContain("vehicle");
+    expect(listed).toContain("person");
+  });
+
+  it("reports false for unknown types", () => {
+    const registry = new EntityTypeRegistry();
+    expect(registry.has("spaceship")).toBe(false);
+    expect(registry.metadataFor("spaceship")).toBeNull();
+  });
+
+  it("registers a new type with defaults derived from its key", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("pet");
+    expect(registry.has("pet")).toBe(true);
+    expect(registry.metadataFor("pet")).toEqual({
+      label: "pet",
+      defaultVisibility: "owner_agent_admin",
+    });
+  });
+
+  it("honours explicit label and default visibility", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("device", {
+      label: "Device",
+      defaultVisibility: "agent_and_admin",
+    });
+    expect(registry.metadataFor("device")).toEqual({
+      label: "Device",
+      defaultVisibility: "agent_and_admin",
+    });
+  });
+
+  it("re-registering with identical metadata is an idempotent no-op", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("device", {
+      label: "Device",
+      defaultVisibility: "agent_and_admin",
+    });
+    registry.register("device", {
+      label: "Device",
+      defaultVisibility: "agent_and_admin",
+    });
+    expect(registry.metadataFor("device")).toEqual({
+      label: "Device",
+      defaultVisibility: "agent_and_admin",
+    });
+  });
+
+  it("re-registering a built-in with equivalent derived metadata is a no-op", () => {
+    const registry = new EntityTypeRegistry();
+    expect(() => registry.register("person")).not.toThrow();
+    expect(registry.metadataFor("person")).toEqual({
+      label: "person",
+      defaultVisibility: "owner_agent_admin",
+    });
+    expect(registry.list()).toHaveLength(BUILT_IN_ENTITY_TYPES.length);
+  });
+
+  it("throws when re-registering with a different label", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("device", { label: "Device" });
+    expect(() => registry.register("device", { label: "Gadget" })).toThrowError(
+      '[EntityTypeRegistry] type "device" already registered with different metadata',
+    );
+  });
+
+  it("throws when re-registering with a different default visibility", () => {
+    const registry = new EntityTypeRegistry();
+    registry.register("device", {
+      defaultVisibility: "owner_only",
+    });
+    expect(() =>
+      registry.register("device", { defaultVisibility: "owner_agent_admin" }),
+    ).toThrowError(/already registered with different metadata/);
+    expect(registry.metadataFor("device")).toEqual({
+      label: "device",
+      defaultVisibility: "owner_only",
+    });
+  });
+});
+
+describe("defaultEntityTypeRegistry", () => {
+  it("knows the built-ins and stays isolated from other instances", () => {
+    expect(defaultEntityTypeRegistry.has("person")).toBe(true);
+
+    const registry = new EntityTypeRegistry();
+    registry.register("isolated-marker");
+    expect(defaultEntityTypeRegistry.has("isolated-marker")).toBe(false);
+  });
+});


### PR DESCRIPTION

Adds `packages/shared/src/knowledge-graph/entity-types.test.ts`, a new co-located vitest suite for the knowledge-graph entity-type primitives (sibling convention of `merge.test.ts`). Test-only change: no production file is touched (+183/-0, one new file).

Coverage drives the real module (no mocks) and asserts observed behavior:

- Module constants: exact built-in entity type list, `SELF_ENTITY_ID`, `DEFAULT_CONNECTOR_ACCOUNT_ID`.
- `normalizeEntityConnectorAccountId`: null/undefined/empty/blank fall back to `"default"`; non-empty values pass through; surrounding whitespace is trimmed while interior spacing and case are preserved (account ids stay opaque and case-sensitive).
- `EntityTypeRegistry`: constructor seeds all five built-ins with themselves as label and `owner_agent_admin` visibility; `list()` returns sorted keys including custom registrations; unknown types report `has() === false` and `metadataFor() === null`; registration honors explicit metadata and derives label/visibility defaults from the key; re-registering identical metadata (including a bare re-register of a built-in) is an idempotent no-op; conflicting label or visibility throws `[EntityTypeRegistry] type "..." already registered with different metadata` and leaves prior metadata intact; instances are isolated from `defaultEntityTypeRegistry`.
- `defaultEntityTypeRegistry`: knows built-ins and is unaffected by other instances' registrations.

No `expectTypeOf` or type-only assertions; the module's runtime surface is exercised directly.

Evidence (fork contributor: hosted CI does not run on this PR):

- `bunx vitest run packages/shared/src/knowledge-graph/entity-types.test.ts` → Test Files 1 passed (1), Tests 18 passed (18). Re-fetched origin/develop immediately before filing and re-ran: same 18/18, and no competing `entity-types.test.ts` exists on current develop.
- `bunx biome check --write packages/shared/src/knowledge-graph/entity-types.test.ts` → "Checked 1 file ... Fixed 1 file" against the repo-root `biome.json` (checkout confirmed not sparse).
- `bunx tsc --noEmit` in `packages/shared` → zero occurrences of the new test file in output (no new type errors).
- Diff touches only the single new test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:34d0f20c4e2c3190621818a19a3853087d9f7258 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
