### PR TITLE
fix(context): authorize cross-world recall at storage

### DIFF
--- a/packages/agent/src/providers/recent-conversations.test.ts
+++ b/packages/agent/src/providers/recent-conversations.test.ts
@@ -10,6 +10,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getVerifiedRelatedEntityIds =
   vi.fn<(runtime: IAgentRuntime, entityId: UUID) => Promise<UUID[]>>();
+const buildCrossWorldConversationAccessContext = vi.fn(
+  async (runtime: IAgentRuntime, message: Memory) => {
+    const related = await getVerifiedRelatedEntityIds(
+      runtime,
+      message.entityId,
+    );
+    const [requesterRooms, agentRooms] = await Promise.all([
+      runtime.getRoomsForParticipants(related),
+      runtime.getRoomsForParticipant(runtime.agentId),
+    ]);
+    const agentRoomSet = new Set(agentRooms);
+    return {
+      requesterEntityId: message.entityId,
+      authorizedRoomIds: Array.from(new Set(requesterRooms)).filter((roomId) =>
+        agentRoomSet.has(roomId),
+      ),
+    };
+  },
+);
 const revalidateOwnerExclusiveDisclosure = vi.fn(
   async (): Promise<Record<string, unknown>> => ({
     allowed: true,
@@ -23,6 +42,7 @@ vi.mock("@elizaos/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@elizaos/core")>();
   return {
     ...actual,
+    buildCrossWorldConversationAccessContext,
     getVerifiedRelatedEntityIds,
     revalidateOwnerExclusiveDisclosure,
     recordOwnerExclusiveSuppression,
@@ -160,6 +180,10 @@ describe("recentConversationsProvider", () => {
     expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ROOM_ID, ALIAS_ROOM_ID],
+      accessContext: {
+        requesterEntityId: ENTITY_ID,
+        authorizedRoomIds: [ROOM_ID, ALIAS_ROOM_ID],
+      },
     });
     expect(getRoomsByIds).toHaveBeenCalledOnce();
     expect(getRoomsByIds).toHaveBeenCalledWith([ROOM_ID, ALIAS_ROOM_ID]);
@@ -195,6 +219,10 @@ describe("recentConversationsProvider", () => {
     expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ALIAS_ROOM_ID],
+      accessContext: {
+        requesterEntityId: ENTITY_ID,
+        authorizedRoomIds: [ROOM_ID, ALIAS_ROOM_ID],
+      },
     });
     expect(result.text).toContain("remote-only context");
   });
@@ -265,6 +293,7 @@ describe("recentConversationsProvider", () => {
       "destination_not_private",
     );
     expect(getVerifiedRelatedEntityIds).not.toHaveBeenCalled();
+    expect(buildCrossWorldConversationAccessContext).not.toHaveBeenCalled();
     expect(runtime.getRoomsForParticipants).not.toHaveBeenCalled();
     expect(runtime.getRoomsForParticipant).not.toHaveBeenCalled();
     expect(runtime.getMemoriesByRoomIds).not.toHaveBeenCalled();

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -18,7 +18,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
-  getVerifiedRelatedEntityIds,
+  buildCrossWorldConversationAccessContext,
   markOwnerExclusiveDisclosureUsed,
   OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
   recordOwnerExclusiveSuppression,
@@ -116,22 +116,15 @@ export const recentConversationsProvider: Provider = {
         return { text: "", values: {}, data: {} };
       }
 
-      const relatedEntityIds = await getVerifiedRelatedEntityIds(
+      const accessContext = await buildCrossWorldConversationAccessContext(
         runtime,
-        entityId,
+        message,
       );
-      const [requesterRoomIds, agentRoomIds] = await Promise.all([
-        runtime.getRoomsForParticipants(relatedEntityIds),
-        runtime.getRoomsForParticipant(runtime.agentId),
-      ]);
-      const agentRooms = new Set(agentRoomIds);
       const recentMessagesOwnsCurrentRoom = runtime.providers?.some(
         (provider) => provider.name?.trim().toUpperCase() === "RECENT_MESSAGES",
       );
-      const roomIds = Array.from(new Set(requesterRoomIds)).filter(
-        (roomId) =>
-          agentRooms.has(roomId) &&
-          (!recentMessagesOwnsCurrentRoom || roomId !== message.roomId),
+      const roomIds = (accessContext.authorizedRoomIds ?? []).filter(
+        (roomId) => !recentMessagesOwnsCurrentRoom || roomId !== message.roomId,
       );
       if (!roomIds || roomIds.length === 0) {
         return { text: "", values: {}, data: {} };
@@ -140,6 +133,7 @@ export const recentConversationsProvider: Provider = {
       const memories = await runtime.getMemoriesByRoomIds({
         tableName: "messages",
         roomIds,
+        accessContext,
       });
 
       if (!memories || memories.length === 0) {

--- a/packages/core/src/access-context.test.ts
+++ b/packages/core/src/access-context.test.ts
@@ -7,7 +7,10 @@
  * elevated access", never "unrestricted".
  */
 import { describe, expect, it } from "vitest";
-import { buildAccessContext } from "./access-context";
+import {
+	buildAccessContext,
+	buildCrossWorldConversationAccessContext,
+} from "./access-context";
 import { createUniqueUuid } from "./entities";
 import type { IAgentRuntime, Memory, UUID } from "./types";
 
@@ -15,6 +18,8 @@ const AGENT = "00000000-0000-0000-0000-0000000000a9" as UUID;
 const USER = "00000000-0000-0000-0000-0000000000u5" as UUID;
 const WORLD = "00000000-0000-0000-0000-00000000w012" as UUID;
 const ROOM = "00000000-0000-0000-0000-00000000r001" as UUID;
+const OTHER_ROOM = "00000000-0000-0000-0000-00000000r002" as UUID;
+const AGENT_ONLY_ROOM = "00000000-0000-0000-0000-00000000r003" as UUID;
 const DISCORD_SERVER_ID = "discord-server-7788";
 
 function runtimeWithRoles(
@@ -37,6 +42,7 @@ function runtimeWithRoles(
 		}),
 		getSetting: () => undefined,
 		getCache: async () => undefined,
+		getService: () => null,
 		getComponents: async () => [],
 		getEntityById: async () => null,
 	} as unknown as IAgentRuntime;
@@ -122,5 +128,25 @@ describe("buildAccessContext", () => {
 		expect(ctx.worldId).toBe(expectedWorldId);
 		expect(ctx.worldId).toBeDefined();
 		expect(ctx.source).toBe("discord");
+	});
+});
+
+describe("buildCrossWorldConversationAccessContext", () => {
+	it("intersects verified requester rooms with agent rooms across worlds", async () => {
+		const runtime = runtimeWithRoles({ [USER]: "OWNER" }, WORLD, {
+			[USER]: "manual",
+		});
+		runtime.getRoomsForParticipants = async () => [ROOM, OTHER_ROOM];
+		runtime.getRoomsForParticipant = async () => [OTHER_ROOM, AGENT_ONLY_ROOM];
+
+		const ctx = await buildCrossWorldConversationAccessContext(
+			runtime,
+			message("discord"),
+		);
+
+		expect(ctx.role).toBe("OWNER");
+		expect(ctx.isOwner).toBe(true);
+		expect(ctx.worldId).toBeUndefined();
+		expect(ctx.authorizedRoomIds).toEqual([OTHER_ROOM]);
 	});
 });

--- a/packages/core/src/access-context.ts
+++ b/packages/core/src/access-context.ts
@@ -1,10 +1,11 @@
 /**
- * Assembles the {@link AccessContext} DTO — requester entity, world scope, role,
- * and owner flag — that authorization checks read for a message-driven request.
- * A thin composition over `roles.ts`: it runs role resolution against the single
- * world `resolveWorldForMessage` selects, so `worldId`, `role`, and `isOwner`
- * are always derived together and can never disagree on which world they scope.
+ * Assembles message-driven access contexts. The base context resolves requester,
+ * world, and role together; the cross-world conversation variant additionally
+ * intersects verified linked-identity rooms with the agent's memberships so
+ * storage can authorize multi-platform recall before ranking or pagination.
  */
+
+import { getVerifiedRelatedEntityIds } from "./identity-clusters";
 import {
 	getLiveEntityMetadataFromMessage,
 	resolveEntityRole,
@@ -57,5 +58,37 @@ export async function buildAccessContext(
 		role,
 		isOwner: role === "OWNER",
 		source: sourceField,
+	};
+}
+
+/**
+ * Build the storage boundary for owner-private conversation continuity across
+ * worlds. Authority still comes from the live delivery world, while the
+ * readable room set is the intersection of the requester's verified identity
+ * cluster and the agent's actual memberships. `worldId` is deliberately
+ * omitted because that verified room set may span multiple platforms/worlds.
+ */
+export async function buildCrossWorldConversationAccessContext(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<AccessContext> {
+	const base = await buildAccessContext(runtime, message);
+	const relatedEntityIds = await getVerifiedRelatedEntityIds(
+		runtime,
+		message.entityId,
+	);
+	const [requesterRoomIds, agentRoomIds] = await Promise.all([
+		runtime.getRoomsForParticipants(relatedEntityIds),
+		runtime.getRoomsForParticipant(runtime.agentId),
+	]);
+	const agentRooms = new Set(agentRoomIds);
+	const authorizedRoomIds = Array.from(new Set(requesterRoomIds)).filter(
+		(roomId) => agentRooms.has(roomId),
+	);
+
+	return {
+		...base,
+		worldId: undefined,
+		authorizedRoomIds,
 	};
 }

--- a/packages/core/src/access-control/provenance-envelope.ts
+++ b/packages/core/src/access-control/provenance-envelope.ts
@@ -657,16 +657,19 @@ function trustedDeliveryTurnDenial(
 async function resolveRequesterAccessContext(
 	runtime: IAgentRuntime,
 	deliveryMessage: Memory,
+	crossWorld: boolean,
 ): Promise<
 	{ ok: true; context: AccessContext } | { ok: false; cause: unknown }
 > {
 	try {
-		// buildAccessContext is the same composition the disclosure gate trusts:
-		// it resolves role/isOwner/worldId against the single world the message
-		// belongs to. Delegating here keeps requester identity derived from the
-		// same process-bound evidence, not caller-supplied fields.
-		const { buildAccessContext } = await import("../access-context");
-		const context = await buildAccessContext(runtime, deliveryMessage);
+		// Both builders derive requester authority from the exact delivery turn.
+		// Cross-world recall additionally resolves a verified room intersection;
+		// same-room recall retains the single-world context.
+		const { buildAccessContext, buildCrossWorldConversationAccessContext } =
+			await import("../access-context");
+		const context = crossWorld
+			? await buildCrossWorldConversationAccessContext(runtime, deliveryMessage)
+			: await buildAccessContext(runtime, deliveryMessage);
 		return { ok: true, context };
 	} catch (cause) {
 		return { ok: false, cause };
@@ -717,9 +720,11 @@ export async function searchCanonicalConversationMemories(
 		};
 	}
 
+	const crossRoomGate: CrossRoomRecallGate = crossRoomRecallGate(revalidated);
 	const requesterResult = await resolveRequesterAccessContext(
 		input.runtime,
 		deliveryMessage,
+		crossRoomGate.allowed,
 	);
 	if (!requesterResult.ok) {
 		input.runtime.reportError(
@@ -741,8 +746,6 @@ export async function searchCanonicalConversationMemories(
 		};
 	}
 	const requester = requesterResult.context;
-
-	const crossRoomGate: CrossRoomRecallGate = crossRoomRecallGate(revalidated);
 
 	// Constrain the vector scan by the attested room BEFORE ranking so a global
 	// top-K cannot starve eligible same-room rows. When cross-room recall is

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -647,6 +647,12 @@ describe("recentMessagesProvider", () => {
 		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith({
 			tableName: "messages",
 			roomIds: [OTHER_ROOM_ID],
+			accessContext: {
+				requesterEntityId: USER_ID,
+				source: "discord",
+				worldId: undefined,
+				authorizedRoomIds: [ROOM_ID, OTHER_ROOM_ID],
+			},
 		});
 		expect(result.data?.recentInteractions).toHaveLength(1);
 		expect(result.values?.recentMessageInteractions).toContain(

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -24,9 +24,9 @@
  * after the live destination is revalidated as an owner-exclusive DM.
  */
 
+import { buildCrossWorldConversationAccessContext } from "../../../access-context.ts";
 import { getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
-import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
 import { isInternalBridgeMessage } from "../../../messaging/automated-turns.ts";
 import {
 	markOwnerExclusiveDisclosureUsed,
@@ -346,23 +346,14 @@ const getRecentInteractions = async (
 		}
 		return [];
 	}
-	const sourceEntityIds = await getVerifiedRelatedEntityIds(
+	if (targetEntityId !== runtime.agentId) return [];
+	const accessContext = await buildCrossWorldConversationAccessContext(
 		runtime,
-		message.entityId,
+		message,
 	);
-	// getRoomsForParticipants is a union query (rooms containing ANY supplied
-	// entity), so intersect the identity-cluster rooms with the target's rooms.
-	// Passing both sides to one call would leak unrelated participant rooms into
-	// recentInteractions.
-	const [sourceRooms, targetRooms] = await Promise.all([
-		runtime.getRoomsForParticipants(sourceEntityIds),
-		runtime.getRoomsForParticipant(targetEntityId),
-	]);
-	const targetRoomIds = new Set(targetRooms);
-	const rooms = Array.from(new Set(sourceRooms)).filter((roomId) =>
-		targetRoomIds.has(roomId),
+	const otherRooms = (accessContext.authorizedRoomIds ?? []).filter(
+		(room) => room !== excludeRoomId,
 	);
-	const otherRooms = rooms.filter((room) => room !== excludeRoomId);
 	if (otherRooms.length === 0) {
 		return [];
 	}
@@ -371,6 +362,7 @@ const getRecentInteractions = async (
 	const interactions = await runtime.getMemoriesByRoomIds({
 		tableName: "messages",
 		roomIds: otherRooms,
+		accessContext,
 	});
 	if (interactions.length > 0) {
 		markOwnerExclusiveDisclosureUsed(message);


### PR DESCRIPTION
Advances #24680. Stacked on #26397; retarget to `develop` after the adapter foundation lands.

## Contract

- Adds one shared cross-world conversation access-context builder.
- Expands only the requester's verified identity cluster.
- Intersects that cluster's room memberships with the agent's actual memberships.
- Passes the resulting `authorizedRoomIds` into storage for recent-conversations, the core recent-interactions fallback, and canonical semantic recall.
- Omits the single delivery `worldId` only for this verified multi-world room set; same-room canonical recall keeps its existing delivery-world constraint.
- Keeps owner-exclusive audience revalidation before identity or room-history queries.

This prevents unauthorized rooms and unrelated same-handle accounts from entering the candidate window before pagination or vector top-K.

## Exact-head verification

- Provider/access/canonical focused suite: 45/45 passed.
- Real AgentRuntime + PGlite canonical Discord/Telegram integration: 3/3 passed.
- Core typecheck: PASS.
- Agent typecheck reaches unrelated current optional-plugin/test baseline failures; no changed-file diagnostic.
- Biome and diff check: PASS.

## Evidence applicability

- Live-model behavior remains covered by #26385 and the cross-world simulated scenario runs recorded there.
- Real connector qualification remains credential-gated; this PR changes the storage authorization boundary, not connector ingress.
