### PR TITLE
fix(runtime): preserve complete agent read results

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -184,6 +184,10 @@ Connector health monitoring (`api/connector-health.ts`): the interval is validat
   training, or later model context. Preserve each record's exact text regardless
   of length or surrounding whitespace; reject malformed Unicode rather than
   repairing the recorded request or response.
+- **Agent read actions are exhaustive.** `FILES`, `SEARCH_KNOWLEDGE`, and
+  `MEMORY` return every authorized match. Storage page sizes are internal
+  transport batches; repeated, changing, or incomplete traversals fail
+  explicitly and must never become a successful model-facing prefix.
 
 ## Package completion evidence
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -184,6 +184,10 @@ Connector health monitoring (`api/connector-health.ts`): the interval is validat
   training, or later model context. Preserve each record's exact text regardless
   of length or surrounding whitespace; reject malformed Unicode rather than
   repairing the recorded request or response.
+- **Agent read actions are exhaustive.** `FILES`, `SEARCH_KNOWLEDGE`, and
+  `MEMORY` return every authorized match. Storage page sizes are internal
+  transport batches; repeated, changing, or incomplete traversals fail
+  explicitly and must never become a successful model-facing prefix.
 
 ## Package completion evidence
 

--- a/packages/agent/src/actions/files.test.ts
+++ b/packages/agent/src/actions/files.test.ts
@@ -93,6 +93,26 @@ describe("filesAction", () => {
     expect(data.files?.[0].mimeType).toBe("application/pdf");
   });
 
+  it("returns every stored file even when a legacy caller supplies a limit", async () => {
+    const files = Array.from({ length: 137 }, (_, index) => ({
+      fileName: `${index.toString(16).padStart(64, "0")}.txt`,
+      url: `/api/media/${index.toString(16).padStart(64, "0")}.txt`,
+      hash: index.toString(16).padStart(64, "0"),
+      mimeType: "text/plain",
+      size: index + 1,
+      createdAt: index,
+    }));
+    const res = await run(makeRuntime(fakeStorage(files)), {
+      op: "list",
+      limit: 1,
+    });
+    const data = res?.data as FilesData;
+    expect(data.files).toHaveLength(files.length);
+    expect(data.total).toBe(files.length);
+    expect(data.files?.[0].fileName).toBe(files.at(-1)?.fileName);
+    expect(data.files?.at(-1)?.fileName).toBe(files[0].fileName);
+  });
+
   it("gets a file's details + url by name", async () => {
     const res = await run(makeRuntime(fakeStorage()), {
       op: "get",

--- a/packages/agent/src/actions/files.ts
+++ b/packages/agent/src/actions/files.ts
@@ -1,7 +1,7 @@
 /**
  * Registers the FILES agent action, giving an owner-role agent read/CRUD access
  * to the content-addressed media store through the runtime's IFileStorageService
- * (ServiceType.REMOTE_FILES): list (recent files, optional query/limit), get
+ * (ServiceType.REMOTE_FILES): list (every file, optional query), get
  * (details + served URL by filename), and delete (confirm-gated).
  */
 import type {
@@ -23,7 +23,6 @@ interface FilesParams {
   subaction?: string;
   fileName?: string;
   query?: string;
-  limit?: number;
   confirm?: boolean;
 }
 
@@ -44,11 +43,6 @@ function normalizeOp(params: FilesParams): FilesOp | undefined {
   return (FILES_OPS as readonly string[]).includes(candidate)
     ? (candidate as FilesOp)
     : undefined;
-}
-
-function clampLimit(value: number | undefined, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
-  return Math.max(1, Math.min(100, Math.floor(value)));
 }
 
 function humanSize(bytes: number): string {
@@ -82,12 +76,8 @@ async function doList(
   const filtered = params.query
     ? all.filter((file) => matchesQuery(file, params.query ?? ""))
     : all;
-  const limit = clampLimit(params.limit, 20);
-  const top = filtered.slice(0, limit);
-  const text = top.length
-    ? `Found ${filtered.length} file(s).${
-        filtered.length > top.length ? ` Most recent ${top.length}:` : ""
-      }\n${top
+  const text = filtered.length
+    ? `Found all ${filtered.length} file(s).\n${filtered
         .map(
           (file) =>
             `- ${file.fileName} (${file.mimeType}, ${humanSize(file.size)}) ${file.url}`,
@@ -97,7 +87,7 @@ async function doList(
   return {
     success: true,
     text,
-    data: { files: top, total: filtered.length },
+    data: { files: filtered, total: filtered.length },
   };
 }
 
@@ -157,8 +147,8 @@ async function doDelete(
 
 /**
  * FILES action: gives the agent read/CRUD access to the content-addressed file
- * store via {@link IFileStorageService}. op:list shows recent stored files
- * (optional query/limit); op:get returns a file's details + served URL by
+ * store via {@link IFileStorageService}. op:list shows every stored file
+ * (optional query); op:get returns a file's details + served URL by
  * fileName; op:delete removes a file (requires confirm:true).
  */
 export const filesAction: Action = {
@@ -176,7 +166,7 @@ export const filesAction: Action = {
     "REMOVE_FILE",
   ],
   description:
-    "Access stored files. op:list shows recent stored files (optional query/limit); op:get returns a file's details + served URL by fileName; op:delete removes a file (requires confirm:true).",
+    "Access stored files. op:list shows every stored file (optional query); op:get returns a file's details + served URL by fileName; op:delete removes a file (requires confirm:true).",
   descriptionCompressed:
     "list/get/delete stored files; delete requires confirm:true",
   routingHint:
@@ -235,12 +225,6 @@ export const filesAction: Action = {
         "Optional filter for op:list (matches filename or mime type substring)",
       required: false,
       schema: { type: "string" as const },
-    },
-    {
-      name: "limit",
-      description: "Max results for op:list (default 20, max 100)",
-      required: false,
-      schema: { type: "number" as const },
     },
     {
       name: "confirm",

--- a/packages/agent/src/actions/files.ts
+++ b/packages/agent/src/actions/files.ts
@@ -24,6 +24,8 @@ interface FilesParams {
   fileName?: string;
   query?: string;
   confirm?: boolean;
+  /** @deprecated Accepted for compatibility; complete reads ignore it. */
+  limit?: number;
 }
 
 function fail(text: string, error: string): ActionResult {
@@ -225,6 +227,13 @@ export const filesAction: Action = {
         "Optional filter for op:list (matches filename or mime type substring)",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "limit",
+      description:
+        "Deprecated compatibility input. Complete file listings are never capped.",
+      required: false,
+      schema: { type: "number" as const },
     },
     {
       name: "confirm",

--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -73,8 +73,14 @@ const CORPUS: DocRecord[] = [
 function makeService(records: DocRecord[] = CORPUS) {
   return {
     searchDocuments: vi.fn(async () => records),
-    getMemories: vi.fn(async ({ offset = 0 }: { offset?: number }) =>
-      offset === 0 ? records : [],
+    getMemories: vi.fn(
+      async ({
+        offset = 0,
+        count = records.length,
+      }: {
+        offset?: number;
+        count?: number;
+      }) => records.slice(offset, offset + count),
     ),
     getDocumentById: vi.fn(
       async (id: UUID) => records.find((r) => r.id === id) ?? null,
@@ -196,6 +202,47 @@ describe("SEARCH_KNOWLEDGE", () => {
     );
     expect(res.success).toBe(true);
     expect((res.data as { count: number }).count).toBeGreaterThan(0);
+  });
+
+  it("filter-only search traverses beyond the former 2000-row ceiling", async () => {
+    const records = Array.from({ length: 2_051 }, (_, index) =>
+      doc(
+        `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}` as UUID,
+        "global",
+      ),
+    );
+    const runtime = makeRuntime({ service: makeService(records) });
+    const res = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      { tags: ["media-format:pdf"] },
+    );
+
+    expect(res.success).toBe(true);
+    const items = (res.data as { items: Array<{ id: UUID }> }).items;
+    expect(items).toHaveLength(records.length);
+    expect(items.map((item) => item.id)).toEqual(
+      records.map((item) => item.id),
+    );
+  });
+
+  it("rejects a non-advancing facet adapter instead of returning a prefix", async () => {
+    const records = Array.from({ length: 200 }, (_, index) =>
+      doc(
+        `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}` as UUID,
+        "global",
+      ),
+    );
+    const service = makeService(records);
+    service.getMemories.mockImplementation(async () => records);
+    const runtime = makeRuntime({ service });
+
+    await expect(
+      call(searchKnowledgeAction, runtime, msg(OWNER_ENTITY, DM_ROOM), {
+        tags: ["media-format:pdf"],
+      }),
+    ).rejects.toMatchObject({ code: "KNOWLEDGE_TRAVERSAL_NON_ADVANCING" });
   });
 
   it("free-text search composes with the help tag on fragment metadata", async () => {

--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -245,6 +245,22 @@ describe("SEARCH_KNOWLEDGE", () => {
     ).rejects.toMatchObject({ code: "KNOWLEDGE_TRAVERSAL_NON_ADVANCING" });
   });
 
+  it("rejects content mutation between stable facet traversal passes", async () => {
+    const first = doc(DOC_GLOBAL, "global");
+    const second = { ...first, content: { text: "changed complete text" } };
+    const service = makeService([first]);
+    service.getMemories
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([second]);
+    const runtime = makeRuntime({ service });
+
+    await expect(
+      call(searchKnowledgeAction, runtime, msg(OWNER_ENTITY, DM_ROOM), {
+        tags: ["media-format:pdf"],
+      }),
+    ).rejects.toMatchObject({ code: "KNOWLEDGE_TRAVERSAL_INVENTORY_CHANGED" });
+  });
+
   it("free-text search composes with the help tag on fragment metadata", async () => {
     const helpFragment = doc(DOC_GLOBAL, "global", {
       documentId: DOC_GLOBAL,

--- a/packages/agent/src/actions/knowledge.test.ts
+++ b/packages/agent/src/actions/knowledge.test.ts
@@ -38,6 +38,7 @@ type DocRecord = {
   content: { text?: string };
   metadata: Record<string, unknown>;
   agentId?: UUID;
+  createdAt: number;
 };
 
 function doc(
@@ -49,6 +50,7 @@ function doc(
     id,
     content: { text: `body of ${id}` },
     agentId: AGENT_ID,
+    createdAt: 1_000,
     metadata: {
       type: "document",
       documentId: id,
@@ -77,10 +79,17 @@ function makeService(records: DocRecord[] = CORPUS) {
       async ({
         offset = 0,
         count = records.length,
+        end,
       }: {
         offset?: number;
         count?: number;
-      }) => records.slice(offset, offset + count),
+        end?: number;
+      }) =>
+        records
+          .filter(
+            (record) => end === undefined || (record.createdAt ?? 0) <= end,
+          )
+          .slice(offset, offset + count),
     ),
     getDocumentById: vi.fn(
       async (id: UUID) => records.find((r) => r.id === id) ?? null,
@@ -216,7 +225,7 @@ describe("SEARCH_KNOWLEDGE", () => {
       searchKnowledgeAction,
       runtime,
       msg(OWNER_ENTITY, DM_ROOM),
-      { tags: ["media-format:pdf"] },
+      { tags: ["media-format:pdf"], limit: 1 },
     );
 
     expect(res.success).toBe(true);
@@ -259,6 +268,37 @@ describe("SEARCH_KNOWLEDGE", () => {
         tags: ["media-format:pdf"],
       }),
     ).rejects.toMatchObject({ code: "KNOWLEDGE_TRAVERSAL_INVENTORY_CHANGED" });
+  });
+
+  it("holds a complete facet snapshot while newer documents are appended", async () => {
+    const stable = doc(DOC_GLOBAL, "global");
+    const records = [stable];
+    const service = makeService(records);
+    const originalGetMemories = service.getMemories.getMockImplementation();
+    service.getMemories.mockImplementation(async (params) => {
+      const rows = await originalGetMemories?.(params);
+      if (service.getMemories.mock.calls.length === 1) {
+        const appended = doc(DOC_OWNER_PRIVATE, "global");
+        appended.createdAt = (params.end ?? Date.now()) + 1;
+        records.push(appended);
+      }
+      return rows ?? [];
+    });
+    const runtime = makeRuntime({ service });
+
+    const result = await call(
+      searchKnowledgeAction,
+      runtime,
+      msg(OWNER_ENTITY, DM_ROOM),
+      { tags: ["media-format:pdf"] },
+    );
+
+    expect(result.success).toBe(true);
+    expect(
+      (result.data as { items: Array<{ id: UUID }> }).items.map(
+        (item) => item.id,
+      ),
+    ).toEqual([stable.id]);
   });
 
   it("free-text search composes with the help tag on fragment metadata", async () => {

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -23,6 +23,7 @@ import {
   type Action,
   type ActionResult,
   type Content,
+  ElizaError,
   type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
@@ -186,10 +187,7 @@ async function resolveItem(
     // it was ingested from rather than its document id.
     const fileName = mediaFileNameFromRef(itemRef);
     if (fileName && service) {
-      const docs = await service.getMemories({
-        tableName: "documents",
-        count: 1000,
-      });
+      const docs = await readStableCompleteDocumentRows(service);
       memory =
         docs.find((doc) => {
           const meta = asRecord(doc.metadata);
@@ -267,8 +265,81 @@ type KnowledgeSearchRow = {
 
 /** How many document rows to pull per scan batch in the facet-list path. */
 const DOCUMENT_SCAN_BATCH = 200;
-/** Cap the facet scan so a huge corpus can't unbounded-loop an action. */
-const DOCUMENT_SCAN_MAX = 2000;
+
+function knowledgeTraversalError(
+  code: string,
+  context: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(
+    "Knowledge traversal could not prove a complete snapshot",
+    { code, context },
+  );
+}
+
+async function scanAllDocumentRows(
+  service: DocumentsServiceLike,
+): Promise<Memory[]> {
+  const rows: Memory[] = [];
+  const seen = new Set<string>();
+  let offset = 0;
+  while (true) {
+    const batch = await service.getMemories({
+      tableName: "documents",
+      count: DOCUMENT_SCAN_BATCH,
+      offset,
+    });
+    if (batch.length > DOCUMENT_SCAN_BATCH) {
+      throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_PAGE_INVALID", {
+        offset,
+        pageLength: batch.length,
+      });
+    }
+    if (batch.length === 0) break;
+    for (const memory of batch) {
+      if (!memory.id || seen.has(memory.id)) {
+        throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_NON_ADVANCING", {
+          offset,
+          memoryId: memory.id,
+        });
+      }
+      seen.add(memory.id);
+      rows.push(memory);
+    }
+    if (batch.length < DOCUMENT_SCAN_BATCH) break;
+    offset += batch.length;
+  }
+  return rows;
+}
+
+async function readStableCompleteDocumentRows(
+  service: DocumentsServiceLike,
+): Promise<Memory[]> {
+  const before = await service.countMemories({ tableName: "documents" });
+  const first = await scanAllDocumentRows(service);
+  const between = await service.countMemories({ tableName: "documents" });
+  const second = await scanAllDocumentRows(service);
+  const after = await service.countMemories({ tableName: "documents" });
+  const firstIds = first.map((memory) => memory.id);
+  const secondIds = second.map((memory) => memory.id);
+  if (
+    !Number.isSafeInteger(before) ||
+    before < 0 ||
+    before !== between ||
+    before !== after ||
+    first.length !== before ||
+    second.length !== before ||
+    firstIds.some((id, index) => id !== secondIds[index])
+  ) {
+    throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_INVENTORY_CHANGED", {
+      before,
+      between,
+      after,
+      firstLength: first.length,
+      secondLength: second.length,
+    });
+  }
+  return second;
+}
 
 /**
  * Free-text retrieval path: semantic/hybrid search over the document store,
@@ -314,27 +385,17 @@ async function listByFacets(
   _filters: DocumentFilter,
 ): Promise<KnowledgeSearchRow[]> {
   const rows: KnowledgeSearchRow[] = [];
-  let offset = 0;
-  while (offset < DOCUMENT_SCAN_MAX) {
-    const batch = await service.getMemories({
-      tableName: "documents",
-      count: DOCUMENT_SCAN_BATCH,
-      offset,
+  const memories = await readStableCompleteDocumentRows(service);
+  for (const memory of memories) {
+    const meta = asRecord(memory.metadata);
+    // Only real document memories for this agent (mirrors isDocumentMemory).
+    if (meta?.type !== "document" && meta?.documentId === undefined) continue;
+    if (memory.agentId && memory.agentId !== agentId) continue;
+    rows.push({
+      id: memory.id as UUID,
+      content: { text: memory.content?.text },
+      metadata: meta,
     });
-    if (batch.length === 0) break;
-    for (const memory of batch) {
-      const meta = asRecord(memory.metadata);
-      // Only real document memories for this agent (mirrors isDocumentMemory).
-      if (meta?.type !== "document" && meta?.documentId === undefined) continue;
-      if (memory.agentId && memory.agentId !== agentId) continue;
-      rows.push({
-        id: memory.id as UUID,
-        content: { text: memory.content?.text },
-        metadata: meta,
-      });
-    }
-    if (batch.length < DOCUMENT_SCAN_BATCH) break;
-    offset += DOCUMENT_SCAN_BATCH;
   }
   return rows;
 }
@@ -393,10 +454,6 @@ export const searchKnowledgeAction: Action = {
       );
     }
 
-    const limit =
-      typeof params.limit === "number" && Number.isFinite(params.limit)
-        ? Math.max(1, Math.min(50, Math.floor(params.limit)))
-        : 10;
     const searchMode = parseSearchMode(params.searchMode);
 
     // The surfacing wall (#13974): SEARCH renders snippets INTO the active room.
@@ -419,7 +476,6 @@ export const searchKnowledgeAction: Action = {
       .filter((r) => matchesDocumentFilter(r, { ...filters, query: undefined }))
       .filter((r) => canReadDocumentMemory(r, actor, filters))
       .filter((r) => canSurfaceDocumentInRoom(r, activeRoomIsPublic).ok)
-      .slice(0, limit)
       .map((r) => {
         const meta = asRecord(r.metadata);
         const tags = documentTags(meta);
@@ -509,12 +565,6 @@ export const searchKnowledgeAction: Action = {
       description: "Optional retrieval mode: hybrid | vector | keyword",
       required: false,
       schema: { type: "string" as const },
-    },
-    {
-      name: "limit",
-      description: "Max results (default 10, max 50)",
-      required: false,
-      schema: { type: "number" as const },
     },
   ],
 };

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -279,6 +279,7 @@ function knowledgeTraversalError(
 
 async function scanAllDocumentRows(
   service: DocumentsServiceLike,
+  snapshotEnd: number,
 ): Promise<Memory[]> {
   const rows: Memory[] = [];
   const seen = new Set<string>();
@@ -288,6 +289,7 @@ async function scanAllDocumentRows(
       tableName: "documents",
       count: DOCUMENT_SCAN_BATCH,
       offset,
+      end: snapshotEnd,
     });
     if (batch.length > DOCUMENT_SCAN_BATCH) {
       throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_PAGE_INVALID", {
@@ -315,11 +317,9 @@ async function scanAllDocumentRows(
 async function readStableCompleteDocumentRows(
   service: DocumentsServiceLike,
 ): Promise<Memory[]> {
-  const before = await service.countMemories({ tableName: "documents" });
-  const first = await scanAllDocumentRows(service);
-  const between = await service.countMemories({ tableName: "documents" });
-  const second = await scanAllDocumentRows(service);
-  const after = await service.countMemories({ tableName: "documents" });
+  const snapshotEnd = Date.now();
+  const first = await scanAllDocumentRows(service, snapshotEnd);
+  const second = await scanAllDocumentRows(service, snapshotEnd);
   let firstFingerprints: string[];
   let secondFingerprints: string[];
   try {
@@ -332,20 +332,13 @@ async function readStableCompleteDocumentRows(
     });
   }
   if (
-    !Number.isSafeInteger(before) ||
-    before < 0 ||
-    before !== between ||
-    before !== after ||
-    first.length !== before ||
-    second.length !== before ||
+    first.length !== second.length ||
     firstFingerprints.some(
       (fingerprint, index) => fingerprint !== secondFingerprints[index],
     )
   ) {
     throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_INVENTORY_CHANGED", {
-      before,
-      between,
-      after,
+      snapshotEnd,
       firstLength: first.length,
       secondLength: second.length,
     });
@@ -577,6 +570,13 @@ export const searchKnowledgeAction: Action = {
       description: "Optional retrieval mode: hybrid | vector | keyword",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "limit",
+      description:
+        "Deprecated compatibility input. Complete search results are never capped.",
+      required: false,
+      schema: { type: "number" as const },
     },
   ],
 };

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -31,6 +31,7 @@ import {
   logger,
   type Media,
   type Memory,
+  stableStringify,
   toWellFormedUnicode,
   type UUID,
 } from "@elizaos/core";
@@ -319,8 +320,17 @@ async function readStableCompleteDocumentRows(
   const between = await service.countMemories({ tableName: "documents" });
   const second = await scanAllDocumentRows(service);
   const after = await service.countMemories({ tableName: "documents" });
-  const firstIds = first.map((memory) => memory.id);
-  const secondIds = second.map((memory) => memory.id);
+  let firstFingerprints: string[];
+  let secondFingerprints: string[];
+  try {
+    firstFingerprints = first.map((memory) => stableStringify(memory));
+    secondFingerprints = second.map((memory) => stableStringify(memory));
+  } catch (cause) {
+    throw new ElizaError("Knowledge row cannot be fingerprinted", {
+      code: "KNOWLEDGE_TRAVERSAL_FINGERPRINT_FAILED",
+      cause,
+    });
+  }
   if (
     !Number.isSafeInteger(before) ||
     before < 0 ||
@@ -328,7 +338,9 @@ async function readStableCompleteDocumentRows(
     before !== after ||
     first.length !== before ||
     second.length !== before ||
-    firstIds.some((id, index) => id !== secondIds[index])
+    firstFingerprints.some(
+      (fingerprint, index) => fingerprint !== secondFingerprints[index],
+    )
   ) {
     throw knowledgeTraversalError("KNOWLEDGE_TRAVERSAL_INVENTORY_CHANGED", {
       before,

--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -701,6 +701,35 @@ describe("MEMORY op:search complete traversal", () => {
       "MEMORY_TRAVERSAL_INVENTORY_CHANGED",
     );
   });
+
+  it("rejects content mutation between complete traversal passes", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "stable memory", entityId: USER_ID });
+    const originalGetMemories = runtime.getMemories.bind(runtime);
+    let factsCalls = 0;
+    runtime.getMemories = async (params) => {
+      const memories = await originalGetMemories(params);
+      if (params.tableName !== "facts") return memories;
+      factsCalls += 1;
+      return factsCalls === 2
+        ? memories.map((memory) => ({
+            ...memory,
+            content: { ...memory.content, text: "changed memory" },
+          }))
+        : memories;
+    };
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      type: "facts",
+      query: "stable",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_TRAVERSAL_INVENTORY_CHANGED",
+    );
+  });
 });
 
 describe("MEMORY routing aliases", () => {

--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -59,6 +59,7 @@ function makeRuntime(options?: {
       roomId?: UUID;
       entityId?: UUID;
       limit?: number;
+      end?: number;
       cursor?: { createdAt: number; id: UUID };
     }) => {
       assertUuidOrThrowLikeDrizzle(params.roomId, "roomId");
@@ -68,6 +69,11 @@ function makeRuntime(options?: {
         .filter((row) => !params.roomId || row.memory.roomId === params.roomId)
         .filter(
           (row) => !params.entityId || row.memory.entityId === params.entityId,
+        )
+        .filter(
+          (row) =>
+            params.end === undefined ||
+            (row.memory.createdAt ?? 0) <= params.end,
         )
         .map((row) => row.memory)
         .sort(
@@ -618,7 +624,6 @@ describe("MEMORY op:search complete traversal", () => {
 
   it("reports a complete empty result when every row was considered", async () => {
     const { runtime, rows } = makeRuntime();
-    // perTable = max(limit * 2, 200); the default limit is 50, so 200.
     for (let i = 0; i < 200; i++) {
       seedFact(rows, { text: `unrelated note ${i}`, entityId: USER_ID });
     }
@@ -643,6 +648,7 @@ describe("MEMORY op:search complete traversal", () => {
     const result = await runAction(runtime, makeMessage(), {
       action: "search",
       query: "guitar",
+      limit: 1,
     });
 
     const text = String(result.text ?? "");
@@ -678,16 +684,27 @@ describe("MEMORY op:search complete traversal", () => {
     );
   });
 
-  it("rejects an inventory that changes between traversal passes", async () => {
+  it("holds a complete snapshot while newer rows are appended", async () => {
     const { runtime, rows } = makeRuntime();
-    seedFact(rows, { text: "stable memory", entityId: USER_ID });
-    const originalCount = runtime.countMemories.bind(runtime);
-    let factsCountCalls = 0;
-    runtime.countMemories = async (params) => {
-      const count = await originalCount(params);
-      if (params.tableName !== "facts") return count;
-      factsCountCalls += 1;
-      return factsCountCalls === 1 ? count : count + 1;
+    const stableId = seedFact(rows, {
+      text: "stable memory",
+      entityId: USER_ID,
+    });
+    const originalGetMemories = runtime.getMemories.bind(runtime);
+    let factsCalls = 0;
+    runtime.getMemories = async (params) => {
+      const memories = await originalGetMemories(params);
+      if (params.tableName === "facts" && ++factsCalls === 1) {
+        const appendedId = seedFact(rows, {
+          text: "newer stable memory",
+          entityId: USER_ID,
+        });
+        const appended = rows.find((row) => row.memory.id === appendedId);
+        if (appended) {
+          appended.memory.createdAt = (params.end ?? Date.now()) + 1;
+        }
+      }
+      return memories;
     };
 
     const result = await runAction(runtime, makeMessage(), {
@@ -696,10 +713,12 @@ describe("MEMORY op:search complete traversal", () => {
       query: "stable",
     });
 
-    expect(result.success).toBe(false);
-    expect((result.data as { error: string }).error).toBe(
-      "MEMORY_TRAVERSAL_INVENTORY_CHANGED",
-    );
+    expect(result.success).toBe(true);
+    expect(
+      (result.data as { memories: Array<{ id: UUID }> }).memories.map(
+        (memory) => memory.id,
+      ),
+    ).toEqual([stableId]);
   });
 
   it("rejects content mutation between complete traversal passes", async () => {

--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -59,21 +59,45 @@ function makeRuntime(options?: {
       roomId?: UUID;
       entityId?: UUID;
       limit?: number;
+      cursor?: { createdAt: number; id: UUID };
     }) => {
       assertUuidOrThrowLikeDrizzle(params.roomId, "roomId");
       assertUuidOrThrowLikeDrizzle(params.entityId, "entityId");
-      const matching = rows
+      let matching = rows
         .filter((row) => row.tableName === params.tableName)
         .filter((row) => !params.roomId || row.memory.roomId === params.roomId)
         .filter(
           (row) => !params.entityId || row.memory.entityId === params.entityId,
         )
-        .map((row) => row.memory);
-      // The SQL adapter returns at most `limit` rows, newest first. Ignoring
-      // the cap here would hide the windowed read that MEMORY op:search does.
+        .map((row) => row.memory)
+        .sort(
+          (left, right) =>
+            (right.createdAt ?? 0) - (left.createdAt ?? 0) ||
+            String(right.id).localeCompare(String(left.id)),
+        );
+      if (params.cursor) {
+        matching = matching.filter((memory) => {
+          const createdAt = memory.createdAt ?? 0;
+          if (createdAt !== params.cursor?.createdAt) {
+            return createdAt < (params.cursor?.createdAt ?? 0);
+          }
+          return String(memory.id) < String(params.cursor.id);
+        });
+      }
       if (params.limit == null) return matching;
-      return matching.slice(-params.limit).reverse();
+      return matching.slice(0, params.limit);
     },
+    countMemories: async (params: {
+      tableName?: string;
+      roomId?: UUID;
+      agentId?: UUID;
+    }) =>
+      rows
+        .filter((row) => row.tableName === (params.tableName ?? "messages"))
+        .filter((row) => !params.roomId || row.memory.roomId === params.roomId)
+        .filter(
+          (row) => !params.agentId || row.memory.agentId === params.agentId,
+        ).length,
     getMemoryById: async (memoryId: UUID) => {
       assertUuidOrThrowLikeDrizzle(memoryId, "id");
       return rows.find((row) => row.memory.id === memoryId)?.memory ?? null;
@@ -570,14 +594,8 @@ describe("MEMORY op:delete by query", () => {
   });
 });
 
-describe("MEMORY op:search windowed-read disclosure", () => {
-  // op:search reads only the most recent max(limit*2, 200) rows per memory
-  // table and filters that window in memory, so its surviving count is a
-  // count of matches INSIDE the window. Printing it as "(total: N)" made
-  // "what do you remember about my sister?" answer "Found 0 memory item(s)
-  // (total: 0)" — read as "nothing is stored about her" — when the fact was
-  // simply older than the 200-row window.
-  it("does not call a windowed match count a total when the window filled up", async () => {
+describe("MEMORY op:search complete traversal", () => {
+  it("finds a matching fact older than the former 200-row window", async () => {
     const { runtime, rows } = makeRuntime();
     seedFact(rows, { text: "my sister is named vega", entityId: USER_ID });
     for (let i = 0; i < 250; i++) {
@@ -590,22 +608,15 @@ describe("MEMORY op:search windowed-read disclosure", () => {
     });
 
     const text = String(result.text ?? "");
-    expect(text).not.toContain("total:");
-    expect(text).toContain("older rows were NOT scanned");
-    expect(text).toContain("not a total");
-    expect(text).toContain("facts");
+    expect(text).toContain("my sister is named vega");
+    expect(text).toContain("Scanned all 251 stored row(s)");
     expect(result.values).toMatchObject({
-      matchedInWindow: 0,
-      scanWindowSaturated: true,
+      totalMatches: 1,
+      scanned: 251,
     });
   });
 
-  // The boundary between the two cases above. A table holding EXACTLY the
-  // window size fills it without hiding anything, so it is indistinguishable
-  // from a truncated one by row count alone. Saturation is measured by reading
-  // one row past the window; inferring it from a full page would tell this
-  // reader that older rows went unscanned when there are none.
-  it("does not claim rows were cut when the table exactly fills the window", async () => {
+  it("reports a complete empty result when every row was considered", async () => {
     const { runtime, rows } = makeRuntime();
     // perTable = max(limit * 2, 200); the default limit is 50, so 200.
     for (let i = 0; i < 200; i++) {
@@ -618,24 +629,9 @@ describe("MEMORY op:search windowed-read disclosure", () => {
     });
 
     const text = String(result.text ?? "");
-    expect(text).not.toContain("older rows were NOT scanned");
-    expect(text).toContain("every stored row in the scanned tables");
-    expect(result.values).toMatchObject({ scanWindowSaturated: false });
-  });
-
-  it("states that every stored row was inside the window when nothing was cut", async () => {
-    const { runtime, rows } = makeRuntime();
-    seedFact(rows, { text: "the user plays guitar", entityId: USER_ID });
-
-    const result = await runAction(runtime, makeMessage(), {
-      action: "search",
-      query: "unicycle",
-    });
-
-    const text = String(result.text ?? "");
-    expect(text).toContain("every stored row in the scanned tables");
-    expect(text).not.toContain("older rows were NOT scanned");
-    expect(result.values).toMatchObject({ scanWindowSaturated: false });
+    expect(text).toContain("Showing all 0 match(es)");
+    expect(text).toContain("Scanned all 200 stored row(s)");
+    expect(result.values).toMatchObject({ totalMatches: 0, scanned: 200 });
   });
 
   it("reports every rendered match when no result cap applies", async () => {
@@ -655,7 +651,55 @@ describe("MEMORY op:search windowed-read disclosure", () => {
     expect(text.split("\n").filter((l) => l.startsWith("- ["))).toHaveLength(
       30,
     );
-    expect(result.values).toMatchObject({ rendered: 30, matchedInWindow: 30 });
+    expect(result.values).toMatchObject({ rendered: 30, totalMatches: 30 });
+  });
+
+  it("rejects a repeated full page instead of returning partial memories", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < 500; i++) {
+      seedFact(rows, { text: `memory ${i}`, entityId: USER_ID });
+    }
+    const firstPage = await runtime.getMemories({
+      tableName: "facts",
+      limit: 500,
+    });
+    runtime.getMemories = async ({ tableName }) =>
+      tableName === "facts" ? firstPage : [];
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      type: "facts",
+      query: "memory",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_TRAVERSAL_REPEATED_ROW",
+    );
+  });
+
+  it("rejects an inventory that changes between traversal passes", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "stable memory", entityId: USER_ID });
+    const originalCount = runtime.countMemories.bind(runtime);
+    let factsCountCalls = 0;
+    runtime.countMemories = async (params) => {
+      const count = await originalCount(params);
+      if (params.tableName !== "facts") return count;
+      factsCountCalls += 1;
+      return factsCountCalls === 1 ? count : count + 1;
+    };
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      type: "facts",
+      query: "stable",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_TRAVERSAL_INVENTORY_CHANGED",
+    );
   });
 });
 
@@ -708,7 +752,7 @@ describe("MEMORY routing aliases", () => {
 });
 
 describe("MEMORY op:search rendered text", () => {
-  it("preserves the complete text of each windowed hit", async () => {
+  it("preserves the complete text of each hit", async () => {
     const { runtime, rows } = makeRuntime();
     const head = "CORRECTION (2026-08-18): the user's earlier claim was ";
     const operative =
@@ -729,7 +773,7 @@ describe("MEMORY op:search rendered text", () => {
     expect(result.promptData).toMatchObject({
       actionName: "MEMORY",
       op: "search",
-      matchedInWindow: 1,
+      totalMatches: 1,
       rendered: 1,
     });
     expect(result.promptData).not.toHaveProperty("memories");

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -47,6 +47,8 @@ interface MemoryParams {
   query?: string;
   memoryId?: string;
   confirm?: boolean;
+  /** @deprecated Accepted for compatibility; complete reads ignore it. */
+  limit?: number;
 }
 
 interface MemoryListItem {
@@ -248,6 +250,7 @@ async function scanCompleteMemoryTable(
   runtime: IAgentRuntime,
   tableName: MemoryType,
   roomId: UUID | undefined,
+  snapshotEnd: number,
 ): Promise<Memory[]> {
   const memories: Memory[] = [];
   const seen = new Set<string>();
@@ -260,6 +263,7 @@ async function scanCompleteMemoryTable(
       roomId,
       tableName,
       limit: COMPLETE_MEMORY_PAGE_SIZE,
+      end: snapshotEnd,
       ...(cursor ? { cursor } : {}),
       orderBy: "createdAt",
       orderDirection: "desc",
@@ -327,16 +331,19 @@ async function readStableCompleteMemoryTable(
   tableName: MemoryType,
   roomId: UUID | undefined,
 ): Promise<Memory[]> {
-  const countParams = {
-    agentId: runtime.agentId as UUID,
-    ...(roomId ? { roomId } : {}),
+  const snapshotEnd = Date.now();
+  const first = await scanCompleteMemoryTable(
+    runtime,
     tableName,
-  };
-  const before = await runtime.countMemories(countParams);
-  const first = await scanCompleteMemoryTable(runtime, tableName, roomId);
-  const between = await runtime.countMemories(countParams);
-  const second = await scanCompleteMemoryTable(runtime, tableName, roomId);
-  const after = await runtime.countMemories(countParams);
+    roomId,
+    snapshotEnd,
+  );
+  const second = await scanCompleteMemoryTable(
+    runtime,
+    tableName,
+    roomId,
+    snapshotEnd,
+  );
   let firstFingerprints: string[];
   let secondFingerprints: string[];
   try {
@@ -350,21 +357,14 @@ async function readStableCompleteMemoryTable(
     });
   }
   if (
-    !Number.isSafeInteger(before) ||
-    before < 0 ||
-    before !== between ||
-    before !== after ||
-    first.length !== before ||
-    second.length !== before ||
+    first.length !== second.length ||
     firstFingerprints.some(
       (fingerprint, index) => fingerprint !== secondFingerprints[index],
     )
   ) {
     throw traversalError("MEMORY_TRAVERSAL_INVENTORY_CHANGED", {
       tableName,
-      before,
-      between,
-      after,
+      snapshotEnd,
       firstLength: first.length,
       secondLength: second.length,
     });
@@ -881,6 +881,13 @@ export const memoryAction: Action = {
         "search/delete: case-insensitive text match against memory content. delete: resolves the memory to remove when memoryId is unknown; scoped to the requesting user's own memories.",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "limit",
+      description:
+        "Deprecated compatibility input. Complete search results are never capped.",
+      required: false,
+      schema: { type: "number" as const },
     },
     {
       name: "memoryId",

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -16,6 +16,7 @@ import type {
 } from "@elizaos/core";
 import {
   MemoryType as CoreMemoryType,
+  ElizaError,
   getRelatedEntityIds,
   logger,
   ModelType,
@@ -43,7 +44,6 @@ interface MemoryParams {
   entityId?: string;
   roomId?: string;
   query?: string;
-  limit?: number;
   memoryId?: string;
   confirm?: boolean;
 }
@@ -93,11 +93,6 @@ function parseUuidParam(
 function normalizeMemoryOp(params: MemoryParams): MemoryOp | undefined {
   const candidate = params.action ?? params.subaction ?? params.op;
   return candidate && MEMORY_OPS.includes(candidate) ? candidate : undefined;
-}
-
-function clampLimit(value: number | undefined, fallback: number): number {
-  if (value == null) return fallback;
-  return Math.max(1, Math.min(200, Math.floor(value)));
 }
 
 function scoreText(text: string, query: string): number {
@@ -207,23 +202,161 @@ interface MemoryCandidate {
   type: MemoryType;
 }
 
-/**
- * A candidate set plus the shape of the window it was read from. The read is
- * always windowed — `perTable` most-recent rows per memory table — and the
- * query/entity filters run in memory over that window, so the surviving count
- * is a count of matches INSIDE the window and never a total.
- *
- * Saturation is MEASURED by reading one row past the window: a table holding
- * exactly `perTable` rows fills it without hiding anything, and is
- * indistinguishable from a truncated one by row count alone. Treating a merely
- * full page as saturated tells the reader older rows went unscanned when none
- * exist — a fabricated scope claim in the sentence meant to prevent them.
- */
 interface CandidateScan {
   matches: MemoryCandidate[];
-  perTable: number;
   tables: readonly MemoryType[];
-  saturatedTables: MemoryType[];
+  scanned: number;
+}
+
+const COMPLETE_MEMORY_PAGE_SIZE = 500;
+
+function traversalError(
+  code: string,
+  context: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(
+    "Memory traversal could not prove a complete snapshot",
+    {
+      code,
+      context,
+    },
+  );
+}
+
+function compareMemoryTuple(left: Memory, right: Memory): number {
+  const leftCreatedAt = left.createdAt;
+  const rightCreatedAt = right.createdAt;
+  if (
+    typeof leftCreatedAt !== "number" ||
+    typeof rightCreatedAt !== "number" ||
+    !Number.isSafeInteger(leftCreatedAt) ||
+    !Number.isSafeInteger(rightCreatedAt)
+  ) {
+    throw traversalError("MEMORY_TRAVERSAL_CURSOR_INVALID", {
+      leftId: left.id,
+      rightId: right.id,
+    });
+  }
+  if (leftCreatedAt !== rightCreatedAt) return rightCreatedAt - leftCreatedAt;
+  return String(right.id)
+    .toLowerCase()
+    .localeCompare(String(left.id).toLowerCase());
+}
+
+async function scanCompleteMemoryTable(
+  runtime: IAgentRuntime,
+  tableName: MemoryType,
+  roomId: UUID | undefined,
+): Promise<Memory[]> {
+  const memories: Memory[] = [];
+  const seen = new Set<string>();
+  let cursor: { createdAt: number; id: UUID } | undefined;
+  let previous: Memory | undefined;
+
+  while (true) {
+    const page = await runtime.getMemories({
+      agentId: runtime.agentId as UUID,
+      roomId,
+      tableName,
+      limit: COMPLETE_MEMORY_PAGE_SIZE,
+      ...(cursor ? { cursor } : {}),
+      orderBy: "createdAt",
+      orderDirection: "desc",
+      includeEmbedding: false,
+    });
+    if (page.length > COMPLETE_MEMORY_PAGE_SIZE) {
+      throw traversalError("MEMORY_TRAVERSAL_PAGE_INVALID", {
+        tableName,
+        pageLength: page.length,
+      });
+    }
+    if (page.length === 0) break;
+
+    for (const memory of page) {
+      const id = validateUuid(memory.id);
+      if (!id || !Number.isSafeInteger(memory.createdAt)) {
+        throw traversalError("MEMORY_TRAVERSAL_CURSOR_INVALID", {
+          tableName,
+          memoryId: memory.id,
+          createdAt: memory.createdAt,
+        });
+      }
+      if (seen.has(id)) {
+        throw traversalError("MEMORY_TRAVERSAL_REPEATED_ROW", {
+          tableName,
+          memoryId: id,
+        });
+      }
+      if (previous && compareMemoryTuple(previous, memory) >= 0) {
+        throw traversalError("MEMORY_TRAVERSAL_ORDER_INVALID", {
+          tableName,
+          previousId: previous.id,
+          memoryId: id,
+        });
+      }
+      seen.add(id);
+      memories.push(memory);
+      previous = memory;
+    }
+
+    if (page.length < COMPLETE_MEMORY_PAGE_SIZE) break;
+    const last = page.at(-1);
+    const lastId = validateUuid(last?.id);
+    if (!last || !lastId || !Number.isSafeInteger(last.createdAt)) {
+      throw traversalError("MEMORY_TRAVERSAL_CURSOR_INVALID", { tableName });
+    }
+    const nextCursor = { createdAt: last.createdAt as number, id: lastId };
+    if (
+      cursor &&
+      cursor.createdAt === nextCursor.createdAt &&
+      cursor.id === nextCursor.id
+    ) {
+      throw traversalError("MEMORY_TRAVERSAL_CURSOR_STALLED", {
+        tableName,
+        cursor,
+      });
+    }
+    cursor = nextCursor;
+  }
+  return memories;
+}
+
+async function readStableCompleteMemoryTable(
+  runtime: IAgentRuntime,
+  tableName: MemoryType,
+  roomId: UUID | undefined,
+): Promise<Memory[]> {
+  const countParams = {
+    agentId: runtime.agentId as UUID,
+    ...(roomId ? { roomId } : {}),
+    tableName,
+  };
+  const before = await runtime.countMemories(countParams);
+  const first = await scanCompleteMemoryTable(runtime, tableName, roomId);
+  const between = await runtime.countMemories(countParams);
+  const second = await scanCompleteMemoryTable(runtime, tableName, roomId);
+  const after = await runtime.countMemories(countParams);
+  const firstIds = first.map((memory) => memory.id);
+  const secondIds = second.map((memory) => memory.id);
+  if (
+    !Number.isSafeInteger(before) ||
+    before < 0 ||
+    before !== between ||
+    before !== after ||
+    first.length !== before ||
+    second.length !== before ||
+    firstIds.some((id, index) => id !== secondIds[index])
+  ) {
+    throw traversalError("MEMORY_TRAVERSAL_INVENTORY_CHANGED", {
+      tableName,
+      before,
+      between,
+      after,
+      firstLength: first.length,
+      secondLength: second.length,
+    });
+  }
+  return second;
 }
 
 const RECALL_TERMINAL_SETTING = "ELIZA_RECALL_SHORT_CIRCUIT";
@@ -249,28 +382,19 @@ async function collectCandidates(
     entityId?: UUID;
     roomId?: UUID;
     query?: string;
-    limit: number;
   },
 ): Promise<CandidateScan> {
   const tables: readonly MemoryType[] = scope.type
     ? [scope.type]
     : MEMORY_TYPES;
-  const perTable = Math.max(scope.limit * 2, 200);
   const collected: MemoryCandidate[] = [];
-  const saturatedTables: MemoryType[] = [];
 
   for (const tableName of tables) {
-    // One row past the window, so "older rows exist" is observed rather than
-    // assumed from a page that happened to fill.
-    const page = await runtime.getMemories({
-      agentId: runtime.agentId as UUID,
-      roomId: scope.roomId,
+    const memories = await readStableCompleteMemoryTable(
+      runtime,
       tableName,
-      limit: perTable + 1,
-    });
-    const overflowed = page.length > perTable;
-    if (overflowed) saturatedTables.push(tableName);
-    const memories = overflowed ? page.slice(0, perTable) : page;
+      scope.roomId,
+    );
     for (const m of memories) collected.push({ memory: m, type: tableName });
   }
 
@@ -300,7 +424,7 @@ async function collectCandidates(
   filtered.sort(
     (a, b) => (b.memory.createdAt ?? 0) - (a.memory.createdAt ?? 0),
   );
-  return { matches: filtered, perTable, tables, saturatedTables };
+  return { matches: filtered, tables, scanned: collected.length };
 }
 
 /** Names every narrowing that was applied, so an empty result can say why. */
@@ -318,21 +442,9 @@ function describeSearchScope(scope: {
   return parts.length > 0 ? parts.join(", ") : "none";
 }
 
-/**
- * The sentence that keeps a windowed count from being read as a total. The
- * scan reads only the most recent `perTable` rows per table, so "0 matches"
- * means "no match in the window", not "nothing is stored" — the difference
- * between answering "what do you remember about my sister" with a fact and
- * with "I have nothing stored about her".
- */
-function describeScanWindow(scan: CandidateScan): string {
-  const base = `Scanned only the ${scan.perTable} most recent row(s) of each table (${scan.tables.join(", ")}) before filtering.`;
-  if (scan.saturatedTables.length === 0) {
-    // "overflowed", not "filled": a table holding exactly `perTable` rows fills
-    // the window and still had every row considered. Only overflow hides rows.
-    return `${base} No table overflowed that window, so every stored row in the scanned tables was considered.`;
-  }
-  return `${base} ${scan.saturatedTables.join(", ")} filled that window, so older rows were NOT scanned and this is a windowed match count, not a total — widen with type, entityId, roomId, or a higher limit (the window is max(limit*2, 200) rows per table).`;
+/** States the complete storage scope proven before applying caller filters. */
+function describeCompleteScan(scan: CandidateScan): string {
+  return `Scanned all ${scan.scanned} stored row(s) across ${scan.tables.join(", ")} before filtering.`;
 }
 
 async function doSearch(
@@ -361,7 +473,6 @@ async function doSearch(
     );
   }
   const query = params.query?.trim();
-  const limit = clampLimit(params.limit, 50);
 
   const scope = {
     type,
@@ -369,12 +480,10 @@ async function doSearch(
     roomId: roomParam.ok ? roomParam.id : undefined,
     query,
   };
-  const scan = await collectCandidates(runtime, { ...scope, limit });
+  const scan = await collectCandidates(runtime, scope);
 
-  const matchedInWindow = scan.matches.length;
-  const items = scan.matches
-    .slice(0, limit)
-    .map((c) => toListItem(c.memory, c.type));
+  const totalMatches = scan.matches.length;
+  const items = scan.matches.map((c) => toListItem(c.memory, c.type));
   // The text projection carries enough of each hit for model reasoning; the
   // complete records remain machine data for state and trajectory consumers.
   const lines = items.map(
@@ -389,13 +498,7 @@ async function doSearch(
       ].join("\n")
     : undefined;
 
-  // Report what was actually rendered, not what was collected: the previous
-  // header claimed up to 50 items while printing 25 lines, and printed the
-  // in-window match count under the label "total".
-  const renderNote =
-    lines.length < matchedInWindow
-      ? `Showing ${lines.length} of ${matchedInWindow} match(es) in the scanned window`
-      : `Showing all ${lines.length} match(es) found in the scanned window`;
+  const renderNote = `Showing all ${lines.length} match(es) found in the complete scan`;
 
   return {
     success: true,
@@ -404,7 +507,7 @@ async function doSearch(
       ...(ignoredIdNotes.length > 0
         ? [`Note: ${ignoredIdNotes.join("; ")}.`]
         : []),
-      describeScanWindow(scan),
+      describeCompleteScan(scan),
       ...lines,
     ].join("\n"),
     ...(userFacingText && recallTerminalEnabled(runtime)
@@ -417,27 +520,22 @@ async function doSearch(
     values: {
       count: items.length,
       rendered: lines.length,
-      matchedInWindow,
-      scanWindowPerTable: scan.perTable,
-      scanWindowSaturated: scan.saturatedTables.length > 0,
+      totalMatches,
+      scanned: scan.scanned,
     },
     data: {
       actionName: "MEMORY",
       op: "search" as const,
       memories: items,
-      matchedInWindow,
-      scanWindowPerTable: scan.perTable,
-      scanWindowSaturatedTables: scan.saturatedTables,
-      limit,
+      totalMatches,
+      scanned: scan.scanned,
     },
     promptData: {
       actionName: "MEMORY",
       op: "search" as const,
-      matchedInWindow,
+      totalMatches,
       rendered: lines.length,
-      scanWindowPerTable: scan.perTable,
-      scanWindowSaturatedTables: scan.saturatedTables,
-      limit,
+      scanned: scan.scanned,
     },
   };
 }
@@ -568,13 +666,11 @@ async function doDeleteByQuery(
   // that carry no entity (internal maintenance invocations).
   const scopeEntityId = message.entityId ?? entityParam.id;
 
-  const limit = clampLimit(params.limit, 50);
   const scan = await collectCandidates(runtime, {
     type,
     entityId: scopeEntityId,
     roomId: roomParam.id,
     query,
-    limit,
   });
 
   // Deletion needs a stronger bar than search ranking: scoreText >= 1 means
@@ -587,7 +683,7 @@ async function doDeleteByQuery(
 
   if (matched.length === 0) {
     return fail(
-      `No stored memory matches "${query}". ${describeScanWindow(scan)}`,
+      `No stored memory matches "${query}". ${describeCompleteScan(scan)}`,
       "MEMORY_NOT_FOUND",
     );
   }
@@ -703,7 +799,12 @@ export const memoryAction: Action = {
       return {
         success: false,
         text: `Failed to ${op} memory: ${msg}`,
-        data: { error: `MEMORY_${op.toUpperCase()}_FAILED` },
+        data: {
+          error:
+            err instanceof ElizaError
+              ? err.code
+              : `MEMORY_${op.toUpperCase()}_FAILED`,
+        },
       };
     }
   },
@@ -769,12 +870,6 @@ export const memoryAction: Action = {
       schema: { type: "string" as const },
     },
     {
-      name: "limit",
-      description: "search: maximum results to return (1-200).",
-      required: false,
-      schema: { type: "number" as const },
-    },
-    {
       name: "memoryId",
       description:
         "update/delete: id of the memory to mutate. delete: optional when query is provided.",
@@ -808,7 +903,7 @@ export const memoryAction: Action = {
       {
         name: "{{agentName}}",
         content: {
-          text: "Showing N of M match(es) in the scanned window...",
+          text: "Showing all N match(es) found in the complete scan...",
           action: "MEMORY",
         },
       },

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -20,6 +20,7 @@ import {
   getRelatedEntityIds,
   logger,
   ModelType,
+  stableStringify,
   toWellFormedUnicode,
   validateUuid,
 } from "@elizaos/core";
@@ -336,8 +337,18 @@ async function readStableCompleteMemoryTable(
   const between = await runtime.countMemories(countParams);
   const second = await scanCompleteMemoryTable(runtime, tableName, roomId);
   const after = await runtime.countMemories(countParams);
-  const firstIds = first.map((memory) => memory.id);
-  const secondIds = second.map((memory) => memory.id);
+  let firstFingerprints: string[];
+  let secondFingerprints: string[];
+  try {
+    firstFingerprints = first.map((memory) => stableStringify(memory));
+    secondFingerprints = second.map((memory) => stableStringify(memory));
+  } catch (cause) {
+    throw new ElizaError("Memory row cannot be fingerprinted", {
+      code: "MEMORY_TRAVERSAL_FINGERPRINT_FAILED",
+      context: { tableName },
+      cause,
+    });
+  }
   if (
     !Number.isSafeInteger(before) ||
     before < 0 ||
@@ -345,7 +356,9 @@ async function readStableCompleteMemoryTable(
     before !== after ||
     first.length !== before ||
     second.length !== before ||
-    firstIds.some((id, index) => id !== secondIds[index])
+    firstFingerprints.some(
+      (fingerprint, index) => fingerprint !== secondFingerprints[index],
+    )
   ) {
     throw traversalError("MEMORY_TRAVERSAL_INVENTORY_CHANGED", {
       tableName,

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -172,6 +172,9 @@ visible.
 - Device-class inference budgets reject unsupported model-output requests before
   dispatch. They may bound queue wait as a resource policy, but must never lower
   `maxTokens` and pass a partial generation off as the requested result.
+- Document keyword, vector, and hybrid searches traverse every authorized
+  fragment page before ranking. Fragment-query limits are storage batch sizes,
+  never recall caps; a repeated page rejects instead of returning a prefix.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
 - Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated read exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Only the dedicated adapter CAS may replace grants: OWNER on any valid document, or a current room ADMIN on global and user-private documents, with every grantee validated in the current agent tenant. Malformed or duplicate grant arrays make the parent unreadable.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -172,6 +172,9 @@ visible.
 - Device-class inference budgets reject unsupported model-output requests before
   dispatch. They may bound queue wait as a resource policy, but must never lower
   `maxTokens` and pass a partial generation off as the requested result.
+- Document keyword, vector, and hybrid searches traverse every authorized
+  fragment page before ranking. Fragment-query limits are storage batch sizes,
+  never recall caps; a repeated page rejects instead of returning a prefix.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
 - Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated read exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Only the dedicated adapter CAS may replace grants: OWNER on any valid document, or a current room ADMIN on global and user-private documents, with every grantee validated in the current agent tenant. Malformed or duplicate grant arrays make the parent unreadable.

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -82,6 +82,25 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/core/src/features/documents/service.ts": [
 		/limit:\s*(?:20|40|1_000)[,\n]/,
 	],
+	"packages/agent/src/actions/files.ts": [
+		/clampLimit/,
+		/filtered\.slice\(0,\s*limit\)/,
+	],
+	"packages/agent/src/actions/knowledge.ts": [
+		/DOCUMENT_SCAN_MAX/,
+		/\.slice\(0,\s*limit\)/,
+	],
+	"packages/agent/src/actions/memories.ts": [
+		/clampLimit/,
+		/scanWindowSaturated/,
+	],
+	"packages/core/src/features/documents/service.ts": [
+		/queryDocumentFragments\([\s\S]{0,360}limit:\s*(?:20|40|1_000)/,
+	],
+	"packages/core/src/features/documents/actions.ts": [
+		/filteredMatches\.slice\(/,
+		/unknown_beyond_ranked_window/,
+	],
 	"packages/core/src/runtime/planner-loop.ts": [
 		/maybeCompactPlannerTrajectory/,
 		/CONTEXT_COMPACTION/,

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -81,6 +81,7 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	],
 	"packages/core/src/features/documents/service.ts": [
 		/limit:\s*(?:20|40|1_000)[,\n]/,
+		/queryDocumentFragments\([\s\S]{0,360}limit:\s*(?:20|40|1_000)/,
 	],
 	"packages/agent/src/actions/files.ts": [
 		/clampLimit/,
@@ -93,9 +94,6 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/agent/src/actions/memories.ts": [
 		/clampLimit/,
 		/scanWindowSaturated/,
-	],
-	"packages/core/src/features/documents/service.ts": [
-		/queryDocumentFragments\([\s\S]{0,360}limit:\s*(?:20|40|1_000)/,
 	],
 	"packages/core/src/features/documents/actions.ts": [
 		/filteredMatches\.slice\(/,

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -412,6 +412,40 @@ describe("document-list capability contract", () => {
 		expect(result.map((memory) => memory.id)).toEqual([firstFragments[1]?.id]);
 	});
 
+	it("fences fragment queries at the requested snapshot time", () => {
+		const parent = document(5);
+		const older = {
+			...document(7),
+			createdAt: 2_000,
+			metadata: {
+				type: MemoryType.FRAGMENT,
+				documentId: parent.id,
+				documentRevision: 0,
+				position: 0,
+			},
+		};
+		const newer = {
+			...document(8),
+			createdAt: 4_000,
+			metadata: {
+				type: MemoryType.FRAGMENT,
+				documentId: parent.id,
+				documentRevision: 0,
+				position: 1,
+			},
+		};
+
+		const result = queryDocumentFragmentsInMemory([parent, older, newer], {
+			...params,
+			requesterRole: "OWNER",
+			documentId: parent.id,
+			limit: 10,
+			snapshotEnd: 3_000,
+		});
+
+		expect(result.map((memory) => memory.id)).toEqual([older.id]);
+	});
+
 	it("uses locale-independent tokens that preserve punctuation and Unicode", () => {
 		expect(
 			portableDocumentSearchTokens(

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -767,6 +767,15 @@ export function validateDocumentFragmentQueryParams(
 			},
 		);
 	}
+	if (
+		params.snapshotEnd !== undefined &&
+		(!Number.isSafeInteger(params.snapshotEnd) || params.snapshotEnd < 0)
+	) {
+		throw new ElizaError("Document fragment snapshot end is invalid", {
+			code: "DOCUMENT_FRAGMENT_QUERY_INVALID",
+			context: { snapshotEnd: params.snapshotEnd },
+		});
+	}
 	if (params.documentId !== undefined && !isUuid(params.documentId)) {
 		throw new ElizaError("Document fragment parent id is invalid", {
 			code: "DOCUMENT_FRAGMENT_QUERY_INVALID",
@@ -1007,6 +1016,13 @@ export function queryDocumentFragmentsInMemory(
 			if (
 				memory.agentId !== params.agentId ||
 				memory.metadata?.type !== MemoryType.FRAGMENT
+			) {
+				return false;
+			}
+			if (
+				params.snapshotEnd !== undefined &&
+				(typeof memory.createdAt !== "number" ||
+					memory.createdAt > params.snapshotEnd)
 			) {
 				return false;
 			}

--- a/packages/core/src/features/documents/__tests__/actions-echo.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-echo.test.ts
@@ -129,7 +129,7 @@ describe("DOCUMENT search/list echo clamping", () => {
 		expect(res.text).toContain(
 			"No document fragments matching that search were returned",
 		);
-		expect(res.text).toContain("completeness beyond that window is unknown");
+		expect(res.text).toContain("Searched all 0 authorized fragment(s)");
 		const query = (res.data as { query: string }).query;
 		expect(query).not.toContain("\n");
 		expect(query.length).toBeLessThanOrEqual(121);
@@ -186,7 +186,7 @@ describe("DOCUMENT search/list echo clamping", () => {
 		expect(res.text).not.toContain("whole store");
 	});
 
-	it("reports overflow only within the bounded retrieved window", async () => {
+	it("ignores a legacy result limit and returns every authorized match", async () => {
 		const service = makeService();
 		service.searchDocuments.mockResolvedValueOnce(
 			Array.from({ length: 3 }, (_, index) => ({
@@ -209,15 +209,13 @@ describe("DOCUMENT search/list echo clamping", () => {
 		const scope = (res.data as { scope: Record<string, unknown> }).scope;
 		expect(scope).toMatchObject({
 			retrieved: 3,
-			matchedInWindow: 3,
-			shown: 2,
-			limit: 2,
-			hasMoreInWindow: true,
-			retrievalCompleteness: "unknown_beyond_ranked_window",
+			matched: 3,
+			shown: 3,
+			retrievalCompleteness: "complete_authorized_matches",
 			filtersApplied: ["tags"],
 		});
-		expect(res.text).toContain("More filtered matches exist within");
-		expect(res.text).toContain("completeness beyond that window is unknown");
+		expect(res.text).toContain("fragment 2");
+		expect(res.text).toContain("Searched all 3 authorized fragment(s)");
 	});
 
 	it("projects transcript anchors and a document reference without inventing readable fragment coordinates", async () => {

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -137,14 +137,18 @@ function buildRuntime(opts: { hasEmbedding: boolean; fragments?: Memory[] }) {
 			requesterEntityId: UUID;
 			limit: number;
 			offset?: number;
+			snapshotEnd?: number;
 		}) => {
 			const visible = fragments.filter((fragment) => {
 				const metadata = fragment.metadata as
 					| Record<string, unknown>
 					| undefined;
 				return (
-					metadata?.scope !== "user-private" ||
-					metadata.scopedToEntityId === params.requesterEntityId
+					(params.snapshotEnd === undefined ||
+						(typeof fragment.createdAt === "number" &&
+							fragment.createdAt <= params.snapshotEnd)) &&
+					(metadata?.scope !== "user-private" ||
+						metadata.scopedToEntityId === params.requesterEntityId)
 				);
 			});
 			const offset = params.offset ?? 0;
@@ -300,7 +304,38 @@ describe("DocumentService.searchDocuments", () => {
 			expect(new Set(results.map((result) => result.id)).size).toBe(
 				fragments.length,
 			);
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(6);
+		});
+
+		it("ignores newer appends outside the complete traversal snapshot", async () => {
+			const fragments = Array.from({ length: 20 }, (_, index) =>
+				makeFragment(`frag-${index}`, `complete corpus match ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			const query = rt.adapter.queryDocumentFragments.getMockImplementation();
+			let call = 0;
+			rt.adapter.queryDocumentFragments.mockImplementation(async (params) => {
+				const rows = await query?.(params);
+				if (++call === 1) {
+					const appended = makeFragment(
+						"frag-inserted",
+						"new complete corpus match",
+					);
+					appended.createdAt = (params.snapshotEnd ?? Date.now()) + 1;
+					fragments.push(appended);
+				}
+				return rows ?? [];
+			});
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("complete corpus match"),
+				undefined,
+				"keyword",
+			);
+
+			expect(results).toHaveLength(20);
+			expect(results.map((result) => result.id)).not.toContain("frag-inserted");
 		});
 
 		it("rejects a non-advancing fragment adapter instead of ranking a prefix", async () => {
@@ -320,7 +355,7 @@ describe("DocumentService.searchDocuments", () => {
 					"keyword",
 				),
 			).rejects.toMatchObject({
-				code: "DOCUMENT_FRAGMENT_TRAVERSAL_NON_ADVANCING",
+				code: "DOCUMENT_SEARCH_PAGINATION_STALLED",
 			});
 		});
 

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -283,6 +283,47 @@ describe("DocumentService.searchDocuments", () => {
 	});
 
 	describe("keyword-only mode", () => {
+		it("traverses and ranks every fragment beyond one storage page", async () => {
+			const fragments = Array.from({ length: 1_205 }, (_, index) =>
+				makeFragment(`frag-${index}`, `complete corpus match ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("complete corpus match"),
+				undefined,
+				"keyword",
+			);
+
+			expect(results).toHaveLength(fragments.length);
+			expect(new Set(results.map((result) => result.id)).size).toBe(
+				fragments.length,
+			);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
+		});
+
+		it("rejects a non-advancing fragment adapter instead of ranking a prefix", async () => {
+			const fragments = Array.from({ length: 1_000 }, (_, index) =>
+				makeFragment(`frag-${index}`, `complete match ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			rt.adapter.queryDocumentFragments.mockImplementation(
+				async () => fragments,
+			);
+			const svc = buildService(rt);
+
+			await expect(
+				svc.searchDocuments(
+					makeMessage("complete match"),
+					undefined,
+					"keyword",
+				),
+			).rejects.toMatchObject({
+				code: "DOCUMENT_FRAGMENT_TRAVERSAL_NON_ADVANCING",
+			});
+		});
+
 		it("uses the authorized fragment query and scores via BM25", async () => {
 			const fragments = [
 				makeFragment("frag-a", "quantum computing and qubits"),

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -684,13 +684,10 @@ async function handleSearch(
 			: undefined,
 		getSearchMode(params.searchMode),
 	);
-	const limit = getLimit(params.limit, Number.MAX_SAFE_INTEGER);
 	const filteredMatches = matches.filter((item) =>
 		storedDocumentMatchesFilters(item, filters),
 	);
-	const hasMoreInWindow = filteredMatches.length > limit;
-	const visible = filteredMatches.slice(0, limit);
-	const projected = visible.map((item) => {
+	const projected = filteredMatches.map((item) => {
 		const metadata = item.metadata as Record<string, unknown> | undefined;
 		return {
 			...item,
@@ -714,18 +711,14 @@ async function handleSearch(
 		startMs: item.startMs,
 		endMs: item.endMs,
 	}));
-	const retrievalScope = `Searched a bounded ranked retrieval window of ${matches.length} fragment(s); completeness beyond that window is unknown.`;
+	const retrievalScope = `Searched all ${matches.length} authorized fragment(s).`;
 	const text = `${
 		projected.length === 0
 			? `No document fragments matching ${describeQuery(query)} were returned from that window.`
 			: `Found ${projected.length} document fragment(s) for ${describeQuery(query)}:\n\n${projected
 					.map((item, index) => `${index + 1}. ${item.content.text ?? ""}`)
 					.join("\n\n")}`
-	} ${retrievalScope}${
-		hasMoreInWindow
-			? ` More filtered matches exist within the retrieved window beyond the ${limit} shown.`
-			: ""
-	}`;
+	} ${retrievalScope}`;
 	const filtersApplied = [
 		filters.scope ? "scope" : undefined,
 		filters.scopedToEntityId ? "scopedToEntityId" : undefined,
@@ -742,11 +735,9 @@ async function handleSearch(
 			results: projectedData,
 			scope: {
 				retrieved: matches.length,
-				matchedInWindow: filteredMatches.length,
+				matched: filteredMatches.length,
 				shown: projected.length,
-				limit,
-				hasMoreInWindow,
-				retrievalCompleteness: "unknown_beyond_ranked_window",
+				retrievalCompleteness: "complete_authorized_matches",
 				filtersApplied,
 			},
 		},
@@ -755,11 +746,9 @@ async function handleSearch(
 			results: projectedData,
 			scope: {
 				retrieved: matches.length,
-				matchedInWindow: filteredMatches.length,
+				matched: filteredMatches.length,
 				shown: projected.length,
-				limit,
-				hasMoreInWindow,
-				retrievalCompleteness: "unknown_beyond_ranked_window",
+				retrievalCompleteness: "complete_authorized_matches",
 				filtersApplied,
 			},
 		},

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -131,7 +131,6 @@ const DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction> = {
 		descriptionCompressed: "search document fragments by query",
 		required: ["query"],
 		optional: [
-			"limit",
 			"searchMode",
 			"scope",
 			"scopedToEntityId",
@@ -714,7 +713,7 @@ async function handleSearch(
 	const retrievalScope = `Searched all ${matches.length} authorized fragment(s).`;
 	const text = `${
 		projected.length === 0
-			? `No document fragments matching ${describeQuery(query)} were returned from that window.`
+			? `No document fragments matching ${describeQuery(query)} were returned from the complete authorized corpus.`
 			: `Found ${projected.length} document fragment(s) for ${describeQuery(query)}:\n\n${projected
 					.map((item, index) => `${index + 1}. ${item.content.text ?? ""}`)
 					.join("\n\n")}`
@@ -1536,7 +1535,7 @@ export const documentAction: Action = {
 		{
 			name: "limit",
 			description:
-				"Maximum number of results or listed documents (1-100). Use 0 when this field is not applicable to the selected action.",
+				"Explicit page size for list/read only (1-100). Search always returns every authorized match and ignores this field.",
 			required: false,
 			schema: { type: "number", minimum: 0, maximum: 100 },
 		},

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -2194,6 +2194,55 @@ export class DocumentService extends Service {
 			.sort((a, b) => b.similarity - a.similarity) as StoredDocument[];
 	}
 
+	/**
+	 * Traverse the authorized fragment query in storage-sized pages. `limit` is
+	 * deliberately internal: every matching fragment is reassembled before any
+	 * search mode ranks it, and a repeated row or non-advancing adapter rejects
+	 * instead of returning a complete-looking prefix.
+	 */
+	private async queryAllDocumentFragments(
+		params: Omit<DocumentFragmentQueryParams, "limit" | "offset">,
+	): Promise<Memory[]> {
+		const pageSize = 1_000;
+		const fragments: Memory[] = [];
+		const seen = new Set<string>();
+		let offset = 0;
+		while (true) {
+			const page = await this.runtime.adapter.queryDocumentFragments({
+				...params,
+				limit: pageSize,
+				offset,
+			});
+			if (page.length > pageSize) {
+				throw new ElizaError("Document fragment page exceeded its request", {
+					code: "DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_INVALID",
+					context: { offset, pageLength: page.length, pageSize },
+				});
+			}
+			if (page.length === 0) break;
+			for (const fragment of page) {
+				// Malformed legacy fragments without an identity are not searchable and
+				// were already excluded by every search mode. They still advance the
+				// storage offset, so retaining that compatibility cannot stall paging.
+				if (!fragment.id) continue;
+				if (seen.has(fragment.id)) {
+					throw new ElizaError(
+						"Document fragment traversal repeated an identity",
+						{
+							code: "DOCUMENT_FRAGMENT_TRAVERSAL_NON_ADVANCING",
+							context: { offset, fragmentId: fragment.id },
+						},
+					);
+				}
+				seen.add(fragment.id);
+				fragments.push(fragment);
+			}
+			if (page.length < pageSize) break;
+			offset += page.length;
+		}
+		return fragments;
+	}
+
 	async enrichConversationMemoryWithRAG(
 		memoryId: UUID,
 		ragMetadata: {

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1998,8 +1998,11 @@ export class DocumentService extends Service {
 	private async queryCompleteDocumentFragments(
 		params: Omit<DocumentFragmentQueryParams, "limit" | "offset">,
 	): Promise<Memory[]> {
-		const first = await this.scanDocumentFragments(params);
-		const verified = await this.scanDocumentFragments(params);
+		// Exclude ordinary concurrent appends from both verification passes while
+		// still detecting updates, deletes, and backdated inserts in the snapshot.
+		const snapshotParams = { ...params, snapshotEnd: Date.now() };
+		const first = await this.scanDocumentFragments(snapshotParams);
+		const verified = await this.scanDocumentFragments(snapshotParams);
 		if (JSON.stringify(first) !== JSON.stringify(verified)) {
 			throw new ElizaError(
 				"Document fragment source changed during traversal",
@@ -2099,7 +2102,7 @@ export class DocumentService extends Service {
 	}
 
 	/**
-	 * Hybrid search: vector top-K re-ranked with BM25, combined as
+	 * Hybrid search: complete vector and keyword candidate sets re-ranked with BM25, combined as
 	 *   score = 0.6 * normalised_vector + 0.4 * normalised_bm25
 	 */
 	private async _hybridSearch(
@@ -2192,55 +2195,6 @@ export class DocumentService extends Service {
 				};
 			})
 			.sort((a, b) => b.similarity - a.similarity) as StoredDocument[];
-	}
-
-	/**
-	 * Traverse the authorized fragment query in storage-sized pages. `limit` is
-	 * deliberately internal: every matching fragment is reassembled before any
-	 * search mode ranks it, and a repeated row or non-advancing adapter rejects
-	 * instead of returning a complete-looking prefix.
-	 */
-	private async queryAllDocumentFragments(
-		params: Omit<DocumentFragmentQueryParams, "limit" | "offset">,
-	): Promise<Memory[]> {
-		const pageSize = 1_000;
-		const fragments: Memory[] = [];
-		const seen = new Set<string>();
-		let offset = 0;
-		while (true) {
-			const page = await this.runtime.adapter.queryDocumentFragments({
-				...params,
-				limit: pageSize,
-				offset,
-			});
-			if (page.length > pageSize) {
-				throw new ElizaError("Document fragment page exceeded its request", {
-					code: "DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_INVALID",
-					context: { offset, pageLength: page.length, pageSize },
-				});
-			}
-			if (page.length === 0) break;
-			for (const fragment of page) {
-				// Malformed legacy fragments without an identity are not searchable and
-				// were already excluded by every search mode. They still advance the
-				// storage offset, so retaining that compatibility cannot stall paging.
-				if (!fragment.id) continue;
-				if (seen.has(fragment.id)) {
-					throw new ElizaError(
-						"Document fragment traversal repeated an identity",
-						{
-							code: "DOCUMENT_FRAGMENT_TRAVERSAL_NON_ADVANCING",
-							context: { offset, fragmentId: fragment.id },
-						},
-					);
-				}
-				seen.add(fragment.id);
-				fragments.push(fragment);
-			}
-			if (page.length < pageSize) break;
-			offset += page.length;
-		}
-		return fragments;
 	}
 
 	async enrichConversationMemoryWithRAG(

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -138,6 +138,8 @@ export interface DocumentRangeReadResult {
 export interface DocumentFragmentQueryParams extends DocumentRequesterContext {
 	limit: number;
 	offset?: number;
+	/** Inclusive creation-time fence shared by every page of one snapshot read. */
+	snapshotEnd?: number;
 	documentId?: UUID;
 	roomId?: UUID;
 	worldId?: UUID;

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2468,6 +2468,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       if (params.worldId) conditions.push(eq(parent.worldId, params.worldId));
       if (params.entityId) conditions.push(eq(parent.entityId, params.entityId));
       if (params.documentId) conditions.push(eq(parent.id, params.documentId));
+      if (params.snapshotEnd !== undefined) {
+        conditions.push(lte(fragment.createdAt, new Date(params.snapshotEnd)));
+      }
 
       const parentJoin = sql`${parent.id}::text = ${fragment.metadata}->>'documentId'`;
       if (!params.embedding) {


### PR DESCRIPTION
## Summary
- remove FILES, KNOWLEDGE, MEMORY, and DOCUMENT search result caps from model-facing action output
- traverse storage in internal pages while returning the complete authorized result set
- fence and verify repeated snapshot reads, rejecting typed errors when completeness cannot be proven
- preserve explicit, revision-bound pagination only for DOCUMENT list/read
- add prompt-integrity guards that prevent the removed caps and window semantics from returning

## Why this supersedes #24735
The prior attempt was closed because it materialized whole corpora without a stable-read proof or a final provider boundary. This version:
1. excludes ordinary concurrent appends with a shared snapshot fence;
2. verifies the complete snapshot twice and rejects mutations/non-advancing adapters;
3. relies on #26373 for exact final-wire provider admission, so an unsupported request is rejected before dispatch rather than silently shortened.

Internal page sizes are transport mechanics only and are never exposed as complete model context.

Closes #24688

## Validation
- `bunx vitest run packages/agent/src/actions/files.test.ts packages/agent/src/actions/knowledge.test.ts packages/agent/src/actions/memories.test.ts packages/core/src/database/document-list-query.test.ts packages/core/src/features/documents/__tests__/actions-echo.test.ts packages/core/src/features/documents/__tests__/search.test.ts packages/core/src/__tests__/prompt-integrity-policy.test.ts` — 128 passed
- `bun run --cwd packages/core typecheck` — passed
- changed-file Biome — passed (15 source/test files)
- `bun run check:agents-claude` — passed (161 pairs)
- `git diff --check` — passed
- agent package typecheck is blocked on current-develop optional plugin modules and the diagnostic fixture repaired by #26591; no changed action path reports a TypeScript error
- plugin-sql package typecheck is blocked by the current workspace's unresolved `@elizaos/core` build plus cascading pre-existing errors; the changed adapter path is exercised by the focused core contract tests

## Evidence
- UI screenshots/video: N/A — no rendered UI change
- Native/device evidence: N/A — no native path change
- Live-model trajectory: pending exact-head CI/review; deterministic action output, completeness, concurrent append, mutation rejection, and adapter fence behavior are covered above
