### PR TITLE
test(core): cover db

### DIFF
--- a/packages/core/src/features/trust/services/db.test.ts
+++ b/packages/core/src/features/trust/services/db.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit coverage for the trust capability's database-handle resolution. The
+ * real `getDb` executes against minimal deterministic runtime fixtures —
+ * no database adapter, network, clock, or mocked module is involved.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import { getDb } from "./db.ts";
+
+function runtimeWithDb(db: unknown): IAgentRuntime {
+	return { db } as unknown as IAgentRuntime;
+}
+
+describe("getDb", () => {
+	it("returns the runtime's attached db handle unchanged", () => {
+		const db = { select: () => {}, insert: () => {} };
+		expect(getDb(runtimeWithDb(db))).toBe(db);
+	});
+
+	it("resolves without touching the handle and forwards calls to it", () => {
+		const select = vi.fn(() => ({ from: () => "row" }));
+		const db = { select };
+		const resolved = getDb(runtimeWithDb(db));
+		expect(select).not.toHaveBeenCalled();
+		expect(resolved).toBe(db);
+		expect(resolved.select("id")?.from()).toBe("row");
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(select).toHaveBeenCalledWith("id");
+	});
+
+	it("throws when the runtime has no db property", () => {
+		const runtime = {} as IAgentRuntime;
+		expect(() => getDb(runtime)).toThrow("[trust] Database not available");
+	});
+
+	it("throws when the runtime db is undefined", () => {
+		expect(() => getDb(runtimeWithDb(undefined))).toThrow(
+			"[trust] Database not available",
+		);
+	});
+
+	it("treats every falsy db value as unavailable", () => {
+		for (const falsy of [null, 0, "", false]) {
+			expect(() => getDb(runtimeWithDb(falsy))).toThrow(
+				"[trust] Database not available",
+			);
+		}
+	});
+
+	it("passes through any truthy handle without validating its shape", () => {
+		const primitiveHandle = "drizzle-handle";
+		expect(getDb(runtimeWithDb(primitiveHandle))).toBe(primitiveHandle);
+	});
+
+	it("throws a plain Error whose message names the trust subsystem", () => {
+		let caught: unknown;
+		try {
+			getDb({} as IAgentRuntime);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(Error);
+		expect((caught as Error).message).toBe("[trust] Database not available");
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/trust/services/db.test.ts` — a new unit suite for the trust capability's database-handle resolver (`getDb` in `packages/core/src/features/trust/services/db.ts`). This module had no same-named test file anywhere on `origin/develop` at filing time (verified via `git ls-tree -r origin/develop`). The diff is one new file, +66/-0; no existing file is touched or deleted.

## Coverage

All cases drive the real `getDb` — no mock stands in for the module under test:

- returns the runtime's attached `db` handle unchanged (`toBe` identity)
- resolves without touching the handle, and forwards chainable query-builder calls to it
- throws when the runtime has no `db` property at all
- throws when `db` is explicitly `undefined`
- treats every falsy value (`null`, `0`, `""`, `false`) as unavailable (table-driven)
- passes through any truthy handle without shape validation (documents availability-check-only semantics)
- throws a plain `Error` whose message is exactly `[trust] Database not available`

## Evidence (local runs; hosted CI does not run on fork PRs)

- `bunx vitest run src/features/trust/services/db.test.ts` (in `packages/core`, real config): **1 file passed, 7 tests passed, 0 failed** — re-run against current `origin/develop` immediately before filing, same result.
- `bunx biome check --write packages/core/src/features/trust/services/db.test.ts`: clean — "Checked 1 file … No fixes applied" (`biome.json` present; worktree confirmed not sparse).
- `bunx tsc --noEmit` in `packages/core`: zero occurrences of `db.test` in output.
- The suite uses no `vi.hoisted`, no `expectTypeOf`, and asserts observed behaviour only.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3ce83cea6ceb16b76a8b59e8a3893df9bee81e28 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
