### PR TITLE
fix(core): restore static smoke formatting

### DIFF
--- a/packages/core/src/messaging/interactions/callback.test.ts
+++ b/packages/core/src/messaging/interactions/callback.test.ts
@@ -4,71 +4,71 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  MAX_CALLBACK_BYTES,
-  decodeCallback,
-  encodeReplyCallback,
-  isInteractionCallback,
+	decodeCallback,
+	encodeReplyCallback,
+	isInteractionCallback,
+	MAX_CALLBACK_BYTES,
 } from "./callback.js";
 
 describe("encodeReplyCallback", () => {
-  it("encodes within limit", () => {
-    const out = encodeReplyCallback("yes");
-    expect(out).toBe("ia1:yes");
-  });
+	it("encodes within limit", () => {
+		const out = encodeReplyCallback("yes");
+		expect(out).toBe("ia1:yes");
+	});
 
-  it("returns null when exceeds limit", () => {
-    const long = "a".repeat(100);
-    expect(encodeReplyCallback(long, { maxBytes: 10 })).toBeNull();
-  });
+	it("returns null when exceeds limit", () => {
+		const long = "a".repeat(100);
+		expect(encodeReplyCallback(long, { maxBytes: 10 })).toBeNull();
+	});
 
-  it("respects custom maxBytes", () => {
-    expect(encodeReplyCallback("hi", { maxBytes: 10 })).toBe("ia1:hi");
-    expect(encodeReplyCallback("hi", { maxBytes: 4 })).toBeNull();
-  });
+	it("respects custom maxBytes", () => {
+		expect(encodeReplyCallback("hi", { maxBytes: 10 })).toBe("ia1:hi");
+		expect(encodeReplyCallback("hi", { maxBytes: 4 })).toBeNull();
+	});
 
-  it("handles empty value", () => {
-    expect(encodeReplyCallback("")).toBe("ia1:");
-  });
+	it("handles empty value", () => {
+		expect(encodeReplyCallback("")).toBe("ia1:");
+	});
 
-  it("handles unicode byte length", () => {
-    const emoji = "\u{1F600}";
-    const out = encodeReplyCallback(emoji, { maxBytes: 64 });
-    expect(typeof out).toBe("string");
-  });
+	it("handles unicode byte length", () => {
+		const emoji = "\u{1F600}";
+		const out = encodeReplyCallback(emoji, { maxBytes: 64 });
+		expect(typeof out).toBe("string");
+	});
 });
 
 describe("isInteractionCallback", () => {
-  it("true for encoded payload", () => {
-    expect(isInteractionCallback("ia1:yes")).toBe(true);
-  });
+	it("true for encoded payload", () => {
+		expect(isInteractionCallback("ia1:yes")).toBe(true);
+	});
 
-  it("false for other strings", () => {
-    expect(isInteractionCallback("other:yes")).toBe(false);
-    expect(isInteractionCallback("")).toBe(false);
-  });
+	it("false for other strings", () => {
+		expect(isInteractionCallback("other:yes")).toBe(false);
+		expect(isInteractionCallback("")).toBe(false);
+	});
 
-  it("false for non-strings", () => {
-    expect(isInteractionCallback(null)).toBe(false);
-    expect(isInteractionCallback(42 as unknown as string)).toBe(false);
-  });
+	it("false for non-strings", () => {
+		expect(isInteractionCallback(null)).toBe(false);
+		expect(isInteractionCallback(42 as unknown as string)).toBe(false);
+	});
 });
 
 describe("decodeCallback", () => {
-  it("decodes valid callback", () => {
-    const encoded = encodeReplyCallback("hello") as string;
-    const decoded = decodeCallback(encoded);
-    expect(decoded?.value).toBe("hello");
-    expect(decoded?.kind).toBe("reply");
-  });
+	it("decodes valid callback", () => {
+		const encoded = encodeReplyCallback("hello") as string;
+		const decoded = decodeCallback(encoded);
+		expect(decoded?.value).toBe("hello");
+		expect(decoded?.kind).toBe("reply");
+	});
 
-  it("returns null for invalid", () => {
-    expect(decodeCallback("bad")).toBeNull();
-    expect(decodeCallback(null as unknown as string)).toBeNull();
-  });
+	it("returns null for invalid", () => {
+		expect(decodeCallback("bad")).toBeNull();
+		expect(decodeCallback(null as unknown as string)).toBeNull();
+	});
 });
 
 describe("MAX_CALLBACK_BYTES", () => {
-  it("is 64", () => {
-    expect(MAX_CALLBACK_BYTES).toBe(64);
-  });
+	it("is 64", () => {
+		expect(MAX_CALLBACK_BYTES).toBe(64);
+	});
 });

--- a/packages/core/src/messaging/interactions/parse.surrogate.test.ts
+++ b/packages/core/src/messaging/interactions/parse.surrogate.test.ts
@@ -4,66 +4,79 @@
  * bun:test, which cannot resolve in that harness.
  */
 import { describe, expect, it } from "vitest";
-
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../utils/well-formed.ts";
 import { findInteractionRegions, MAX_TASK_TITLE_LEN } from "./parse.ts";
-import { toWellFormedUnicode, truncateWellFormed } from "../../utils/well-formed.ts";
 
 describe("parse surrogate-safe task title truncation", () => {
-  it("raw slice at max-1 splits a surrogate pair, truncateWellFormed does not", () => {
-    // MAX_TASK_TITLE_LEN = 200, truncation cut is at 199 code units.
-    // Build a title where the 199th code unit is a high surrogate.
-    // "a".repeat(198) occupies 198, then 𝄞 (U+1D11E) occupies 2 units (D834 DD1E).
-    const boundaryTitle = "a".repeat(MAX_TASK_TITLE_LEN - 2) + "𝄞" + "b".repeat(50);
-    expect(boundaryTitle.length).toBeGreaterThan(MAX_TASK_TITLE_LEN);
+	it("raw slice at max-1 splits a surrogate pair, truncateWellFormed does not", () => {
+		// MAX_TASK_TITLE_LEN = 200, truncation cut is at 199 code units.
+		// Build a title where the 199th code unit is a high surrogate.
+		// "a".repeat(198) occupies 198, then 𝄞 (U+1D11E) occupies 2 units (D834 DD1E).
+		const boundaryTitle =
+			"a".repeat(MAX_TASK_TITLE_LEN - 2) + "𝄞" + "b".repeat(50);
+		expect(boundaryTitle.length).toBeGreaterThan(MAX_TASK_TITLE_LEN);
 
-    const rawCut = boundaryTitle.slice(0, MAX_TASK_TITLE_LEN - 1);
-    // Raw slice lands on the lead half of the surrogate pair.
-    expect(rawCut.length).toBe(MAX_TASK_TITLE_LEN - 1);
-    // Must be lone surrogate -> not well-formed.
-    expect((rawCut as unknown as { isWellFormed?: () => boolean }).isWellFormed?.call(rawCut) ?? (() => {
-      // Fallback when engine lacks isWellFormed: check lone surrogate directly
-      const last = rawCut.charCodeAt(rawCut.length - 1);
-      return !(last >= 0xd800 && last <= 0xdbff);
-    })()).toBe(false);
-    // Also verify via JSON lone-surrogate signal: JSON.stringify emits \ud834 escape for lone high surrogate
-    expect(rawCut.charCodeAt(rawCut.length - 1)).toBe(0xd834);
+		const rawCut = boundaryTitle.slice(0, MAX_TASK_TITLE_LEN - 1);
+		// Raw slice lands on the lead half of the surrogate pair.
+		expect(rawCut.length).toBe(MAX_TASK_TITLE_LEN - 1);
+		// Must be lone surrogate -> not well-formed.
+		expect(
+			(
+				rawCut as unknown as { isWellFormed?: () => boolean }
+			).isWellFormed?.call(rawCut) ??
+				(() => {
+					// Fallback when engine lacks isWellFormed: check lone surrogate directly
+					const last = rawCut.charCodeAt(rawCut.length - 1);
+					return !(last >= 0xd800 && last <= 0xdbff);
+				})(),
+		).toBe(false);
+		// Also verify via JSON lone-surrogate signal: JSON.stringify emits \ud834 escape for lone high surrogate
+		expect(rawCut.charCodeAt(rawCut.length - 1)).toBe(0xd834);
 
-    const safeCut = truncateWellFormed(boundaryTitle, MAX_TASK_TITLE_LEN - 1);
-    expect(safeCut.isWellFormed?.() ?? toWellFormedUnicode(safeCut) === safeCut).toBe(true);
-    expect(safeCut.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN - 1);
-    // backs off by one so no lone surrogate
-    expect(safeCut.charCodeAt(safeCut.length - 1)).not.toBe(0xd834);
-    const safeTitle = `${safeCut}…`;
-    expect(safeTitle.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN);
-    expect(toWellFormedUnicode(safeTitle) === safeTitle).toBe(true);
-  });
+		const safeCut = truncateWellFormed(boundaryTitle, MAX_TASK_TITLE_LEN - 1);
+		expect(
+			safeCut.isWellFormed?.() ?? toWellFormedUnicode(safeCut) === safeCut,
+		).toBe(true);
+		expect(safeCut.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN - 1);
+		// backs off by one so no lone surrogate
+		expect(safeCut.charCodeAt(safeCut.length - 1)).not.toBe(0xd834);
+		const safeTitle = `${safeCut}…`;
+		expect(safeTitle.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN);
+		expect(toWellFormedUnicode(safeTitle) === safeTitle).toBe(true);
+	});
 
-  it("findInteractionRegions truncates task titles without creating lone surrogates", () => {
-    const emojiTitle = "a".repeat(MAX_TASK_TITLE_LEN - 2) + "😀" + "c".repeat(50);
-    const threadId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-    const text = `[TASK:${threadId}]${emojiTitle}[/TASK]`;
-    const regions = findInteractionRegions(text);
-    expect(regions.length).toBe(1);
-    const block = regions[0].block as { kind: string; title: string };
-    expect(block.kind).toBe("task");
-    expect(block.title.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN);
-    expect(block.title.endsWith("…")).toBe(true);
-    // Well-formed: no lone surrogate
-    expect(toWellFormedUnicode(block.title) === block.title).toBe(true);
-    // Native isWellFormed when available
-    const isWellFormed = (block.title as unknown as { isWellFormed?: () => boolean }).isWellFormed;
-    if (typeof isWellFormed === "function") {
-      expect(block.title.isWellFormed()).toBe(true);
-    }
-  });
+	it("findInteractionRegions truncates task titles without creating lone surrogates", () => {
+		const emojiTitle =
+			"a".repeat(MAX_TASK_TITLE_LEN - 2) + "😀" + "c".repeat(50);
+		const threadId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+		const text = `[TASK:${threadId}]${emojiTitle}[/TASK]`;
+		const regions = findInteractionRegions(text);
+		expect(regions.length).toBe(1);
+		const block = regions[0].block as { kind: string; title: string };
+		expect(block.kind).toBe("task");
+		expect(block.title.length).toBeLessThanOrEqual(MAX_TASK_TITLE_LEN);
+		expect(block.title.endsWith("…")).toBe(true);
+		// Well-formed: no lone surrogate
+		expect(toWellFormedUnicode(block.title) === block.title).toBe(true);
+		// Native isWellFormed when available
+		const isWellFormed = (
+			block.title as unknown as { isWellFormed?: () => boolean }
+		).isWellFormed;
+		if (typeof isWellFormed === "function") {
+			expect(block.title.isWellFormed()).toBe(true);
+		}
+	});
 
-  it("emoji at exact boundary does not produce invalid JSON", () => {
-    const title = "x".repeat(MAX_TASK_TITLE_LEN - 2) + "𝄞" + "y".repeat(10);
-    const cut = truncateWellFormed(title, MAX_TASK_TITLE_LEN - 1) + "…";
-    // JSON.stringify on well-formed text never emits lone surrogate escapes
-    const json = JSON.stringify({ title: cut });
-    expect(json).not.toContain("\\ud834");
-    expect(json).not.toContain("\\udd1e");
-    expect(() => JSON.parse(json)).not.toThrow();
-  });
+	it("emoji at exact boundary does not produce invalid JSON", () => {
+		const title = "x".repeat(MAX_TASK_TITLE_LEN - 2) + "𝄞" + "y".repeat(10);
+		const cut = truncateWellFormed(title, MAX_TASK_TITLE_LEN - 1) + "…";
+		// JSON.stringify on well-formed text never emits lone surrogate escapes
+		const json = JSON.stringify({ title: cut });
+		expect(json).not.toContain("\\ud834");
+		expect(json).not.toContain("\\udd1e");
+		expect(() => JSON.parse(json)).not.toThrow();
+	});
 });

--- a/packages/core/src/runtime/private-action-gate.test.ts
+++ b/packages/core/src/runtime/private-action-gate.test.ts
@@ -3,48 +3,63 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { isAutonomousTurn, privateActionAllowedOnTurn } from "./private-action-gate.js";
+import {
+	isAutonomousTurn,
+	privateActionAllowedOnTurn,
+} from "./private-action-gate.js";
 
 describe("isAutonomousTurn", () => {
-  it("false for undefined", () => {
-    expect(isAutonomousTurn(undefined)).toBe(false);
-  });
+	it("false for undefined", () => {
+		expect(isAutonomousTurn(undefined)).toBe(false);
+	});
 
-  it("false for missing metadata", () => {
-    expect(isAutonomousTurn({ content: {} } as never)).toBe(false);
-    expect(isAutonomousTurn({ content: { metadata: null } } as never)).toBe(false);
-  });
+	it("false for missing metadata", () => {
+		expect(isAutonomousTurn({ content: {} } as never)).toBe(false);
+		expect(isAutonomousTurn({ content: { metadata: null } } as never)).toBe(
+			false,
+		);
+	});
 
-  it("true only when isAutonomous === true", () => {
-    expect(
-      isAutonomousTurn({ content: { metadata: { isAutonomous: true } } } as never),
-    ).toBe(true);
-    expect(
-      isAutonomousTurn({ content: { metadata: { isAutonomous: false } } } as never),
-    ).toBe(false);
-    expect(
-      isAutonomousTurn({ content: { metadata: { isAutonomous: 1 } } } as never),
-    ).toBe(false);
-  });
+	it("true only when isAutonomous === true", () => {
+		expect(
+			isAutonomousTurn({
+				content: { metadata: { isAutonomous: true } },
+			} as never),
+		).toBe(true);
+		expect(
+			isAutonomousTurn({
+				content: { metadata: { isAutonomous: false } },
+			} as never),
+		).toBe(false);
+		expect(
+			isAutonomousTurn({ content: { metadata: { isAutonomous: 1 } } } as never),
+		).toBe(false);
+	});
 
-  it("false for non-object metadata", () => {
-    expect(isAutonomousTurn({ content: { metadata: "yes" } } as never)).toBe(false);
-  });
+	it("false for non-object metadata", () => {
+		expect(isAutonomousTurn({ content: { metadata: "yes" } } as never)).toBe(
+			false,
+		);
+	});
 });
 
 describe("privateActionAllowedOnTurn", () => {
-  it("allows non-private always", () => {
-    expect(privateActionAllowedOnTurn({ private: false }, undefined)).toBe(true);
-    expect(privateActionAllowedOnTurn({ private: undefined } as never, undefined)).toBe(
-      true,
-    );
-  });
+	it("allows non-private always", () => {
+		expect(privateActionAllowedOnTurn({ private: false }, undefined)).toBe(
+			true,
+		);
+		expect(
+			privateActionAllowedOnTurn({ private: undefined } as never, undefined),
+		).toBe(true);
+	});
 
-  it("allows private only on autonomous", () => {
-    const auto = { content: { metadata: { isAutonomous: true } } } as never;
-    const user = { content: { metadata: { isAutonomous: false } } } as never;
-    expect(privateActionAllowedOnTurn({ private: true }, auto)).toBe(true);
-    expect(privateActionAllowedOnTurn({ private: true }, user)).toBe(false);
-    expect(privateActionAllowedOnTurn({ private: true }, undefined)).toBe(false);
-  });
+	it("allows private only on autonomous", () => {
+		const auto = { content: { metadata: { isAutonomous: true } } } as never;
+		const user = { content: { metadata: { isAutonomous: false } } } as never;
+		expect(privateActionAllowedOnTurn({ private: true }, auto)).toBe(true);
+		expect(privateActionAllowedOnTurn({ private: true }, user)).toBe(false);
+		expect(privateActionAllowedOnTurn({ private: true }, undefined)).toBe(
+			false,
+		);
+	});
 });


### PR DESCRIPTION
## Summary

Formats the three core tests that currently make every core-affecting PR fail the hosted static-smoke lint closure. No test logic changes.

## Verification

- `bun run --cwd packages/core lint:check`: PASS (warnings/infos only, zero errors)
- `git diff --check`: PASS
- Biome changed only formatting in the three named tests.
