### PR TITLE
test(ui): cover sensitive

### DIFF
--- a/packages/ui/src/agent-surface/sensitive.test.ts
+++ b/packages/ui/src/agent-surface/sensitive.test.ts
@@ -1,0 +1,160 @@
+/** Verifies agent-surface sensitivity classification through the real module. */
+// @vitest-environment jsdom
+
+/**
+ * Covers isSensitiveAgentElement: the descriptor.sensitive flag, the
+ * data-agent-sensitive attribute, native password / one-time-code input
+ * signals, and the free-text scan across descriptor fields, element
+ * attributes, and associated form labels. Uses real DOM nodes under jsdom;
+ * no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isSensitiveAgentElement,
+  SENSITIVE_AGENT_ELEMENT_REASON,
+} from "./sensitive";
+import type { AgentElementDescriptor } from "./types";
+
+function makeDescriptor(
+  overrides: Partial<AgentElementDescriptor> = {},
+): AgentElementDescriptor {
+  return { id: "profile.display-name", label: "Display name", ...overrides };
+}
+
+describe("isSensitiveAgentElement", () => {
+  it("returns true when descriptor.sensitive is set, even without an element", () => {
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ sensitive: true }), null),
+    ).toBe(true);
+  });
+
+  it("returns false for a benign descriptor with no element", () => {
+    expect(isSensitiveAgentElement(makeDescriptor(), undefined)).toBe(false);
+  });
+
+  it("scans every descriptor text field for sensitive wording", () => {
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ id: "login.token" }), null),
+    ).toBe(true);
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ label: "Access Token" }), null),
+    ).toBe(true);
+    expect(
+      isSensitiveAgentElement(
+        makeDescriptor({ label: "PASSWORD", group: "auth" }),
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isSensitiveAgentElement(
+        makeDescriptor({ group: "secret", label: "Name" }),
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isSensitiveAgentElement(
+        makeDescriptor({ description: "Your seed phrase backup" }),
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for benign and near-miss wording", () => {
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ label: "Email address" }), null),
+    ).toBe(false);
+    // Word boundaries: "token" must not match inside "Tokenizer".
+    expect(
+      isSensitiveAgentElement(
+        makeDescriptor({ label: "Tokenizer settings" }),
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it("treats data-agent-sensitive=true and =1 as sensitive", () => {
+    for (const value of ["true", "1"]) {
+      const el = document.createElement("div");
+      el.setAttribute("data-agent-sensitive", value);
+      expect(isSensitiveAgentElement(makeDescriptor(), el)).toBe(true);
+    }
+  });
+
+  it("keeps scanning when data-agent-sensitive is neither true nor 1", () => {
+    const marked = document.createElement("div");
+    marked.setAttribute("data-agent-sensitive", "false");
+    expect(isSensitiveAgentElement(makeDescriptor(), marked)).toBe(false);
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ label: "bearer" }), marked),
+    ).toBe(true);
+  });
+
+  it("honours descriptor.sensitive=false while DOM signals stay authoritative", () => {
+    const el = document.createElement("input");
+    el.type = "password";
+    expect(
+      isSensitiveAgentElement(makeDescriptor({ sensitive: false }), el),
+    ).toBe(true);
+  });
+
+  it("flags password inputs by input type", () => {
+    const input = document.createElement("input");
+    input.type = "password";
+    expect(isSensitiveAgentElement(makeDescriptor(), input)).toBe(true);
+  });
+
+  it("flags inputs declaring autocomplete=one-time-code", () => {
+    const input = document.createElement("input");
+    input.setAttribute("autocomplete", "one-time-code");
+    expect(isSensitiveAgentElement(makeDescriptor(), input)).toBe(true);
+  });
+
+  it("scans element attributes for sensitive wording", () => {
+    const cases: Array<[string, string]> = [
+      ["name", "refresh_token"],
+      ["id", "client-secret"],
+      ["aria-label", "API key"],
+      ["placeholder", "Enter bearer token"],
+      ["autocomplete", "current-password"],
+    ];
+    for (const [attr, value] of cases) {
+      const el = document.createElement("div");
+      el.setAttribute(attr, value);
+      expect(isSensitiveAgentElement(makeDescriptor(), el)).toBe(true);
+    }
+  });
+
+  it("scans the text of associated labels for form controls", () => {
+    for (const tag of ["input", "textarea", "select"] as const) {
+      const control = document.createElement(tag);
+      const label = document.createElement("label");
+      label.textContent = "Recovery passphrase";
+      label.append(control);
+      expect(isSensitiveAgentElement(makeDescriptor(), control)).toBe(true);
+    }
+  });
+
+  it("does not treat label text as associated for non-form elements", () => {
+    const label = document.createElement("label");
+    label.textContent = "Private key material";
+    const section = document.createElement("section");
+    label.append(section);
+    expect(isSensitiveAgentElement(makeDescriptor(), section)).toBe(false);
+  });
+
+  it("matches multi-word terms across separator styles", () => {
+    for (const label of ["api_key", "api-key", "api key"]) {
+      expect(isSensitiveAgentElement(makeDescriptor({ label }), null)).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("SENSITIVE_AGENT_ELEMENT_REASON", () => {
+  it("exposes the shared refusal reason", () => {
+    expect(SENSITIVE_AGENT_ELEMENT_REASON).toBe(
+      "sensitive element cannot be read or filled through the agent surface",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new co-located unit suite, `packages/ui/src/agent-surface/sensitive.test.ts`, covering `isSensitiveAgentElement` and `SENSITIVE_AGENT_ELEMENT_REASON` in `packages/ui/src/agent-surface/sensitive.ts`, which previously had no same-named test anywhere in the repo.

The suite drives the real module against real jsdom DOM nodes (no mocks) and covers every branch:

- `descriptor.sensitive === true` wins immediately, including with `null`/`undefined` elements
- `data-agent-sensitive` accepts `"true"` and `"1"`; any other value falls through to the text scan
- native input signals: `type="password"` and `autocomplete="one-time-code"`
- free-text scan across all descriptor fields (`id`, `label`, `group`, `description`), case-insensitive
- attribute scan (`name`, `id`, `aria-label`, `placeholder`, `autocomplete`)
- associated `<label>` text for labelable controls (input, textarea, select) and the non-form-element negative
- separator variants (`api_key`, `api-key`, `api key`) and word-boundary near-misses (`"Tokenizer settings"` stays clean)
- benign descriptors return false

Test-only diff: one new file, +160/-0, no production behaviour changed.

## Verification

Fork contributor: hosted CI does not run on this pull request; local runs quoted below.

- `bunx vitest run packages/ui/src/agent-surface/sensitive.test.ts`: **1 test file passed, 14/14 tests passed** (run twice: before and after formatting).
- `bunx biome check --write packages/ui/src/agent-surface/sensitive.test.ts`: fixed formatting once; second read-only pass reports "No fixes applied".
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics referencing `sensitive.test.ts`.
- `sensitive.ts` is byte-identical between this branch's base (`35bb14be`), current `origin/develop` (`c0801ba9`), so the counts above reproduce on current develop.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0e89b098e67eecb3f2a73dc27542931b84be87db -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
