### PR TITLE
fix(plugin-local-inference): guard route resume download against non-206 responses

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression coverage for resumed model downloads in the route-level
+ * `downloadModel` path, exercised through the real exported
+ * `applyLocalInferenceManagementMutation({ op: "start_download" })` handler with
+ * a temp `ELIZA_STATE_DIR` and a real local HTTP origin (issue #26629).
+ *
+ * Before the fix, `downloadModel` sent `Range: bytes=<n>-` whenever a `.part`
+ * file existed and then opened the staging file in append mode without checking
+ * that the origin honored the range. A CDN/mirror/gated-proxy that ignores Range
+ * and answers HTTP 200 with the FULL body had that body appended onto the stale
+ * partial bytes, producing a corrupt GGUF that still passed the 4-byte magic
+ * gate, was renamed to final, and registered as an installed model with a
+ * miscomputed size (`existingPartial + fullSize`).
+ *
+ * These tests stand up two local origins — one that HONORS Range (206 + the
+ * remaining bytes) and one that IGNORES it (200 + the full body) — seed a stale
+ * `.part`, drive the real mutation, and assert the final `models/<id>.gguf`
+ * bytes exactly equal the full file in BOTH cases, plus that the registry size
+ * matches the true file length. No mocks: real fs + real HTTP; only
+ * `ELIZA_STATE_DIR` and `ELIZA_HF_BASE_URL` are redirected.
+ */
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyLocalInferenceManagementMutation } from "./local-inference-routes.js";
+
+const MODEL_ID = "eliza-1-2b";
+// Full artifact the origin will ultimately serve. Begins with the GGUF magic so
+// the 4-byte integrity gate cannot distinguish correct from corrupt output.
+const FULL = Buffer.from("GGUFREAL-MODEL-BODY");
+// Stale partial left behind by an interrupted attempt. Its first 4 bytes are
+// also "GGUF", so a corrupt append still passes the magic check.
+const STALE = Buffer.from("GGUFSTALE-PARTIAL");
+
+const originalStateDir = process.env.ELIZA_STATE_DIR;
+const originalHfBase = process.env.ELIZA_HF_BASE_URL;
+const originalHfBases = process.env.ELIZA_HF_BASE_URLS;
+const originalCloudKey = process.env.ELIZAOS_CLOUD_API_KEY;
+
+let tempStateDir: string;
+let server: http.Server;
+let baseUrl: string;
+
+function localInferenceRoot(): string {
+	return path.join(tempStateDir, "local-inference");
+}
+
+function partialPath(): string {
+	return path.join(localInferenceRoot(), "downloads", `${MODEL_ID}.part`);
+}
+
+function finalPath(): string {
+	return path.join(localInferenceRoot(), "models", `${MODEL_ID}.gguf`);
+}
+
+function readRegistryFile(): {
+	models: Array<{ id: string; sizeBytes: number; path: string }>;
+} {
+	return JSON.parse(
+		readFileSync(path.join(localInferenceRoot(), "registry.json"), "utf8"),
+	);
+}
+
+function seedStalePartial(): void {
+	mkdirSync(path.join(localInferenceRoot(), "downloads"), { recursive: true });
+	mkdirSync(path.join(localInferenceRoot(), "models"), { recursive: true });
+	writeFileSync(partialPath(), STALE);
+}
+
+/**
+ * Start a local origin. When `honorRange` is true it behaves like a compliant
+ * server: a `Range: bytes=<n>-` request yields `206` with only the remaining
+ * bytes. When false it models the misbehaving CDN/mirror/proxy: it ignores
+ * Range entirely and always answers `200` with the full body.
+ */
+async function startOrigin(honorRange: boolean): Promise<void> {
+	server = http.createServer((req, res) => {
+		const range = req.headers.range;
+		if (honorRange && typeof range === "string") {
+			const match = /bytes=(\d+)-/.exec(range);
+			const start = match ? Number.parseInt(match[1], 10) : 0;
+			const slice = FULL.subarray(start);
+			res.writeHead(206, {
+				"content-length": String(slice.length),
+				"content-range": `bytes ${start}-${FULL.length - 1}/${FULL.length}`,
+			});
+			res.end(slice);
+			return;
+		}
+		res.writeHead(200, { "content-length": String(FULL.length) });
+		res.end(FULL);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as { port: number };
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	process.env.ELIZA_HF_BASE_URL = baseUrl;
+}
+
+/**
+ * Poll until the download job has fully completed — i.e. the registry row is
+ * written. `downloadModel` renames the staging file into place BEFORE it hashes
+ * and registers the model, so waiting only for the final file would race the
+ * background completion (and the afterEach teardown). Return the registered
+ * size so the caller can assert on it.
+ */
+async function waitForInstalledSize(): Promise<number> {
+	for (let attempt = 0; attempt < 800; attempt += 1) {
+		try {
+			const entry = readRegistryFile().models.find(
+				(model) => model.id === MODEL_ID,
+			);
+			if (entry) return entry.sizeBytes;
+		} catch {
+			// registry.json not written yet — keep polling.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error("timed out waiting for the model to be installed");
+}
+
+describe("local-inference route resume download (#26629)", () => {
+	beforeEach(() => {
+		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-li-resume-"));
+		process.env.ELIZA_STATE_DIR = tempStateDir;
+		// Force the mirror path to our local origin only — no cloud proxy or the
+		// public HuggingFace fallback may be contacted from the test.
+		delete process.env.ELIZA_HF_BASE_URLS;
+		delete process.env.ELIZAOS_CLOUD_API_KEY;
+		mkdirSync(localInferenceRoot(), { recursive: true });
+	});
+
+	afterEach(async () => {
+		// Abort any in-flight download so a background transfer cannot write into
+		// the temp dir after teardown or leak into the next test's module state.
+		await applyLocalInferenceManagementMutation({ op: "cancel_download" });
+		if (server) {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		}
+		rmSync(tempStateDir, { recursive: true, force: true });
+		const restore = (key: string, value: string | undefined) => {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		};
+		restore("ELIZA_STATE_DIR", originalStateDir);
+		restore("ELIZA_HF_BASE_URL", originalHfBase);
+		restore("ELIZA_HF_BASE_URLS", originalHfBases);
+		restore("ELIZAOS_CLOUD_API_KEY", originalCloudKey);
+	});
+
+	it("restarts from byte 0 when the origin ignores Range and answers HTTP 200", async () => {
+		seedStalePartial();
+		await startOrigin(false);
+
+		const result = await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+		expect(result.op).toBe("start_download");
+
+		// registry.json size must reflect the true file length, not the old
+		// `existingPartial + fullSize` miscomputation.
+		const installedSize = await waitForInstalledSize();
+		expect(installedSize).toBe(FULL.length);
+
+		const stored = readFileSync(finalPath());
+		// The corrupt-append bug produced 36 bytes
+		// ("GGUFSTALE-PARTIALGGUFREAL-MODEL-BODY"); the fix must yield exactly the
+		// full body with the stale partial discarded.
+		expect(stored.length).toBe(FULL.length);
+		expect(stored.equals(FULL)).toBe(true);
+	});
+
+	it("resumes correctly when the origin honors Range with HTTP 206", async () => {
+		// Seed a partial that is a genuine PREFIX of the full body, so a correct
+		// 206 resume (append remaining bytes) reconstructs the exact file.
+		const prefixLen = 4; // "GGUF"
+		mkdirSync(path.join(localInferenceRoot(), "downloads"), {
+			recursive: true,
+		});
+		mkdirSync(path.join(localInferenceRoot(), "models"), { recursive: true });
+		writeFileSync(partialPath(), FULL.subarray(0, prefixLen));
+		await startOrigin(true);
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+
+		const installedSize = await waitForInstalledSize();
+		expect(installedSize).toBe(FULL.length);
+
+		const stored = readFileSync(finalPath());
+		expect(stored.length).toBe(FULL.length);
+		expect(stored.equals(FULL)).toBe(true);
+	});
+});

--- a/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
@@ -12,11 +12,13 @@
  * gate, was renamed to final, and registered as an installed model with a
  * miscomputed size (`existingPartial + fullSize`).
  *
- * These tests stand up two local origins — one that HONORS Range (206 + the
- * remaining bytes) and one that IGNORES it (200 + the full body) — seed a stale
- * `.part`, drive the real mutation, and assert the final `models/<id>.gguf`
- * bytes exactly equal the full file in BOTH cases, plus that the registry size
- * matches the true file length. No mocks: real fs + real HTTP; only
+ * These tests stand up local origins that model the compliant server (206 + the
+ * remaining bytes), the CDN/mirror that ignores Range (200 + the full body), and
+ * misbehaving proxies that answer 206 with a Content-Range whose start is
+ * misaligned to — or missing for — the requested resume offset. Each seeds a
+ * stale `.part`, drives the real mutation, and asserts the final
+ * `models/<id>.gguf` bytes exactly equal the full file plus that the registry
+ * size matches the true file length. No mocks: real fs + real HTTP; only
  * `ELIZA_STATE_DIR` and `ELIZA_HF_BASE_URL` are redirected.
  */
 import {
@@ -105,6 +107,31 @@ async function startOrigin(honorRange: boolean): Promise<void> {
 }
 
 /**
+ * Start a misbehaving proxy origin: it always answers `206 Partial Content`
+ * with the FULL body regardless of the requested Range, and stamps a
+ * `Content-Range` header from `contentRange` (or omits it entirely when null).
+ * This models a proxy that ignores Range semantics but still returns a 206
+ * status — exactly the case where a naive `statusCode === 206` gate would
+ * append the full body onto the stale partial and corrupt the GGUF.
+ */
+async function startMisalignedRangeOrigin(
+	contentRange: string | null,
+): Promise<void> {
+	server = http.createServer((_req, res) => {
+		const headers: Record<string, string> = {
+			"content-length": String(FULL.length),
+		};
+		if (contentRange !== null) headers["content-range"] = contentRange;
+		res.writeHead(206, headers);
+		res.end(FULL);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as { port: number };
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	process.env.ELIZA_HF_BASE_URL = baseUrl;
+}
+
+/**
  * Poll until the download job has fully completed — i.e. the registry row is
  * written. `downloadModel` renames the staging file into place BEFORE it hashes
  * and registers the model, so waiting only for the final file would race the
@@ -174,6 +201,47 @@ describe("local-inference route resume download (#26629)", () => {
 		// The corrupt-append bug produced 36 bytes
 		// ("GGUFSTALE-PARTIALGGUFREAL-MODEL-BODY"); the fix must yield exactly the
 		// full body with the stale partial discarded.
+		expect(stored.length).toBe(FULL.length);
+		expect(stored.equals(FULL)).toBe(true);
+	});
+
+	it("restarts from byte 0 when a 206 Content-Range is misaligned to the requested offset", async () => {
+		seedStalePartial();
+		// STALE is 17 bytes, so the resume request is `Range: bytes=17-`. The proxy
+		// answers 206 but claims the body starts at byte 0 — a misaligned range that
+		// must NOT be appended onto the stale partial.
+		await startMisalignedRangeOrigin(
+			`bytes 0-${FULL.length - 1}/${FULL.length}`,
+		);
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+
+		const installedSize = await waitForInstalledSize();
+		expect(installedSize).toBe(FULL.length);
+
+		const stored = readFileSync(finalPath());
+		expect(stored.length).toBe(FULL.length);
+		expect(stored.equals(FULL)).toBe(true);
+	});
+
+	it("restarts from byte 0 when a 206 omits the Content-Range header", async () => {
+		seedStalePartial();
+		// A 206 with no Content-Range cannot be validated as aligned to the resume
+		// offset, so the fix must fail closed and restart from byte 0.
+		await startMisalignedRangeOrigin(null);
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+
+		const installedSize = await waitForInstalledSize();
+		expect(installedSize).toBe(FULL.length);
+
+		const stored = readFileSync(finalPath());
 		expect(stored.length).toBe(FULL.length);
 		expect(stored.equals(FULL)).toBe(true);
 	});

--- a/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts
@@ -15,11 +15,15 @@
  * These tests stand up local origins that model the compliant server (206 + the
  * remaining bytes), the CDN/mirror that ignores Range (200 + the full body), and
  * misbehaving proxies that answer 206 with a Content-Range whose start is
- * misaligned to — or missing for — the requested resume offset. Each seeds a
- * stale `.part`, drives the real mutation, and asserts the final
- * `models/<id>.gguf` bytes exactly equal the full file plus that the registry
- * size matches the true file length. No mocks: real fs + real HTTP; only
- * `ELIZA_STATE_DIR` and `ELIZA_HF_BASE_URL` are redirected.
+ * misaligned to — or missing for — the requested resume offset. The misaligned
+ * proxy serves ONLY the bytes its Content-Range declares (a tail slice), so a
+ * resume that reset its write offset to 0 but kept reading that same response
+ * would rename a truncated file; the fix must discard it and re-fetch the full
+ * body with a range-less request. Each seeds a stale `.part`, drives the real
+ * mutation, and asserts the final `models/<id>.gguf` bytes exactly equal the
+ * full file plus that the registry size matches the true file length. No mocks:
+ * real fs + real HTTP; only `ELIZA_STATE_DIR` and `ELIZA_HF_BASE_URL` are
+ * redirected.
  */
 import {
 	mkdirSync,
@@ -107,22 +111,47 @@ async function startOrigin(honorRange: boolean): Promise<void> {
 }
 
 /**
- * Start a misbehaving proxy origin: it always answers `206 Partial Content`
- * with the FULL body regardless of the requested Range, and stamps a
- * `Content-Range` header from `contentRange` (or omits it entirely when null).
- * This models a proxy that ignores Range semantics but still returns a 206
- * status — exactly the case where a naive `statusCode === 206` gate would
- * append the full body onto the stale partial and corrupt the GGUF.
+ * Start a misbehaving proxy origin that answers a `Range` request with a
+ * `206 Partial Content` whose `Content-Range` is misaligned to — or missing
+ * for — the requested resume offset. Crucially it behaves like a STANDARDS-
+ * COMPLIANT origin for that 206: the body is exactly the bytes its own
+ * `Content-Range` declares (a tail slice), not the full artifact. A naive
+ * `statusCode === 206` resume that reset `effectiveStart` to 0 but kept reading
+ * this same response would therefore write a truncated slice at byte 0 and
+ * rename a corrupt `.gguf`. The fix must instead discard this response and
+ * issue a fresh range-less request, which this origin answers with `200` + the
+ * FULL body. When `contentRange` is null the origin sends a 206 with no
+ * `Content-Range` header (a proxy that strips it) and the full body, which is
+ * still unverifiable and must trigger the same range-less restart.
  */
 async function startMisalignedRangeOrigin(
 	contentRange: string | null,
 ): Promise<void> {
-	server = http.createServer((_req, res) => {
-		const headers: Record<string, string> = {
-			"content-length": String(FULL.length),
-		};
-		if (contentRange !== null) headers["content-range"] = contentRange;
-		res.writeHead(206, headers);
+	server = http.createServer((req, res) => {
+		const hasRange = typeof req.headers.range === "string";
+		if (hasRange && contentRange !== null) {
+			// Serve exactly the bytes this Content-Range advertises, as a compliant
+			// server would — the whole point of the regression is that reusing this
+			// body at byte 0 yields a truncated file.
+			const match = /bytes\s+(\d+)-(\d+)\//.exec(contentRange);
+			const start = match ? Number.parseInt(match[1], 10) : 0;
+			const end = match ? Number.parseInt(match[2], 10) : FULL.length - 1;
+			const slice = FULL.subarray(start, end + 1);
+			res.writeHead(206, {
+				"content-length": String(slice.length),
+				"content-range": contentRange,
+			});
+			res.end(slice);
+			return;
+		}
+		if (hasRange && contentRange === null) {
+			// 206 with no Content-Range: unverifiable, must still trigger a restart.
+			res.writeHead(206, { "content-length": String(FULL.length) });
+			res.end(FULL);
+			return;
+		}
+		// The fix's fresh range-less request: answer 200 with the full artifact.
+		res.writeHead(200, { "content-length": String(FULL.length) });
 		res.end(FULL);
 	});
 	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -212,6 +241,30 @@ describe("local-inference route resume download (#26629)", () => {
 		// must NOT be appended onto the stale partial.
 		await startMisalignedRangeOrigin(
 			`bytes 0-${FULL.length - 1}/${FULL.length}`,
+		);
+
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		});
+
+		const installedSize = await waitForInstalledSize();
+		expect(installedSize).toBe(FULL.length);
+
+		const stored = readFileSync(finalPath());
+		expect(stored.length).toBe(FULL.length);
+		expect(stored.equals(FULL)).toBe(true);
+	});
+
+	it("restarts from byte 0 when a 206 returns only its declared misaligned tail bytes", async () => {
+		seedStalePartial();
+		// STALE is 17 bytes, so the resume request is `Range: bytes=17-`. The proxy
+		// answers 206 but declares `bytes 5-18/19` and — like a compliant server —
+		// sends ONLY that 14-byte tail. Writing that slice at byte 0 would produce a
+		// truncated, corrupt model; the fix must discard it and re-fetch the full
+		// body with a range-less request.
+		await startMisalignedRangeOrigin(
+			`bytes 5-${FULL.length - 1}/${FULL.length}`,
 		);
 
 		await applyLocalInferenceManagementMutation({

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -502,6 +502,24 @@ async function openDownloadResponse(
 	});
 }
 
+/**
+ * Parse the zero-based start byte from an RFC 7233
+ * `Content-Range: bytes <start>-<end>/<total>` response header. Returns null
+ * when the header is absent, is an array, or does not match the
+ * `bytes <start>-...` grammar, so a caller can treat an unparseable range as
+ * "do not trust this resume" and restart from byte 0 rather than appending
+ * misaligned bytes onto a stale partial.
+ */
+export function parseContentRangeStart(
+	value: string | string[] | undefined,
+): number | null {
+	if (typeof value !== "string") return null;
+	const match = /^\s*bytes\s+(\d+)-/i.exec(value);
+	if (!match) return null;
+	const start = Number.parseInt(match[1], 10);
+	return Number.isFinite(start) ? start : null;
+}
+
 async function ensureLocalInferenceDirs(): Promise<void> {
 	await fsp.mkdir(modelsDir(), { recursive: true });
 	await fsp.mkdir(downloadsDir(), { recursive: true });
@@ -745,16 +763,26 @@ async function downloadModel(
 		if (statusCode < 200 || statusCode >= 300) {
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
-		// Resume is only valid when the origin honored our Range request with a 206
-		// Partial Content. CDN redirect targets, gated/proxy repos, and mirrors
-		// frequently ignore Range and answer 200 with the FULL body; appending that
-		// onto the stale `.part` bytes produces a corrupt GGUF that still passes the
-		// 4-byte magic check. Restart from byte 0 in that case, mirroring the
-		// canonical guard in services/downloader.ts (statusCode !== 206 -> restart).
+		// Resume is only trustworthy when the origin honored our Range request with
+		// a 206 Partial Content AND its Content-Range starts exactly at the byte we
+		// asked to resume from. CDN redirect targets, gated/proxy repos, and mirrors
+		// frequently ignore Range and answer 200 with the FULL body; a misbehaving
+		// proxy can also answer 206 with a misaligned or missing Content-Range.
+		// Appending any of those onto the stale `.part` bytes produces a corrupt
+		// GGUF that still passes the 4-byte magic check. Restart from byte 0 unless
+		// the range is a valid 206 aligned to `existingPartial`, mirroring the
+		// canonical guard in services/downloader.ts and failing closed on any
+		// ambiguity.
 		let effectiveStart = existingPartial;
-		if (existingPartial > 0 && statusCode !== 206) {
-			effectiveStart = 0;
-			record.received = 0;
+		if (existingPartial > 0) {
+			const rangeStart =
+				statusCode === 206
+					? parseContentRangeStart(response.headers["content-range"])
+					: null;
+			if (rangeStart !== existingPartial) {
+				effectiveStart = 0;
+				record.received = 0;
+			}
 		}
 		const contentLength = Number.parseInt(
 			String(response.headers["content-length"] ?? "0"),

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -745,16 +745,27 @@ async function downloadModel(
 		if (statusCode < 200 || statusCode >= 300) {
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
+		// Resume is only valid when the origin honored our Range request with a 206
+		// Partial Content. CDN redirect targets, gated/proxy repos, and mirrors
+		// frequently ignore Range and answer 200 with the FULL body; appending that
+		// onto the stale `.part` bytes produces a corrupt GGUF that still passes the
+		// 4-byte magic check. Restart from byte 0 in that case, mirroring the
+		// canonical guard in services/downloader.ts (statusCode !== 206 -> restart).
+		let effectiveStart = existingPartial;
+		if (existingPartial > 0 && statusCode !== 206) {
+			effectiveStart = 0;
+			record.received = 0;
+		}
 		const contentLength = Number.parseInt(
 			String(response.headers["content-length"] ?? "0"),
 			10,
 		);
 		if (Number.isFinite(contentLength) && contentLength > 0) {
-			record.total = existingPartial + contentLength;
+			record.total = effectiveStart + contentLength;
 		}
 
 		const stream = fs.createWriteStream(partialPath, {
-			flags: existingPartial > 0 ? "a" : "w",
+			flags: effectiveStart > 0 ? "a" : "w",
 		});
 		let lastSampleAt = Date.now();
 		let lastSampleBytes = record.received;

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -773,6 +773,7 @@ async function downloadModel(
 		// the range is a valid 206 aligned to `existingPartial`, mirroring the
 		// canonical guard in services/downloader.ts and failing closed on any
 		// ambiguity.
+		let downloadResponse = response;
 		let effectiveStart = existingPartial;
 		if (existingPartial > 0) {
 			const rangeStart =
@@ -782,10 +783,39 @@ async function downloadModel(
 			if (rangeStart !== existingPartial) {
 				effectiveStart = 0;
 				record.received = 0;
+				// A non-206 (e.g. 200) already carries the FULL representation, so its
+				// body can be written from byte 0 as-is. A 206 is different: a
+				// standards-compliant origin sends ONLY the bytes its Content-Range
+				// declares, so reusing a misaligned/absent-range 206 body would write
+				// that partial slice at byte 0 and rename a truncated file. Discard the
+				// rejected partial response and issue a fresh full-content request (no
+				// Range) so the write starts from a real byte 0. Fail closed if the
+				// origin still refuses to return a full 200 for a range-less request.
+				if (statusCode === 206) {
+					response.resume();
+					const fullHeaders = { ...headers };
+					delete fullHeaders.range;
+					downloadResponse = await openDownloadResponse(
+						downloadUrl,
+						fullHeaders,
+						abortController.signal,
+					);
+					const fullStatus = downloadResponse.statusCode ?? 0;
+					if (fullStatus < 200 || fullStatus >= 300) {
+						throw new Error(
+							`HTTP ${fullStatus} ${downloadResponse.statusMessage ?? ""}`,
+						);
+					}
+					if (fullStatus === 206) {
+						throw new Error(
+							"Origin returned 206 Partial Content for a range-less request; refusing to install a possibly truncated model",
+						);
+					}
+				}
 			}
 		}
 		const contentLength = Number.parseInt(
-			String(response.headers["content-length"] ?? "0"),
+			String(downloadResponse.headers["content-length"] ?? "0"),
 			10,
 		);
 		if (Number.isFinite(contentLength) && contentLength > 0) {
@@ -799,7 +829,7 @@ async function downloadModel(
 		let lastSampleBytes = record.received;
 
 		try {
-			for await (const chunk of response) {
+			for await (const chunk of downloadResponse) {
 				const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 				if (!stream.write(Buffer.from(value))) {
 					await new Promise<void>((resolve) => stream.once("drain", resolve));


### PR DESCRIPTION
# Relates to

Closes #26629

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates were run (see **Known gaps / failures** for the `bun run verify` scope note).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branch is based on the latest `origin/develop` (`51617538d7`); `git rev-list --count HEAD..origin/develop` == 0; zero conflicts.
- [x] Focused gates pass post-sync; the full `bun run verify` scope is documented in **Known gaps / failures**.

# Risks

Low. The change is a small guard plus one pure helper
(`parseContentRangeStart`) inside one function (`downloadModel`), with no
signature or public-API change. It only affects the interrupted-download resume
path in the route-level model downloader, and it makes that path strictly safer.
The correctly-aligned 206 (honor-range) resume path is preserved and covered by
a test.

# Background

## What does this PR do?

Fixes a model-file corruption in the route-level downloader
`downloadModel` (`plugins/plugin-local-inference/src/local-inference-routes.ts`).

To resume an interrupted download it sent a `Range: bytes=<n>-` header and opened
the staging `.part` file in **append** mode whenever a partial file existed
(`flags: existingPartial > 0 ? "a" : "w"`), **without verifying the origin
honored the range**. When the origin ignored `Range` and replied **HTTP 200 with
the full body** — common for CDN redirect targets, gated/proxy repos, and
mirrors — the full body was appended onto the stale partial bytes, producing a
**corrupt GGUF**. `record.total` was also miscomputed as `existingPartial +
fullSize`.

The corruption passed the only integrity check (`isGgufFile` reads just the first
4 bytes, which were still `GGUF` from the old partial), and there is no sha256
verification against an expected hash (the catalog carries no per-GGUF expected
digest, only an optional `bundleManifestSha256`), so the corrupt file was renamed
to final, registered as an installed model, and auto-assigned to the
`TEXT_SMALL`/`TEXT_LARGE`/`TEXT_EMBEDDING` slots via `ensureDefaultAssignment`.

The fix treats the resume response as trustworthy **only** when it is a `206`
whose `Content-Range` starts exactly at the requested resume offset
(`existingPartial`). A pure helper `parseContentRangeStart` parses the RFC 7233
`bytes <start>-<end>/<total>` header; the guard restarts from byte 0 whenever the
status is not `206`, the `Content-Range` is missing/unparseable, or its start does
not equal `existingPartial`.

Crucially, restarting cannot reuse the rejected response body. A `200` already
carries the full representation, so it can be written from byte 0 as-is. A `206`,
however, carries **only the bytes its `Content-Range` declares** on a compliant
origin; writing that partial slice at byte 0 would rename a truncated `.gguf`.
So when the untrusted resume response is a `206`, the fix now **discards it and
issues a fresh range-less request** for the full body before writing (failing
closed if the origin still answers `206` to a request without a `Range` header).
This closes the follow-up review point (ss251) that a compliant proxy returning
a misaligned/absent-range `206` with only its declared tail would otherwise be
written at byte 0 and installed as a truncated model. Restarting resets
`record.received`, computes `record.total` from the effective start, and opens the
staging file with `flags: "w"`. (`services/downloader.ts` carries the sibling
`statusCode !== 206` guard; tightening it to the same Content-Range check is
tracked separately to keep this PR scoped to the route path under review.)

```diff
+// Pure helper: RFC 7233 `Content-Range: bytes <start>-<end>/<total>` -> start.
+export function parseContentRangeStart(
+	value: string | string[] | undefined,
+): number | null {
+	if (typeof value !== "string") return null;
+	const match = /^\s*bytes\s+(\d+)-/i.exec(value);
+	if (!match) return null;
+	const start = Number.parseInt(match[1], 10);
+	return Number.isFinite(start) ? start : null;
+}
 ...
 		const statusCode = response.statusCode ?? 0;
 		if (statusCode < 200 || statusCode >= 300) {
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
+		// Resume is only trustworthy when the origin honored our Range with a 206
+		// AND its Content-Range starts exactly at the byte we asked to resume from.
+		// A 200 (Range ignored) or a 206 with a misaligned/missing Content-Range
+		// would append misaligned bytes onto the stale `.part`, corrupting the GGUF
+		// while still passing the 4-byte magic check. Fail closed -> restart from 0.
+		let downloadResponse = response;
+		let effectiveStart = existingPartial;
+		if (existingPartial > 0) {
+			const rangeStart =
+				statusCode === 206
+					? parseContentRangeStart(response.headers["content-range"])
+					: null;
+			if (rangeStart !== existingPartial) {
+				effectiveStart = 0;
+				record.received = 0;
+				// A 206 body carries only its declared range; discard it and refetch
+				// the full body with a range-less request so the write starts at a
+				// real byte 0. Fail closed if the origin still answers 206.
+				if (statusCode === 206) {
+					response.resume();
+					const fullHeaders = { ...headers };
+					delete fullHeaders.range;
+					downloadResponse = await openDownloadResponse(
+						downloadUrl, fullHeaders, abortController.signal);
+					const fullStatus = downloadResponse.statusCode ?? 0;
+					if (fullStatus < 200 || fullStatus >= 300 || fullStatus === 206) {
+						throw new Error(`HTTP ${fullStatus} ...`);
+					}
+				}
+			}
+		}
 		const contentLength = Number.parseInt(
-			String(response.headers["content-length"] ?? "0"),
+			String(downloadResponse.headers["content-length"] ?? "0"),
 			10,
 		);
 		if (Number.isFinite(contentLength) && contentLength > 0) {
-			record.total = existingPartial + contentLength;
+			record.total = effectiveStart + contentLength;
 		}
 
 		const stream = fs.createWriteStream(partialPath, {
-			flags: existingPartial > 0 ? "a" : "w",
+			flags: effectiveStart > 0 ? "a" : "w",
 		});
+		// ... then: for await (const chunk of downloadResponse) { ... }
```

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Scope boundary

One function (`downloadModel`) plus a new exported pure helper
(`parseContentRangeStart`) in `local-inference-routes.ts`, plus new regression
tests. No signature, route, or catalog change. The correctly-aligned 206 resume
path is intentionally preserved; an untrusted 206 is discarded and the full body
is refetched with a range-less request rather than reusing the partial body. This
does not touch the sibling `services/downloader.ts`.

# Documentation changes needed?

My changes do not require a change to the project documentation (internal
downloader behavior; no public surface change).

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/local-inference-routes.resume.test.ts` — a
real-fs + real-local-HTTP regression test that drives the exported
`applyLocalInferenceManagementMutation({ op: "start_download" })`.

## Detailed testing steps

```bash
cd plugins/plugin-local-inference
# Passing-after (all five resume paths):
npx vitest run src/local-inference-routes.resume.test.ts
# Failing-before (revert only the guard in local-inference-routes.ts to the
# prior 206-alignment check): the tail-only misaligned-206 test fails with
# `timed out waiting for the model to be installed` — the truncated slice fails
# the GGUF magic gate and is never installed.
```

The tests stand up five local-origin behaviors — HONORS `Range` (206 + remaining
bytes), IGNORES `Range` (200 + full body), a 206 whose **misaligned**
Content-Range advertises `bytes 0-…` while the origin still returns the full
body, a compliant 206 that returns **only its declared misaligned tail slice**
(`bytes 5-18/19` → 14 bytes), and a 206 with a **missing** Content-Range — each
seeds a stale `.part`, drives the real mutation, and asserts the final
`models/<id>.gguf` bytes and the `registry.json` size exactly equal the full file
(correct resume for the aligned 206, clean restart via a fresh range-less refetch
for every other case). Only `ELIZA_STATE_DIR` and `ELIZA_HF_BASE_URL` are
redirected; no mocks.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:7a9bd3abe790d674a53e6d3c93be10325746620d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a backend model-downloader guard.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a backend model-downloader guard.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed path is a background download.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - fork-only contributor account has no push access to the elizaOS/eliza pr-evidence release and token auth cannot mint a user-attachments upload; the verbatim failing-before (1 failed | 4 passed) and passing-after (5 passed) Vitest output plus the route suite are inline in the Backend + frontend logs section, reproduced against head f46b3d6 (rebased onto origin/develop 5161753)
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/network change; the download runs server-side.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a file-download integrity fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - same fork-only hosting constraint blocks an external upload; the byte-level hexdump and length/registry-size comparison of the corrupt file (append-onto-stale, and the truncated tail slice a compliant misaligned 206 would write) versus the corrected 19-byte GGUF is inline in the Domain artifacts section, regenerated against head f46b3d6 (rebased onto origin/develop 5161753)
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; this is a file-download integrity fix.`

## Backend + frontend logs

Focused Vitest output driving the real exported mutation
`applyLocalInferenceManagementMutation({ op: "start_download" })` →
`startDownload` → `downloadModel` against a real local HTTP origin.

<details>
<summary>Failing-before (guard reverted to the prior 206-alignment check): the compliant tail-only misaligned 206 renames a truncated file that fails the GGUF gate</summary>

```
 Warn [local-inference] Download failed for eliza-1-2b: Downloaded file is not a valid GGUF
 ✓ ... restarts from byte 0 when the origin ignores Range and answers HTTP 200
 ✓ ... restarts from byte 0 when a 206 Content-Range is misaligned to the requested offset
 × ... restarts from byte 0 when a 206 returns only its declared misaligned tail bytes
   → timed out waiting for the model to be installed
 ✓ ... restarts from byte 0 when a 206 omits the Content-Range header
 ✓ ... resumes correctly when the origin honors Range with HTTP 206

      Tests  1 failed | 4 passed (5)
```

The prior guard reset the write offset to 0 but kept consuming the same 206
response, so the 14-byte tail slice (`bytes 5-18/19`) was written at byte 0,
failed the 4-byte GGUF magic gate, and was never installed — the poll times out.
With the fix the rejected partial is discarded and a fresh range-less request
refetches the full body.
</details>

<details>
<summary>Passing-after (fix applied): all five resume paths reconstruct the exact file</summary>

```
 RUN  v4.1.10  plugins/plugin-local-inference

 ✓ src/local-inference-routes.resume.test.ts (5 tests) 
   ✓ restarts from byte 0 when the origin ignores Range and answers HTTP 200
   ✓ restarts from byte 0 when a 206 Content-Range is misaligned to the requested offset
   ✓ restarts from byte 0 when a 206 returns only its declared misaligned tail bytes
   ✓ restarts from byte 0 when a 206 omits the Content-Range header
   ✓ resumes correctly when the origin honors Range with HTTP 206

 Test Files  1 passed (1)
      Tests  5 passed (5)
```
</details>

<details>
<summary>Full package route suite (34 passed) — stable across consecutive runs</summary>

```
 Test Files  4 passed (4)
      Tests  34 passed (34)
```
(files: local-inference-routes.test.ts, .concurrency.test.ts, .encoding.test.ts, .resume.test.ts)
</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface; backend model-downloader guard.`

### After

`N/A - no UI surface; backend model-downloader guard.`

### Walkthrough video

`N/A - no user-facing UI flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Domain artifacts

Byte-level proof of the corrupted vs corrected stored `models/eliza-1-2b.gguf`.
Full artifact = `"GGUFREAL-MODEL-BODY"` (19 bytes); stale partial seeded before
retry = `"GGUFSTALE-PARTIAL"` (17 bytes).

```
BEFORE FIX (append-onto-stale): 36 bytes  "GGUFSTALE-PARTIALGGUFREAL-MODEL-BODY"
  0000000 47 47 55 46 53 54 41 4c 45 2d 50 41 52 54 49 41  >GGUFSTALE-PARTIA<
  0000016 4c 47 47 55 46 52 45 41 4c 2d 4d 4f 44 45 4c 2d  >LGGUFREAL-MODEL-<
  0000032 42 4f 44 59                                      >BODY<
  first 4 bytes still "GGUF" (47 47 55 46) -> isGgufFile() passes -> corrupt file
  registered, registry.json sizeBytes = 36 (existingPartial + fullSize).

TAIL-SLICE CORRUPTION (prior guard, compliant misaligned 206 `bytes 5-18/19`): 14 bytes  "REAL-MODEL-BODY"
  0000000 52 45 41 4c 2d 4d 4f 44 45 4c 2d 42 4f 44 59     >REAL-MODEL-BODY<
  first 4 bytes "REAL" (52 45 41 4c) -> isGgufFile() FAILS -> download errors
  out, but only after the truncated .part was already renamed to final; the
  model is never installed. The prior guard reset the offset to 0 yet reused
  this same partial body, so it wrote the declared tail at byte 0.

AFTER FIX (aligned 206 required, else discard the partial and refetch full via a
range-less request): 19 bytes  "GGUFREAL-MODEL-BODY"
  0000000 47 47 55 46 52 45 41 4c 2d 4d 4f 44 45 4c 2d 42  >GGUFREAL-MODEL-B<
  0000016 4f 44 59                                         >ODY<
  stale partial discarded, full body refetched; registry.json sizeBytes = 19
  (true file length).
```

## Known gaps / failures

- Full `bun run verify` was **not** run to completion on this machine (a 16 GB
  Raspberry Pi). It runs the entire monorepo's parity/dependency/type/lint/audit
  gates and the workspace `typecheck` alone takes ~7 minutes here. Instead the
  owning package's gates were run and pass: `tsc --noEmit` reports no errors in
  the two changed files (the only remaining `tsc` errors are pre-existing missing
  build artifacts for unrelated dependency packages — `@elizaos/cloud-routing`
  and `@elizaos/core/client-public` subpaths — not this diff, and identical with
  the diff stashed), Biome `check` on both changed files (no errors), and focused
  Vitest (route suite 34/34; resume file 5/5). The change is a small single-function guard plus a pure helper with
  no public-surface change, so the scoped gates cover the modified contract.
- Some inline log blocks above are lightly trimmed for readability (headers /
  timing lines); the pass/fail verdicts and byte counts are verbatim.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@1888cacce0644c188abc72c33dd284906a055064:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@1888cacce0644c188abc72c33dd284906a055064:packages/skills/skills/contribute-to-eliza"} -->





