### PR TITLE
test(ui): cover element-reporter.hooks

### DIFF
--- a/packages/ui/src/agent-surface/element-reporter.hooks.test.ts
+++ b/packages/ui/src/agent-surface/element-reporter.hooks.test.ts
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+/**
+ * Coverage for element-reporter.hooks: `buildPayload` snapshot-to-report
+ * mapping against a real `ViewAgentRegistry`, and the subscribe/POST hook's
+ * debounce, inertness, and cleanup behaviour. The registry and payload builder
+ * are exercised for real; only the transport boundary (`fetchWithCsrf`) and
+ * navigation/url helpers are mocked, and debounce timing uses fake timers.
+ */
+import { type RenderHookResult, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import {
+  buildPayload,
+  useAgentSurfaceElementReporter,
+} from "./element-reporter.hooks";
+import { ViewAgentRegistry } from "./registry";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(async () => new Response(null, { status: 204 })),
+}));
+
+vi.mock("../navigation", () => ({
+  getWindowNavigationPath: vi.fn(() => "/chat"),
+}));
+
+vi.mock("../utils/asset-url", () => ({
+  resolveApiUrl: (path: string) => path,
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+
+function makeRegistry(
+  viewId = "wallet",
+  viewType: "gui" | "tui" | "xr" = "gui",
+): ViewAgentRegistry {
+  return new ViewAgentRegistry(viewId, viewType);
+}
+
+describe("buildPayload", () => {
+  it("passes view identity through and preserves registry order", () => {
+    const registry = makeRegistry("wallet", "tui");
+    const unregisterAmount = registry.register(
+      {
+        id: "amount",
+        label: "Amount",
+        role: "text-input",
+        order: 20,
+        getValue: () => "5",
+      },
+      () => null,
+    );
+    // Registered later but sorts first via the lower order key.
+    registry.register(
+      { id: "send", label: "Send", role: "button", order: 10 },
+      () => null,
+    );
+    try {
+      const payload = buildPayload(registry);
+      expect(payload.viewId).toBe("wallet");
+      expect(payload.viewType).toBe("tui");
+      expect(payload.elements.map((e) => e.id)).toEqual(["send", "amount"]);
+    } finally {
+      unregisterAmount();
+    }
+  });
+
+  it("includes string values and omits non-string values", () => {
+    const registry = makeRegistry("form");
+    registry.register(
+      { id: "text", label: "Text", role: "text-input", getValue: () => "5" },
+      () => null,
+    );
+    registry.register(
+      {
+        id: "check",
+        label: "Check",
+        role: "toggle",
+        getValue: () => true,
+      },
+      () => null,
+    );
+    registry.register({ id: "bare", label: "Bare" }, () => null);
+
+    const payload = buildPayload(registry);
+    expect(payload.elements.map((e) => e.id)).toEqual([
+      "text",
+      "check",
+      "bare",
+    ]);
+    expect(payload.elements[0]).toMatchObject({
+      id: "text",
+      role: "text-input",
+      label: "Text",
+      value: "5",
+    });
+    // A boolean DOM value is not a reportable string value.
+    expect("value" in payload.elements[1]).toBe(false);
+    expect("value" in payload.elements[2]).toBe(false);
+  });
+
+  it("reports focus only for the element that owns document focus", () => {
+    const focusedInput = document.createElement("input");
+    const idleInput = document.createElement("input");
+    document.body.append(focusedInput, idleInput);
+    focusedInput.focus();
+
+    const registry = makeRegistry("composer");
+    try {
+      registry.register(
+        {
+          id: "focused",
+          label: "Focused",
+          role: "text-input",
+          getValue: () => "typed",
+        },
+        () => focusedInput,
+      );
+      registry.register(
+        { id: "idle", label: "Idle", role: "button" },
+        () => idleInput,
+      );
+
+      const payload = buildPayload(registry);
+      expect(payload.elements[0]).toMatchObject({
+        id: "focused",
+        value: "typed",
+        focused: true,
+      });
+      expect("focused" in payload.elements[1]).toBe(false);
+    } finally {
+      focusedInput.remove();
+      idleInput.remove();
+    }
+  });
+
+  it("redacts values of sensitive elements even when they hold one", () => {
+    const registry = makeRegistry("auth");
+    registry.register(
+      {
+        id: "password",
+        label: "Password",
+        role: "text-input",
+        sensitive: true,
+        getValue: () => "secret-value",
+      },
+      () => null,
+    );
+
+    const payload = buildPayload(registry);
+    expect(payload.elements[0]).toMatchObject({
+      id: "password",
+      label: "Password",
+    });
+    expect("value" in payload.elements[0]).toBe(false);
+  });
+
+  it("returns an empty element list for an empty view", () => {
+    const registry = makeRegistry("empty", "xr");
+    const payload = buildPayload(registry);
+    expect(payload).toEqual({ viewId: "empty", viewType: "xr", elements: [] });
+  });
+});
+
+describe("useAgentSurfaceElementReporter", () => {
+  type ReporterProps = { registry: ViewAgentRegistry | null };
+  let view: RenderHookResult<void, ReporterProps> | null = null;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  function renderReporter(registry: ViewAgentRegistry | null) {
+    const mountedHook = renderHook(
+      (props: ReporterProps) => useAgentSurfaceElementReporter(props.registry),
+      { initialProps: { registry } },
+    );
+    view = mountedHook;
+    return mountedHook;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchWithCsrfMock.mockClear();
+  });
+
+  afterEach(() => {
+    view?.unmount();
+    view = null;
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    vi.useRealTimers();
+  });
+
+  async function advancePastDebounce(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(600);
+  }
+
+  function lastPostBody(): Record<string, unknown> {
+    const calls = fetchWithCsrfMock.mock.calls;
+    const init = calls[calls.length - 1]?.[1];
+    return JSON.parse(String(init?.body));
+  }
+
+  it("is inert in the NODE_ENV=test runner regardless of registry state", async () => {
+    const registry = makeRegistry();
+    registry.register(
+      { id: "amount", label: "Amount", getValue: () => "5" },
+      () => null,
+    );
+    renderReporter(registry);
+
+    await advancePastDebounce();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing with a null registry even outside the test environment", async () => {
+    process.env.NODE_ENV = "production";
+    renderReporter(null);
+
+    await advancePastDebounce();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("posts the initial debounced snapshot to the view elements endpoint", async () => {
+    process.env.NODE_ENV = "production";
+    const registry = makeRegistry("wallet", "gui");
+    registry.register(
+      {
+        id: "send.amount",
+        label: "Amount",
+        role: "text-input",
+        sensitive: false,
+        getValue: () => "5",
+      },
+      () => null,
+    );
+    renderReporter(registry);
+
+    await advancePastDebounce();
+
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchWithCsrfMock.mock.calls[0];
+    expect(url).toBe("/api/views/wallet/elements");
+    expect(init?.method).toBe("POST");
+    expect(lastPostBody()).toEqual({
+      elements: [
+        { id: "send.amount", role: "text-input", label: "Amount", value: "5" },
+      ],
+      viewPath: "/chat",
+      viewType: "gui",
+    });
+  });
+
+  it("coalesces rapid registry updates into one debounced POST", async () => {
+    process.env.NODE_ENV = "production";
+    const registry = makeRegistry("wallet");
+    registry.register({ id: "a", label: "A" }, () => null);
+    renderReporter(registry);
+
+    registry.touch();
+    registry.register({ id: "b", label: "B" }, () => null);
+    registry.touch();
+
+    await advancePastDebounce();
+
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+    expect(lastPostBody().elements).toHaveLength(2);
+  });
+
+  it("skips the POST when the snapshot has no elements", async () => {
+    process.env.NODE_ENV = "production";
+    const registry = makeRegistry("blank");
+    renderReporter(registry);
+
+    await advancePastDebounce();
+    registry.touch();
+    await advancePastDebounce();
+
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pending flush on unmount and ignores later updates", async () => {
+    process.env.NODE_ENV = "production";
+    const registry = makeRegistry("wallet");
+    registry.register({ id: "a", label: "A" }, () => null);
+    const mountedHook = renderReporter(registry);
+    mountedHook.unmount();
+    view = null;
+    registry.touch(); // after unsubscribe this must not schedule anything
+
+    await advancePastDebounce();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("re-subscribes when the registry instance changes, dropping the old flush", async () => {
+    process.env.NODE_ENV = "production";
+    const first = makeRegistry("view-a");
+    first.register({ id: "a", label: "A" }, () => null);
+    const mountedHook = renderReporter(first);
+
+    const second = makeRegistry("view-b");
+    second.register({ id: "b", label: "B" }, () => null);
+    mountedHook.rerender({ registry: second });
+
+    await advancePastDebounce();
+
+    // view-a's pending timer was cancelled by the effect cleanup; only view-b reports.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+    expect(fetchWithCsrfMock.mock.calls[0][0]).toBe(
+      "/api/views/view-b/elements",
+    );
+    expect(lastPostBody().elements).toEqual([
+      { id: "b", role: "region", label: "B" },
+    ]);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/agent-surface/element-reporter.hooks.test.ts` — a new unit suite for `element-reporter.hooks.ts`, which has no same-named test file on develop. The diff touches only this new test file (+313/−0); no existing suite is modified or rewritten.

## Coverage

`buildPayload` (against a real `ViewAgentRegistry`):

- view identity passthrough (`viewId` / `viewType`, including `tui` and `xr`)
- registration order preserved through explicit `order` keys (later-registered element sorting first)
- string values included; non-string values (boolean accessor) omitted; absent values produce no key
- sensitive elements keep their value redacted even while holding one
- focus reported only for the element that owns `document.activeElement`; non-focused elements get no `focused` key
- empty view → `{ viewId, viewType, elements: [] }`

`useAgentSurfaceElementReporter`:

- deliberate inertness under `NODE_ENV=test` even with a populated registry (the repo's runner I/O convention)
- no-op for a `null` registry outside the test environment
- initial debounced POST to `/api/views/:viewId/elements` with the exact payload shape (`elements`, `viewPath`, `viewType`)
- rapid registry updates coalesce into one POST carrying the latest snapshot
- empty snapshots never POST
- unmount cancels the pending flush and later updates schedule nothing
- switching the registry instance drops the old view's pending flush; only the new view reports

The suite drives the real module under test end to end; only the transport boundary (`fetchWithCsrf`) plus the navigation/url helpers are mocked at their module boundary, and debounce timing uses fake timers.

## Evidence (test-only change — no production behaviour modified)

- `bunx vitest run src/agent-surface/element-reporter.hooks.test.ts` → Test Files 1 passed (1), Tests 12 passed (12). Re-run against current `origin/develop` immediately before filing.
- `bunx biome check src/agent-surface/element-reporter.hooks.test.ts` → clean.
- `bunx tsc --noEmit` in `packages/ui` → zero diagnostics referencing the new file.
- Diff contains exactly one new test file; `git diff --stat` shows insertions only.

Note: this is a fork contribution, so hosted CI does not run on this PR. The counts above are from local runs of the repository's own tooling.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0f3cce9389fa8db6b41df990771b8007f13dbc6f -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
