### PR TITLE
test(ui): cover csrf-cookie

### DIFF
--- a/packages/ui/src/api/auth/csrf-cookie.test.ts
+++ b/packages/ui/src/api/auth/csrf-cookie.test.ts
@@ -1,0 +1,113 @@
+/** Covers readCsrfTokenFromCookie against a real jsdom cookie jar; deterministic unit harness, no module mocks. */
+// @vitest-environment jsdom
+
+/**
+ * The unit under test performs one synchronous read of the raw
+ * `document.cookie` string, so each case seeds that jar directly and asserts
+ * on the decoded token (or its deliberate absence).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readCsrfTokenFromCookie } from "./csrf-cookie";
+import { CSRF_COOKIE_NAME } from "./sessions";
+
+function setCookie(pair: string) {
+  // biome-ignore lint/suspicious/noDocumentCookie: seeding the sync cookie jar the code under test reads.
+  document.cookie = pair;
+}
+
+function clearCookies() {
+  for (const name of [
+    CSRF_COOKIE_NAME,
+    "other",
+    `prefixed_${CSRF_COOKIE_NAME}`,
+    "ELIZA_CSRF",
+  ]) {
+    setCookie(`${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`);
+  }
+}
+
+describe("readCsrfTokenFromCookie", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearCookies();
+  });
+
+  it("decodes the URL-encoded token from the readable companion cookie", () => {
+    setCookie("other=value");
+    setCookie(`${CSRF_COOKIE_NAME}=token%3Dwith%3Bencoded%20parts`);
+
+    expect(readCsrfTokenFromCookie()).toBe("token=with;encoded parts");
+  });
+
+  it("returns null when only unrelated cookies exist", () => {
+    setCookie("other=value");
+
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+
+  it("returns null when the cookie jar is completely empty", () => {
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+
+  it("returns null when there is no browser document at all", () => {
+    vi.stubGlobal("document", undefined);
+
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+
+  it("matches the cookie name case-sensitively", () => {
+    setCookie(`ELIZA_CSRF=${CSRF_COOKIE_NAME}-in-different-case`);
+
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+
+  it("ignores cookies whose names merely contain the CSRF name as a suffix", () => {
+    setCookie(`prefixed_${CSRF_COOKIE_NAME}=noise`);
+
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+
+  it("finds the real token among lookalike neighbours before it", () => {
+    setCookie(`prefixed_${CSRF_COOKIE_NAME}=noise`);
+    setCookie(`${CSRF_COOKIE_NAME}=real`);
+
+    expect(readCsrfTokenFromCookie()).toBe("real");
+  });
+
+  it("finds the real token among lookalike neighbours after it", () => {
+    setCookie(`${CSRF_COOKIE_NAME}=real`);
+    setCookie(`prefixed_${CSRF_COOKIE_NAME}=noise`);
+
+    expect(readCsrfTokenFromCookie()).toBe("real");
+  });
+
+  it("trims the separator whitespace the jar places between cookie parts", () => {
+    setCookie("other=value");
+    setCookie(`${CSRF_COOKIE_NAME}=trimmed-token`);
+
+    // The jar serialises multiple cookies with "; ", so the CSRF part arrives
+    // space-prefixed and only trimming makes the prefix match.
+    expect(document.cookie).toContain("; ");
+    expect(readCsrfTokenFromCookie()).toBe("trimmed-token");
+  });
+
+  it("returns the decoded empty string when the cookie value is empty", () => {
+    setCookie(`${CSRF_COOKIE_NAME}=`);
+    setCookie("other=value");
+
+    expect(readCsrfTokenFromCookie()).toBe("");
+  });
+
+  it("treats a malformed percent-escape as an absent token instead of throwing", () => {
+    setCookie(`${CSRF_COOKIE_NAME}=%E0%A4%A`);
+    expect(() => decodeURIComponent("%E0%A4%A")).toThrow();
+    setCookie("other=value");
+
+    expect(readCsrfTokenFromCookie()).toBeNull();
+  });
+});


### PR DESCRIPTION

## What

Adds a dedicated unit suite for `packages/ui/src/api/auth/csrf-cookie.ts`, which had no same-named test file anywhere on `develop`. The diff is one new file, `+113/-0`; it changes no production code.

## Coverage

`readCsrfTokenFromCookie()` is exercised through its real contract against a real jsdom cookie jar (no module mocks):

- decodes a URL-encoded token value (`token%3Dwith%3Bencoded%20parts` -> `token=with;encoded parts`)
- returns null when only unrelated cookies exist, and when the cookie jar is completely empty
- returns null when there is no browser `document` at all (`typeof document === "undefined"` branch)
- matches the cookie name case-sensitively (`ELIZA_CSRF` does not match)
- ignores cookies whose names merely contain `eliza_csrf` as a suffix, both before and after the real cookie in the jar (prefix anchoring on the trimmed part)
- trims the `"; "` separator whitespace the cookie jar places between parts
- returns the decoded empty string for an empty cookie value
- treats a malformed percent-escape as an absent token instead of throwing (the existing J3 catch), with an inline sanity assertion that the fixture really throws under `decodeURIComponent`

The no-DOM branch, the J3 malformed-escape branch, prefix anchoring, case sensitivity, and empty-value behaviour are not reached by the existing `csrf-client.test.ts`.

## Verification (local; fork PRs do not run hosted CI)

All counts below are from real runs against current `origin/develop` (`c0801ba95ef0`) immediately before filing:

- `bunx vitest run src/api/auth/csrf-cookie.test.ts` (in `packages/ui`): **Test Files 1 passed (1), Tests 11 passed (11)** - run twice; the second run reproduced identical counts on the same base that this branch is cut from.
- `bunx biome check src/api/auth/csrf-cookie.test.ts`: clean ("Checked 1 file... No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output.
- `git diff origin/develop...HEAD --stat`: exactly `packages/ui/src/api/auth/csrf-cookie.test.ts | 113 ++++++++++++++++++++++++++++` - a single new test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c92f1ebc5418fc6c106227e6ed07291a7aa89f30 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
