### PR TITLE
test(ui): cover client-agent-consumer-keys

### DIFF
--- a/packages/ui/src/api/client-agent-consumer-keys.test.ts
+++ b/packages/ui/src/api/client-agent-consumer-keys.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit coverage for the OWNER-only consumer-key admin verbs that
+ * client-agent-consumer-keys installs on ElizaClient: list / create / update /
+ * rotate against /api/accounts/consumer-keys*, including response-shape
+ * validation (a malformed agent reply must throw instead of rendering
+ * undefined fields) and the one-time plaintext-key contract. Transport stubbed
+ * via ElizaClient.fetch; no live agent.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS } from "./client-agent-consumer-keys";
+import { ElizaClient } from "./client-base";
+
+function clientWithBody(body: unknown): {
+  client: ElizaClient;
+  fetchMock: ReturnType<typeof vi.fn>;
+} {
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  const fetchMock = vi.fn(async () => body);
+  client.fetch = fetchMock as unknown as typeof client.fetch;
+  return { client, fetchMock };
+}
+
+function validSummary(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: "ck-1",
+    label: "CI pool",
+    enabled: true,
+    dailyTokenQuota: 1000,
+    keyPrefix: "ck_live_ab12",
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides,
+  };
+}
+
+describe("CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS", () => {
+  it("keeps the documented independent-hop 10s REST budget", () => {
+    expect(CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+});
+
+describe("ElizaClient.listConsumerKeys", () => {
+  it("GETs the pool with the default 10s budget and parses every summary", async () => {
+    const summary = validSummary({ lastUsedAt: 300 });
+    const { client, fetchMock } = clientWithBody({ keys: [summary] });
+    const result = await client.listConsumerKeys();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/accounts/consumer-keys",
+      undefined,
+      { timeoutMs: CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS },
+    );
+    expect(result).toEqual([summary]);
+  });
+
+  it("forwards a caller-supplied timeoutMs instead of the default", async () => {
+    const { client, fetchMock } = clientWithBody({ keys: [] });
+    await client.listConsumerKeys(1234);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/accounts/consumer-keys",
+      undefined,
+      { timeoutMs: 1234 },
+    );
+  });
+
+  it("omits lastUsedAt for a key that was never used", async () => {
+    const { client } = clientWithBody({ keys: [validSummary()] });
+    const [result] = await client.listConsumerKeys();
+    expect(result).not.toHaveProperty("lastUsedAt");
+  });
+
+  it("accepts a null dailyTokenQuota as an unbounded key", async () => {
+    const { client } = clientWithBody({
+      keys: [validSummary({ dailyTokenQuota: null })],
+    });
+    await expect(client.listConsumerKeys()).resolves.toEqual([
+      validSummary({ dailyTokenQuota: null }),
+    ]);
+  });
+
+  it("rejects a non-record reply such as null or an array", async () => {
+    for (const body of [null, [validSummary()]]) {
+      const { client } = clientWithBody(body);
+      await expect(client.listConsumerKeys()).rejects.toThrow(
+        "Malformed consumer-key list from agent",
+      );
+    }
+  });
+
+  it("rejects a reply whose keys field is not an array", async () => {
+    const { client } = clientWithBody({ keys: validSummary() });
+    await expect(client.listConsumerKeys()).rejects.toThrow(
+      "Malformed consumer-key list from agent",
+    );
+  });
+
+  it("rejects an element whose required fields are mistyped", async () => {
+    const { client } = clientWithBody({
+      keys: [validSummary({ enabled: "yes" })],
+    });
+    await expect(client.listConsumerKeys()).rejects.toThrow(
+      "Malformed consumer-key record from agent",
+    );
+  });
+
+  it("rejects a dailyTokenQuota that is neither null nor a number", async () => {
+    const { client } = clientWithBody({
+      keys: [validSummary({ dailyTokenQuota: "1000" })],
+    });
+    await expect(client.listConsumerKeys()).rejects.toThrow(
+      "Malformed consumer-key record from agent",
+    );
+  });
+
+  it("drops a non-numeric lastUsedAt rather than rejecting the record", async () => {
+    // Observed behaviour: only a numeric lastUsedAt is spread into the
+    // summary, so a mistyped one is silently omitted instead of failing.
+    const { client } = clientWithBody({
+      keys: [validSummary({ lastUsedAt: "300" })],
+    });
+    const [result] = await client.listConsumerKeys();
+    expect(result).not.toHaveProperty("lastUsedAt");
+    expect(result).toMatchObject(validSummary());
+  });
+});
+
+describe("ElizaClient.createConsumerKey", () => {
+  it("POSTs the patch body and returns the one-time key plus consumer", async () => {
+    const summary = validSummary();
+    const { client, fetchMock } = clientWithBody({
+      key: "ck_live_new_secret",
+      consumer: summary,
+    });
+    const result = await client.createConsumerKey({ label: "nightly" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/accounts/consumer-keys", {
+      method: "POST",
+      body: JSON.stringify({ label: "nightly" }),
+    });
+    expect(result).toEqual({
+      key: "ck_live_new_secret",
+      consumer: summary,
+    });
+  });
+
+  it("rejects an empty plaintext key", async () => {
+    const { client } = clientWithBody({
+      key: "",
+      consumer: validSummary(),
+    });
+    await expect(client.createConsumerKey({})).rejects.toThrow(
+      "Malformed consumer-key create/rotate response",
+    );
+  });
+
+  it("rejects a non-string plaintext key", async () => {
+    const { client } = clientWithBody({
+      key: 42,
+      consumer: validSummary(),
+    });
+    await expect(client.createConsumerKey({})).rejects.toThrow(
+      "Malformed consumer-key create/rotate response",
+    );
+  });
+
+  it("rejects a consumer payload that fails summary validation", async () => {
+    const { client } = clientWithBody({
+      key: "ck_live_new_secret",
+      consumer: validSummary({ createdAt: "100" }),
+    });
+    await expect(client.createConsumerKey({})).rejects.toThrow(
+      "Malformed consumer-key record from agent",
+    );
+  });
+});
+
+describe("ElizaClient.updateConsumerKey", () => {
+  it("PATCHes the percent-encoded path and returns the updated summary", async () => {
+    const id = "ck/1 x";
+    const summary = validSummary({ id });
+    const { client, fetchMock } = clientWithBody({ consumer: summary });
+    const result = await client.updateConsumerKey(id, { enabled: false });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/accounts/consumer-keys/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ enabled: false }),
+      },
+    );
+    expect(result).toEqual(summary);
+  });
+
+  it("rejects a non-record update reply", async () => {
+    const { client } = clientWithBody(null);
+    await expect(
+      client.updateConsumerKey("ck-1", { enabled: false }),
+    ).rejects.toThrow("Malformed consumer-key update response");
+  });
+
+  it("rejects a consumer field that fails summary validation", async () => {
+    const { client } = clientWithBody({
+      consumer: validSummary({ keyPrefix: 7 }),
+    });
+    await expect(
+      client.updateConsumerKey("ck-1", { label: "renamed" }),
+    ).rejects.toThrow("Malformed consumer-key record from agent");
+  });
+});
+
+describe("ElizaClient.rotateConsumerKey", () => {
+  it("POSTs to the rotate endpoint and returns the replacement key", async () => {
+    const id = "ck 9";
+    const summary = validSummary({ id });
+    const { client, fetchMock } = clientWithBody({
+      key: "ck_live_rotated",
+      consumer: summary,
+    });
+    const result = await client.rotateConsumerKey(id);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/accounts/consumer-keys/${encodeURIComponent(id)}/rotate`,
+      { method: "POST" },
+    );
+    expect(result).toEqual({ key: "ck_live_rotated", consumer: summary });
+  });
+
+  it("rejects a malformed rotate reply", async () => {
+    const { client } = clientWithBody({ consumer: validSummary() });
+    await expect(client.rotateConsumerKey("ck-1")).rejects.toThrow(
+      "Malformed consumer-key create/rotate response",
+    );
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite, `packages/ui/src/api/client-agent-consumer-keys.test.ts` (+232/-0, new file only), covering the OWNER-only consumer-key admin verbs that `client-agent-consumer-keys` installs on `ElizaClient`: `listConsumerKeys`, `createConsumerKey`, `updateConsumerKey`, and `rotateConsumerKey`, plus the exported `CONSUMER_KEYS_LIST_FETCH_TIMEOUT_MS`.

## Why

The module had no same-named test file anywhere in the repo, despite owning strict response-shape validation contracts: every malformed agent reply must throw (`Malformed consumer-key …`) instead of rendering undefined fields, and plaintext keys must flow straight to the caller. This pins those contracts.

## Coverage (19 cases)

- **list**: default 10s timeout budget forwarded as `{ timeoutMs }`; caller-supplied `timeoutMs` passthrough; summary parsing incl. `lastUsedAt` present/omitted; null `dailyTokenQuota` accepted; non-record reply (null / array), non-array `keys`, mistyped element fields, and non-null-non-number `dailyTokenQuota` all rejected; observed behavior that a non-numeric `lastUsedAt` is dropped rather than rejected.
- **create**: POST body + path asserted on the transport mock; one-time key + consumer returned verbatim; empty-string key, non-string key, and malformed consumer payload rejected.
- **update**: percent-encoded id path + PATCH body asserted; parsed `response.consumer` returned; non-record reply and failing consumer validation rejected.
- **rotate**: `/rotate` endpoint with encoded id asserted; replacement key + consumer returned; malformed rotate reply rejected.

Transport is stubbed via `ElizaClient.fetch` exactly like the neighboring `client-agent-models-config.test.ts`; the real prototype methods under test execute unmodified.

## Verification (local, fork CI does not run on this PR)

- `bunx vitest run src/api/client-agent-consumer-keys.test.ts` (in `packages/ui`): **Test Files 1 passed (1), Tests 19 passed (19)**
- `bunx biome check --write packages/ui/src/api/client-agent-consumer-keys.test.ts`: clean, no fixes applied
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics referencing the new file
- The diff touches only the single new test file (+232/-0); no production behavior changes.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c0801ba95ef008b72152116ba22d1f2bbf134858 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
