### PR TITLE
fix(browser-bridge): harden automatic companion lifecycle

### DIFF
--- a/.github/workflows/browser-bridge-windows-security.yml
+++ b/.github/workflows/browser-bridge-windows-security.yml
@@ -10,9 +10,12 @@ permissions:
 jobs:
   windows-security-contract:
     runs-on: windows-2025
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.14
@@ -22,7 +25,10 @@ jobs:
       - name: Execute Windows PowerShell 5.1 security helpers
         shell: powershell
         run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+      - name: Compile and probe staged Windows native host
+        shell: powershell
+        run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
       - name: Run browser broker security contracts
         shell: powershell
         working-directory: packages/app-core/platforms/electrobun
-        run: bunx vitest run --config vitest.electrobun.config.ts src/native/browser-bridge-broker-secret.test.ts src/native/browser-bridge-broker-server.test.ts
+        run: bunx vitest run --config vitest.electrobun.config.ts src/native/browser-bridge-broker-secret.test.ts src/native/browser-bridge-broker-server.test.ts src/native/browser-bridge-registration.test.ts src/native/browser-bridge-unregister.test.ts src/native/browser-bridge-windows-native-host-proof.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,7 @@ jobs:
         run: |
           set -euo pipefail
           for pair in $RESULTS; do
+            name="${pair%%=*}"
             result="${pair#*=}"
             if [ "$result" != "success" ]; then
               echo "::error title=CI aggregate::$name finished with $result"

--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -26,8 +26,8 @@ env:
   NODE_OPTIONS: "--max-old-space-size=8192"
 
 jobs:
-  static-smoke:
-    name: All Tests Passed
+  source-smoke:
+    name: Source static smoke
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -148,3 +148,29 @@ jobs:
         env:
           TURBO_SCM_BASE: ${{ steps.diff.outputs.merge_base }}
         run: node packages/scripts/run-turbo.mjs run build --concurrency=4 --affected --output-logs=errors-only
+
+  browser-bridge-windows-security:
+    name: Browser bridge Windows security
+    uses: ./.github/workflows/browser-bridge-windows-security.yml
+
+  static-smoke:
+    name: All Tests Passed
+    if: always()
+    needs: [source-smoke, browser-bridge-windows-security]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require source and Windows security lanes
+        env:
+          RESULTS: >-
+            source-smoke=${{ needs.source-smoke.result }}
+            browser-bridge-windows-security=${{ needs.browser-bridge-windows-security.result }}
+        run: |
+          set -euo pipefail
+          for pair in $RESULTS; do
+            name="${pair%%=*}"
+            result="${pair#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error title=PR admission::$name finished with $result"
+              exit 1
+            fi
+          done

--- a/packages/agent/src/api/server-cookie-cors-boundary.real-server.test.ts
+++ b/packages/agent/src/api/server-cookie-cors-boundary.real-server.test.ts
@@ -66,7 +66,10 @@ beforeEach(async () => {
         typeof req.headers.authorization === "string"
           ? req.headers.authorization
           : "";
-      if (authorization === "Bearer explicit-session") {
+      if (
+        options.allowBearerAuth !== false &&
+        authorization === "Bearer explicit-session"
+      ) {
         return { ok: true, role: "OWNER", identityId: "owner" };
       }
       if (!options.allowCookieAuth) return { ok: false, role: "NONE" };
@@ -264,6 +267,25 @@ describe("browser companion owner enrollment boundary", () => {
         },
       });
       expect(nonOwner.status).toBe(403);
+
+      const wrongCsrf = await fetch(endpointPath(pathname), {
+        method: "POST",
+        headers: {
+          Cookie: "eliza_session=browser-session",
+          "X-Eliza-CSRF": "wrong-csrf",
+        },
+      });
+      expect(wrongCsrf.status).toBe(401);
+
+      const bearerSubstitution = await fetch(endpointPath(pathname), {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer explicit-session",
+          Cookie: "eliza_session=invalid-session",
+          "X-Eliza-CSRF": "valid-csrf",
+        },
+      });
+      expect(bearerSubstitution.status).toBe(401);
 
       const owner = await fetch(endpointPath(pathname), {
         method: "POST",

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1612,6 +1612,10 @@ async function handleRequest(
   // CORS trust set; arbitrary reflected origins remain bearer-only.
   const allowHostCookieAuth =
     requestOrigin === undefined || isCredentialedCorsOrigin(requestOrigin);
+  const requireBrowserCompanionOwnerSession = isBrowserCompanionOwnerMutation(
+    method,
+    pathname,
+  );
   let hostSessionAuthorization: AgentHttpRequestAuthorization = {
     ok: false,
     role: "NONE",
@@ -1627,7 +1631,11 @@ async function handleRequest(
         hostSessionAuthorization = await resolveAuthorization(
           req,
           state.runtime,
-          { allowCookieAuth: allowHostCookieAuth },
+          {
+            allowCookieAuth: allowHostCookieAuth,
+            allowTrustedLocalBypass: !requireBrowserCompanionOwnerSession,
+            allowBearerAuth: !requireBrowserCompanionOwnerSession,
+          },
         );
         return hostSessionAuthorization;
       }
@@ -1829,7 +1837,7 @@ async function handleRequest(
     return;
   }
 
-  if (isBrowserCompanionOwnerMutation(method, pathname)) {
+  if (requireBrowserCompanionOwnerSession) {
     if (!hasBrowserCompanionOwnerSessionCookie(req)) {
       json(res, { error: "Owner session required" }, 401);
       return;

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -55,6 +55,13 @@ export interface AgentHttpRequestAuthorizationOptions {
    * bearer-token authentication.
    */
   allowCookieAuth: boolean;
+  /**
+   * False for boundaries that require a real browser owner session. The host
+   * must not replace that session with ambient same-machine trust.
+   */
+  allowTrustedLocalBypass?: boolean;
+  /** False when explicit bearer credentials must not substitute for a cookie. */
+  allowBearerAuth?: boolean;
 }
 
 /** Public (digest-free) consumer-key record surfaced to the owner dashboard. */

--- a/packages/app-core/packaging/inno/ElizaOSApp.iss
+++ b/packages/app-core/packaging/inno/ElizaOSApp.iss
@@ -51,3 +51,6 @@ Source: "{#MySetupIconFile}"; DestDir: "{app}"; DestName: "{#MyAppIconFile}"; Fl
 Name: "{autoprograms}\{#MyDefaultGroupName}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppIconFile}"
 Name: "{autoprograms}\{#MyDefaultGroupName}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\{#MyAppIconFile}"
+
+[UninstallRun]
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ""{app}\Resources\app\browser-bridge-unregister.ps1"" -InstallDir ""{app}"""; RunOnceId: "BrowserBridgeNativeHost"; Flags: runhidden waituntilterminated

--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -444,6 +444,7 @@ export function resolveElectrobunCopyMap({
     "build/browser-bridge-release.json": "browser-bridge-release.json",
     "scripts/browser-bridge-pipe-host.ps1": "browser-bridge-pipe-host.ps1",
     "scripts/browser-bridge-secret.ps1": "browser-bridge-secret.ps1",
+    "scripts/browser-bridge-unregister.ps1": "browser-bridge-unregister.ps1",
   };
   if (process.platform === "darwin" && resolveAppleTeamId(process.env)) {
     copy["build/browser-bridge-signing.json"] = "browser-bridge-signing.json";

--- a/packages/app-core/platforms/electrobun/scripts/browser-bridge-pipe-host.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/browser-bridge-pipe-host.ps1
@@ -115,7 +115,9 @@ function Read-Exact([System.IO.Stream]$stream, [int]$count) {
     if ($read -eq 0) { throw "stream closed" }
     $offset += $read
   }
-  return $buffer
+  # PowerShell enumerates arrays returned from functions by default. Preserve
+  # the byte[] so Stream.Write and BitConverter receive their required type.
+  return ,$buffer
 }
 while ($true) {
   $pipe.WaitForConnection()

--- a/packages/app-core/platforms/electrobun/scripts/browser-bridge-unregister.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/browser-bridge-unregister.ps1
@@ -1,0 +1,89 @@
+# Removes only Chrome and Firefox native-host registrations owned by this installation.
+param(
+  [Parameter(Mandatory = $true)][string]$InstallDir,
+  [string]$ConfigDir = (Join-Path $env:LOCALAPPDATA "elizaOS\BrowserBridge")
+)
+
+$ErrorActionPreference = "Stop"
+$hostName = "ai.elizaos.browserbridge"
+$expectedHostPath = [System.IO.Path]::GetFullPath(
+  (Join-Path $InstallDir "Resources\app\browser-bridge-native-host.exe")
+)
+
+function Get-DefaultRegistryValue([string]$SubKey) {
+  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey($SubKey, $false)
+  if ($null -eq $key) { return $null }
+  try {
+    return $key.GetValue(
+      $null,
+      $null,
+      [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+    )
+  } finally {
+    $key.Dispose()
+  }
+}
+
+function Test-ManifestOwnership([string]$ManifestPath) {
+  if (-not [System.IO.File]::Exists($ManifestPath)) { return $null }
+  try {
+    $manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+    if ($manifest.name -ne $hostName -or -not $manifest.path) { return $false }
+    $manifestHostPath = [System.IO.Path]::GetFullPath([string]$manifest.path)
+    return [System.String]::Equals(
+      $manifestHostPath,
+      $expectedHostPath,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  } catch {
+    return $false
+  }
+}
+
+$registrations = @(
+  @{
+    Browser = "chrome"
+    RegistrySubKey = "Software\Google\Chrome\NativeMessagingHosts\$hostName"
+  },
+  @{
+    Browser = "firefox"
+    RegistrySubKey = "Software\Mozilla\NativeMessagingHosts\$hostName"
+  }
+)
+
+foreach ($registration in $registrations) {
+  $manifestPath = [System.IO.Path]::GetFullPath(
+    (Join-Path $ConfigDir "$($registration.Browser)\$hostName.json")
+  )
+  $registeredPath = Get-DefaultRegistryValue $registration.RegistrySubKey
+  $registryOwnsManifest = $null -ne $registeredPath -and
+    [System.String]::Equals(
+      [System.IO.Path]::GetFullPath([string]$registeredPath),
+      $manifestPath,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  $manifestOwned = Test-ManifestOwnership $manifestPath
+
+  if ($registryOwnsManifest -and $manifestOwned -eq $true) {
+    [Microsoft.Win32.Registry]::CurrentUser.DeleteSubKeyTree(
+      $registration.RegistrySubKey,
+      $false
+    )
+  }
+  if ($registryOwnsManifest -and $manifestOwned -eq $true) {
+    Remove-Item -LiteralPath $manifestPath -Force
+  }
+}
+
+foreach ($directory in @(
+  (Join-Path $ConfigDir "chrome"),
+  (Join-Path $ConfigDir "firefox"),
+  $ConfigDir
+)) {
+  if (
+    [System.IO.Directory]::Exists($directory) -and
+    (Get-ChildItem -LiteralPath $directory -Force | Select-Object -First 1).Count -eq 0
+  ) {
+    Remove-Item -LiteralPath $directory -Force
+  }
+}

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
@@ -53,18 +53,25 @@ try {
   $start.RedirectStandardInput = $true
   $start.RedirectStandardOutput = $true
   $start.RedirectStandardError = $true
-  # Keep the binary native-messaging header at byte zero under Windows
-  # PowerShell 5.1; the default redirected writer emits a UTF-8 BOM.
-  $start.StandardInputEncoding = New-Object System.Text.UTF8Encoding($false)
   $start.EnvironmentVariables["ELIZA_STATE_DIR"] = $stateRoot
   $start.EnvironmentVariables["ELIZA_BROWSER_BRIDGE_CHROME_EXTENSION_IDS"] = $extensionId
   $process = New-Object System.Diagnostics.Process
   $process.StartInfo = $start
-  if (-not $process.Start()) { throw "compiled Windows browser native host did not start" }
+  # Windows PowerShell 5.1 has no ProcessStartInfo.StandardInputEncoding.
+  # Construct StandardInput while Console.InputEncoding is BOM-free so the
+  # binary native-messaging header remains at byte zero.
+  $previousInputEncoding = [Console]::InputEncoding
+  [Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false)
   try {
-    $process.StandardInput.BaseStream.Write($requestHeader, 0, $requestHeader.Length)
-    $process.StandardInput.BaseStream.Write($requestBytes, 0, $requestBytes.Length)
-    $process.StandardInput.BaseStream.Flush()
+    if (-not $process.Start()) { throw "compiled Windows browser native host did not start" }
+    $processInput = $process.StandardInput.BaseStream
+  } finally {
+    [Console]::InputEncoding = $previousInputEncoding
+  }
+  try {
+    $processInput.Write($requestHeader, 0, $requestHeader.Length)
+    $processInput.Write($requestBytes, 0, $requestBytes.Length)
+    $processInput.Flush()
     $process.StandardInput.Close()
     if (-not $process.WaitForExit(15000)) {
       $process.Kill()

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
@@ -53,6 +53,9 @@ try {
   $start.RedirectStandardInput = $true
   $start.RedirectStandardOutput = $true
   $start.RedirectStandardError = $true
+  # Keep the binary native-messaging header at byte zero under Windows
+  # PowerShell 5.1; the default redirected writer emits a UTF-8 BOM.
+  $start.StandardInputEncoding = New-Object System.Text.UTF8Encoding($false)
   $start.EnvironmentVariables["ELIZA_STATE_DIR"] = $stateRoot
   $start.EnvironmentVariables["ELIZA_BROWSER_BRIDGE_CHROME_EXTENSION_IDS"] = $extensionId
   $process = New-Object System.Diagnostics.Process

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
@@ -1,0 +1,105 @@
+# Compiles the Windows native host, stages its adjacent DPAPI helper, and proves the packaged lookup path is live.
+$ErrorActionPreference = "Stop"
+$electrobunRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$tempRoot = Join-Path $env:TEMP ("eliza-browser-host-proof-" + [Guid]::NewGuid().ToString("N"))
+$stageRoot = Join-Path $tempRoot "stage"
+$stateRoot = Join-Path $tempRoot "state"
+$nativeHost = Join-Path $stageRoot "browser-bridge-native-host.exe"
+$secretHelperSource = Join-Path $PSScriptRoot "browser-bridge-secret.ps1"
+$secretHelper = Join-Path $stageRoot "browser-bridge-secret.ps1"
+$secretPath = Join-Path $stateRoot "browser-bridge\broker-secret"
+$extensionId = "abcdefghijklmnopabcdefghijklmnop"
+$requestId = "123e4567-e89b-42d3-a456-426614174000"
+
+try {
+  [void][System.IO.Directory]::CreateDirectory($stageRoot)
+  Push-Location $electrobunRoot
+  try {
+    & bun build --compile --minify --target bun-windows-x64 `
+      "src/native/browser-bridge-native-host-main.ts" `
+      --outfile $nativeHost
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $nativeHost -PathType Leaf)) {
+      throw "compiled Windows browser native host was not produced"
+    }
+  } finally {
+    Pop-Location
+  }
+
+  Copy-Item -LiteralPath $secretHelperSource -Destination $secretHelper
+  $createdSecret = & powershell.exe -NoLogo -NoProfile -NonInteractive `
+    -ExecutionPolicy Bypass -File $secretHelper -Operation get-or-create -Path $secretPath
+  if ($LASTEXITCODE -ne 0 -or [Convert]::FromBase64String([string]$createdSecret).Length -ne 32) {
+    throw "staged DPAPI broker secret creation failed"
+  }
+
+  $request = @{
+    v = 1
+    type = "browser_bridge.enroll"
+    requestId = $requestId
+    nonce = "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM"
+    browser = "chrome"
+    extensionId = $extensionId
+    extensionVersion = "1.2.3"
+    profileId = "123e4567-e89b-42d3-a456-426614174001"
+  } | ConvertTo-Json -Compress
+  $requestBytes = [Text.Encoding]::UTF8.GetBytes($request)
+  $requestHeader = [BitConverter]::GetBytes([uint32]$requestBytes.Length)
+
+  $start = New-Object System.Diagnostics.ProcessStartInfo
+  $start.FileName = $nativeHost
+  $start.Arguments = "chrome-extension://$extensionId/"
+  $start.UseShellExecute = $false
+  $start.CreateNoWindow = $true
+  $start.RedirectStandardInput = $true
+  $start.RedirectStandardOutput = $true
+  $start.RedirectStandardError = $true
+  $start.EnvironmentVariables["ELIZA_STATE_DIR"] = $stateRoot
+  $start.EnvironmentVariables["ELIZA_BROWSER_BRIDGE_CHROME_EXTENSION_IDS"] = $extensionId
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $start
+  if (-not $process.Start()) { throw "compiled Windows browser native host did not start" }
+  try {
+    $process.StandardInput.BaseStream.Write($requestHeader, 0, $requestHeader.Length)
+    $process.StandardInput.BaseStream.Write($requestBytes, 0, $requestBytes.Length)
+    $process.StandardInput.BaseStream.Flush()
+    $process.StandardInput.Close()
+    if (-not $process.WaitForExit(15000)) {
+      $process.Kill()
+      throw "compiled Windows browser native host timed out"
+    }
+    $stderr = $process.StandardError.ReadToEnd()
+    $stdout = New-Object System.IO.MemoryStream
+    try {
+      $process.StandardOutput.BaseStream.CopyTo($stdout)
+      $responseFrame = $stdout.ToArray()
+    } finally {
+      $stdout.Dispose()
+    }
+    if ($process.ExitCode -ne 0 -or $responseFrame.Length -lt 5) {
+      throw "compiled Windows browser native host failed: $stderr"
+    }
+    $responseLength = [BitConverter]::ToUInt32($responseFrame, 0)
+    if ($responseLength -eq 0 -or $responseFrame.Length -ne $responseLength + 4) {
+      throw "compiled Windows browser native host returned an invalid native-message frame"
+    }
+    $responseJson = [Text.Encoding]::UTF8.GetString($responseFrame, 4, $responseLength)
+    $response = $responseJson | ConvertFrom-Json
+    if ($response.requestId -ne $requestId -or $response.type -ne "browser_bridge.error") {
+      throw "compiled Windows browser native host returned an unbound response"
+    }
+    if ($response.code -eq "app_not_running") {
+      throw "compiled Windows browser native host did not resolve its adjacent DPAPI helper"
+    }
+    if ($response.code -ne "broker_unavailable" -or -not $response.retryable) {
+      throw "compiled Windows browser native host returned an unexpected result: $responseJson"
+    }
+  } finally {
+    if (-not $process.HasExited) { $process.Kill() }
+    $process.Dispose()
+  }
+  Write-Output "staged compiled Windows browser native host resolved its adjacent DPAPI helper"
+} finally {
+  if (Test-Path -LiteralPath $tempRoot) {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+  }
+}

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
@@ -25,12 +25,19 @@ function Invoke-SecurePipeRoundTrip {
   $start.RedirectStandardInput = $true
   $start.RedirectStandardOutput = $true
   $start.RedirectStandardError = $true
-  # Process.StandardInput otherwise prepends a UTF-8 BOM before the raw native
-  # messaging frame written through BaseStream on Windows PowerShell 5.1.
-  $start.StandardInputEncoding = New-Object System.Text.UTF8Encoding($false)
   $process = New-Object System.Diagnostics.Process
   $process.StartInfo = $start
-  if (-not $process.Start()) { throw "secure pipe helper did not start" }
+  # Windows PowerShell 5.1 has no ProcessStartInfo.StandardInputEncoding.
+  # Process.StandardInput inherits Console.InputEncoding when it constructs its
+  # writer, so make that encoding BOM-free before accessing BaseStream.
+  $previousInputEncoding = [Console]::InputEncoding
+  [Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false)
+  try {
+    if (-not $process.Start()) { throw "secure pipe helper did not start" }
+    $processInput = $process.StandardInput.BaseStream
+  } finally {
+    [Console]::InputEncoding = $previousInputEncoding
+  }
   $client = $null
   try {
     $readyLine = $process.StandardError.ReadLine()
@@ -57,9 +64,9 @@ function Invoke-SecurePipeRoundTrip {
     }
     $response = [Text.Encoding]::UTF8.GetBytes('{"probe":"response"}')
     $responseHeader = [BitConverter]::GetBytes([uint32]$response.Length)
-    $process.StandardInput.BaseStream.Write($responseHeader, 0, 4)
-    $process.StandardInput.BaseStream.Write($response, 0, $response.Length)
-    $process.StandardInput.BaseStream.Flush()
+    $processInput.Write($responseHeader, 0, 4)
+    $processInput.Write($response, 0, $response.Length)
+    $processInput.Flush()
     $receivedHeader = Read-Exact $client 4
     $receivedLength = [BitConverter]::ToUInt32($receivedHeader, 0)
     $received = Read-Exact $client $receivedLength

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
@@ -12,7 +12,7 @@ function Read-Exact([System.IO.Stream]$Stream, [int]$Count) {
     if ($read -eq 0) { throw "probe stream closed" }
     $offset += $read
   }
-  return $buffer
+  return ,$buffer
 }
 function Invoke-SecurePipeRoundTrip {
   $pipeName = "eliza-probe-" + [Guid]::NewGuid().ToString("N")
@@ -63,6 +63,12 @@ function Invoke-SecurePipeRoundTrip {
     if ([Text.Encoding]::UTF8.GetString($received) -ne '{"probe":"response"}') {
       throw "secure pipe response forwarding mismatch"
     }
+  } catch {
+    if ($process.HasExited) {
+      $helperError = $process.StandardError.ReadToEnd()
+      throw "secure pipe helper exited with code $($process.ExitCode): $helperError $($_.Exception.Message)"
+    }
+    throw
   } finally {
     if ($null -ne $client) { $client.Dispose() }
     if (-not $process.HasExited) { $process.Kill() }

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
@@ -64,6 +64,9 @@ function Invoke-SecurePipeRoundTrip {
       throw "secure pipe response forwarding mismatch"
     }
   } catch {
+    if (-not $process.HasExited) {
+      [void]$process.WaitForExit(2000)
+    }
     if ($process.HasExited) {
       $helperError = $process.StandardError.ReadToEnd()
       throw "secure pipe helper exited with code $($process.ExitCode): $helperError $($_.Exception.Message)"

--- a/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
@@ -25,6 +25,9 @@ function Invoke-SecurePipeRoundTrip {
   $start.RedirectStandardInput = $true
   $start.RedirectStandardOutput = $true
   $start.RedirectStandardError = $true
+  # Process.StandardInput otherwise prepends a UTF-8 BOM before the raw native
+  # messaging frame written through BaseStream on Windows PowerShell 5.1.
+  $start.StandardInputEncoding = New-Object System.Text.UTF8Encoding($false)
   $process = New-Object System.Diagnostics.Process
   $process.StartInfo = $start
   if (-not $process.Start()) { throw "secure pipe helper did not start" }

--- a/packages/app-core/platforms/electrobun/scripts/verify-windows-installer-proof.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/verify-windows-installer-proof.ps1
@@ -37,6 +37,21 @@ function Resolve-ShortcutTarget([string]$ShortcutPath) {
   }
 }
 
+function Get-CurrentUserDefaultRegistryValue([string]$RegistryKey) {
+  $subKey = $RegistryKey -replace '^HKCU\\', ''
+  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey($subKey, $false)
+  if ($null -eq $key) { return $null }
+  try {
+    return $key.GetValue(
+      $null,
+      $null,
+      [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+    )
+  } finally {
+    $key.Dispose()
+  }
+}
+
 $resolvedArtifactsDir = (Resolve-Path $ArtifactsDir).Path
 $resolvedBuildDir = $null
 try {
@@ -57,6 +72,8 @@ $summary = [ordered]@{
   installer = $null
   installerSizeBytes = 0
   launcherPath = $null
+  browserNativeHostPath = $null
+  browserRegistrationManifests = @()
   startMenuShortcut = $null
   shortcutTarget = $null
   uninstallerPath = $null
@@ -64,10 +81,13 @@ $summary = [ordered]@{
     installerExecuted = $false
     installRootExists = $false
     launcherExists = $false
+    browserHelpersExist = $false
+    browserRegistrationsInstalled = $false
     shortcutExists = $false
     backendReachable = $false
     uninstallExecuted = $false
     uninstallCleanup = $false
+    browserRegistrationsRemoved = $false
   }
   notes = @()
 }
@@ -122,6 +142,56 @@ try {
   }
   $summary.launcherPath = $launcher.FullName
   $summary.checks.launcherExists = $true
+
+  $nativeHost = Get-ChildItem -Path $ProofInstallDir -Recurse -File -Filter "browser-bridge-native-host.exe" -ErrorAction SilentlyContinue |
+    Sort-Object FullName |
+    Select-Object -First 1
+  $secretHelper = Get-ChildItem -Path $ProofInstallDir -Recurse -File -Filter "browser-bridge-secret.ps1" -ErrorAction SilentlyContinue |
+    Sort-Object FullName |
+    Select-Object -First 1
+  $unregisterHelper = Get-ChildItem -Path $ProofInstallDir -Recurse -File -Filter "browser-bridge-unregister.ps1" -ErrorAction SilentlyContinue |
+    Sort-Object FullName |
+    Select-Object -First 1
+  if (-not $nativeHost -or -not $secretHelper -or -not $unregisterHelper) {
+    throw "Installed browser bridge host or Windows lifecycle helper is missing"
+  }
+  $summary.browserNativeHostPath = $nativeHost.FullName
+  $summary.checks.browserHelpersExist = $true
+
+  $browserRegistrations = @(
+    @{
+      RegistryKey = "HKCU\Software\Google\Chrome\NativeMessagingHosts\ai.elizaos.browserbridge"
+      ManifestPath = Join-Path $env:LOCALAPPDATA "elizaOS\BrowserBridge\chrome\ai.elizaos.browserbridge.json"
+    },
+    @{
+      RegistryKey = "HKCU\Software\Mozilla\NativeMessagingHosts\ai.elizaos.browserbridge"
+      ManifestPath = Join-Path $env:LOCALAPPDATA "elizaOS\BrowserBridge\firefox\ai.elizaos.browserbridge.json"
+    }
+  )
+  foreach ($registration in $browserRegistrations) {
+    $registeredManifestPath = Get-CurrentUserDefaultRegistryValue $registration.RegistryKey
+    if (
+      $null -eq $registeredManifestPath -or
+      -not [System.String]::Equals(
+        [System.IO.Path]::GetFullPath([string]$registeredManifestPath),
+        [System.IO.Path]::GetFullPath($registration.ManifestPath),
+        [System.StringComparison]::OrdinalIgnoreCase
+      ) -or
+      -not (Test-Path -LiteralPath $registration.ManifestPath)
+    ) {
+      throw "Browser native-host registration was not installed: $($registration.RegistryKey)"
+    }
+    $manifest = Get-Content -LiteralPath $registration.ManifestPath -Raw | ConvertFrom-Json
+    if (-not [System.String]::Equals(
+      [System.IO.Path]::GetFullPath([string]$manifest.path),
+      [System.IO.Path]::GetFullPath($nativeHost.FullName),
+      [System.StringComparison]::OrdinalIgnoreCase
+    )) {
+      throw "Browser native-host manifest points at the wrong executable: $($registration.ManifestPath)"
+    }
+    $summary.browserRegistrationManifests += $registration.ManifestPath
+  }
+  $summary.checks.browserRegistrationsInstalled = $true
 
   $startMenuRoots = @(
     (Join-Path $env:APPDATA "Microsoft\\Windows\\Start Menu\\Programs"),
@@ -183,6 +253,14 @@ try {
   }
 
   $summary.checks.uninstallCleanup = $true
+
+  foreach ($registration in $browserRegistrations) {
+    & reg.exe query $registration.RegistryKey /ve 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0 -or (Test-Path -LiteralPath $registration.ManifestPath)) {
+      throw "Uninstall left a browser native-host registration behind: $($registration.RegistryKey)"
+    }
+  }
+  $summary.checks.browserRegistrationsRemoved = $true
   $summary.status = "passed"
   $summary.notes += "Windows clean installer proof completed successfully."
 } catch {

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -94,6 +94,9 @@ describe("Electrobun Store packaging", () => {
     ).toBe(true);
     expect(Object.values(copy)).toContain("eliza-dist/package.json");
     expect(Object.values(copy)).not.toContain("remotes");
+    expect(copy["scripts/browser-bridge-unregister.ps1"]).toBe(
+      "browser-bridge-unregister.ps1",
+    );
   });
 
   it("omits the embedded runtime tree for external API desktop builds", () => {

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./browser-bridge-broker-secret";
 
 const roots: string[] = [];
+const posixIt = process.platform === "win32" ? it.skip : it;
 
 describe("browser bridge broker secret", () => {
   afterEach(() => {
@@ -20,7 +21,7 @@ describe("browser bridge broker secret", () => {
       fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it("creates and reuses exactly 32 private bytes", () => {
+  posixIt("creates and reuses exactly 32 private bytes", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "browser-secret-"));
     roots.push(stateDir);
     const env = { ELIZA_STATE_DIR: stateDir };
@@ -35,7 +36,7 @@ describe("browser bridge broker secret", () => {
     expect(fs.statSync(secretPath).mode & 0o777).toBe(0o600);
   });
 
-  it("rejects permissive or malformed secret files", () => {
+  posixIt("rejects permissive or malformed secret files", () => {
     const stateDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "browser-secret-bad-"),
     );
@@ -50,76 +51,87 @@ describe("browser bridge broker secret", () => {
     expect(() => loadBrowserBridgeBrokerSecret(env)).toThrow("mode-0600");
   });
 
-  it("rejects symlinked, permissive, or wrong-owner secret directories", () => {
-    const stateDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-secret-dir-"),
-    );
-    const target = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-secret-target-"),
-    );
-    roots.push(stateDir, target);
-    const env = { ELIZA_STATE_DIR: stateDir };
-    const directory = path.dirname(resolveBrowserBridgeBrokerSecretPath(env));
-    fs.symlinkSync(target, directory);
-    expect(() => loadOrCreateBrowserBridgeBrokerSecret(env)).toThrow("symlink");
-    fs.unlinkSync(directory);
-    fs.mkdirSync(directory, { mode: 0o755 });
-    expect(() => loadOrCreateBrowserBridgeBrokerSecret(env)).toThrow(
-      "real mode-0700 directory",
-    );
-    fs.chmodSync(directory, 0o700);
-    const currentUid = process.getuid?.() ?? 501;
-    expect(() =>
-      loadOrCreateBrowserBridgeBrokerSecret(
-        env,
-        () => Buffer.alloc(32, 1),
-        currentUid + 1,
-      ),
-    ).toThrow("not owned by the current user");
-  });
+  posixIt(
+    "rejects symlinked, permissive, or wrong-owner secret directories",
+    () => {
+      const stateDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-secret-dir-"),
+      );
+      const target = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-secret-target-"),
+      );
+      roots.push(stateDir, target);
+      const env = { ELIZA_STATE_DIR: stateDir };
+      const directory = path.dirname(resolveBrowserBridgeBrokerSecretPath(env));
+      fs.symlinkSync(target, directory);
+      expect(() => loadOrCreateBrowserBridgeBrokerSecret(env)).toThrow(
+        "symlink",
+      );
+      fs.unlinkSync(directory);
+      fs.mkdirSync(directory, { mode: 0o755 });
+      expect(() => loadOrCreateBrowserBridgeBrokerSecret(env)).toThrow(
+        "real mode-0700 directory",
+      );
+      fs.chmodSync(directory, 0o700);
+      const currentUid = process.getuid?.() ?? 501;
+      expect(() =>
+        loadOrCreateBrowserBridgeBrokerSecret(
+          env,
+          () => Buffer.alloc(32, 1),
+          currentUid + 1,
+        ),
+      ).toThrow("not owned by the current user");
+    },
+  );
 
-  it("rejects symlink traversal above the private secret directory", () => {
-    const realStateDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-secret-real-"),
-    );
-    const linkRoot = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-secret-link-"),
-    );
-    roots.push(realStateDir, linkRoot);
-    const stateLink = path.join(linkRoot, "state");
-    fs.symlinkSync(realStateDir, stateLink);
-    expect(() =>
-      loadOrCreateBrowserBridgeBrokerSecret(
-        { ELIZA_STATE_DIR: stateLink },
-        () => Buffer.alloc(32, 1),
-      ),
-    ).toThrow("traverses a symlink");
-  });
+  posixIt(
+    "rejects symlink traversal above the private secret directory",
+    () => {
+      const realStateDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-secret-real-"),
+      );
+      const linkRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-secret-link-"),
+      );
+      roots.push(realStateDir, linkRoot);
+      const stateLink = path.join(linkRoot, "state");
+      fs.symlinkSync(realStateDir, stateLink);
+      expect(() =>
+        loadOrCreateBrowserBridgeBrokerSecret(
+          { ELIZA_STATE_DIR: stateLink },
+          () => Buffer.alloc(32, 1),
+        ),
+      ).toThrow("traverses a symlink");
+    },
+  );
 
-  it("rejects a secret replaced between validation and descriptor open", () => {
-    const stateDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-secret-race-"),
-    );
-    roots.push(stateDir);
-    const env = { ELIZA_STATE_DIR: stateDir };
-    loadOrCreateBrowserBridgeBrokerSecret(env, () => Buffer.alloc(32, 1));
-    const secretPath = resolveBrowserBridgeBrokerSecretPath(env);
-    const originalPath = `${secretPath}.original`;
-    const open = fs.openSync.bind(fs);
-    let replaced = false;
-    const openSpy = vi.spyOn(fs, "openSync").mockImplementation((...args) => {
-      if (args[0] === secretPath && !replaced) {
-        replaced = true;
-        fs.renameSync(secretPath, originalPath);
-        fs.writeFileSync(secretPath, Buffer.alloc(32, 2), { mode: 0o600 });
-      }
-      return open(...args);
-    });
-    expect(() => loadBrowserBridgeBrokerSecret(env)).toThrow(
-      "changed while opening",
-    );
-    openSpy.mockRestore();
-  });
+  posixIt(
+    "rejects a secret replaced between validation and descriptor open",
+    () => {
+      const stateDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-secret-race-"),
+      );
+      roots.push(stateDir);
+      const env = { ELIZA_STATE_DIR: stateDir };
+      loadOrCreateBrowserBridgeBrokerSecret(env, () => Buffer.alloc(32, 1));
+      const secretPath = resolveBrowserBridgeBrokerSecretPath(env);
+      const originalPath = `${secretPath}.original`;
+      const open = fs.openSync.bind(fs);
+      let replaced = false;
+      const openSpy = vi.spyOn(fs, "openSync").mockImplementation((...args) => {
+        if (args[0] === secretPath && !replaced) {
+          replaced = true;
+          fs.renameSync(secretPath, originalPath);
+          fs.writeFileSync(secretPath, Buffer.alloc(32, 2), { mode: 0o600 });
+        }
+        return open(...args);
+      });
+      expect(() => loadBrowserBridgeBrokerSecret(env)).toThrow(
+        "changed while opening",
+      );
+      openSpy.mockRestore();
+    },
+  );
 
   it("routes Windows secrets through the DPAPI helper without POSIX mode checks", () => {
     const expected = Buffer.alloc(32, 17);

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.test.ts
@@ -8,6 +8,7 @@ import {
   loadBrowserBridgeBrokerSecret,
   loadOrCreateBrowserBridgeBrokerSecret,
   resolveBrowserBridgeBrokerSecretPath,
+  resolveWindowsBrowserBridgeSecretHelper,
   windowsBrowserBridgeSecretInvocation,
 } from "./browser-bridge-broker-secret";
 
@@ -173,6 +174,17 @@ describe("browser bridge broker secret", () => {
         "relative.ps1",
       ),
     ).toThrow("helper path is invalid");
+  });
+
+  it("resolves the helper beside a Bun-compiled native host executable", () => {
+    expect(
+      resolveWindowsBrowserBridgeSecretHelper(
+        "/$bunfs/root/native",
+        (candidate) =>
+          candidate === "C:\\Eliza\\Resources\\app\\browser-bridge-secret.ps1",
+        "C:\\Eliza\\Resources\\app\\browser-bridge-native-host.exe",
+      ),
+    ).toBe("C:\\Eliza\\Resources\\app\\browser-bridge-secret.ps1");
   });
 
   it("rejects failed or malformed Windows DPAPI helper output", () => {

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-secret.ts
@@ -27,8 +27,18 @@ export interface BrowserBridgeBrokerSecretOptions {
 export function resolveWindowsBrowserBridgeSecretHelper(
   moduleDir = MODULE_DIR,
   exists: (candidate: string) => boolean = fs.existsSync,
+  executablePath = process.execPath,
 ): string {
+  const executablePathApi = path.win32.isAbsolute(executablePath)
+    ? path.win32
+    : path;
   const candidates = [
+    // Bun-compiled native hosts expose source modules under /$bunfs/root, while
+    // the packaged helper is copied beside the executable.
+    executablePathApi.resolve(
+      executablePathApi.dirname(executablePath),
+      "browser-bridge-secret.ps1",
+    ),
     path.resolve(moduleDir, "browser-bridge-secret.ps1"),
     path.resolve(moduleDir, "..", "browser-bridge-secret.ps1"),
     path.resolve(moduleDir, "..", "..", "scripts", "browser-bridge-secret.ps1"),

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./browser-bridge-native-protocol";
 
 const roots: string[] = [];
+const posixIt = process.platform === "win32" ? it.skip : it;
 
 function fakeWindowsHelper(options: { exitOnKill: boolean }): {
   child: ChildProcessWithoutNullStreams;
@@ -60,82 +61,90 @@ describe("browser bridge broker IPC", () => {
       fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it("round-trips one authenticated bounded frame over a mode-0600 Unix socket", async () => {
-    const stateDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-broker-ipc-"),
-    );
-    roots.push(stateDir);
-    const descriptor = createUnixBrokerTransportDescriptor(
-      { ELIZA_STATE_DIR: stateDir },
-      process.getuid?.() ?? 501,
-    );
-    const secret = Buffer.alloc(32, 14);
-    const nowMs = 1_800_000_000_000;
-    const extensionId = "abcdefghijklmnopabcdefghijklmnop";
-    const profileId = "123e4567-e89b-42d3-a456-426614174001";
-    const broker = new BrowserBridgeEnrollmentBroker({
-      apiBase: "http://127.0.0.1:31337",
-      ownerSession: async () => ({
-        sessionId: "owner-session",
-        csrfToken: "owner-csrf",
-        expiresAt: Date.now() + 60_000,
-      }),
-      brokerSecret: secret,
-      callerAllowlist: {
-        chromeExtensionIds: [extensionId],
-        firefoxExtensionIds: [],
-        safariExtensionIds: [],
-      },
-      now: () => nowMs,
-      fetchImpl: async () =>
-        new Response(
-          JSON.stringify({
-            companion: {
-              id: "companion-1",
-              browser: "chrome",
-              profileId,
-              profileLabel: "Personal",
-              label: "Chrome Personal",
-            },
-            pairingToken: "pairing-secret",
-            pairingTokenExpiresAt: null,
-          }),
-          { status: 201 },
-        ),
-    });
-    const server = await startBrowserBridgeBrokerServer({ descriptor, broker });
-    try {
-      expect(fs.statSync(descriptor.socketPath).mode & 0o777).toBe(0o600);
-      const envelope = signBrokerEnvelope(
-        {
-          protocol: BROWSER_BRIDGE_BROKER_PROTOCOL,
-          timestampMs: nowMs,
-          caller: { browser: "chrome", id: extensionId },
-          request: {
-            v: 1,
-            type: "browser_bridge.enroll",
-            requestId: "123e4567-e89b-42d3-a456-426614174000",
-            nonce: Buffer.alloc(32, 2).toString("base64url"),
-            browser: "chrome",
-            extensionId,
-            extensionVersion: "1.2.3",
-            profileId,
-          },
-        },
-        secret,
+  posixIt(
+    "round-trips one authenticated bounded frame over a mode-0600 Unix socket",
+    async () => {
+      const stateDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-broker-ipc-"),
       );
-      const response = await new NodeBrowserBridgeBrokerTransport(
-        descriptor,
-      ).request(Buffer.from(JSON.stringify(envelope), "utf8"));
-      expect(JSON.parse(Buffer.from(response).toString("utf8"))).toMatchObject({
-        type: "browser_bridge.enroll_result",
-        config: { companionId: "companion-1" },
+      roots.push(stateDir);
+      const descriptor = createUnixBrokerTransportDescriptor(
+        { ELIZA_STATE_DIR: stateDir },
+        process.getuid?.() ?? 501,
+      );
+      const secret = Buffer.alloc(32, 14);
+      const nowMs = 1_800_000_000_000;
+      const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+      const profileId = "123e4567-e89b-42d3-a456-426614174001";
+      const broker = new BrowserBridgeEnrollmentBroker({
+        apiBase: "http://127.0.0.1:31337",
+        ownerSession: async () => ({
+          sessionId: "owner-session",
+          csrfToken: "owner-csrf",
+          expiresAt: Date.now() + 60_000,
+        }),
+        brokerSecret: secret,
+        callerAllowlist: {
+          chromeExtensionIds: [extensionId],
+          firefoxExtensionIds: [],
+          safariExtensionIds: [],
+        },
+        now: () => nowMs,
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              companion: {
+                id: "companion-1",
+                browser: "chrome",
+                profileId,
+                profileLabel: "Personal",
+                label: "Chrome Personal",
+              },
+              pairingToken: "pairing-secret",
+              pairingTokenExpiresAt: null,
+            }),
+            { status: 201 },
+          ),
       });
-    } finally {
-      await server.close();
-    }
-    expect(fs.existsSync(descriptor.socketPath)).toBe(false);
-  });
+      const server = await startBrowserBridgeBrokerServer({
+        descriptor,
+        broker,
+      });
+      try {
+        expect(fs.statSync(descriptor.socketPath).mode & 0o777).toBe(0o600);
+        const envelope = signBrokerEnvelope(
+          {
+            protocol: BROWSER_BRIDGE_BROKER_PROTOCOL,
+            timestampMs: nowMs,
+            caller: { browser: "chrome", id: extensionId },
+            request: {
+              v: 1,
+              type: "browser_bridge.enroll",
+              requestId: "123e4567-e89b-42d3-a456-426614174000",
+              nonce: Buffer.alloc(32, 2).toString("base64url"),
+              browser: "chrome",
+              extensionId,
+              extensionVersion: "1.2.3",
+              profileId,
+            },
+          },
+          secret,
+        );
+        const response = await new NodeBrowserBridgeBrokerTransport(
+          descriptor,
+        ).request(Buffer.from(JSON.stringify(envelope), "utf8"));
+        expect(
+          JSON.parse(Buffer.from(response).toString("utf8")),
+        ).toMatchObject({
+          type: "browser_bridge.enroll_result",
+          config: { companionId: "companion-1" },
+        });
+      } finally {
+        await server.close();
+      }
+      expect(fs.existsSync(descriptor.socketPath)).toBe(false);
+    },
+  );
 
   it("creates Windows pipes with an at-creation DACL and remote-client rejection", async () => {
     const descriptor = createWindowsBrokerTransportDescriptor(

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
@@ -180,7 +180,7 @@ describe("browser bridge broker IPC", () => {
     expect(executableProbe).toContain("Invoke-SecurePipeRoundTrip");
     expect(executableProbe).toContain("StandardOutput.BaseStream");
     expect(executableProbe).toContain("StandardInput.BaseStream");
-    expect(executableProbe).toContain("StandardInputEncoding");
+    expect(executableProbe).toContain("[Console]::InputEncoding");
     expect(executableProbe).toContain("return ,$buffer");
     expect(executableProbe).toContain("StandardError.ReadToEnd()");
   });

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
@@ -168,6 +168,7 @@ describe("browser bridge broker IPC", () => {
     expect(helper).toContain('sid.Value.StartsWith("S-1-5-5-"');
     expect(helper).toContain('"D:P(A;;GA;;;SY)(A;;GA;;;"');
     expect(helper).toContain("new NamedPipeServerStream(");
+    expect(helper).toContain("return ,$buffer");
     const executableProbe = fs.readFileSync(
       path.resolve(
         import.meta.dirname,
@@ -179,6 +180,8 @@ describe("browser bridge broker IPC", () => {
     expect(executableProbe).toContain("Invoke-SecurePipeRoundTrip");
     expect(executableProbe).toContain("StandardOutput.BaseStream");
     expect(executableProbe).toContain("StandardInput.BaseStream");
+    expect(executableProbe).toContain("return ,$buffer");
+    expect(executableProbe).toContain("StandardError.ReadToEnd()");
   });
 
   it("reaps a Windows helper whose startup readiness times out", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-broker-server.test.ts
@@ -180,6 +180,7 @@ describe("browser bridge broker IPC", () => {
     expect(executableProbe).toContain("Invoke-SecurePipeRoundTrip");
     expect(executableProbe).toContain("StandardOutput.BaseStream");
     expect(executableProbe).toContain("StandardInput.BaseStream");
+    expect(executableProbe).toContain("StandardInputEncoding");
     expect(executableProbe).toContain("return ,$buffer");
     expect(executableProbe).toContain("StandardError.ReadToEnd()");
   });

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-desktop-lifecycle.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-desktop-lifecycle.ts
@@ -31,6 +31,10 @@ import {
   installBrowserBridgeRegistration,
   resolveBrowserBridgeNativeHostExecutable,
 } from "./browser-bridge-registration";
+import {
+  PersistentNativeEnrollmentReplayGuard,
+  resolveBrowserBridgeReplayStorePath,
+} from "./browser-bridge-replay-store";
 
 let stopActiveBroker: (() => Promise<void>) | null = null;
 let activeApiBase: string | null = null;
@@ -156,11 +160,16 @@ export async function startBrowserBridgeDesktopLifecycle(options: {
     return false;
   }
   const secret = loadOrCreateBrowserBridgeBrokerSecret(env);
+  const replayGuard = new PersistentNativeEnrollmentReplayGuard(
+    resolveBrowserBridgeReplayStorePath(env),
+    secret,
+  );
   const broker = new BrowserBridgeEnrollmentBroker({
     apiBase: options.apiBase,
     ownerSession: async () => resolveDesktopOwnerSession(options.apiBase, env),
     brokerSecret: secret,
     callerAllowlist: allowlist,
+    replayGuard,
   });
   const servers: BrowserBridgeBrokerServerHandle[] = [];
   const server = await startBrowserBridgeBrokerServer({
@@ -195,6 +204,7 @@ export async function startBrowserBridgeDesktopLifecycle(options: {
             loadOrCreateMacBrowserBridgeSharedSecret
           )(appGroupContainer),
           callerAllowlist: allowlist,
+          replayGuard,
         });
         servers.push(
           await startBrowserBridgeBrokerServer({

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-adapter.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-adapter.test.ts
@@ -1,7 +1,10 @@
 /** Exercises owner-authorized native enrollment against a deterministic loopback pairing API. */
 
 import { describe, expect, it, vi } from "vitest";
-import { pairBrowserBridgeCompanionAsDesktopOwner } from "./browser-bridge-enrollment-adapter";
+import {
+  pairBrowserBridgeCompanionAsDesktopOwner,
+  revokeBrowserBridgeCompanionAsDesktopOwner,
+} from "./browser-bridge-enrollment-adapter";
 
 type PairingFetch = NonNullable<
   Parameters<typeof pairBrowserBridgeCompanionAsDesktopOwner>[0]["fetchImpl"]
@@ -14,6 +17,37 @@ const ownerSession = {
 };
 
 describe("browser bridge enrollment adapter", () => {
+  it("revokes through the owner cookie and CSRF authority", async () => {
+    const fetchImpl = vi.fn<PairingFetch>(
+      async () =>
+        new Response(JSON.stringify({ revoked: true }), { status: 200 }),
+    );
+    await expect(
+      revokeBrowserBridgeCompanionAsDesktopOwner({
+        apiBase: "http://127.0.0.1:31337",
+        ownerSession,
+        companionId: "companion-1",
+        fetchImpl,
+      }),
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "http://127.0.0.1:31337/api/browser-bridge/companions/companion-1/revoke",
+      ),
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+        headers: expect.objectContaining({
+          cookie: "eliza_session=owner-session",
+          "x-eliza-csrf": "owner-csrf",
+        }),
+      }),
+    );
+    expect(fetchImpl.mock.calls[0]?.[1]?.headers).not.toHaveProperty(
+      "authorization",
+    );
+  });
+
   it("uses the existing owner cookie and CSRF authority on loopback", async () => {
     const fetchImpl = vi.fn<PairingFetch>(
       async (_input, _init) =>

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-adapter.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-adapter.ts
@@ -8,6 +8,8 @@ import type { BrowserBridgeNativeBrowser } from "./browser-bridge-native-protoco
 
 export const BROWSER_BRIDGE_PAIR_ENDPOINT =
   "/api/browser-bridge/companions/pair";
+export const BROWSER_BRIDGE_REVOKE_ENDPOINT = (companionId: string): string =>
+  `/api/browser-bridge/companions/${encodeURIComponent(companionId)}/revoke`;
 const DEFAULT_PAIR_TIMEOUT_MS = 10_000;
 
 export class BrowserBridgePairingError extends Error {
@@ -27,6 +29,38 @@ function isLoopbackHostname(hostname: string): boolean {
     normalized === "127.0.0.1" ||
     normalized === "::1"
   );
+}
+
+function requireLoopbackApiBase(apiBase: string): URL {
+  const parsed = new URL(apiBase);
+  if (
+    parsed.protocol !== "http:" ||
+    !isLoopbackHostname(parsed.hostname) ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error(
+      "browser companion owner actions require the loopback desktop API",
+    );
+  }
+  return parsed;
+}
+
+function requireCurrentOwnerSession(ownerSession: DesktopSession): void {
+  if (ownerSession.expiresAt <= Date.now()) {
+    throw new Error("desktop owner session is expired");
+  }
+}
+
+function ownerHeaders(ownerSession: DesktopSession): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    cookie: `eliza_session=${encodeURIComponent(ownerSession.sessionId)}`,
+    "x-eliza-csrf": ownerSession.csrfToken,
+  };
 }
 
 export interface BrowserBridgePairingResult {
@@ -100,23 +134,8 @@ export async function pairBrowserBridgeCompanionAsDesktopOwner(options: {
   fetchImpl?: FetchLike;
   timeoutMs?: number;
 }): Promise<BrowserBridgePairingResult> {
-  const apiBase = new URL(options.apiBase);
-  if (
-    apiBase.protocol !== "http:" ||
-    !isLoopbackHostname(apiBase.hostname) ||
-    apiBase.username !== "" ||
-    apiBase.password !== "" ||
-    apiBase.pathname !== "/" ||
-    apiBase.search !== "" ||
-    apiBase.hash !== ""
-  ) {
-    throw new Error(
-      "browser enrollment pairing requires the loopback desktop API",
-    );
-  }
-  if (options.ownerSession.expiresAt <= Date.now()) {
-    throw new Error("desktop owner session is expired");
-  }
+  const apiBase = requireLoopbackApiBase(options.apiBase);
+  requireCurrentOwnerSession(options.ownerSession);
   const abortController = new AbortController();
   const timeoutMs = options.timeoutMs ?? DEFAULT_PAIR_TIMEOUT_MS;
   const timeout = setTimeout(() => abortController.abort(), timeoutMs);
@@ -125,11 +144,7 @@ export async function pairBrowserBridgeCompanionAsDesktopOwner(options: {
       new URL(BROWSER_BRIDGE_PAIR_ENDPOINT, apiBase),
       {
         method: "POST",
-        headers: {
-          "content-type": "application/json",
-          cookie: `eliza_session=${encodeURIComponent(options.ownerSession.sessionId)}`,
-          "x-eliza-csrf": options.ownerSession.csrfToken,
-        },
+        headers: ownerHeaders(options.ownerSession),
         body: JSON.stringify({
           ...options.payload,
           pairingKind: "native_enrollment",
@@ -161,6 +176,46 @@ export async function pairBrowserBridgeCompanionAsDesktopOwner(options: {
       );
     }
     return validatePairingResult(await response.json());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function revokeBrowserBridgeCompanionAsDesktopOwner(options: {
+  apiBase: string;
+  ownerSession: DesktopSession;
+  companionId: string;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+}): Promise<void> {
+  const apiBase = requireLoopbackApiBase(options.apiBase);
+  requireCurrentOwnerSession(options.ownerSession);
+  if (!options.companionId || options.companionId.length > 256) {
+    throw new Error("browser companion ID is invalid");
+  }
+  const abortController = new AbortController();
+  const timeout = setTimeout(
+    () => abortController.abort(),
+    options.timeoutMs ?? DEFAULT_PAIR_TIMEOUT_MS,
+  );
+  try {
+    const response = await (options.fetchImpl ?? fetch)(
+      new URL(BROWSER_BRIDGE_REVOKE_ENDPOINT(options.companionId), apiBase),
+      {
+        method: "POST",
+        headers: ownerHeaders(options.ownerSession),
+        body: JSON.stringify({}),
+        signal: abortController.signal,
+      },
+    );
+    if (!response.ok) {
+      throw new BrowserBridgePairingError(
+        response.status === 401
+          ? "app_not_authenticated"
+          : "broker_unavailable",
+        `browser companion revoke API rejected the owner request with status ${response.status}`,
+      );
+    }
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.test.ts
@@ -1,17 +1,28 @@
 /** Exercises authenticated broker enrollment and canonical bounded responses. */
 
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserBridgeEnrollmentBroker } from "./browser-bridge-enrollment-broker";
 import {
   BROWSER_BRIDGE_BROKER_PROTOCOL,
   signBrokerEnvelope,
 } from "./browser-bridge-native-protocol";
+import { PersistentNativeEnrollmentReplayGuard } from "./browser-bridge-replay-store";
 
 const secret = Buffer.alloc(32, 9);
 const nowMs = 1_800_000_000_000;
 const callerId = "abcdefghijklmnopabcdefghijklmnop";
 const requestId = "123e4567-e89b-42d3-a456-426614174000";
 const profileId = "123e4567-e89b-42d3-a456-426614174001";
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 function request(nonce = Buffer.alloc(32, 4).toString("base64url")) {
   return signBrokerEnvelope(
@@ -186,6 +197,48 @@ describe("browser bridge enrollment broker", () => {
       code: "broker_unavailable",
       retryable: true,
     });
+  });
+
+  it("rejects an exact envelope after broker restart before calling the pairing API", async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-browser-broker-replay-"),
+    );
+    temporaryDirectories.push(directory);
+    const replayPath = path.join(directory, "browser-bridge", "replay.json");
+    const fetchImpl = vi.fn(async () => new Response("{}", { status: 500 }));
+    const ownerSession = async () => ({
+      sessionId: "owner-session",
+      csrfToken: "owner-csrf",
+      expiresAt: Date.now() + 60_000,
+    });
+    const envelope = request(Buffer.alloc(32, 10).toString("base64url"));
+    const first = new BrowserBridgeEnrollmentBroker({
+      ...baseOptions,
+      ownerSession,
+      fetchImpl,
+      replayGuard: new PersistentNativeEnrollmentReplayGuard(
+        replayPath,
+        secret,
+      ),
+    });
+    await first.handle(envelope);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const restarted = new BrowserBridgeEnrollmentBroker({
+      ...baseOptions,
+      ownerSession,
+      fetchImpl,
+      replayGuard: new PersistentNativeEnrollmentReplayGuard(
+        replayPath,
+        secret,
+      ),
+    });
+    await expect(restarted.handle(envelope)).resolves.toMatchObject({
+      type: "browser_bridge.error",
+      code: "broker_unavailable",
+      retryable: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("preserves the typed revoked pairing state at the extension boundary", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.test.ts
@@ -45,6 +45,28 @@ function request(nonce = Buffer.alloc(32, 4).toString("base64url")) {
   );
 }
 
+function revokeRequest(nonce = Buffer.alloc(32, 11).toString("base64url")) {
+  return signBrokerEnvelope(
+    {
+      protocol: BROWSER_BRIDGE_BROKER_PROTOCOL,
+      timestampMs: nowMs,
+      caller: { browser: "chrome", id: callerId },
+      request: {
+        v: 1,
+        type: "browser_bridge.revoke",
+        requestId,
+        nonce,
+        browser: "chrome",
+        extensionId: callerId,
+        extensionVersion: "1.2.3",
+        profileId,
+        companionId: "companion-1",
+      },
+    },
+    secret,
+  );
+}
+
 const baseOptions = {
   apiBase: "http://127.0.0.1:31337",
   brokerSecret: secret,
@@ -57,6 +79,41 @@ const baseOptions = {
 };
 
 describe("browser bridge enrollment broker", () => {
+  it("translates native revoke into an owner-authenticated API mutation", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ revoked: true }), { status: 200 }),
+    );
+    const broker = new BrowserBridgeEnrollmentBroker({
+      ...baseOptions,
+      ownerSession: async () => ({
+        sessionId: "owner-session",
+        csrfToken: "owner-csrf",
+        expiresAt: Date.now() + 60_000,
+      }),
+      fetchImpl,
+    });
+    await expect(broker.handle(revokeRequest())).resolves.toEqual({
+      v: 1,
+      type: "browser_bridge.revoke_result",
+      requestId,
+      nonce: Buffer.alloc(32, 11).toString("base64url"),
+      revoked: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "http://127.0.0.1:31337/api/browser-bridge/companions/companion-1/revoke",
+      ),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          cookie: "eliza_session=owner-session",
+          "x-eliza-csrf": "owner-csrf",
+        }),
+      }),
+    );
+  });
+
   it("returns the canonical narrow config after native and owner authentication", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-enrollment-broker.ts
@@ -7,7 +7,9 @@ import type { DesktopSession, FetchLike } from "./auth-bridge";
 import {
   BrowserBridgePairingError,
   pairBrowserBridgeCompanionAsDesktopOwner,
+  revokeBrowserBridgeCompanionAsDesktopOwner,
 } from "./browser-bridge-enrollment-adapter";
+import type { BrowserBridgeNativeRevokeResult } from "./browser-bridge-native-protocol";
 import {
   authenticateBrokerEnvelope,
   type BrowserBridgeCallerAllowlist,
@@ -32,6 +34,7 @@ export interface BrowserBridgeEnrollmentBrokerOptions {
 
 export type BrowserBridgeEnrollmentBrokerResponse =
   | BrowserBridgeNativeEnrollmentResult
+  | BrowserBridgeNativeRevokeResult
   | BrowserBridgeNativeErrorResponse;
 
 function mapProtocolErrorCode(code: string): BrowserBridgeNativeErrorCode {
@@ -65,6 +68,21 @@ export class BrowserBridgeEnrollmentBroker {
           requestId,
           code: "app_not_authenticated",
           retryable: true,
+        };
+      }
+      if (envelope.request.type === "browser_bridge.revoke") {
+        await revokeBrowserBridgeCompanionAsDesktopOwner({
+          apiBase: this.options.apiBase,
+          ownerSession,
+          companionId: envelope.request.companionId,
+          fetchImpl: this.options.fetchImpl,
+        });
+        return {
+          v: 1,
+          type: "browser_bridge.revoke_result",
+          requestId,
+          nonce: envelope.request.nonce,
+          revoked: true,
         };
       }
       const pairing = await pairBrowserBridgeCompanionAsDesktopOwner({

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-host-entry.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-host-entry.ts
@@ -18,8 +18,8 @@ import {
   BrowserBridgeNativeProtocolError,
   encodeNativeMessage,
   NativeMessageDecoder,
-  parseNativeEnrollmentRequest,
   parseNativeHostLaunchCaller,
+  parseNativeRequest,
 } from "./browser-bridge-native-protocol";
 
 export const FIREFOX_BROWSER_BRIDGE_EXTENSION_ID = "browser-bridge@elizaos.ai";
@@ -209,7 +209,7 @@ export async function runBrowserBridgeNativeHostStdio(options: {
       let response: unknown;
       try {
         if (!host) {
-          const request = parseNativeEnrollmentRequest(message);
+          const request = parseNativeRequest(message);
           response = externalError(request.requestId, "app_not_running");
         } else {
           response = await host.handle(message);

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-host.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-host.ts
@@ -10,8 +10,8 @@ import {
   BrowserBridgeNativeProtocolError,
   type BrowserBridgeNativeResponse,
   createAuthenticatedBrokerEnvelope,
-  parseNativeEnrollmentRequest,
-  parseNativeEnrollmentResponse,
+  parseNativeRequest,
+  parseNativeResponse,
 } from "./browser-bridge-native-protocol";
 
 export class BrowserBridgeNativeHost {
@@ -29,7 +29,7 @@ export class BrowserBridgeNativeHost {
     input: unknown,
     signal?: AbortSignal,
   ): Promise<BrowserBridgeNativeResponse> {
-    const request = parseNativeEnrollmentRequest(input);
+    const request = parseNativeRequest(input);
     const envelope = createAuthenticatedBrokerEnvelope({
       request,
       launchedCaller: this.options.launchedCaller,
@@ -53,10 +53,11 @@ export class BrowserBridgeNativeHost {
           : "broker response JSON is invalid",
       );
     }
-    const response = parseNativeEnrollmentResponse(decoded);
+    const response = parseNativeResponse(decoded);
     if (
       response.requestId !== request.requestId ||
-      (response.type === "browser_bridge.enroll_result" &&
+      ((response.type === "browser_bridge.enroll_result" ||
+        response.type === "browser_bridge.revoke_result") &&
         response.nonce !== request.nonce)
     ) {
       throw new BrowserBridgeNativeProtocolError(

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-protocol.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-protocol.ts
@@ -24,6 +24,22 @@ export interface BrowserBridgeNativeEnrollmentRequest {
   profileId: string;
 }
 
+export interface BrowserBridgeNativeRevokeRequest {
+  v: 1;
+  type: "browser_bridge.revoke";
+  requestId: string;
+  nonce: string;
+  browser: BrowserBridgeNativeBrowser;
+  extensionId: string;
+  extensionVersion: string;
+  profileId: string;
+  companionId: string;
+}
+
+export type BrowserBridgeNativeRequest =
+  | BrowserBridgeNativeEnrollmentRequest
+  | BrowserBridgeNativeRevokeRequest;
+
 export interface BrowserBridgeNativeEnrollmentConfig {
   apiBaseUrl: string;
   companionId: string;
@@ -44,6 +60,14 @@ export interface BrowserBridgeNativeEnrollmentResult {
   config: BrowserBridgeNativeEnrollmentConfig;
 }
 
+export interface BrowserBridgeNativeRevokeResult {
+  v: 1;
+  type: "browser_bridge.revoke_result";
+  requestId: string;
+  nonce: string;
+  revoked: true;
+}
+
 export type BrowserBridgeNativeErrorCode =
   | "app_not_running"
   | "app_not_authenticated"
@@ -61,6 +85,7 @@ export interface BrowserBridgeNativeErrorResponse {
 
 export type BrowserBridgeNativeResponse =
   | BrowserBridgeNativeEnrollmentResult
+  | BrowserBridgeNativeRevokeResult
   | BrowserBridgeNativeErrorResponse;
 
 export interface BrowserBridgeNativeCaller {
@@ -72,7 +97,7 @@ export interface BrowserBridgeBrokerEnvelope {
   protocol: typeof BROWSER_BRIDGE_BROKER_PROTOCOL;
   timestampMs: number;
   caller: BrowserBridgeNativeCaller;
-  request: BrowserBridgeNativeEnrollmentRequest;
+  request: BrowserBridgeNativeRequest;
   mac: string;
 }
 
@@ -263,6 +288,56 @@ export function parseNativeEnrollmentRequest(
   };
 }
 
+export function parseNativeRequest(input: unknown): BrowserBridgeNativeRequest {
+  if (!isRecord(input)) {
+    throw new BrowserBridgeNativeProtocolError(
+      "invalid_message",
+      "native browser bridge message must be an object",
+    );
+  }
+  if (input.type === "browser_bridge.enroll") {
+    return parseNativeEnrollmentRequest(input);
+  }
+  if (input.type !== "browser_bridge.revoke") {
+    throw new BrowserBridgeNativeProtocolError(
+      "unsupported_protocol",
+      "native browser bridge request version or type is unsupported",
+    );
+  }
+  assertExactKeys(input, [
+    "v",
+    "type",
+    "requestId",
+    "nonce",
+    "browser",
+    "extensionId",
+    "extensionVersion",
+    "profileId",
+    "companionId",
+  ]);
+  if (input.v !== 1) {
+    throw new BrowserBridgeNativeProtocolError(
+      "unsupported_protocol",
+      "native browser bridge request version is unsupported",
+    );
+  }
+  const common = parseNativeEnrollmentRequest({
+    v: input.v,
+    type: "browser_bridge.enroll",
+    requestId: input.requestId,
+    nonce: input.nonce,
+    browser: input.browser,
+    extensionId: input.extensionId,
+    extensionVersion: input.extensionVersion,
+    profileId: input.profileId,
+  });
+  return {
+    ...common,
+    type: "browser_bridge.revoke",
+    companionId: requiredString(input, "companionId", 256),
+  };
+}
+
 const NATIVE_ERROR_CODES = new Set<BrowserBridgeNativeErrorCode>([
   "app_not_running",
   "app_not_authenticated",
@@ -406,6 +481,36 @@ export function parseNativeEnrollmentResponse(
   };
 }
 
+export function parseNativeResponse(
+  input: unknown,
+): BrowserBridgeNativeResponse {
+  if (
+    isRecord(input) &&
+    input.v === 1 &&
+    input.type === "browser_bridge.revoke_result"
+  ) {
+    assertExactKeys(input, ["v", "type", "requestId", "nonce", "revoked"]);
+    const nonce = requiredString(input, "nonce", 43);
+    if (!/^[A-Za-z0-9_-]{43}$/.test(nonce) || input.revoked !== true) {
+      throw new BrowserBridgeNativeProtocolError(
+        "invalid_response",
+        "native revoke result is invalid",
+      );
+    }
+    return {
+      v: 1,
+      type: "browser_bridge.revoke_result",
+      requestId: requireUuid(
+        requiredString(input, "requestId", 36),
+        "requestId",
+      ),
+      nonce,
+      revoked: true,
+    };
+  }
+  return parseNativeEnrollmentResponse(input);
+}
+
 export function parseBrokerEnvelope(
   input: unknown,
 ): BrowserBridgeBrokerEnvelope {
@@ -452,7 +557,7 @@ export function parseBrokerEnvelope(
       browser: parseBrowser(input.caller.browser),
       id: requiredString(input.caller, "id", 256),
     },
-    request: parseNativeEnrollmentRequest(input.request),
+    request: parseNativeRequest(input.request),
     mac: requiredString(input, "mac", 128),
   };
 }
@@ -467,7 +572,7 @@ function allowedCallerIds(
 }
 
 export function assertNativeHostCaller(
-  request: BrowserBridgeNativeEnrollmentRequest,
+  request: BrowserBridgeNativeRequest,
   caller: BrowserBridgeNativeCaller,
   allowlist: BrowserBridgeCallerAllowlist,
 ): void {
@@ -486,7 +591,7 @@ export function assertNativeHostCaller(
 export function canonicalBrokerEnvelopeData(
   envelope: Omit<BrowserBridgeBrokerEnvelope, "mac">,
 ): string {
-  return [
+  const fields = [
     envelope.protocol,
     String(envelope.timestampMs),
     envelope.caller.browser,
@@ -499,7 +604,11 @@ export function canonicalBrokerEnvelopeData(
     envelope.request.extensionId,
     envelope.request.extensionVersion,
     envelope.request.profileId,
-  ].join("\n");
+  ];
+  if (envelope.request.type === "browser_bridge.revoke") {
+    fields.push(envelope.request.companionId);
+  }
+  return fields.join("\n");
 }
 
 export function signBrokerEnvelope(
@@ -520,7 +629,7 @@ export function signBrokerEnvelope(
 }
 
 export function createAuthenticatedBrokerEnvelope(options: {
-  request: BrowserBridgeNativeEnrollmentRequest;
+  request: BrowserBridgeNativeRequest;
   launchedCaller: BrowserBridgeNativeCaller;
   allowlist: BrowserBridgeCallerAllowlist;
   secret: Uint8Array;

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
@@ -201,6 +201,7 @@ describe("browser bridge native revoke integration", () => {
       now: () => nowMs,
       randomUUID: () => requestId,
       randomBytes: () => new Uint8Array(32).fill(13),
+      timeoutMs: 10,
     });
     const oldConfig = {
       apiBaseUrl: "http://127.0.0.1:31337",
@@ -215,15 +216,18 @@ describe("browser bridge native revoke integration", () => {
     let persistedConfig: BrowserBridgeCompanionConfig | null = oldConfig;
     const enrollment = coordinator.enroll({ browser: "chrome", profileId });
     await pairStarted;
+    await expect(enrollment).rejects.toMatchObject({
+      code: "native_enrollment_timeout",
+    });
 
-    let abandonedConfig: BrowserBridgeCompanionConfig | null = null;
+    let abandonedConfigs: readonly BrowserBridgeCompanionConfig[] = [];
     const disconnect = performDurableDisconnect({
       cancelSync: async () => undefined,
       cancelEnrollment: async () => {
-        abandonedConfig = await coordinator.cancel();
+        abandonedConfigs = await coordinator.cancel();
       },
       revoke: async () => {
-        const targets = [persistedConfig, abandonedConfig].filter(
+        const targets = [persistedConfig, ...abandonedConfigs].filter(
           (config): config is BrowserBridgeCompanionConfig => config !== null,
         );
         await Promise.all(
@@ -248,10 +252,6 @@ describe("browser bridge native revoke integration", () => {
       new Set(["companion-old", "companion-new"]),
     );
     releasePair();
-
-    await expect(enrollment).rejects.toMatchObject({
-      code: "native_enrollment_cancelled",
-    });
     await disconnect;
     expect(activeCompanions.size).toBe(0);
     expect(persistedConfig).toBeNull();

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import type { BrowserBridgeCompanionConfig } from "../../../../../browser-bridge-extension/src/browser-bridge-contracts";
+import { performDurableDisconnect } from "../../../../../browser-bridge-extension/src/durable-disconnect";
 import {
+  EMPTY_NATIVE_ENROLLMENT_STATE,
+  NativeEnrollmentCoordinator,
   type NativeRevokeRequest,
   revokeNativeCompanion,
 } from "../../../../../browser-bridge-extension/src/native-enrollment";
@@ -100,5 +104,156 @@ describe("browser bridge native revoke integration", () => {
     });
     expect(init?.headers).not.toHaveProperty("authorization");
     expect(JSON.stringify(init)).not.toContain("extension-pairing-token");
+  });
+
+  it("quiesces delayed enrollment and revokes both old and newly minted companions before clearing", async () => {
+    const activeCompanions = new Set(["companion-old"]);
+    let releasePair!: () => void;
+    const pairRelease = new Promise<void>((resolve) => {
+      releasePair = resolve;
+    });
+    let notifyPairStarted!: () => void;
+    const pairStarted = new Promise<void>((resolve) => {
+      notifyPairStarted = resolve;
+    });
+    const ownerFetch = vi.fn<FetchLike>(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/pair")) {
+        activeCompanions.add("companion-new");
+        notifyPairStarted();
+        await pairRelease;
+        return new Response(
+          JSON.stringify({
+            companion: {
+              id: "companion-new",
+              browser: "chrome",
+              profileId,
+              profileLabel: "Personal",
+              label: "Chrome Personal",
+            },
+            pairingToken: "new-pairing-token",
+            pairingTokenExpiresAt: null,
+          }),
+          { status: 201 },
+        );
+      }
+      const match = url.pathname.match(/\/companions\/([^/]+)\/revoke$/);
+      if (!match) return new Response("not found", { status: 404 });
+      activeCompanions.delete(decodeURIComponent(match[1]));
+      return new Response(JSON.stringify({ revoked: true }), { status: 200 });
+    });
+    const secret = Buffer.alloc(32, 22);
+    const nowMs = 1_800_000_000_000;
+    const broker = new BrowserBridgeEnrollmentBroker({
+      apiBase: "http://127.0.0.1:31337",
+      ownerSession: async () => ({
+        sessionId: "owner-session",
+        csrfToken: "owner-csrf",
+        expiresAt: Date.now() + 60_000,
+      }),
+      brokerSecret: secret,
+      callerAllowlist: {
+        chromeExtensionIds: [callerId],
+        firefoxExtensionIds: [],
+        safariExtensionIds: [],
+      },
+      fetchImpl: ownerFetch,
+      now: () => nowMs,
+    });
+    const transport: BrowserBridgeBrokerTransport = {
+      descriptor: {
+        kind: "unix",
+        socketPath: "/tmp/browser-bridge-race.sock",
+        directoryMode: 0o700,
+        socketMode: 0o600,
+        expectedUid: 501,
+        directoryPolicy: "managed",
+      },
+      request: async (bytes) =>
+        Buffer.from(
+          JSON.stringify(
+            await broker.handle(
+              JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown,
+            ),
+          ),
+        ),
+    };
+    const host = new BrowserBridgeNativeHost({
+      launchedCaller: { browser: "chrome", id: callerId },
+      allowlist: {
+        chromeExtensionIds: [callerId],
+        firefoxExtensionIds: [],
+        safariExtensionIds: [],
+      },
+      brokerSecret: secret,
+      transport,
+      now: () => nowMs,
+    });
+    let state = { ...EMPTY_NATIVE_ENROLLMENT_STATE };
+    const coordinator = new NativeEnrollmentCoordinator({
+      getExtensionId: () => callerId,
+      getExtensionVersion: () => "1.2.3",
+      send: async (request) => await host.handle(request),
+      loadState: async () => state,
+      saveState: async (next) => {
+        state = next;
+      },
+      now: () => nowMs,
+      randomUUID: () => requestId,
+      randomBytes: () => new Uint8Array(32).fill(13),
+    });
+    const oldConfig = {
+      apiBaseUrl: "http://127.0.0.1:31337",
+      companionId: "companion-old",
+      pairingToken: "old-pairing-token",
+      pairingTokenExpiresAt: "2030-01-01T00:00:00.000Z",
+      browser: "chrome" as const,
+      profileId,
+      profileLabel: "Personal",
+      label: "Chrome Personal",
+    };
+    let persistedConfig: BrowserBridgeCompanionConfig | null = oldConfig;
+    const enrollment = coordinator.enroll({ browser: "chrome", profileId });
+    await pairStarted;
+
+    let abandonedConfig: BrowserBridgeCompanionConfig | null = null;
+    const disconnect = performDurableDisconnect({
+      cancelSync: async () => undefined,
+      cancelEnrollment: async () => {
+        abandonedConfig = await coordinator.cancel();
+      },
+      revoke: async () => {
+        const targets = [persistedConfig, abandonedConfig].filter(
+          (config): config is BrowserBridgeCompanionConfig => config !== null,
+        );
+        await Promise.all(
+          targets.map(
+            async (config) =>
+              await revokeNativeCompanion({
+                config,
+                extensionId: callerId,
+                extensionVersion: "1.2.3",
+                send: async (request) => await host.handle(request),
+              }),
+          ),
+        );
+      },
+      suppressEnrollment: async () => undefined,
+      clearConfig: async () => {
+        expect(activeCompanions.size).toBe(0);
+        persistedConfig = null;
+      },
+    });
+    expect(activeCompanions).toEqual(
+      new Set(["companion-old", "companion-new"]),
+    );
+    releasePair();
+
+    await expect(enrollment).rejects.toMatchObject({
+      code: "native_enrollment_cancelled",
+    });
+    await disconnect;
+    expect(activeCompanions.size).toBe(0);
+    expect(persistedConfig).toBeNull();
   });
 });

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-native-revoke.integration.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Exercises extension Disconnect through the authenticated native host and
+ * desktop broker into the owner-cookie and CSRF revocation boundary.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  type NativeRevokeRequest,
+  revokeNativeCompanion,
+} from "../../../../../browser-bridge-extension/src/native-enrollment";
+import type { FetchLike } from "./auth-bridge";
+import type { BrowserBridgeBrokerTransport } from "./browser-bridge-broker-transport";
+import { BrowserBridgeEnrollmentBroker } from "./browser-bridge-enrollment-broker";
+import { BrowserBridgeNativeHost } from "./browser-bridge-native-host";
+
+const callerId = "abcdefghijklmnopabcdefghijklmnop";
+const requestId = "123e4567-e89b-42d3-a456-426614174000";
+const profileId = "123e4567-e89b-42d3-a456-426614174001";
+
+describe("browser bridge native revoke integration", () => {
+  it("keeps owner credentials in the broker while revoking the requested companion", async () => {
+    const ownerFetch = vi.fn<FetchLike>(
+      async (_input, _init) =>
+        new Response(JSON.stringify({ revoked: true }), { status: 200 }),
+    );
+    const secret = Buffer.alloc(32, 21);
+    const nowMs = 1_800_000_000_000;
+    const broker = new BrowserBridgeEnrollmentBroker({
+      apiBase: "http://127.0.0.1:31337",
+      ownerSession: async () => ({
+        sessionId: "owner-session",
+        csrfToken: "owner-csrf",
+        expiresAt: Date.now() + 60_000,
+      }),
+      brokerSecret: secret,
+      callerAllowlist: {
+        chromeExtensionIds: [callerId],
+        firefoxExtensionIds: [],
+        safariExtensionIds: [],
+      },
+      fetchImpl: ownerFetch,
+      now: () => nowMs,
+    });
+    const transport: BrowserBridgeBrokerTransport = {
+      descriptor: {
+        kind: "unix",
+        socketPath: "/tmp/browser-bridge-revoke.sock",
+        directoryMode: 0o700,
+        socketMode: 0o600,
+        expectedUid: 501,
+        directoryPolicy: "managed",
+      },
+      request: async (bytes) =>
+        Buffer.from(
+          JSON.stringify(
+            await broker.handle(
+              JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown,
+            ),
+          ),
+        ),
+    };
+    const host = new BrowserBridgeNativeHost({
+      launchedCaller: { browser: "chrome", id: callerId },
+      allowlist: {
+        chromeExtensionIds: [callerId],
+        firefoxExtensionIds: [],
+        safariExtensionIds: [],
+      },
+      brokerSecret: secret,
+      transport,
+      now: () => nowMs,
+    });
+
+    await expect(
+      revokeNativeCompanion({
+        config: {
+          apiBaseUrl: "http://127.0.0.1:31337",
+          companionId: "companion-1",
+          pairingToken: "extension-pairing-token",
+          pairingTokenExpiresAt: "2030-01-01T00:00:00.000Z",
+          browser: "chrome",
+          profileId,
+          profileLabel: "Personal",
+          label: "Chrome Personal",
+        },
+        extensionId: callerId,
+        extensionVersion: "1.2.3",
+        randomUUID: () => requestId,
+        randomBytes: () => new Uint8Array(32).fill(12),
+        send: async (request: NativeRevokeRequest) =>
+          await host.handle(request),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ownerFetch).toHaveBeenCalledTimes(1);
+    const init = ownerFetch.mock.calls[0]?.[1];
+    expect(init?.headers).toMatchObject({
+      cookie: "eliza_session=owner-session",
+      "x-eliza-csrf": "owner-csrf",
+    });
+    expect(init?.headers).not.toHaveProperty("authorization");
+    expect(JSON.stringify(init)).not.toContain("extension-pairing-token");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
@@ -31,7 +31,7 @@ describe("browser bridge registration lifecycle", () => {
       fs.rmSync(root, { force: true, recursive: true });
   });
 
-  posixIt("plans exact macOS and Linux per-user manifest locations", () => {
+  it("plans exact target-platform per-user manifest locations", () => {
     const mac = createBrowserBridgeRegistrationPlan({
       platform: "darwin",
       homeDir: "/Users/eliza",
@@ -55,31 +55,39 @@ describe("browser bridge registration lifecycle", () => {
       "/home/eliza/.config/google-chrome/NativeMessagingHosts/ai.elizaos.browserbridge.json",
       "/home/eliza/.mozilla/native-messaging-hosts/ai.elizaos.browserbridge.json",
     ]);
+    const windows = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: ["bridge@elizaos.ai"],
+    });
+    expect(windows.manifests.map((entry) => entry.manifestPath)).toEqual([
+      "C:\\Users\\eliza\\AppData\\Local\\elizaOS\\BrowserBridge\\chrome\\ai.elizaos.browserbridge.json",
+      "C:\\Users\\eliza\\AppData\\Local\\elizaOS\\BrowserBridge\\firefox\\ai.elizaos.browserbridge.json",
+    ]);
   });
 
-  posixIt(
-    "resolves the dedicated packaged host instead of the desktop executable",
-    () => {
-      expect(
-        resolveBrowserBridgeNativeHostExecutable(
-          "/Applications/Eliza.app/Contents/Resources/bun/native",
-          "darwin",
-          (candidate) =>
-            candidate ===
-            "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
-        ),
-      ).toBe(
-        "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
-      );
-      expect(() =>
-        resolveBrowserBridgeNativeHostExecutable(
-          "/tmp/native",
-          "linux",
-          () => false,
-        ),
-      ).toThrow("executable is missing");
-    },
-  );
+  it("resolves the dedicated packaged host instead of the desktop executable", () => {
+    expect(
+      resolveBrowserBridgeNativeHostExecutable(
+        "/Applications/Eliza.app/Contents/Resources/bun/native",
+        "darwin",
+        (candidate) =>
+          candidate ===
+          "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
+      ),
+    ).toBe(
+      "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
+    );
+    expect(() =>
+      resolveBrowserBridgeNativeHostExecutable(
+        "/tmp/native",
+        "linux",
+        () => false,
+      ),
+    ).toThrow("executable is missing");
+  });
 
   posixIt(
     "writes private manifests atomically and removes only exact planned files",
@@ -118,6 +126,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\Eliza.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: ["bridge@elizaos.ai"],
@@ -151,6 +160,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: ["bridge@elizaos.ai"],
@@ -213,6 +223,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: [],
@@ -252,6 +263,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: [],
@@ -291,6 +303,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: [],
@@ -322,6 +335,7 @@ describe("browser bridge registration lifecycle", () => {
       platform: "win32",
       homeDir: "C:\\Users\\eliza",
       windowsConfigDir: root,
+      pathApi: path,
       executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: [],

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
@@ -14,6 +14,7 @@ import {
 
 const roots: string[] = [];
 const chromeId = "abcdefghijklmnopabcdefghijklmnop";
+const posixIt = process.platform === "win32" ? it.skip : it;
 
 function requireRegistryKey(
   manifest: BrowserBridgeRegistrationPlan["manifests"][number],
@@ -30,7 +31,7 @@ describe("browser bridge registration lifecycle", () => {
       fs.rmSync(root, { force: true, recursive: true });
   });
 
-  it("plans exact macOS and Linux per-user manifest locations", () => {
+  posixIt("plans exact macOS and Linux per-user manifest locations", () => {
     const mac = createBrowserBridgeRegistrationPlan({
       platform: "darwin",
       homeDir: "/Users/eliza",
@@ -56,51 +57,57 @@ describe("browser bridge registration lifecycle", () => {
     ]);
   });
 
-  it("resolves the dedicated packaged host instead of the desktop executable", () => {
-    expect(
-      resolveBrowserBridgeNativeHostExecutable(
-        "/Applications/Eliza.app/Contents/Resources/bun/native",
-        "darwin",
-        (candidate) =>
-          candidate ===
-          "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
-      ),
-    ).toBe(
-      "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
-    );
-    expect(() =>
-      resolveBrowserBridgeNativeHostExecutable(
-        "/tmp/native",
-        "linux",
-        () => false,
-      ),
-    ).toThrow("executable is missing");
-  });
-
-  it("writes private manifests atomically and removes only exact planned files", () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), "browser-registration-"),
-    );
-    roots.push(root);
-    const plan = createBrowserBridgeRegistrationPlan({
-      platform: "linux",
-      homeDir: root,
-      executablePath: "/opt/eliza/eliza-browser-bridge-host",
-      chromeExtensionIds: [chromeId],
-      firefoxExtensionIds: ["bridge@elizaos.ai"],
-    });
-    installBrowserBridgeRegistration(plan);
-    for (const manifest of plan.manifests) {
-      expect(fs.readFileSync(manifest.manifestPath, "utf8")).toBe(
-        manifest.contents,
+  posixIt(
+    "resolves the dedicated packaged host instead of the desktop executable",
+    () => {
+      expect(
+        resolveBrowserBridgeNativeHostExecutable(
+          "/Applications/Eliza.app/Contents/Resources/bun/native",
+          "darwin",
+          (candidate) =>
+            candidate ===
+            "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
+        ),
+      ).toBe(
+        "/Applications/Eliza.app/Contents/Resources/bun/browser-bridge-native-host",
       );
-      expect(fs.statSync(manifest.manifestPath).mode & 0o777).toBe(0o600);
-    }
-    uninstallBrowserBridgeRegistration(plan);
-    expect(
-      plan.manifests.every((entry) => !fs.existsSync(entry.manifestPath)),
-    ).toBe(true);
-  });
+      expect(() =>
+        resolveBrowserBridgeNativeHostExecutable(
+          "/tmp/native",
+          "linux",
+          () => false,
+        ),
+      ).toThrow("executable is missing");
+    },
+  );
+
+  posixIt(
+    "writes private manifests atomically and removes only exact planned files",
+    () => {
+      const root = fs.mkdtempSync(
+        path.join(os.tmpdir(), "browser-registration-"),
+      );
+      roots.push(root);
+      const plan = createBrowserBridgeRegistrationPlan({
+        platform: "linux",
+        homeDir: root,
+        executablePath: "/opt/eliza/eliza-browser-bridge-host",
+        chromeExtensionIds: [chromeId],
+        firefoxExtensionIds: ["bridge@elizaos.ai"],
+      });
+      installBrowserBridgeRegistration(plan);
+      for (const manifest of plan.manifests) {
+        expect(fs.readFileSync(manifest.manifestPath, "utf8")).toBe(
+          manifest.contents,
+        );
+        expect(fs.statSync(manifest.manifestPath).mode & 0o777).toBe(0o600);
+      }
+      uninstallBrowserBridgeRegistration(plan);
+      expect(
+        plan.manifests.every((entry) => !fs.existsSync(entry.manifestPath)),
+      ).toBe(true);
+    },
+  );
 
   it("plans and applies exact HKCU keys through the injected Windows executor", () => {
     const root = fs.mkdtempSync(
@@ -185,10 +192,12 @@ describe("browser bridge registration lifecycle", () => {
       expect(fs.readFileSync(manifest.manifestPath)).toEqual(
         previousFiles.get(manifest.manifestPath),
       );
-      expect(fs.statSync(manifest.manifestPath).mode & 0o777).toBe(0o640);
-      expect(
-        fs.statSync(path.dirname(manifest.manifestPath)).mode & 0o777,
-      ).toBe(previousDirectoryModes.get(path.dirname(manifest.manifestPath)));
+      if (process.platform !== "win32") {
+        expect(fs.statSync(manifest.manifestPath).mode & 0o777).toBe(0o640);
+        expect(
+          fs.statSync(path.dirname(manifest.manifestPath)).mode & 0o777,
+        ).toBe(previousDirectoryModes.get(path.dirname(manifest.manifestPath)));
+      }
       expect(registryValues.get(requireRegistryKey(manifest))).toBe(
         `C:\\previous\\${manifest.browser}.json`,
       );

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  type BrowserBridgeRegistrationPlan,
   createBrowserBridgeRegistrationPlan,
   installBrowserBridgeRegistration,
   resolveBrowserBridgeNativeHostExecutable,
@@ -13,6 +14,15 @@ import {
 
 const roots: string[] = [];
 const chromeId = "abcdefghijklmnopabcdefghijklmnop";
+
+function requireRegistryKey(
+  manifest: BrowserBridgeRegistrationPlan["manifests"][number],
+): string {
+  if (!manifest.windowsRegistryKey) {
+    throw new Error("expected Windows registry key");
+  }
+  return manifest.windowsRegistryKey;
+}
 
 describe("browser bridge registration lifecycle", () => {
   afterEach(() => {
@@ -105,7 +115,16 @@ describe("browser bridge registration lifecycle", () => {
       chromeExtensionIds: [chromeId],
       firefoxExtensionIds: ["bridge@elizaos.ai"],
     });
-    const registry = { setDefaultValue: vi.fn(), deleteKey: vi.fn() };
+    const values = new Map<string, string>();
+    const registry = {
+      readDefaultValue: vi.fn((key: string) => values.get(key) ?? null),
+      setDefaultValue: vi.fn((key: string, value: string) => {
+        values.set(key, value);
+      }),
+      deleteKey: vi.fn((key: string) => {
+        values.delete(key);
+      }),
+    };
     installBrowserBridgeRegistration(plan, registry);
     expect(registry.setDefaultValue).toHaveBeenCalledTimes(2);
     expect(registry.setDefaultValue.mock.calls.map(([key]) => key)).toEqual([
@@ -114,5 +133,205 @@ describe("browser bridge registration lifecycle", () => {
     ]);
     uninstallBrowserBridgeRegistration(plan, registry);
     expect(registry.deleteKey).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores prior manifests and registry values after a partial Windows failure", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "browser-registration-rollback-"),
+    );
+    roots.push(root);
+    const plan = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      windowsConfigDir: root,
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: ["bridge@elizaos.ai"],
+    });
+    const previousFiles = new Map<string, Buffer>();
+    const previousDirectoryModes = new Map<string, number>();
+    const registryValues = new Map<string, string>();
+    for (const [index, manifest] of plan.manifests.entries()) {
+      const previous = Buffer.from(`previous-${index}`);
+      previousFiles.set(manifest.manifestPath, previous);
+      fs.mkdirSync(path.dirname(manifest.manifestPath), { recursive: true });
+      fs.chmodSync(path.dirname(manifest.manifestPath), 0o750);
+      previousDirectoryModes.set(path.dirname(manifest.manifestPath), 0o750);
+      fs.writeFileSync(manifest.manifestPath, previous, { mode: 0o640 });
+      registryValues.set(
+        requireRegistryKey(manifest),
+        `C:\\previous\\${manifest.browser}.json`,
+      );
+    }
+    let injected = false;
+    const registry = {
+      readDefaultValue: vi.fn((key: string) => registryValues.get(key) ?? null),
+      setDefaultValue: vi.fn((key: string, value: string) => {
+        registryValues.set(key, value);
+        if (key.includes("Mozilla") && !injected) {
+          injected = true;
+          throw new Error("injected registry failure");
+        }
+      }),
+      deleteKey: vi.fn((key: string) => {
+        registryValues.delete(key);
+      }),
+    };
+
+    expect(() => installBrowserBridgeRegistration(plan, registry)).toThrow(
+      "injected registry failure",
+    );
+    for (const manifest of plan.manifests) {
+      expect(fs.readFileSync(manifest.manifestPath)).toEqual(
+        previousFiles.get(manifest.manifestPath),
+      );
+      expect(fs.statSync(manifest.manifestPath).mode & 0o777).toBe(0o640);
+      expect(
+        fs.statSync(path.dirname(manifest.manifestPath)).mode & 0o777,
+      ).toBe(previousDirectoryModes.get(path.dirname(manifest.manifestPath)));
+      expect(registryValues.get(requireRegistryKey(manifest))).toBe(
+        `C:\\previous\\${manifest.browser}.json`,
+      );
+    }
+  });
+
+  it("removes newly created manifests and keys after a partial Windows failure", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "browser-registration-clean-rollback-"),
+    );
+    roots.push(root);
+    const plan = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      windowsConfigDir: root,
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: [],
+    });
+    const registryValues = new Map<string, string>();
+    let injected = false;
+    const registry = {
+      readDefaultValue: vi.fn(() => null),
+      setDefaultValue: vi.fn((key: string, value: string) => {
+        registryValues.set(key, value);
+        if (!injected) {
+          injected = true;
+          throw new Error("injected registry failure");
+        }
+      }),
+      deleteKey: vi.fn((key: string) => {
+        registryValues.delete(key);
+      }),
+    };
+
+    expect(() => installBrowserBridgeRegistration(plan, registry)).toThrow(
+      "injected registry failure",
+    );
+    expect(registryValues.size).toBe(0);
+    expect(
+      plan.manifests.every((manifest) => !fs.existsSync(manifest.manifestPath)),
+    ).toBe(true);
+    expect(fs.readdirSync(root)).toEqual([]);
+  });
+
+  it("preserves both registration and rollback failures", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "browser-registration-double-failure-"),
+    );
+    roots.push(root);
+    const plan = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      windowsConfigDir: root,
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: [],
+    });
+    const primary = new Error("injected registration failure");
+    const cleanup = new Error("injected rollback failure");
+    const registry = {
+      readDefaultValue: vi.fn(() => null),
+      setDefaultValue: vi.fn(() => {
+        throw primary;
+      }),
+      deleteKey: vi.fn(() => {
+        throw cleanup;
+      }),
+    };
+
+    let received: unknown;
+    try {
+      installBrowserBridgeRegistration(plan, registry);
+    } catch (error) {
+      received = error;
+    }
+    expect(received).toBeInstanceOf(AggregateError);
+    if (!(received instanceof AggregateError)) {
+      throw new Error("expected aggregate registration rollback failure");
+    }
+    expect(received.cause).toBe(primary);
+    expect(received.errors).toEqual([primary, cleanup]);
+  });
+
+  it("does not remove a registration replaced by another installation", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "browser-registration-owned-"),
+    );
+    roots.push(root);
+    const plan = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      windowsConfigDir: root,
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: [],
+    });
+    const manifest = plan.manifests[0];
+    if (!manifest) throw new Error("expected Chrome registration manifest");
+    fs.mkdirSync(path.dirname(manifest.manifestPath), { recursive: true });
+    fs.writeFileSync(manifest.manifestPath, "newer manifest", "utf8");
+    const registry = {
+      readDefaultValue: vi.fn(() => manifest.manifestPath),
+      setDefaultValue: vi.fn(),
+      deleteKey: vi.fn(),
+    };
+
+    uninstallBrowserBridgeRegistration(plan, registry);
+
+    expect(registry.deleteKey).not.toHaveBeenCalled();
+    expect(fs.readFileSync(manifest.manifestPath, "utf8")).toBe(
+      "newer manifest",
+    );
+  });
+
+  it("preserves an exact manifest when the Windows registry pointer was replaced", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "browser-registration-registry-replaced-"),
+    );
+    roots.push(root);
+    const plan = createBrowserBridgeRegistrationPlan({
+      platform: "win32",
+      homeDir: "C:\\Users\\eliza",
+      windowsConfigDir: root,
+      executablePath: "C:\\Program Files\\Eliza\\browser-host.exe",
+      chromeExtensionIds: [chromeId],
+      firefoxExtensionIds: [],
+    });
+    const manifest = plan.manifests[0];
+    if (!manifest) throw new Error("expected Chrome registration manifest");
+    fs.mkdirSync(path.dirname(manifest.manifestPath), { recursive: true });
+    fs.writeFileSync(manifest.manifestPath, manifest.contents, "utf8");
+    const registry = {
+      readDefaultValue: vi.fn(() => "C:\\OtherApp\\native-host.json"),
+      setDefaultValue: vi.fn(),
+      deleteKey: vi.fn(),
+    };
+
+    uninstallBrowserBridgeRegistration(plan, registry);
+
+    expect(registry.deleteKey).not.toHaveBeenCalled();
+    expect(fs.readFileSync(manifest.manifestPath, "utf8")).toBe(
+      manifest.contents,
+    );
   });
 });

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.ts
@@ -4,6 +4,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -112,22 +113,58 @@ export function createBrowserBridgeRegistrationPlan(options: {
   return { platform: options.platform, manifests };
 }
 
-function atomicWritePrivateFile(filePath: string, contents: string): void {
+function atomicWritePrivateFile(
+  filePath: string,
+  contents: string | Uint8Array,
+  mode = 0o600,
+): void {
   const directory = path.dirname(filePath);
   fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
   fs.chmodSync(directory, 0o700);
-  const temporaryPath = `${filePath}.${process.pid}.tmp`;
-  fs.writeFileSync(temporaryPath, contents, { encoding: "utf8", mode: 0o600 });
-  fs.chmodSync(temporaryPath, 0o600);
-  fs.renameSync(temporaryPath, filePath);
+  const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    if (typeof contents === "string") {
+      fs.writeFileSync(temporaryPath, contents, { encoding: "utf8", mode });
+    } else {
+      fs.writeFileSync(temporaryPath, contents, { mode });
+    }
+    fs.chmodSync(temporaryPath, mode);
+    fs.renameSync(temporaryPath, filePath);
+  } catch (error) {
+    // error-policy:J2 preserve both the write failure and a failed temporary-file cleanup.
+    try {
+      fs.rmSync(temporaryPath, { force: true });
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "native-host manifest write and cleanup failed",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 
 export interface WindowsRegistryExecutor {
+  readDefaultValue(key: string): string | null;
   setDefaultValue(key: string, value: string): void;
   deleteKey(key: string): void;
 }
 
 export const defaultWindowsRegistryExecutor: WindowsRegistryExecutor = {
+  readDefaultValue(key) {
+    const result = spawnSync("reg.exe", ["query", key, "/ve"], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    if (result.status === 1) return null;
+    if (result.status !== 0)
+      throw new Error("native-host registry query failed");
+    const match = result.stdout.match(/\sREG_SZ\s+(.*?)(?:\r?\n|$)/);
+    if (!match)
+      throw new Error("native-host registry query returned an invalid value");
+    return match[1] ?? "";
+  },
   setDefaultValue(key, value) {
     const result = spawnSync(
       "reg.exe",
@@ -148,18 +185,117 @@ export const defaultWindowsRegistryExecutor: WindowsRegistryExecutor = {
   },
 };
 
+interface ManifestDirectorySnapshot {
+  directoryPath: string;
+  previousMode: number | null;
+  missingDirectories: string[];
+}
+
+function snapshotManifestDirectory(
+  filePath: string,
+): ManifestDirectorySnapshot {
+  const directoryPath = path.dirname(filePath);
+  if (fs.existsSync(directoryPath)) {
+    return {
+      directoryPath,
+      previousMode: fs.statSync(directoryPath).mode & 0o777,
+      missingDirectories: [],
+    };
+  }
+  const missingDirectories: string[] = [];
+  let current = directoryPath;
+  while (!fs.existsSync(current)) {
+    missingDirectories.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return { directoryPath, previousMode: null, missingDirectories };
+}
+
+function restoreManifestDirectory(snapshot: ManifestDirectorySnapshot): void {
+  if (snapshot.previousMode !== null) {
+    fs.chmodSync(snapshot.directoryPath, snapshot.previousMode);
+    return;
+  }
+  for (const directory of snapshot.missingDirectories) {
+    try {
+      fs.rmdirSync(directory);
+    } catch (error) {
+      // error-policy:J6 another registration or concurrent writer may still own the directory.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error;
+    }
+  }
+}
+
 export function installBrowserBridgeRegistration(
   plan: BrowserBridgeRegistrationPlan,
   windowsRegistry: WindowsRegistryExecutor = defaultWindowsRegistryExecutor,
 ): void {
-  for (const manifest of plan.manifests) {
-    atomicWritePrivateFile(manifest.manifestPath, manifest.contents);
-    if (manifest.windowsRegistryKey) {
-      windowsRegistry.setDefaultValue(
-        manifest.windowsRegistryKey,
-        manifest.manifestPath,
+  const snapshots = plan.manifests.map((manifest) => ({
+    manifest,
+    file: fs.existsSync(manifest.manifestPath)
+      ? {
+          contents: fs.readFileSync(manifest.manifestPath),
+          mode: fs.statSync(manifest.manifestPath).mode & 0o777,
+        }
+      : null,
+    directory: snapshotManifestDirectory(manifest.manifestPath),
+    registryValue: manifest.windowsRegistryKey
+      ? windowsRegistry.readDefaultValue(manifest.windowsRegistryKey)
+      : null,
+  }));
+  const rollback: Array<() => void> = [];
+  try {
+    for (const snapshot of snapshots) {
+      const { manifest } = snapshot;
+      rollback.push(() => {
+        if (snapshot.file) {
+          atomicWritePrivateFile(
+            manifest.manifestPath,
+            snapshot.file.contents,
+            snapshot.file.mode,
+          );
+        } else {
+          fs.rmSync(manifest.manifestPath, { force: true });
+        }
+        restoreManifestDirectory(snapshot.directory);
+      });
+      atomicWritePrivateFile(manifest.manifestPath, manifest.contents);
+      const registryKey = manifest.windowsRegistryKey;
+      if (registryKey) {
+        rollback.push(() => {
+          if (snapshot.registryValue === null) {
+            windowsRegistry.deleteKey(registryKey);
+          } else {
+            windowsRegistry.setDefaultValue(
+              registryKey,
+              snapshot.registryValue,
+            );
+          }
+        });
+        windowsRegistry.setDefaultValue(registryKey, manifest.manifestPath);
+      }
+    }
+  } catch (error) {
+    // error-policy:J2 partial registration is rolled back before preserving the install failure.
+    const rollbackFailures: unknown[] = [];
+    for (const restore of rollback.reverse()) {
+      try {
+        restore();
+      } catch (rollbackError) {
+        rollbackFailures.push(rollbackError);
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackFailures],
+        "native-host registration and rollback failed",
+        { cause: error },
       );
     }
+    throw error;
   }
 }
 
@@ -168,10 +304,22 @@ export function uninstallBrowserBridgeRegistration(
   windowsRegistry: WindowsRegistryExecutor = defaultWindowsRegistryExecutor,
 ): void {
   for (const manifest of plan.manifests) {
+    const manifestOwned =
+      fs.existsSync(manifest.manifestPath) &&
+      fs.readFileSync(manifest.manifestPath, "utf8") === manifest.contents;
+    let registryOwned = true;
     if (manifest.windowsRegistryKey) {
-      windowsRegistry.deleteKey(manifest.windowsRegistryKey);
+      const registeredManifest = windowsRegistry.readDefaultValue(
+        manifest.windowsRegistryKey,
+      );
+      registryOwned = registeredManifest === manifest.manifestPath;
+      if (registryOwned && manifestOwned) {
+        windowsRegistry.deleteKey(manifest.windowsRegistryKey);
+      }
     }
-    fs.rmSync(manifest.manifestPath, { force: true });
+    if (manifestOwned && registryOwned) {
+      fs.rmSync(manifest.manifestPath, { force: true });
+    }
   }
 }
 

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-registration.ts
@@ -32,16 +32,25 @@ export function createBrowserBridgeRegistrationPlan(options: {
   chromeExtensionIds: readonly string[];
   firefoxExtensionIds: readonly string[];
   windowsConfigDir?: string;
+  pathApi?: Pick<typeof path, "join">;
 }): BrowserBridgeRegistrationPlan {
   const manifests: BrowserBridgeRegistrationPlan["manifests"] = [];
   const manifestName = `${BROWSER_BRIDGE_NATIVE_HOST_NAME}.json`;
+  const pathApi =
+    options.pathApi ?? (options.platform === "win32" ? path.win32 : path.posix);
   const windowsConfigDir =
     options.windowsConfigDir ??
-    path.join(options.homeDir, "AppData", "Local", "elizaOS", "BrowserBridge");
+    pathApi.join(
+      options.homeDir,
+      "AppData",
+      "Local",
+      "elizaOS",
+      "BrowserBridge",
+    );
   if (options.chromeExtensionIds.length > 0) {
     const manifestPath =
       options.platform === "darwin"
-        ? path.join(
+        ? pathApi.join(
             options.homeDir,
             "Library",
             "Application Support",
@@ -51,8 +60,8 @@ export function createBrowserBridgeRegistrationPlan(options: {
             manifestName,
           )
         : options.platform === "win32"
-          ? path.join(windowsConfigDir, "chrome", manifestName)
-          : path.join(
+          ? pathApi.join(windowsConfigDir, "chrome", manifestName)
+          : pathApi.join(
               options.homeDir,
               ".config",
               "google-chrome",
@@ -78,7 +87,7 @@ export function createBrowserBridgeRegistrationPlan(options: {
   if (options.firefoxExtensionIds.length > 0) {
     const manifestPath =
       options.platform === "darwin"
-        ? path.join(
+        ? pathApi.join(
             options.homeDir,
             "Library",
             "Application Support",
@@ -87,8 +96,8 @@ export function createBrowserBridgeRegistrationPlan(options: {
             manifestName,
           )
         : options.platform === "win32"
-          ? path.join(windowsConfigDir, "firefox", manifestName)
-          : path.join(
+          ? pathApi.join(windowsConfigDir, "firefox", manifestName)
+          : pathApi.join(
               options.homeDir,
               ".mozilla",
               "native-messaging-hosts",
@@ -339,11 +348,14 @@ export function resolveBrowserBridgeNativeHostExecutable(
   moduleDir: string,
   platform: NodeJS.Platform = process.platform,
   exists: (candidate: string) => boolean = fs.existsSync,
+  pathApi: Pick<typeof path, "resolve"> = platform === "win32"
+    ? path.win32
+    : path.posix,
 ): string {
   const executableName = `browser-bridge-native-host${platform === "win32" ? ".exe" : ""}`;
   const candidates = [
-    path.resolve(moduleDir, "..", executableName),
-    path.resolve(moduleDir, "..", "..", "build", executableName),
+    pathApi.resolve(moduleDir, "..", executableName),
+    pathApi.resolve(moduleDir, "..", "..", "build", executableName),
   ];
   const resolved = candidates.find(exists);
   if (!resolved)

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-replay-store.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-replay-store.test.ts
@@ -1,0 +1,100 @@
+/** Exercises the real filesystem-backed native-enrollment replay boundary. */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BrowserBridgeNativeProtocolError } from "./browser-bridge-native-protocol";
+import { PersistentNativeEnrollmentReplayGuard } from "./browser-bridge-replay-store";
+
+const directories: string[] = [];
+
+function replayPath(): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "eliza-browser-replay-"),
+  );
+  directories.push(directory);
+  return path.join(directory, "browser-bridge", "enrollment-replay.json");
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("PersistentNativeEnrollmentReplayGuard", () => {
+  it("rejects the same nonce after broker recreation without persisting it in plaintext", () => {
+    const filePath = replayPath();
+    const key = crypto.randomBytes(32);
+    new PersistentNativeEnrollmentReplayGuard(filePath, key).consume(
+      "restart-sensitive-nonce",
+      1_000,
+    );
+
+    expect(fs.readFileSync(filePath, "utf8")).not.toContain(
+      "restart-sensitive-nonce",
+    );
+    expect(() =>
+      new PersistentNativeEnrollmentReplayGuard(filePath, key).consume(
+        "restart-sensitive-nonce",
+        1_001,
+      ),
+    ).toThrowError(
+      expect.objectContaining<Partial<BrowserBridgeNativeProtocolError>>({
+        code: "replayed_nonce",
+      }),
+    );
+  }, 20_000);
+
+  it("serializes consumes from distinct broker guards against the same store", () => {
+    const filePath = replayPath();
+    const key = crypto.randomBytes(32);
+    const first = new PersistentNativeEnrollmentReplayGuard(filePath, key);
+    const second = new PersistentNativeEnrollmentReplayGuard(filePath, key);
+
+    first.consume("shared-nonce", 2_000);
+    expect(() => second.consume("shared-nonce", 2_000)).toThrowError(
+      expect.objectContaining<Partial<BrowserBridgeNativeProtocolError>>({
+        code: "replayed_nonce",
+      }),
+    );
+  }, 20_000);
+
+  it("fails closed when the persisted replay document is corrupt", () => {
+    const filePath = replayPath();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, "not-json", { mode: 0o600 });
+
+    expect(() =>
+      new PersistentNativeEnrollmentReplayGuard(
+        filePath,
+        crypto.randomBytes(32),
+      ).consume("nonce", 3_000),
+    ).toThrowError(
+      expect.objectContaining<Partial<BrowserBridgeNativeProtocolError>>({
+        code: "replay_store_corrupt",
+      }),
+    );
+  }, 20_000);
+
+  it("prunes expired entries before enforcing capacity", () => {
+    const filePath = replayPath();
+    const key = crypto.randomBytes(32);
+    const guard = new PersistentNativeEnrollmentReplayGuard(
+      filePath,
+      key,
+      10,
+      1,
+    );
+    guard.consume("expired", 4_000);
+    guard.consume("replacement", 4_010);
+
+    expect(() => guard.consume("overflow", 4_010)).toThrowError(
+      expect.objectContaining<Partial<BrowserBridgeNativeProtocolError>>({
+        code: "replay_capacity_exceeded",
+      }),
+    );
+  }, 20_000);
+});

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-replay-store.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-replay-store.ts
@@ -1,0 +1,187 @@
+/** Persists consumed native-enrollment nonces across broker and app restarts. */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "./auth-bridge";
+import {
+  BrowserBridgeNativeProtocolError,
+  NATIVE_MESSAGE_CLOCK_SKEW_MS,
+  NativeEnrollmentReplayGuard,
+} from "./browser-bridge-native-protocol";
+
+interface ReplayStoreDocument {
+  version: 1;
+  entries: Array<{ digest: string; expiresAt: number }>;
+}
+
+export function resolveBrowserBridgeReplayStorePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(
+    resolveStateDir(env),
+    "browser-bridge",
+    "enrollment-replay.json",
+  );
+}
+
+function parseReplayStore(value: string): ReplayStoreDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    // error-policy:J2 corrupt security state must fail closed with a typed protocol error.
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_corrupt",
+      `native enrollment replay store is invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { version?: unknown }).version !== 1 ||
+    !Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_corrupt",
+      "native enrollment replay store has an invalid schema",
+    );
+  }
+  const entries = (parsed as ReplayStoreDocument).entries;
+  if (
+    entries.some(
+      (entry) =>
+        typeof entry !== "object" ||
+        entry === null ||
+        typeof entry.digest !== "string" ||
+        !/^[a-f0-9]{64}$/.test(entry.digest) ||
+        typeof entry.expiresAt !== "number" ||
+        !Number.isSafeInteger(entry.expiresAt),
+    )
+  ) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_corrupt",
+      "native enrollment replay store contains an invalid entry",
+    );
+  }
+  return { version: 1, entries };
+}
+
+function readReplayStore(filePath: string): ReplayStoreDocument {
+  if (!fs.existsSync(filePath)) return { version: 1, entries: [] };
+  const stat = fs.lstatSync(filePath);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_unsafe",
+      "native enrollment replay store must be a regular file",
+    );
+  }
+  if (process.platform !== "win32" && (stat.mode & 0o777) !== 0o600) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_unsafe",
+      "native enrollment replay store must use mode 0600",
+    );
+  }
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_unsafe",
+      "native enrollment replay store is not owned by the current user",
+    );
+  }
+  return parseReplayStore(fs.readFileSync(filePath, "utf8"));
+}
+
+function ensureReplayStoreDirectory(filePath: string): string {
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryStat = fs.lstatSync(directory);
+  if (
+    directoryStat.isSymbolicLink() ||
+    !directoryStat.isDirectory() ||
+    (process.platform !== "win32" &&
+      ((directoryStat.mode & 0o777) !== 0o700 ||
+        (typeof process.getuid === "function" &&
+          directoryStat.uid !== process.getuid())))
+  ) {
+    throw new BrowserBridgeNativeProtocolError(
+      "replay_store_unsafe",
+      "native enrollment replay directory must be a real directory",
+    );
+  }
+  return directory;
+}
+
+function atomicWriteReplayStore(
+  filePath: string,
+  document: ReplayStoreDocument,
+): void {
+  ensureReplayStoreDirectory(filePath);
+  const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporaryPath, JSON.stringify(document), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    fs.renameSync(temporaryPath, filePath);
+    if (process.platform !== "win32") fs.chmodSync(filePath, 0o600);
+  } catch (error) {
+    // error-policy:J2 clean the private temporary file before preserving persistence failure.
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      // error-policy:J2 a failed cleanup is preserved alongside the write failure.
+      if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw new AggregateError(
+          [error, cleanupError],
+          "native enrollment replay store write and cleanup failed",
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+export class PersistentNativeEnrollmentReplayGuard extends NativeEnrollmentReplayGuard {
+  /**
+   * Consumption is synchronous and the Electrobun desktop is single-instance;
+   * desktop lifecycle wiring shares one guard across both native brokers.
+   */
+  constructor(
+    private readonly filePath: string,
+    private readonly digestKey: Uint8Array,
+    private readonly storeTtlMs = NATIVE_MESSAGE_CLOCK_SKEW_MS * 2,
+    private readonly storeCapacity = 4096,
+  ) {
+    super(storeTtlMs, storeCapacity);
+    if (digestKey.byteLength < 32) {
+      throw new BrowserBridgeNativeProtocolError(
+        "weak_broker_secret",
+        "replay digest key must contain at least 32 bytes",
+      );
+    }
+  }
+
+  override consume(nonce: string, nowMs: number): void {
+    const digest = crypto
+      .createHmac("sha256", this.digestKey)
+      .update(nonce, "utf8")
+      .digest("hex");
+    const document = readReplayStore(this.filePath);
+    const entries = document.entries.filter((entry) => entry.expiresAt > nowMs);
+    if (entries.some((entry) => entry.digest === digest)) {
+      throw new BrowserBridgeNativeProtocolError(
+        "replayed_nonce",
+        "native enrollment nonce has already been used",
+      );
+    }
+    if (entries.length >= this.storeCapacity) {
+      throw new BrowserBridgeNativeProtocolError(
+        "replay_capacity_exceeded",
+        "native enrollment replay window is full",
+      );
+    }
+    entries.push({ digest, expiresAt: nowMs + this.storeTtlMs });
+    atomicWriteReplayStore(this.filePath, { version: 1, entries });
+  }
+}

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-unregister.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-unregister.test.ts
@@ -1,0 +1,37 @@
+/** Verifies that Windows packaging invokes an ownership-guarded browser registration cleanup. */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("browser bridge Windows uninstall integration", () => {
+  it("ships a guarded cleanup helper through the real Inno uninstall lifecycle", () => {
+    const helper = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../scripts/browser-bridge-unregister.ps1",
+      ),
+      "utf8",
+    );
+    const inno = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../../packaging/inno/ElizaOSApp.iss",
+      ),
+      "utf8",
+    );
+
+    expect(helper).toContain("[Microsoft.Win32.Registry]::CurrentUser");
+    expect(helper).toContain("Test-ManifestOwnership");
+    expect(helper).toContain("browser-bridge-native-host.exe");
+    expect(helper).toContain("[System.StringComparison]::OrdinalIgnoreCase");
+    expect(helper).toContain(
+      "if ($registryOwnsManifest -and $manifestOwned -eq $true)",
+    );
+    expect(helper).not.toContain("$null -eq $registeredPath -or");
+    expect(helper).toContain("DeleteSubKeyTree");
+    expect(inno).toContain("[UninstallRun]");
+    expect(inno).toContain("browser-bridge-unregister.ps1");
+    expect(inno).toContain('RunOnceId: "BrowserBridgeNativeHost"');
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
@@ -39,7 +39,7 @@ describe("browser bridge hosted Windows native-host proof", () => {
     expect(proofSource).toContain("--target bun-windows-x64");
     expect(proofSource).toContain('"browser-bridge-secret.ps1"');
     expect(proofSource).toContain('ELIZA_STATE_DIR"] = $stateRoot');
-    expect(proofSource).toContain("StandardInputEncoding");
+    expect(proofSource).toContain("[Console]::InputEncoding");
     expect(proofSource).toContain('$response.code -eq "app_not_running"');
     expect(proofSource).toContain('$response.code -ne "broker_unavailable"');
   });

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
@@ -1,0 +1,57 @@
+/** Verifies the hosted Windows lane retains its staged compiled-host and registration lifecycle proof. */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../../../../..");
+const workflowSource = fs.readFileSync(
+  path.join(repoRoot, ".github/workflows/browser-bridge-windows-security.yml"),
+  "utf8",
+);
+const proofSource = fs.readFileSync(
+  path.join(
+    repoRoot,
+    "packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1",
+  ),
+  "utf8",
+);
+const installerProofSource = fs.readFileSync(
+  path.join(
+    repoRoot,
+    "packages/app-core/platforms/electrobun/scripts/verify-windows-installer-proof.ps1",
+  ),
+  "utf8",
+);
+
+describe("browser bridge hosted Windows native-host proof", () => {
+  it("runs a staged compiled-host probe and registration lifecycle contracts", () => {
+    expect(workflowSource).toContain("timeout-minutes: 30");
+    expect(workflowSource).toContain(
+      "- name: Compile and probe staged Windows native host\n        shell: powershell\n        run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1",
+    );
+    expect(workflowSource).toContain("browser-bridge-registration.test.ts");
+    expect(workflowSource).toContain("browser-bridge-unregister.test.ts");
+  });
+
+  it("distinguishes adjacent-helper success from the app-not-running fallback", () => {
+    expect(proofSource).toContain("bun build --compile --minify");
+    expect(proofSource).toContain("--target bun-windows-x64");
+    expect(proofSource).toContain('"browser-bridge-secret.ps1"');
+    expect(proofSource).toContain('ELIZA_STATE_DIR"] = $stateRoot');
+    expect(proofSource).toContain('$response.code -eq "app_not_running"');
+    expect(proofSource).toContain('$response.code -ne "broker_unavailable"');
+  });
+
+  it("requires registry defaults to point at the installed manifests", () => {
+    expect(installerProofSource).toContain(
+      "Get-CurrentUserDefaultRegistryValue $registration.RegistryKey",
+    );
+    expect(installerProofSource).toContain(
+      "[System.IO.Path]::GetFullPath([string]$registeredManifestPath)",
+    );
+    expect(installerProofSource).toContain(
+      "[System.IO.Path]::GetFullPath($registration.ManifestPath)",
+    );
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
@@ -39,6 +39,7 @@ describe("browser bridge hosted Windows native-host proof", () => {
     expect(proofSource).toContain("--target bun-windows-x64");
     expect(proofSource).toContain('"browser-bridge-secret.ps1"');
     expect(proofSource).toContain('ELIZA_STATE_DIR"] = $stateRoot');
+    expect(proofSource).toContain("StandardInputEncoding");
     expect(proofSource).toContain('$response.code -eq "app_not_running"');
     expect(proofSource).toContain('$response.code -ne "broker_unavailable"');
   });

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -1335,6 +1335,9 @@ function assertInnoTemplateTargetsBundledLauncher() {
     '#define MyAppIconFile "ElizaOSApp.ico"',
     'Source: "{#MySetupIconFile}"; DestDir: "{app}"; DestName: "{#MyAppIconFile}"; Flags: ignoreversion',
     "UninstallDisplayIcon={app}\\{#MyAppIconFile}",
+    "[UninstallRun]",
+    "browser-bridge-unregister.ps1",
+    'RunOnceId: "BrowserBridgeNativeHost"',
     'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; IconFilename: "{app}\\{#MyAppIconFile}"',
     'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\\{#MyAppIconFile}"',
   ];
@@ -1344,7 +1347,7 @@ function assertInnoTemplateTargetsBundledLauncher() {
 
   if (missingSnippets.length > 0) {
     console.error(
-      "release-check: Eliza.iss must point Windows shortcuts at bin\\launcher.exe and use Eliza.ico for uninstall and shortcut icons.",
+      "release-check: the Inno template must target the bundled launcher and clean owned browser registrations on uninstall.",
     );
     for (const snippet of missingSnippets) {
       console.error(`  - ${snippet}`);

--- a/packages/app-core/src/api/auth.test.ts
+++ b/packages/app-core/src/api/auth.test.ts
@@ -98,10 +98,11 @@ function makeReq(options: {
 }
 
 function loopbackReq(
-  headers: http.IncomingHttpHeaders = {},
+  options: { method?: string; headers?: http.IncomingHttpHeaders } = {},
 ): http.IncomingMessage {
   return makeReq({
-    headers: { host: "localhost:2138", ...headers },
+    method: options.method,
+    headers: { host: "localhost:2138", ...(options.headers ?? {}) },
     remoteAddress: "127.0.0.1",
   });
 }
@@ -651,6 +652,67 @@ describe("resolveAuthorizedRouteRole", () => {
         store: memoryStore({}),
       }),
     ).resolves.toEqual({ ok: true, role: "OWNER" });
+  });
+
+  it("requires the real cookie and CSRF when trusted-loopback and bearer bypasses are disabled", async () => {
+    const session = sessionRow({
+      id: "sess-strict-owner",
+      identityId: "id-owner",
+    });
+    const store = memoryStore({
+      sessions: { "sess-strict-owner": session },
+      identities: { "id-owner": { id: "id-owner", kind: "owner" } },
+    });
+    const strictOptions = {
+      store,
+      now: EMBED_NOW,
+      allowTrustedLocalBypass: false,
+      allowBearerAuth: false,
+    } as const;
+
+    await expect(
+      resolveAuthorizedRouteRole(
+        loopbackReq({
+          method: "POST",
+          headers: {
+            cookie: "eliza_session=sess-strict-owner",
+            [CSRF_HEADER_NAME]: "wrong-csrf",
+          },
+        }),
+        strictOptions,
+      ),
+    ).resolves.toEqual({ ok: false, status: 403, reason: "csrf_required" });
+
+    await expect(
+      resolveAuthorizedRouteRole(
+        loopbackReq({
+          method: "POST",
+          headers: {
+            authorization: "Bearer sess-strict-owner",
+            cookie: "eliza_session=missing",
+            [CSRF_HEADER_NAME]: deriveCsrfToken(session),
+          },
+        }),
+        strictOptions,
+      ),
+    ).resolves.toEqual({ ok: false, status: 401, reason: "Unauthorized" });
+
+    await expect(
+      resolveAuthorizedRouteRole(
+        loopbackReq({
+          method: "POST",
+          headers: {
+            cookie: "eliza_session=sess-strict-owner",
+            [CSRF_HEADER_NAME]: deriveCsrfToken(session),
+          },
+        }),
+        strictOptions,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      role: "OWNER",
+      identityId: "id-owner",
+    });
   });
 
   it("rate-limits a remote caller after 20 failed attempts", async () => {

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -403,6 +403,8 @@ type AuthorizedRouteRoleOptions =
       state: CompatStateLike;
       store?: never;
       allowCookieAuth?: boolean;
+      allowTrustedLocalBypass?: boolean;
+      allowBearerAuth?: boolean;
       skipCsrf?: boolean;
       now?: number;
       readSetting?: never;
@@ -411,6 +413,8 @@ type AuthorizedRouteRoleOptions =
       store: AuthStore;
       state?: never;
       allowCookieAuth?: boolean;
+      allowTrustedLocalBypass?: boolean;
+      allowBearerAuth?: boolean;
       skipCsrf?: boolean;
       now?: number;
       readSetting?: (key: string) => unknown;
@@ -447,7 +451,9 @@ export async function resolveAuthorizedRouteRole(
   // Trusted local requests bypass the rate limiter, matching the ordering in
   // {@link ensureCompatApiAuthorized}. A burst of failed renderer auth attempts
   // must not block the desktop shell's local login-persistence request.
-  if (isTrustedLocalRequest(req)) return { ok: true, role: "OWNER" };
+  if (options.allowTrustedLocalBypass !== false && isTrustedLocalRequest(req)) {
+    return { ok: true, role: "OWNER" };
+  }
 
   const ip = req.socket.remoteAddress ?? null;
   if (isAuthRateLimited(ip)) {
@@ -474,7 +480,8 @@ export async function resolveAuthorizedRouteRole(
       return { ok: false, status: 401, reason: "Unauthorized" };
     }
 
-    const providedToken = getProvidedApiToken(req);
+    const providedToken =
+      options.allowBearerAuth === false ? null : getProvidedApiToken(req);
     if (providedToken && tokenMatches(expectedToken, providedToken)) {
       return { ok: true, role: "OWNER" };
     }
@@ -513,7 +520,8 @@ export async function resolveAuthorizedRouteRole(
     }
   }
 
-  const provided = getProvidedApiToken(req);
+  const provided =
+    options.allowBearerAuth === false ? null : getProvidedApiToken(req);
   if (provided) {
     const sessionFromBearer = await findActiveSession(
       store,

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -47,6 +47,8 @@ export function installAgentHostBridge(): void {
   > = async (req, runtime, options) => {
     const resolved = await resolveAuthorizedRouteRole(req, {
       allowCookieAuth: options.allowCookieAuth,
+      allowTrustedLocalBypass: options.allowTrustedLocalBypass,
+      allowBearerAuth: options.allowBearerAuth,
       state: {
         current: runtime,
       },

--- a/packages/browser-bridge-extension/README.md
+++ b/packages/browser-bridge-extension/README.md
@@ -63,8 +63,11 @@ On startup and before sync, the extension asks the registered
 `ai.elizaos.browserbridge` native-messaging host for a short-lived companion
 credential. The desktop broker authenticates the current OS user and is the
 authority for the API origin and credential. A loopback page or server cannot
-enroll an extension. Explicit disconnects and server revocations suppress
-automatic enrollment. The normal popup never displays or imports pairing
+enroll an extension. Explicit Disconnect uses the same authenticated native
+channel so the desktop broker, not the pairing bearer token, performs the
+owner-cookie and CSRF revocation. Owner credentials never enter extension
+storage. Explicit disconnects and server revocations suppress automatic
+enrollment. The normal popup never displays or imports pairing
 credentials. Its explicit Reconnect action clears extension-local suppression
 and retries the native broker; a revoked browser remains blocked until the
 owner resets the durable revocation in authenticated Eliza settings.

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -19,6 +19,10 @@ import type {
 import { CoalescingSyncRunner } from "../src/coalescing-sync-runner";
 import { sendWithContentScriptRecovery } from "../src/content-script-messaging";
 import {
+  disconnectFailureMessage,
+  performDurableDisconnect,
+} from "../src/durable-disconnect";
+import {
   BROWSER_BRIDGE_NATIVE_HOST,
   isNativeEnrollmentRevocation,
   NativeEnrollmentCoordinator,
@@ -26,6 +30,10 @@ import {
   type NativeEnrollmentRequest,
   shouldProbeRevokedEnrollment,
 } from "../src/native-enrollment";
+import {
+  OperationCancelledError,
+  OperationGeneration,
+} from "../src/operation-generation";
 import type {
   BackgroundState,
   CompanionConfig,
@@ -110,6 +118,7 @@ let backgroundState: BackgroundState = {
 let rememberedTabs: RememberedTab[] = [];
 let syncDebounceScheduled = false;
 let activeSessionId: string | null = null;
+const operationGeneration = new OperationGeneration();
 
 const nativeEnrollment = new NativeEnrollmentCoordinator({
   getExtensionId,
@@ -175,9 +184,7 @@ async function setState(next: Partial<BackgroundState>): Promise<void> {
 }
 
 async function readConfig(): Promise<CompanionConfig | null> {
-  const config = await loadCompanionConfig();
-  backgroundState.config = config;
-  return config;
+  return await loadCompanionConfig();
 }
 
 async function describePermissionState(): Promise<{
@@ -337,28 +344,38 @@ async function buildPreflightRequest(
 async function preflightAndSync(
   client: BrowserBridgeRelayClient,
   config: CompanionConfig,
+  generation: number,
 ) {
-  const preflight = await client.preflight(await buildPreflightRequest(config));
+  operationGeneration.assertCurrent(generation);
+  const preflightRequest = await buildPreflightRequest(config);
+  operationGeneration.assertCurrent(generation);
+  const preflight = await client.preflight(preflightRequest);
+  operationGeneration.assertCurrent(generation);
   backgroundState.settings = preflight.settings;
-  return await client.sync(
-    await buildSyncRequest(
-      config,
-      preflight.settings,
-      preflight.settingsVersion,
-    ),
+  const syncRequest = await buildSyncRequest(
+    config,
+    preflight.settings,
+    preflight.settingsVersion,
   );
+  operationGeneration.assertCurrent(generation);
+  const response = await client.sync(syncRequest);
+  operationGeneration.assertCurrent(generation);
+  return response;
 }
 
 async function runContentAction(
   tabId: number,
   expectedUrl: string,
   action: DomActionRequest,
+  generation: number,
 ): Promise<Record<string, unknown>> {
+  operationGeneration.assertCurrent(generation);
   const response = await sendContentScriptMessage(tabId, {
     type: "browser-bridge:execute-dom-action",
     expectedUrl,
     action,
   });
+  operationGeneration.assertCurrent(generation);
   if (response.ok === false) {
     throw new Error(response.error);
   }
@@ -373,8 +390,11 @@ async function executeAction(
   currentTabId: number | null,
   expectedActionIndex: number,
   attemptId: string,
+  generation: number,
 ): Promise<{ currentTabId: number | null; result: Record<string, unknown> }> {
-  const freshSync = await preflightAndSync(client, config);
+  operationGeneration.assertCurrent(generation);
+  const freshSync = await preflightAndSync(client, config, generation);
+  operationGeneration.assertCurrent(generation);
   backgroundState.settings = freshSync.settings;
   if (
     freshSync.session?.id !== session.id ||
@@ -390,11 +410,15 @@ async function executeAction(
       "The browser session action changed before action execution.",
     );
   }
-  const leasedSession = await client.beginSessionAction(session.id, {
-    currentActionIndex: expectedActionIndex,
-    actionId: freshAction.id,
-    attemptId,
-  });
+  const leasedSession = await operationGeneration.runCurrent(
+    generation,
+    async () =>
+      await client.beginSessionAction(session.id, {
+        currentActionIndex: expectedActionIndex,
+        actionId: freshAction.id,
+        attemptId,
+      }),
+  );
   const executableAction = leasedSession.actions[expectedActionIndex];
   if (
     leasedSession.currentActionIndex !== expectedActionIndex ||
@@ -404,9 +428,12 @@ async function executeAction(
     throw new Error("The browser action lease does not match its checkpoint.");
   }
   const openTabs = await queryTabs({});
+  operationGeneration.assertCurrent(generation);
   const openWindows = await getAllWindows();
+  operationGeneration.assertCurrent(generation);
   const focusedTab =
     (await queryTabs({ active: true, lastFocusedWindow: true }))[0] ?? null;
+  operationGeneration.assertCurrent(generation);
   const target = resolveBrowserActionTarget({
     actionKind: executableAction.kind,
     actionTabId: executableAction.tabId,
@@ -432,6 +459,8 @@ async function executeAction(
       `${executableAction.kind} requires an authorized target URL`,
     );
   }
+  const grantedOrigins = await getGrantedOrigins();
+  operationGeneration.assertCurrent(generation);
   const authorizationError = browserActionAuthorizationError({
     settings: freshSync.settings,
     target: {
@@ -439,7 +468,7 @@ async function executeAction(
       incognito: target.incognito,
       focusedActive: target.focusedActive,
     },
-    grantedOrigins: await getGrantedOrigins(),
+    grantedOrigins,
     currentFocusedUrl: focusedTab?.url ?? null,
   });
   if (authorizationError) {
@@ -450,11 +479,13 @@ async function executeAction(
       if (!executableAction.url) {
         throw new Error("open requires url");
       }
+      operationGeneration.assertCurrent(generation);
       const tab = await createTab({
         url: executableAction.url,
         active: true,
         ...(target.windowId === null ? {} : { windowId: target.windowId }),
       });
+      operationGeneration.assertCurrent(generation);
       return {
         currentTabId: typeof tab.id === "number" ? tab.id : null,
         result: {
@@ -470,11 +501,13 @@ async function executeAction(
       }
       const tabId = resolvedTabId;
       if (tabId === null) {
+        operationGeneration.assertCurrent(generation);
         const tab = await createTab({
           url: executableAction.url,
           active: true,
           ...(target.windowId === null ? {} : { windowId: target.windowId }),
         });
+        operationGeneration.assertCurrent(generation);
         return {
           currentTabId: typeof tab.id === "number" ? tab.id : null,
           result: {
@@ -484,12 +517,16 @@ async function executeAction(
           },
         };
       }
+      operationGeneration.assertCurrent(generation);
       const tab = await updateTab(tabId, {
         url: executableAction.url,
         active: true,
       });
+      operationGeneration.assertCurrent(generation);
       if (typeof tab.windowId === "number") {
+        operationGeneration.assertCurrent(generation);
         await focusWindow(tab.windowId);
+        operationGeneration.assertCurrent(generation);
       }
       return {
         currentTabId: tabId,
@@ -504,9 +541,13 @@ async function executeAction(
       if (tabId === null) {
         throw new Error("focus_tab requires a target tab");
       }
+      operationGeneration.assertCurrent(generation);
       const tab = await updateTab(tabId, { active: true });
+      operationGeneration.assertCurrent(generation);
       if (typeof tab.windowId === "number") {
+        operationGeneration.assertCurrent(generation);
         await focusWindow(tab.windowId);
+        operationGeneration.assertCurrent(generation);
       }
       return {
         currentTabId: tabId,
@@ -520,7 +561,9 @@ async function executeAction(
       if (tabId === null) {
         throw new Error("reload requires a target tab");
       }
+      operationGeneration.assertCurrent(generation);
       await reloadTab(tabId);
+      operationGeneration.assertCurrent(generation);
       return {
         currentTabId: tabId,
         result: {
@@ -535,9 +578,12 @@ async function executeAction(
       }
       return {
         currentTabId: tabId,
-        result: await runContentAction(tabId, targetUrl, {
-          kind: "history_back",
-        }),
+        result: await runContentAction(
+          tabId,
+          targetUrl,
+          { kind: "history_back" },
+          generation,
+        ),
       };
     }
     case "forward": {
@@ -547,9 +593,12 @@ async function executeAction(
       }
       return {
         currentTabId: tabId,
-        result: await runContentAction(tabId, targetUrl, {
-          kind: "history_forward",
-        }),
+        result: await runContentAction(
+          tabId,
+          targetUrl,
+          { kind: "history_forward" },
+          generation,
+        ),
       };
     }
     case "click":
@@ -561,11 +610,16 @@ async function executeAction(
       }
       return {
         currentTabId: tabId,
-        result: await runContentAction(tabId, targetUrl, {
-          kind: executableAction.kind,
-          selector: executableAction.selector ?? null,
-          text: executableAction.text ?? null,
-        }),
+        result: await runContentAction(
+          tabId,
+          targetUrl,
+          {
+            kind: executableAction.kind,
+            selector: executableAction.selector ?? null,
+            text: executableAction.text ?? null,
+          },
+          generation,
+        ),
       };
     }
     case "read_page":
@@ -575,10 +629,12 @@ async function executeAction(
       if (tabId === null) {
         throw new Error(`${executableAction.kind} requires a target tab`);
       }
+      operationGeneration.assertCurrent(generation);
       const response = await sendContentScriptMessage(tabId, {
         type: "browser-bridge:capture-page",
         expectedUrl: targetUrl,
       });
+      operationGeneration.assertCurrent(generation);
       if (response.ok === false || !response.page) {
         throw new Error(
           "error" in response ? response.error : "page capture failed",
@@ -608,7 +664,9 @@ async function executeAction(
 async function executeSession(
   client: BrowserBridgeRelayClient,
   session: LifeOpsBrowserSession,
+  generation: number,
 ): Promise<void> {
+  operationGeneration.assertCurrent(generation);
   if (activeSessionId === session.id) {
     return;
   }
@@ -648,8 +706,10 @@ async function executeSession(
       index < session.actions.length;
       index += 1
     ) {
+      operationGeneration.assertCurrent(generation);
       const action = session.actions[index];
       const config = await readConfig();
+      operationGeneration.assertCurrent(generation);
       if (!config) {
         throw new Error("Browser companion configuration is unavailable.");
       }
@@ -667,7 +727,9 @@ async function executeSession(
         currentTabId,
         index,
         attemptId,
+        generation,
       );
+      operationGeneration.assertCurrent(generation);
       currentTabId = outcome.currentTabId;
       actionResults[action.id] = outcome.result;
       await client.updateSessionProgress(session.id, {
@@ -682,10 +744,12 @@ async function executeSession(
           lastActionKind: action.kind,
         },
       });
+      operationGeneration.assertCurrent(generation);
       completionActionId = action.id;
       completionAttemptId = attemptId;
       activeAttempt = null;
     }
+    operationGeneration.assertCurrent(generation);
     await client.completeSession(session.id, {
       status: "done",
       currentActionIndex: session.actions.length,
@@ -695,10 +759,14 @@ async function executeSession(
         actionResults,
       },
     });
+    operationGeneration.assertCurrent(generation);
     await setState({
       lastSessionStatus: `completed ${session.title}`,
     });
   } catch (error) {
+    if (error instanceof OperationCancelledError) {
+      return;
+    }
     let conflict =
       (error instanceof RelayApiError && error.status === 409) ||
       activeAttempt === null;
@@ -731,8 +799,12 @@ async function executeSession(
       lastSessionStatus: `${conflict ? "conflicted" : "failed"} ${session.title}`,
     });
   } finally {
-    activeSessionId = null;
-    await saveState();
+    if (activeSessionId === session.id) {
+      activeSessionId = null;
+    }
+    if (operationGeneration.isCurrent(generation)) {
+      await saveState();
+    }
   }
 }
 
@@ -837,13 +909,18 @@ function isCompanionTokenExpired(config: CompanionConfig): boolean {
 
 async function enrollNativeCompanion(options: {
   bypassBackoff?: boolean;
+  generation: number;
 }): Promise<CompanionConfig> {
+  operationGeneration.assertCurrent(options.generation);
   const profileId = await getOrCreateExtensionProfileId();
+  operationGeneration.assertCurrent(options.generation);
   const config = await nativeEnrollment.enroll(
     { browser: __BROWSER_BRIDGE_KIND__, profileId },
     { bypassBackoff: options.bypassBackoff },
   );
+  operationGeneration.assertCurrent(options.generation);
   const persisted = await persistCompanionConfig(config);
+  operationGeneration.assertCurrent(options.generation);
   if (!persisted) {
     throw new NativeEnrollmentError(
       "The native enrollment host returned an invalid companion config.",
@@ -857,18 +934,27 @@ async function enrollNativeCompanion(options: {
 
 async function ensureCompanionConfig(options: {
   bypassNativeBackoff?: boolean;
+  generation: number;
 }): Promise<CompanionConfig> {
+  operationGeneration.assertCurrent(options.generation);
   const existing = await readConfig();
+  operationGeneration.assertCurrent(options.generation);
   if (existing && !isCompanionTokenExpired(existing)) return existing;
   if (existing) await clearCompanionConfig();
   return await enrollNativeCompanion({
     bypassBackoff: options.bypassNativeBackoff === true,
+    generation: options.generation,
   });
 }
 
-async function performCompanionSync(config: CompanionConfig): Promise<void> {
+async function performCompanionSync(
+  config: CompanionConfig,
+  generation: number,
+): Promise<void> {
+  operationGeneration.assertCurrent(generation);
   const client = new BrowserBridgeRelayClient(config);
-  const response = await preflightAndSync(client, config);
+  const response = await preflightAndSync(client, config, generation);
+  operationGeneration.assertCurrent(generation);
   await setState({
     syncing: false,
     lastSyncAt: new Date().toISOString(),
@@ -879,11 +965,14 @@ async function performCompanionSync(config: CompanionConfig): Promise<void> {
     rememberedTabCount: response.tabs.length,
   });
   if (response.session) {
-    await executeSession(client, response.session);
+    await executeSession(client, response.session, generation);
   }
+  operationGeneration.assertCurrent(generation);
   try {
     await syncBlockingRules(config.apiBaseUrl);
+    operationGeneration.assertCurrent(generation);
   } catch (error) {
+    if (error instanceof OperationCancelledError) throw error;
     // error-policy:J4 Blocking-policy failure is shown in extension state
     // without fabricating successful rule synchronization.
     await setState({
@@ -895,18 +984,21 @@ async function performCompanionSync(config: CompanionConfig): Promise<void> {
 interface SyncRunRequest {
   reason: string;
   bypassNativeBackoff: boolean;
+  generation: number;
 }
 
 async function runSyncAttempt({
   reason,
   bypassNativeBackoff,
+  generation,
 }: SyncRunRequest): Promise<BackgroundState> {
-  await setState({
-    syncing: true,
-    lastError: null,
-  });
-
   try {
+    operationGeneration.assertCurrent(generation);
+    await setState({
+      syncing: true,
+      lastError: null,
+    });
+    operationGeneration.assertCurrent(generation);
     const probeOwnerReset = shouldProbeRevokedEnrollment(
       reason,
       backgroundState.connectionIssue,
@@ -917,13 +1009,20 @@ async function runSyncAttempt({
       // rejects enrollment until its durable owner-controlled tombstone is
       // actually reset.
       await resetNativeEnrollmentState();
+      operationGeneration.assertCurrent(generation);
     }
     const config = await ensureCompanionConfig({
       bypassNativeBackoff: bypassNativeBackoff || probeOwnerReset,
+      generation,
     });
+    operationGeneration.assertCurrent(generation);
     await setState({ config });
-    await performCompanionSync(config);
+    operationGeneration.assertCurrent(generation);
+    await performCompanionSync(config, generation);
   } catch (error) {
+    if (error instanceof OperationCancelledError) {
+      return backgroundState;
+    }
     // error-policy:J1 The sync-loop boundary translates failures into durable
     // extension state and revokes invalid local pairing state.
     const isPairingInvalid = isCompanionAuthError(error);
@@ -939,9 +1038,12 @@ async function runSyncAttempt({
       try {
         const renewed = await enrollNativeCompanion({
           bypassBackoff: true,
+          generation,
         });
+        operationGeneration.assertCurrent(generation);
         await setState({ config: renewed });
-        await performCompanionSync(renewed);
+        operationGeneration.assertCurrent(generation);
+        await performCompanionSync(renewed, generation);
         return backgroundState;
       } catch (renewalError) {
         finalError = renewalError;
@@ -951,6 +1053,9 @@ async function runSyncAttempt({
       await suppressNativeEnrollment(
         isRevoked ? "companion_revoked" : "credential_invalid",
       );
+    }
+    if (finalError instanceof OperationCancelledError) {
+      return backgroundState;
     }
     const finalPairingError = isCompanionAuthError(finalError)
       ? finalError
@@ -992,6 +1097,7 @@ const syncRunner = new CoalescingSyncRunner<SyncRunRequest, BackgroundState>(
     reason: current === null ? next.reason : "queued",
     bypassNativeBackoff:
       (current?.bypassNativeBackoff ?? false) || next.bypassNativeBackoff,
+    generation: next.generation,
   }),
   runSyncAttempt,
 );
@@ -1000,9 +1106,17 @@ async function syncNow(
   reason: string,
   options: { bypassNativeBackoff?: boolean } = {},
 ): Promise<BackgroundState> {
+  if (operationGeneration.isBlocked) return backgroundState;
+  if (
+    backgroundState.connectionIssue === "owner_disconnected" &&
+    reason !== "owner-reconnect"
+  ) {
+    return backgroundState;
+  }
   return await syncRunner.request({
     reason,
     bypassNativeBackoff: options.bypassNativeBackoff === true,
+    generation: operationGeneration.capture(),
   });
 }
 
@@ -1058,21 +1172,48 @@ async function handlePopupMessage(
         return { ok: true, state: backgroundState };
       }
       case "browser-bridge:clear-config": {
-        await clearCompanionConfig();
-        await suppressNativeEnrollment("owner_disconnected");
-        rememberedTabs = [];
+        if (operationGeneration.isBlocked) {
+          throw new Error("Browser bridge disconnect is already in progress.");
+        }
+        operationGeneration.cancelAndBlock();
         activeSessionId = null;
-        await setState({
-          config: null,
-          settings: null,
-          lastError: null,
-          lastSessionStatus: null,
-          lastSyncAt: null,
-          rememberedTabCount: 0,
-          settingsSummary: null,
-          connectionIssue: "owner_disconnected",
-        });
-        return { ok: true, state: backgroundState };
+        try {
+          const config = await readConfig();
+          await performDurableDisconnect({
+            cancelSync: async () => await syncRunner.cancelPending(),
+            cancelEnrollment: async () => await nativeEnrollment.cancel(),
+            revoke: config
+              ? async () => await new BrowserBridgeRelayClient(config).revoke()
+              : null,
+            clearConfig: clearCompanionConfig,
+            suppressEnrollment: async () =>
+              await suppressNativeEnrollment("owner_disconnected"),
+          });
+          rememberedTabs = [];
+          await setState({
+            config: null,
+            settings: null,
+            lastError: null,
+            lastSessionStatus: null,
+            lastSyncAt: null,
+            rememberedTabCount: 0,
+            settingsSummary: null,
+            connectionIssue: "owner_disconnected",
+          });
+          return { ok: true, state: backgroundState };
+        } catch (error) {
+          // error-policy:J1 Disconnect is a user-facing boundary. It must not
+          // report success or erase the only usable credential when durable
+          // server revocation could not be confirmed.
+          const message = disconnectFailureMessage(error);
+          await setState({
+            syncing: false,
+            lastError: message,
+          });
+          throw new Error(message);
+        } finally {
+          operationGeneration.resume();
+        }
       }
       case "browser-bridge:sync-now": {
         return {

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -28,6 +28,8 @@ import {
   NativeEnrollmentCoordinator,
   NativeEnrollmentError,
   type NativeEnrollmentRequest,
+  type NativeRevokeRequest,
+  revokeNativeCompanion,
   shouldProbeRevokedEnrollment,
 } from "../src/native-enrollment";
 import {
@@ -1183,7 +1185,17 @@ async function handlePopupMessage(
             cancelSync: async () => await syncRunner.cancelPending(),
             cancelEnrollment: async () => await nativeEnrollment.cancel(),
             revoke: config
-              ? async () => await new BrowserBridgeRelayClient(config).revoke()
+              ? async () =>
+                  await revokeNativeCompanion({
+                    config,
+                    extensionId: getExtensionId(),
+                    extensionVersion: getManifestVersion(),
+                    send: async (request: NativeRevokeRequest) =>
+                      await sendNativeMessage<NativeRevokeRequest, unknown>(
+                        BROWSER_BRIDGE_NATIVE_HOST,
+                        request,
+                      ),
+                  })
               : null,
             clearConfig: clearCompanionConfig,
             suppressEnrollment: async () =>

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -1180,23 +1180,45 @@ async function handlePopupMessage(
         operationGeneration.cancelAndBlock();
         activeSessionId = null;
         try {
-          const config = await readConfig();
+          let abandonedEnrollmentConfig: CompanionConfig | null = null;
           await performDurableDisconnect({
             cancelSync: async () => await syncRunner.cancelPending(),
-            cancelEnrollment: async () => await nativeEnrollment.cancel(),
-            revoke: config
-              ? async () =>
-                  await revokeNativeCompanion({
-                    config,
-                    extensionId: getExtensionId(),
-                    extensionVersion: getManifestVersion(),
-                    send: async (request: NativeRevokeRequest) =>
-                      await sendNativeMessage<NativeRevokeRequest, unknown>(
-                        BROWSER_BRIDGE_NATIVE_HOST,
-                        request,
-                      ),
-                  })
-              : null,
+            cancelEnrollment: async () => {
+              abandonedEnrollmentConfig = await nativeEnrollment.cancel();
+            },
+            revoke: async () => {
+              const persistedConfig = await readConfig();
+              const targets = new Map<string, CompanionConfig>();
+              if (persistedConfig) {
+                targets.set(persistedConfig.companionId, persistedConfig);
+              }
+              if (abandonedEnrollmentConfig) {
+                targets.set(
+                  abandonedEnrollmentConfig.companionId,
+                  abandonedEnrollmentConfig,
+                );
+              }
+              const results = await Promise.allSettled(
+                [...targets.values()].map(
+                  async (config) =>
+                    await revokeNativeCompanion({
+                      config,
+                      extensionId: getExtensionId(),
+                      extensionVersion: getManifestVersion(),
+                      send: async (request: NativeRevokeRequest) =>
+                        await sendNativeMessage<NativeRevokeRequest, unknown>(
+                          BROWSER_BRIDGE_NATIVE_HOST,
+                          request,
+                        ),
+                    }),
+                ),
+              );
+              const failure = results.find(
+                (result): result is PromiseRejectedResult =>
+                  result.status === "rejected",
+              );
+              if (failure) throw failure.reason;
+            },
             clearConfig: clearCompanionConfig,
             suppressEnrollment: async () =>
               await suppressNativeEnrollment("owner_disconnected"),

--- a/packages/browser-bridge-extension/entrypoints/background.ts
+++ b/packages/browser-bridge-extension/entrypoints/background.ts
@@ -930,6 +930,7 @@ async function enrollNativeCompanion(options: {
       false,
     );
   }
+  nativeEnrollment.confirmPersisted(persisted.companionId);
   backgroundState.config = persisted;
   return persisted;
 }
@@ -1180,11 +1181,11 @@ async function handlePopupMessage(
         operationGeneration.cancelAndBlock();
         activeSessionId = null;
         try {
-          let abandonedEnrollmentConfig: CompanionConfig | null = null;
+          let abandonedEnrollmentConfigs: readonly CompanionConfig[] = [];
           await performDurableDisconnect({
             cancelSync: async () => await syncRunner.cancelPending(),
             cancelEnrollment: async () => {
-              abandonedEnrollmentConfig = await nativeEnrollment.cancel();
+              abandonedEnrollmentConfigs = await nativeEnrollment.cancel();
             },
             revoke: async () => {
               const persistedConfig = await readConfig();
@@ -1192,7 +1193,7 @@ async function handlePopupMessage(
               if (persistedConfig) {
                 targets.set(persistedConfig.companionId, persistedConfig);
               }
-              if (abandonedEnrollmentConfig) {
+              for (const abandonedEnrollmentConfig of abandonedEnrollmentConfigs) {
                 targets.set(
                   abandonedEnrollmentConfig.companionId,
                   abandonedEnrollmentConfig,

--- a/packages/browser-bridge-extension/scripts/extension-smoke.mjs
+++ b/packages/browser-bridge-extension/scripts/extension-smoke.mjs
@@ -158,10 +158,27 @@ async function launchExtensionContext(chromium) {
   }
 }
 
+async function waitForRenderedFrame(page) {
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+  });
+}
+
 async function saveScreenshot(page, name) {
+  await waitForRenderedFrame(page);
   await fsp.mkdir(resultsDir, { recursive: true });
   const screenshotPath = path.join(resultsDir, `${name}.png`);
   await page.screenshot({ path: screenshotPath, fullPage: true });
+}
+
+async function savePopupScreenshot(page, name) {
+  await waitForRenderedFrame(page);
+  await fsp.mkdir(resultsDir, { recursive: true });
+  const screenshotPath = path.join(resultsDir, `${name}.png`);
+  await page.locator(".panel").screenshot({ path: screenshotPath });
 }
 
 async function saveFailureScreenshot(page, name) {
@@ -633,7 +650,7 @@ async function runPairAndSyncScenario(chromium) {
         "Connected to Eliza",
         120_000,
       );
-      await saveScreenshot(popupPage, "chrome-website-access-granted");
+      await savePopupScreenshot(popupPage, "chrome-website-access-granted");
     }
     const compactPopup = await popupPage.evaluate(
       (apiOrigin) => ({
@@ -646,7 +663,7 @@ async function runPairAndSyncScenario(chromium) {
     if (compactPopup.hasDiagnostics || compactPopup.exposesApiOrigin) {
       throw new Error("Chrome popup exposed removed connection diagnostics.");
     }
-    await saveScreenshot(popupPage, "chrome-pair-and-sync-success");
+    await savePopupScreenshot(popupPage, "chrome-pair-and-sync-success");
 
     const syncRequests = mockServer.requests.filter(
       (request) =>

--- a/packages/browser-bridge-extension/src/api-client.test.ts
+++ b/packages/browser-bridge-extension/src/api-client.test.ts
@@ -100,6 +100,28 @@ describe("BrowserBridgeRelayClient", () => {
     );
   });
 
+  it("revokes the authenticated companion through the durable server route", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ revoked: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      new BrowserBridgeRelayClient(config).revoke(),
+    ).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example.com/root/api/browser-bridge/companions/revoke",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+        headers: expect.objectContaining({
+          Authorization: "Bearer pairing-token",
+          "Content-Type": "application/json",
+          "X-Browser-Bridge-Companion-Id": "companion-1",
+        }),
+      }),
+    );
+  });
+
   it("preflights without browser data and rejects a data-bearing response", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/browser-bridge-extension/src/api-client.test.ts
+++ b/packages/browser-bridge-extension/src/api-client.test.ts
@@ -100,28 +100,6 @@ describe("BrowserBridgeRelayClient", () => {
     );
   });
 
-  it("revokes the authenticated companion through the durable server route", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ revoked: true }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      new BrowserBridgeRelayClient(config).revoke(),
-    ).resolves.toBeUndefined();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://agent.example.com/root/api/browser-bridge/companions/revoke",
-      expect.objectContaining({
-        method: "POST",
-        body: "{}",
-        headers: expect.objectContaining({
-          Authorization: "Bearer pairing-token",
-          "Content-Type": "application/json",
-          "X-Browser-Bridge-Companion-Id": "companion-1",
-        }),
-      }),
-    );
-  });
-
   it("preflights without browser data and rejects a data-bearing response", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/browser-bridge-extension/src/api-client.ts
+++ b/packages/browser-bridge-extension/src/api-client.ts
@@ -276,6 +276,27 @@ export class BrowserBridgeRelayClient {
     );
   }
 
+  async revoke(): Promise<void> {
+    await withBrowserBridgeRequestTimeout(
+      "Browser companion revocation",
+      async (signal) => {
+        const response = await fetch(
+          joinUrl(
+            this.config.apiBaseUrl,
+            "/api/browser-bridge/companions/revoke",
+          ),
+          {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify({}),
+            signal,
+          },
+        );
+        if (!response.ok) await throwApiError(response);
+      },
+    );
+  }
+
   async sync(
     request: CompanionSyncRequest,
   ): Promise<BrowserBridgeCompanionSyncResponse> {

--- a/packages/browser-bridge-extension/src/api-client.ts
+++ b/packages/browser-bridge-extension/src/api-client.ts
@@ -276,27 +276,6 @@ export class BrowserBridgeRelayClient {
     );
   }
 
-  async revoke(): Promise<void> {
-    await withBrowserBridgeRequestTimeout(
-      "Browser companion revocation",
-      async (signal) => {
-        const response = await fetch(
-          joinUrl(
-            this.config.apiBaseUrl,
-            "/api/browser-bridge/companions/revoke",
-          ),
-          {
-            method: "POST",
-            headers: this.headers(),
-            body: JSON.stringify({}),
-            signal,
-          },
-        );
-        if (!response.ok) await throwApiError(response);
-      },
-    );
-  }
-
   async sync(
     request: CompanionSyncRequest,
   ): Promise<BrowserBridgeCompanionSyncResponse> {

--- a/packages/browser-bridge-extension/src/coalescing-sync-runner.test.ts
+++ b/packages/browser-bridge-extension/src/coalescing-sync-runner.test.ts
@@ -109,4 +109,39 @@ describe("CoalescingSyncRunner", () => {
       { reason: "queued", bypassNativeBackoff: true },
     ]);
   });
+
+  it("drops queued work when the active generation is cancelled", async () => {
+    const activeAttempt = deferred();
+    const activeAttemptBegan = deferred();
+    const attempts: string[] = [];
+    const runner = new CoalescingSyncRunner<SyncRequest, SyncState>(
+      (_current, next) => next,
+      async (request) => {
+        attempts.push(request.reason);
+        if (request.reason === "startup") {
+          activeAttemptBegan.resolve();
+          await activeAttempt.promise;
+        }
+        return { connected: true };
+      },
+    );
+
+    const active = runner.request({
+      reason: "startup",
+      bypassNativeBackoff: false,
+    });
+    await activeAttemptBegan.promise;
+    const queued = runner.request({
+      reason: "alarm",
+      bypassNativeBackoff: false,
+    });
+
+    const cancellation = runner.cancelPending();
+    activeAttempt.resolve();
+
+    await expect(cancellation).resolves.toBeUndefined();
+    await expect(active).resolves.toEqual({ connected: true });
+    await expect(queued).resolves.toEqual({ connected: true });
+    expect(attempts).toEqual(["startup"]);
+  });
 });

--- a/packages/browser-bridge-extension/src/coalescing-sync-runner.ts
+++ b/packages/browser-bridge-extension/src/coalescing-sync-runner.ts
@@ -6,6 +6,7 @@
 export class CoalescingSyncRunner<TRequest, TResult> {
   private pendingRequest: TRequest | null = null;
   private runnerPromise: Promise<TResult> | null = null;
+  private generation = 0;
 
   constructor(
     private readonly mergeRequests: (
@@ -21,8 +22,9 @@ export class CoalescingSyncRunner<TRequest, TResult> {
       return this.runnerPromise;
     }
 
+    const generation = this.generation;
     const runner = Promise.resolve()
-      .then(async () => await this.drain())
+      .then(async () => await this.drain(generation))
       .finally(() => {
         if (this.runnerPromise === runner) {
           this.runnerPromise = null;
@@ -32,11 +34,30 @@ export class CoalescingSyncRunner<TRequest, TResult> {
     return runner;
   }
 
-  private async drain(): Promise<TResult> {
+  /**
+   * Drops queued work and waits until the active generation can no longer
+   * publish a result through the runner.
+   */
+  async cancelPending(): Promise<void> {
+    this.generation += 1;
+    this.pendingRequest = null;
+    const active = this.runnerPromise;
+    this.runnerPromise = null;
+    if (active) {
+      try {
+        await active;
+      } catch {
+        // error-policy:J5 The caller that requested this same runner promise
+        // remains the primary observer of its rejection.
+      }
+    }
+  }
+
+  private async drain(generation: number): Promise<TResult> {
     const firstRequest = this.takePendingRequest();
     let result = await this.execute(firstRequest);
 
-    while (this.pendingRequest !== null) {
+    while (generation === this.generation && this.pendingRequest !== null) {
       result = await this.execute(this.takePendingRequest());
     }
 

--- a/packages/browser-bridge-extension/src/durable-disconnect.test.ts
+++ b/packages/browser-bridge-extension/src/durable-disconnect.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit coverage for the durable Disconnect transaction, including the failure
+ * contract that retains the only usable credential when server revoke fails.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  disconnectFailureMessage,
+  performDurableDisconnect,
+} from "./durable-disconnect";
+
+describe("performDurableDisconnect", () => {
+  it("waits for cancellation and revocation before clearing local state", async () => {
+    const events: string[] = [];
+    await performDurableDisconnect({
+      cancelSync: async () => {
+        events.push("sync-cancelled");
+      },
+      cancelEnrollment: async () => {
+        events.push("enrollment-cancelled");
+      },
+      revoke: async () => {
+        events.push("server-revoked");
+      },
+      clearConfig: async () => {
+        events.push("config-cleared");
+      },
+      suppressEnrollment: async () => {
+        events.push("enrollment-suppressed");
+      },
+    });
+
+    expect(events.slice(0, 3).sort()).toEqual([
+      "enrollment-cancelled",
+      "server-revoked",
+      "sync-cancelled",
+    ]);
+    expect(events.slice(3)).toEqual([
+      "enrollment-suppressed",
+      "config-cleared",
+    ]);
+  });
+
+  it("retains config and reports failure when server revocation fails", async () => {
+    const clearConfig = vi.fn(async () => undefined);
+    const suppressEnrollment = vi.fn(async () => undefined);
+
+    const disconnect = performDurableDisconnect({
+      cancelSync: async () => undefined,
+      cancelEnrollment: async () => undefined,
+      revoke: async () => {
+        throw new Error("agent unavailable");
+      },
+      clearConfig,
+      suppressEnrollment,
+    });
+
+    let observedError: unknown = null;
+    try {
+      await disconnect;
+    } catch (error) {
+      observedError = error;
+    }
+    expect(observedError).toBeInstanceOf(Error);
+    expect(disconnectFailureMessage(observedError)).toBe(
+      "Disconnect failed: agent unavailable",
+    );
+    expect(clearConfig).not.toHaveBeenCalled();
+    expect(suppressEnrollment).not.toHaveBeenCalled();
+  });
+
+  it("retains config when durable enrollment suppression fails", async () => {
+    const clearConfig = vi.fn(async () => undefined);
+
+    await expect(
+      performDurableDisconnect({
+        cancelSync: async () => undefined,
+        cancelEnrollment: async () => undefined,
+        revoke: async () => undefined,
+        clearConfig,
+        suppressEnrollment: async () => {
+          throw new Error("storage unavailable");
+        },
+      }),
+    ).rejects.toThrow("storage unavailable");
+    expect(clearConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/browser-bridge-extension/src/durable-disconnect.test.ts
+++ b/packages/browser-bridge-extension/src/durable-disconnect.test.ts
@@ -29,15 +29,36 @@ describe("performDurableDisconnect", () => {
       },
     });
 
-    expect(events.slice(0, 3).sort()).toEqual([
+    expect(events.slice(0, 2).sort()).toEqual([
       "enrollment-cancelled",
-      "server-revoked",
       "sync-cancelled",
     ]);
-    expect(events.slice(3)).toEqual([
+    expect(events.slice(2)).toEqual([
+      "server-revoked",
       "enrollment-suppressed",
       "config-cleared",
     ]);
+  });
+
+  it("does not resolve revocation until asynchronous enrollment cancellation quiesces", async () => {
+    let releaseEnrollment: (() => void) | null = null;
+    const enrollmentSettled = new Promise<void>((resolve) => {
+      releaseEnrollment = resolve;
+    });
+    const revoke = vi.fn(async () => undefined);
+    const disconnect = performDurableDisconnect({
+      cancelSync: async () => undefined,
+      cancelEnrollment: async () => await enrollmentSettled,
+      revoke,
+      clearConfig: async () => undefined,
+      suppressEnrollment: async () => undefined,
+    });
+
+    await Promise.resolve();
+    expect(revoke).not.toHaveBeenCalled();
+    releaseEnrollment?.();
+    await disconnect;
+    expect(revoke).toHaveBeenCalledTimes(1);
   });
 
   it("retains config and reports failure when server revocation fails", async () => {

--- a/packages/browser-bridge-extension/src/durable-disconnect.ts
+++ b/packages/browser-bridge-extension/src/durable-disconnect.ts
@@ -1,0 +1,34 @@
+/**
+ * Coordinates extension cancellation and authenticated server revocation.
+ * Local credentials are erased only after every cancellation observer settles
+ * and durable revocation succeeds.
+ */
+export type DurableDisconnectDependencies = {
+  cancelSync: () => Promise<void>;
+  cancelEnrollment: () => Promise<void>;
+  revoke: (() => Promise<void>) | null;
+  clearConfig: () => Promise<void>;
+  suppressEnrollment: () => Promise<void>;
+};
+
+export function disconnectFailureMessage(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `Disconnect failed: ${detail}`;
+}
+
+export async function performDurableDisconnect(
+  dependencies: DurableDisconnectDependencies,
+): Promise<void> {
+  const results = await Promise.allSettled([
+    dependencies.cancelSync(),
+    dependencies.cancelEnrollment(),
+    dependencies.revoke?.() ?? Promise.resolve(),
+  ]);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+
+  await dependencies.suppressEnrollment();
+  await dependencies.clearConfig();
+}

--- a/packages/browser-bridge-extension/src/durable-disconnect.ts
+++ b/packages/browser-bridge-extension/src/durable-disconnect.ts
@@ -19,15 +19,16 @@ export function disconnectFailureMessage(error: unknown): string {
 export async function performDurableDisconnect(
   dependencies: DurableDisconnectDependencies,
 ): Promise<void> {
-  const results = await Promise.allSettled([
+  const cancellationResults = await Promise.allSettled([
     dependencies.cancelSync(),
     dependencies.cancelEnrollment(),
-    dependencies.revoke?.() ?? Promise.resolve(),
   ]);
-  const failure = results.find(
+  const cancellationFailure = cancellationResults.find(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
-  if (failure) throw failure.reason;
+  if (cancellationFailure) throw cancellationFailure.reason;
+
+  await dependencies.revoke?.();
 
   await dependencies.suppressEnrollment();
   await dependencies.clearConfig();

--- a/packages/browser-bridge-extension/src/native-enrollment.test.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.test.ts
@@ -257,6 +257,33 @@ describe("native enrollment", () => {
     await expect(Promise.all([first, second])).resolves.toHaveLength(2);
   });
 
+  it("fences an in-flight enrollment without clearing disconnect suppression", async () => {
+    let resolveResponse: ((value: unknown) => void) | null = null;
+    let request: NativeEnrollmentRequest | null = null;
+    const test = harness(
+      async (nextRequest) =>
+        await new Promise((resolve) => {
+          request = nextRequest;
+          resolveResponse = resolve;
+        }),
+    );
+    const enrollment = test.coordinator.enroll({
+      browser: "chrome",
+      profileId: PROFILE_ID,
+    });
+    await vi.waitFor(() => expect(request).not.toBeNull());
+
+    const cancellation = test.coordinator.cancel();
+    resolveResponse?.(resultFor(request as NativeEnrollmentRequest));
+
+    await expect(enrollment).rejects.toMatchObject({
+      code: "native_enrollment_cancelled",
+      retryable: false,
+    });
+    await expect(cancellation).resolves.toBeUndefined();
+    expect(test.state()).toEqual(EMPTY_NATIVE_ENROLLMENT_STATE);
+  });
+
   it("times out, persists bounded backoff, and blocks an early retry", async () => {
     vi.useFakeTimers();
     const test = harness(async () => await new Promise(() => undefined), 100);

--- a/packages/browser-bridge-extension/src/native-enrollment.test.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.test.ts
@@ -319,7 +319,11 @@ describe("native enrollment", () => {
       code: "native_enrollment_cancelled",
       retryable: false,
     });
-    await expect(cancellation).resolves.toBeUndefined();
+    await expect(cancellation).resolves.toMatchObject({
+      companionId: "companion-123",
+      browser: "chrome",
+      profileId: PROFILE_ID,
+    });
     expect(test.state()).toEqual(EMPTY_NATIVE_ENROLLMENT_STATE);
   });
 

--- a/packages/browser-bridge-extension/src/native-enrollment.test.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.test.ts
@@ -319,11 +319,13 @@ describe("native enrollment", () => {
       code: "native_enrollment_cancelled",
       retryable: false,
     });
-    await expect(cancellation).resolves.toMatchObject({
-      companionId: "companion-123",
-      browser: "chrome",
-      profileId: PROFILE_ID,
-    });
+    await expect(cancellation).resolves.toEqual([
+      expect.objectContaining({
+        companionId: "companion-123",
+        browser: "chrome",
+        profileId: PROFILE_ID,
+      }),
+    ]);
     expect(test.state()).toEqual(EMPTY_NATIVE_ENROLLMENT_STATE);
   });
 
@@ -348,6 +350,42 @@ describe("native enrollment", () => {
     await expect(
       test.coordinator.enroll({ browser: "chrome", profileId: PROFILE_ID }),
     ).rejects.toMatchObject({ code: "native_enrollment_backoff" });
+  });
+
+  it("keeps a timed-out native request in the cancellation barrier and returns its late companion", async () => {
+    vi.useFakeTimers();
+    let request: NativeEnrollmentRequest | null = null;
+    let resolveResponse: ((value: unknown) => void) | null = null;
+    const test = harness(
+      async (nextRequest) =>
+        await new Promise((resolve) => {
+          request = nextRequest;
+          resolveResponse = resolve;
+        }),
+      100,
+    );
+    const enrollment = test.coordinator.enroll({
+      browser: "chrome",
+      profileId: PROFILE_ID,
+    });
+    await vi.waitFor(() => expect(request).not.toBeNull());
+    const rejection = expect(enrollment).rejects.toMatchObject({
+      code: "native_enrollment_timeout",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await rejection;
+
+    let cancellationSettled = false;
+    const cancellation = test.coordinator.cancel().then((configs) => {
+      cancellationSettled = true;
+      return configs;
+    });
+    await Promise.resolve();
+    expect(cancellationSettled).toBe(false);
+    resolveResponse?.(resultFor(request as NativeEnrollmentRequest));
+    await expect(cancellation).resolves.toEqual([
+      expect.objectContaining({ companionId: "companion-123" }),
+    ]);
   });
 
   it("lets one explicit retry bypass backoff without bypassing validation", async () => {

--- a/packages/browser-bridge-extension/src/native-enrollment.test.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.test.ts
@@ -12,6 +12,8 @@ import {
   type NativeEnrollmentRequest,
   type NativeEnrollmentResponse,
   type NativeEnrollmentState,
+  type NativeRevokeRequest,
+  revokeNativeCompanion,
   shouldProbeRevokedEnrollment,
 } from "./native-enrollment";
 
@@ -69,6 +71,43 @@ afterEach(() => {
 });
 
 describe("native enrollment", () => {
+  it("revokes through a strictly bound native owner channel", async () => {
+    let observed: NativeRevokeRequest | null = null;
+    await expect(
+      revokeNativeCompanion({
+        config: {
+          apiBaseUrl: "http://127.0.0.1:31337",
+          companionId: "companion-123",
+          pairingToken: "secret-token-value",
+          pairingTokenExpiresAt: new Date(NOW + 60 * 60 * 1_000).toISOString(),
+          browser: "chrome",
+          profileId: PROFILE_ID,
+          profileLabel: "Work",
+          label: "Chrome Work",
+        },
+        extensionId: "abcdefghijklmnopabcdefghijklmnop",
+        extensionVersion: "2.0.3",
+        randomUUID: () => PROFILE_ID,
+        randomBytes: () => new Uint8Array(32).fill(7),
+        send: async (request) => {
+          observed = request;
+          return {
+            v: 1,
+            type: "browser_bridge.revoke_result",
+            requestId: request.requestId,
+            nonce: request.nonce,
+            revoked: true,
+          };
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(observed).toMatchObject({
+      type: "browser_bridge.revoke",
+      companionId: "companion-123",
+      profileId: PROFILE_ID,
+    });
+  });
+
   it("probes an owner reset only on the bounded recovery alarm", () => {
     expect(shouldProbeRevokedEnrollment("alarm", "recovery_required")).toBe(
       true,

--- a/packages/browser-bridge-extension/src/native-enrollment.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.ts
@@ -489,6 +489,7 @@ export class NativeEnrollmentCoordinator {
   private readonly randomUUID: () => string;
   private readonly randomBytes: (length: number) => Uint8Array;
   private readonly timeoutMs: number;
+  private generation = 0;
 
   constructor(private readonly dependencies: NativeEnrollmentDependencies) {
     this.now = dependencies.now ?? Date.now;
@@ -514,7 +515,8 @@ export class NativeEnrollmentCoordinator {
       }
       return await this.inFlight.promise;
     }
-    const promise = this.runEnrollment(bindings, options);
+    const generation = this.generation;
+    const promise = this.runEnrollment(bindings, options, generation);
     this.inFlight = { key, promise };
     try {
       return await promise;
@@ -523,11 +525,41 @@ export class NativeEnrollmentCoordinator {
     }
   }
 
+  /**
+   * Fences an enrollment already awaiting the native host. The returned
+   * promise settles only after that attempt can no longer write retry state.
+   */
+  async cancel(): Promise<void> {
+    this.generation += 1;
+    const active = this.inFlight?.promise ?? null;
+    this.inFlight = null;
+    if (active) {
+      try {
+        await active;
+      } catch {
+        // error-policy:J5 The enroll caller remains the primary observer of
+        // the same in-flight native protocol rejection.
+      }
+    }
+  }
+
+  private assertCurrent(generation: number): void {
+    if (generation !== this.generation) {
+      throw new NativeEnrollmentError(
+        "Native enrollment was cancelled.",
+        "native_enrollment_cancelled",
+        false,
+      );
+    }
+  }
+
   private async runEnrollment(
     bindings: EnrollmentBindings,
     options: { bypassBackoff?: boolean },
+    generation: number,
   ): Promise<BrowserBridgeCompanionConfig> {
     const state = await this.dependencies.loadState();
+    this.assertCurrent(generation);
     if (state.suppressedReason) {
       throw new NativeEnrollmentError(
         "Automatic browser enrollment is disabled after an explicit disconnect or revocation.",
@@ -575,12 +607,15 @@ export class NativeEnrollmentCoordinator {
         this.dependencies.send(request),
         timeout,
       ]);
+      this.assertCurrent(generation);
       const response = validateNativeEnrollmentResponse(
         rawResponse,
         request,
         this.now(),
       );
+      this.assertCurrent(generation);
       await this.dependencies.saveState({ ...EMPTY_NATIVE_ENROLLMENT_STATE });
+      this.assertCurrent(generation);
       return response.config;
     } catch (error) {
       // error-policy:J1 Enrollment is the native-protocol boundary. It records
@@ -593,6 +628,9 @@ export class NativeEnrollmentCoordinator {
               "native_host_unavailable",
               true,
             );
+      if (normalized.code === "native_enrollment_cancelled") {
+        throw normalized;
+      }
       const failures = Math.min(state.consecutiveFailures + 1, 32);
       await this.dependencies.saveState({
         consecutiveFailures: failures,

--- a/packages/browser-bridge-extension/src/native-enrollment.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.ts
@@ -559,7 +559,13 @@ export class NativeEnrollmentCoordinator {
   private readonly randomBytes: (length: number) => Uint8Array;
   private readonly timeoutMs: number;
   private generation = 0;
-  private abandonedConfig: BrowserBridgeCompanionConfig | null = null;
+  private readonly pendingNativeRequests = new Set<
+    Promise<NativeEnrollmentResult>
+  >();
+  private readonly uncommittedConfigs = new Map<
+    string,
+    BrowserBridgeCompanionConfig
+  >();
 
   constructor(private readonly dependencies: NativeEnrollmentDependencies) {
     this.now = dependencies.now ?? Date.now;
@@ -596,27 +602,27 @@ export class NativeEnrollmentCoordinator {
   }
 
   /**
-   * Fences an enrollment already awaiting the native host. The returned
-   * promise settles only after that attempt can no longer write retry state.
-   * If the broker minted a companion before observing cancellation, the
-   * abandoned config is returned so durable Disconnect can revoke it.
+   * Fences enrollment and awaits every underlying native request, including a
+   * request whose public timeout already fired. Broker-issued configs that
+   * were not confirmed in durable storage are returned for owner revocation.
    */
-  async cancel(): Promise<BrowserBridgeCompanionConfig | null> {
+  async cancel(): Promise<readonly BrowserBridgeCompanionConfig[]> {
     this.generation += 1;
-    this.abandonedConfig = null;
     const active = this.inFlight?.promise ?? null;
+    const pendingNativeRequests = [...this.pendingNativeRequests];
     this.inFlight = null;
-    if (active) {
-      try {
-        await active;
-      } catch {
-        // error-policy:J5 The enroll caller remains the primary observer of
-        // the same in-flight native protocol rejection.
-      }
-    }
-    const abandoned = this.abandonedConfig;
-    this.abandonedConfig = null;
+    const pending = active
+      ? [active, ...pendingNativeRequests]
+      : pendingNativeRequests;
+    if (pending.length > 0) await Promise.allSettled(pending);
+    const abandoned = [...this.uncommittedConfigs.values()];
+    this.uncommittedConfigs.clear();
     return abandoned;
+  }
+
+  /** Removes a broker-issued config only after durable extension storage succeeds. */
+  confirmPersisted(companionId: string): void {
+    this.uncommittedConfigs.delete(companionId);
   }
 
   private assertCurrent(generation: number): void {
@@ -679,18 +685,25 @@ export class NativeEnrollmentCoordinator {
           );
         }, this.timeoutMs);
       });
-      const rawResponse = await Promise.race([
-        this.dependencies.send(request),
-        timeout,
-      ]);
-      const response = validateNativeEnrollmentResponse(
-        rawResponse,
-        request,
-        this.now(),
-      );
-      if (generation !== this.generation) {
-        this.abandonedConfig = response.config;
-      }
+      const nativeResponse = this.dependencies.send(request).then((raw) => {
+        const response = validateNativeEnrollmentResponse(
+          raw,
+          request,
+          this.now(),
+        );
+        this.uncommittedConfigs.set(
+          response.config.companionId,
+          response.config,
+        );
+        return response;
+      });
+      this.pendingNativeRequests.add(nativeResponse);
+      void nativeResponse
+        .finally(() => this.pendingNativeRequests.delete(nativeResponse))
+        .catch(() => {
+          // error-policy:J5 runEnrollment or cancel observes this same native rejection.
+        });
+      const response = await Promise.race([nativeResponse, timeout]);
       this.assertCurrent(generation);
       await this.dependencies.saveState({ ...EMPTY_NATIVE_ENROLLMENT_STATE });
       this.assertCurrent(generation);

--- a/packages/browser-bridge-extension/src/native-enrollment.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.ts
@@ -559,6 +559,7 @@ export class NativeEnrollmentCoordinator {
   private readonly randomBytes: (length: number) => Uint8Array;
   private readonly timeoutMs: number;
   private generation = 0;
+  private abandonedConfig: BrowserBridgeCompanionConfig | null = null;
 
   constructor(private readonly dependencies: NativeEnrollmentDependencies) {
     this.now = dependencies.now ?? Date.now;
@@ -597,9 +598,12 @@ export class NativeEnrollmentCoordinator {
   /**
    * Fences an enrollment already awaiting the native host. The returned
    * promise settles only after that attempt can no longer write retry state.
+   * If the broker minted a companion before observing cancellation, the
+   * abandoned config is returned so durable Disconnect can revoke it.
    */
-  async cancel(): Promise<void> {
+  async cancel(): Promise<BrowserBridgeCompanionConfig | null> {
     this.generation += 1;
+    this.abandonedConfig = null;
     const active = this.inFlight?.promise ?? null;
     this.inFlight = null;
     if (active) {
@@ -610,6 +614,9 @@ export class NativeEnrollmentCoordinator {
         // the same in-flight native protocol rejection.
       }
     }
+    const abandoned = this.abandonedConfig;
+    this.abandonedConfig = null;
+    return abandoned;
   }
 
   private assertCurrent(generation: number): void {
@@ -676,12 +683,14 @@ export class NativeEnrollmentCoordinator {
         this.dependencies.send(request),
         timeout,
       ]);
-      this.assertCurrent(generation);
       const response = validateNativeEnrollmentResponse(
         rawResponse,
         request,
         this.now(),
       );
+      if (generation !== this.generation) {
+        this.abandonedConfig = response.config;
+      }
       this.assertCurrent(generation);
       await this.dependencies.saveState({ ...EMPTY_NATIVE_ENROLLMENT_STATE });
       this.assertCurrent(generation);

--- a/packages/browser-bridge-extension/src/native-enrollment.ts
+++ b/packages/browser-bridge-extension/src/native-enrollment.ts
@@ -76,6 +76,19 @@ export type NativeEnrollmentRequest = {
   profileId: string;
 };
 
+export type NativeRevokeRequest = Omit<NativeEnrollmentRequest, "type"> & {
+  type: "browser_bridge.revoke";
+  companionId: string;
+};
+
+export type NativeRevokeResult = {
+  v: 1;
+  type: "browser_bridge.revoke_result";
+  requestId: string;
+  nonce: string;
+  revoked: true;
+};
+
 export type NativeEnrollmentResult = {
   v: 1;
   type: "browser_bridge.enroll_result";
@@ -96,6 +109,62 @@ export type NativeEnrollmentFailure = {
 export type NativeEnrollmentResponse =
   | NativeEnrollmentResult
   | NativeEnrollmentFailure;
+
+export async function revokeNativeCompanion(options: {
+  config: BrowserBridgeCompanionConfig;
+  extensionId: string;
+  extensionVersion: string;
+  send: (request: NativeRevokeRequest) => Promise<unknown>;
+  randomUUID?: () => string;
+  randomBytes?: (length: number) => Uint8Array;
+}): Promise<void> {
+  const requestId = (options.randomUUID ?? (() => crypto.randomUUID()))();
+  const nonce = base64Url(
+    (
+      options.randomBytes ??
+      ((length) => crypto.getRandomValues(new Uint8Array(length)))
+    )(32),
+  );
+  const request: NativeRevokeRequest = {
+    v: 1,
+    type: "browser_bridge.revoke",
+    requestId,
+    nonce,
+    extensionId: validateBinding(options.extensionId, "extensionId"),
+    extensionVersion: validateBinding(
+      options.extensionVersion,
+      "extensionVersion",
+    ),
+    browser: options.config.browser,
+    profileId: validateUuid(options.config.profileId, "profileId"),
+    companionId: validateBinding(options.config.companionId, "companionId"),
+  };
+  if (!UUID_PATTERN.test(requestId) || !NONCE_PATTERN.test(nonce)) {
+    throw new NativeEnrollmentError(
+      "Native revoke request entropy is invalid.",
+      "invalid_native_request",
+      false,
+    );
+  }
+  enforceMessageSize(request);
+  const response = await options.send(request);
+  enforceMessageSize(response);
+  if (
+    !isRecord(response) ||
+    !hasExactKeys(response, ["v", "type", "requestId", "nonce", "revoked"]) ||
+    response.v !== 1 ||
+    response.type !== "browser_bridge.revoke_result" ||
+    response.requestId !== request.requestId ||
+    response.nonce !== request.nonce ||
+    response.revoked !== true
+  ) {
+    throw new NativeEnrollmentError(
+      "Native revoke response is invalid or does not match its request.",
+      "invalid_native_response",
+      false,
+    );
+  }
+}
 
 export type NativeEnrollmentSuppressionReason =
   | "owner_disconnected"

--- a/packages/browser-bridge-extension/src/operation-generation.test.ts
+++ b/packages/browser-bridge-extension/src/operation-generation.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic coverage for disconnect generation fencing around browser
+ * action side effects and their subsequent server publications.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  OperationCancelledError,
+  OperationGeneration,
+} from "./operation-generation";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("OperationGeneration", () => {
+  it("prevents an in-flight action from publishing progress or completion", async () => {
+    const generation = new OperationGeneration();
+    const lease = generation.capture();
+    const action = deferred();
+    const progress = vi.fn();
+    const completion = vi.fn();
+    const session = (async () => {
+      generation.assertCurrent(lease);
+      await action.promise;
+      generation.assertCurrent(lease);
+      await progress();
+      generation.assertCurrent(lease);
+      await completion();
+    })();
+
+    generation.cancelAndBlock();
+    action.resolve();
+
+    await expect(session).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(progress).not.toHaveBeenCalled();
+    expect(completion).not.toHaveBeenCalled();
+  });
+
+  it("prevents a side effect after cancellation settles an awaited lease", async () => {
+    const generation = new OperationGeneration();
+    const lease = generation.capture();
+    const actionLease = deferred();
+    const sideEffect = vi.fn();
+    const action = (async () => {
+      await generation.runCurrent(lease, async () => await actionLease.promise);
+      sideEffect();
+    })();
+
+    generation.cancelAndBlock();
+    actionLease.resolve();
+
+    await expect(action).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(sideEffect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/browser-bridge-extension/src/operation-generation.ts
+++ b/packages/browser-bridge-extension/src/operation-generation.ts
@@ -1,0 +1,50 @@
+/**
+ * Fences asynchronous extension work across explicit disconnect boundaries so
+ * an older enrollment, sync, or browser session cannot publish stale state.
+ */
+export class OperationCancelledError extends Error {
+  constructor() {
+    super("Browser bridge operation was cancelled.");
+    this.name = "OperationCancelledError";
+  }
+}
+
+export class OperationGeneration {
+  private generation = 0;
+  private blocked = false;
+
+  capture(): number {
+    return this.generation;
+  }
+
+  get isBlocked(): boolean {
+    return this.blocked;
+  }
+
+  cancelAndBlock(): void {
+    this.generation += 1;
+    this.blocked = true;
+  }
+
+  resume(): void {
+    this.blocked = false;
+  }
+
+  isCurrent(generation: number): boolean {
+    return !this.blocked && generation === this.generation;
+  }
+
+  assertCurrent(generation: number): void {
+    if (!this.isCurrent(generation)) throw new OperationCancelledError();
+  }
+
+  async runCurrent<T>(
+    generation: number,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    this.assertCurrent(generation);
+    const result = await operation();
+    this.assertCurrent(generation);
+    return result;
+  }
+}

--- a/packages/browser-bridge-extension/src/webextension.test.ts
+++ b/packages/browser-bridge-extension/src/webextension.test.ts
@@ -8,6 +8,7 @@ import {
   getManifestVersion,
   hasWebsiteAccess,
   queryTabs,
+  requestAllWebsiteAccess,
   requestWebsiteAccess,
   sendNativeMessage,
   sendTabMessage,
@@ -102,6 +103,28 @@ describe("browser extension operation deadlines", () => {
       { origins: [origin] },
       expect.any(Function),
     );
+  });
+
+  it("accepts a permission that the browser committed despite a false request callback", async () => {
+    const contains = vi.fn(
+      (_request: { origins: string[] }, callback: (allowed: boolean) => void) =>
+        callback(true),
+    );
+    const request = vi.fn(
+      (_request: { origins: string[] }, callback: (allowed: boolean) => void) =>
+        callback(false),
+    );
+    vi.stubGlobal("chrome", {
+      runtime: {},
+      permissions: { contains, request },
+    });
+
+    await expect(requestAllWebsiteAccess()).resolves.toBe(true);
+    await expect(requestWebsiteAccess("https://example.com/*")).resolves.toBe(
+      true,
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(contains).toHaveBeenCalledTimes(2);
   });
 
   it("uses the typed native-messaging wrapper and surfaces runtime errors", async () => {

--- a/packages/browser-bridge-extension/src/webextension.ts
+++ b/packages/browser-bridge-extension/src/webextension.ts
@@ -623,9 +623,15 @@ export async function requestAllWebsiteAccess(): Promise<boolean> {
   if (!permissions?.request) {
     throw new Error("permissions.request is unavailable");
   }
-  return await invokeAsync<boolean>("permissions.request", (callback) =>
-    permissions.request?.({ origins: ["https://*/*", "http://*/*"] }, callback),
+  const granted = await invokeAsync<boolean>(
+    "permissions.request",
+    (callback) =>
+      permissions.request?.(
+        { origins: ["https://*/*", "http://*/*"] },
+        callback,
+      ),
   );
+  return granted || (await hasAllUrlHostPermission());
 }
 
 /** Requests the browser-managed grant for one exact HTTP(S) origin. */
@@ -636,9 +642,11 @@ export async function requestWebsiteAccess(
   if (!permissions?.request) {
     throw new Error("permissions.request is unavailable");
   }
-  return await invokeAsync<boolean>("permissions.request", (callback) =>
-    permissions.request?.({ origins: [originPattern] }, callback),
+  const granted = await invokeAsync<boolean>(
+    "permissions.request",
+    (callback) => permissions.request?.({ origins: [originPattern] }, callback),
   );
+  return granted || (await hasWebsiteAccess(originPattern));
 }
 
 export async function getGrantedOrigins(): Promise<string[]> {

--- a/packages/scripts/__tests__/ci-required-aggregate.test.ts
+++ b/packages/scripts/__tests__/ci-required-aggregate.test.ts
@@ -1,0 +1,63 @@
+/** Proves the canonical CI aggregate reports the exact failed dependency without masking it under strict shell mode. */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const workflow = Bun.YAML.parse(
+  readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8"),
+) as Workflow;
+const aggregateSource = workflow.jobs?.required?.steps?.find(
+  (step) => step.name === "Require every CI job to succeed",
+)?.run;
+
+if (!aggregateSource) {
+  throw new Error("CI required aggregate has no executable body");
+}
+
+function executeAggregate(results: string) {
+  return spawnSync("bash", ["-c", aggregateSource], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, RESULTS: results },
+  });
+}
+
+describe("CI required aggregate", () => {
+  test("accepts successful dependencies", () => {
+    const result = executeAggregate(
+      "quality=success tests-client=success browser-bridge-windows-security=success",
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  test("names the first failed dependency under strict shell mode", () => {
+    const result = executeAggregate(
+      "quality=success tests-client=failure browser-bridge-windows-security=success",
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe(
+      "::error title=CI aggregate::tests-client finished with failure\n",
+    );
+    expect(result.stderr).toBe("");
+  });
+});

--- a/packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
+++ b/packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
@@ -1,4 +1,4 @@
-/** Verifies the sole PR workflow stays cancelable, static-only, and fail-closed over the affected workspace closure. */
+/** Verifies PR admission combines affected static checks with Windows browser-bridge security. */
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -12,21 +12,40 @@ const source = readFileSync(
 );
 const workflow = Bun.YAML.parse(source) as {
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
-  jobs?: Record<string, { name?: string; steps?: Array<{ run?: string }> }>;
+  jobs?: Record<
+    string,
+    {
+      name?: string;
+      uses?: string;
+      needs?: string[];
+      steps?: Array<{ run?: string }>;
+    }
+  >;
 };
 
 describe("PR Static Smoke workflow", () => {
-  test("owns one cancelable static job with the stable admission context", () => {
+  test("owns cancelable source and Windows lanes behind the stable admission context", () => {
     expect(workflow.concurrency?.group).toContain(
       "github.event.pull_request.number",
     );
     expect(workflow.concurrency?.["cancel-in-progress"]).toBeTrue();
-    expect(Object.keys(workflow.jobs ?? {})).toEqual(["static-smoke"]);
+    expect(Object.keys(workflow.jobs ?? {})).toEqual([
+      "source-smoke",
+      "browser-bridge-windows-security",
+      "static-smoke",
+    ]);
+    expect(workflow.jobs?.["browser-bridge-windows-security"]?.uses).toBe(
+      "./.github/workflows/browser-bridge-windows-security.yml",
+    );
+    expect(workflow.jobs?.["static-smoke"]?.needs).toEqual([
+      "source-smoke",
+      "browser-bridge-windows-security",
+    ]);
     expect(workflow.jobs?.["static-smoke"]?.name).toBe("All Tests Passed");
   });
 
   test("fails closed over mergeability, secrets, workflows, and affected static checks", () => {
-    const commands = (workflow.jobs?.["static-smoke"]?.steps ?? [])
+    const commands = (workflow.jobs?.["source-smoke"]?.steps ?? [])
       .map((step) => step.run ?? "")
       .join("\n");
     expect(commands).toContain("git merge-tree --write-tree");

--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -28,7 +28,18 @@ describe("repository ruleset contract", () => {
     });
     expect(admission.on.merge_group).toEqual({ types: ["checks_requested"] });
     expect(admission.jobs["static-smoke"].name).toBe("All Tests Passed");
-    expect(Object.keys(admission.jobs)).toEqual(["static-smoke"]);
+    expect(Object.keys(admission.jobs)).toEqual([
+      "source-smoke",
+      "browser-bridge-windows-security",
+      "static-smoke",
+    ]);
+    expect(admission.jobs["static-smoke"].needs).toEqual([
+      "source-smoke",
+      "browser-bridge-windows-security",
+    ]);
+    expect(admission.jobs["browser-bridge-windows-security"].uses).toBe(
+      "./.github/workflows/browser-bridge-windows-security.yml",
+    );
     expect(admission.concurrency["cancel-in-progress"]).toBeTrue();
   });
 

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
@@ -270,6 +270,7 @@ export function BrowserSessionPolicyPanel({
   );
 
   if (phase === "loading") {
+    if (hideWhenEmpty) return null;
     return (
       <div
         data-testid="browser-session-policy-loading"

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -224,7 +224,7 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     expect(screen.queryByTestId("view-header")).toBeNull();
   });
 
-  it("omits Browser Bridge administration while preserving session approvals", async () => {
+  it("keeps bridge recovery reachable without adding idle administration UI", async () => {
     walletStateHarness.plugins.push({ name: "@elizaos/plugin-browser" });
     render(<BrowserWorkspaceView />);
 
@@ -234,6 +234,18 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     expect(
       await screen.findByTestId("browser-session-policy-error"),
     ).not.toBeNull();
+  });
+
+  it("keeps bridge recovery reachable while a browser tab is open", async () => {
+    walletStateHarness.plugins.push({ name: "@elizaos/plugin-browser" });
+    vi.mocked(client.getBrowserWorkspace).mockResolvedValue(GOOGLE_WORKSPACE);
+    render(<BrowserWorkspaceView />);
+
+    expect(await screen.findByTitle("Google")).not.toBeNull();
+    expect(
+      await screen.findByTestId("browser-session-policy-error"),
+    ).not.toBeNull();
+    expect(screen.getByTestId("browser-session-policy-dock")).not.toBeNull();
   });
 
   it("floats the navigation toolbar as its own glass panel above the web surface", async () => {

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2607,6 +2607,17 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         </div>
       ) : null}
 
+      {browserBridgeSupported && !browserBridgeUnsupportedInNativeLocalMode ? (
+        <div
+          data-testid="browser-session-policy-dock"
+          className="pointer-events-none absolute inset-x-3 bottom-3 z-30 max-h-[min(40%,24rem)] overflow-y-auto"
+        >
+          <div className="pointer-events-auto mx-auto w-full max-w-xl rounded-sm bg-background/95 shadow-lg">
+            <BrowserSessionPolicyPanel api={client} hideWhenEmpty />
+          </div>
+        </div>
+      ) : null}
+
       {workspace.tabs.length === 0 ? (
         loading ? (
           <div className="flex h-full items-center justify-center">
@@ -2631,16 +2642,6 @@ export function BrowserWorkspaceView(): React.JSX.Element {
                   defaultValue: "No page open",
                 })}
               />
-              {/* Bottom + side chat clearance is reserved once, on the scroller
-                above — repeating it on this grid double-counted the inset in
-                short landscape and squeezed the column off-canvas. */}
-              {workspace.mode === "web" &&
-              browserBridgeSupported &&
-              !browserBridgeUnsupportedInNativeLocalMode ? (
-                <div className="w-full max-w-xl px-6 pb-4">
-                  <BrowserSessionPolicyPanel api={client} hideWhenEmpty />
-                </div>
-              ) : null}
             </div>
           </div>
         )

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -1137,8 +1137,39 @@ export class BrowserDomain {
     companionId: string,
     pairingToken: string,
   ): Promise<BrowserBridgeCompanionRevokeResponse> {
-    const companion = await this.requireBrowserCompanion(
+    const normalizedCompanionId = requireNonEmptyString(
       companionId,
+      "companionId",
+    );
+    const credential = await this.ctx.repository.getBrowserCompanionCredential(
+      this.ctx.agentId(),
+      normalizedCompanionId,
+    );
+    if (
+      credential?.pairingTokenHash ===
+      hashBrowserCompanionPairingToken(pairingToken)
+    ) {
+      const revocation =
+        await this.ctx.repository.getBrowserCompanionRevocation(
+          this.ctx.agentId(),
+          this.ctx.ownerEntityId(),
+          credential.companion.browser,
+          credential.companion.profileId,
+        );
+      if (revocation) {
+        return {
+          companion: {
+            ...credential.companion,
+            connectionState: "disconnected",
+            pairingTokenRevokedAt: revocation.revokedAt,
+            updatedAt: revocation.revokedAt,
+          },
+          revokedAt: revocation.revokedAt,
+        };
+      }
+    }
+    const companion = await this.requireBrowserCompanion(
+      normalizedCompanionId,
       pairingToken,
     );
     return this.revokeBrowserCompanion(companion.id);

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -7948,7 +7948,24 @@ export class LifeOpsRepository {
                 connection_state = 'disconnected',
                 updated_at = ${sqlQuote(args.revokedAt)}
           WHERE agent_id = ${sqlQuote(args.agentId)}
-            AND id = ${sqlQuote(args.companion.id)}`,
+            AND browser = ${sqlQuote(args.companion.browser)}`,
+      );
+      await executeRawSqlTx(
+        tx,
+        `UPDATE app_lifeops.life_workflow_browser_sessions
+            SET status = 'failed',
+                result_json = (result_json::jsonb || ${sqlJson({
+                  code: "browser_companion_revoked",
+                  error: "Browser companion was disconnected",
+                })}::jsonb)::text,
+                metadata_json = (metadata_json::jsonb - 'browserActionAttempt')::text,
+                updated_at = ${sqlQuote(args.revokedAt)},
+                finished_at = ${sqlQuote(args.revokedAt)}
+          WHERE agent_id = ${sqlQuote(args.agentId)}
+            AND browser = ${sqlQuote(args.companion.browser)}
+            AND subject_type = 'owner'
+            AND subject_id = ${sqlQuote(args.ownerEntityId)}
+            AND status IN ('queued', 'running', 'awaiting_confirmation')`,
       );
       await executeRawSqlTx(
         tx,

--- a/plugins/plugin-personal-assistant/test/browser-companion-revocation.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/browser-companion-revocation.pglite.test.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentRuntime } from "@elizaos/core";
+import { randomUUID } from "node:crypto";
 import {
   type BrowserBridgeCompanionPairingResponse,
   createBrowserBridgeCompanionStatus,
@@ -15,7 +16,10 @@ import {
   type BrowserDomainDeps,
 } from "../src/lifeops/domains/browser-service.js";
 import type { LifeOpsContext } from "../src/lifeops/lifeops-context.js";
-import { LifeOpsRepository } from "../src/lifeops/repository.js";
+import {
+  createLifeOpsBrowserSession,
+  LifeOpsRepository,
+} from "../src/lifeops/repository.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -85,6 +89,135 @@ afterAll(async () => {
 });
 
 describe("browser companion revocation persistence", () => {
+  it("makes companion self-revocation idempotent without accepting another token", async () => {
+    const ownerEntityId = "owner-self-revocation-idempotency";
+    const pairing = await pair(ownerEntityId, "profile-self-revoke");
+    const siblingPairing = await pair(
+      ownerEntityId,
+      "profile-self-revoke-sibling",
+    );
+    const session = createLifeOpsBrowserSession({
+      agentId: runtime.agentId,
+      domain: "browser",
+      subjectType: "owner",
+      subjectId: ownerEntityId,
+      visibilityScope: "owner",
+      contextPolicy: "owner_private",
+      workflowId: null,
+      browser: "chrome",
+      companionId: pairing.companion.id,
+      profileId: pairing.companion.profileId,
+      windowId: "window-1",
+      tabId: "tab-1",
+      title: "revocation execution fence",
+      status: "running",
+      actions: [
+        {
+          id: "action-1",
+          kind: "read_page",
+          label: "Read page",
+          url: null,
+          selector: null,
+          text: null,
+          accountAffecting: false,
+          requiresConfirmation: false,
+          metadata: {},
+        },
+      ],
+      currentActionIndex: 0,
+      awaitingConfirmationForActionId: null,
+      result: {},
+      metadata: {
+        browserActionAttempt: {
+          actionId: "action-1",
+          actionIndex: 0,
+          attemptId: "attempt-1",
+        },
+      },
+      finishedAt: null,
+    });
+    await repository.createBrowserSession(session);
+    const siblingSession = createLifeOpsBrowserSession({
+      ...session,
+      id: randomUUID(),
+      companionId: siblingPairing.companion.id,
+      profileId: siblingPairing.companion.profileId,
+      title: "browser-wide sibling revocation fence",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await repository.createBrowserSession(siblingSession);
+    const first = await browserDomain(
+      ownerEntityId,
+    ).revokeBrowserCompanionFromCompanion(
+      pairing.companion.id,
+      pairing.pairingToken,
+    );
+    await expect(
+      repository.updateBrowserSessionProgressFromCompanion({
+        agentId: runtime.agentId,
+        sessionId: session.id,
+        companion: pairing.companion,
+        expectedActionIndex: 0,
+        completedActionId: "action-1",
+        attemptId: "attempt-1",
+        currentActionIndex: 1,
+        resultPatch: { action: "finished" },
+        metadataPatch: {},
+        updatedAt: new Date().toISOString(),
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      repository.getBrowserSession(runtime.agentId, session.id),
+    ).resolves.toMatchObject({
+      status: "failed",
+      result: { code: "browser_companion_revoked" },
+      finishedAt: first.revokedAt,
+    });
+    await expect(
+      repository.getBrowserSession(runtime.agentId, siblingSession.id),
+    ).resolves.toMatchObject({
+      status: "failed",
+      result: { code: "browser_companion_revoked" },
+      finishedAt: first.revokedAt,
+    });
+    await expect(
+      repository.getBrowserCompanionCredential(
+        runtime.agentId,
+        siblingPairing.companion.id,
+      ),
+    ).resolves.toMatchObject({
+      companion: {
+        connectionState: "disconnected",
+        pairingTokenRevokedAt: first.revokedAt,
+      },
+    });
+    repository = new LifeOpsRepository(runtime);
+
+    await expect(
+      browserDomain(ownerEntityId).revokeBrowserCompanionFromCompanion(
+        pairing.companion.id,
+        pairing.pairingToken,
+      ),
+    ).resolves.toMatchObject({
+      companion: {
+        id: pairing.companion.id,
+        connectionState: "disconnected",
+        pairingTokenRevokedAt: first.revokedAt,
+      },
+      revokedAt: first.revokedAt,
+    });
+    await expect(
+      browserDomain(ownerEntityId).revokeBrowserCompanionFromCompanion(
+        pairing.companion.id,
+        "lobr_wrong-token",
+      ),
+    ).rejects.toMatchObject({
+      status: 401,
+      code: "browser_bridge_companion_token_revoked",
+    });
+  });
+
   it("enforces native TTL, survives restart, blocks reinstall identities, and requires owner reset", async () => {
     const ownerEntityId = "owner-revocation-a";
     const beforePairMs = Date.now();

--- a/plugins/plugin-personal-assistant/test/browser-companion-revocation.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/browser-companion-revocation.pglite.test.ts
@@ -3,8 +3,8 @@
  * expiry against the real PGlite repository across fresh service instances.
  */
 
-import type { AgentRuntime } from "@elizaos/core";
 import { randomUUID } from "node:crypto";
+import type { AgentRuntime } from "@elizaos/core";
 import {
   type BrowserBridgeCompanionPairingResponse,
   createBrowserBridgeCompanionStatus,


### PR DESCRIPTION
## Summary

Hardens the merged automatic browser companion path for Chrome, Firefox, and Safari while keeping healthy connection UI invisible.

- require a real owner cookie plus CSRF for pairing, owner revoke, and reset; local trust and bearer substitution are disabled on those mutations
- persist enrollment replay protection across broker/app restarts with private atomic state shared by both desktop brokers
- make Disconnect a durable transaction: cancel old work, revoke server state, suppress enrollment, then erase credentials
- fence async enrollment, sync, session publication, and browser side effects across Disconnect
- fail every active owner session and disconnect every profile covered by browser-wide revocation
- make Windows registration transactional, ownership-safe on uninstall, and package the uninstall helper
- add staged compiled-host, DPAPI helper, installer registry-target, workflow aggregate, and exact-head Windows proofs
- render no bridge setup/status UI while healthy; expose the compact policy dock only for active, revoked, or failed state

Closes acceptance gaps tracked in #23898. The issue should remain open until physical/store acceptance is attached.

## Verification

- `bun install`: pass
- `bun run build:core`: 60/60 tasks pass at `04f56f8537dd18b77608ebfbb0501e1c5cb73f02`
- extension focused security/cancellation: 55/55, typecheck pass, lint pass
- Electrobun browser/Windows security: 42/42, typecheck pass, lint pass
- app-core auth: 52/52
- agent real-server cookie/CSRF: 7/7
- UI browser policy/workspace: 35/35
- PGlite revocation: 5/5
- workflow contracts: 9/9
- `actionlint`: pass
- PowerShell parse for all touched lifecycle scripts: pass
- five affected browser visual inspection cycles: all four mobile/desktop/iPad captures good; zero broken, needs-work, hover, density, or minimalism failures

`bun run verify` reaches the global type/lint graph but current `origin/develop` fails on unrelated pre-existing formatting errors in `packages/shared` (`dev-settings-banner-style.test.ts` and `safe-diagnostic-error.test.ts`). No changed file is implicated; hosted exact-head admission remains required before merge.

## Remaining acceptance boundary

This PR adds deterministic and hosted Windows proof, but it does not by itself constitute physical Chrome/Firefox/Safari store-signing acceptance or Windows/Linux hardware acceptance. Those stay tracked on #23898.

<!-- evidence-head:cb65bf48e42592e65ef46d5ecba841cd7dbdd43a -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-before-browser-desktop.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-after-browser-desktop.png)

<!-- evidence-row:backend-logs -->
- [x] [26655-backend-exact-head-cb65bf48.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-backend-exact-head-cb65bf48.log)

<!-- evidence-row:frontend-logs -->
- [x] [26655-frontend-exact-head-cb65bf48.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-frontend-exact-head-cb65bf48.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic browser lifecycle and native authorization change; no model prompt, model output, or LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [26655-domain-exact-head-cb65bf48.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-domain-exact-head-cb65bf48.md)

<!-- evidence-row:ocr-review -->
- [x] [26655-ocr-browser-desktop-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-ocr-browser-desktop-review.md)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/26655-video-cb65bf48.webm




