### PR TITLE
fix(voice): overlap runtime warmups with call setup

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -209,7 +209,10 @@ app.post("/", async (c) => {
     );
     const priorConversationPromise = Promise.resolve(
       dbRead
-        .select({ messages: sharedRuntimeHistory.messages })
+        // Continuity needs only evidence and recency, never the potentially
+        // large JSON history payload. The media turn hydrates complete history
+        // separately through the canonical conversation Durable Object.
+        .select({ updatedAt: sharedRuntimeHistory.updated_at })
         .from(sharedRuntimeHistory)
         .where(
           and(
@@ -232,7 +235,9 @@ app.post("/", async (c) => {
       ...(priorCall?.receivedAt
         ? { priorCallAt: priorCall.receivedAt.getTime() }
         : {}),
-      historyMessages: priorConversation ? priorConversation.messages : [],
+      historyMessages: priorConversation
+        ? [{ createdAt: priorConversation.updatedAt.getTime() }]
+        : [],
     });
     callOpening = await claimInboundCallOpeningContext(
       {

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -336,6 +336,7 @@ app.get("/", async (c) => {
   ): Promise<void> => {
     if (session || starting || closed) return;
     starting = true;
+    const bootstrapStartedAt = Date.now();
     if (event.streamSid !== event.start.streamSid) {
       closeBootstrapBoundary(1008, "stream identity mismatch");
       return;
@@ -366,6 +367,7 @@ app.get("/", async (c) => {
       closeBootstrapBoundary(1008, "invalid stream bootstrap");
       return;
     }
+    const tokenVerifiedAt = Date.now();
     const claim = await awaitTwilioBootstrapPhase(
       claimVoiceSessionToken(claims.jti, claims.exp, rawRedis ?? undefined),
       () => closed,
@@ -376,6 +378,7 @@ app.get("/", async (c) => {
       closeBootstrapBoundary(1008, "stream bootstrap already used");
       return;
     }
+    const tokenClaimedAt = Date.now();
     if (
       event.start.callSid !== claims.callSid ||
       event.start.accountSid !== claims.accountSid
@@ -456,11 +459,16 @@ app.get("/", async (c) => {
       downlink,
     });
     session.start();
+    const sessionStartedAt = Date.now();
     for (const frame of pendingMedia.splice(0)) session.pushUplinkAudio(frame);
     logger.info("[twilio-media] realtime call connected", {
       callSid: event.start.callSid,
       streamSid,
       agentId: claims.agentId,
+      tokenVerificationMs: tokenVerifiedAt - bootstrapStartedAt,
+      tokenClaimMs: tokenClaimedAt - tokenVerifiedAt,
+      sessionConstructionMs: sessionStartedAt - tokenClaimedAt,
+      bootstrapTotalMs: sessionStartedAt - bootstrapStartedAt,
     });
   };
 

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -90,11 +90,11 @@ export async function hydrateVoiceSharedAgentScope(
           );
         };
 
-        // Publish the authorization gate as soon as the authoritative agent
-        // lookup succeeds. Character and admission prefills are latency hints;
-        // keeping this write behind either one turns a slow optional dependency
-        // into the full 503/backoff staircase on the caller's first response.
-        await cache.set(
+        // Start every independent warmup immediately after authoritative scope
+        // validation. In particular, the exact conversation Durable Object now
+        // loads history and the AgentRuntime kernel while the Redis scope write
+        // is in flight instead of waiting behind that network round trip.
+        const scopeWrite = cache.set(
           CacheKeys.sharedAgentScope.voice(
             claims.organizationId,
             claims.userId,
@@ -103,11 +103,10 @@ export async function hydrateVoiceSharedAgentScope(
           agent,
           CacheTTL.sharedAgentScope.resolve,
         );
-
-        // error-policy:J7 a failed character prefill leaves the next turn on
-        // its existing retryable warming path rather than failing hydration.
         const optionalWarmups: Promise<unknown>[] = [
           hydrateCharacter().catch((error) => {
+            // error-policy:J7 character hydration is latency-only; the next
+            // turn retains the canonical typed cache-warming retry fallback.
             logger.warn("[voice-scope-hydration] character prefill failed", {
               agentId: claims.agentId,
               characterId,
@@ -181,6 +180,11 @@ export async function hydrateVoiceSharedAgentScope(
             }),
           );
         }
+
+        // Publish the authorization gate as soon as its own write completes.
+        // Optional warmups are latency hints and never delay this gate; their
+        // failures remain contained on the existing retryable turn path.
+        await scopeWrite;
         await Promise.all(optionalWarmups);
       }),
   );


### PR DESCRIPTION
Closes #22817

## What changed
- Start the exact conversation Durable Object / AgentRuntime prewarm concurrently with the Redis authorization-scope write and other independent warmups.
- Resolve returning-caller continuity from the history row timestamp instead of transferring the full JSON message history; the canonical Durable Object still hydrates complete history for the real turn.
- Add privacy-bounded media bootstrap phase timings for token verification, token claim, session construction, and total bootstrap.

## Why
The fixed greeting already overlaps prewarm, but the most expensive first-turn warmup was still serialized behind a Redis network round trip. Returning-call greeting selection also loaded a potentially large history payload that it never consumed.

## Verification
- `bun test packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts` — 7 pass
- `bun run --cwd packages/cloud/api typecheck` — pass (TypeScript + production Worker dry-run)
- Focused voice/runtime suites — 62 pass across continuity, lifecycle/barge-in, timing, real AgentRuntime planner, cache hotpath, and persona contracts
- `bunx biome check` on all changed files — pass
- `git diff --check` — pass
- `bun run verify` — reaches workspace lint, then fails on two pre-existing formatting errors in `packages/shared/src/dev-settings-banner-style.test.ts` and `packages/shared/src/utils/safe-diagnostic-error.test.ts`; neither file is changed here.

## Live acceptance
After develop-to-main promotion, place a fresh +1 808 788 1821 call and correlate the new bootstrap, EOT, planner/provider, and first-audio timings. Provider routing is intentionally unchanged.