### PR TITLE
test(ui): cover client-base

### DIFF
--- a/packages/ui/src/api/client-base.test.ts
+++ b/packages/ui/src/api/client-base.test.ts
@@ -1,0 +1,381 @@
+/** Verifies client-base's exported helpers and send-queue policy through the package's configured test harness. */
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://localhost/"}
+
+/**
+ * Unit coverage for the base client surface not owned by the topic suites:
+ * id minting, the module-level network-status API, the StreamGenerationError
+ * contract, assistant-text normalization, and the offline WS send queue.
+ * Real module logic; only the browser WebSocket builtin is stubbed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NETWORK_STATUS_CHANGE_EVENT } from "../events";
+import {
+  __getLastKnownNetworkConnected,
+  __resetNetworkStatusForTests,
+  ElizaClient,
+  generateChatClientMessageId,
+  isNetworkCurrentlyConnected,
+  isStreamGenerationError,
+  onNetworkStatusChange,
+  StreamGenerationError,
+} from "./client-base";
+
+const GENERIC_NO_RESPONSE_TEXT =
+  "Sorry, I couldn't generate a response right now. Please try again.";
+
+interface FakeWs {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+}
+
+function stubWebSocketWithInstances(): FakeWs[] {
+  const instances: FakeWs[] = [];
+  class WebSocketStub {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    readyState = WebSocketStub.CONNECTING;
+    sent: string[] = [];
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    constructor(readonly url: string) {
+      instances.push(this);
+    }
+    send(payload: string): void {
+      this.sent.push(payload);
+    }
+    close(): void {}
+  }
+  vi.stubGlobal("WebSocket", WebSocketStub);
+  return instances;
+}
+
+function openSocket(instances: FakeWs[]): void {
+  instances[0].readyState = 1; // OPEN
+  instances[0].onopen?.();
+}
+
+function sentFrames(socket: FakeWs): Record<string, unknown>[] {
+  return socket.sent.map(
+    (payload) => JSON.parse(payload) as Record<string, unknown>,
+  );
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+function dispatchNetworkStatus(connected: unknown): void {
+  document.dispatchEvent(
+    new CustomEvent(NETWORK_STATUS_CHANGE_EVENT, {
+      detail: { connected },
+    }),
+  );
+}
+
+describe("ElizaClient message id minting", () => {
+  it("mints distinct non-empty ids across repeated calls", () => {
+    const ids = Array.from({ length: 200 }, () =>
+      ElizaClient.generateMessageId(),
+    );
+    for (const id of ids) {
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    }
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("backs generateChatClientMessageId with the same uniqueness contract", () => {
+    const ids = Array.from({ length: 50 }, () => generateChatClientMessageId());
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("network status module API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    __resetNetworkStatusForTests();
+  });
+
+  it("starts connected and notifies subscribers only on real transitions", () => {
+    expect(isNetworkCurrentlyConnected()).toBe(true);
+    expect(__getLastKnownNetworkConnected()).toBe(true);
+
+    const seen: boolean[] = [];
+    onNetworkStatusChange((connected) => seen.push(connected));
+
+    // Repeating the current state is not a transition: no notification.
+    dispatchNetworkStatus(true);
+    expect(seen).toEqual([]);
+
+    dispatchNetworkStatus(false);
+    expect(seen).toEqual([false]);
+    expect(isNetworkCurrentlyConnected()).toBe(false);
+
+    dispatchNetworkStatus(true);
+    expect(seen).toEqual([false, true]);
+    expect(isNetworkCurrentlyConnected()).toBe(true);
+  });
+
+  it("stops notifying after the unsubscribe function runs", () => {
+    const seen: boolean[] = [];
+    const unsubscribe = onNetworkStatusChange((connected) =>
+      seen.push(connected),
+    );
+
+    unsubscribe();
+    dispatchNetworkStatus(false);
+
+    expect(seen).toEqual([]);
+    // The cached module state still tracks the bridge transition; only the
+    // subscriber notification is suppressed by unsubscribing.
+    expect(isNetworkCurrentlyConnected()).toBe(false);
+  });
+
+  it("ignores malformed bridge events instead of flipping connectivity", () => {
+    const seen: boolean[] = [];
+    onNetworkStatusChange((connected) => seen.push(connected));
+
+    dispatchNetworkStatus("yes");
+    dispatchNetworkStatus(undefined);
+    document.dispatchEvent(new CustomEvent(NETWORK_STATUS_CHANGE_EVENT));
+    document.dispatchEvent(new Event(NETWORK_STATUS_CHANGE_EVENT));
+
+    expect(seen).toEqual([]);
+    expect(__getLastKnownNetworkConnected()).toBe(true);
+  });
+
+  it("resets cached state and drops subscribers on the test-only reset", () => {
+    const seen: boolean[] = [];
+    onNetworkStatusChange((connected) => seen.push(connected));
+
+    dispatchNetworkStatus(false);
+    expect(__getLastKnownNetworkConnected()).toBe(false);
+
+    __resetNetworkStatusForTests();
+    expect(__getLastKnownNetworkConnected()).toBe(true);
+
+    dispatchNetworkStatus(false);
+    expect(seen).toEqual([false]);
+    expect(__getLastKnownNetworkConnected()).toBe(false);
+  });
+});
+
+describe("StreamGenerationError", () => {
+  it("carries the gate fields and names itself for downstream guards", () => {
+    const error = new StreamGenerationError({
+      message: "generation failed",
+      failureKind: "no_provider",
+      accountConnect: { provider: "openrouter" } as never,
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("generation failed");
+    expect(error.name).toBe("StreamGenerationError");
+    expect(error.failureKind).toBe("no_provider");
+    expect(error.accountConnect).toEqual({ provider: "openrouter" });
+  });
+
+  it("leaves the structured fields undefined when absent", () => {
+    const error = new StreamGenerationError({ message: "boom" });
+
+    expect(error.failureKind).toBeUndefined();
+    expect(error.accountConnect).toBeUndefined();
+  });
+
+  it("accepts StreamGenerationError instances and rejects everything else", () => {
+    const error = new StreamGenerationError({ message: "x" });
+    class Other extends Error {}
+
+    expect(isStreamGenerationError(error)).toBe(true);
+    expect(isStreamGenerationError(new Error("plain"))).toBe(false);
+    expect(isStreamGenerationError(new Other("sub"))).toBe(false);
+    expect(isStreamGenerationError(null)).toBe(false);
+    expect(isStreamGenerationError(undefined)).toBe(false);
+    expect(isStreamGenerationError("generation failed")).toBe(false);
+  });
+});
+
+describe("assistant text normalization", () => {
+  let client: ElizaClient;
+
+  beforeEach(() => {
+    client = new ElizaClient("https://agent.example.test");
+  });
+
+  it("passes ordinary replies through trimmed and whitespace-tidied", () => {
+    expect(client.normalizeAssistantText("  Hello world.  ")).toBe(
+      "Hello world.",
+    );
+  });
+
+  it("unwraps a leaked reply-payload object into the user-facing reply", () => {
+    expect(client.normalizeAssistantText('{"reply":"107"}')).toBe("107");
+    expect(
+      client.normalizeAssistantText(
+        '{"shouldRespond":"RESPOND","contexts":["simple"],"replyText":"Hello there"}',
+      ),
+    ).toBe("Hello there");
+  });
+
+  it("strips stage directions from otherwise usable replies", () => {
+    expect(client.normalizeAssistantText("_blushes_ Hi there.")).toBe(
+      "Hi there.",
+    );
+    expect(client.normalizeAssistantText("Hello! *waves* I am here.")).toBe(
+      "Hello! I am here.",
+    );
+  });
+
+  it("maps blanks and no-response variants to the generic notice", () => {
+    expect(client.normalizeAssistantText("")).toBe(GENERIC_NO_RESPONSE_TEXT);
+    expect(client.normalizeAssistantText("   ")).toBe(GENERIC_NO_RESPONSE_TEXT);
+    expect(client.normalizeAssistantText("no response")).toBe(
+      GENERIC_NO_RESPONSE_TEXT,
+    );
+    expect(client.normalizeAssistantText("(No Response)")).toBe(
+      GENERIC_NO_RESPONSE_TEXT,
+    );
+  });
+
+  it("returns empty rather than the notice for stripped-to-nothing content", () => {
+    expect(client.normalizeAssistantText("*smiles*")).toBe("");
+  });
+
+  it("treats non-string input as a missing reply", () => {
+    expect(client.normalizeAssistantText(undefined as unknown as string)).toBe(
+      GENERIC_NO_RESPONSE_TEXT,
+    );
+  });
+
+  it("keeps greetings quiet instead of substituting the generic notice", () => {
+    expect(client.normalizeGreetingText("")).toBe("");
+    expect(client.normalizeGreetingText("   ")).toBe("");
+    expect(client.normalizeGreetingText("(no response)")).toBe("");
+    expect(client.normalizeGreetingText(" Hello! _waves_ ")).toBe("Hello!");
+  });
+});
+
+describe("ElizaClient.sendWsMessage offline queue", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    __resetNetworkStatusForTests();
+  });
+
+  it("stamps a msgId on queued frames and preserves caller-supplied ones", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test");
+    client.connectWs();
+
+    client.sendWsMessage({ type: "agent_event" });
+    client.sendWsMessage({ type: "other", msgId: "caller-id" });
+
+    openSocket(instances);
+    const frames = sentFrames(instances[0]).filter(
+      (frame) => frame.type !== "auth",
+    );
+
+    expect(frames.map((frame) => frame.type)).toEqual(["agent_event", "other"]);
+    const stamped = frames[0].msgId;
+    expect(typeof stamped).toBe("string");
+    expect((stamped as string).length).toBeGreaterThan(0);
+    expect(frames[1].msgId).toBe("caller-id");
+  });
+
+  it("sends immediately without queueing once the socket is open", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test");
+    client.connectWs();
+
+    openSocket(instances);
+    client.sendWsMessage({ type: "ping" });
+
+    const frames = sentFrames(instances[0]);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].type).toBe("ping");
+    expect(typeof frames[0].msgId).toBe("string");
+  });
+
+  it("keeps only the newest active-conversation update while offline", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test");
+    client.connectWs();
+
+    client.sendWsMessage({ type: "active-conversation", n: 1 });
+    client.sendWsMessage({ type: "status", n: 2 });
+    client.sendWsMessage({ type: "active-conversation", n: 3 });
+
+    openSocket(instances);
+    const frames = sentFrames(instances[0]);
+
+    expect(frames.map((frame) => frame.n)).toEqual([2, 3]);
+    expect(frames.every((frame) => typeof frame.msgId === "string")).toBe(true);
+  });
+
+  it("caps the offline queue at 32 frames and drops the oldest first", async () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test");
+    client.connectWs();
+
+    for (let i = 0; i < 34; i++) {
+      client.sendWsMessage({ type: "queued", n: i });
+    }
+
+    openSocket(instances);
+    const frames = sentFrames(instances[0]);
+
+    expect(frames).toHaveLength(32);
+    expect(frames[0].n).toBe(2);
+    expect(frames[31].n).toBe(33);
+  });
+});
+
+describe("replayable WS event backlog", () => {
+  it("replays at most the newest 8 backlogged navigation frames to a late handler", async () => {
+    const client = new ElizaClient("https://agent.example.test");
+
+    for (let i = 0; i < 10; i++) {
+      client.deliverWsMessageForTest({
+        type: "shell:navigate:view",
+        n: i,
+      });
+    }
+
+    const received: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => received.push(data));
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(8);
+    expect(received[0].n).toBe(2);
+    expect(received[7].n).toBe(9);
+  });
+
+  it("drains the backlog after replay so a second late handler gets nothing", async () => {
+    const client = new ElizaClient("https://agent.example.test");
+    client.deliverWsMessageForTest({
+      type: "shell:navigate:view",
+      viewId: "settings",
+    });
+
+    const first: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => first.push(data));
+    await flushMicrotasks();
+
+    const second: Record<string, unknown>[] = [];
+    client.onWsEvent("shell:navigate:view", (data) => second.push(data));
+    await flushMicrotasks();
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual([]);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/api/client-base.test.ts`, a new unit suite for
`packages/ui/src/api/client-base.ts`, which had topic-scoped suites
(csrf, resume, warming-retry, websocket, …) but no coverage for several of
its exported surfaces. The diff is one new test file: +N/−0, no production
code touched.

## Coverage added (behavioral, real module — only the browser WebSocket builtin is stubbed)

- **`StreamGenerationError` / `isStreamGenerationError`** — gate fields
  (`failureKind`, `accountConnect`) carried through; defaults undefined;
  name set for downstream guards; instanceof guard accepts the class and
  rejects plain/subclassed Errors and primitives.
- **Network-status module API** — transition-only notifications via the
  bridged document event (`NETWORK_STATUS_CHANGE_EVENT`); repeat states do
  not re-notify; unsubscribe stops delivery while cached state still tracks
  the bridge; malformed bridge events (missing/non-boolean
  `detail.connected`, missing detail) are ignored; `__resetNetworkStatusForTests`
  restores connected state and drops subscribers.
- **Id minting** — `ElizaClient.generateMessageId()` distinct non-empty ids
  across 200 calls; `generateChatClientMessageId()` same contract.
- **Assistant text normalization** — `normalizeAssistantText` trims/tidies
  ordinary replies, unwraps leaked reply-payload objects
  (`{"reply":"107"}`, response-handler `replyText` shapes), strips stage
  directions, maps blanks and `no response` variants to the generic notice,
  returns "" for stage-only content, treats non-string input as missing;
  `normalizeGreetingText` stays quiet ("") where the reply path substitutes
  the notice.
- **Offline WS send queue** — queued frames get a stamped `msgId`;
  caller-supplied `msgId` preserved verbatim; immediate send when open;
  `active-conversation` dedupe keeps only the newest offline update;
  32-frame cap evicts oldest first (34 enqueued → first two dropped).
- **Replayable backlog** — at most the newest 8 backlogged
  `shell:navigate:view` frames replay to a late handler; backlog drains so
  a second late handler receives nothing.

No overlap with the existing `client-base-*` topic suites: those own the
SSE streaming paths, CSRF headers, 202-resume/warming-retry classification,
and connection policy branches; this file pins the exported helpers above,
none of which were previously exercised directly.

## Verification (fork PR — hosted CI does not run on this repository's pull requests)

All commands run against current `origin/develop` (`c0801ba9`) in the shared checkout:

1. `bunx vitest run src/api/client-base.test.ts` (packages/ui):
   **Test Files 1 passed (1) · Tests 22 passed (22)**
2. `bunx biome check src/api/client-base.test.ts`: clean —
   `Checked 1 file in 36ms. No fixes applied.` (after the formatting `--write` pass)
3. `bunx tsc --noEmit` (packages/ui): zero mentions of
   `client-base.test.ts` anywhere in the output — no new type errors.
4. The diff touches exactly one new file:
   `packages/ui/src/api/client-base.test.ts`. No deletions, no source changes.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c1f546ea2fec09bb2a0f3187eb396be42dba97c9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
