### PR TITLE
test(core): cover action-search-keywords

### DIFF
--- a/packages/core/src/i18n/action-search-keywords.test.ts
+++ b/packages/core/src/i18n/action-search-keywords.test.ts
@@ -64,3 +64,118 @@ describe("action-search-keywords", () => {
 		expect(matchCount).toBe(2);
 	});
 });
+
+describe("action-search-keywords resolution edge cases", () => {
+	it("normalizes digit- and separator-delimited action names to keyword stems", () => {
+		expect(actionNameToKeywordStem("send2FA-code")).toBe("send2FaCode");
+		expect(actionNameToKeywordStem("-__ create--task __-")).toBe("createTask");
+		expect(actionNameToKeywordStem("CREATE")).toBe("create");
+		expect(actionNameToKeywordStem("")).toBe("");
+	});
+
+	it("returns no sources when neither the action name nor any context resolves", () => {
+		expect(
+			getActionSearchKeywordSources({ name: "definitelyNotARealActionXyz" }),
+		).toEqual([]);
+		expect(getActionSearchKeywordSources({ name: "" })).toEqual([]);
+	});
+
+	it("emits dotted source keys by recursing into nested keyword documents", () => {
+		const sources = getActionSearchKeywordSources({ name: "create_task" });
+		expect(sources.map((s) => s.key)).toContain("action.createTask.request");
+	});
+
+	it("lists the action stem's sources before context-derived sources", () => {
+		const keys = getActionSearchKeywordSources({
+			name: "CREATE_TASK",
+			contexts: ["tasks"],
+		}).map((s) => s.key);
+		expect(keys.indexOf("action.createTask.request")).toBeGreaterThanOrEqual(0);
+		expect(keys.indexOf("contextSignal.tasks.strong")).toBeGreaterThan(
+			keys.indexOf("action.createTask.request"),
+		);
+	});
+
+	it("deduplicates stems contributed by both the action name and multiple contexts", () => {
+		const sources = getActionSearchKeywordSources({
+			name: "CREATE_TASK",
+			contexts: ["automation", "productivity", "tasks"],
+		});
+		expect(
+			sources.filter((s) => s.key === "action.createTask.request").length,
+		).toBe(1);
+		expect(sources.map((s) => s.key)).toContain("contextSignal.tasks.strong");
+	});
+
+	it("normalizes context entries and ignores non-string or unknown values", () => {
+		const keys = getActionSearchKeywordSources({
+			name: "",
+			contexts: ["  TASKS ", 42, null, "", false, "unknownContext"],
+		}).map((s) => s.key);
+		expect(keys).toEqual([
+			"contextSignal.tasks.strong",
+			"action.createTask.request",
+			"action.manageTasks.request",
+		]);
+	});
+
+	it("treats non-array context values as no contexts", () => {
+		expect(
+			getActionSearchKeywordSources({ name: "", contexts: "tasks" }),
+		).toEqual([]);
+		expect(
+			getActionSearchKeywordSources({ name: "", contexts: { tasks: true } }),
+		).toEqual([]);
+	});
+
+	it("includes locale terms by default and omits them when includeAllLocales is false", () => {
+		const all = getActionSearchKeywordTerms({ name: "", contexts: ["tasks"] });
+		expect(all[0]).toBe("task");
+		expect(all).toContain("tarea");
+
+		const baseOnly = getActionSearchKeywordTerms({
+			name: "",
+			contexts: ["tasks"],
+			includeAllLocales: false,
+		});
+		expect(baseOnly).toContain("task");
+		expect(baseOnly).not.toContain("tarea");
+		expect(baseOnly.length).toBeLessThan(all.length);
+	});
+
+	it("merges a stem shared by multiple contexts into one set of sources", () => {
+		const sendMessageKeys = getActionSearchKeywordSources({
+			name: "",
+			contexts: ["phone", "messaging"],
+		})
+			.map((s) => s.key)
+			.filter((key) => key.startsWith("contextSignal.send_message."))
+			.sort();
+		expect(sendMessageKeys).toEqual([
+			"contextSignal.send_message.strong",
+			"contextSignal.send_message.weak",
+		]);
+	});
+
+	it("deduplicates terms repeated across different sources case-insensitively", () => {
+		const terms = getActionSearchKeywordTerms({
+			name: "",
+			contexts: ["tasks"],
+		});
+		expect(terms.filter((t) => t.toLowerCase() === "reminder").length).toBe(1);
+	});
+
+	it("counts unique matched terms and respects word boundaries", () => {
+		expect(
+			countActionSearchKeywordMatches(["buy milk"], ["milk", "milk"]),
+		).toBe(1);
+		expect(countActionSearchKeywordMatches([], ["milk"])).toBe(0);
+		expect(countActionSearchKeywordMatches(["buy milk"], [])).toBe(0);
+		expect(
+			countActionSearchKeywordMatches(["PLEASE REPLY SOON"], ["reply"]),
+		).toBe(1);
+		expect(
+			countActionSearchKeywordMatches(["forwarding this along"], ["forward"]),
+		).toBe(0);
+	});
+});


### PR DESCRIPTION

## What

Adds unit test coverage for `packages/core/src/i18n/action-search-keywords.ts` by appending a new `describe("action-search-keywords resolution edge cases")` block (11 cases) to the existing suite at `packages/core/src/i18n/action-search-keywords.test.ts`.

**Additive only:** the diff is `+115/-0` against one test file. No existing case, import, or line was modified or removed; no production source changed.

## New coverage

- `actionNameToKeywordStem`: digit boundaries (`send2FA-code` -> `send2FaCode`), separator/underscore noise (`-__ create--task __-`), single uppercase word, empty string.
- `getActionSearchKeywordSources`: empty result when neither name nor contexts resolve; dotted keys from nested docs (`action.createTask.request`); action stem ordered before context stems; stem deduplication when the action name and three contexts (`automation`, `productivity`, `tasks`) all contribute `action.createTask`; context normalization (`"  TASKS "` works; numbers, `null`, booleans, blanks, unknown contexts are ignored); non-array context values treated as no contexts; exact source-key set for the `tasks` context (`contextSignal.tasks.strong`, `action.createTask.request`, `action.manageTasks.request`); merged sources for a stem shared by two contexts (`phone` + `messaging` both map `contextSignal.send_message` -> exactly `strong` and `weak` once each).
- `getActionSearchKeywordTerms`: locale terms included by default and omitted with `includeAllLocales: false` (anchored on real data: base term `task` first, Spanish-only `tarea` present/absent); cross-source case-insensitive term deduplication (`reminder` appears in both `contextSignal.tasks.strong` and `action.createTask.request` bases yet survives once).
- `countActionSearchKeywordMatches`: repeated terms count once (set semantics); empty texts or terms return 0; case-insensitive match (`PLEASE REPLY SOON` vs `reply`); ASCII word-boundary semantics (`forward` does not match `forwarding`).

All assertions drive the real module and its generated keyword data — no mocks.

## Evidence (test-only change)

- `bunx vitest run packages/core/src/i18n/action-search-keywords.test.ts`: **1 file passed, 15 passed (15)** — 4 pre-existing + 11 new.
- `bunx biome check --write` on the touched file: clean ("No fixes applied" on re-check).
- `bunx tsc --noEmit` in `packages/core`: zero mentions of `action-search-keywords.test` in output.
- Diff touches exactly one file: `packages/core/src/i18n/action-search-keywords.test.ts`, `+115/-0`.

Note: this is a fork contribution, so hosted CI does not run on this pull request; the local runs above are the verification record.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cda14614d6fab7f454bcb305e96380975b937649 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
