### PR TITLE
test(ui): cover client-agent

### DIFF
--- a/packages/ui/src/api/client-agent.test.ts
+++ b/packages/ui/src/api/client-agent.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Unit coverage for uncovered `ElizaClient` verbs contributed by
+ * `./client-agent`: bootstrap-exchange status mapping, PTY session lifecycle
+ * (spawn/stop/subscribe/resize/legacy scrollback fallback), overlay-layout and
+ * stream-source plumbing, and the `chunkPtyInput` cap/surrogate branches not
+ * exercised by the shared paste suite. Transport stubbed, no live agent.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { chunkPtyInput, MAX_PTY_INPUT_CHUNK_LENGTH } from "./client-agent";
+import { ElizaClient } from "./client-base";
+
+function makeClient(): {
+  client: ElizaClient;
+  sent: Array<Record<string, unknown>>;
+} {
+  setBootConfig({ branding: {} });
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  const sent: Array<Record<string, unknown>> = [];
+  vi.spyOn(client, "sendWsMessage").mockImplementation(
+    (data: Record<string, unknown>) => {
+      sent.push(data);
+    },
+  );
+  return { client, sent };
+}
+
+function stubFetch(
+  client: ElizaClient,
+  respond: (
+    path: string,
+    init?: unknown,
+    options?: unknown,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(respond);
+  client.fetch = fetchMock as unknown as typeof client.fetch;
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("postBootstrapExchange", () => {
+  it("returns a typed success and POSTs the token with allowNonOk parsing", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () =>
+        ({
+          sessionId: "sess-1",
+          expiresAt: 1893456000000,
+          identityId: "id-1",
+        }) as Record<string, unknown>,
+    );
+
+    const result = await client.postBootstrapExchange("tok-1");
+
+    expect(result).toEqual({
+      ok: true,
+      sessionId: "sess-1",
+      expiresAt: 1893456000000,
+      identityId: "id-1",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/bootstrap/exchange",
+      { method: "POST", body: JSON.stringify({ token: "tok-1" }) },
+      { allowNonOk: true },
+    );
+  });
+
+  it.each([
+    ["rate_limited", 429],
+    ["db_unavailable", 503],
+    ["missing_issuer_env", 503],
+    ["missing_container_env", 503],
+    ["missing_token", 400],
+    ["unrecognized_reason", 401],
+  ])("maps reason %s to status %s", async (reason, status) => {
+    const { client } = makeClient();
+    stubFetch(
+      client,
+      async () => ({ error: "boom", reason }) as Record<string, unknown>,
+    );
+
+    const result = await client.postBootstrapExchange("tok-1");
+
+    expect(result).toEqual({
+      ok: false,
+      status,
+      error: "boom",
+      reason,
+    });
+  });
+
+  it("falls back to the generic error when the failure body omits one", async () => {
+    const { client } = makeClient();
+    stubFetch(client, async () => ({}) as Record<string, unknown>);
+
+    const result = await client.postBootstrapExchange("tok-1");
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: "exchange_failed",
+    });
+  });
+
+  it("rejects a partial success body instead of faking a session", async () => {
+    const { client } = makeClient();
+    stubFetch(
+      client,
+      async () => ({ sessionId: "only-sid" }) as Record<string, unknown>,
+    );
+
+    const result = await client.postBootstrapExchange("tok-1");
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: "exchange_failed",
+    });
+  });
+});
+
+describe("PTY session lifecycle verbs", () => {
+  it("spawns a PTY session by POSTing the JSON options and unwrapping sessionId", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () =>
+        ({ session: { sessionId: "pty-9" } }) as Record<string, unknown>,
+    );
+
+    const result = await client.spawnPtySession({ kind: "eliza-code" });
+
+    expect(result).toEqual({ sessionId: "pty-9" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/pty/sessions", {
+      method: "POST",
+      body: JSON.stringify({ kind: "eliza-code" }),
+    });
+  });
+
+  it("serializes omitted spawn options into an empty JSON object body", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () =>
+        ({ session: { sessionId: "pty-0" } }) as Record<string, unknown>,
+    );
+
+    const result = await client.spawnPtySession();
+
+    expect(result).toEqual({ sessionId: "pty-0" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/pty/sessions", {
+      method: "POST",
+      body: "{}",
+    });
+  });
+
+  it("stops a session with DELETE against the URI-encoded path", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () => ({ ok: true }) as Record<string, unknown>,
+    );
+
+    const result = await client.stopPtySession("a b/c");
+
+    expect(result).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("/api/pty/sessions/a%20b%2Fc", {
+      method: "DELETE",
+    });
+  });
+
+  it("translates a failed stop request into an explicit false", async () => {
+    const { client } = makeClient();
+    client.fetch = vi.fn(async () => {
+      throw new Error("agent offline");
+    });
+
+    const result = await client.stopPtySession("sess-1");
+
+    expect(result).toBe(false);
+  });
+
+  it("sends exact WS frames for subscribe, unsubscribe, and resize in call order", () => {
+    const { client, sent } = makeClient();
+
+    client.subscribePtyOutput("s-1");
+    client.resizePty("s-1", 132, 43);
+    client.unsubscribePtyOutput("s-1");
+
+    expect(sent).toEqual([
+      { type: "pty-subscribe", sessionId: "s-1" },
+      { type: "pty-resize", sessionId: "s-1", cols: 132, rows: 43 },
+      { type: "pty-unsubscribe", sessionId: "s-1" },
+    ]);
+  });
+});
+
+describe("getPtyBufferedOutput scrollback hydration", () => {
+  it("returns primary-route output verbatim", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(client, async (path) => {
+      if (path === "/api/pty/sessions/s-1/buffered-output") {
+        return { output: "scrollback text" };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await client.getPtyBufferedOutput("s-1");
+
+    expect(result).toBe("scrollback text");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes a missing output field on the primary route without falling back", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(client, async (path) => {
+      if (path === "/api/pty/sessions/s-1/buffered-output") {
+        return { output: null };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const result = await client.getPtyBufferedOutput("s-1");
+
+    expect(result).toBe("");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries older coding-agent sessions behind the legacy route", async () => {
+    const { client } = makeClient();
+    const seenPaths: string[] = [];
+    stubFetch(client, async (path) => {
+      seenPaths.push(path);
+      if (path === "/api/pty/sessions/old-1/buffered-output") {
+        throw new Error("404 — legacy session");
+      }
+      return { output: "legacy scrollback" };
+    });
+
+    const result = await client.getPtyBufferedOutput("old-1");
+
+    expect(result).toBe("legacy scrollback");
+    expect(seenPaths).toEqual([
+      "/api/pty/sessions/old-1/buffered-output",
+      "/api/coding-agents/old-1/buffered-output",
+    ]);
+  });
+
+  it("degrades to an empty replay when both routes fail", async () => {
+    const { client } = makeClient();
+    client.fetch = vi.fn(async () => {
+      throw new Error("agent unreachable");
+    });
+
+    const result = await client.getPtyBufferedOutput("s-1");
+
+    expect(result).toBe("");
+  });
+
+  it("URI-encodes the sessionId on both routes", async () => {
+    const { client } = makeClient();
+    const seenPaths: string[] = [];
+    stubFetch(client, async (path) => {
+      seenPaths.push(path);
+      if (path.endsWith("buffered-output") && path.includes("coding-agents")) {
+        return { output: "ok" };
+      }
+      throw new Error("use legacy route");
+    });
+
+    await client.getPtyBufferedOutput("a b");
+
+    expect(seenPaths[0]).toBe("/api/pty/sessions/a%20b/buffered-output");
+    expect(seenPaths[1]).toBe("/api/coding-agents/a%20b/buffered-output");
+  });
+});
+
+describe("overlay layout and stream source plumbing", () => {
+  it("omits the query string when no destination is given for reads", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () => ({ ok: true, layout: null }) as Record<string, unknown>,
+    );
+
+    await client.getOverlayLayout();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/stream/overlay-layout");
+  });
+
+  it("URI-encodes the destination filter on reads and writes", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () => ({ ok: true }) as Record<string, unknown>,
+    );
+
+    await client.getOverlayLayout("dest/1");
+    await client.saveOverlayLayout({ left: 1 }, "d 1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/stream/overlay-layout?destination=dest%2F1",
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/stream/overlay-layout?destination=d%201",
+      { method: "POST", body: JSON.stringify({ layout: { left: 1 } }) },
+    );
+  });
+
+  it("drops an absent customUrl from the serialized stream-source body", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () => ({ ok: true }) as Record<string, unknown>,
+    );
+
+    await client.setStreamSource("camera");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/stream/source", {
+      method: "POST",
+      body: '{"sourceType":"camera"}',
+    });
+  });
+
+  it("keeps a provided customUrl in the stream-source body", async () => {
+    const { client } = makeClient();
+    const fetchMock = stubFetch(
+      client,
+      async () => ({ ok: true }) as Record<string, unknown>,
+    );
+
+    await client.setStreamSource("custom", "rtsp://host/stream");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/stream/source", {
+      method: "POST",
+      body: JSON.stringify({
+        sourceType: "custom",
+        customUrl: "rtsp://host/stream",
+      }),
+    });
+  });
+});
+
+describe("chunkPtyInput — cap boundaries beyond the shared paste suite", () => {
+  it("pins the exported default cap at the server's 4096-unit limit", () => {
+    expect(MAX_PTY_INPUT_CHUNK_LENGTH).toBe(4096);
+  });
+
+  it("honors an explicit smaller maxLength", () => {
+    expect(chunkPtyInput("abcdefghij", 4)).toEqual(["abcd", "efgh", "ij"]);
+    expect(chunkPtyInput("abcde", 5)).toEqual(["abcde"]);
+    expect(chunkPtyInput("abcdef", 5)).toEqual(["abcde", "f"]);
+  });
+
+  it("leaves the cut alone when a LOW surrogate sits at the boundary", () => {
+    // The pair's low half at end-1 is not a high surrogate, so the chunker
+    // keeps the natural cut — which here still contains the whole pair.
+    expect(chunkPtyInput("\uD83D\uDE00ab", 2)).toEqual(["\uD83D\uDE00", "ab"]);
+  });
+
+  it("documents the degenerate width-1 guard that splits pairs into lone surrogates", () => {
+    // The end - start > 1 guard disables surrogate handling entirely at
+    // width 1; each UTF-16 unit becomes its own chunk. Observed behavior.
+    expect(chunkPtyInput("\uD83D\uDE00x", 1)).toEqual([
+      "\uD83D",
+      "\uDE00",
+      "x",
+    ]);
+  });
+
+  it("reassembles mixed ASCII and emoji under a small odd cap", () => {
+    const input = `log ${"x".repeat(17)} done \u{1F600} tail`;
+    const chunks = chunkPtyInput(input, 5);
+
+    expect(chunks.join("")).toBe(input);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(5);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

No linked issue: standalone test-coverage addition for an untested module, filed per the repository's coverage-lane practice.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and sits exactly at the current `origin/develop` tip (`c0801ba95ef008b72152116ba22d1f2bbf134858`, re-fetched immediately before filing); the diff is one new file, so no conflicts are possible.
- [x] Scoped verification was run instead of the full `bun run verify` gate because this PR is strictly test-additive (exact commands and observed counts under **Testing**). No failure is being hidden.
- [x] A reviewer can confirm the change from the evidence attached below without reading the code.

# Sync with develop

- [x] Branch cut from the `origin/develop` head at filing time; re-fetched and confirmed develop had not moved (`c0801ba95ef008b72152116ba22d1f2bbf134858`) and that no same-named suite exists on it.
- [x] Full `bun run verify` intentionally not run for this test-only diff; scoped gates are quoted verbatim under **Testing**.

# Risks

**Low.** The diff is one new file, `packages/ui/src/api/client-agent.test.ts`, `+387/-0`. It changes no production source, no exports, no routes, no schemas, and no configuration. Worst case is a flaky or wrong assertion, which can only affect CI signal, not runtime behavior. Existing suites for this module (including `client-agent-pty-input.test.ts`) are untouched — this PR adds coverage only for surfaces they do not reach.

# Background

## What does this PR do?

Adds a unit suite for the agent-domain client module `packages/ui/src/api/client-agent.ts`, which had no same-named test file anywhere in the repository on `origin/develop`.

All assertions drive the real module through `ElizaClient` with only the transport stubbed (the house pattern used by sibling suites in `packages/ui/src/api/`). Coverage added:

- **`postBootstrapExchange`**: success requires all three typed fields before `ok: true`; a partial success body is rejected rather than faked; reason→status bucket mapping (`rate_limited`→429; `db_unavailable`/`missing_issuer_env`/`missing_container_env`→503; `missing_token`→400; unknown→401); default `exchange_failed` error; request POSTs `{token}` with `allowNonOk` parsing.
- **PTY session lifecycle verbs**: `spawnPtySession` JSON body serialization (omitted options → `{}`) and `res.session.sessionId` unwrapping; `stopPtySession` DELETE against the URI-encoded path, success → `true`, transport failure → explicit `false`; exact WS frames for `subscribePtyOutput` / `unsubscribePtyOutput` / `resizePty` in call order.
- **`getPtyBufferedOutput` scrollback hydration**: primary-route output verbatim; missing-output normalized to `""` without a fallback call; legacy `/api/coding-agents/:id/buffered-output` retry on primary failure; empty-string degrade when both routes fail; sessionId URI-encoded on both routes.
- **Overlay / stream-source plumbing**: query string omitted when no destination is supplied; destination filters URI-encoded on read and write; `{layout}` envelope on save; absent `customUrl` dropped from the serialized body while a provided URL is kept.
- **`chunkPtyInput` branches beyond the shared paste suite** (`client-agent-pty-input.test.ts` already covers paste splitting + surrogate protection at the 4096 cap): exported cap pinned at 4096; explicit smaller `maxLength` honored; low-surrogate-at-cut left unshifted (pair whole by construction); degenerate width-1 guard documented as observed behavior (one lone surrogate per unit); lossless reassembly of mixed ASCII+emoji under a small odd cap.

No `vi.mock` of the system under test, no `vi.hoisted`, no type-level assertions — expectations record what the module actually does on current `develop`.

## What kind of change is this?

Improvements (misc. changes to existing features) — test-only, behavior-preserving.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/api/client-agent.test.ts`, then re-run the single command under **Detailed testing steps**.

## Detailed testing steps

All commands were run from `packages/ui` on the exact PR head tree, with `biome.json` / root `tsconfig.json` present and the worktree confirmed non-sparse (so the tools ran with real configuration):

```text
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" \
  bunx vitest run src/api/client-agent.test.ts
→ Test Files  1 passed (1)
→ Tests       28 passed (28)
```

Re-fetched `origin/develop` (still `c0801ba95ef…`, unchanged) and re-ran the identical command immediately before filing: **1 file passed, 28/28 tests passed**.

```text
bunx biome check --write src/api/client-agent.test.ts
→ first invocation applied formatting fixes to the new file;
  final read-only check: "Checked 1 file in 166ms. No fixes applied."

bunx tsc --noEmit   # from packages/ui
→ exit 1 with 11 pre-existing diagnostics in unrelated files
  (src/cloud/public-pages/* missing libphonenumber-js types,
   DevicesRuntimesSection.tsx missing @paulmillr/qr, auth-client.test.ts);
  the string "client-agent.test" appears nowhere in the compiler output —
  zero new errors introduced by this diff.
```

None: automated tests are acceptable. Reviewer reproduction is the single `bunx vitest run` command above.

# Evidence Gate

Evidence must match the exact commit reviewed. Head SHA at filing: `c0801ba95ef008b72152116ba22d1f2bbf134858`.

This is a frontend-package but non-UI test-only change: no rendered surface is touched and no runtime behavior changes, so the capture-based rows do not apply. Every applicable row is marked with a concrete reason rather than left blank.

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff; no UI surface affected`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; no UI surface affected`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only diff; no user flow changed`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no production code path modified; the vitest summary above is the executable proof`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no rendered surface involved; the suite runs pure client logic under vitest`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model call path modified; the suite stubs only the HTTP/WS transport`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - suite asserts captured WS frames and stubbed-fetch calls inside vitest; no persistent artifacts outside the test process`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface`

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; the suite exercises already-shipped client verbs offline.`

## Backend + frontend logs

`N/A - nothing to attach beyond the tool summaries quoted under Testing.`

## Screenshots (before / after) + video walkthrough

`N/A - test-only change with no visual diff (no .tsx/.css/.svg files touched).`

## Known gaps / failures

- Full `bun run verify` was not executed for this PR; per the test-only evidence bar, verification is exactly: the focused vitest run (quoted, re-run against current `origin/develop` immediately before filing), a clean `biome check` on the touched file, and `tsc --noEmit` on the owning package with the new file absent from all diagnostics.
- This contribution comes from a fork: hosted GitHub Actions CI does not run on this pull request. All green results above are local runs against the exact head commit, not hosted CI.
- One assertion was corrected during development to match observed behavior (`saveOverlayLayout` serializes `{ layout }` as an envelope) rather than an assumed shape.

## Maintainer CI exception record

`N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c0801ba95ef008b72152116ba22d1f2bbf134858 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
