### PR TITLE
test(cloud): cover Worker runtime bindings shim

### DIFF
--- a/packages/cloud/shared/src/lib/runtime/cloud-bindings.test.ts
+++ b/packages/cloud/shared/src/lib/runtime/cloud-bindings.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Covers the per-request Worker bindings shim.
+ *
+ * On Workers, secrets live on `c.env` rather than `process.env`, so
+ * `getCloudAwareEnv()` overlays the request store on top of the process
+ * environment. Two rules make that safe: only STRING bindings shadow — a
+ * non-string binding (R2 bucket, Queue, Hyperdrive config) must fall through to
+ * `process.env` rather than being handed to a caller expecting a secret string
+ * — and outside a request the process environment is returned untouched, so
+ * Node callers are unaffected.
+ *
+ * Environment writes are scoped to this suite's own variable names and undone
+ * afterwards.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getCloudAwareEnv,
+  getCloudBinding,
+  hasCloudBindingsContext,
+  runWithCloudBindings,
+  runWithCloudBindingsAsync,
+} from "./cloud-bindings";
+
+const VAR = "TEST_CLOUD_BINDING_VAR";
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  delete process.env[VAR];
+});
+
+describe("outside a request", () => {
+  test("reports no bindings context", () => {
+    expect(hasCloudBindingsContext()).toBe(false);
+  });
+
+  test("returns process.env itself, not a copy or proxy", () => {
+    expect(getCloudAwareEnv()).toBe(process.env);
+  });
+
+  test("reads a process variable normally", () => {
+    process.env[VAR] = "from-process";
+    expect(getCloudAwareEnv()[VAR]).toBe("from-process");
+  });
+
+  test("resolves no worker binding", () => {
+    expect(getCloudBinding("ANY")).toBeUndefined();
+  });
+});
+
+describe("inside a request", () => {
+  test("reports a bindings context", () => {
+    expect(runWithCloudBindings({}, () => hasCloudBindingsContext())).toBe(true);
+  });
+
+  test("a string binding shadows the process variable", () => {
+    process.env[VAR] = "from-process";
+    const seen = runWithCloudBindings({ [VAR]: "from-worker" }, () => getCloudAwareEnv()[VAR]);
+    expect(seen).toBe("from-worker");
+  });
+
+  test("a string binding is visible even with no process variable", () => {
+    const seen = runWithCloudBindings({ [VAR]: "worker-only" }, () => getCloudAwareEnv()[VAR]);
+    expect(seen).toBe("worker-only");
+  });
+
+  test("falls through to process.env for an unbound name", () => {
+    process.env[VAR] = "from-process";
+    expect(runWithCloudBindings({ OTHER: "x" }, () => getCloudAwareEnv()[VAR])).toBe(
+      "from-process",
+    );
+  });
+
+  test("a NON-string binding does not shadow the process variable", () => {
+    // R2 buckets, Queues and Hyperdrive configs live in the same store; handing
+    // one to a caller expecting a secret string would be worse than missing it.
+    process.env[VAR] = "from-process";
+    for (const binding of [{ bucket: true }, 42, null, undefined, ["a"], () => "x"]) {
+      const seen = runWithCloudBindings({ [VAR]: binding }, () => getCloudAwareEnv()[VAR]);
+      expect(seen).toBe("from-process");
+    }
+  });
+
+  test("does not leak the store's inherited properties as env values", () => {
+    const store = Object.create({ INHERITED: "nope" }) as Record<string, unknown>;
+    expect(runWithCloudBindings(store, () => getCloudAwareEnv().INHERITED)).toBeUndefined();
+  });
+
+  test("passes symbol lookups through to process.env", () => {
+    const seen = runWithCloudBindings({ [VAR]: "from-worker" }, () =>
+      Object.prototype.toString.call(getCloudAwareEnv()),
+    );
+    expect(seen).toBe("[object Object]");
+  });
+
+  test("clears the context once the scope exits", () => {
+    runWithCloudBindings({ [VAR]: "from-worker" }, () => undefined);
+    expect(hasCloudBindingsContext()).toBe(false);
+    expect(getCloudAwareEnv()).toBe(process.env);
+  });
+
+  test("returns the callback's value", () => {
+    expect(runWithCloudBindings({}, () => 7)).toBe(7);
+  });
+});
+
+describe("getCloudBinding", () => {
+  test("returns a non-string binding the env view deliberately hides", () => {
+    const bucket = { put: () => undefined };
+    expect(runWithCloudBindings({ R2: bucket }, () => getCloudBinding("R2"))).toBe(bucket);
+  });
+
+  test("returns undefined for an unbound name inside a request", () => {
+    expect(runWithCloudBindings({ A: 1 }, () => getCloudBinding("B"))).toBeUndefined();
+  });
+});
+
+describe("scoping", () => {
+  test("a nested scope shadows and then restores the outer bindings", () => {
+    const observed = runWithCloudBindings({ [VAR]: "outer" }, () => {
+      const inner = runWithCloudBindings({ [VAR]: "inner" }, () => getCloudAwareEnv()[VAR]);
+      return { inner, after: getCloudAwareEnv()[VAR] };
+    });
+    expect(observed).toEqual({ inner: "inner", after: "outer" });
+  });
+
+  test("the async variant survives an await boundary", async () => {
+    const seen = await runWithCloudBindingsAsync({ [VAR]: "from-worker" }, async () => {
+      await tick();
+      return getCloudAwareEnv()[VAR];
+    });
+    expect(seen).toBe("from-worker");
+  });
+
+  test("concurrent requests never observe each other's bindings", async () => {
+    const [a, b] = await Promise.all([
+      runWithCloudBindingsAsync({ [VAR]: "req-a" }, async () => {
+        await tick();
+        await tick();
+        return getCloudAwareEnv()[VAR];
+      }),
+      runWithCloudBindingsAsync({ [VAR]: "req-b" }, async () => {
+        await tick();
+        return getCloudAwareEnv()[VAR];
+      }),
+    ]);
+    expect([a, b]).toEqual(["req-a", "req-b"]);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/cloud/shared/src/lib/runtime/cloud-bindings.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `c0801ba95ef008b72152116ba22d1f2bbf134858`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The outside-a-request case asserts **object identity** (`toBe(process.env)`), so a regression that started returning a proxy or copy on the Node path would fail rather than pass on equality. The non-string rule is exercised across six binding shapes rather than one. Environment writes are confined to a single suite-specific variable name and undone in `afterEach`.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/runtime/cloud-bindings.ts` is how every shared library reads secrets on Workers, where they live on `c.env` rather than `process.env`. It had **no dedicated test file**.

Two rules make the overlay safe, and both are pinned:

| Rule | Why it matters |
|---|---|
| only **string** bindings shadow | R2 buckets, Queues, and Hyperdrive configs live in the same store; handing one to a caller expecting a secret string is worse than the value being missing. Asserted for object, number, `null`, `undefined`, array, and function bindings. |
| outside a request, `process.env` is returned untouched | asserted by object **identity**, so Node callers are provably unaffected |

Also covered: an unbound name falls through to `process.env`; the store's **inherited** properties do not leak as env values; symbol lookups pass through to the target; `getCloudBinding` returns exactly the non-string bindings the env view hides; a nested scope shadows then restores the outer bindings; the context clears once a scope exits; the async variant survives an `await`; and two concurrent requests never observe each other's bindings.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/runtime/cloud-bindings.test.ts`, the "a NON-string binding does not shadow the process variable" case.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/runtime/cloud-bindings.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:6c1c18066c8192bb20e9c8c3bfd0dd300a66fe9f -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ bun test src/lib/runtime/cloud-bindings.test.ts
 18 pass
 0 fail
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 18/18 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is identity assertions on the Node path and six binding shapes on the non-string rule.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
