### PR TITLE
release: promote develop to main (2026-08-23 voice latency)

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -209,7 +209,10 @@ app.post("/", async (c) => {
     );
     const priorConversationPromise = Promise.resolve(
       dbRead
-        .select({ messages: sharedRuntimeHistory.messages })
+        // Continuity needs only evidence and recency, never the potentially
+        // large JSON history payload. The media turn hydrates complete history
+        // separately through the canonical conversation Durable Object.
+        .select({ updatedAt: sharedRuntimeHistory.updated_at })
         .from(sharedRuntimeHistory)
         .where(
           and(
@@ -232,7 +235,9 @@ app.post("/", async (c) => {
       ...(priorCall?.receivedAt
         ? { priorCallAt: priorCall.receivedAt.getTime() }
         : {}),
-      historyMessages: priorConversation ? priorConversation.messages : [],
+      historyMessages: priorConversation
+        ? [{ createdAt: priorConversation.updatedAt.getTime() }]
+        : [],
     });
     callOpening = await claimInboundCallOpeningContext(
       {

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -336,6 +336,7 @@ app.get("/", async (c) => {
   ): Promise<void> => {
     if (session || starting || closed) return;
     starting = true;
+    const bootstrapStartedAt = Date.now();
     if (event.streamSid !== event.start.streamSid) {
       closeBootstrapBoundary(1008, "stream identity mismatch");
       return;
@@ -366,6 +367,7 @@ app.get("/", async (c) => {
       closeBootstrapBoundary(1008, "invalid stream bootstrap");
       return;
     }
+    const tokenVerifiedAt = Date.now();
     const claim = await awaitTwilioBootstrapPhase(
       claimVoiceSessionToken(claims.jti, claims.exp, rawRedis ?? undefined),
       () => closed,
@@ -376,6 +378,7 @@ app.get("/", async (c) => {
       closeBootstrapBoundary(1008, "stream bootstrap already used");
       return;
     }
+    const tokenClaimedAt = Date.now();
     if (
       event.start.callSid !== claims.callSid ||
       event.start.accountSid !== claims.accountSid
@@ -456,11 +459,16 @@ app.get("/", async (c) => {
       downlink,
     });
     session.start();
+    const sessionStartedAt = Date.now();
     for (const frame of pendingMedia.splice(0)) session.pushUplinkAudio(frame);
     logger.info("[twilio-media] realtime call connected", {
       callSid: event.start.callSid,
       streamSid,
       agentId: claims.agentId,
+      tokenVerificationMs: tokenVerifiedAt - bootstrapStartedAt,
+      tokenClaimMs: tokenClaimedAt - tokenVerifiedAt,
+      sessionConstructionMs: sessionStartedAt - tokenClaimedAt,
+      bootstrapTotalMs: sessionStartedAt - bootstrapStartedAt,
     });
   };
 

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -90,11 +90,11 @@ export async function hydrateVoiceSharedAgentScope(
           );
         };
 
-        // Publish the authorization gate as soon as the authoritative agent
-        // lookup succeeds. Character and admission prefills are latency hints;
-        // keeping this write behind either one turns a slow optional dependency
-        // into the full 503/backoff staircase on the caller's first response.
-        await cache.set(
+        // Start every independent warmup immediately after authoritative scope
+        // validation. In particular, the exact conversation Durable Object now
+        // loads history and the AgentRuntime kernel while the Redis scope write
+        // is in flight instead of waiting behind that network round trip.
+        const scopeWrite = cache.set(
           CacheKeys.sharedAgentScope.voice(
             claims.organizationId,
             claims.userId,
@@ -103,11 +103,10 @@ export async function hydrateVoiceSharedAgentScope(
           agent,
           CacheTTL.sharedAgentScope.resolve,
         );
-
-        // error-policy:J7 a failed character prefill leaves the next turn on
-        // its existing retryable warming path rather than failing hydration.
         const optionalWarmups: Promise<unknown>[] = [
           hydrateCharacter().catch((error) => {
+            // error-policy:J7 character hydration is latency-only; the next
+            // turn retains the canonical typed cache-warming retry fallback.
             logger.warn("[voice-scope-hydration] character prefill failed", {
               agentId: claims.agentId,
               characterId,
@@ -181,6 +180,11 @@ export async function hydrateVoiceSharedAgentScope(
             }),
           );
         }
+
+        // Publish the authorization gate as soon as its own write completes.
+        // Optional warmups are latency hints and never delay this gate; their
+        // failures remain contained on the existing retryable turn path.
+        await scopeWrite;
         await Promise.all(optionalWarmups);
       }),
   );

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -10,8 +10,6 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { Service, ServiceType } from "@elizaos/core";
 import { getDocumentProxy } from "unpdf";
-import { parsePdfSpecDate } from "./pdf-date.ts";
-
 import type {
   PdfConversionResult,
   PdfDocumentInfo,
@@ -19,6 +17,7 @@ import type {
   PdfMetadata,
   PdfPageInfo,
 } from "../types";
+import { parsePdfSpecDate } from "./pdf-date.js";
 
 type PdfTextItem = { str: string };
 
@@ -145,7 +144,7 @@ function normalizeExtractionOptions(
  * `info.CreationDate`/`info.ModDate`, not an ISO-8601 string. The groups mirror
  * `PDFDateString.toDateObject` in pdf.js so real-world documents round-trip.
  */
-export { parsePdfSpecDate } from "./pdf-date.ts";
+export { parsePdfSpecDate } from "./pdf-date.js";
 
 function parseMetadataDate(value: unknown): Date | undefined {
   if (value instanceof Date) {


### PR DESCRIPTION
## Promotion
Promotes the current exact `develop` head `0d9b34de51319e2bd592b67d2d651cbe8ae3d57c` to production.

Includes the reviewed voice cold-start optimization from #26657:
- overlaps exact conversation Durable Object / AgentRuntime prewarm with Redis scope publication
- avoids loading full history JSON for greeting continuity
- adds privacy-bounded media bootstrap timings

## Evidence
- #26657 exact-head PR Static Smoke: pass
- cloud API typecheck + production Worker dry-run: pass
- focused voice/runtime/persona contracts: pass
- production routing intentionally unchanged

## Acceptance
After deployment, verify production health at the merge SHA and place a fresh +1 808 788 1821 call to collect bootstrap, EOT, planner/provider, and first-audio timings.