### PR TITLE
test(ui): cover client-types-core

### DIFF
--- a/packages/ui/src/api/client-types-core.error-guards.test.ts
+++ b/packages/ui/src/api/client-types-core.error-guards.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Covers the runtime surface of client-types-core: ApiError construction and
+ * property semantics plus the isApiError / isRateLimitedError /
+ * isCloudAgentGoneError guards. Complements client-types-core.api-error.test.ts,
+ * which pins the structured-body privacy contract.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  ApiError,
+  isApiError,
+  isCloudAgentGoneError,
+  isRateLimitedError,
+} from "./client-types-core";
+
+function wrapError(cause: unknown): Error {
+  const wrapper = new Error("agent selection failed");
+  (wrapper as Error & { cause?: unknown }).cause = cause;
+  return wrapper;
+}
+
+describe("ApiError construction", () => {
+  test("is an Error named ApiError carrying its classification fields", () => {
+    const error = new ApiError({
+      kind: "http",
+      path: "/api/agents",
+      status: 402,
+      code: "insufficient_credits",
+      message: "insufficient credits",
+      retryAfter: 30,
+    });
+
+    expect(error instanceof Error).toBe(true);
+    expect(error.name).toBe("ApiError");
+    expect(error.message).toBe("insufficient credits");
+    expect(error.kind).toBe("http");
+    expect(error.path).toBe("/api/agents");
+    expect(error.status).toBe(402);
+    expect(error.code).toBe("insufficient_credits");
+    expect(error.retryAfter).toBe(30);
+  });
+
+  test("stores optional fields as undefined when omitted", () => {
+    const error = new ApiError({
+      kind: "network",
+      path: "/api/status",
+      message: "connection refused",
+    });
+
+    expect(error.status).toBeUndefined();
+    expect(error.code).toBeUndefined();
+    expect(error.retryAfter).toBeUndefined();
+    expect(error.data).toBeUndefined();
+  });
+
+  test("keeps the parsed body readable but hidden from enumeration and writes", () => {
+    const body = { error: "quota_exceeded", detail: "plan limit" };
+    const error = new ApiError({
+      kind: "http",
+      path: "/api/test",
+      message: "failed",
+      status: 402,
+      data: body,
+    });
+
+    expect(error.data).toBe(body);
+    const descriptor = Object.getOwnPropertyDescriptor(error, "data");
+    expect(descriptor?.enumerable).toBe(false);
+    expect(descriptor?.writable).toBe(false);
+    expect(descriptor?.configurable).toBe(false);
+    expect(Object.keys(error)).not.toContain("data");
+    expect(JSON.stringify(error)).not.toContain("plan limit");
+  });
+
+  test("wires cause through to the underlying error and leaves it unset otherwise", () => {
+    const root = new Error("socket hang up");
+    const wrapped = new ApiError({
+      kind: "timeout",
+      path: "/api/chat",
+      message: "request timed out",
+      cause: root,
+    });
+    expect(wrapped.cause).toBe(root);
+
+    const unwrapped = new ApiError({
+      kind: "parse",
+      path: "/api/chat",
+      message: "bad json",
+    });
+    expect(unwrapped.cause).toBeUndefined();
+  });
+});
+
+describe("isApiError", () => {
+  test("accepts ApiError instances only", () => {
+    const apiError = new ApiError({
+      kind: "network",
+      path: "/api/x",
+      message: "boom",
+    });
+    expect(isApiError(apiError)).toBe(true);
+    expect(isApiError(new Error("plain"))).toBe(false);
+    expect(isApiError(null)).toBe(false);
+    expect(isApiError(undefined)).toBe(false);
+    expect(isApiError("timeout")).toBe(false);
+    expect(isApiError({ kind: "timeout", path: "/api/x" })).toBe(false);
+  });
+});
+
+describe("isRateLimitedError", () => {
+  test("matches HTTP 429 regardless of the body code", () => {
+    expect(
+      isRateLimitedError(
+        new ApiError({
+          kind: "http",
+          path: "/api/chat",
+          status: 429,
+          message: "slow down",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRateLimitedError(
+        new ApiError({
+          kind: "http",
+          path: "/api/chat",
+          status: 429,
+          code: "rate_limit_exceeded",
+          message: "slow down",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the structured rate-limit code even on another status", () => {
+    expect(
+      isRateLimitedError(
+        new ApiError({
+          kind: "http",
+          path: "/api/chat",
+          status: 500,
+          code: "rate_limit_exceeded",
+          message: "limited",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects other statuses, non-ApiError values, and missing input", () => {
+    expect(
+      isRateLimitedError(
+        new ApiError({
+          kind: "http",
+          path: "/api/chat",
+          status: 503,
+          message: "unavailable",
+        }),
+      ),
+    ).toBe(false);
+    expect(isRateLimitedError({ status: 429 })).toBe(false);
+    expect(
+      isRateLimitedError(Object.assign(new Error("nope"), { status: 429 })),
+    ).toBe(false);
+    expect(isRateLimitedError(null)).toBe(false);
+  });
+});
+
+describe("isCloudAgentGoneError", () => {
+  test("accepts agent_not_found with a 404 or an absent status", () => {
+    expect(
+      isCloudAgentGoneError(
+        new ApiError({
+          kind: "http",
+          path: "/api/agents/a",
+          status: 404,
+          code: "agent_not_found",
+          message: "gone",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isCloudAgentGoneError(
+        new ApiError({
+          kind: "http",
+          path: "/api/agents/a",
+          code: "agent_not_found",
+          message: "gone",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not treat other codes or statuses of the same shape as gone", () => {
+    expect(
+      isCloudAgentGoneError(
+        new ApiError({
+          kind: "http",
+          path: "/api/agents/a",
+          status: 404,
+          code: "agent_not_running",
+          message: "cold",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isCloudAgentGoneError(
+        new ApiError({
+          kind: "http",
+          path: "/api/agents/a",
+          status: 503,
+          code: "agent_not_found",
+          message: "odd",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("walks the cause chain past recoverable states to the definitive row-gone error", () => {
+    const gone = new ApiError({
+      kind: "http",
+      path: "/api/agents/a",
+      status: 404,
+      code: "agent_not_found",
+      message: "row missing",
+    });
+    const cold = new ApiError({
+      kind: "http",
+      path: "/api/agents/a",
+      status: 503,
+      code: "agent_not_running",
+      message: "not running",
+    });
+
+    expect(isCloudAgentGoneError(wrapError(gone))).toBe(true);
+    expect(isCloudAgentGoneError(wrapError(cold))).toBe(false);
+    expect(isCloudAgentGoneError(wrapError(wrapError(cold)))).toBe(false);
+
+    const coldThenGone = new ApiError({
+      kind: "http",
+      path: "/api/agents/a",
+      status: 503,
+      code: "agent_not_running",
+      message: "outer probe",
+      cause: gone,
+    });
+    expect(isCloudAgentGoneError(coldThenGone)).toBe(true);
+
+    const wrongStatusThenGone = new ApiError({
+      kind: "http",
+      path: "/api/agents/a",
+      status: 503,
+      code: "agent_not_found",
+      message: "legacy body",
+      cause: gone,
+    });
+    expect(isCloudAgentGoneError(wrongStatusThenGone)).toBe(true);
+  });
+
+  test("stops walking after five links", () => {
+    const gone = new ApiError({
+      kind: "http",
+      path: "/api/agents/a",
+      status: 404,
+      code: "agent_not_found",
+      message: "gone",
+    });
+
+    let reachable: unknown = gone;
+    for (let depth = 0; depth < 4; depth += 1) {
+      reachable = wrapError(reachable);
+    }
+    expect(isCloudAgentGoneError(reachable)).toBe(true);
+
+    reachable = wrapError(reachable);
+    expect(isCloudAgentGoneError(reachable)).toBe(false);
+  });
+
+  test("rejects non-Error input even when shaped like the gone marker", () => {
+    expect(isCloudAgentGoneError(null)).toBe(false);
+    expect(
+      isCloudAgentGoneError({ code: "agent_not_found", status: 404 }),
+    ).toBe(false);
+    expect(isCloudAgentGoneError("agent_not_found")).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite, `packages/ui/src/api/client-types-core.error-guards.test.ts`, covering the runtime surface of `client-types-core.ts`:

- **`ApiError` construction** — classification fields (`kind`, `path`, `status`, `code`, `retryAfter`) are stored as given; optional fields read back as `undefined` when omitted; the parsed body passed as `data` stays directly readable but is non-enumerable, non-writable and non-configurable (so it is absent from `Object.keys` and from `JSON.stringify` output); `cause` is wired through when provided and unset otherwise.
- **`isApiError`** — accepts only `ApiError` instances; rejects plain `Error`s, lookalike objects, primitives, `null`, `undefined`.
- **`isRateLimitedError`** — matches HTTP 429 regardless of body code, matches the structured `rate_limit_exceeded` code even on another status, rejects other statuses and any non-`ApiError` value.
- **`isCloudAgentGoneError`** — accepts `agent_not_found` with a 404 or an absent status; does not treat `agent_not_running` or a wrong-status `agent_not_found` as gone; walks the `cause` chain past recoverable states to the definitive row-gone error; stops walking after five links (boundary proven at exactly 4 vs 5 wrappers); rejects non-`Error` input even when shaped like the gone marker.

## Why

The module's only existing coverage is `client-types-core.api-error.test.ts`, which pins a single case (structured-body privacy). The three error guards and the constructor's remaining property semantics had no tests. This PR is strictly additive: one new test file, no changes to existing tests or production code.

## Evidence (local runs at head `e71ddba4b1078cd8c4256f531e7a4ab57cf94607`, base origin/develop @ `c0801ba95ef0`)

This PR comes from a contributor fork, so hosted CI does not run on it. All checks were run locally against current `origin/develop` immediately before filing:

- `bunx vitest run src/api/client-types-core.error-guards.test.ts` in `packages/ui` (package vitest.config.ts): **Test Files 1 passed (1), Tests 13 passed (13)**.
- `bunx biome check src/api/client-types-core.error-guards.test.ts`: clean, "No fixes applied" after formatting.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: the new file appears nowhere in the output.
- Diff: exactly one new file, +284/-0. No deletions anywhere.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e71ddba4b1078cd8c4256f531e7a4ab57cf94607 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
