### PR TITLE
fix(cloud): stop leaking the live MCP crucial-tool config to callers

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Covers the two-tier MCP tool visibility config.
+ *
+ * `CRUCIAL_TOOLS` is module-level state, and the crucial action-name set is
+ * built once and cached. So the accessors' documented "returns a copy" contract
+ * is load-bearing: if a caller can reach the live arrays, a single `push` or
+ * `splice` permanently changes which tools every agent sees in its prompt, and
+ * the cached name set makes the corruption inconsistent on top of that.
+ *
+ * Pure config + lookups — no MCP transport.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getAllCrucialTools,
+  getCrucialToolsForServer,
+  isCrucialTool,
+  shouldRegisterRawMcpTools,
+} from "./tool-visibility";
+
+const INJECTED = "injected_tool";
+
+// If an accessor leaks the live array, the mutation cases below would corrupt
+// module state for every later case. Undo it so each case stands alone and the
+// failures reported are the real ones rather than knock-on damage.
+afterEach(() => {
+  for (const tools of Object.values(getAllCrucialTools())) {
+    const at = tools.indexOf(INJECTED);
+    if (at !== -1) tools.splice(at, 1);
+  }
+});
+
+describe("isCrucialTool", () => {
+  test("recognizes a configured tool", () => {
+    expect(isCrucialTool("google", "gmail_send")).toBe(true);
+    expect(isCrucialTool("github", "github_status")).toBe(true);
+  });
+
+  test("normalizes server and tool the same way action naming does", () => {
+    expect(isCrucialTool("Google", "GMAIL_SEND")).toBe(true);
+    expect(isCrucialTool("  google  ", "gmail send")).toBe(true);
+    expect(isCrucialTool("google", "gmail-send")).toBe(true);
+  });
+
+  test("rejects a tool that is not configured for that server", () => {
+    expect(isCrucialTool("google", "gmail_delete_everything")).toBe(false);
+    expect(isCrucialTool("unknown-server", "gmail_send")).toBe(false);
+  });
+
+  test("does not treat a tool as crucial for the wrong server", () => {
+    // `calendar_list_events` is crucial for google and microsoft only.
+    expect(isCrucialTool("github", "calendar_list_events")).toBe(false);
+  });
+
+  test("returns a stable answer across repeated calls", () => {
+    // The name set is built once and cached.
+    expect([
+      isCrucialTool("google", "gmail_send"),
+      isCrucialTool("google", "gmail_send"),
+      isCrucialTool("google", "gmail_send"),
+    ]).toEqual([true, true, true]);
+  });
+});
+
+describe("getCrucialToolsForServer", () => {
+  test("returns the configured tools, matching the server case-insensitively", () => {
+    expect(getCrucialToolsForServer("google")).toContain("gmail_send");
+    expect(getCrucialToolsForServer("GOOGLE")).toContain("gmail_send");
+  });
+
+  test("returns an empty list for an unknown server", () => {
+    expect(getCrucialToolsForServer("nope")).toEqual([]);
+    expect(getCrucialToolsForServer("")).toEqual([]);
+  });
+
+  test("does not hand the caller the live config array", () => {
+    // A push here would permanently change what every agent sees.
+    const first = getCrucialToolsForServer("google");
+    first.push(INJECTED);
+    expect(getCrucialToolsForServer("google")).not.toContain(INJECTED);
+  });
+});
+
+describe("getAllCrucialTools", () => {
+  test("exposes every configured server", () => {
+    const all = getAllCrucialTools();
+    expect(Object.keys(all).length).toBeGreaterThan(0);
+    expect(all.google).toContain("gmail_send");
+  });
+
+  test("is not the live object", () => {
+    const copy = getAllCrucialTools();
+    copy.injectedServer = ["x"];
+    expect(getAllCrucialTools()).not.toHaveProperty("injectedServer");
+  });
+
+  test("does not share its nested arrays with the live config", () => {
+    // A shallow copy still leaks every tool list by reference.
+    const copy = getAllCrucialTools();
+    copy.google?.push(INJECTED);
+    expect(getAllCrucialTools().google).not.toContain(INJECTED);
+    expect(getCrucialToolsForServer("google")).not.toContain(INJECTED);
+  });
+});
+
+describe("config integrity", () => {
+  test("every server lists at least one tool and no duplicates", () => {
+    for (const [server, tools] of Object.entries(getAllCrucialTools())) {
+      expect(tools.length, `${server} must list tools`).toBeGreaterThan(0);
+      expect(new Set(tools).size, `${server} must not repeat a tool`).toBe(tools.length);
+    }
+  });
+
+  test("every configured tool is reported as crucial for its own server", () => {
+    for (const [server, tools] of Object.entries(getAllCrucialTools())) {
+      for (const tool of tools) {
+        expect(isCrucialTool(server, tool), `${server}/${tool}`).toBe(true);
+      }
+    }
+  });
+
+  test("server keys are lowercase, so the lookup can find them", () => {
+    for (const server of Object.keys(getAllCrucialTools())) {
+      expect(server).toBe(server.toLowerCase());
+    }
+  });
+});
+
+describe("shouldRegisterRawMcpTools", () => {
+  test("registers raw tools for an ordinary server", () => {
+    for (const server of ["google", "github", "", "doordash-clone"]) {
+      expect(shouldRegisterRawMcpTools(server)).toBe(true);
+    }
+  });
+
+  test("withholds them for doordash, case- and whitespace-insensitively", () => {
+    for (const server of ["doordash", "DoorDash", "  DOORDASH  "]) {
+      expect(shouldRegisterRawMcpTools(server)).toBe(false);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.ts
@@ -137,14 +137,23 @@ export function isCrucialTool(serverName: string, toolName: string): boolean {
  * Returns the list of crucial tool names for a given server.
  */
 export function getCrucialToolsForServer(serverName: string): string[] {
-  return CRUCIAL_TOOLS[serverName.toLowerCase()] ?? [];
+  // Copy, not the live array: `CRUCIAL_TOOLS` is module state and the crucial
+  // action-name set is built once and cached, so one `push` by a caller would
+  // permanently change which tools every agent sees in its prompt — and do it
+  // inconsistently, because the cached set is not rebuilt.
+  return [...(CRUCIAL_TOOLS[serverName.toLowerCase()] ?? [])];
 }
 
 /**
  * Returns a copy of all crucial tools configuration.
  */
 export function getAllCrucialTools(): Record<string, string[]> {
-  return { ...CRUCIAL_TOOLS };
+  // A spread copies only the outer record; every tool list would still be the
+  // live array. Copy each one so the documented "copy" actually isolates the
+  // caller from the module's configuration.
+  return Object.fromEntries(
+    Object.entries(CRUCIAL_TOOLS).map(([server, tools]) => [server, [...tools]]),
+  );
 }
 
 /** Raw DoorDash tools stay callable by its facade but are never agent actions. */


### PR DESCRIPTION
# Relates to

Found while adding coverage for the previously untested `packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.ts`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red/green evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `0d9b34de51319e2bd592b67d2d651cbe8ae3d57c`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

@@RISKS@@

# Background

## What does this PR do?

`getCrucialToolsForServer` returned `CRUCIAL_TOOLS[server]` **directly**, and `getAllCrucialTools` — documented as returning *"a copy"* — used a spread, which copies only the outer record and leaves every tool list as the live array.

`CRUCIAL_TOOLS` is module state, and the crucial action-name set derived from it is **built once and cached**. So a single `push` or `splice` by any caller:

1. permanently changes which tools every agent sees in its prompt, and
2. does it **inconsistently** — `isCrucialTool` keeps answering from the set captured before the mutation, while the accessors report the mutated list.

Both accessors now return real copies: a fresh array per server, and a fresh record of fresh arrays.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The reasoning is captured as a comment at the call site.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/eliza/plugin-mcp/tool-visibility.test.ts` — the "does not hand the caller the live config array" and "does not share its nested arrays" cases.

## Detailed testing steps

```bash
cd packages/cloud/shared && bun test src/lib/eliza/plugin-mcp/tool-visibility.test.ts
```

To confirm the suite is not vacuous, revert `tool-visibility.ts` (keep the test) and re-run — exactly 2 of 16 fail, and they are the two defects above.

Worth noting: the suite carries an `afterEach` that undoes any leaked-array mutation. Without it the leak makes unrelated config-integrity assertions fail as **collateral** (4 failures instead of 2), which obscures which defect is real. The cleanup keeps the red signal honest.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:7cac837841094f05e526afd0208d15d4586806a1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; this changes a config accessor.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; this changes a config accessor.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the behavior is whether a caller can mutate the shared crucial-tool configuration, evidenced by the test logs below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure function with no logging; the red/green run below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the concrete values produced by the real function before and after are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure function, no logging.` The authoritative record is the red/green run below.

### Red — production fix reverted, test unchanged

```
 (fail) getCrucialToolsForServer > does not hand the caller the live config array
 (fail) getAllCrucialTools > does not share its nested arrays with the live config

 14 pass
 2 fail
```

### Green — with the fix, at this exact head

```
$ bun test src/lib/eliza/plugin-mcp/tool-visibility.test.ts
 16 pass
 0 fail
```

## Domain artifacts

Effect of a caller mutating the returned value:

| caller action | before | after |
|---|---|---|
| `getCrucialToolsForServer("google").push(x)` | `x` **appears** in the module's config for every later caller | module config unchanged |
| `getAllCrucialTools().google.push(x)` | same — the spread shared the nested array | module config unchanged |
| `getAllCrucialTools().newServer = [...]` | already isolated (outer spread) | unchanged |

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on both changed files.
- **Suite:** 16/16 passing at this exact head; the module previously had no test file.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
