### PR TITLE
test(ui): cover character editor helpers

### DIFF
--- a/packages/ui/src/components/character/character-editor-helpers.test.ts
+++ b/packages/ui/src/components/character/character-editor-helpers.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Covers the pure helpers behind the character editor.
+ *
+ * `buildCharacterDraftFromPreset` seeds an editable draft from a shared roster
+ * preset, so it must deep-copy every list it carries over: a draft that shared
+ * arrays with the preset would let one user's edits rewrite the preset for
+ * every later character built from it. Token substitution has to reach every
+ * field the preset can carry, not just the obvious ones.
+ *
+ * `shouldApplyPresetDefaults` decides whether preset defaults overwrite user
+ * edits, so it must stay false for the one case that would destroy work — a
+ * saved character with real content whose name still matches the roster entry.
+ *
+ * Pure functions — no React.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { CharacterRosterEntry } from "./CharacterRoster";
+import {
+  buildCharacterDraftFromPreset,
+  getFirstRunPresetStyles,
+  replaceCharacterToken,
+  shouldApplyPresetDefaults,
+} from "./character-editor-helpers.ts";
+
+function preset(overrides: Record<string, unknown> = {}) {
+  return {
+    bio: ["I am {{name}}."],
+    system: "You are {{agentName}}.",
+    adjectives: ["curious"],
+    style: { all: ["all-1"], chat: ["chat-1"], post: ["post-1"] },
+    messageExamples: [
+      [
+        { user: "{{user1}}", content: { text: "hi {{name}}" } },
+        {
+          user: "{{agentName}}",
+          content: { text: "hello from {{agentName}}" },
+        },
+      ],
+    ],
+    postExamples: ["a post by {{name}}"],
+    ...overrides,
+  };
+}
+
+const entry = (name: string, overrides: Record<string, unknown> = {}) =>
+  ({ name, preset: preset(overrides) }) as unknown as CharacterRosterEntry;
+
+describe("getFirstRunPresetStyles", () => {
+  it("returns an empty list for anything that is not an options object", () => {
+    for (const value of [null, undefined, "x", 42, []]) {
+      expect(getFirstRunPresetStyles(value)).toEqual([]);
+    }
+  });
+
+  it("returns an empty list when styles is absent or not an array", () => {
+    expect(getFirstRunPresetStyles({})).toEqual([]);
+    expect(getFirstRunPresetStyles({ styles: "nope" })).toEqual([]);
+    expect(getFirstRunPresetStyles({ styles: null })).toEqual([]);
+  });
+
+  it("returns the styles array when present", () => {
+    const styles = [{ id: "a" }];
+    expect(getFirstRunPresetStyles({ styles })).toBe(styles);
+  });
+});
+
+describe("replaceCharacterToken", () => {
+  it("replaces both token spellings", () => {
+    expect(replaceCharacterToken("{{name}} and {{agentName}}", "Momo")).toBe(
+      "Momo and Momo",
+    );
+  });
+
+  it("replaces every occurrence, not just the first", () => {
+    expect(replaceCharacterToken("{{name}} {{name}} {{name}}", "Momo")).toBe(
+      "Momo Momo Momo",
+    );
+  });
+
+  it("leaves text without tokens untouched", () => {
+    expect(replaceCharacterToken("plain text", "Momo")).toBe("plain text");
+    expect(replaceCharacterToken("", "Momo")).toBe("");
+  });
+
+  it("leaves unrelated tokens alone", () => {
+    expect(replaceCharacterToken("{{user1}}", "Momo")).toBe("{{user1}}");
+  });
+});
+
+describe("buildCharacterDraftFromPreset", () => {
+  it("uses the roster name for both name and username", () => {
+    const draft = buildCharacterDraftFromPreset(entry("Momo"));
+    expect(draft.name).toBe("Momo");
+    expect(draft.username).toBe("Momo");
+  });
+
+  it("substitutes tokens in bio, system, and post examples", () => {
+    const draft = buildCharacterDraftFromPreset(entry("Momo"));
+    expect(draft.bio).toBe("I am Momo.");
+    expect(draft.system).toBe("You are Momo.");
+    expect(draft.postExamples).toEqual(["a post by Momo"]);
+  });
+
+  it("joins multi-line bios with newlines", () => {
+    const draft = buildCharacterDraftFromPreset(
+      entry("Momo", { bio: ["line one", "line two"] }),
+    );
+    expect(draft.bio).toBe("line one\nline two");
+  });
+
+  it("maps the agent speaker to the character name and substitutes example text", () => {
+    const [conversation] = buildCharacterDraftFromPreset(
+      entry("Momo"),
+    ).messageExamples;
+    expect(conversation?.examples[1]?.name).toBe("Momo");
+    expect(conversation?.examples[1]?.content.text).toBe("hello from Momo");
+    expect(conversation?.examples[0]?.content.text).toBe("hi Momo");
+  });
+
+  it("leaves a non-agent speaker token as the substituted user token", () => {
+    const [conversation] = buildCharacterDraftFromPreset(
+      entry("Momo"),
+    ).messageExamples;
+    expect(conversation?.examples[0]?.name).toBe("{{user1}}");
+  });
+
+  it("does not share its arrays with the preset", () => {
+    // A shared array would let one character's edits rewrite the preset for
+    // every later character built from it.
+    const rosterEntry = entry("Momo");
+    const source = rosterEntry.preset as unknown as ReturnType<typeof preset>;
+    const draft = buildCharacterDraftFromPreset(rosterEntry);
+
+    draft.adjectives.push("injected");
+    draft.style.all.push("injected");
+    draft.style.chat.push("injected");
+    draft.style.post.push("injected");
+
+    expect(source.adjectives).not.toContain("injected");
+    expect(source.style.all).not.toContain("injected");
+    expect(source.style.chat).not.toContain("injected");
+    expect(source.style.post).not.toContain("injected");
+  });
+
+  it("carries an empty preset through without throwing", () => {
+    const draft = buildCharacterDraftFromPreset(
+      entry("Momo", {
+        bio: [],
+        adjectives: [],
+        style: { all: [], chat: [], post: [] },
+        messageExamples: [],
+        postExamples: [],
+      }),
+    );
+    expect(draft.bio).toBe("");
+    expect(draft.messageExamples).toEqual([]);
+  });
+});
+
+describe("shouldApplyPresetDefaults", () => {
+  it("applies defaults when there is no meaningful content", () => {
+    expect(shouldApplyPresetDefaults(false, "Chen", "Momo")).toBe(true);
+    expect(shouldApplyPresetDefaults(false, "Momo", "Momo")).toBe(true);
+    expect(shouldApplyPresetDefaults(false, null, "Momo")).toBe(true);
+  });
+
+  it("does NOT overwrite real content when the name still matches", () => {
+    // The one case that would destroy the user's work.
+    expect(shouldApplyPresetDefaults(true, "Momo", "Momo")).toBe(false);
+  });
+
+  it("matches the name case- and whitespace-insensitively", () => {
+    expect(shouldApplyPresetDefaults(true, "  momo  ", "Momo")).toBe(false);
+    expect(shouldApplyPresetDefaults(true, "MOMO", "momo")).toBe(false);
+  });
+
+  it("applies defaults when the user switched to a different preset", () => {
+    expect(shouldApplyPresetDefaults(true, "Chen", "Momo")).toBe(true);
+  });
+
+  it("applies defaults when the saved name is missing or unusable", () => {
+    expect(shouldApplyPresetDefaults(true, null, "Momo")).toBe(true);
+    expect(shouldApplyPresetDefaults(true, undefined, "Momo")).toBe(true);
+    expect(shouldApplyPresetDefaults(true, "   ", "Momo")).toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/components/character/character-editor-helpers.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `0d9b34de51319e2bd592b67d2d651cbe8ae3d57c`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. The isolation case mutates every copied list on the draft and asserts the source preset is untouched, so a regression to a shallow copy fails rather than passing on equality. `shouldApplyPresetDefaults` is asserted in both directions — including the single false case that protects user work — so a helper that always returned true would fail.

# Background

## What does this PR do?

`packages/ui/src/components/character/character-editor-helpers.ts` seeds every character draft from a shared roster preset. It had **no dedicated test file**.

| Area | Contract pinned |
|---|---|
| draft isolation | `buildCharacterDraftFromPreset` deep-copies `adjectives` and all three `style` lists. A shared array would let one character's edits rewrite the preset for **every later character** built from it. |
| token substitution | reaches bio, system, post examples, and message-example text — not just the obvious fields |
| speaker mapping | the `{{agentName}}` speaker becomes the character name; an unrelated speaker token is left alone |
| bio joining | multi-line bios join with newlines |
| replacement scope | every occurrence of a token is replaced, not just the first |
| overwrite guard | `shouldApplyPresetDefaults` is **false** only for a saved character with real content whose name still matches — the one case that would destroy user work — and true for fresh state, a preset switch, or a missing/whitespace-only saved name |
| name matching | case- and whitespace-insensitive |
| input hygiene | `getFirstRunPresetStyles` returns `[]` for a non-object, a missing `styles`, or a non-array `styles` |

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/character/character-editor-helpers.test.ts`, the "does not share its arrays with the preset" and `shouldApplyPresetDefaults` cases.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/components/character/character-editor-helpers.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:908e72d6dc2c2d1bf48ed1e10da21c1a4652c4a8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/components/character/character-editor-helpers.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 19/19 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is the mutate-then-assert-source isolation check and both-direction overwrite-guard cases.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
