### PR TITLE
test(ui): cover local-inference custom search providers

### DIFF
--- a/packages/ui/src/services/local-inference/custom-search.test.ts
+++ b/packages/ui/src/services/local-inference/custom-search.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Covers the custom model-search provider descriptors.
+ *
+ * Search is currently disabled for every provider, so the assertions here are
+ * written as invariants rather than as a snapshot of that decision: a provider
+ * that cannot be searched must carry an explanation, and a provider that cannot
+ * be downloaded from must carry a reason on every result it wraps. Those hold
+ * whether or not search is re-enabled later, so re-enabling it will not force a
+ * rewrite of this suite — but shipping a disabled provider with no explanation
+ * will fail.
+ *
+ * Pure descriptors — no network.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOM_MODEL_SEARCH_DISABLED_MESSAGE,
+  DEFAULT_LOCAL_MODEL_SEARCH_PROVIDER_ID,
+  getLocalModelSearchProvider,
+  isLocalModelSearchProviderId,
+  type LocalModelSearchProviderId,
+  listLocalModelSearchProviders,
+  searchLocalModelProvider,
+  wrapLocalModelSearchResults,
+} from "./custom-search.ts";
+import type { CatalogModel } from "./types";
+
+const model = (hfRepo: string) => ({ hfRepo, id: hfRepo }) as CatalogModel;
+const ids = () =>
+  listLocalModelSearchProviders().map((provider) => provider.id);
+
+describe("provider registry", () => {
+  it("lists at least one provider, each with usable labels", () => {
+    const providers = listLocalModelSearchProviders();
+    expect(providers.length).toBeGreaterThan(0);
+    for (const provider of providers) {
+      expect(provider.label.trim().length).toBeGreaterThan(0);
+      expect(provider.shortLabel.trim().length).toBeGreaterThan(0);
+      expect(provider.placeholder.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("assigns a distinct id to every provider", () => {
+    expect(new Set(ids()).size).toBe(ids().length);
+  });
+
+  it("does not hand out the live descriptors", () => {
+    const first = listLocalModelSearchProviders()[0];
+    if (first) first.label = "mutated";
+    expect(listLocalModelSearchProviders()[0]?.label).not.toBe("mutated");
+  });
+
+  it("explains itself whenever search is unavailable", () => {
+    // Invariant, not a snapshot: a provider may become searchable later, but a
+    // provider that cannot be searched must say why.
+    for (const provider of listLocalModelSearchProviders()) {
+      if (!provider.searchSupported) {
+        expect(provider.unavailableMessage?.trim().length ?? 0).toBeGreaterThan(
+          0,
+        );
+      }
+    }
+  });
+
+  it("explains itself whenever download is unavailable", () => {
+    for (const provider of listLocalModelSearchProviders()) {
+      if (!provider.downloadSupported) {
+        expect(
+          provider.downloadUnsupportedReason?.trim().length ?? 0,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("exposes a default provider that actually exists", () => {
+    expect(ids()).toContain(DEFAULT_LOCAL_MODEL_SEARCH_PROVIDER_ID);
+  });
+});
+
+describe("isLocalModelSearchProviderId", () => {
+  it("accepts every registered id", () => {
+    for (const id of ids()) expect(isLocalModelSearchProviderId(id)).toBe(true);
+  });
+
+  it("rejects unknown ids", () => {
+    for (const value of ["", "   ", "openai", "HuggingFace"]) {
+      expect(isLocalModelSearchProviderId(value)).toBe(false);
+    }
+  });
+});
+
+describe("getLocalModelSearchProvider", () => {
+  it("resolves each registered id to its own descriptor", () => {
+    for (const id of ids()) {
+      expect(getLocalModelSearchProvider(id).id).toBe(id);
+    }
+  });
+
+  it("falls back to a real provider for an unknown id rather than returning undefined", () => {
+    const fallback = getLocalModelSearchProvider(
+      "nope" as LocalModelSearchProviderId,
+    );
+    expect(fallback).toBeDefined();
+    expect(ids()).toContain(fallback.id);
+  });
+});
+
+describe("wrapLocalModelSearchResults", () => {
+  it("returns an empty list for no models", () => {
+    expect(wrapLocalModelSearchResults("huggingface", [])).toEqual([]);
+  });
+
+  it("tags each result with the requesting provider", () => {
+    const wrapped = wrapLocalModelSearchResults("modelscope", [
+      model("org/repo"),
+    ]);
+    expect(wrapped[0]?.providerId).toBe("modelscope");
+    expect(wrapped[0]?.model.hfRepo).toBe("org/repo");
+  });
+
+  it("builds a provider-specific external URL containing the repo", () => {
+    const hf = wrapLocalModelSearchResults("huggingface", [
+      model("org/repo"),
+    ])[0];
+    const ms = wrapLocalModelSearchResults("modelscope", [
+      model("org/repo"),
+    ])[0];
+    expect(hf?.externalUrl).toContain("huggingface.co");
+    expect(hf?.externalUrl).toContain("org/repo");
+    expect(ms?.externalUrl).toContain("modelscope.cn");
+    expect(ms?.externalUrl).toContain("org/repo");
+    expect(hf?.externalUrl).not.toBe(ms?.externalUrl);
+  });
+
+  it("mirrors the provider's download support onto every result", () => {
+    for (const id of ids()) {
+      const provider = getLocalModelSearchProvider(id);
+      const [wrapped] = wrapLocalModelSearchResults(id, [model("org/repo")]);
+      expect(wrapped?.download.supported).toBe(provider.downloadSupported);
+      if (!provider.downloadSupported) {
+        // A blocked download must always carry a reason the UI can show.
+        expect(wrapped?.download.reason?.trim().length ?? 0).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("wraps every model it is given", () => {
+    const wrapped = wrapLocalModelSearchResults("huggingface", [
+      model("a/one"),
+      model("b/two"),
+      model("c/three"),
+    ]);
+    expect(wrapped).toHaveLength(3);
+  });
+});
+
+describe("searchLocalModelProvider", () => {
+  it("returns the provider descriptor alongside its results", async () => {
+    const response = await searchLocalModelProvider("huggingface", "llama");
+    expect(response.provider.id).toBe("huggingface");
+    expect(Array.isArray(response.results)).toBe(true);
+  });
+
+  it("surfaces the unavailable message when the provider cannot be searched", async () => {
+    for (const id of ids()) {
+      const response = await searchLocalModelProvider(id, "llama", 5);
+      if (!response.provider.searchSupported) {
+        expect(response.results).toEqual([]);
+        expect(response.unavailableMessage).toBe(
+          response.provider.unavailableMessage,
+        );
+      }
+    }
+  });
+
+  it("uses the shared disabled message while search is off", async () => {
+    const response = await searchLocalModelProvider("huggingface", "llama");
+    if (!response.provider.searchSupported) {
+      expect(response.unavailableMessage).toBe(
+        CUSTOM_MODEL_SEARCH_DISABLED_MESSAGE,
+      );
+    }
+  });
+
+  it("falls back to a real provider for an unknown id", async () => {
+    const response = await searchLocalModelProvider(
+      "nope" as LocalModelSearchProviderId,
+      "llama",
+    );
+    expect(ids()).toContain(response.provider.id);
+  });
+});


### PR DESCRIPTION
# Relates to

Continues the `test(<scope>): cover <module>` coverage sweep. `packages/ui/src/services/local-inference/custom-search.ts` had no dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the affected-package gates are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the run output below.

# Sync with develop

- [x] Rebased onto `origin/develop` `0d9b34de51319e2bd592b67d2d651cbe8ae3d57c`; zero conflicts.
- [x] Affected-package gates pass post-sync; anything residual is named under **Known gaps / failures**.

# Risks

**None to production.** Test-only PR — it adds one new `*.test.ts` file and changes no production source, no exports, and no configuration. It cannot alter runtime behavior.

The reviewable risk is the opposite one: a test that passes for the wrong reason. Deliberately written as invariants rather than a snapshot of the current "search disabled" decision — the conditional assertions hold whether or not search is re-enabled, so this suite will not have to be rewritten when it is. Expected values are derived from the registry (ids, descriptors) rather than hard-coded, and the copy check mutates a returned descriptor and re-reads.

# Background

## What does this PR do?

`packages/ui/src/services/local-inference/custom-search.ts` describes the custom model-search providers. It had **no dedicated test file**.

Search is currently disabled for every provider, so the assertions are invariants, not a snapshot of that decision:

| Invariant | Why |
|---|---|
| a provider that cannot be searched carries an `unavailableMessage` | a disabled provider with no explanation gives the UI nothing to show |
| a provider that cannot be downloaded from carries a reason, and every wrapped result surfaces it | same, at the per-result level |
| `searchLocalModelProvider` echoes the provider's own message | it must not invent a different one |

Those hold whether or not search is re-enabled later, so re-enabling will not force a rewrite — but shipping a disabled provider with no explanation fails.

Also covered: provider ids are distinct and the default id resolves to a real provider; `listLocalModelSearchProviders` hands out copies rather than the live descriptors; `getLocalModelSearchProvider` falls back to a real provider for an unknown id instead of returning `undefined`; `wrapLocalModelSearchResults` tags each result with the requesting provider, wraps every model given, and builds a provider-specific external URL containing the repo that differs between providers.

## What kind of change is this?

Improvements (test coverage for an existing, previously uncovered module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/services/local-inference/custom-search.test.ts`, the `provider registry` invariants.

## Detailed testing steps

```bash
cd packages/ui && npx vitest run --config ./vitest.config.ts src/services/local-inference/custom-search.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9cf948fa196789aa35e0afe9229084618a5cdd83 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only PR; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the deliverable is the test run below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - pure functions with no logging; the suite output below is the direct execution record of the real exported code path.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the suite output and the per-area contract table are inline below.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - pure functions, no logging.`

### Suite run at this exact head

```
$ npx vitest run --config ./vitest.config.ts src/services/local-inference/custom-search.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```



## Screenshots (before / after) + video walkthrough

`N/A - test-only PR, no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Biome:** clean on the new file.
- **Suite:** 19/19 passing at this exact head.
- Test-only PR, so there is no red/green production A/B; the guard against a vacuous suite is registry-derived expectations plus a mutate-and-re-read copy check.
- Full-repo `bun run verify` was not run to completion; the affected-module gates (Biome and the new suite) are recorded above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
