### PR TITLE
test(core): cover managed-provider error taxonomy

### DIFF
--- a/packages/core/src/integrations/managed-provider/errors.test.ts
+++ b/packages/core/src/integrations/managed-provider/errors.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Exercises the managed-provider failure taxonomy against the real error
+ * classes: field preservation on `ManagedProviderError` (code, context,
+ * retryAfterMs, native cause chain), the transient-vs-fatal severity
+ * classification over the complete code list, the instance-narrowing helper's
+ * discrimination against the base `ElizaError`, and the exhaustive mapping onto
+ * the capability execution-outcome codes. Fully deterministic — no network,
+ * runtime, or clock involved.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../../errors";
+import {
+	isManagedProviderError,
+	MANAGED_PROVIDER_ERROR_CODES,
+	ManagedProviderError,
+	toCapabilityExecutionErrorCode,
+} from "./errors";
+
+/** Codes whose failures are expected to be transient and retryable. */
+const EPHEMERAL_CODES = [
+	"RATE_LIMITED",
+	"PROVIDER_TIMEOUT",
+	"PROVIDER_NETWORK",
+	"PROVIDER_FAILURE",
+] as const;
+
+describe("ManagedProviderError", () => {
+	it("carries name, message, code, context, retryAfterMs, and the native cause", () => {
+		const cause = new Error("token refresh failed");
+		const error = new ManagedProviderError("The provider rejected the call.", {
+			code: "AUTH_EXPIRED",
+			context: { providerId: "linear", attempt: 2 },
+			retryAfterMs: 4_000,
+			cause,
+		});
+
+		expect(error).toBeInstanceOf(ManagedProviderError);
+		expect(error).toBeInstanceOf(ElizaError);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("ManagedProviderError");
+		expect(error.message).toBe("The provider rejected the call.");
+		expect(error.code).toBe("AUTH_EXPIRED");
+		expect(error.context).toEqual({ providerId: "linear", attempt: 2 });
+		expect(error.retryAfterMs).toBe(4_000);
+		expect(error.cause).toBe(cause);
+	});
+
+	it("classifies exactly the transient codes as ephemeral and everything else as fatal", () => {
+		for (const code of MANAGED_PROVIDER_ERROR_CODES) {
+			const error = new ManagedProviderError(`probe ${code}`, { code });
+			if ((EPHEMERAL_CODES as readonly string[]).includes(code)) {
+				expect(error.severity).toBe("ephemeral");
+			} else {
+				expect(error.severity).toBe("fatal");
+			}
+		}
+	});
+
+	it("leaves retryAfterMs undefined when the provider declares none", () => {
+		const error = new ManagedProviderError("The provider was rate limited.", {
+			code: "RATE_LIMITED",
+		});
+
+		expect(error.retryAfterMs).toBeUndefined();
+	});
+});
+
+describe("isManagedProviderError", () => {
+	it("accepts ManagedProviderError instances", () => {
+		const error = new ManagedProviderError("boom", {
+			code: "PROVIDER_FAILURE",
+		});
+
+		expect(isManagedProviderError(error)).toBe(true);
+	});
+
+	it("rejects the base ElizaError, plain errors, and non-errors", () => {
+		const baseElizaError = new ElizaError("boom", { code: "UNCLASSIFIED" });
+		const plainError = new Error("boom");
+
+		expect(isManagedProviderError(baseElizaError)).toBe(false);
+		expect(isManagedProviderError(plainError)).toBe(false);
+		expect(isManagedProviderError(null)).toBe(false);
+		expect(isManagedProviderError(undefined)).toBe(false);
+		expect(isManagedProviderError("PROVIDER_TIMEOUT")).toBe(false);
+		expect(isManagedProviderError({ code: "PROVIDER_TIMEOUT" })).toBe(false);
+	});
+});
+
+describe("toCapabilityExecutionErrorCode", () => {
+	it("maps every managed-provider code onto its capability execution outcome", () => {
+		const expectedByCode: Record<string, string> = {
+			INVALID_INPUT: "invalid_request",
+			AUTH_EXPIRED: "authentication_failed",
+			AUTH_REVOKED: "authentication_failed",
+			RATE_LIMITED: "rate_limited",
+			PROVIDER_TIMEOUT: "timeout",
+			MALFORMED_RESPONSE: "schema_drift",
+			PROVIDER_REJECTED: "provider_error",
+			PROVIDER_FAILURE: "provider_error",
+			PROVIDER_NETWORK: "provider_error",
+			RESPONSE_TOO_LARGE: "provider_error",
+			CONNECTION_UNAVAILABLE: "unknown_error",
+			ENDPOINT_BLOCKED: "unknown_error",
+			PAGINATION_OVERFLOW: "unknown_error",
+		};
+
+		for (const code of MANAGED_PROVIDER_ERROR_CODES) {
+			expect(Object.hasOwn(expectedByCode, code)).toBe(true);
+			expect(toCapabilityExecutionErrorCode(code)).toBe(expectedByCode[code]);
+		}
+		expect(Object.keys(expectedByCode).sort()).toEqual(
+			[...MANAGED_PROVIDER_ERROR_CODES].sort(),
+		);
+	});
+
+	it("maps auth expiry and revocation onto the same authentication outcome", () => {
+		expect(toCapabilityExecutionErrorCode("AUTH_EXPIRED")).toBe(
+			toCapabilityExecutionErrorCode("AUTH_REVOKED"),
+		);
+	});
+});


### PR DESCRIPTION

## Summary

Adds a dedicated unit suite for the managed-provider failure taxonomy at `packages/core/src/integrations/managed-provider/errors.ts`. Test-only change: no production behavior is modified, and the diff is one new file (`+N/-0`).

## What the suite covers

- **`ManagedProviderError` field preservation** — name, message, `code`, structured `context`, optional `retryAfterMs`, and the native `cause` chain (asserted by identity against the wrapped error), plus `instanceof` against `ManagedProviderError`, `ElizaError`, and `Error`.
- **Severity classification** — iterates the complete exported `MANAGED_PROVIDER_ERROR_CODES` list and asserts exactly the four transient codes (`RATE_LIMITED`, `PROVIDER_TIMEOUT`, `PROVIDER_NETWORK`, `PROVIDER_FAILURE`) classify as `ephemeral`, with every remaining code classified as `fatal`.
- **`retryAfterMs` default** — stays `undefined` when the provider declares none.
- **`isManagedProviderError` narrowing** — accepts real instances and rejects the base `ElizaError`, plain `Error`s, primitives, and lookalike object literals (the base-class discrimination guards accidental widening of the taxonomy).
- **`toCapabilityExecutionErrorCode` exhaustiveness** — asserts every managed-provider code maps onto its documented capability execution outcome, cross-checks that the expectation table covers exactly the exported code list (no silent drift when codes are added), and pins auth expiry/revocation onto the same authentication outcome.

The harness is fully deterministic: it drives the real classes with inline literals — no network, runtime, clock, filesystem, or module mocks.

## Verification (observed on this exact head)

- `bunx vitest run packages/core/src/integrations/managed-provider/errors.test.ts` → **Test Files 1 passed (1); Tests 7 passed (7)**.
- `bunx biome check packages/core/src/integrations/managed-provider/errors.test.ts` → clean ("Checked 1 file … No fixes applied" after the formatting pass).
- `bunx tsc --noEmit` in `packages/core` → the new test file appears nowhere in the output (`packages/core/tsconfig.json` excludes `src/**/*.test.ts`; vitest remains the runtime gate for this file).
- Diff touches only the new test file.

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are from local runs at the pushed head.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9b8dc7da5bf7de955f84e1b3ec203a8c9e3dda9f -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
