### PR TITLE
test(ui): cover i18n-locale-client

### DIFF
--- a/packages/ui/src/api/i18n-locale-client.test.ts
+++ b/packages/ui/src/api/i18n-locale-client.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit coverage for the i18n locale-suggestion client (`fetchSuggestedLanguage`)
+ * through the package's configured test harness. Only the CSRF transport seam
+ * is mocked; boot config flows through the real store, the direct/dedicated
+ * cloud-base gating through the real capability classifiers, and suggested tags
+ * through the real `normalizeLanguage`, so every asserted value is computed by
+ * the module under test from controlled boundary responses (real `Response`
+ * objects).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { fetchWithCsrf } from "./csrf-client";
+import { fetchSuggestedLanguage } from "./i18n-locale-client";
+
+vi.mock("./csrf-client", () => ({ fetchWithCsrf: vi.fn() }));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function installWindow(location: { origin: string; hostname: string }): void {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location },
+  });
+}
+
+const BROWSER_LOCATION = {
+  origin: "https://app.elizaos.com",
+  hostname: "app.elizaos.com",
+};
+
+describe("fetchSuggestedLanguage", () => {
+  beforeEach(() => {
+    fetchWithCsrfMock.mockReset();
+    setBootConfig({ branding: {} });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  it("returns null outside a browser window without contacting the endpoint", async () => {
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on localhost development origins where no geo hint applies", async () => {
+    installWindow({ origin: "http://localhost:3000", hostname: "localhost" });
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("treats loopback IPs as local development and skips the request", async () => {
+    for (const hostname of ["127.0.0.1", "::1"]) {
+      installWindow({ origin: `http://[${hostname}]:3000`, hostname });
+      await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+      expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it("requests the locale endpoint on window.location.origin when no API base is configured", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockResolvedValueOnce(jsonResponse({ language: "ja" }));
+    await expect(fetchSuggestedLanguage()).resolves.toBe("ja");
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "https://app.elizaos.com/api/i18n/locale",
+    );
+  });
+
+  it("builds the endpoint URL from a trailing-slash API base without doubling the slash", async () => {
+    installWindow(BROWSER_LOCATION);
+    setBootConfig({ branding: {}, apiBase: "https://api.elizaos.com/" });
+    fetchWithCsrfMock.mockResolvedValueOnce(jsonResponse({ language: "ko" }));
+    await expect(fetchSuggestedLanguage()).resolves.toBe("ko");
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "https://api.elizaos.com/api/i18n/locale",
+    );
+  });
+
+  it("skips direct cloud agent bases because they expose no app-shell routes", async () => {
+    setBootConfig({
+      branding: {},
+      apiBase: "https://eliza.app/api/v1/eliza/agents/agent-abc123",
+    });
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+    expect(fetchWithCsrfMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes regional and case variants of the suggested tag", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(jsonResponse({ language: "ZH-hans-SG" }))
+      .mockResolvedValueOnce(jsonResponse({ language: "en-US" }));
+    await expect(fetchSuggestedLanguage()).resolves.toBe("zh-CN");
+    await expect(fetchSuggestedLanguage()).resolves.toBe("en");
+  });
+
+  it("maps an unsupported suggestion onto the default language instead of failing", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockResolvedValueOnce(
+      jsonResponse({ language: "fr-FR" }),
+    );
+    await expect(fetchSuggestedLanguage()).resolves.toBe("en");
+  });
+
+  it("maps an explicitly empty suggestion onto the default language", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockResolvedValueOnce(jsonResponse({ language: "" }));
+    await expect(fetchSuggestedLanguage()).resolves.toBe("en");
+  });
+
+  it("degrades to no suggestion when the endpoint answers non-ok", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockResolvedValueOnce(
+      new Response("service unavailable", { status: 503 }),
+    );
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+  });
+
+  it("degrades to no suggestion when the endpoint is unreachable", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockRejectedValueOnce(
+      new TypeError("network unreachable"),
+    );
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+  });
+
+  it("ignores malformed JSON bodies", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock.mockResolvedValueOnce(
+      new Response("<html>under maintenance</html>", { status: 200 }),
+    );
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+  });
+
+  it("requires a string language field in the suggestion payload", async () => {
+    installWindow(BROWSER_LOCATION);
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(jsonResponse(null))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({ language: 7 }));
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+    await expect(fetchSuggestedLanguage()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

Adds the first unit suite for `packages/ui/src/api/i18n-locale-client.ts`, which previously had no same-named test anywhere in the repo. The module implements the advisory first-visit language suggestion (`GET /api/i18n/locale`) consumed by the UI shell.

## What is covered

The suite drives the real `fetchSuggestedLanguage()` and asserts behaviour, not mock echoes:

- **Gating before any network I/O** - returns null with zero transport calls outside a browser window, on `localhost`, and on loopback hosts (`127.0.0.1`, `::1`).
- **Real cloud-base gating** - a direct cloud agent base (`/api/v1/eliza/agents/<id>`) is skipped because it exposes no app-shell routes; this flows through the real `supportsFullAppShellRoutes` / shared-agent-base classifiers, not a stub.
- **URL construction** - the endpoint is resolved from `window.location.origin` when no API base is configured, and from an explicit boot-config `apiBase` with the trailing slash stripped (no doubled slash).
- **Real normalization** - suggested tags flow through the real `normalizeLanguage`: `ZH-hans-SG` becomes `zh-CN`, `en-US` becomes `en`, unsupported `fr-FR` falls back to default `en`, empty string falls back to default `en`.
- **Advisory degrade contract (J4)** - non-ok status (503), unreachable endpoint (rejected fetch), malformed JSON body, and payloads without a string `language` field (null body, missing field, numeric value) all resolve to `null` instead of throwing, so callers fall back to the browser language as designed.

Only the CSRF transport seam is mocked (matching sibling suites such as `auth-client.test.ts`); every asserted value is computed by the module under test from real `Response` objects.

## Verification (test-only diff)

- `bunx vitest run src/api/i18n-locale-client.test.ts` (packages/ui): **1 file passed, 13/13 tests passed** - re-fetched origin/develop immediately before filing and re-ran: the module source is byte-identical to current develop.
- `bunx biome check --write src/api/i18n-locale-client.test.ts`: clean (checked 1 file).
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output (zero type errors introduced).
- The diff touches only the new test file (+N/-0); no production code changed.

Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are quoted directly from local runs of the pinned toolchain.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0d9b34de51319e2bd592b67d2d651cbe8ae3d57c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
