### PR TITLE
test(ui): cover runtime-mode-client

### DIFF
--- a/packages/ui/src/api/runtime-mode-client.test.ts
+++ b/packages/ui/src/api/runtime-mode-client.test.ts
@@ -53,7 +53,7 @@ describe("fetchRuntimeModeSnapshot", () => {
 
     await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
     expect(fetchMock.mock.calls[0][0]).toBe(
-      "http://localhost/api/runtime/mode",
+      `${window.location.origin}/api/runtime/mode`,
     );
   });
 

--- a/packages/ui/src/api/runtime-mode-client.test.ts
+++ b/packages/ui/src/api/runtime-mode-client.test.ts
@@ -1,0 +1,182 @@
+/** Covers the runtime-mode snapshot client's validation and fallback contract against a stubbed global fetch. */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { fetchRuntimeModeSnapshot } from "./runtime-mode-client";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchRuntimeModeSnapshot", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    window.sessionStorage.removeItem("elizaos_api_base");
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(okResponse({}));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    setBootConfig({ branding: {} });
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the validated snapshot and strips the apiBase trailing slash from the request URL", async () => {
+    setBootConfig({
+      branding: {},
+      apiBase: "http://agent.example.com/",
+    });
+    const snapshot = {
+      mode: "remote",
+      deploymentRuntime: "cloud",
+      isRemoteController: true,
+      remoteApiBaseConfigured: true,
+    };
+    fetchMock.mockResolvedValue(okResponse(snapshot));
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toEqual(snapshot);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://agent.example.com/api/runtime/mode",
+    );
+  });
+
+  it("requests window.location.origin when no apiBase is configured", async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://localhost/api/runtime/mode",
+    );
+  });
+
+  it("accepts every documented mode value", async () => {
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      fetchMock.mockResolvedValue(
+        okResponse({
+          mode,
+          deploymentRuntime: "local",
+          isRemoteController: false,
+          remoteApiBaseConfigured: false,
+        }),
+      );
+
+      await expect(fetchRuntimeModeSnapshot()).resolves.toEqual({
+        mode,
+        deploymentRuntime: "local",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      });
+    }
+  });
+
+  it("accepts every documented deploymentRuntime value", async () => {
+    for (const deploymentRuntime of ["local", "cloud", "remote"] as const) {
+      fetchMock.mockResolvedValue(
+        okResponse({
+          mode: "local",
+          deploymentRuntime,
+          isRemoteController: false,
+          remoteApiBaseConfigured: false,
+        }),
+      );
+
+      await expect(fetchRuntimeModeSnapshot()).resolves.toMatchObject({
+        deploymentRuntime,
+      });
+    }
+  });
+
+  it("coerces truthy-but-not-true snapshot booleans to false", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({
+        mode: "remote",
+        deploymentRuntime: "cloud",
+        isRemoteController: "true",
+        remoteApiBaseConfigured: 1,
+      }),
+    );
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toEqual({
+      mode: "remote",
+      deploymentRuntime: "cloud",
+      isRemoteController: false,
+      remoteApiBaseConfigured: false,
+    });
+  });
+
+  it("defaults missing snapshot booleans to false", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({ mode: "local", deploymentRuntime: "local" }),
+    );
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toEqual({
+      mode: "local",
+      deploymentRuntime: "local",
+      isRemoteController: false,
+      remoteApiBaseConfigured: false,
+    });
+  });
+
+  it("returns null when the endpoint is unreachable", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    for (const status of [404, 500]) {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ mode: "local" }), { status }),
+      );
+
+      await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+    }
+  });
+
+  it("returns null when the body is not JSON", async () => {
+    fetchMock.mockResolvedValue(new Response("<html>not json</html>"));
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+  });
+
+  it("returns null when the body is JSON null", async () => {
+    fetchMock.mockResolvedValue(new Response("null"));
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+  });
+
+  it("returns null for an unknown mode", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({
+        mode: "hybrid",
+        deploymentRuntime: "local",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      }),
+    );
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+  });
+
+  it("returns null for an unknown deploymentRuntime", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({
+        mode: "local",
+        deploymentRuntime: "local-only",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      }),
+    );
+
+    await expect(fetchRuntimeModeSnapshot()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

Adds `packages/ui/src/api/runtime-mode-client.test.ts` — the first unit suite for `fetchRuntimeModeSnapshot()`. No same-named test file existed anywhere on `develop` at filing time. This is a test-only change; no production behaviour is modified.

## What is covered

The suite drives the real module chain — `modeBase()` → `fetchWithCsrf()` → agent-transport selection → global `fetch` — stubbing only the network boundary:

- Request URL resolution: configured `apiBase` is used with its trailing slash stripped; with no `apiBase`, the request resolves against `window.location.origin`
- All documented `mode` values are accepted: `local`, `local-only`, `cloud`, `remote`
- All documented `deploymentRuntime` values are accepted: `local`, `cloud`, `remote`
- Snapshot booleans coerce strictly: truthy-but-not-`true` values (`"true"`, `1`) and missing fields read as `false`
- Every null-fallback branch of the advisory-snapshot contract: unreachable endpoint, non-2xx status (404, 500), unparseable body, JSON `null` body, unknown `mode`, unknown `deploymentRuntime`

## Evidence

- `bunx vitest run src/api/runtime-mode-client.test.ts` (in `packages/ui`): **Test Files 1 passed (1); Tests 12 passed (12)**, re-run against current `origin/develop` (`0d9b34de`) immediately before filing
- `bunx biome check --write packages/ui/src/api/runtime-mode-client.test.ts`: clean ("Checked 1 file … Fixed 1 file")
- `bunx tsc --noEmit` in `packages/ui`: zero mentions of `runtime-mode-client.test.ts` in output; the 12 reported errors are pre-existing in unrelated files
- The diff touches exactly one new test file (+182/−0)

Fork contributor: hosted CI does not run on this pull request; the counts above are local runs against the current base.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8b618a7d485c6a2392aa99cf96405c4500a03394 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
