### PR TITLE
fix(cloud): resolve affiliate themes by own key, not prototype chain

### DIFF
--- a/packages/cloud/shared/src/lib/config/affiliate-themes.test.ts
+++ b/packages/cloud/shared/src/lib/config/affiliate-themes.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Exercises affiliate theme resolution against untrusted identifiers. The
+ * theme registry is a plain object reached from a URL `source` parameter and
+ * from character metadata, so lookup must resolve only registry-owned keys:
+ * inherited `Object.prototype` members must never be mistaken for a theme.
+ * Pure module, no harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AFFILIATE_THEMES,
+  type AffiliateTheme,
+  getAffiliateIdFromCharacter,
+  getAffiliateIds,
+  getAffiliateTheme,
+  getThemeCSSVariables,
+  hasAffiliateTheme,
+  resolveCharacterTheme,
+} from "./affiliate-themes";
+
+/** Keys every plain object inherits but no registry actually declares. */
+const INHERITED_KEYS = [
+  "toString",
+  "valueOf",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "__defineGetter__",
+] as const;
+
+function isAffiliateTheme(value: unknown): value is AffiliateTheme {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<AffiliateTheme>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.colors === "object" &&
+    candidate.colors !== null
+  );
+}
+
+describe("getAffiliateTheme", () => {
+  test("returns the default theme for the default id", () => {
+    expect(getAffiliateTheme("default").id).toBe("default");
+  });
+
+  test("falls back to default for nullish ids", () => {
+    expect(getAffiliateTheme(undefined).id).toBe("default");
+    expect(getAffiliateTheme(null).id).toBe("default");
+    expect(getAffiliateTheme("").id).toBe("default");
+  });
+
+  test("falls back to default for unregistered ids", () => {
+    expect(getAffiliateTheme("no-such-affiliate").id).toBe("default");
+  });
+
+  test.each(INHERITED_KEYS)("falls back to default for inherited key %s", (key) => {
+    expect(getAffiliateTheme(key).id).toBe("default");
+  });
+
+  test("always returns a structurally valid theme", () => {
+    for (const key of [...INHERITED_KEYS, "default", "nope", ""]) {
+      expect(isAffiliateTheme(getAffiliateTheme(key))).toBe(true);
+    }
+  });
+});
+
+describe("hasAffiliateTheme", () => {
+  test("is true only for registered ids", () => {
+    expect(hasAffiliateTheme("default")).toBe(true);
+    expect(hasAffiliateTheme("no-such-affiliate")).toBe(false);
+  });
+
+  test.each(INHERITED_KEYS)("is false for inherited key %s", (key) => {
+    expect(hasAffiliateTheme(key)).toBe(false);
+  });
+
+  test("agrees with the enumerated id list", () => {
+    const ids = getAffiliateIds();
+    for (const id of ids) expect(hasAffiliateTheme(id)).toBe(true);
+    for (const key of INHERITED_KEYS) expect(ids).not.toContain(key);
+  });
+
+  test("implies getAffiliateTheme returns that exact theme", () => {
+    for (const id of getAffiliateIds()) {
+      expect(getAffiliateTheme(id)).toBe(AFFILIATE_THEMES[id]);
+    }
+  });
+});
+
+describe("resolveCharacterTheme", () => {
+  test("prefers a registered source over character metadata", () => {
+    const theme = resolveCharacterTheme("default", {
+      affiliate: { affiliateId: "unregistered" },
+    });
+    expect(theme.id).toBe("default");
+  });
+
+  test("falls back to the default theme with no inputs", () => {
+    expect(resolveCharacterTheme(null, null).id).toBe("default");
+    expect(resolveCharacterTheme(undefined, undefined).id).toBe("default");
+  });
+
+  test("ignores an unregistered source", () => {
+    expect(resolveCharacterTheme("nope", null).id).toBe("default");
+  });
+
+  test.each(INHERITED_KEYS)("ignores inherited key %s supplied as the source param", (key) => {
+    const theme = resolveCharacterTheme(key, null);
+    expect(isAffiliateTheme(theme)).toBe(true);
+    expect(theme.id).toBe("default");
+  });
+
+  test.each(INHERITED_KEYS)("ignores inherited key %s supplied via character metadata", (key) => {
+    const theme = resolveCharacterTheme(null, {
+      affiliate: { affiliateId: key },
+    });
+    expect(isAffiliateTheme(theme)).toBe(true);
+    expect(theme.id).toBe("default");
+  });
+
+  test("resolved theme always yields usable CSS variables", () => {
+    for (const key of [...INHERITED_KEYS, "default", "nope"]) {
+      const vars = getThemeCSSVariables(resolveCharacterTheme(key, null));
+      expect(typeof vars["--theme-primary"]).toBe("string");
+      expect(vars["--theme-primary"].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getAffiliateIdFromCharacter", () => {
+  test("reads the nested affiliate id", () => {
+    expect(getAffiliateIdFromCharacter({ affiliate: { affiliateId: "abc" } })).toBe("abc");
+  });
+
+  test("returns undefined for missing or empty metadata", () => {
+    expect(getAffiliateIdFromCharacter(null)).toBeUndefined();
+    expect(getAffiliateIdFromCharacter(undefined)).toBeUndefined();
+    expect(getAffiliateIdFromCharacter({})).toBeUndefined();
+    expect(getAffiliateIdFromCharacter({ affiliate: {} })).toBeUndefined();
+  });
+});
+
+describe("getThemeCSSVariables", () => {
+  test("maps every colour slot onto a --theme-* custom property", () => {
+    const theme = getAffiliateTheme("default");
+    expect(getThemeCSSVariables(theme)).toEqual({
+      "--theme-primary": theme.colors.primary,
+      "--theme-primary-light": theme.colors.primaryLight,
+      "--theme-accent": theme.colors.accent,
+      "--theme-background": theme.colors.background,
+      "--theme-gradient-from": theme.colors.gradientFrom,
+      "--theme-gradient-to": theme.colors.gradientTo,
+    });
+  });
+
+  test("every declared theme exposes non-empty RGB triplets", () => {
+    for (const id of getAffiliateIds()) {
+      for (const value of Object.values(getThemeCSSVariables(AFFILIATE_THEMES[id]))) {
+        expect(value).toMatch(/^\d{1,3} \d{1,3} \d{1,3}$/);
+      }
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/config/affiliate-themes.ts
+++ b/packages/cloud/shared/src/lib/config/affiliate-themes.ts
@@ -209,11 +209,11 @@ export const AFFILIATE_THEMES: Record<string, AffiliateTheme> = {
  * Falls back to default theme if affiliate ID is not found.
  */
 export function getAffiliateTheme(affiliateId: string | undefined | null): AffiliateTheme {
-  if (!affiliateId) {
+  if (!affiliateId || !hasAffiliateTheme(affiliateId)) {
     return AFFILIATE_THEMES["default"];
   }
 
-  return AFFILIATE_THEMES[affiliateId] || AFFILIATE_THEMES["default"];
+  return AFFILIATE_THEMES[affiliateId];
 }
 
 /**
@@ -227,7 +227,10 @@ export function getAffiliateIds(): string[] {
  * Check if an affiliate theme exists
  */
 export function hasAffiliateTheme(affiliateId: string): boolean {
-  return affiliateId in AFFILIATE_THEMES;
+  // Own-key check, not `in`: the registry is a plain object reached from an
+  // untrusted URL parameter, and `in` also resolves inherited Object.prototype
+  // members ("toString", "constructor", ...) as if they were themes.
+  return Object.hasOwn(AFFILIATE_THEMES, affiliateId);
 }
 
 /**


### PR DESCRIPTION
# Relates to

No existing issue. Found while writing first-time regression coverage for
`packages/cloud/shared/src/lib/config/affiliate-themes.ts`, which is reachable
as a public subpath export (`@elizaos/cloud-shared/lib/config/affiliate-themes`)
and had no test file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] Package lint + tests pass post-sync.

# Risks

**Low.** Two-line semantic change in one module, plus a new test file. The fix
strictly narrows which lookup keys resolve: every key the registry actually
declares behaves exactly as before (asserted by the
`hasAffiliateTheme implies getAffiliateTheme returns that exact theme` test).
Only inherited `Object.prototype` keys change behaviour, and they change from
"returns a Function / crashes" to "returns the default theme".

# Background

## What does this PR do?

`AFFILIATE_THEMES` is a plain object literal, so it inherits from
`Object.prototype`. Both accessors resolved through that prototype chain:

```ts
export function hasAffiliateTheme(affiliateId: string): boolean {
  return affiliateId in AFFILIATE_THEMES;   // true for "toString", "constructor", ...
}

export function getAffiliateTheme(affiliateId: string | undefined | null): AffiliateTheme {
  if (!affiliateId) return AFFILIATE_THEMES["default"];
  return AFFILIATE_THEMES[affiliateId] || AFFILIATE_THEMES["default"];
}
```

The `|| default` guard cannot fire for those keys, because
`AFFILIATE_THEMES["toString"]` is an inherited **function** — truthy. So the
caller receives `Object.prototype.toString` typed as an `AffiliateTheme`.

This is reachable from untrusted input. `resolveCharacterTheme` documents its
own priority order as *"URL source param > character metadata > default"*, and
gates on `hasAffiliateTheme(source)` — which returns `true` for the same
inherited keys. Both the URL path and the `character_data.affiliate.affiliateId`
metadata path are affected.

The downstream consequence is a crash, not just a wrong value. Feeding the
result into the module's own `getThemeCSSVariables` throws:

```
TypeError: undefined is not an object (evaluating 'theme.colors.primary')
    at getThemeCSSVariables (affiliate-themes.ts:239:30)
```

Fix: make the existence check an own-key check with `Object.hasOwn`, and route
the getter through it so the two can no longer disagree.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/config/affiliate-themes.test.ts` — new, 47 cases.
The eight-key `INHERITED_KEYS` table drives the regression cases across
`getAffiliateTheme`, `hasAffiliateTheme`, and both `resolveCharacterTheme`
input paths.

The suite is not tautological: it pins the observable contract rather than
re-deriving it. `isAffiliateTheme()` structurally validates the returned value
instead of trusting the declared TypeScript type, the CSS-variable test asserts
the resolved theme is actually *usable* (this is the case that reproduced the
`TypeError`), and `hasAffiliateTheme` is cross-checked for agreement with both
`getAffiliateIds()` and `getAffiliateTheme()` so the two accessors cannot drift
apart again.

## Detailed testing steps

Reproduce on `develop` (no patch), then confirm the fix:

```bash
# RED — checkout this branch, revert only the production file
git checkout origin/develop -- packages/cloud/shared/src/lib/config/affiliate-themes.ts
bun test --cwd packages/cloud/shared src/lib/config/affiliate-themes.test.ts
#  13 pass, 34 fail  <- includes the TypeError above

# GREEN — restore the fix
git checkout HEAD -- packages/cloud/shared/src/lib/config/affiliate-themes.ts
bun test --cwd packages/cloud/shared src/lib/config/affiliate-themes.test.ts
#  47 pass, 0 fail
```

# Evidence Gate

<!-- evidence-head:95400271fedc08d826d67221a52441dce1970810 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface; this is a pure config-resolution module in packages/cloud/shared (server/isomorphic lib), and the diff touches no .tsx/.css/.svg.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the change is a pure-function lookup contract, fully covered by the RED/GREEN test transcript below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module emits no log lines; the observable behaviour is its return value, asserted directly in the suite.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; the module performs no I/O.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test transcripts attached below (the domain artifact for a pure module is its assertion output).
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - this module performs no I/O and emits no log lines.`

<details>
<summary>RED — production file reverted to <code>develop</code>, test file kept</summary>

```
(fail) resolveCharacterTheme > ignores inherited key toLocaleString supplied via character metadata
128 |       expect(isAffiliateTheme(theme)).toBe(true);
                                            ^
error: expect(received).toBe(expected)
Expected: true
Received: false

(fail) resolveCharacterTheme > resolved theme always yields usable CSS variables
239 |     "--theme-primary": theme.colors.primary,
                                   ^
TypeError: undefined is not an object (evaluating 'theme.colors.primary')
      at getThemeCSSVariables (packages/cloud/shared/src/lib/config/affiliate-themes.ts:239:30)
      at <anonymous> (packages/cloud/shared/src/lib/config/affiliate-themes.test.ts:135:20)

 13 pass
 34 fail
 66 expect() calls
Ran 47 tests across 1 file. [80.00ms]
```

</details>

<details>
<summary>GREEN — with the fix applied</summary>

```
bun test v1.3.11 (af24e281)

 47 pass
 0 fail
 112 expect() calls
Ran 47 tests across 1 file. [9.00ms]
```

</details>

<details>
<summary>No contamination — full <code>src/lib/config/</code> directory</summary>

```
bun test v1.3.11 (af24e281)

 156 pass
 0 fail
 522 expect() calls
Ran 156 tests across 17 files. [9.43s]
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface. The diff is confined to
packages/cloud/shared/src/lib/config/ and touches no rendered component.`

# Known gaps / failures

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to this two-line change. The owning package's
lint and test lanes were run and pass:

- `npx biome check` — clean on both files
- `bun test src/lib/config/` — 156 pass / 0 fail

I did **not** widen the fix beyond the prototype-chain defect. In particular
`getAffiliateIdFromCharacter` still returns `affiliate.affiliateId` without a
`typeof` guard, so a non-string metadata value is returned as-is. After this
change that value can no longer resolve to a bogus theme (it fails
`Object.hasOwn` and falls back to default), so it is not a live defect — I left
it alone rather than expanding the diff.
