### PR TITLE
test(cloud): pin team credential pool provider surface

### DIFF
--- a/packages/cloud/shared/src/lib/services/team-credential-pool/provider-map.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/provider-map.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pins the team credential pool's provider surface (#11332). Two invariants
+ * matter beyond the type system: the pooled and subscription provider sets must
+ * stay disjoint, because Phase 1 must refuse per-seat licenses outright; and
+ * the env-var map must stay identical to the canonical
+ * DIRECT_ACCOUNT_PROVIDER_ENV it mirrors, because a pooled key is delivered to
+ * the agent under that name. That canonical map is pinned literally below
+ * rather than imported: `@elizaos/auth/types` transitively reaches
+ * `@elizaos/cloud-routing`, which is not built in this package's test lane.
+ * Pure module, no harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  isPooledDirectProvider,
+  isSubscriptionProviderId,
+  keyLast4,
+  POOLED_DIRECT_PROVIDERS,
+  POOLED_PROVIDER_ENV_KEYS,
+  POOLED_PROVIDER_SECRET_PROVIDER,
+  SUBSCRIPTION_PROVIDER_IDS,
+} from "./provider-map";
+
+describe("provider sets", () => {
+  test("pooled and subscription provider ids are disjoint", () => {
+    const subscription = new Set<string>(SUBSCRIPTION_PROVIDER_IDS);
+    const overlap = POOLED_DIRECT_PROVIDERS.filter((id) => subscription.has(id));
+    expect(overlap).toEqual([]);
+  });
+
+  test("no subscription provider is accepted as poolable", () => {
+    for (const id of SUBSCRIPTION_PROVIDER_IDS) {
+      expect(isPooledDirectProvider(id)).toBe(false);
+    }
+  });
+
+  test("no pooled provider is classified as a subscription", () => {
+    for (const id of POOLED_DIRECT_PROVIDERS) {
+      expect(isSubscriptionProviderId(id)).toBe(false);
+    }
+  });
+
+  test("neither list contains duplicates", () => {
+    expect(new Set(POOLED_DIRECT_PROVIDERS).size).toBe(POOLED_DIRECT_PROVIDERS.length);
+    expect(new Set(SUBSCRIPTION_PROVIDER_IDS).size).toBe(SUBSCRIPTION_PROVIDER_IDS.length);
+  });
+
+  test("every id is a non-empty lowercase slug", () => {
+    for (const id of [...POOLED_DIRECT_PROVIDERS, ...SUBSCRIPTION_PROVIDER_IDS]) {
+      expect(id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+});
+
+describe("isPooledDirectProvider", () => {
+  test("accepts exactly the declared pooled providers", () => {
+    for (const id of POOLED_DIRECT_PROVIDERS) {
+      expect(isPooledDirectProvider(id)).toBe(true);
+    }
+  });
+
+  test("rejects unknown, empty, and near-miss values", () => {
+    for (const value of [
+      "",
+      "anthropic",
+      "anthropic-api ",
+      " anthropic-api",
+      "ANTHROPIC-API",
+      "openai",
+      "not-a-provider",
+    ]) {
+      expect(isPooledDirectProvider(value)).toBe(false);
+    }
+  });
+
+  test("rejects inherited Object.prototype keys", () => {
+    for (const key of ["toString", "constructor", "hasOwnProperty", "valueOf"]) {
+      expect(isPooledDirectProvider(key)).toBe(false);
+      expect(isSubscriptionProviderId(key)).toBe(false);
+    }
+  });
+});
+
+describe("provider lookup tables", () => {
+  test("every pooled provider has an env key", () => {
+    for (const id of POOLED_DIRECT_PROVIDERS) {
+      expect(Object.hasOwn(POOLED_PROVIDER_ENV_KEYS, id)).toBe(true);
+      expect(POOLED_PROVIDER_ENV_KEYS[id]).toMatch(/^[A-Z][A-Z0-9_]*$/);
+    }
+  });
+
+  test("every pooled provider has a secrets-vault provider", () => {
+    for (const id of POOLED_DIRECT_PROVIDERS) {
+      expect(Object.hasOwn(POOLED_PROVIDER_SECRET_PROVIDER, id)).toBe(true);
+      expect(typeof POOLED_PROVIDER_SECRET_PROVIDER[id]).toBe("string");
+      expect(POOLED_PROVIDER_SECRET_PROVIDER[id].length).toBeGreaterThan(0);
+    }
+  });
+
+  test("the lookup tables carry no keys beyond the pooled set", () => {
+    const pooled = [...POOLED_DIRECT_PROVIDERS].sort();
+    expect(Object.keys(POOLED_PROVIDER_ENV_KEYS).sort()).toEqual(pooled);
+    expect(Object.keys(POOLED_PROVIDER_SECRET_PROVIDER).sort()).toEqual(pooled);
+  });
+
+  test("distinct providers never share one env var", () => {
+    const envKeys = Object.values(POOLED_PROVIDER_ENV_KEYS);
+    expect(new Set(envKeys).size).toBe(envKeys.length);
+  });
+
+  // Mirror of DIRECT_ACCOUNT_PROVIDER_ENV in packages/auth/src/types.ts, which
+  // this module's own doc comment names as the source of truth. Pinned by value
+  // so a rename on either side fails here instead of silently handing the agent
+  // a key under a name it does not read.
+  test("env map matches the canonical DIRECT_ACCOUNT_PROVIDER_ENV", () => {
+    expect(POOLED_PROVIDER_ENV_KEYS).toEqual({
+      "anthropic-api": "ANTHROPIC_API_KEY",
+      "openai-api": "OPENAI_API_KEY",
+      "deepseek-api": "DEEPSEEK_API_KEY",
+      "zai-api": "ZAI_API_KEY",
+      "moonshot-api": "MOONSHOT_API_KEY",
+      "cerebras-api": "CEREBRAS_API_KEY",
+    });
+  });
+});
+
+describe("keyLast4", () => {
+  test("returns the final four characters of a realistic key", () => {
+    expect(keyLast4("sk-ant-api03-abcdefghijklmnop9Z7q")).toBe("9Z7q");
+    expect(keyLast4("0123456789")).toBe("6789");
+  });
+
+  test("is exactly four characters for any key of at least four", () => {
+    for (const key of ["abcd", "abcde", "x".repeat(200)]) {
+      expect(keyLast4(key).length).toBe(4);
+    }
+  });
+
+  test("preserves the tail verbatim, including non-alphanumerics", () => {
+    expect(keyLast4("secret-_+=")).toBe("-_+=");
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/services/team-credential-pool/provider-map.ts`
(#11332) had no test file; this adds first-time coverage for its provider surface.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures** for a pre-existing unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 16 cases pinning the invariants `provider-map.ts` depends on but does not
enforce.

The security-relevant one is **disjointness**. The module's own header states
Phase 1 pools provider API keys only, and that subscription providers are
per-seat licenses that must be rejected. Nothing enforces that today: the two
arrays are independent literals, and `isPooledDirectProvider` is a plain
`.includes` over one of them. If an id were ever added to
`POOLED_DIRECT_PROVIDERS` that also appears in `SUBSCRIPTION_PROVIDER_IDS`,
`service.ts` would accept it for pooling with no complaint.

The second is the **env-var mapping**. `POOLED_PROVIDER_ENV_KEYS` is documented
as matching `DIRECT_ACCOUNT_PROVIDER_ENV` (`packages/auth/src/types.ts`) — that
name is how a pooled key actually reaches the agent process. A rename on either
side currently fails silently: the key is materialized under a name nothing
reads.

Also covered: exhaustiveness of both lookup tables at runtime (not just via the
`Record<PooledDirectProvider, …>` type), no two providers sharing an env var,
no duplicate ids, slug shape, and the `keyLast4` tail contract.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`provider-map.test.ts` — the `provider sets` block. That is the invariant with
a real consequence if it breaks.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/services/team-credential-pool/provider-map.test.ts
```

To confirm the suite is not vacuous, I ran two mutations against the production
file (both reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `"zai-api": "ZAI_API_KEY"` → `"Z_AI_API_KEY"` | 15 pass, **1 fail** |
| `"anthropic-subscription"` appended to `POOLED_DIRECT_PROVIDERS` | 10 pass, **6 fail** |

The second mutation is the one that matters — it is exactly the drift the
module's header warns against, and it now fails four independent assertions
including `no pooled provider is classified as a subscription`.

# Evidence Gate

<!-- evidence-head:dfd957decb3b59f1f570fea108bea535a4560037 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; this PR adds assertions over pure constants.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module under test emits no log lines and performs no I/O.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 16 pass
 0 fail
 88 expect() calls
Ran 16 tests across 1 file. [9.00ms]
```

</details>

<details>
<summary>Mutation 1 — env var renamed in the production file</summary>

```
 15 pass
 1 fail
 88 expect() calls
Ran 16 tests across 1 file. [12.00ms]
```

</details>

<details>
<summary>Mutation 2 — subscription provider added to the pooled set</summary>

```
(fail) provider sets > no pooled provider is classified as a subscription
(fail) provider lookup tables > every pooled provider has an env key
(fail) provider lookup tables > every pooled provider has a secrets-vault provider
(fail) provider lookup tables > the lookup tables carry no keys beyond the pooled set
 10 pass
 6 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff, no UI surface.`

# Known gaps / failures

**Pre-existing, unrelated blocker.** Running the whole
`src/lib/services/team-credential-pool/` directory shows 34 failures and 2
errors, all from:

```
error: Cannot find module '@elizaos/cloud-routing'
  from packages/core/src/cloud-routing.ts
```

These are present with or without this PR — I baselined it by moving my file
out and re-running:

| Run | Result |
|---|---|
| directory **without** this PR's file | 1 pass, 34 fail, 2 errors (35 tests) |
| directory **with** this PR's file | 17 pass, 34 fail, 2 errors (51 tests) |

Identical failure count; this PR adds 16 passing tests and zero failures.

That same unbuilt dependency is why the env-var assertion pins
`DIRECT_ACCOUNT_PROVIDER_ENV` **by value** instead of importing it —
`@elizaos/auth/types` transitively reaches `@elizaos/cloud-routing` and cannot
load in this package's test lane. The trade-off is stated in the test header:
a literal pin still fails on a rename from either side, but a reviewer should
know it is a mirror, not a live cross-import. If the maintainers would rather
have the real import, the cleaner fix is to make that constant reachable
without the routing dependency, which is out of scope here.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
