### PR TITLE
test(ui): pin org role ladder and pooled provider mirror

### DIFF
--- a/packages/ui/src/cloud/organization/data/cloud-org-types.test.ts
+++ b/packages/ui/src/cloud/organization/data/cloud-org-types.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the org RBAC ladder and the pooled-provider list this module mirrors.
+ * `canManageOrg` gates the org settings surface, so its ordering and its
+ * fail-closed behaviour on unknown roles are the contract worth freezing; the
+ * provider list is a hand-maintained mirror of the cloud-shared source of truth
+ * and drifts silently. Pure module, no harness.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  canManageOrg,
+  isOrgOwner,
+  isOrgRole,
+  ORG_ROLE_RANK,
+  type OrgRole,
+  orgRoleRank,
+  POOLED_PROVIDER_LABELS,
+  POOLED_PROVIDERS,
+} from "./cloud-org-types";
+
+const ROLES: OrgRole[] = ["owner", "admin", "member"];
+
+/** Values that must never be mistaken for a role. */
+const NON_ROLES = [
+  "",
+  " ",
+  "Owner",
+  "OWNER",
+  "owner ",
+  "admin\n",
+  "guest",
+  "root",
+  "superuser",
+  "toString",
+  "constructor",
+  "hasOwnProperty",
+  "__proto__",
+  null,
+  undefined,
+] as const;
+
+describe("isOrgRole", () => {
+  it("accepts exactly the three declared roles", () => {
+    for (const role of ROLES) expect(isOrgRole(role)).toBe(true);
+  });
+
+  it("rejects near-misses, inherited keys, and nullish values", () => {
+    for (const value of NON_ROLES) expect(isOrgRole(value)).toBe(false);
+  });
+
+  it("rejects non-string types", () => {
+    for (const value of [0, 1, 2, true, false, {}, [], Symbol("owner")]) {
+      expect(isOrgRole(value)).toBe(false);
+    }
+  });
+});
+
+describe("orgRoleRank", () => {
+  it("orders the ladder owner > admin > member", () => {
+    expect(orgRoleRank("owner")).toBeGreaterThan(orgRoleRank("admin"));
+    expect(orgRoleRank("admin")).toBeGreaterThan(orgRoleRank("member"));
+  });
+
+  it("agrees with the exported rank table", () => {
+    for (const role of ROLES)
+      expect(orgRoleRank(role)).toBe(ORG_ROLE_RANK[role]);
+  });
+
+  it("fails closed below every real tier for unknown roles", () => {
+    const lowest = Math.min(...ROLES.map((role) => ORG_ROLE_RANK[role]));
+    for (const value of NON_ROLES) {
+      expect(orgRoleRank(value as string | null | undefined)).toBe(-1);
+      expect(orgRoleRank(value as string | null | undefined)).toBeLessThan(
+        lowest,
+      );
+    }
+  });
+
+  it("assigns every role a distinct rank", () => {
+    const ranks = ROLES.map((role) => ORG_ROLE_RANK[role]);
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});
+
+describe("canManageOrg", () => {
+  it("admits owner and admin", () => {
+    expect(canManageOrg("owner")).toBe(true);
+    expect(canManageOrg("admin")).toBe(true);
+  });
+
+  it("refuses member", () => {
+    expect(canManageOrg("member")).toBe(false);
+  });
+
+  it("refuses every unknown or nullish role", () => {
+    for (const value of NON_ROLES) {
+      expect(canManageOrg(value as string | null | undefined)).toBe(false);
+    }
+  });
+
+  it("is exactly rank >= admin", () => {
+    for (const role of ROLES) {
+      expect(canManageOrg(role)).toBe(orgRoleRank(role) >= ORG_ROLE_RANK.admin);
+    }
+  });
+});
+
+describe("isOrgOwner", () => {
+  it("is true only for owner", () => {
+    expect(isOrgOwner("owner")).toBe(true);
+    expect(isOrgOwner("admin")).toBe(false);
+    expect(isOrgOwner("member")).toBe(false);
+  });
+
+  it("refuses every unknown or nullish role", () => {
+    for (const value of NON_ROLES) {
+      expect(isOrgOwner(value as string | null | undefined)).toBe(false);
+    }
+  });
+
+  it("implies canManageOrg", () => {
+    for (const role of ROLES) {
+      if (isOrgOwner(role)) expect(canManageOrg(role)).toBe(true);
+    }
+  });
+
+  it("is the unique top of the ladder", () => {
+    const top = Math.max(...ROLES.map((role) => ORG_ROLE_RANK[role]));
+    for (const role of ROLES) {
+      expect(isOrgOwner(role)).toBe(ORG_ROLE_RANK[role] === top);
+    }
+  });
+});
+
+describe("pooled providers", () => {
+  // Mirror of POOLED_DIRECT_PROVIDERS in
+  // cloud/shared/src/lib/services/team-credential-pool/provider-map.ts, which
+  // this module's doc comment names as the source of truth. @elizaos/ui
+  // deliberately does not depend on the cloud-shared bundle, so the list is
+  // pinned by value: drift on either side fails here instead of silently
+  // rendering a provider the backend refuses (or omitting one it accepts).
+  it("matches the cloud-shared pooled provider list", () => {
+    expect([...POOLED_PROVIDERS]).toEqual([
+      "anthropic-api",
+      "openai-api",
+      "deepseek-api",
+      "zai-api",
+      "moonshot-api",
+      "cerebras-api",
+    ]);
+  });
+
+  it("never includes a Phase-2 subscription provider", () => {
+    for (const id of [
+      "anthropic-subscription",
+      "openai-codex",
+      "gemini-cli",
+      "zai-coding",
+      "kimi-coding",
+      "deepseek-coding",
+    ]) {
+      expect([...POOLED_PROVIDERS]).not.toContain(id);
+    }
+  });
+
+  it("carries no duplicates", () => {
+    expect(new Set(POOLED_PROVIDERS).size).toBe(POOLED_PROVIDERS.length);
+  });
+
+  it("labels exactly the declared providers, with no empty label", () => {
+    expect(Object.keys(POOLED_PROVIDER_LABELS).sort()).toEqual(
+      [...POOLED_PROVIDERS].sort(),
+    );
+    for (const id of POOLED_PROVIDERS) {
+      expect(POOLED_PROVIDER_LABELS[id].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives every provider a distinct label", () => {
+    const labels = Object.values(POOLED_PROVIDER_LABELS);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/ui/src/cloud/organization/data/cloud-org-types.ts`
had no test file; this adds first-time coverage for its RBAC helpers and its
mirrored provider list.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 20 cases over the org role ladder (`isOrgRole`, `orgRoleRank`,
`canManageOrg`, `isOrgOwner`) and the pooled-provider list.

`canManageOrg` is the gate for the org settings surface. Two properties are
worth freezing rather than leaving implicit:

- **It must fail closed.** `orgRoleRank` returns `-1` for anything it does not
  recognize, and the suite asserts that `-1` is strictly below *every* real
  tier — computed from `ORG_ROLE_RANK`, not hardcoded, so the assertion still
  holds if a tier is added. Covered inputs include casing variants
  (`"Owner"`, `"OWNER"`), whitespace (`"owner "`, `"admin\n"`), nullish, wrong
  types, and inherited `Object.prototype` keys (`"toString"`, `"__proto__"`).
- **The helpers must not drift apart.** `canManageOrg` is asserted to be
  *exactly* `rank >= admin`, and `isOrgOwner` to be exactly the unique top of
  the ladder — so a future edit to one cannot silently disagree with the table.

`POOLED_PROVIDERS` is a hand-maintained mirror. The module's own header says
`@elizaos/ui` deliberately does not depend on the cloud-shared bundle, and that
if the backend contract changes **both** must be updated. Nothing enforces the
second half today. The suite pins the list by value and separately asserts no
Phase-2 subscription provider can appear in it — the drift that would render a
provider the backend refuses.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`cloud-org-types.test.ts` — the `canManageOrg` and `pooled providers` blocks.

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/cloud/organization/data/cloud-org-types.test.ts
```

To confirm the suite is not vacuous, I ran two mutations against the production
file (both reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `canManageOrg` gate lowered `>= ORG_ROLE_RANK.admin` → `>= ORG_ROLE_RANK.member` | 18 pass, **2 fail** |
| `"anthropic-subscription"` appended to `POOLED_PROVIDERS` | 17 pass, **3 fail** |

The first is the privilege-escalation shape the gate exists to prevent: it
makes every `member` able to manage the org, and the suite catches it on both
the direct case and the `is exactly rank >= admin` consistency check.

# Evidence Gate

<!-- evidence-head:602607729e5108a50b86d11dd6076ae843dabbf0 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff. The new file is a .test.ts over pure functions and constants; no .tsx/.css/.svg is touched and no component renders.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; this PR adds assertions over pure functions.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module under test performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; no component is mounted.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test; nothing renders.`

<details>
<summary>New suite — passing</summary>

```
 RUN  v4.1.10 packages/ui

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  96ms
```

</details>

<details>
<summary>Mutation A — canManageOrg gate lowered to member</summary>

```
 × canManageOrg > refuses member
 × canManageOrg > is exactly rank >= admin

 FAIL  src/cloud/organization/data/cloud-org-types.test.ts > canManageOrg > refuses member
 FAIL  src/cloud/organization/data/cloud-org-types.test.ts > canManageOrg > is exactly rank >= admin
      Tests  2 failed | 18 passed (20)
```

</details>

<details>
<summary>Mutation B — subscription provider added to POOLED_PROVIDERS</summary>

```
 × pooled providers > matches the cloud-shared pooled provider list
 × pooled providers > never includes a Phase-2 subscription provider
 × pooled providers > labels exactly the declared providers, with no empty label
      Tests  3 failed | 17 passed (20)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff. No rendered surface changes, so audit:app would produce
no before/after delta.`

# Known gaps / failures

The provider list is pinned **by value**, not by importing
`POOLED_DIRECT_PROVIDERS`. That is deliberate and matches the module's stated
architecture rule (`@elizaos/ui` must not depend on the cloud-shared server
bundle), but a reviewer should know the trade-off: this catches drift from
either side by failing, yet it is a second mirror rather than a single source of
truth. Collapsing the two would mean publishing that list through a browser-safe
package, which is a larger change than a test PR should make.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
