### PR TITLE
test(cloud): pin agent web-UI URL resolution

### DIFF
--- a/packages/cloud/shared/src/lib/eliza-agent-web-ui.test.ts
+++ b/packages/cloud/shared/src/lib/eliza-agent-web-ui.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Pins agent web-UI URL resolution. The module documents a three-way
+ * distinction its callers depend on — omitted baseDomain falls back to env then
+ * the built-in default, while an explicitly supplied one never falls back and
+ * yields null when it normalizes away — and that distinction is carried by an
+ * Object.hasOwn check that is easy to break. Also covers the direct/preferred
+ * ordering and the host-preserving path applicator. Deterministic: process.env
+ * is saved and restored per test; no network.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  getAgentBaseDomain,
+  getClientSafeElizaAgentWebUiUrl,
+  getElizaAgentDirectWebUiUrl,
+  getElizaAgentPublicWebUiUrl,
+  getPreferredElizaAgentWebUiUrl,
+} from "./eliza-agent-web-ui";
+
+const DEFAULT_DOMAIN = "cloud.eliza.app";
+const ENV_KEY = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
+const SANDBOX_ID = "sbx-1234";
+
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  savedEnv = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = savedEnv;
+});
+
+const sandbox = (over: Record<string, unknown> = {}) =>
+  ({
+    id: SANDBOX_ID,
+    headscale_ip: null,
+    web_ui_port: null,
+    bridge_port: null,
+    ...over,
+  }) as never;
+
+describe("getAgentBaseDomain", () => {
+  test("falls back to the built-in default when env is unset", () => {
+    expect(getAgentBaseDomain()).toBe(DEFAULT_DOMAIN);
+  });
+
+  test("treats blank and whitespace-only env as unset", () => {
+    for (const value of ["", "   ", "\t\n"]) {
+      process.env[ENV_KEY] = value;
+      expect(getAgentBaseDomain()).toBe(DEFAULT_DOMAIN);
+    }
+  });
+
+  test("strips scheme, path, and trailing dots from env", () => {
+    const cases: Array<[string, string]> = [
+      ["example.com", "example.com"],
+      ["  example.com  ", "example.com"],
+      ["https://example.com", "example.com"],
+      ["http://example.com", "example.com"],
+      ["https://example.com/some/path", "example.com"],
+      ["example.com/", "example.com"],
+      ["example.com...", "example.com"],
+    ];
+    for (const [input, expected] of cases) {
+      process.env[ENV_KEY] = input;
+      expect(getAgentBaseDomain()).toBe(expected);
+    }
+  });
+
+  test("falls back to the default when env normalizes to nothing", () => {
+    for (const value of ["https://", "/", "..."]) {
+      process.env[ENV_KEY] = value;
+      expect(getAgentBaseDomain()).toBe(DEFAULT_DOMAIN);
+    }
+  });
+});
+
+describe("getElizaAgentPublicWebUiUrl — omitted baseDomain", () => {
+  test("uses the built-in default when env is unset", () => {
+    expect(getElizaAgentPublicWebUiUrl(sandbox())).toBe(`https://${SANDBOX_ID}.${DEFAULT_DOMAIN}`);
+  });
+
+  test("uses env when set", () => {
+    process.env[ENV_KEY] = "agents.example.com";
+    expect(getElizaAgentPublicWebUiUrl(sandbox())).toBe(`https://${SANDBOX_ID}.agents.example.com`);
+  });
+
+  test("an explicit undefined is the same as omitting it", () => {
+    process.env[ENV_KEY] = "agents.example.com";
+    expect(getElizaAgentPublicWebUiUrl(sandbox(), { baseDomain: undefined })).toBe(
+      getElizaAgentPublicWebUiUrl(sandbox()),
+    );
+  });
+
+  test("never returns null on the fallback path", () => {
+    for (const value of ["", "https://", "..."]) {
+      process.env[ENV_KEY] = value;
+      expect(getElizaAgentPublicWebUiUrl(sandbox())).not.toBeNull();
+    }
+  });
+});
+
+describe("getElizaAgentPublicWebUiUrl — supplied baseDomain", () => {
+  test("uses the override verbatim after normalization", () => {
+    process.env[ENV_KEY] = "env.example.com";
+    expect(
+      getElizaAgentPublicWebUiUrl(sandbox(), {
+        baseDomain: "https://override.example.com/ignored",
+      }),
+    ).toBe(`https://${SANDBOX_ID}.override.example.com`);
+  });
+
+  test("returns null rather than falling back to env or the default", () => {
+    process.env[ENV_KEY] = "env.example.com";
+    for (const baseDomain of [null, "", "   ", "https://", "/", "..."]) {
+      expect(getElizaAgentPublicWebUiUrl(sandbox(), { baseDomain })).toBeNull();
+    }
+  });
+});
+
+describe("path application", () => {
+  test("a root path leaves the base URL untouched", () => {
+    const base = `https://${SANDBOX_ID}.${DEFAULT_DOMAIN}`;
+    expect(getElizaAgentPublicWebUiUrl(sandbox(), { path: "/" })).toBe(base);
+    expect(getElizaAgentPublicWebUiUrl(sandbox(), { path: "" })).toBe(base);
+  });
+
+  test("carries pathname, search, and hash", () => {
+    const url = getElizaAgentPublicWebUiUrl(sandbox(), {
+      path: "/chat?tab=logs#top",
+    });
+    expect(url).not.toBeNull();
+    const parsed = new URL(url as string);
+    expect(parsed.pathname).toBe("/chat");
+    expect(parsed.search).toBe("?tab=logs");
+    expect(parsed.hash).toBe("#top");
+  });
+
+  test("an absolute or protocol-relative path cannot move the host", () => {
+    for (const path of [
+      "https://evil.example.net/steal",
+      "//evil.example.net/steal",
+      "http://evil.example.net:9999/steal",
+    ]) {
+      const url = getElizaAgentPublicWebUiUrl(sandbox(), { path });
+      expect(url).not.toBeNull();
+      const parsed = new URL(url as string);
+      expect(parsed.host).toBe(`${SANDBOX_ID}.${DEFAULT_DOMAIN}`);
+      expect(parsed.protocol).toBe("https:");
+      expect(parsed.pathname).toBe("/steal");
+    }
+  });
+
+  test("resolves a relative path against the agent origin", () => {
+    const url = getElizaAgentPublicWebUiUrl(sandbox(), { path: "logs" });
+    expect(new URL(url as string).host).toBe(`${SANDBOX_ID}.${DEFAULT_DOMAIN}`);
+  });
+});
+
+describe("getElizaAgentDirectWebUiUrl", () => {
+  test("returns null without a headscale ip", () => {
+    expect(getElizaAgentDirectWebUiUrl(sandbox({ web_ui_port: 8080 }))).toBeNull();
+  });
+
+  test("returns null when neither port is usable", () => {
+    for (const over of [
+      { headscale_ip: "100.64.0.1" },
+      { headscale_ip: "100.64.0.1", web_ui_port: 0, bridge_port: 0 },
+      { headscale_ip: "100.64.0.1", web_ui_port: null, bridge_port: null },
+    ]) {
+      expect(getElizaAgentDirectWebUiUrl(sandbox(over))).toBeNull();
+    }
+  });
+
+  test("prefers web_ui_port over bridge_port", () => {
+    expect(
+      getElizaAgentDirectWebUiUrl(
+        sandbox({
+          headscale_ip: "100.64.0.1",
+          web_ui_port: 8080,
+          bridge_port: 9090,
+        }),
+      ),
+    ).toBe("http://100.64.0.1:8080");
+  });
+
+  test("falls back to bridge_port when web_ui_port is absent", () => {
+    expect(
+      getElizaAgentDirectWebUiUrl(sandbox({ headscale_ip: "100.64.0.1", bridge_port: 9090 })),
+    ).toBe("http://100.64.0.1:9090");
+  });
+
+  test("applies the path without changing host or scheme", () => {
+    const url = getElizaAgentDirectWebUiUrl(
+      sandbox({ headscale_ip: "100.64.0.1", web_ui_port: 8080 }),
+      { path: "/health" },
+    );
+    const parsed = new URL(url as string);
+    expect(parsed.protocol).toBe("http:");
+    expect(parsed.host).toBe("100.64.0.1:8080");
+    expect(parsed.pathname).toBe("/health");
+  });
+});
+
+describe("getPreferredElizaAgentWebUiUrl", () => {
+  test("prefers the public URL when one resolves", () => {
+    expect(
+      getPreferredElizaAgentWebUiUrl(sandbox({ headscale_ip: "100.64.0.1", web_ui_port: 8080 })),
+    ).toBe(`https://${SANDBOX_ID}.${DEFAULT_DOMAIN}`);
+  });
+
+  test("falls back to the direct URL when the override suppresses the public one", () => {
+    expect(
+      getPreferredElizaAgentWebUiUrl(sandbox({ headscale_ip: "100.64.0.1", web_ui_port: 8080 }), {
+        baseDomain: null,
+      }),
+    ).toBe("http://100.64.0.1:8080");
+  });
+
+  test("returns null when neither route resolves", () => {
+    expect(getPreferredElizaAgentWebUiUrl(sandbox(), { baseDomain: null })).toBeNull();
+  });
+});
+
+describe("getClientSafeElizaAgentWebUiUrl", () => {
+  test("returns null without a canonical url — it never reads env", () => {
+    process.env[ENV_KEY] = "agents.example.com";
+    expect(
+      getClientSafeElizaAgentWebUiUrl(sandbox({ headscale_ip: "100.64.0.1", web_ui_port: 8080 })),
+    ).toBeNull();
+  });
+
+  test("returns null for an empty canonical url", () => {
+    expect(getClientSafeElizaAgentWebUiUrl(sandbox({ canonicalWebUiUrl: "" }))).toBeNull();
+    expect(getClientSafeElizaAgentWebUiUrl(sandbox({ canonicalWebUiUrl: null }))).toBeNull();
+  });
+
+  test("applies the path to the canonical url", () => {
+    expect(
+      getClientSafeElizaAgentWebUiUrl(sandbox({ canonicalWebUiUrl: "https://agent.example.com" }), {
+        path: "/chat",
+      }),
+    ).toBe("https://agent.example.com/chat");
+  });
+
+  test("an absolute path cannot move the canonical host", () => {
+    const url = getClientSafeElizaAgentWebUiUrl(
+      sandbox({ canonicalWebUiUrl: "https://agent.example.com" }),
+      { path: "https://evil.example.net/steal" },
+    );
+    expect(new URL(url as string).host).toBe("agent.example.com");
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/eliza-agent-web-ui.ts` had no
test file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 26 cases over agent web-UI URL resolution.

The contract worth freezing is the **three-way `baseDomain` distinction** the
module's own doc comment spells out, which is carried by a single line:

```ts
const baseDomainOptionSupplied =
  Object.hasOwn(options, "baseDomain") && rawOpt !== undefined;
```

- omitted, or explicitly `undefined` → resolve from
  `ELIZA_CLOUD_AGENT_BASE_DOMAIN`, then the built-in default; **never null**
- any other value, including `null` and `""` → use only that value after
  normalization, and return **`null`** if it does not yield a hostname — no
  silent fallback, because callers read `null` as "no public URL for this
  override"

Both halves of that predicate are load-bearing and neither is obvious; dropping
either one silently changes which callers get a URL.

The suite also pins `applyPath`, which copies only `pathname`/`search`/`hash`
onto the agent origin. That means a caller-supplied path cannot relocate the
host — `"https://evil.example.net/steal"` and `"//evil.example.net/steal"` both
resolve to `/steal` on the agent's own host. That property is currently
implicit in the choice to assign three fields instead of returning the resolved
URL, so it is asserted directly for all three URL builders.

Remaining coverage: env normalization (scheme/path/trailing-dot stripping,
blank-as-unset), `web_ui_port` preferred over `bridge_port` with port `0`
treated as unusable, public-over-direct preference ordering, and
`getClientSafeElizaAgentWebUiUrl` never reading `process.env` (it is the
client-safe seam).

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`eliza-agent-web-ui.test.ts` — the two `getElizaAgentPublicWebUiUrl` blocks
(omitted vs supplied `baseDomain`) and `path application`.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/eliza-agent-web-ui.test.ts
```

To confirm the suite is not vacuous, I ran two mutations against the production
file (both reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| drop `&& rawOpt !== undefined` from the supplied-check | 25 pass, **1 fail** |
| `applyPath` returns `normalizedPath.toString()` instead of copying three fields | 21 pass, **5 fail** |

The second mutation is the host-relocation shape: with it applied,
`path: "https://evil.example.net/steal"` returns a URL on `evil.example.net`.

# Evidence Gate

<!-- evidence-head:4d33d50c12d3e5b8540feb9bde6aef7271bc6c0d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a server-side URL builder; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns strings and is fully covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module emits no log lines; its observable behaviour is its return value, asserted directly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; the module performs no network I/O.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - the module performs no I/O and emits no log lines.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 26 pass
 0 fail
 63 expect() calls
Ran 26 tests across 1 file. [9.00ms]
```

</details>

<details>
<summary>Mutation A — supplied-check loses its undefined guard</summary>

```
(fail) getElizaAgentPublicWebUiUrl - omitted baseDomain > an explicit undefined is the same as omitting it
 25 pass
 1 fail
```

</details>

<details>
<summary>Mutation B — applyPath returns the resolved path URL directly</summary>

```
(fail) path application > an absolute or protocol-relative path cannot move the host
(fail) path application > resolves a relative path against the agent origin
(fail) getElizaAgentDirectWebUiUrl > applies the path without changing host or scheme
(fail) getClientSafeElizaAgentWebUiUrl > applies the path to the canonical url
(fail) getClientSafeElizaAgentWebUiUrl > an absolute path cannot move the canonical host
 21 pass
 5 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side module; no UI surface.`

# Known gaps / failures

The suite mutates `process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN` and restores the
prior value in `afterEach` (including the unset case). That is safe under
`bun test --isolate`, which is this package's configured lane, but worth
flagging since env mutation is shared state.

I did **not** assert anything about `getPreferredElizaAgentWebUiUrl` falling
through to the direct URL when `baseDomain: null` suppresses the public one
being *correct* — only that it is the current behaviour. It is arguably
surprising, since the docs say callers use `null` to mean "no public URL for
this override", yet the preferred helper then hands back an internal Headscale
address. I left it alone rather than guess at intent; if it is wrong, that is a
separate behavioural change and this test would need updating alongside it.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
