### PR TITLE
test(core): cover native-features.edge

### DIFF
--- a/packages/core/src/plugins/__tests__/native-features-edge.test.ts
+++ b/packages/core/src/plugins/__tests__/native-features-edge.test.ts
@@ -49,4 +49,74 @@ describe("native-features.edge", () => {
 	it("resolves no feature from service types on the edge", () => {
 		expect(resolveNativeRuntimeFeatureFromServiceType("anything")).toBeNull();
 	});
+
+	it("throws with the exact dedicated-host message for every feature", () => {
+		const features = Object.keys(nativeRuntimeFeatureDefaults) as Array<
+			keyof typeof nativeRuntimeFeatureDefaults
+		>;
+		for (const feature of features) {
+			expect(() => getNativeRuntimeFeaturePlugin(feature)).toThrow(
+				new RegExp(
+					`^Core native feature ${feature} requires a dedicated runtime host$`,
+				),
+			);
+		}
+	});
+
+	it("maps every remaining plugin name back to its feature", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName("relationships")).toBe(
+			"relationships",
+		);
+		expect(resolveNativeRuntimeFeatureFromPluginName("trajectories")).toBe(
+			"trajectories",
+		);
+		expect(resolveNativeRuntimeFeatureFromPluginName("advanced-memory")).toBe(
+			"advancedMemory",
+		);
+	});
+
+	it("treats undefined and empty plugin names as unresolved", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName(undefined)).toBeNull();
+		expect(resolveNativeRuntimeFeatureFromPluginName("")).toBeNull();
+	});
+
+	it("matches plugin names exactly, case-sensitively, without trimming", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName("Documents")).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName("advancedPlanning"),
+		).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName(" advanced-memory "),
+		).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName("advanced-memory-extra"),
+		).toBeNull();
+	});
+
+	it("does not resolve inherited object keys as plugin names", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName("toString")).toBeNull();
+	});
+
+	it("declares the complete feature-to-plugin-name mapping", () => {
+		expect(nativeRuntimeFeaturePluginNames).toEqual({
+			documents: "documents",
+			relationships: "relationships",
+			trajectories: "trajectories",
+			advancedPlanning: "advanced-planning",
+			advancedMemory: "advanced-memory",
+		});
+	});
+
+	it("ignores every feature name, plugin name, and empty service type", () => {
+		const inputs = [
+			"",
+			...Object.keys(nativeRuntimeFeatureDefaults),
+			...Object.values(nativeRuntimeFeaturePluginNames),
+		];
+		for (const serviceType of inputs) {
+			expect(
+				resolveNativeRuntimeFeatureFromServiceType(serviceType),
+			).toBeNull();
+		}
+	});
 });


### PR DESCRIPTION

## What

Additive-only test coverage for `packages/core/src/plugins/native-features.edge.ts`, appended to the existing suite at `packages/core/src/plugins/__tests__/native-features-edge.test.ts`. **+70/−0 — no line of the existing suite is removed or rewritten.**

This is a **test-only change**: no production file is touched and no runtime behavior changes. As a fork contributor, hosted GitHub CI does not run on this PR; all verification below was executed locally against `origin/develop` (`0d9b34de5131`) and the exact commands and counts are quoted.

## Why these cases

The existing suite covered one throw site, two plugin-name resolutions, and one service type. The added cases close the remaining observable branches of the module:

- **`getNativeRuntimeFeaturePlugin` throws for *all five* features with the exact message** `` ^Core native feature <feature> requires a dedicated runtime host$ `` (anchored regex, so interpolation of each feature value is asserted exactly, not just as a substring).
- **Plugin-name resolution completed:** `relationships`, `trajectories`, and `advanced-memory` → their features (joining the already-covered `documents` / `advanced-planning`).
- **Nullish inputs:** `undefined` and `""` both return `null` (the `if (!pluginName)` branch beyond `null`).
- **Matching is exact:** case differs (`Documents`, `advancedPlanning`), padded (`" advanced-memory "`), and extended (`advanced-memory-extra`) names all return `null`.
- **Prototype safety:** an inherited object key (`toString`) does not resolve, guarding the linear scan against accidental lookup-based matches.
- **Whole-object equality** for `nativeRuntimeFeaturePluginNames`, so a missing key, extra key, or wrongly kebab-cased mapping fails clearly.
- **`resolveNativeRuntimeFeatureFromServiceType` ignores every input class on the edge:** empty string, every feature name, and every configured plugin name all return `null`.

All expectations record behavior observed by running the real module — no mocks, no `vi.hoisted`, no type-level assertions.

## Evidence (test-only bar)

1. **vitest** (bunx vitest run src/plugins/__tests__/native-features-edge.test.ts, from packages/core):
   `Test Files 1 passed (1) · Tests 12 passed (12)` — 5 pre-existing + 7 new.
2. **biome** (`bunx biome check --write packages/core/src/plugins/__tests__/native-features-edge.test.ts`, root config): clean — "Checked 1 file. No fixes applied."
3. **TypeScript:** `bunx tsc --noEmit` in packages/core produces no line mentioning `native-features-edge.test`. Because the package tsconfig excludes `src/**/__tests__/**`, a supplementary single-file strict check was also run over the test file (`tsc --ignoreConfig --noEmit --strict ...`): exit 0.
4. **Diff surface:** only `packages/core/src/plugins/__tests__/native-features-edge.test.ts` changes; +70 insertions, 0 deletions.

## Notes

- The suite runs under vitest (the runner that owns packages/core per its package scripts); no `vi.hoisted()` is used anywhere in the diff.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0231127adf300e69ebd31cddd1d5cb4ed3d60213 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
