### PR TITLE
fix(cloud): match stateless indicators on word boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/stateful-detection.test.ts
+++ b/packages/cloud/shared/src/lib/services/stateful-detection.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Exercises database-requirement detection. The stateless list is an early
+ * exit that overrides every later signal, so it must not fire on a word it
+ * merely appears inside — "demographic" is not "demo". Also pins the documented
+ * confidence ladder and the keyword-count thresholds. Pure module, no harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { analyzePrompt, getDetailedAnalysis, requiresDatabase } from "./stateful-detection";
+
+describe("stateless early exit", () => {
+  test("fires on a genuine stateless app", () => {
+    for (const prompt of [
+      "a simple calculator",
+      "a unit converter",
+      "a landing page for my band",
+      "a countdown to launch day",
+      "a weather widget",
+    ]) {
+      const result = analyzePrompt(prompt);
+      expect(result.requiresDatabase).toBe(false);
+      expect(result.confidence).toBe(0.9);
+    }
+  });
+
+  test("does not fire on a word that merely contains an indicator", () => {
+    const cases: Array<[string, string]> = [
+      ["an app to track demographic data for my research", "demo"],
+      ["a CRM to manage embedded device inventory", "embed"],
+      ["a tool to log clockwise rotations of my machines", "clock"],
+    ];
+    for (const [prompt, substring] of cases) {
+      expect(prompt.toLowerCase()).toContain(substring);
+      expect(requiresDatabase(prompt)).toBe(true);
+    }
+  });
+
+  test("a substring collision does not suppress a strong phrase match", () => {
+    const result = analyzePrompt("a habit tracker for my demographic study group");
+    expect(result.requiresDatabase).toBe(true);
+    expect(result.matchedPhrases).toContain("habit tracker");
+    expect(result.confidence).toBe(0.95);
+  });
+
+  test("still matches an indicator standing as its own word", () => {
+    expect(requiresDatabase("a demo of my portfolio tracker")).toBe(false);
+    expect(requiresDatabase("an embed for my notes dashboard")).toBe(false);
+  });
+
+  test("matches a multi-word stateless indicator", () => {
+    expect(requiresDatabase("a coming soon splash page")).toBe(false);
+    expect(requiresDatabase("an api proxy for my data")).toBe(false);
+  });
+});
+
+describe("strong phrase matches", () => {
+  test("a single phrase is enough, at the documented confidence", () => {
+    for (const prompt of [
+      "I want to keep track of my running",
+      "an app with user accounts",
+      "a shopping cart for my store",
+      "somewhere to write journal entries",
+    ]) {
+      const result = analyzePrompt(prompt);
+      expect(result.requiresDatabase).toBe(true);
+      expect(result.confidence).toBe(0.95);
+      expect(result.matchedPhrases.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("reports every phrase it matched", () => {
+    const result = analyzePrompt("a todo list with a shopping cart");
+    expect(result.matchedPhrases).toContain("todo list");
+    expect(result.matchedPhrases).toContain("shopping cart");
+  });
+});
+
+describe("keyword thresholds", () => {
+  test("one keyword is not enough", () => {
+    const result = analyzePrompt("something to add numbers");
+    expect(result.matchedIndicators).toEqual(["add"]);
+    expect(result.requiresDatabase).toBe(false);
+    expect(result.confidence).toBe(0.6);
+  });
+
+  test("zero keywords is not enough", () => {
+    const result = analyzePrompt("a page about volcanoes");
+    expect(result.matchedIndicators).toEqual([]);
+    expect(result.requiresDatabase).toBe(false);
+    expect(result.confidence).toBe(0.6);
+  });
+
+  test("two keywords cross the threshold at lower confidence", () => {
+    const result = analyzePrompt("edit and delete rows");
+    expect(result.matchedIndicators.length).toBe(2);
+    expect(result.requiresDatabase).toBe(true);
+    expect(result.confidence).toBe(0.7);
+  });
+
+  test("three or more keywords raise confidence", () => {
+    const result = analyzePrompt("create, edit and delete my records");
+    expect(result.matchedIndicators.length).toBeGreaterThanOrEqual(3);
+    expect(result.requiresDatabase).toBe(true);
+    expect(result.confidence).toBe(0.85);
+  });
+
+  test("keywords match on word boundaries, not substrings", () => {
+    // "additional" contains "add"; "listen" contains "list".
+    const result = analyzePrompt("additional information for listeners");
+    expect(result.matchedIndicators).toEqual([]);
+    expect(result.requiresDatabase).toBe(false);
+  });
+
+  test("is case-insensitive", () => {
+    expect(requiresDatabase("CREATE, EDIT AND DELETE MY RECORDS")).toBe(true);
+    expect(analyzePrompt("A Simple CALCULATOR").requiresDatabase).toBe(false);
+  });
+});
+
+describe("result shape", () => {
+  test("confidence is always a probability", () => {
+    for (const prompt of [
+      "",
+      "a calculator",
+      "keep track of my habits",
+      "add edit delete",
+      "a page about volcanoes",
+    ]) {
+      const { confidence } = analyzePrompt(prompt);
+      expect(confidence).toBeGreaterThanOrEqual(0);
+      expect(confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("an empty prompt requires no database", () => {
+    const result = analyzePrompt("");
+    expect(result.requiresDatabase).toBe(false);
+    expect(result.matchedIndicators).toEqual([]);
+    expect(result.matchedPhrases).toEqual([]);
+  });
+
+  test("requiresDatabase agrees with analyzePrompt", () => {
+    for (const prompt of [
+      "a calculator",
+      "keep track of my habits",
+      "add edit delete",
+      "a page about volcanoes",
+      "an app to track demographic data",
+    ]) {
+      expect(requiresDatabase(prompt)).toBe(analyzePrompt(prompt).requiresDatabase);
+    }
+  });
+
+  test("matched lists never contain duplicates", () => {
+    const result = analyzePrompt("track and track and track my data records");
+    expect(new Set(result.matchedIndicators).size).toBe(result.matchedIndicators.length);
+  });
+});
+
+describe("getDetailedAnalysis", () => {
+  test("names the matching phrase when one drove the decision", () => {
+    const result = getDetailedAnalysis("I want to keep track of my running");
+    expect(result.summary).toBe('Database required (phrase match: "keep track of")');
+  });
+
+  test("counts keywords when no phrase matched", () => {
+    const result = getDetailedAnalysis("create, edit and delete my records");
+    expect(result.summary).toBe(
+      `Database required (${result.matchedIndicators.length} keyword matches)`,
+    );
+  });
+
+  test("says so plainly when no database is needed", () => {
+    expect(getDetailedAnalysis("a calculator").summary).toBe("No database required");
+  });
+
+  test("carries the full analyzePrompt result through", () => {
+    const prompt = "create, edit and delete my records";
+    const { summary, ...rest } = getDetailedAnalysis(prompt);
+    expect(typeof summary).toBe("string");
+    expect(rest).toEqual(analyzePrompt(prompt));
+  });
+});

--- a/packages/cloud/shared/src/lib/services/stateful-detection.ts
+++ b/packages/cloud/shared/src/lib/services/stateful-detection.ts
@@ -158,6 +158,17 @@ const STATELESS_INDICATORS = [
   "splash page",
 ] as const;
 
+/**
+ * Word-boundary matchers for the stateless list. Built once, and anchored the
+ * same way the stateful keywords are: a bare `includes` would let "demographic"
+ * match "demo" and "embedded" match "embed", and because the stateless check is
+ * an early exit that outranks every later signal, one such collision silently
+ * classifies a tracker or CRM as needing no database.
+ */
+const STATELESS_PATTERNS = STATELESS_INDICATORS.map(
+  (indicator) => new RegExp(`\\b${indicator}\\b`, "i"),
+);
+
 export interface DetectionResult {
   /** Whether database is likely required */
   requiresDatabase: boolean;
@@ -189,8 +200,8 @@ export function analyzePrompt(prompt: string): DetectionResult {
   const matchedPhrases: string[] = [];
 
   // Check for stateless indicators first (early exit)
-  for (const indicator of STATELESS_INDICATORS) {
-    if (lower.includes(indicator)) {
+  for (const pattern of STATELESS_PATTERNS) {
+    if (pattern.test(lower)) {
       return {
         requiresDatabase: false,
         confidence: 0.9,


### PR DESCRIPTION
# Relates to

No existing issue. Found while writing first-time regression coverage for
`packages/cloud/shared/src/lib/services/stateful-detection.ts`, which is
reachable as a public subpath export
(`@elizaos/cloud-shared/lib/services/stateful-detection`) and had no test file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low.** Two-line semantic change plus a new test file. The change strictly
narrows what the stateless early exit matches, and it makes the module
internally consistent — the stateful keyword pass immediately below already
used the exact same `\b…\b` anchoring.

# Background

## What does this PR do?

`analyzePrompt` has two matching passes that were anchored differently:

```ts
// stateless — substring
for (const indicator of STATELESS_INDICATORS) {
  if (lower.includes(indicator)) { /* early exit */ }
}

// stateful — word boundary
for (const indicator of STATEFUL_INDICATORS) {
  const regex = new RegExp(`\\b${indicator}\\b`, "i");
  ...
}
```

The substring form fires on any word that merely *contains* an indicator:

| Prompt | Matches | Because |
|---|---|---|
| "an app to track demographic data for my research" | `demo` | **demo**graphic |
| "a CRM to manage embedded device inventory" | `embed` | **embed**ded |
| "a tool to log clockwise rotations of my machines" | `clock` | **clock**wise |

This matters more than a mis-scored confidence because the stateless check is
an **early exit** — it returns before the phrase pass and the keyword pass ever
run. So a single collision overrides every stateful signal in the prompt:

```
analyzePrompt("a habit tracker for my demographic study group")
  → { requiresDatabase: false, confidence: 0.9, matchedPhrases: [] }
```

…even though `"habit tracker"` is in `STATEFUL_PHRASES` and would otherwise
have returned `requiresDatabase: true` at `0.95`. The consequence for a
consumer is provisioning an app with no database when the user explicitly asked
for a tracker.

The fix anchors the stateless list the same way and precompiles the patterns
once instead of rebuilding a `RegExp` per prompt.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`stateful-detection.test.ts`, `stateless early exit` block. The two regression
cases assert the collision substring is genuinely present in the prompt before
asserting the classification, so they cannot pass for the wrong reason.

## Detailed testing steps

```bash
# RED — revert only the production file
git checkout origin/develop -- packages/cloud/shared/src/lib/services/stateful-detection.ts
bun test --cwd packages/cloud/shared src/lib/services/stateful-detection.test.ts
#  19 pass, 2 fail

# GREEN — restore the fix
git checkout HEAD -- packages/cloud/shared/src/lib/services/stateful-detection.ts
bun test --cwd packages/cloud/shared src/lib/services/stateful-detection.test.ts
#  21 pass, 0 fail
```

The suite also pins behaviour the fix must **not** change: genuine stateless
apps still early-exit at `0.9`, multi-word indicators ("coming soon", "api
proxy") still match, the phrase pass still returns `0.95`, and the keyword
ladder still sits at 0/1 → false, 2 → `0.7`, 3+ → `0.85`.

# Evidence Gate

<!-- evidence-head:816f927583b4aba5a511b2328fe287f2fcf5122d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface; this is a pure string-analysis module in packages/cloud/shared and the diff touches no .tsx/.css/.svg.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the change is a pure-function classification contract, covered by the RED/GREEN transcript below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module emits no log lines and performs no I/O; its observable behaviour is its return value, asserted directly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched. (The module's input is called a "prompt" but it is a user app description analysed with keyword matching, explicitly "without AI overhead" per its header — no model call is involved.)`
<!-- evidence-row:domain-artifacts -->
- [x] Test transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model is invoked; see the llm-trajectory row above.`

## Backend + frontend logs

`N/A - the module performs no I/O and emits no log lines.`

<details>
<summary>RED — production file reverted to <code>develop</code>, test file kept</summary>

```
(fail) stateless early exit > does not fire on a word that merely contains an indicator
(fail) stateless early exit > a substring collision does not suppress a strong phrase match
 19 pass
 2 fail
```

</details>

<details>
<summary>GREEN — with the fix applied</summary>

```
bun test v1.3.11 (af24e281)

 21 pass
 0 fail
 77 expect() calls
Ran 21 tests across 1 file. [9.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface; the diff is confined to a server-side lib module.`

# Known gaps / failures

**Behaviour change worth naming explicitly.** Word-boundary matching no longer
matches plural forms — `"a calculators app"` previously early-exited on
`calculator` and now falls through to the keyword pass. I judged that
acceptable because the two failure directions are not symmetric: a **missed**
stateless match is soft (it falls through to a pass that still needs 2+ stateful
keywords before saying "database required"), whereas a **false** stateless match
is hard (it early-exits and discards every other signal). Making the dangerous
path the precise one is the point of the change. I did not add `s?` pluralisation
because it invites its own edge cases and I could not verify it against real
prompts.

I could not exercise this against a live consumer: `requiresDatabase` /
`analyzePrompt` currently have **no in-repo callers** — the module is reachable
only through the `./lib/*` subpath export. So the harm above is demonstrated at
the module's own contract, not end-to-end through a provisioning flow. If the
maintainers consider this module dead and slated for removal, this PR is easy to
drop; I did not want to leave the inconsistency in a published entry point on
that assumption.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to this change. `npx biome check` is clean on
both files.
