### PR TITLE
test(core): cover layout

### DIFF
--- a/packages/core/src/messaging/interactions/layout.test.ts
+++ b/packages/core/src/messaging/interactions/layout.test.ts
@@ -151,3 +151,729 @@ describe("messaging interactions layout", () => {
 		);
 	});
 });
+
+describe("messaging interactions layout branch coverage", () => {
+	describe("toNeutralLayout", () => {
+		it("wraps choice options into rows of three by default and preserves order", () => {
+			const labels = ["A", "B", "C", "D", "E", "F", "G"];
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-wrap",
+				scope: "wrap",
+				prompt: "Wrap",
+				options: labels.map((label) => ({
+					label,
+					value: label.toLowerCase(),
+				})),
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.rows.map((row) => row.buttons?.length)).toEqual([3, 3, 1]);
+			expect(
+				layout.rows
+					.flatMap((row) => row.buttons ?? [])
+					.map((button) => button.label),
+			).toEqual(labels);
+			expect(layout.needsFallback).toBe(false);
+		});
+
+		it("wraps an exact multiple of buttons per row without an empty trailing row", () => {
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-even",
+				scope: "even",
+				options: [
+					{ label: "1", value: "one" },
+					{ label: "2", value: "two" },
+					{ label: "3", value: "three" },
+					{ label: "4", value: "four" },
+				],
+			};
+			const layout = toNeutralLayout(block, { maxButtonsPerRow: 2 });
+			expect(layout.rows.map((row) => row.buttons?.length)).toEqual([2, 2]);
+		});
+
+		it("keeps a callback payload that exactly fills the default byte budget", () => {
+			const value = "y".repeat(60);
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-boundary",
+				scope: "boundary",
+				options: [{ label: "Long", value }],
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.needsFallback).toBe(false);
+			expect(layout.rows[0]?.buttons?.[0]?.callbackData).toBe(`ia1:${value}`);
+		});
+
+		it("forces fallback when an option exceeds the native callback budget", () => {
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-big",
+				scope: "big",
+				options: [{ label: "Too long", value: "z".repeat(100) }],
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.rows).toEqual([]);
+			expect(layout.needsFallback).toBe(true);
+		});
+
+		it("honors a connector-specific callback budget", () => {
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-budget",
+				scope: "budget",
+				options: [
+					{ label: "Fits Discord", value: "d".repeat(90) },
+					{ label: "Fits nowhere", value: "w".repeat(120) },
+				],
+			};
+			const layout = toNeutralLayout(block, { maxCallbackBytes: 100 });
+			expect(layout.rows[0]?.buttons?.map((b) => b.label)).toEqual([
+				"Fits Discord",
+			]);
+			expect(layout.needsFallback).toBe(true);
+		});
+
+		it("projects empty choice options to no rows without forcing fallback", () => {
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-empty",
+				scope: "empty",
+				prompt: "Nothing to pick",
+				options: [],
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.text).toBe("Nothing to pick");
+			expect(layout.rows).toEqual([]);
+			expect(layout.needsFallback).toBe(false);
+		});
+
+		it("throws RangeError for invalid maxButtonsPerRow values", () => {
+			const block: InteractionBlock = {
+				kind: "choice",
+				id: "c-invalid",
+				scope: "invalid",
+				options: [{ label: "Only", value: "only" }],
+			};
+			for (const invalid of [
+				0,
+				-2,
+				1.5,
+				Number.NaN,
+				Number.POSITIVE_INFINITY,
+			]) {
+				expect(() =>
+					toNeutralLayout(block, { maxButtonsPerRow: invalid }),
+				).toThrow(RangeError);
+			}
+		});
+
+		it("renders reply and prompt followups as secondary callback buttons", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "f-reply",
+				options: [
+					{ kind: "reply", payload: "show cats", label: "Show cats" },
+					{ kind: "prompt", payload: "why?", label: "Ask why" },
+				],
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.rows).toHaveLength(1);
+			expect(layout.rows[0]?.buttons).toEqual([
+				{
+					label: "Show cats",
+					callbackData: "ia1:show cats",
+					style: "secondary",
+				},
+				{ label: "Ask why", callbackData: "ia1:why?", style: "secondary" },
+			]);
+			expect(layout.needsFallback).toBeUndefined();
+		});
+
+		it("renders resolved navigate followups as link-out buttons", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "f-nav",
+				options: [
+					{ kind: "navigate", payload: "grid", label: "Open grid" },
+					{ kind: "reply", payload: "hi", label: "Say hi" },
+				],
+			};
+			const layout = toNeutralLayout(block, {
+				resolveNavigateUrl: (payload) =>
+					payload === "grid" ? "https://app.example/?view=grid" : undefined,
+			});
+			expect(layout.rows[0]?.buttons?.[0]).toEqual({
+				label: "Open grid",
+				url: "https://app.example/?view=grid",
+				style: "secondary",
+			});
+			expect(layout.rows[0]?.buttons?.[1]?.callbackData).toBe("ia1:hi");
+		});
+
+		it("falls back to a reply callback when navigation cannot be resolved", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "f-navmiss",
+				options: [
+					{ kind: "navigate", payload: "missing-view", label: "Missing" },
+				],
+			};
+			const layout = toNeutralLayout(block, {
+				resolveNavigateUrl: () => undefined,
+			});
+			expect(layout.rows[0]?.buttons?.[0]).toEqual({
+				label: "Missing",
+				callbackData: "ia1:missing-view",
+				style: "secondary",
+			});
+		});
+
+		it("silently drops followup payloads beyond the callback budget", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "f-big",
+				options: [
+					{ kind: "reply", payload: "ok", label: "Ok" },
+					{ kind: "reply", payload: "p".repeat(70), label: "Too big" },
+				],
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.rows[0]?.buttons?.map((b) => b.label)).toEqual(["Ok"]);
+			expect(layout.needsFallback).toBeUndefined();
+		});
+
+		it("renders a resolvable task as a titled primary link-out", () => {
+			const block: InteractionBlock = {
+				kind: "task",
+				threadId: "task-1",
+				title: "Water Tracker Page",
+			};
+			const layout = toNeutralLayout(block, {
+				resolveUrl: () => "https://app.example/orchestrator?taskId=task-1",
+			});
+			expect(layout.text).toBe("Water Tracker Page");
+			expect(layout.rows).toEqual([
+				{
+					buttons: [
+						{
+							label: "Open task",
+							url: "https://app.example/orchestrator?taskId=task-1",
+							style: "primary",
+						},
+					],
+				},
+			]);
+			expect(layout.needsFallback).toBe(false);
+		});
+
+		it("renders an unresolvable task as dashboard-only with no dangling title", () => {
+			const block: InteractionBlock = {
+				kind: "task",
+				threadId: "task-2",
+				title: "Daily Quote Page",
+			};
+			const layout = toNeutralLayout(block);
+			expect(layout.text).toBe("");
+			expect(layout.rows).toEqual([]);
+			expect(layout.needsFallback).toBe(false);
+		});
+
+		it("links a form out with the configured submit label", () => {
+			const block: InteractionBlock = {
+				kind: "form",
+				id: "form-link",
+				title: "Survey",
+				description: "Tell us your thoughts",
+				submitLabel: "Start survey",
+				fields: [],
+			};
+			const layout = toNeutralLayout(block, {
+				resolveUrl: () => "https://forms.example/s/1",
+			});
+			expect(layout.text).toBe("Survey");
+			expect(layout.rows).toEqual([
+				{
+					buttons: [
+						{
+							label: "Start survey",
+							url: "https://forms.example/s/1",
+							style: "primary",
+						},
+					],
+				},
+			]);
+			expect(layout.needsFallback).toBeUndefined();
+		});
+
+		it("uses the default Open form label when no submit label is set", () => {
+			const block: InteractionBlock = {
+				kind: "form",
+				id: "form-default-label",
+				fields: [],
+			};
+			const layout = toNeutralLayout(block, {
+				resolveUrl: () => "https://forms.example/s/2",
+			});
+			expect(layout.text).toBeUndefined();
+			expect(layout.rows[0]?.buttons?.[0]).toEqual({
+				label: "Open form",
+				url: "https://forms.example/s/2",
+				style: "primary",
+			});
+		});
+
+		it("invites a free-text reply for a form without a hosted page", () => {
+			const full: InteractionBlock = {
+				kind: "form",
+				id: "form-full",
+				title: "Survey",
+				description: "Tell us your thoughts",
+				fields: [],
+			};
+			expect(toNeutralLayout(full)).toEqual({
+				text: `Survey\n\n${FORM_FREE_TEXT_INVITE}`,
+				rows: [],
+				needsFallback: true,
+			});
+
+			const descriptionOnly: InteractionBlock = {
+				kind: "form",
+				id: "form-desc",
+				description: "Describe me",
+				fields: [],
+			};
+			expect(toNeutralLayout(descriptionOnly).text).toBe(
+				`Describe me\n\n${FORM_FREE_TEXT_INVITE}`,
+			);
+
+			const blank: InteractionBlock = {
+				kind: "form",
+				id: "form-blank",
+				title: "   ",
+				fields: [],
+			};
+			expect(toNeutralLayout(blank).text).toBe(FORM_FREE_TEXT_INVITE);
+
+			const bare: InteractionBlock = {
+				kind: "form",
+				id: "form-bare",
+				fields: [],
+			};
+			const bareLayout = toNeutralLayout(bare);
+			expect(bareLayout.text).toBe(FORM_FREE_TEXT_INVITE);
+			expect(bareLayout.rows).toEqual([]);
+			expect(bareLayout.needsFallback).toBe(true);
+		});
+
+		it("prefers the resolver URL over a secret block's own entry URL", () => {
+			const block: InteractionBlock = {
+				kind: "secret",
+				id: "secret-precedence",
+				secretKind: "oauth",
+				provider: "github",
+				reason: "Connect GitHub",
+				url: "https://block.example/oauth",
+			};
+			const layout = toNeutralLayout(block, {
+				resolveUrl: () => "https://resolver.example/oauth/github",
+			});
+			expect(layout.rows[0]?.buttons?.[0]?.url).toBe(
+				"https://resolver.example/oauth/github",
+			);
+			expect(layout.needsFallback).toBe(false);
+		});
+
+		it("labels secret buttons per secret kind and provider", () => {
+			const oauthWithoutProvider = toNeutralLayout({
+				kind: "secret",
+				id: "secret-oauth-anon",
+				secretKind: "oauth",
+				url: "https://id.example/consent",
+			});
+			expect(oauthWithoutProvider.rows[0]?.buttons?.[0]?.label).toBe(
+				"Connect account",
+			);
+
+			const labeledSecret = toNeutralLayout({
+				kind: "secret",
+				id: "secret-labeled",
+				secretKind: "secret",
+				submitLabel: "Add OpenAI key",
+				url: "https://keys.example",
+			});
+			expect(labeledSecret.rows[0]?.buttons?.[0]?.label).toBe("Add OpenAI key");
+
+			const defaultSecret = toNeutralLayout({
+				kind: "secret",
+				id: "secret-default-label",
+				secretKind: "secret",
+				url: "https://vault.example",
+			});
+			expect(defaultSecret.rows[0]?.buttons?.[0]?.label).toBe(
+				"Provide securely",
+			);
+		});
+	});
+
+	describe("toPlainTextFallback", () => {
+		it("offers the custom-answer invite only when custom answers are allowed", () => {
+			const custom: InteractionBlock = {
+				kind: "choice",
+				id: "pt-custom",
+				scope: "custom",
+				prompt: "Favorite fruit?",
+				options: [{ label: "Apple", value: "apple" }],
+				allowCustom: true,
+			};
+			expect(toPlainTextFallback(custom)).toBe(
+				"Favorite fruit?\n1. Apple\nReply with a number or your own answer.",
+			);
+		});
+
+		it("drops a blank choice prompt and keeps the numbered list", () => {
+			const blankPrompt: InteractionBlock = {
+				kind: "choice",
+				id: "pt-blank-prompt",
+				scope: "blank-prompt",
+				prompt: "   ",
+				options: [{ label: "Red", value: "red" }],
+			};
+			expect(toPlainTextFallback(blankPrompt)).toBe(
+				"1. Red\nReply with a number.",
+			);
+		});
+
+		it("renders followup suggestions with resolved navigation links", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "pt-followups",
+				options: [
+					{ kind: "reply", payload: "say-hi", label: "Say hi" },
+					{ kind: "navigate", payload: "grid", label: "Open grid" },
+					{ kind: "reply", payload: "gone", label: "   " },
+				],
+			};
+			expect(
+				toPlainTextFallback(block, {
+					resolveNavigateUrl: (payload) =>
+						payload === "grid" ? "https://app.example/?view=grid" : undefined,
+				}),
+			).toBe(
+				"Suggestions: Say hi / Open grid (https://app.example/?view=grid)",
+			);
+		});
+
+		it("returns undefined for followups whose labels are all blank", () => {
+			const block: InteractionBlock = {
+				kind: "followups",
+				id: "pt-followups-blank",
+				options: [{ kind: "reply", payload: "x", label: "  " }],
+			};
+			expect(toPlainTextFallback(block)).toBeUndefined();
+		});
+
+		it("joins the task title and URL only when the task resolves", () => {
+			const block: InteractionBlock = {
+				kind: "task",
+				threadId: "task-3",
+				title: "Clean Database",
+			};
+			expect(
+				toPlainTextFallback(block, {
+					resolveUrl: () => "https://app.example/orchestrator?taskId=task-3",
+				}),
+			).toBe("Clean Database\nhttps://app.example/orchestrator?taskId=task-3");
+			expect(toPlainTextFallback(block)).toBeUndefined();
+		});
+
+		it("keeps whichever form prose exists and always appends the invite", () => {
+			expect(
+				toPlainTextFallback({
+					kind: "form",
+					id: "pt-form-title",
+					title: "Survey",
+					fields: [],
+				}),
+			).toBe(`Survey\n\n${FORM_FREE_TEXT_INVITE}`);
+			expect(
+				toPlainTextFallback({
+					kind: "form",
+					id: "pt-form-description",
+					description: "Thoughts?",
+					fields: [],
+				}),
+			).toBe(`Thoughts?\n\n${FORM_FREE_TEXT_INVITE}`);
+			expect(
+				toPlainTextFallback({
+					kind: "form",
+					id: "pt-form-blank",
+					title: "  ",
+					description: " \t ",
+					fields: [],
+				}),
+			).toBe(FORM_FREE_TEXT_INVITE);
+		});
+
+		it("falls back to the block URL for secrets and explains a missing link", () => {
+			expect(
+				toPlainTextFallback(
+					{
+						kind: "secret",
+						id: "pt-secret-resolver",
+						secretKind: "oauth",
+						reason: "Connect GitHub",
+						url: "https://block.example/gh",
+					},
+					{ resolveUrl: () => "https://resolver.example/gh" },
+				),
+			).toBe("Connect GitHub\nhttps://resolver.example/gh");
+
+			expect(
+				toPlainTextFallback({
+					kind: "secret",
+					id: "pt-secret-url",
+					secretKind: "secret",
+					reason: "API key",
+					url: "https://keys.example",
+				}),
+			).toBe("API key\nhttps://keys.example");
+
+			expect(
+				toPlainTextFallback({
+					kind: "secret",
+					id: "pt-secret-no-reason",
+					secretKind: "secret",
+					url: "https://keys.example",
+				}),
+			).toBe("https://keys.example");
+
+			expect(
+				toPlainTextFallback({
+					kind: "secret",
+					id: "pt-secret-no-url",
+					secretKind: "secret",
+					reason: "Vault token",
+				}),
+			).toBe("Vault token\nA secure link for this is not available here yet.");
+
+			expect(
+				toPlainTextFallback({
+					kind: "secret",
+					id: "pt-secret-bare",
+					secretKind: "secret",
+				}),
+			).toBe("A secure link for this is not available here yet.");
+		});
+	});
+
+	describe("renderInteractionsAsPlainText", () => {
+		it("treats nullish input as empty plain text", () => {
+			expect(renderInteractionsAsPlainText(undefined)).toEqual({
+				text: "",
+				hadBlocks: false,
+			});
+			expect(renderInteractionsAsPlainText(null)).toEqual({
+				text: "",
+				hadBlocks: false,
+			});
+		});
+
+		it("parses marker blocks and appends fallbacks in document order", () => {
+			const marked = [
+				"Pick a starting point:",
+				"[TASK:9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d]Water Tracker Page[/TASK]",
+				"[FOLLOWUPS]",
+				"reply:say-hi=Say hi",
+				"navigate:/dashboard=Open dashboard",
+				"[/FOLLOWUPS]",
+			].join("\n");
+			const { text, hadBlocks } = renderInteractionsAsPlainText(marked, {
+				resolveUrl: () => "https://app.example/orchestrator?taskId=t",
+				resolveNavigateUrl: () => "https://app.example/dashboard",
+			});
+			expect(hadBlocks).toBe(true);
+			expect(text).toContain("Pick a starting point:");
+			expect(text).toContain(
+				"Water Tracker Page\nhttps://app.example/orchestrator?taskId=t",
+			);
+			expect(text).toContain(
+				"Suggestions: Say hi / Open dashboard (https://app.example/dashboard)",
+			);
+			expect(text.indexOf("Water Tracker Page")).toBeLessThan(
+				text.indexOf("Suggestions:"),
+			);
+			expect(text).not.toContain("[TASK:");
+			expect(text).not.toContain("[/FOLLOWUPS]");
+			expect(text).not.toContain("reply:say-hi");
+		});
+
+		it("omits fallback sections for blocks that cannot produce one", () => {
+			const marked =
+				"Working on it.\n[TASK:abcdef123456]Daily Quote Page[/TASK]";
+			const { text, hadBlocks } = renderInteractionsAsPlainText(marked);
+			expect(hadBlocks).toBe(true);
+			expect(text).toBe("Working on it.");
+		});
+
+		it("strips an unclaimed terminal marker fragment instead of restoring it", () => {
+			const broken = "Hello\n[CHOICE:test]\napple=Apple";
+			const { text, hadBlocks } = renderInteractionsAsPlainText(broken);
+			expect(hadBlocks).toBe(false);
+			expect(text).toBe("Hello");
+		});
+
+		it("strips dashboard-only markers from connector-bound text", () => {
+			const { text, hadBlocks } = renderInteractionsAsPlainText(
+				"Before\n[CONFIG:google_calendars]\nafter",
+			);
+			expect(hadBlocks).toBe(false);
+			expect(text).not.toContain("[CONFIG:");
+			expect(text).toContain("Before");
+			expect(text).toContain("after");
+		});
+	});
+
+	describe("renderContentInteractionsAsPlainText", () => {
+		const oauthSecret: InteractionBlock = {
+			kind: "secret",
+			id: "content-secret",
+			secretKind: "oauth",
+			provider: "github",
+			reason: "Connect GitHub to continue",
+			url: "https://oauth.example/gh",
+		};
+
+		it("delegates to the text renderer for nullish and marker-free content", () => {
+			expect(renderContentInteractionsAsPlainText(undefined)).toEqual({
+				text: "",
+				hadBlocks: false,
+			});
+			expect(renderContentInteractionsAsPlainText(null)).toEqual({
+				text: "",
+				hadBlocks: false,
+			});
+			expect(
+				renderContentInteractionsAsPlainText({ text: "Just words" }),
+			).toEqual({ text: "Just words", hadBlocks: false });
+		});
+
+		it("lets typed interactions win over conflicting text markers", () => {
+			const { text, hadBlocks } = renderContentInteractionsAsPlainText({
+				text: "Answer below:\n[CHOICE:mood]\nhappy=Happy\n[/CHOICE]",
+				interactions: [oauthSecret],
+			});
+			expect(hadBlocks).toBe(true);
+			expect(text).toContain("Answer below:");
+			expect(text).toContain(
+				"Connect GitHub to continue\nhttps://oauth.example/gh",
+			);
+			expect(text).not.toContain("Happy");
+			expect(text).not.toContain("1.");
+		});
+
+		it("renders out-of-band interactions that have no text marker", () => {
+			const { text, hadBlocks } = renderContentInteractionsAsPlainText({
+				text: "Here you go.",
+				interactions: [oauthSecret],
+			});
+			expect(hadBlocks).toBe(true);
+			expect(text).toBe(
+				"Here you go.\n\nConnect GitHub to continue\nhttps://oauth.example/gh",
+			);
+		});
+
+		it("renders typed interactions even when the text is blank or missing", () => {
+			const choice: InteractionBlock = {
+				kind: "choice",
+				id: "content-choice",
+				scope: "confirm",
+				prompt: "Ship it?",
+				options: [{ label: "Yes", value: "yes" }],
+			};
+			expect(
+				renderContentInteractionsAsPlainText({ interactions: [choice] }).text,
+			).toBe("Ship it?\n1. Yes\nReply with a number.");
+
+			const { text, hadBlocks } = renderContentInteractionsAsPlainText({
+				text: "   ",
+				interactions: [choice],
+			});
+			expect(hadBlocks).toBe(true);
+			expect(text).toBe("Ship it?\n1. Yes\nReply with a number.");
+		});
+	});
+
+	describe("buildInteractionUrlResolver", () => {
+		it("returns no resolvers when no app base URL is configured", () => {
+			expect(buildInteractionUrlResolver(undefined)).toEqual({});
+			expect(buildInteractionUrlResolver(null)).toEqual({});
+			expect(buildInteractionUrlResolver("")).toEqual({});
+		});
+
+		it("normalizes trailing slashes on the base URL", () => {
+			const resolver = buildInteractionUrlResolver("https://app.example///");
+			expect(
+				resolver.resolveUrl?.({
+					kind: "task",
+					threadId: "abc12345",
+					title: "T",
+				}),
+			).toBe("https://app.example/orchestrator?taskId=abc12345");
+			expect(resolver.resolveNavigateUrl?.("home")).toBe(
+				"https://app.example/?view=home",
+			);
+		});
+
+		it("percent-encodes task thread ids in orchestrator links", () => {
+			const resolver = buildInteractionUrlResolver("https://app.example");
+			expect(
+				resolver.resolveUrl?.({
+					kind: "task",
+					threadId: "a b/c?d",
+					title: "T",
+				}),
+			).toBe("https://app.example/orchestrator?taskId=a%20b%2Fc%3Fd");
+		});
+
+		it("does not fabricate URLs for blocks without a hosted route", () => {
+			const resolver = buildInteractionUrlResolver("https://app.example");
+			expect(
+				resolver.resolveUrl?.({ kind: "form", id: "r-form", fields: [] }),
+			).toBeUndefined();
+			expect(
+				resolver.resolveUrl?.({
+					kind: "secret",
+					id: "r-secret",
+					secretKind: "oauth",
+				}),
+			).toBeUndefined();
+			expect(
+				resolver.resolveUrl?.({
+					kind: "choice",
+					id: "r-choice",
+					scope: "scope",
+					options: [],
+				}),
+			).toBeUndefined();
+			expect(
+				resolver.resolveUrl?.({
+					kind: "followups",
+					id: "r-followups",
+					options: [],
+				}),
+			).toBeUndefined();
+		});
+
+		it("maps navigate payloads to view routes and keeps dashboard paths", () => {
+			const resolver = buildInteractionUrlResolver("https://app.example/");
+			expect(resolver.resolveNavigateUrl?.("my view")).toBe(
+				"https://app.example/?view=my%20view",
+			);
+			expect(resolver.resolveNavigateUrl?.("/settings/profile")).toBe(
+				"https://app.example/settings/profile",
+			);
+			expect(resolver.resolveNavigateUrl?.("")).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION

## Summary

Extends `packages/core/src/messaging/interactions/layout.test.ts` with 39 new vitest cases covering branches of the interaction-block layout projection (`toNeutralLayout`, `toPlainTextFallback`, `renderInteractionsAsPlainText`, `renderContentInteractionsAsPlainText`, `buildInteractionUrlResolver`) that had no coverage. Test-only diff: **+726/-0** — purely additive; every one of the 6 pre-existing cases is untouched.

## What the new cases cover

- **`toNeutralLayout`**: default 3-per-row wrapping with order preservation; exact-multiple wrapping with no empty trailing row; callback payload exactly filling the default 64-byte budget (`ia1:` prefix contract asserted literally, not round-tripped through the encoder); an oversize option forcing `needsFallback`; connector-specific `maxCallbackBytes` budget (Discord-style 100-char case); empty choice options; `RangeError` on invalid `maxButtonsPerRow` (0, negative, fractional, NaN, Infinity); followups reply/prompt chips as secondary `ia1:` callback buttons; resolved navigate chips as link-out buttons; unresolved navigate falling back to reply callbacks; silent drop of oversize followup payloads (followups never set `needsFallback`); task blocks resolved (title + single primary "Open task" button) and unresolvable (empty text, no rows, no dangling title); form link-out with custom/default submit label; form free-text invite variants (title+description, description-only, whitespace-only, bare); secret resolver-URL precedence over `block.url`; secret label matrix (oauth without provider → "Connect account", custom submitLabel, default "Provide securely").
- **`toPlainTextFallback`**: `allowCustom` invite variant; blank prompt filtered while the numbered list stays; followup suggestions with resolved navigation links appended and blank labels removed; all-blank followups returning `undefined`; task title+URL join vs `undefined` when unresolved; form prose trimming/filtering with the free-text invite always present; secret resolver-vs-block URL precedence, missing-reason handling, and the unavailable-link message.
- **`renderInteractionsAsPlainText`**: nullish input; real bracket-marker fixtures (`[TASK:<uuid>]…[/TASK]`, `[FOLLOWUPS]`) parsed and their fallbacks appended in document order with all marker bodies removed; an unusable fallback omitted while `hadBlocks` stays true (unresolvable dashboard-only task card renders as cleaned prose only); an unclaimed terminal marker fragment stripped from output with `hadBlocks: false`; dashboard-only `[CONFIG:…]` markers stripped from connector-bound text.
- **`renderContentInteractionsAsPlainText`**: nullish and marker-free content delegating to the text renderer; typed `interactions` overriding conflicting text markers (only typed blocks produce fallbacks, markers are still cleaned); out-of-band secret requests rendered even with no marker representation; blank or missing `text` still rendering typed controls with no leading separator.
- **`buildInteractionUrlResolver`**: undefined/null/empty base returns no resolvers at all; trailing-slash normalization of the base; percent-encoded `taskId` in orchestrator links; no fabricated URLs for form/secret/choice/followups blocks; navigate payload mapped to a view route vs a kept `/`-prefixed dashboard path; empty payload → `undefined`.

All expectations record observed behavior of the module as it stands on this base — no aspirational assertions.

## Verification (observed at this exact head)

- `bunx vitest run packages/core/src/messaging/interactions/layout.test.ts` → **Test Files 1 passed (1), Tests 45 passed (45)** (6 pre-existing + 39 new).
- `bunx biome check packages/core/src/messaging/interactions/layout.test.ts` → clean (`Checked 1 file … No fixes applied`), run with the repository's root `biome.json`.
- `bunx tsc --noEmit` in `packages/core` → zero diagnostics mentioning `layout.test.ts`.
- `git diff --numstat` → `726	0` for the single touched file: additions only, no deletions, no other files touched.

This is a fork contribution, so hosted CI does not run on this pull request; the counts above were produced locally at this head and are quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:61195bcca200bde5f0196a0e126329d91f3e11aa -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
