### PR TITLE
test(ui): pin pendant error classification and cause-chain safety

### DIFF
--- a/packages/ui/src/pendant/pendant-errors.test.ts
+++ b/packages/ui/src/pendant/pendant-errors.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Pins pendant failure classification. The cause-chain walker is the part with
+ * a real hazard: it follows attacker-agnostic but arbitrarily shaped
+ * `Error.cause` links, so a cycle must terminate rather than hang the caller.
+ * Also covers permission precedence over the deepest-message heuristic and the
+ * code/category mapping recovery logic keys off. Pure module, no harness.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyPendantConnectionError,
+  createPendantError,
+  type PendantErrorCode,
+  PendantPermissionDeniedError,
+  pendantErrorCauseChain,
+} from "./pendant-errors";
+
+const ALL_CODES: PendantErrorCode[] = [
+  "permission-denied",
+  "pendant-lost",
+  "reconnect-exhausted",
+  "asr-failed",
+  "connection",
+  "generic",
+];
+
+/** Build `new Error(a, {cause: new Error(b, {cause: ...})})` from outermost in. */
+function nested(...messages: string[]): Error {
+  let current: Error | undefined;
+  for (const message of [...messages].reverse()) {
+    current = current
+      ? new Error(message, { cause: current })
+      : new Error(message);
+  }
+  return current as Error;
+}
+
+describe("pendantErrorCauseChain", () => {
+  it("returns a single-element chain for a bare error", () => {
+    const error = new Error("boom");
+    expect(pendantErrorCauseChain(error)).toEqual([error]);
+  });
+
+  it("walks nested causes outermost first", () => {
+    const chain = pendantErrorCauseChain(nested("outer", "middle", "inner"));
+    expect(chain.map((c) => (c as Error).message)).toEqual([
+      "outer",
+      "middle",
+      "inner",
+    ]);
+  });
+
+  it("terminates on a self-referential cause", () => {
+    const error = new Error("loop");
+    (error as Error & { cause: unknown }).cause = error;
+    expect(pendantErrorCauseChain(error)).toEqual([error]);
+  });
+
+  it("terminates on a two-node cycle", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    (a as Error & { cause: unknown }).cause = b;
+    const chain = pendantErrorCauseChain(a);
+    expect(chain).toEqual([a, b]);
+  });
+
+  it("terminates on a longer cycle", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    const c = new Error("c", { cause: b });
+    (a as Error & { cause: unknown }).cause = c;
+    expect(pendantErrorCauseChain(c).length).toBe(3);
+  });
+
+  it("stops at a non-Error cause without following it further", () => {
+    const inner = { cause: new Error("never reached") };
+    const chain = pendantErrorCauseChain(new Error("outer", { cause: inner }));
+    expect(chain.length).toBe(2);
+    expect(chain[1]).toBe(inner);
+  });
+
+  it("handles non-Error and nullish inputs", () => {
+    expect(pendantErrorCauseChain("boom")).toEqual(["boom"]);
+    expect(pendantErrorCauseChain(null)).toEqual([null]);
+    expect(pendantErrorCauseChain(42)).toEqual([42]);
+    expect(pendantErrorCauseChain(undefined)).toEqual([]);
+  });
+
+  it("does not conflate distinct errors with identical messages", () => {
+    const inner = new Error("same");
+    const outer = new Error("same", { cause: inner });
+    expect(pendantErrorCauseChain(outer)).toEqual([outer, inner]);
+  });
+});
+
+describe("createPendantError", () => {
+  it("maps every code to a category and a non-empty message", () => {
+    for (const code of ALL_CODES) {
+      const error = createPendantError(code);
+      expect(error.code).toBe(code);
+      expect(error.category.length).toBeGreaterThan(0);
+      expect(error.message.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("never returns undefined for a declared code", () => {
+    for (const code of ALL_CODES) {
+      expect(createPendantError(code)).toBeDefined();
+    }
+  });
+
+  it("groups both reconnect codes under one recovery category", () => {
+    expect(createPendantError("pendant-lost").category).toBe("reconnect");
+    expect(createPendantError("reconnect-exhausted").category).toBe(
+      "reconnect",
+    );
+  });
+
+  it("maps the remaining codes to their own categories", () => {
+    expect(createPendantError("permission-denied").category).toBe("permission");
+    expect(createPendantError("asr-failed").category).toBe("transcription");
+    expect(createPendantError("connection").category).toBe("connection");
+    expect(createPendantError("generic").category).toBe("generic");
+  });
+
+  it("appends a connection detail when one is given", () => {
+    expect(createPendantError("connection", "adapter off").message).toBe(
+      "Pendant connection failed: adapter off",
+    );
+  });
+
+  it("falls back to the plain connection message for an empty detail", () => {
+    for (const detail of [undefined, ""]) {
+      expect(createPendantError("connection", detail).message).toBe(
+        "Pendant connection failed.",
+      );
+    }
+  });
+
+  it("ignores a detail for codes that do not take one", () => {
+    for (const code of [
+      "permission-denied",
+      "pendant-lost",
+      "reconnect-exhausted",
+      "asr-failed",
+    ] as const) {
+      expect(createPendantError(code, "ignored detail").message).toBe(
+        createPendantError(code).message,
+      );
+    }
+  });
+
+  it("treats every failure as recoverable", () => {
+    for (const code of ALL_CODES) {
+      expect(createPendantError(code).recoverable).toBe(true);
+    }
+  });
+});
+
+describe("classifyPendantConnectionError", () => {
+  it("detects a permission error at the top of the chain", () => {
+    const result = classifyPendantConnectionError(
+      new PendantPermissionDeniedError(),
+    );
+    expect(result.code).toBe("permission-denied");
+    expect(result.category).toBe("permission");
+  });
+
+  it("detects a permission error buried in the chain", () => {
+    const buried = new Error("connect failed", {
+      cause: new Error("gatt", { cause: new PendantPermissionDeniedError() }),
+    });
+    expect(classifyPendantConnectionError(buried).code).toBe(
+      "permission-denied",
+    );
+  });
+
+  it("detects a NotAllowedError DOMException", () => {
+    const denied = new DOMException("denied", "NotAllowedError");
+    expect(classifyPendantConnectionError(denied).code).toBe(
+      "permission-denied",
+    );
+    expect(
+      classifyPendantConnectionError(new Error("outer", { cause: denied }))
+        .code,
+    ).toBe("permission-denied");
+  });
+
+  it("does not treat another DOMException name as a permission error", () => {
+    const other = new DOMException("gone", "NetworkError");
+    expect(classifyPendantConnectionError(other).code).toBe("connection");
+  });
+
+  it("permission wins over a deeper non-permission error", () => {
+    const mixed = new PendantPermissionDeniedError();
+    (mixed as Error & { cause: unknown }).cause = new Error("deepest detail");
+    const result = classifyPendantConnectionError(mixed);
+    expect(result.code).toBe("permission-denied");
+    expect(result.message).not.toContain("deepest detail");
+  });
+
+  it("uses the deepest error message as the connection detail", () => {
+    const result = classifyPendantConnectionError(
+      nested("outer", "middle", "root cause"),
+    );
+    expect(result.code).toBe("connection");
+    expect(result.message).toBe("Pendant connection failed: root cause");
+  });
+
+  it("falls back to the plain message when nothing in the chain is an Error", () => {
+    for (const value of ["boom", null, 42, { message: "not an error" }]) {
+      const result = classifyPendantConnectionError(value);
+      expect(result.code).toBe("connection");
+      expect(result.message).toBe("Pendant connection failed.");
+    }
+  });
+
+  it("terminates on a cyclic chain", () => {
+    const a = new Error("a");
+    const b = new Error("b", { cause: a });
+    (a as Error & { cause: unknown }).cause = b;
+    expect(classifyPendantConnectionError(a).code).toBe("connection");
+  });
+});
+
+describe("PendantPermissionDeniedError", () => {
+  it("is an Error carrying a stable name", () => {
+    const error = new PendantPermissionDeniedError();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("PendantPermissionDeniedError");
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a custom message", () => {
+    expect(new PendantPermissionDeniedError("custom").message).toBe("custom");
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/ui/src/pendant/pendant-errors.ts` had no test
file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 26 cases over pendant failure classification.

The part with a genuine hazard is `pendantErrorCauseChain`. It walks native
`Error.cause` links, whose shape it does not control, and its only protection
against a cycle is a `seen` set:

```ts
while (current !== undefined) {
  if (typeof current === "object" && current !== null) {
    if (seen.has(current)) break;
    seen.add(current);
  }
  ...
}
```

The header comment already promises this ("without looping on malformed error
objects") but nothing held it to that. The suite pins three cycle shapes —
self-referential, two-node, and three-node — plus the case where a cycle
reaches `classifyPendantConnectionError`, which is the caller that actually
runs on a failed connection.

It also pins:

- **Permission precedence.** `PendantPermissionDeniedError` and a
  `NotAllowedError` `DOMException` classify as `permission-denied` from
  anywhere in the chain, and win over a deeper error that would otherwise
  supply the connection detail. A `DOMException` with a *different* name must
  not be mistaken for a permission failure.
- **The deepest-message heuristic.** The manual reverse scan exists because
  consumer packages type-check under lib targets older than es2023 (so
  `Array#findLast` is unavailable); the suite asserts it picks the innermost
  message, not the outermost.
- **Code → category mapping**, which recovery logic keys off: both reconnect
  codes collapse to one `reconnect` category, and every code yields a
  non-empty message.
- **Chain termination on a non-Error link** — the walk stops there rather than
  reading `.cause` off a plain object.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`pendant-errors.test.ts`, `pendantErrorCauseChain` block — specifically the
three cycle cases.

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/pendant/pendant-errors.test.ts
```

To confirm the suite is not vacuous, I ran two mutations against the production
file (both reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| remove the `if (seen.has(current)) break;` cycle guard | 22 pass, **4 fail** |
| drop the `break` from the deepest-error reverse scan | 25 pass, **1 fail** |

The first mutation does not merely fail an assertion — the chain grows without
bound and the run dies with `RangeError: Invalid array length` after each of the
four cycle tests spends ~1.5–2s allocating. That is the failure mode the guard
prevents, reproduced.

# Evidence Gate

<!-- evidence-head:3c96342c21b2ffeb9d8bbf4d5170273054a06925 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff. The new file is a .test.ts over pure error-classification functions; no .tsx/.css/.svg is touched and no component renders.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns typed error objects, covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; nothing is mounted.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
 RUN  v4.1.10 packages/ui

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Duration  97ms
```

</details>

<details>
<summary>Mutation A — cycle guard removed</summary>

```
 × pendantErrorCauseChain > terminates on a self-referential cause 1538ms
 × pendantErrorCauseChain > terminates on a two-node cycle 1995ms
 × pendantErrorCauseChain > terminates on a longer cycle 1829ms
 × classifyPendantConnectionError > terminates on a cyclic chain 1939ms

RangeError: Invalid array length
```

</details>

<details>
<summary>Mutation B — deepest-error scan loses its break</summary>

```
 × classifyPendantConnectionError > uses the deepest error message as the connection detail
      Tests  1 failed | 25 passed (26)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff. No rendered surface changes, so audit:app would produce
no before/after delta.`

# Known gaps / failures

**One latent inconsistency I found and did not change.** `createPendantError`
resolves its detail two different ways:

```ts
case "connection": message: detail ? `…: ${detail}` : "Pendant connection failed."
case "generic":    message: detail ?? "Pendant failed."
```

`??` is nullish-only, so `createPendantError("generic", "")` returns an **empty**
user-facing message where the `connection` branch would correctly fall back. I
traced both in-repo call sites that pass a detail (`pendant-connection.ts:346`
and `:608`) and both use `"connection"`, so this is not currently reachable —
it is a latent trap, not a live defect. I left it alone rather than ship a
behavioural change I could not demonstrate harm for; the suite documents the
current `connection` fallback so a future fix has a baseline.

I did not add coverage for `pendant-connection.ts` itself, which is the stateful
consumer — it needs a Bluetooth transport harness, which is a much larger piece
of work than this PR.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
