### PR TITLE
test(ui): cover dashboard-route-error.helpers

### DIFF
--- a/packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts
+++ b/packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the dashboard route error message formatter
+ * (`formatDashboardRouteErrorMessage`): the pure branch table that maps an
+ * unknown route-error value to user-facing text. Deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { formatDashboardRouteErrorMessage } from "./dashboard-route-error.helpers";
+
+const FALLBACK = "An unexpected error occurred while loading this page.";
+
+describe("formatDashboardRouteErrorMessage", () => {
+  it("returns the message of a plain Error instance", () => {
+    expect(formatDashboardRouteErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns the message of an Error subclass via instanceof", () => {
+    expect(
+      formatDashboardRouteErrorMessage(new TypeError("not a function")),
+    ).toBe("not a function");
+  });
+
+  it("returns an empty string for an Error constructed with an empty message", () => {
+    expect(formatDashboardRouteErrorMessage(new Error(""))).toBe("");
+  });
+
+  it("passes a non-empty string through unchanged", () => {
+    expect(formatDashboardRouteErrorMessage("network unreachable")).toBe(
+      "network unreachable",
+    );
+  });
+
+  it("preserves whitespace and unicode in string input", () => {
+    expect(formatDashboardRouteErrorMessage("  402: 支払いが必要 🚧 ")).toBe(
+      "  402: 支払いが必要 🚧 ",
+    );
+  });
+
+  it("returns an empty string for empty-string input instead of the fallback", () => {
+    expect(formatDashboardRouteErrorMessage("")).toBe("");
+  });
+
+  it("falls back for null", () => {
+    expect(formatDashboardRouteErrorMessage(null)).toBe(FALLBACK);
+  });
+
+  it("falls back for undefined", () => {
+    expect(formatDashboardRouteErrorMessage(undefined)).toBe(FALLBACK);
+  });
+
+  it("uses one stable fallback string shared by both nullish branches", () => {
+    expect(formatDashboardRouteErrorMessage(null)).toBe(
+      formatDashboardRouteErrorMessage(undefined),
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds a co-located unit suite for `packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.ts`, which had no same-named test file anywhere in the repository on `develop` (verified via `git ls-tree -r --name-only origin/develop`). The module exports one pure function, `formatDashboardRouteErrorMessage(error: Error | string | null | undefined): string`, used by the dashboard route error surface.

The suite drives the real module (no mocks) and covers every branch of the implementation:

- `Error` instance → returns `.message`
- `Error` subclass (`TypeError`) → `instanceof` branch still wins
- plain string pass-through, including whitespace/unicode preservation
- empty-string input returns `""` (the `typeof === "string"` branch precedes any falsiness check — recorded as observed)
- `new Error("")` returns `""`
- `null` and `undefined` both fall back to `"An unexpected error occurred while loading this page."`
- the two nullish branches share one stable fallback string

## Test-only change

This pull request changes **no production behaviour**. The diff is one new test file, +55/-0.

## Verification

All commands run at head `8e316086ffc3aef0aed2b154a84a441bee7fcb91` against current `origin/develop` (`0d9b34de5131`):

1. **Vitest** (runner that owns this package: `bunx vitest run src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts` from `packages/ui`):
   ```
    Test Files  1 passed (1)
         Tests  9 passed (9)
   ```
2. **Biome**: `bunx biome check --write packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts` → `Checked 1 file in 482ms. No fixes applied.`
3. **TypeScript**: `bunx tsc --noEmit` in `packages/ui`; grep for `dashboard-route-error.helpers.test` over the full output matched nothing — zero new type errors from this change.
4. The diff touches only `packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts`.

No `expectTypeOf` and no `vi.hoisted` are used; assertions are behavioural against the real module.

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are quoted from local runs.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8e316086ffc3aef0aed2b154a84a441bee7fcb91 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
