### PR TITLE
test(cloud): pin database URL resolution and its fail-closed guards

### DIFF
--- a/packages/cloud/shared/src/db/database-url.test.ts
+++ b/packages/cloud/shared/src/db/database-url.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Pins database URL resolution. The consequential property is the fail-closed
+ * one: production and CI must never silently fall back to a local file-backed
+ * PGlite store, and the opt-out kill switch must win over that fallback. Also
+ * covers explicit-URL precedence and the non-clobbering mutation contract of
+ * applyDatabaseUrlFallback. Every case injects its own env; process.env is
+ * never read or mutated.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import {
+  applyDatabaseUrlFallback,
+  getLocalPGliteDatabaseUrl,
+  resolveDatabaseUrl,
+} from "./database-url";
+
+const REMOTE = "postgres://user:pw@db.example.com:5432/prod";
+const TEST_REMOTE = "postgres://user:pw@db.example.com:5432/test";
+
+/** A local-dev env: not production, not CI. */
+const local = (over: Record<string, string | undefined> = {}) => ({
+  NODE_ENV: "development",
+  ...over,
+});
+
+describe("getLocalPGliteDatabaseUrl", () => {
+  test("resolves the default data dir to an absolute pglite url", () => {
+    const url = getLocalPGliteDatabaseUrl({});
+    expect(url.startsWith("pglite://")).toBe(true);
+    expect(path.isAbsolute(url.slice("pglite://".length))).toBe(true);
+  });
+
+  test("prefers PGLITE_DATA_DIR over LOCAL_DATABASE_PATH", () => {
+    const url = getLocalPGliteDatabaseUrl({
+      PGLITE_DATA_DIR: "/tmp/chosen",
+      LOCAL_DATABASE_PATH: "/tmp/ignored",
+    });
+    expect(url).toBe("pglite:///tmp/chosen");
+  });
+
+  test("falls back to LOCAL_DATABASE_PATH when PGLITE_DATA_DIR is absent", () => {
+    expect(getLocalPGliteDatabaseUrl({ LOCAL_DATABASE_PATH: "/tmp/fallback" })).toBe(
+      "pglite:///tmp/fallback",
+    );
+  });
+
+  test("treats a blank override as unset", () => {
+    const blank = getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: "" });
+    expect(blank).toBe(getLocalPGliteDatabaseUrl({}));
+  });
+
+  test("resolves a relative dir against the working directory", () => {
+    expect(getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: "relative/store" })).toBe(
+      `pglite://${path.resolve(process.cwd(), "relative/store")}`,
+    );
+  });
+
+  test("leaves an already-absolute dir untouched", () => {
+    expect(getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: path.resolve("/var/data") })).toBe(
+      `pglite://${path.resolve("/var/data")}`,
+    );
+  });
+
+  test("is stable across calls with the same env", () => {
+    const env = local({ PGLITE_DATA_DIR: "some/dir" });
+    expect(getLocalPGliteDatabaseUrl(env)).toBe(getLocalPGliteDatabaseUrl(env));
+  });
+});
+
+describe("resolveDatabaseUrl — explicit URLs win", () => {
+  test("TEST_DATABASE_URL outranks DATABASE_URL", () => {
+    expect(resolveDatabaseUrl({ TEST_DATABASE_URL: TEST_REMOTE, DATABASE_URL: REMOTE })).toBe(
+      TEST_REMOTE,
+    );
+  });
+
+  test("DATABASE_URL is used when TEST_DATABASE_URL is absent or blank", () => {
+    expect(resolveDatabaseUrl({ DATABASE_URL: REMOTE })).toBe(REMOTE);
+    expect(resolveDatabaseUrl({ TEST_DATABASE_URL: "", DATABASE_URL: REMOTE })).toBe(REMOTE);
+  });
+
+  test("an explicit URL wins in production", () => {
+    expect(resolveDatabaseUrl({ NODE_ENV: "production", DATABASE_URL: REMOTE })).toBe(REMOTE);
+  });
+
+  test("an explicit URL wins over the kill switch", () => {
+    expect(
+      resolveDatabaseUrl({
+        DISABLE_LOCAL_PGLITE_FALLBACK: "1",
+        DATABASE_URL: REMOTE,
+      }),
+    ).toBe(REMOTE);
+  });
+});
+
+describe("resolveDatabaseUrl — fail closed", () => {
+  test("production never falls back to a local store", () => {
+    const url = resolveDatabaseUrl({ NODE_ENV: "production" });
+    expect(url).toBeNull();
+  });
+
+  test("CI never falls back to a local store", () => {
+    expect(resolveDatabaseUrl({ NODE_ENV: "development", CI: "true" })).toBeNull();
+    expect(resolveDatabaseUrl({ NODE_ENV: "test", CI: "true" })).toBeNull();
+  });
+
+  test("the kill switch suppresses the fallback in local execution", () => {
+    expect(resolveDatabaseUrl(local({ DISABLE_LOCAL_PGLITE_FALLBACK: "1" }))).toBeNull();
+  });
+
+  test("the kill switch is exact — only the string '1' disables", () => {
+    for (const value of ["0", "true", "yes", "", " 1", "1 "]) {
+      expect(resolveDatabaseUrl(local({ DISABLE_LOCAL_PGLITE_FALLBACK: value }))).not.toBeNull();
+    }
+  });
+
+  test("no resolved URL is ever a pglite store outside local execution", () => {
+    for (const env of [
+      { NODE_ENV: "production" },
+      { NODE_ENV: "production", CI: "true" },
+      { NODE_ENV: "development", CI: "true" },
+    ]) {
+      expect(resolveDatabaseUrl(env)).toBeNull();
+    }
+  });
+});
+
+describe("resolveDatabaseUrl — local fallback", () => {
+  test("falls back to PGlite in local development", () => {
+    expect(resolveDatabaseUrl(local())).toBe(getLocalPGliteDatabaseUrl(local()));
+  });
+
+  test("falls back for test and for an unset NODE_ENV", () => {
+    for (const env of [{ NODE_ENV: "test" }, {}]) {
+      expect(resolveDatabaseUrl(env)?.startsWith("pglite://")).toBe(true);
+    }
+  });
+
+  test("honours the data-dir override on the fallback path", () => {
+    expect(resolveDatabaseUrl(local({ PGLITE_DATA_DIR: "/tmp/x" }))).toBe("pglite:///tmp/x");
+  });
+
+  test("CI set to anything but 'true' is still local", () => {
+    expect(resolveDatabaseUrl(local({ CI: "false" }))?.startsWith("pglite://")).toBe(true);
+  });
+});
+
+describe("applyDatabaseUrlFallback", () => {
+  test("writes the resolved URL into DATABASE_URL", () => {
+    const env = local();
+    const url = applyDatabaseUrlFallback(env);
+    expect(url).not.toBeNull();
+    expect(env.DATABASE_URL).toBe(url as string);
+  });
+
+  test("never clobbers an existing DATABASE_URL", () => {
+    const env = local({ DATABASE_URL: REMOTE });
+    expect(applyDatabaseUrlFallback(env)).toBe(REMOTE);
+    expect(env.DATABASE_URL).toBe(REMOTE);
+  });
+
+  test("leaves DATABASE_URL alone even when the resolved URL differs", () => {
+    // TEST_DATABASE_URL outranks DATABASE_URL, so the resolved value is NOT
+    // the one already in DATABASE_URL. A plain assignment would overwrite the
+    // production handle with the test one; `??=` must not.
+    const env = local({
+      DATABASE_URL: REMOTE,
+      TEST_DATABASE_URL: TEST_REMOTE,
+    });
+    expect(applyDatabaseUrlFallback(env)).toBe(TEST_REMOTE);
+    expect(env.DATABASE_URL).toBe(REMOTE);
+  });
+
+  test("sets TEST_DATABASE_URL only under NODE_ENV=test", () => {
+    const testEnv: Record<string, string | undefined> = { NODE_ENV: "test" };
+    applyDatabaseUrlFallback(testEnv);
+    expect(testEnv.TEST_DATABASE_URL).toBe(testEnv.DATABASE_URL);
+
+    const devEnv: Record<string, string | undefined> = local();
+    applyDatabaseUrlFallback(devEnv);
+    expect(devEnv.TEST_DATABASE_URL).toBeUndefined();
+  });
+
+  test("never clobbers an existing TEST_DATABASE_URL", () => {
+    const env: Record<string, string | undefined> = {
+      NODE_ENV: "test",
+      TEST_DATABASE_URL: TEST_REMOTE,
+    };
+    applyDatabaseUrlFallback(env);
+    expect(env.TEST_DATABASE_URL).toBe(TEST_REMOTE);
+  });
+
+  test("leaves env untouched when nothing resolves", () => {
+    const env: Record<string, string | undefined> = { NODE_ENV: "production" };
+    expect(applyDatabaseUrlFallback(env)).toBeNull();
+    expect(env.DATABASE_URL).toBeUndefined();
+    expect(env.TEST_DATABASE_URL).toBeUndefined();
+  });
+
+  test("is idempotent", () => {
+    const env = local();
+    const first = applyDatabaseUrlFallback(env);
+    const snapshot = { ...env };
+    expect(applyDatabaseUrlFallback(env)).toBe(first as string);
+    expect(env).toEqual(snapshot);
+  });
+
+  test("agrees with resolveDatabaseUrl on a fresh env", () => {
+    for (const base of [
+      local(),
+      { NODE_ENV: "production" },
+      local({ DISABLE_LOCAL_PGLITE_FALLBACK: "1" }),
+      { DATABASE_URL: REMOTE },
+    ]) {
+      expect(applyDatabaseUrlFallback({ ...base })).toBe(resolveDatabaseUrl({ ...base }));
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/db/database-url.ts` had no test
file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 28 cases over `resolveDatabaseUrl` / `applyDatabaseUrlFallback` /
`getLocalPGliteDatabaseUrl`.

The property worth freezing is the **fail-closed** one. This module decides
whether a missing `DATABASE_URL` silently becomes a file-backed PGlite store
under `.eliza/.pgdata`. That is correct for local dev and wrong everywhere
else, and the whole guard is one line:

```ts
function isLocalExecution(env: EnvLike): boolean {
  return env.NODE_ENV !== "production" && env.CI !== "true";
}
```

If either half of that regresses, nothing throws — the process just comes up
pointed at an empty local database. The suite asserts production, CI, and
`production+CI` all resolve to `null`, and separately that
`DISABLE_LOCAL_PGLITE_FALLBACK=1` suppresses the fallback while an explicit
`DATABASE_URL` still wins over that kill switch.

Also pinned: `TEST_DATABASE_URL` outranks `DATABASE_URL`; the kill switch is
exact-match on `"1"` (`"true"`, `"0"`, `" 1"` do not disable); relative data
dirs resolve absolute so the API, migrations, and tests all touch one store;
and `applyDatabaseUrlFallback` is idempotent and never clobbers an env var that
is already set.

Every case injects its own `EnvLike` object — `process.env` is never read or
mutated, so the suite is order-independent.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`database-url.test.ts`, `resolveDatabaseUrl — fail closed` block.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/db/database-url.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| drop the `env.CI !== "true"` half of `isLocalExecution` | 25 pass, **2 fail** |
| invert precedence to `DATABASE_URL \|\| TEST_DATABASE_URL` | 26 pass, **1 fail** |
| `env.DATABASE_URL ??= url` → `env.DATABASE_URL = url` | 27 pass, **1 fail** |

**The third mutation initially survived, and that is worth calling out.** My
first "never clobbers an existing DATABASE_URL" test set only `DATABASE_URL`,
so the resolved URL *was* the existing value and a plain assignment was
indistinguishable from `??=`. I added a case that sets `TEST_DATABASE_URL` too
— resolution then returns the test handle while `DATABASE_URL` holds the
production one, so an overwrite is visible. That is the shape that would
actually hurt: the production handle being replaced by the test one.

# Evidence Gate

<!-- evidence-head:2b2ffb45e3167d9c926840545a76b8ebada1d47b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a server-side config resolver; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns a connection string, covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module emits no log lines and opens no connection; its observable behaviour is its return value and the env keys it sets, both asserted directly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - the module resolves a string; it never connects, so there is no
connection log to show.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 28 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — CI guard dropped</summary>

```
(fail) resolveDatabaseUrl - fail closed > CI never falls back to a local store
(fail) resolveDatabaseUrl - fail closed > no resolved URL is ever a pglite store outside local execution
 25 pass
 2 fail
```

</details>

<details>
<summary>Mutation B — explicit-URL precedence inverted</summary>

```
(fail) resolveDatabaseUrl - explicit URLs win > TEST_DATABASE_URL outranks DATABASE_URL
 26 pass
 1 fail
```

</details>

<details>
<summary>Mutation C — <code>??=</code> turned into <code>=</code> (after adding the discriminating case)</summary>

```
(fail) applyDatabaseUrlFallback > leaves DATABASE_URL alone even when the resolved URL differs
 27 pass
 1 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side module; no UI surface.`

# Known gaps / failures

This suite exercises the resolver's **decision**, not the connection it
implies. It does not stand up PGlite or Postgres and does not prove that a
`pglite://` URL is actually usable by `drizzle-orm/pglite` — that belongs to
the client's own lane. So "production fails closed" here means "resolves to
`null`", not "the process was observed refusing to start".

`getLocalPGliteDatabaseUrl` reads `process.cwd()` for relative paths, so the
two relative-path assertions compare against `path.resolve(process.cwd(), …)`
rather than a hardcoded string. That keeps them correct under any runner cwd,
but it does mean those two cases mirror the implementation's own call rather
than pinning a literal.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
