### PR TITLE
test(ui): cover useAppearanceApplyChannel

### DIFF
--- a/packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx
@@ -8,7 +8,9 @@
 
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { UI_LANGUAGES } from "../i18n";
 import { __setAppValueForTests } from "../state/app-store";
+import { ACCENT_PRESETS } from "../state/ui-preferences";
 import { emitViewEvent } from "../views/view-event-bus";
 import {
   APPEARANCE_APPLY_EVENT,
@@ -72,5 +74,85 @@ describe("useAppearanceApplyChannel", () => {
     expect(setters.setUiAccent).not.toHaveBeenCalled();
     expect(setters.setUiLanguage).not.toHaveBeenCalled();
     expect(setters.setHomeTimeWidgetHidden).not.toHaveBeenCalled();
+  });
+
+  it("applies a partial payload without touching unrelated setters", () => {
+    const setters = mountChannel();
+    apply({ accentId: "amber", unknownField: "ignored" });
+
+    expect(setters.setUiAccent).toHaveBeenCalledTimes(1);
+    expect(setters.setUiAccent).toHaveBeenCalledWith("amber");
+    expect(setters.setUiThemeMode).not.toHaveBeenCalled();
+    expect(setters.setUiLanguage).not.toHaveBeenCalled();
+    expect(setters.setHomeTimeWidgetHidden).not.toHaveBeenCalled();
+  });
+
+  it("accepts false as a valid homeTimeWidgetHidden value", () => {
+    const setters = mountChannel();
+    apply({ homeTimeWidgetHidden: false });
+
+    expect(setters.setHomeTimeWidgetHidden).toHaveBeenCalledTimes(1);
+    expect(setters.setHomeTimeWidgetHidden).toHaveBeenCalledWith(false);
+  });
+
+  it("ignores non-string values for the semantic token fields", () => {
+    const setters = mountChannel();
+    apply({
+      themeMode: null,
+      accentId: 7,
+      language: { id: "es" },
+    });
+
+    expect(setters.setUiThemeMode).not.toHaveBeenCalled();
+    expect(setters.setUiAccent).not.toHaveBeenCalled();
+    expect(setters.setUiLanguage).not.toHaveBeenCalled();
+  });
+
+  it("applies every supported theme mode token", () => {
+    const setters = mountChannel();
+    apply({ themeMode: "light" });
+    apply({ themeMode: "dark" });
+    apply({ themeMode: "system" });
+
+    expect(setters.setUiThemeMode).toHaveBeenCalledTimes(3);
+    expect(setters.setUiThemeMode).toHaveBeenNthCalledWith(1, "light");
+    expect(setters.setUiThemeMode).toHaveBeenNthCalledWith(2, "dark");
+    expect(setters.setUiThemeMode).toHaveBeenNthCalledWith(3, "system");
+  });
+
+  it("accepts every configured accent preset id", () => {
+    const setters = mountChannel();
+    for (const preset of ACCENT_PRESETS) {
+      apply({ accentId: preset.id });
+    }
+
+    expect(setters.setUiAccent).toHaveBeenCalledTimes(ACCENT_PRESETS.length);
+    for (const [index, preset] of ACCENT_PRESETS.entries()) {
+      expect(setters.setUiAccent).toHaveBeenNthCalledWith(index + 1, preset.id);
+    }
+  });
+
+  it("accepts every configured UI language code", () => {
+    const setters = mountChannel();
+    for (const language of UI_LANGUAGES) {
+      apply({ language });
+    }
+
+    expect(setters.setUiLanguage).toHaveBeenCalledTimes(UI_LANGUAGES.length);
+    for (const [index, language] of UI_LANGUAGES.entries()) {
+      expect(setters.setUiLanguage).toHaveBeenNthCalledWith(
+        index + 1,
+        language,
+      );
+    }
+  });
+
+  it("keeps applying events after the first one", () => {
+    const setters = mountChannel();
+    apply({ themeMode: "light" });
+    apply({ themeMode: "dark" });
+
+    expect(setters.setUiThemeMode).toHaveBeenCalledTimes(2);
+    expect(setters.setUiThemeMode).toHaveBeenLastCalledWith("dark");
   });
 });


### PR DESCRIPTION

## What this changes

Adds 7 new cases to the existing co-located suite for
`packages/ui/src/backgrounds/useAppearanceApplyChannel.ts` (+82/−0, test-only;
no production file is touched).

The module already had two cases (full valid payload; unrecognized string
tokens). This PR fills the remaining branch gaps by driving the real hook
through the real view-event bus against a seeded app store:

- partial payloads apply only their valid field and leave unrelated setters
  untouched (unknown extra keys are ignored);
- `homeTimeWidgetHidden: false` is accepted as a real boolean (distinct from
  the already-covered rejected `"false"` string);
- non-string values for `themeMode` / `accentId` / `language` (`null`, number,
  object) are ignored by the typeof guards;
- every supported theme mode token (`light`, `dark`, `system`) is applied in
  order;
- every configured accent preset id from `ACCENT_PRESETS` and every configured
  language code from `UI_LANGUAGES` is accepted, proving the accept-sets derive
  from configuration rather than a hardcoded subset;
- the channel stays live across successive events (later event applies again,
  last call wins).

Assertions observe actual behavior of the real module — the only doubles are
the four persisted-preference setter callbacks at the external boundary.

## Verification

Test-only change; all counts below were re-produced on current `origin/develop`
immediately before filing.

- `bunx vitest run src/backgrounds/useAppearanceApplyChannel.test.tsx`
  (in `packages/ui`): **Test Files 1 passed (1), Tests 9 passed (9)**
  (2 pre-existing + 7 new).
- `bunx biome check --write packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx`:
  clean.
- `bunx tsc --noEmit` in `packages/ui`, grepped for the test file:
  **no output** — zero type errors introduced.

Note: this comes from a fork, so hosted CI does not run on this pull request;
the commands above are the complete verification record. No runtime behavior
changes — the diff contains only the one test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b5e15f203a71818f67fbcdefb5b5d1a7136b3553 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
