### PR TITLE
test(cloud): pin model preference sanitization and merge order

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/model-preferences.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/model-preferences.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Pins model-preference sanitization and merge order. These values select
+ * which model a hosted agent calls, and they arrive from stored JSON, so the
+ * allowlist must reject unknown and inherited keys and the merge must be
+ * last-wins per key rather than whole-object replacement. Pure module, no
+ * harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  MODEL_PREFERENCE_KEYS,
+  type ModelPreferences,
+  mergeModelPreferences,
+  normalizeModelPreferences,
+  sanitizeModelPreferences,
+} from "./model-preferences";
+
+describe("MODEL_PREFERENCE_KEYS", () => {
+  test("is non-empty and free of duplicates", () => {
+    expect(MODEL_PREFERENCE_KEYS.length).toBeGreaterThan(0);
+    expect(new Set(MODEL_PREFERENCE_KEYS).size).toBe(MODEL_PREFERENCE_KEYS.length);
+  });
+
+  test("every key is a camelCase name ending in Model", () => {
+    for (const key of MODEL_PREFERENCE_KEYS) {
+      expect(key).toMatch(/^[a-z][A-Za-z]*Model$/);
+    }
+  });
+});
+
+describe("sanitizeModelPreferences — rejected input", () => {
+  test("rejects non-objects", () => {
+    for (const value of [null, undefined, 0, 1, "", "x", true, false]) {
+      expect(sanitizeModelPreferences(value)).toBeUndefined();
+    }
+  });
+
+  test("rejects arrays", () => {
+    expect(sanitizeModelPreferences([])).toBeUndefined();
+    expect(sanitizeModelPreferences([{ smallModel: "a" }])).toBeUndefined();
+  });
+
+  test("rejects an array even when it carries an allowlisted property", () => {
+    // A plain array is rejected by the key allowlist anyway, so this is the
+    // case that actually isolates the Array.isArray guard: without it, the
+    // property below would be read straight off the array and returned as a
+    // valid preference set.
+    const arrayWithProperty = Object.assign([], { smallModel: "sneaky" });
+    expect(sanitizeModelPreferences(arrayWithProperty)).toBeUndefined();
+  });
+
+  test("returns undefined rather than an empty object", () => {
+    expect(sanitizeModelPreferences({})).toBeUndefined();
+    expect(sanitizeModelPreferences({ unknownKey: "value" })).toBeUndefined();
+  });
+
+  test("drops blank and whitespace-only values", () => {
+    expect(sanitizeModelPreferences({ smallModel: "", largeModel: "   \t\n" })).toBeUndefined();
+  });
+
+  test("drops non-string values", () => {
+    expect(
+      sanitizeModelPreferences({
+        smallModel: 42,
+        largeModel: null,
+        megaModel: {},
+        nanoModel: ["a"],
+        plannerModel: true,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("sanitizeModelPreferences — accepted input", () => {
+  test("keeps every declared key", () => {
+    const input = Object.fromEntries(MODEL_PREFERENCE_KEYS.map((key) => [key, `model-for-${key}`]));
+    const result = sanitizeModelPreferences(input);
+    expect(Object.keys(result ?? {}).sort()).toEqual([...MODEL_PREFERENCE_KEYS].sort());
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(sanitizeModelPreferences({ smallModel: "  gpt-x  " })).toEqual({
+      smallModel: "gpt-x",
+    });
+  });
+
+  test("strips keys outside the allowlist", () => {
+    const result = sanitizeModelPreferences({
+      smallModel: "keep",
+      __proto__: "evil",
+      constructor: "evil",
+      toString: "evil",
+      arbitrary: "evil",
+    });
+    expect(result).toEqual({ smallModel: "keep" });
+  });
+
+  test("keeps the valid entries alongside invalid ones", () => {
+    expect(
+      sanitizeModelPreferences({
+        smallModel: "keep",
+        largeModel: "",
+        megaModel: 7,
+      }),
+    ).toEqual({ smallModel: "keep" });
+  });
+
+  test("returns a fresh object rather than the input", () => {
+    const input = { smallModel: "a" };
+    expect(sanitizeModelPreferences(input)).not.toBe(input);
+  });
+
+  test("does not mutate its input", () => {
+    const input = { smallModel: "  a  ", junk: "b" };
+    const snapshot = { ...input };
+    sanitizeModelPreferences(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  test("is idempotent", () => {
+    const once = sanitizeModelPreferences({ smallModel: " a ", megaModel: "b" });
+    expect(sanitizeModelPreferences(once)).toEqual(once as ModelPreferences);
+  });
+});
+
+describe("mergeModelPreferences", () => {
+  test("returns undefined when nothing contributes a value", () => {
+    expect(mergeModelPreferences()).toBeUndefined();
+    expect(mergeModelPreferences(undefined, undefined)).toBeUndefined();
+    expect(mergeModelPreferences({}, {})).toBeUndefined();
+  });
+
+  test("skips undefined entries", () => {
+    expect(mergeModelPreferences(undefined, { smallModel: "a" }, undefined)).toEqual({
+      smallModel: "a",
+    });
+  });
+
+  test("later sources win per key", () => {
+    expect(mergeModelPreferences({ smallModel: "first" }, { smallModel: "second" })).toEqual({
+      smallModel: "second",
+    });
+  });
+
+  test("merges per key rather than replacing the whole object", () => {
+    expect(
+      mergeModelPreferences({ smallModel: "a", largeModel: "b" }, { largeModel: "c" }),
+    ).toEqual({ smallModel: "a", largeModel: "c" });
+  });
+
+  test("a blank value does not erase an earlier one", () => {
+    expect(mergeModelPreferences({ smallModel: "keep" }, { smallModel: "   " })).toEqual({
+      smallModel: "keep",
+    });
+  });
+
+  test("trims as it merges", () => {
+    expect(mergeModelPreferences({ smallModel: "  a  " })).toEqual({
+      smallModel: "a",
+    });
+  });
+
+  test("ignores keys outside the allowlist", () => {
+    expect(
+      mergeModelPreferences({
+        smallModel: "keep",
+        rogueModel: "drop",
+      } as ModelPreferences),
+    ).toEqual({ smallModel: "keep" });
+  });
+
+  test("does not mutate its sources", () => {
+    const first = { smallModel: "a" };
+    const second = { largeModel: "b" };
+    const snapshots = [{ ...first }, { ...second }];
+    mergeModelPreferences(first, second);
+    expect([first, second]).toEqual(snapshots);
+  });
+
+  test("a single source round-trips through sanitize", () => {
+    const input = { smallModel: " a ", megaModel: "b" };
+    expect(mergeModelPreferences(input)).toEqual(
+      sanitizeModelPreferences(input) as ModelPreferences,
+    );
+  });
+});
+
+describe("normalizeModelPreferences", () => {
+  test("agrees with sanitizeModelPreferences", () => {
+    for (const input of [
+      undefined,
+      {},
+      { smallModel: "a" },
+      { smallModel: "  a  ", largeModel: "" },
+    ] as Array<ModelPreferences | undefined>) {
+      expect(normalizeModelPreferences(input)).toEqual(
+        sanitizeModelPreferences(input) as ModelPreferences,
+      );
+    }
+  });
+
+  test("is idempotent", () => {
+    const once = normalizeModelPreferences({ smallModel: " a " });
+    expect(normalizeModelPreferences(once)).toEqual(once as ModelPreferences);
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/eliza/model-preferences.ts`
had no test file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 26 cases over `sanitizeModelPreferences`, `mergeModelPreferences`, and
`normalizeModelPreferences`.

These values decide **which model a hosted agent calls**, and they arrive from
stored JSON, so two contracts matter:

- **The key allowlist.** `sanitizeModelPreferences` iterates
  `MODEL_PREFERENCE_KEYS` rather than the input's own keys. That is what keeps
  `__proto__`, `constructor`, `toString`, and arbitrary junk out of the result.
  The suite asserts the allowlist survives, that an all-invalid input returns
  `undefined` rather than an empty object, and that non-string values (`42`,
  `null`, `{}`, `["a"]`, `true`) are dropped rather than coerced.
- **Merge is per key, last-wins.** `mergeModelPreferences` must not replace one
  source wholesale with the next, and — the case with a real consequence — **a
  blank value must not erase an earlier one**. Otherwise an empty field in a
  later config layer silently unsets a model the earlier layer had chosen.

Also pinned: trimming on both paths, non-mutation of inputs, idempotency, and
that `normalizeModelPreferences` agrees with `sanitizeModelPreferences` (it is
currently a thin delegate, so this holds it there).

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`model-preferences.test.ts` — `strips keys outside the allowlist` and
`a blank value does not erase an earlier one`.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/eliza/model-preferences.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| allowlist loop replaced with an `Object.keys(source)` passthrough | 23 pass, **2 fail** |
| merge accepts any string, so a blank value overwrites | 24 pass, **1 fail** |
| `Array.isArray` guard dropped from the input check | 25 pass, **1 fail** |

**The third mutation initially survived**, and the reason is worth stating: a
plain array is already rejected by the key allowlist (its indices are not
preference keys), so `sanitizeModelPreferences([…])` returns `undefined` with
or without the guard. I added a case using
`Object.assign([], { smallModel: "sneaky" })` — an array that genuinely carries
an allowlisted property — which is the only shape that isolates the guard. See
**Known gaps** for how reachable I think that actually is.

# Evidence Gate

<!-- evidence-head:bd8284266eecd9fdd114777ecb552f61412f7bb2 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a pure sanitization module; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns a plain object, covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model is invoked. This module selects model *names* but never calls one, and the diff is test-only.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call happens in or below this module; it resolves configuration
strings only.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 26 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — allowlist replaced with an Object.keys passthrough</summary>

```
(fail) sanitizeModelPreferences - rejected input > returns undefined rather than an empty object
(fail) sanitizeModelPreferences - accepted input > strips keys outside the allowlist
 23 pass
 2 fail
```

</details>

<details>
<summary>Mutation B — merge lets a blank value overwrite</summary>

```
(fail) mergeModelPreferences > a blank value does not erase an earlier one
 24 pass
 1 fail
```

</details>

<details>
<summary>Mutation C — Array.isArray guard dropped (after adding the discriminating case)</summary>

```
(fail) sanitizeModelPreferences - rejected input > rejects an array even when it carries an allowlisted property
 25 pass
 1 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side module; no UI surface.`

# Known gaps / failures

**Honest note on the array-guard case.** `JSON.parse` cannot produce an array
with a named property, so if these preferences only ever arrive as parsed JSON
the `Array.isArray` check is defence-in-depth rather than a live boundary. I
kept the test because it documents what the guard is for and makes its removal
visible, but a reviewer should read it as pinning a defensive branch, not as
evidence of a reachable attack.

I did not add coverage for **who calls these helpers** or in what layering
order (defaults → org → agent). The merge semantics are pinned here in
isolation; whether the call sites pass their sources in the intended order is a
separate contract owned by those modules, and I could not verify it without
pulling in the runtime.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
