### PR TITLE
test(ui): cover lock-on-button.variants

### DIFF
--- a/packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.test.ts
+++ b/packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the LockOnButton cva contract (`lockOnButtonVariants`):
+ * shared base classes, tone/size segments, default fallbacks, and
+ * unknown-key behaviour. Pure function, deterministic, no DOM.
+ */
+import { describe, expect, it } from "vitest";
+import { lockOnButtonVariants } from "./lock-on-button.variants";
+
+const BASE =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm border text-sm font-medium transition-colors    disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer";
+
+const TONE_SEGMENTS = {
+  primary:
+    "border-accent bg-accent text-accent-foreground hover:bg-accent-hover",
+  outline:
+    "border-border bg-bg-elevated text-txt hover:border-border-strong hover:bg-bg-hover",
+  ghost:
+    "border-transparent bg-transparent text-txt/70 hover:border-border hover:bg-bg-hover hover:text-txt",
+  hud: "border-accent/40 bg-accent-subtle text-accent hover:border-accent/70 hover:bg-accent/20",
+} as const;
+
+const SIZE_SEGMENTS = {
+  sm: "h-8 px-3 text-xs",
+  md: "h-10 px-4",
+  lg: "h-12 px-6",
+} as const;
+
+describe("lockOnButtonVariants", () => {
+  it("emits the shared base classes first, then tone, then size", () => {
+    const out = lockOnButtonVariants({ variant: "hud", size: "sm" });
+    expect(out.startsWith(`${BASE} `)).toBe(true);
+    expect(out.indexOf(TONE_SEGMENTS.hud)).toBeGreaterThan(0);
+    expect(out.indexOf(SIZE_SEGMENTS.sm)).toBeGreaterThan(
+      out.indexOf(TONE_SEGMENTS.hud),
+    );
+  });
+
+  it("defaults to the primary tone and md size when called with no arguments", () => {
+    const out = lockOnButtonVariants();
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.primary} ${SIZE_SEGMENTS.md}`);
+  });
+
+  it.each(Object.entries(TONE_SEGMENTS))(
+    "applies the %s tone segment and no other tone segment",
+    (tone, segment) => {
+      const out = lockOnButtonVariants({
+        variant: tone as keyof typeof TONE_SEGMENTS,
+      });
+      expect(out).toContain(` ${segment}`);
+      for (const [other, otherSegment] of Object.entries(TONE_SEGMENTS)) {
+        if (other !== tone) {
+          expect(out).not.toContain(otherSegment);
+        }
+      }
+    },
+  );
+
+  it.each(Object.entries(SIZE_SEGMENTS))(
+    "applies the %s size segment and no other size segment",
+    (size, segment) => {
+      const out = lockOnButtonVariants({
+        size: size as keyof typeof SIZE_SEGMENTS,
+      });
+      expect(out).toContain(` ${segment}`);
+      for (const [other, otherSegment] of Object.entries(SIZE_SEGMENTS)) {
+        if (other !== size) {
+          expect(out).not.toContain(otherSegment);
+        }
+      }
+    },
+  );
+
+  it("keeps the primary tone default when only a size override is given", () => {
+    const out = lockOnButtonVariants({ size: "lg" });
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.primary} ${SIZE_SEGMENTS.lg}`);
+  });
+
+  it("combines independent tone and size overrides", () => {
+    const out = lockOnButtonVariants({ variant: "outline", size: "sm" });
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.outline} ${SIZE_SEGMENTS.sm}`);
+  });
+
+  it("falls back to both defaults when props are explicitly undefined", () => {
+    const out = lockOnButtonVariants({
+      variant: undefined,
+      size: undefined,
+    });
+    expect(out).toBe(lockOnButtonVariants());
+  });
+
+  it("emits no tone classes for an unknown tone instead of throwing", () => {
+    const out = lockOnButtonVariants({
+      variant: "bogus" as keyof typeof TONE_SEGMENTS,
+    });
+    expect(out).toBe(`${BASE} ${SIZE_SEGMENTS.md}`);
+  });
+
+  it("treats an empty props object exactly like no arguments", () => {
+    expect(lockOnButtonVariants({})).toBe(lockOnButtonVariants());
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located unit test suite for `lockOnButtonVariants`, the cva variant
contract behind the LockOnButton Cloud console component
(`packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.ts`).
No same-named test file existed anywhere in the repository on current
`develop`.

## Why

The module defines the tone/size Tailwind class contract consumed by every
rendered LockOnButton state, but had zero direct coverage. This PR is
test-only: it adds one new file and changes no production behaviour.

## What the tests assert

All cases drive the real module directly — no mocks, no stubs:

- the shared base class run is emitted first, then the tone segment, then the
  size segment;
- calling with no arguments resolves to the documented defaults
  (primary tone + md size), asserted as an exact full output string;
- each of the four tones (`primary`, `outline`, `ghost`, `hud`) emits exactly
  its own segment and none of the other three;
- each of the three sizes (`sm`, `md`, `lg`) emits exactly its own segment and
  none of the others;
- a size-only override keeps the primary tone default;
- independent tone + size overrides combine;
- explicitly-`undefined` props fall back to both defaults;
- an unknown tone key contributes no classes instead of throwing (observed
  cva fail-open behaviour);
- an empty props object is indistinguishable from no arguments.

## Verification

Run against current `origin/develop` immediately before filing:

- `bunx vitest run src/cloud-ui/components/brand/lock-on-button.variants.test.ts`
  in `packages/ui`: **1 test file passed, 14/14 tests passed**.
- `bunx biome check packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.test.ts`
  (repo root config, non-sparse checkout): **clean**, no fixes applied.
- `bunx tsc --noEmit` in `packages/ui`: the package has pre-existing errors
  elsewhere, but **no diagnostic mentions the new test file** — grepping the
  full tsc output for `lock-on-button.variants.test` returns zero matches.
- The diff is a single new file (`+101/-0`); nothing else is touched.
- This pull request comes from a fork, so hosted CI does **not** run on it;
  the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a4074216fd20d52948ce7fa6668c6cbd1fac87af -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
