### PR TITLE
test(core): pin heuristic trajectory reward scoring

### DIFF
--- a/packages/core/src/features/trajectories/reward-service.test.ts
+++ b/packages/core/src/features/trajectories/reward-service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Pins heuristic trajectory scoring. The reward is a weighted average whose
+ * divisor is built from only the components actually present, so a missing
+ * metric must reweight the rest rather than drag the score toward zero; the
+ * result must stay inside [-1, 1]; and group scoring must not divide by a zero
+ * range when every trajectory scores alike. Pure module, no runtime.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	createRewardService,
+	RewardService,
+	scoreTrajectory,
+	scoreTrajectoryGroup,
+} from "./reward-service.ts";
+import type { Trajectory } from "./types.ts";
+
+type Metrics = Trajectory["metrics"];
+
+function trajectory(
+	metrics: Partial<Metrics> = {},
+	environmentReward?: number,
+): Trajectory {
+	return {
+		trajectoryId: "00000000-0000-0000-0000-000000000001",
+		agentId: "00000000-0000-0000-0000-000000000002",
+		startTime: 0,
+		steps: [],
+		totalReward: 0,
+		rewardComponents: { environmentReward } as Trajectory["rewardComponents"],
+		metrics: {
+			episodeLength: 1,
+			finalStatus: "completed",
+			...metrics,
+		} as Metrics,
+		metadata: {},
+	} as Trajectory;
+}
+
+describe("scoreTrajectory — bounds", () => {
+	it("never leaves the [-1, 1] range", async () => {
+		const extremes = [
+			trajectory({ finalPnL: 1e9, successRate: 1 }, 1),
+			trajectory({ finalPnL: -1e9, successRate: 0, finalStatus: "error" }, -1),
+			trajectory({ finalPnL: 0, successRate: 0.5 }, 0),
+			trajectory({}, undefined),
+		];
+		for (const t of extremes) {
+			const score = await scoreTrajectory(t);
+			expect(score).toBeGreaterThanOrEqual(-1);
+			expect(score).toBeLessThanOrEqual(1);
+			expect(Number.isFinite(score)).toBe(true);
+		}
+	});
+
+	it("clamps an out-of-range environment reward instead of propagating it", async () => {
+		const high = await scoreTrajectory(trajectory({}, 1000));
+		const atOne = await scoreTrajectory(trajectory({}, 1));
+		expect(high).toBeCloseTo(atOne, 10);
+
+		const low = await scoreTrajectory(trajectory({}, -1000));
+		const atMinusOne = await scoreTrajectory(trajectory({}, -1));
+		expect(low).toBeCloseTo(atMinusOne, 10);
+	});
+});
+
+describe("scoreTrajectory — component weighting", () => {
+	it("scores a completed run with no other signal at the completion value", async () => {
+		// Only the completion component contributes, so the weighted average is
+		// that component's own value rather than a fraction of it.
+		expect(await scoreTrajectory(trajectory())).toBeCloseTo(1, 10);
+	});
+
+	it("scores a non-completed run with no other signal at the penalty value", async () => {
+		for (const finalStatus of [
+			"active",
+			"terminated",
+			"error",
+			"timeout",
+		] as const) {
+			expect(await scoreTrajectory(trajectory({ finalStatus }))).toBeCloseTo(
+				-0.5,
+				10,
+			);
+		}
+	});
+
+	it("reweights rather than penalising when a metric is absent", async () => {
+		// A perfect run scores 1 whether or not the optional metrics are present.
+		const bare = await scoreTrajectory(trajectory());
+		const full = await scoreTrajectory(
+			trajectory({ finalPnL: 1e6, successRate: 1 }, 1),
+		);
+		expect(bare).toBeCloseTo(1, 6);
+		expect(full).toBeCloseTo(1, 6);
+	});
+
+	it("maps a 0..1 success rate onto -1..1 before weighting", async () => {
+		// Holding status at "completed", only the success and completion
+		// components contribute (weights 0.3 and 0.2, divisor 0.5):
+		//   successRate 0 -> (-1 * 0.3 + 1 * 0.2) / 0.5 = -0.2
+		//   successRate 1 -> ( 1 * 0.3 + 1 * 0.2) / 0.5 =  1.0
+		expect(await scoreTrajectory(trajectory({ successRate: 0 }))).toBeCloseTo(
+			-0.2,
+			10,
+		);
+		expect(await scoreTrajectory(trajectory({ successRate: 1 }))).toBeCloseTo(
+			1,
+			10,
+		);
+	});
+
+	it("is monotonic in success rate", async () => {
+		const scores = await Promise.all(
+			[0, 0.25, 0.5, 0.75, 1].map((successRate) =>
+				scoreTrajectory(trajectory({ successRate })),
+			),
+		);
+		for (let i = 1; i < scores.length; i += 1) {
+			expect(scores[i]).toBeGreaterThan(scores[i - 1]);
+		}
+	});
+
+	it("treats a mid success rate as neutral for its component", async () => {
+		// successRate 0.5 -> component 0, so only completion contributes.
+		const mid = await scoreTrajectory(trajectory({ successRate: 0.5 }));
+		expect(mid).toBeCloseTo((1 * 0.2) / 0.5, 10);
+	});
+
+	it("is monotonic in P&L", async () => {
+		const scores = await Promise.all(
+			[-5000, -500, 0, 500, 5000].map((finalPnL) =>
+				scoreTrajectory(trajectory({ finalPnL })),
+			),
+		);
+		for (let i = 1; i < scores.length; i += 1) {
+			expect(scores[i]).toBeGreaterThan(scores[i - 1]);
+		}
+	});
+
+	it("treats zero P&L as neutral for its component", async () => {
+		const zero = await scoreTrajectory(trajectory({ finalPnL: 0 }));
+		expect(zero).toBeCloseTo((1 * 0.2) / 0.6, 10);
+	});
+
+	it("saturates rather than overflowing on extreme P&L", async () => {
+		const big = await scoreTrajectory(trajectory({ finalPnL: 1e12 }));
+		const bigger = await scoreTrajectory(trajectory({ finalPnL: 1e15 }));
+		expect(big).toBeCloseTo(bigger, 10);
+		expect(big).toBeLessThanOrEqual(1);
+	});
+});
+
+describe("scoreTrajectoryGroup", () => {
+	it("returns an empty array for an empty group", async () => {
+		expect(await scoreTrajectoryGroup([])).toEqual([]);
+	});
+
+	it("returns one absolute score for a single trajectory", async () => {
+		const [score] = await scoreTrajectoryGroup([trajectory()]);
+		expect(score).toBeCloseTo(1, 10);
+		expect(score).toBeGreaterThanOrEqual(0);
+		expect(score).toBeLessThanOrEqual(1);
+	});
+
+	it("gives every member 0.5 when the group has no spread", async () => {
+		const scores = await scoreTrajectoryGroup([
+			trajectory(),
+			trajectory(),
+			trajectory(),
+		]);
+		expect(scores).toEqual([0.5, 0.5, 0.5]);
+	});
+
+	it("min-max normalises a group with spread", async () => {
+		const scores = await scoreTrajectoryGroup([
+			trajectory({ finalStatus: "error" }),
+			trajectory({ successRate: 0.5 }),
+			trajectory(),
+		]);
+		expect(Math.min(...scores)).toBe(0);
+		expect(Math.max(...scores)).toBe(1);
+		expect(scores.length).toBe(3);
+	});
+
+	it("preserves input order and length", async () => {
+		const scores = await scoreTrajectoryGroup([
+			trajectory(),
+			trajectory({ finalStatus: "error" }),
+		]);
+		expect(scores.length).toBe(2);
+		expect(scores[0]).toBeGreaterThan(scores[1]);
+	});
+
+	it("keeps every score inside [0, 1] and finite", async () => {
+		const scores = await scoreTrajectoryGroup([
+			trajectory({ finalPnL: -1e9, finalStatus: "error" }),
+			trajectory({ finalPnL: 1e9, successRate: 1 }, 1),
+			trajectory({ successRate: 0.25 }),
+		]);
+		for (const score of scores) {
+			expect(Number.isFinite(score)).toBe(true);
+			expect(score).toBeGreaterThanOrEqual(0);
+			expect(score).toBeLessThanOrEqual(1);
+		}
+	});
+});
+
+describe("service construction", () => {
+	it("createRewardService returns a usable service", async () => {
+		const service = createRewardService();
+		expect(service).toBeInstanceOf(RewardService);
+		expect(await service.scoreTrajectory(trajectory())).toBeCloseTo(1, 10);
+	});
+
+	it("accepts an archetype without changing the heuristic score", async () => {
+		const plain = createRewardService();
+		const themed = createRewardService({ archetype: "trader" });
+		const t = trajectory({ finalPnL: 250, successRate: 0.75 }, 0.5);
+		expect(await themed.scoreTrajectory(t)).toBe(
+			await plain.scoreTrajectory(t),
+		);
+	});
+
+	it("scores identically through the class and the free functions", async () => {
+		const t = trajectory({ finalPnL: 120, successRate: 0.6 }, 0.2);
+		expect(await scoreTrajectory(t)).toBe(
+			await new RewardService().scoreTrajectory(t),
+		);
+	});
+
+	it("is deterministic across repeated calls", async () => {
+		const t = trajectory({ finalPnL: 42, successRate: 0.4 }, -0.3);
+		const first = await scoreTrajectory(t);
+		expect(await scoreTrajectory(t)).toBe(first);
+		expect(await scoreTrajectory(t)).toBe(first);
+	});
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/core/src/features/trajectories/reward-service.ts`
had no test file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 21 cases over heuristic trajectory scoring.

The subtle part is that `computeHeuristicReward` builds its divisor as it goes
— `weightSum` accumulates only the weights of components that are actually
present, then divides. That means an absent metric **reweights** the remaining
components rather than scoring as zero. It is easy to "simplify" that into a
fixed divisor and silently make every partial trajectory score low, so the
suite pins it directly: a perfect run scores `1` whether or not the optional
metrics are supplied.

Assertions are stated as the arithmetic they check rather than as magic
numbers, e.g. a mid success rate contributes nothing, so only completion
remains and the score is `(1 * 0.2) / 0.5`.

Also pinned:

- **Bounds.** No input produces a non-finite score or one outside `[-1, 1]`,
  including `±1e9` P&L.
- **Clamping.** An environment reward of `1000` scores the same as `1`.
- **Saturation.** `tanh` means `1e12` and `1e15` P&L converge instead of
  overflowing.
- **Monotonicity** in both P&L and success rate.
- **Group normalisation.** Empty group → `[]`; a single trajectory gets an
  absolute score; a spread group is min-max normalised to exactly `0` and `1`;
  and — the one with a real failure mode — a group with **no** spread returns
  `0.5` for every member instead of dividing by a zero range.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`reward-service.test.ts` — `reweights rather than penalising when a metric is
absent` and `gives every member 0.5 when the group has no spread`.

## Detailed testing steps

```bash
bun run --cwd packages/core test src/features/trajectories/reward-service.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| remove the `reward / weightSum` division | 13 pass, **8 fail** |
| remove the `range === 0` guard in group normalisation | 20 pass, **1 fail** |
| remove the `Math.max(-1, Math.min(1, …))` environment clamp | 20 pass, **1 fail** |

# Evidence Gate

<!-- evidence-head:6597800b294b85d37a9c2d550112f1c3315bad48 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a pure scoring module; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns numbers, covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines; no runtime, service, or database is involved.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model is invoked. The module scores *recorded* trajectories with arithmetic heuristics (its header states it is for when game knowledge is unavailable); there is no judge-model path in the code under test, and the diff is test-only.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below. Trajectory fixtures are constructed in-test against the real `Trajectory` type.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - the heuristic path makes no model call; see the llm-trajectory row.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
 RUN  v4.1.10 packages/core

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  98ms
```

</details>

<details>
<summary>Mutation A — weighted-average divisor removed</summary>

```
 × scores a completed run with no other signal at the completion value
 × scores a non-completed run with no other signal at the penalty value
 × reweights rather than penalising when a metric is absent
 × maps a 0..1 success rate onto -1..1 before weighting
 × treats a mid success rate as neutral for its component
 × treats zero P&L as neutral for its component
 × returns one absolute score for a single trajectory
 × createRewardService returns a usable service
      Tests  8 failed | 13 passed (21)
```

</details>

<details>
<summary>Mutation B — zero-range guard removed</summary>

```
 × scoreTrajectoryGroup > gives every member 0.5 when the group has no spread
      Tests  1 failed | 20 passed (21)
```

</details>

<details>
<summary>Mutation C — environment reward clamp removed</summary>

```
 × scoreTrajectory - bounds > clamps an out-of-range environment reward instead of propagating it
      Tests  1 failed | 20 passed (21)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a core scoring module; no UI surface.`

# Known gaps / failures

**Two things I found and deliberately did not change.**

1. `scoreTrajectory` branches on `useHeuristics` but **both branches are
   identical** — `useHeuristics: false` currently does nothing. It reads as a
   placeholder for a non-heuristic path that does not exist yet. Removing the
   dead branch would be a guess at intent, and asserting the option *works*
   would be asserting something false, so the suite simply does not exercise
   the flag. Flagging it here for the owner.

2. Group scoring is discontinuous at size 1. One trajectory gets an **absolute**
   score `(s + 1) / 2`; two or more get a **relative** min-max score, so the
   best member is always `1` and the worst always `0` regardless of absolute
   quality. That is plausibly intentional for relative-advantage training, so I
   pinned the current behaviour on both sides rather than calling it a bug.

**A correction on my own process, since it affects how to read the suite.** My
first draft asserted that `successRate: 0` with `finalStatus: "error"` scores
`-1`. It scores `-0.8`, because the completion penalty is `-0.5` rather than
`-1`. The code was right and my expectation was wrong; I replaced that case
with one that pins the component mapping exactly (`-0.2` and `1.0` at fixed
status) plus a monotonicity check, rather than loosening the tolerance until it
passed.

`bun run verify` was not run to completion in this environment — it builds all
three core targets and is unrelated to a test-only diff. `npx biome check` is
clean on the new file.
