### PR TITLE
test(cloud): pin automation interval bounds and config defaults

### DIFF
--- a/packages/cloud/shared/src/lib/services/automation-constants.test.ts
+++ b/packages/cloud/shared/src/lib/services/automation-constants.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Pins the shared automation interval bounds and the defaults helpers. The
+ * bounds are a ladder (MIN_ALLOWED <= DEFAULT_MIN <= DEFAULT_MAX <=
+ * MAX_ALLOWED) that nothing enforces, and the helpers merge by object spread —
+ * which has a sharp edge worth documenting: a key present with an explicit
+ * `undefined` overwrites the default rather than falling back to it. Pure
+ * module, no harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AUTOMATION_INTERVALS,
+  DISCORD_AUTOMATION_DEFAULTS,
+  getDiscordConfigWithDefaults,
+  getTelegramConfigWithDefaults,
+  getTwitterConfigWithDefaults,
+  TELEGRAM_AUTOMATION_DEFAULTS,
+  TWITTER_AUTOMATION_DEFAULTS,
+} from "./automation-constants";
+
+describe("AUTOMATION_INTERVALS", () => {
+  test("forms a consistent bounds ladder", () => {
+    expect(AUTOMATION_INTERVALS.MIN_ALLOWED).toBeLessThanOrEqual(AUTOMATION_INTERVALS.DEFAULT_MIN);
+    expect(AUTOMATION_INTERVALS.DEFAULT_MIN).toBeLessThanOrEqual(AUTOMATION_INTERVALS.DEFAULT_MAX);
+    expect(AUTOMATION_INTERVALS.DEFAULT_MAX).toBeLessThanOrEqual(AUTOMATION_INTERVALS.MAX_ALLOWED);
+  });
+
+  test("every bound is a positive whole number of minutes", () => {
+    for (const value of Object.values(AUTOMATION_INTERVALS)) {
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThan(0);
+    }
+  });
+
+  test("the allowed window is wider than the default window", () => {
+    expect(AUTOMATION_INTERVALS.MIN_ALLOWED).toBeLessThan(AUTOMATION_INTERVALS.MAX_ALLOWED);
+    expect(
+      AUTOMATION_INTERVALS.MAX_ALLOWED - AUTOMATION_INTERVALS.MIN_ALLOWED,
+    ).toBeGreaterThanOrEqual(AUTOMATION_INTERVALS.DEFAULT_MAX - AUTOMATION_INTERVALS.DEFAULT_MIN);
+  });
+});
+
+describe("per-service defaults", () => {
+  const suites = [
+    ["discord", DISCORD_AUTOMATION_DEFAULTS, "announceInterval"],
+    ["telegram", TELEGRAM_AUTOMATION_DEFAULTS, "announceInterval"],
+    ["twitter", TWITTER_AUTOMATION_DEFAULTS, "postInterval"],
+  ] as const;
+
+  test.each(suites)("%s ships disabled", (_name, defaults) => {
+    expect(defaults.enabled).toBe(false);
+  });
+
+  test.each(suites)(
+    "%s interval defaults come from the shared table",
+    (_name, defaults, prefix) => {
+      const record = defaults as unknown as Record<string, number>;
+      expect(record[`${prefix}Min`]).toBe(AUTOMATION_INTERVALS.DEFAULT_MIN);
+      expect(record[`${prefix}Max`]).toBe(AUTOMATION_INTERVALS.DEFAULT_MAX);
+    },
+  );
+
+  test.each(suites)("%s min interval never exceeds its max", (_name, defaults, prefix) => {
+    const record = defaults as unknown as Record<string, number>;
+    expect(record[`${prefix}Min`]).toBeLessThanOrEqual(record[`${prefix}Max`]);
+  });
+
+  test.each(suites)("%s intervals sit inside the allowed window", (_name, defaults, prefix) => {
+    const record = defaults as unknown as Record<string, number>;
+    for (const key of [`${prefix}Min`, `${prefix}Max`]) {
+      expect(record[key]).toBeGreaterThanOrEqual(AUTOMATION_INTERVALS.MIN_ALLOWED);
+      expect(record[key]).toBeLessThanOrEqual(AUTOMATION_INTERVALS.MAX_ALLOWED);
+    }
+  });
+
+  test("no automation ships with an outbound behaviour pre-enabled", () => {
+    expect(DISCORD_AUTOMATION_DEFAULTS.autoAnnounce).toBe(false);
+    expect(TELEGRAM_AUTOMATION_DEFAULTS.autoAnnounce).toBe(false);
+    expect(TWITTER_AUTOMATION_DEFAULTS.autoPost).toBe(false);
+    expect(TWITTER_AUTOMATION_DEFAULTS.autoReply).toBe(false);
+    expect(TWITTER_AUTOMATION_DEFAULTS.autoEngage).toBe(false);
+    expect(TWITTER_AUTOMATION_DEFAULTS.discovery).toBe(false);
+  });
+});
+
+describe("config merge helpers", () => {
+  const helpers = [
+    ["discord", getDiscordConfigWithDefaults, DISCORD_AUTOMATION_DEFAULTS],
+    ["telegram", getTelegramConfigWithDefaults, TELEGRAM_AUTOMATION_DEFAULTS],
+    ["twitter", getTwitterConfigWithDefaults, TWITTER_AUTOMATION_DEFAULTS],
+  ] as const;
+
+  test.each(helpers)("%s returns the defaults for null", (_name, helper, defaults) => {
+    expect(helper(null)).toEqual({ ...defaults });
+  });
+
+  test.each(helpers)(
+    "%s returns the defaults for undefined and for an empty object",
+    (_name, helper, defaults) => {
+      expect(helper(undefined)).toEqual({ ...defaults });
+      expect(helper({})).toEqual({ ...defaults });
+    },
+  );
+
+  test.each(helpers)("%s lets a supplied value win", (_name, helper) => {
+    expect(helper({ enabled: true }).enabled).toBe(true);
+  });
+
+  test.each(helpers)("%s keeps unrelated defaults intact", (_name, helper, defaults) => {
+    const merged = helper({ enabled: true }) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(defaults)) {
+      if (key === "enabled") continue;
+      expect(merged[key]).toBe(value);
+    }
+  });
+
+  test.each(helpers)("%s passes through unknown keys", (_name, helper) => {
+    expect((helper({ future: "x" }) as Record<string, unknown>).future).toBe("x");
+  });
+
+  test.each(helpers)("%s does not mutate the shared defaults", (_name, helper, defaults) => {
+    const snapshot = { ...defaults };
+    helper({ enabled: true });
+    expect({ ...defaults }).toEqual(snapshot);
+  });
+
+  test.each(helpers)("%s returns a fresh object each call", (_name, helper) => {
+    expect(helper({})).not.toBe(helper({}));
+  });
+
+  // Documents the spread edge rather than endorsing it: a key that is PRESENT
+  // with an explicit `undefined` overwrites the default instead of falling back
+  // to it. Callers currently re-defend downstream (see the `|| DEFAULTS.x`
+  // pattern in discord-automation/app-automation.ts), so this is a trap for a
+  // future caller rather than a live defect.
+  test.each(helpers)(
+    "%s: an explicit undefined overwrites the default (spread semantics)",
+    (_name, helper) => {
+      const merged = helper({ enabled: undefined }) as Record<string, unknown>;
+      expect("enabled" in merged).toBe(true);
+      expect(merged.enabled).toBeUndefined();
+    },
+  );
+});


### PR DESCRIPTION
# Relates to

No existing issue.
`packages/cloud/shared/src/lib/services/automation-constants.ts` had no test
file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 40 cases (13 tests, most table-driven across Discord / Telegram / Twitter)
over the shared automation constants.

Two things are worth freezing:

- **The bounds ladder.** `MIN_ALLOWED <= DEFAULT_MIN <= DEFAULT_MAX <=
  MAX_ALLOWED` is stated only by the comments, and the three per-service
  default blocks each restate the interval values by reference. If someone
  retunes one constant, nothing today notices that a service's default now sits
  outside the allowed window. The suite checks the ladder and separately checks
  each service's own min/max against it.
- **Safe-by-default posting.** Every automation ships with `enabled: false` and
  every outbound behaviour off — `autoAnnounce`, `autoPost`, `autoReply`,
  `autoEngage`, `discovery`. This is the kind of default that is embarrassing to
  flip by accident, since it decides whether a newly configured agent starts
  posting on its own.

The merge helpers are covered for `null`, `undefined`, `{}`, supplied-value
precedence, unknown-key passthrough, non-mutation of the shared frozen
defaults, and fresh-object-per-call.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`automation-constants.test.ts` — `forms a consistent bounds ladder` and
`no automation ships with an outbound behaviour pre-enabled`.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/services/automation-constants.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `MIN_ALLOWED: 30` → `180` (above `DEFAULT_MIN`) | 36 pass, **4 fail** |
| `TWITTER_AUTOMATION_DEFAULTS.autoPost` → `true` | 39 pass, **1 fail** |
| Discord `announceIntervalMin`/`Max` swapped | 38 pass, **2 fail** |

# Evidence Gate

<!-- evidence-head:0318debbd098a48930994db462f70c2ca2458807 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a constants module; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module exports constants and a spread helper.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines; no automation is started by anything in this diff.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 40 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — MIN_ALLOWED raised above DEFAULT_MIN</summary>

```
(fail) AUTOMATION_INTERVALS > forms a consistent bounds ladder
(fail) per-service defaults > discord intervals sit inside the allowed window
(fail) per-service defaults > telegram intervals sit inside the allowed window
(fail) per-service defaults > twitter intervals sit inside the allowed window
 36 pass
 4 fail
```

</details>

<details>
<summary>Mutation B — twitter autoPost defaults on</summary>

```
(fail) per-service defaults > no automation ships with an outbound behaviour pre-enabled
 39 pass
 1 fail
```

</details>

<details>
<summary>Mutation C — discord min/max interval swapped</summary>

```
(fail) per-service defaults > discord interval defaults come from the shared table
(fail) per-service defaults > discord min interval never exceeds its max
 38 pass
 2 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side constants module; no UI surface.`

# Known gaps / failures

**One test documents a trap rather than endorsing a behaviour**, and I want to
be explicit about it. The helpers merge with object spread:

```ts
return { ...DISCORD_AUTOMATION_DEFAULTS, ...config };
```

A key that is **present with an explicit `undefined`** — the shape you get from
a nullable DB column mapped to `undefined` — overwrites the default rather than
falling back to it, so `announceIntervalMin` can come out `undefined` despite a
default existing. I checked the consumers before treating this as a defect:
`discord-automation/app-automation.ts:390-392` already re-applies
`|| DISCORD_AUTOMATION_DEFAULTS.announceIntervalMin`, and the sibling services
follow the same pattern. So the clobber is currently neutralised downstream and
this is a trap for a **future** caller, not a live bug — which is why I pinned
the current behaviour with an explanatory comment instead of "fixing" the
helper and changing semantics under existing callers.

These tests assert the constants and the merge in isolation. They do not start
an automation or verify that a scheduler honours the intervals; that belongs to
the per-service automation lanes.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
