### PR TITLE
test(ui): pin extra settings-group registry

### DIFF
--- a/packages/ui/src/cloud/settings/cloud-settings-group.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-group.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Pins the extra settings-group registry. Its store lives on a `Symbol.for`
+ * key so every bundle in the process shares one list, which means the registry
+ * is realm-global state: these cases save and restore it rather than assuming a
+ * clean slate. Covers last-write-wins, order-based listing, defensive copying,
+ * and the pinned group-id constants. No DOM, no runtime.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CLOUD_SETTINGS_GROUP_ID,
+  DEVELOPER_SETTINGS_GROUP_ID,
+  type ExtraSettingsGroupDef,
+  getExtraSettingsGroup,
+  listExtraSettingsGroups,
+  registerSettingsGroup,
+} from "./cloud-settings-group";
+
+const STORE_KEY = Symbol.for("elizaos.ui.cloud-settings-group-registry");
+
+type Store = { groups: Map<string, ExtraSettingsGroupDef> };
+
+function store(): Store | undefined {
+  return (globalThis as Record<PropertyKey, unknown>)[STORE_KEY] as
+    | Store
+    | undefined;
+}
+
+let saved: Array<[string, ExtraSettingsGroupDef]> = [];
+
+beforeEach(() => {
+  saved = [...(store()?.groups ?? new Map())];
+  store()?.groups.clear();
+});
+
+afterEach(() => {
+  const current = store();
+  if (!current) return;
+  current.groups.clear();
+  for (const [id, def] of saved) current.groups.set(id, def);
+});
+
+const group = (
+  id: string,
+  order: number,
+  label = `Label ${id}`,
+): ExtraSettingsGroupDef => ({ id, label, order });
+
+describe("registerSettingsGroup", () => {
+  it("makes a group retrievable by id", () => {
+    registerSettingsGroup(group("alpha", 1));
+    expect(getExtraSettingsGroup("alpha")).toEqual(group("alpha", 1));
+  });
+
+  it("last write for an id wins", () => {
+    registerSettingsGroup(group("alpha", 1, "First"));
+    registerSettingsGroup(group("alpha", 9, "Second"));
+    expect(getExtraSettingsGroup("alpha")).toEqual({
+      id: "alpha",
+      label: "Second",
+      order: 9,
+    });
+    expect(listExtraSettingsGroups()).toHaveLength(1);
+  });
+
+  it("stores a copy, so mutating the caller's object does not leak in", () => {
+    const def = group("alpha", 1);
+    registerSettingsGroup(def);
+    def.label = "mutated";
+    def.order = 99;
+    expect(getExtraSettingsGroup("alpha")).toEqual(group("alpha", 1));
+  });
+
+  it("keeps distinct ids separate", () => {
+    registerSettingsGroup(group("alpha", 1));
+    registerSettingsGroup(group("beta", 2));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});
+
+describe("getExtraSettingsGroup", () => {
+  it("returns undefined for an unregistered id", () => {
+    expect(getExtraSettingsGroup("nope")).toBeUndefined();
+  });
+
+  it("returns undefined for inherited Object.prototype keys", () => {
+    for (const key of [
+      "toString",
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      expect(getExtraSettingsGroup(key)).toBeUndefined();
+    }
+  });
+
+  it("is exact — no trimming or case folding", () => {
+    registerSettingsGroup(group("alpha", 1));
+    for (const key of ["Alpha", "ALPHA", " alpha", "alpha "]) {
+      expect(getExtraSettingsGroup(key)).toBeUndefined();
+    }
+  });
+});
+
+describe("listExtraSettingsGroups", () => {
+  it("is empty when nothing is registered", () => {
+    expect(listExtraSettingsGroups()).toEqual([]);
+  });
+
+  it("sorts by order, not by insertion or id", () => {
+    registerSettingsGroup(group("zeta", 3));
+    registerSettingsGroup(group("alpha", 1));
+    registerSettingsGroup(group("mid", 2));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "mid",
+      "zeta",
+    ]);
+  });
+
+  it("supports fractional orders that interleave with the built-in slots", () => {
+    // Built-ins occupy 0 (agent), 1 (system), 2 (security); 1.5 sits between.
+    registerSettingsGroup(group("security-ish", 2.5));
+    registerSettingsGroup(group("cloud", 1.5));
+    expect(listExtraSettingsGroups().map((g) => g.order)).toEqual([1.5, 2.5]);
+  });
+
+  it("supports negative orders sorting ahead of everything", () => {
+    registerSettingsGroup(group("late", 5));
+    registerSettingsGroup(group("early", -1));
+    expect(listExtraSettingsGroups()[0]?.id).toBe("early");
+  });
+
+  it("keeps registration order among equal orders", () => {
+    registerSettingsGroup(group("first", 1));
+    registerSettingsGroup(group("second", 1));
+    registerSettingsGroup(group("third", 1));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("returns a fresh array that callers cannot use to corrupt the registry", () => {
+    registerSettingsGroup(group("alpha", 1));
+    const listed = listExtraSettingsGroups();
+    listed.push(group("injected", 0));
+    listed.reverse();
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual(["alpha"]);
+  });
+
+  it("reflects a re-registration in the new position", () => {
+    registerSettingsGroup(group("alpha", 5));
+    registerSettingsGroup(group("beta", 1));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "beta",
+      "alpha",
+    ]);
+    registerSettingsGroup(group("alpha", 0));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});
+
+describe("pinned group ids", () => {
+  it("are stable, distinct, non-empty slugs", () => {
+    expect(CLOUD_SETTINGS_GROUP_ID).toBe("cloud");
+    expect(DEVELOPER_SETTINGS_GROUP_ID).toBe("developer");
+    expect(CLOUD_SETTINGS_GROUP_ID).not.toBe(DEVELOPER_SETTINGS_GROUP_ID);
+    for (const id of [CLOUD_SETTINGS_GROUP_ID, DEVELOPER_SETTINGS_GROUP_ID]) {
+      expect(id).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+
+  it("do not collide with the pinned built-in group ids", () => {
+    for (const builtin of ["agent", "system", "security"]) {
+      expect(CLOUD_SETTINGS_GROUP_ID).not.toBe(builtin);
+      expect(DEVELOPER_SETTINGS_GROUP_ID).not.toBe(builtin);
+    }
+  });
+});
+
+describe("shared store identity", () => {
+  it("registers into the Symbol.for store every bundle reads", () => {
+    registerSettingsGroup(group("alpha", 1));
+    expect(store()?.groups.get("alpha")).toEqual(group("alpha", 1));
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/ui/src/cloud/settings/cloud-settings-group.ts` had
no test file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 17 cases over the extra settings-group registry.

This registry exists so hosts can add groups such as Cloud or Developer
**without** mutating `SETTINGS_GROUP_ORDER` in `settings-section-meta.ts`,
which the app-core `dev-route-catalog` parity test pins. So the behaviour that
matters is ordering: fractional orders must interleave correctly with the
built-in slots (0 agent, 1 system, 2 security), negative orders must sort
ahead, and equal orders must preserve registration order.

Also pinned:

- **Last-write-wins** per id, and that a re-registration moves the group to its
  new position rather than duplicating it.
- **The defensive copy on register** (`{ ...group }`) — mutating the caller's
  object afterwards must not reach into the registry.
- **The returned array is a copy** — pushing to it or reversing it cannot
  corrupt the store.
- **Exact id lookup** — no trimming or case folding, and inherited
  `Object.prototype` keys (`toString`, `constructor`, `__proto__`) return
  `undefined` rather than resolving off the prototype chain.

**On test isolation**, which is the real subtlety here: the store is held on
`Symbol.for("elizaos.ui.cloud-settings-group-registry")`, so it is
**realm-global** and shared with anything else registering groups in the same
process. The suite therefore snapshots the store in `beforeEach`, clears it,
and restores the exact prior contents in `afterEach` — it never assumes it
starts empty, and it leaves the process as it found it.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`cloud-settings-group.test.ts` — the `listExtraSettingsGroups` block, plus the
`beforeEach`/`afterEach` save-and-restore at the top.

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/cloud/settings/cloud-settings-group.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `set(group.id, { ...group })` → `set(group.id, group)` (drop the copy) | 16 pass, **1 fail** |
| drop the `.sort((a, b) => a.order - b.order)` | 13 pass, **4 fail** |
| **control:** rewrite the same sort as `values().toArray().sort(...)` | **17 pass, 0 fail** |

The third is a deliberate control rather than a defect: an
observably-equivalent rewrite must **not** fail, which shows the cases key on
behaviour rather than on the shape of the implementation.

# Evidence Gate

<!-- evidence-head:efb0867ae24ff7918ce04661c079a75b74b9aead -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff. The module is a plain registry with no rendered output; no .tsx/.css/.svg is touched and no component renders.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns an array of group definitions.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; nothing is mounted.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
 RUN  v4.1.10 packages/ui

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  91ms
```

</details>

<details>
<summary>Mutation A — defensive copy on register removed</summary>

```
 × registerSettingsGroup > stores a copy, so mutating the caller's object does not leak in
      Tests  1 failed | 16 passed (17)
```

</details>

<details>
<summary>Mutation B — order sort removed</summary>

```
 × listExtraSettingsGroups > sorts by order, not by insertion or id
 × listExtraSettingsGroups > supports fractional orders that interleave with the built-in slots
 × listExtraSettingsGroups > supports negative orders sorting ahead of everything
 × listExtraSettingsGroups > reflects a re-registration in the new position
      Tests  4 failed | 13 passed (17)
```

</details>

<details>
<summary>Mutation C (control) — equivalent sort rewrite</summary>

```
      Tests  17 passed (17)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff. The registry has no rendered surface of its own, so
audit:app would produce no before/after delta.`

# Known gaps / failures

**A hazard I found and did not fix.** `listExtraSettingsGroups` sorts with
`(a, b) => a.order - b.order`. If a group is ever registered with a non-finite
`order`, that comparator returns `NaN`, which `Array.prototype.sort` treats as
"leave as is" — so one bad entry can leave the **other** groups in arbitrary
order rather than merely misplacing itself. TypeScript types `order` as
`number`, so this needs an untyped or `Number(...)`-derived value from host code
to reach; I could not demonstrate a real caller doing that, so I did not change
the comparator. I deliberately did not add a test asserting the current
behaviour either, since that would pin a hazard as expected. Flagging it for
the owner instead.

**Test isolation caveat.** Because the store is realm-global, this suite
manipulates shared process state. The save/clear/restore bracket makes it
correct under the package's normal runner, but a future test that registers
groups at module scope (outside a hook) in the same process could still
interleave. Worth knowing if these ever go parallel in-process.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
