### PR TITLE
test(cloud): pin fragment template ids and prompt rendering

### DIFF
--- a/packages/cloud/shared/src/lib/fragments/templates.test.ts
+++ b/packages/cloud/shared/src/lib/fragments/templates.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Pins fragment template id suffixing and the prompt renderer. The renderer
+ * builds model-facing content, so the repository prompt-integrity rule applies:
+ * every template must appear complete, with no cap or elision. The id helpers
+ * are an encode/decode pair and must round-trip. NODE_ENV is saved and restored
+ * per test; no harness.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import templates, {
+  getTemplateId,
+  getTemplateIdSuffix,
+  type Templates,
+  templatesToPrompt,
+} from "./templates";
+
+let savedNodeEnv: string | undefined;
+
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV;
+});
+
+afterEach(() => {
+  if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = savedNodeEnv;
+});
+
+describe("getTemplateIdSuffix", () => {
+  test("appends -dev only under NODE_ENV=development", () => {
+    process.env.NODE_ENV = "development";
+    expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer-dev");
+  });
+
+  test("returns the id unchanged in every other environment", () => {
+    for (const value of ["production", "test", "staging", ""]) {
+      process.env.NODE_ENV = value;
+      expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer");
+    }
+  });
+
+  test("returns the id unchanged when NODE_ENV is unset", () => {
+    delete process.env.NODE_ENV;
+    expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer");
+  });
+
+  test("matches NODE_ENV exactly — no casing or whitespace tolerance", () => {
+    for (const value of ["Development", "DEVELOPMENT", " development", "development "]) {
+      process.env.NODE_ENV = value;
+      expect(getTemplateIdSuffix("x")).toBe("x");
+    }
+  });
+});
+
+describe("getTemplateId", () => {
+  test("strips a trailing -dev", () => {
+    expect(getTemplateId("nextjs-developer-dev")).toBe("nextjs-developer");
+  });
+
+  test("leaves an id without the suffix alone", () => {
+    expect(getTemplateId("nextjs-developer")).toBe("nextjs-developer");
+    expect(getTemplateId("code-interpreter-v1")).toBe("code-interpreter-v1");
+  });
+
+  test("only strips at the end, not in the middle", () => {
+    expect(getTemplateId("my-dev-app")).toBe("my-dev-app");
+    expect(getTemplateId("dev-tools")).toBe("dev-tools");
+  });
+
+  test("strips exactly one suffix", () => {
+    expect(getTemplateId("x-dev-dev")).toBe("x-dev");
+  });
+
+  test("handles the empty string", () => {
+    expect(getTemplateId("")).toBe("");
+  });
+});
+
+describe("id round-trip", () => {
+  test("decode undoes encode in development", () => {
+    process.env.NODE_ENV = "development";
+    for (const id of [
+      "code-interpreter-v1",
+      "nextjs-developer",
+      "vue-developer",
+      "streamlit-developer",
+      "gradio-developer",
+    ]) {
+      expect(getTemplateId(getTemplateIdSuffix(id))).toBe(id);
+    }
+  });
+
+  test("decode undoes encode in production", () => {
+    process.env.NODE_ENV = "production";
+    for (const id of ["nextjs-developer", "vue-developer"]) {
+      expect(getTemplateId(getTemplateIdSuffix(id))).toBe(id);
+    }
+  });
+});
+
+describe("template catalog", () => {
+  const entries = Object.entries(templates);
+
+  test("is non-empty and every id is unique", () => {
+    expect(entries.length).toBeGreaterThan(0);
+    expect(new Set(Object.keys(templates)).size).toBe(entries.length);
+  });
+
+  test("every template carries a usable shape", () => {
+    for (const [id, t] of entries) {
+      expect(id.length).toBeGreaterThan(0);
+      expect(t.name.trim().length).toBeGreaterThan(0);
+      expect(t.instructions.trim().length).toBeGreaterThan(0);
+      expect(t.file.trim().length).toBeGreaterThan(0);
+      expect(Array.isArray(t.lib)).toBe(true);
+      expect(t.lib.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every port is either null or a valid TCP port", () => {
+    for (const [, t] of entries) {
+      if (t.port === null) continue;
+      expect(Number.isInteger(t.port)).toBe(true);
+      expect(t.port).toBeGreaterThan(0);
+      expect(t.port).toBeLessThanOrEqual(65535);
+    }
+  });
+
+  test("no dependency entry is blank", () => {
+    for (const [, t] of entries) {
+      for (const lib of t.lib) {
+        expect(typeof lib).toBe("string");
+        expect(lib.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("every catalog id decodes to a stable base id", () => {
+    for (const id of Object.keys(templates)) {
+      const base = getTemplateId(id);
+      expect(base.length).toBeGreaterThan(0);
+      expect(getTemplateId(base)).toBe(base);
+    }
+  });
+});
+
+describe("templatesToPrompt", () => {
+  const fixture = {
+    alpha: {
+      name: "Alpha",
+      lib: ["one", "two"],
+      file: "a.py",
+      instructions: "Does alpha things.",
+      port: 8501,
+    },
+    beta: {
+      name: "Beta",
+      lib: ["three"],
+      file: "",
+      instructions: "Does beta things.",
+      port: null,
+    },
+  } as unknown as Templates;
+
+  test("numbers entries from one, in insertion order", () => {
+    const lines = templatesToPromptLines(fixture);
+    expect(lines[0].startsWith("1. alpha:")).toBe(true);
+    expect(lines[1].startsWith("2. beta:")).toBe(true);
+  });
+
+  test("renders instructions, file, dependencies, and port", () => {
+    const [first] = templatesToPromptLines(fixture);
+    expect(first).toContain('"Does alpha things."');
+    expect(first).toContain("File: a.py");
+    expect(first).toContain("Dependencies installed: one, two");
+    expect(first).toContain("Port: 8501");
+  });
+
+  test("substitutes 'none' for a missing file or port", () => {
+    const [, second] = templatesToPromptLines(fixture);
+    expect(second).toContain("File: none");
+    expect(second).toContain("Port: none");
+  });
+
+  test("emits exactly one line per template, with no trailing newline", () => {
+    const rendered = templatesToPrompt(fixture);
+    expect(rendered.split("\n")).toHaveLength(2);
+    expect(rendered.endsWith("\n")).toBe(false);
+  });
+
+  test("renders the real catalog completely, with no elision", () => {
+    const rendered = templatesToPrompt(templates);
+    const ids = Object.keys(templates);
+    expect(rendered.split("\n")).toHaveLength(ids.length);
+    for (const id of ids) expect(rendered).toContain(`${id}:`);
+    expect(rendered).not.toContain("…");
+    expect(rendered).not.toMatch(/truncat/i);
+  });
+
+  test("carries every dependency of every template through", () => {
+    const rendered = templatesToPrompt(templates);
+    for (const t of Object.values(templates)) {
+      for (const lib of t.lib) expect(rendered).toContain(lib);
+    }
+  });
+
+  test("does not cap a long catalog", () => {
+    const many = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [
+        `tpl-${i}`,
+        {
+          name: `T${i}`,
+          lib: [`lib-${i}`],
+          file: `f${i}.py`,
+          instructions: `I${i}`,
+          port: null,
+        },
+      ]),
+    ) as unknown as Templates;
+    const rendered = templatesToPrompt(many);
+    expect(rendered.split("\n")).toHaveLength(200);
+    expect(rendered).toContain("200. tpl-199:");
+    expect(rendered).toContain("lib-199");
+  });
+
+  test("returns an empty string for an empty catalog", () => {
+    expect(templatesToPrompt({} as unknown as Templates)).toBe("");
+  });
+
+  test("is deterministic", () => {
+    expect(templatesToPrompt(templates)).toBe(templatesToPrompt(templates));
+  });
+});
+
+function templatesToPromptLines(input: Templates): string[] {
+  return templatesToPrompt(input).split("\n");
+}


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/fragments/templates.ts` had
no test file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 25 cases over the fragment template catalog.

`templatesToPrompt` renders the catalog into text handed to a code-generation
model, which puts it under the repository rule that model-facing content must
not be capped or elided. The suite enforces that mechanically: the real catalog
renders one line per template with **every** dependency of every template
present, and a synthetic 200-template catalog renders all 200 (asserted by line
count and by the last entry, not just a spot check).

`getTemplateIdSuffix` / `getTemplateId` are an encode/decode pair, so they are
tested as one: the suffix is appended **only** under `NODE_ENV=development`
(exact match — `"Development"`, `" development"` do not count), and decode
strips `-dev` **only at the end**, so `"my-dev-app"` and `"dev-tools"` survive
intact. Round-trip is asserted in both environments.

The catalog itself gets shape assertions — unique ids, non-blank name /
instructions / file, at least one dependency, no blank dependency string, and
every port either `null` or a valid TCP port.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`templates.test.ts` — the `templatesToPrompt` block, especially
`renders the real catalog completely, with no elision`.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/fragments/templates.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `Object.entries(templates)` → `.slice(0, 3)` (cap the prompt) | 22 pass, **3 fail** |
| `/-dev$/` → `/-dev/` (strip anywhere, not just at the end) | 20 pass, **5 fail** |
| `${index + 1}.` → `${index}.` (number from zero) | 23 pass, **2 fail** |

# Evidence Gate

<!-- evidence-head:8499fc61f69b14150ae56b81a2a09db20e08e32d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a constants + string-rendering module; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns a string, covered by the transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no live model is invoked. templatesToPrompt *builds* text that a code-generation model would later receive, but issues no call itself, and this diff is test-only — a live run would exercise nothing this PR changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row; no model call in the module under test.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 25 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — prompt renderer capped at 3 templates</summary>

```
(fail) templatesToPrompt > renders the real catalog completely, with no elision
(fail) templatesToPrompt > carries every dependency of every template through
(fail) templatesToPrompt > does not cap a long catalog
 22 pass
 3 fail
```

</details>

<details>
<summary>Mutation B — -dev stripped anywhere rather than at the end</summary>

```
(fail) getTemplateId > strips a trailing -dev
(fail) getTemplateId > leaves an id without the suffix alone
(fail) getTemplateId > only strips at the end, not in the middle
(fail) id round-trip > decode undoes encode in development
(fail) id round-trip > decode undoes encode in production
 20 pass
 5 fail
```

</details>

<details>
<summary>Mutation C — prompt numbering starts at zero</summary>

```
(fail) templatesToPrompt > numbers entries from one, in insertion order
(fail) templatesToPrompt > does not cap a long catalog
 23 pass
 2 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side module; no UI surface.`

# Known gaps / failures

**An inconsistency I found and did not change.** Four of the five catalog keys
are wrapped in `getTemplateIdSuffix(...)`, but `"code-interpreter-v1"` is a
plain literal. So under `NODE_ENV=development` the other four gain a `-dev`
suffix and that one does not. That may be entirely correct — the sandbox
provider may simply have no `-dev` variant of that image — so I did not
"normalise" it. The catalog tests are written against `Object.keys(templates)`
rather than hardcoded ids, so they hold either way; flagging it for the owner.

**A structural limit worth naming.** The catalog keys are computed at *module
load*, so the suffixing of the real `templates` object is fixed by whatever
`NODE_ENV` was set when the module was first imported. The suite therefore
tests `getTemplateIdSuffix` **directly** (it reads `process.env` per call) and
does not attempt to re-import the module under a different `NODE_ENV`. Proving
the dev-mode catalog keys would need module-registry resetting, which I judged
more fragile than it is worth.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
