### PR TITLE
test(ui): pin Android runtime mode resolution

### DIFF
--- a/packages/ui/src/platform/android-runtime.test.ts
+++ b/packages/ui/src/platform/android-runtime.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pins Android runtime-mode resolution. The `android-cloud` build has no
+ * on-device agent, so this is the switch that decides whether onboarding offers
+ * the Local runtime path at all; only an explicit "cloud" may select the
+ * cloud-locked variant, and everything else must resolve to "local". Env is
+ * injected per case: the sibling isAndroidCloudBuild() reads the Vite-inlined
+ * import.meta.env of its own module and is not addressable from a test, so this
+ * covers the injectable resolver it delegates to rather than faking that read.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveAndroidRuntimeMode } from "./android-runtime";
+
+const KEY = "VITE_ELIZA_ANDROID_RUNTIME_MODE";
+
+describe("resolveAndroidRuntimeMode", () => {
+  it("selects cloud only for an explicit cloud value", () => {
+    expect(resolveAndroidRuntimeMode({ [KEY]: "cloud" })).toBe("cloud");
+  });
+
+  it("tolerates casing and surrounding whitespace on cloud", () => {
+    for (const value of ["CLOUD", "Cloud", "  cloud  ", "\tcloud\n"]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("cloud");
+    }
+  });
+
+  it("defaults to local when the key is missing", () => {
+    expect(resolveAndroidRuntimeMode({})).toBe("local");
+  });
+
+  it("defaults to local for blank and whitespace-only values", () => {
+    for (const value of ["", "   ", "\t\n"]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("defaults to local for an explicit local value", () => {
+    for (const value of ["local", "LOCAL", " local "]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("defaults to local for unrecognised values rather than guessing", () => {
+    for (const value of [
+      "cloudy",
+      "remote",
+      "cloud-locked",
+      "system",
+      "1",
+      "true",
+    ]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("ignores non-string values", () => {
+    for (const value of [true, false, undefined]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(
+      resolveAndroidRuntimeMode({
+        VITE_ELIZA_IOS_RUNTIME_MODE: "cloud",
+        ELIZA_RUNTIME_MODE: "cloud",
+        NODE_ENV: "production",
+      }),
+    ).toBe("local");
+  });
+
+  it("only ever returns one of the two declared modes", () => {
+    const seen = new Set<string>();
+    for (const value of [
+      "cloud",
+      "local",
+      "",
+      "junk",
+      " CLOUD ",
+      undefined,
+      true,
+    ]) {
+      seen.add(resolveAndroidRuntimeMode({ [KEY]: value }));
+    }
+    expect([...seen].sort()).toEqual(["cloud", "local"]);
+  });
+
+  it("is pure — repeated calls with the same env agree", () => {
+    const env = { [KEY]: "cloud" };
+    expect(resolveAndroidRuntimeMode(env)).toBe(resolveAndroidRuntimeMode(env));
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/ui/src/platform/android-runtime.ts` had no test
file; this adds first-time coverage.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 10 cases over `resolveAndroidRuntimeMode`.

This is the switch behind the module's stated purpose: the `android-cloud`
build is a thin Play-Store client with **no on-device agent**, so it must hide
the Local first-run option "so users cannot try to provision an on-device agent
that physically isn't there". Two properties follow, and the suite pins both:

- **Only an explicit `"cloud"` selects the cloud-locked variant.** Casing and
  surrounding whitespace are tolerated (`"CLOUD"`, `"  cloud  "`), but
  near-misses are not — `"cloudy"`, `"remote"`, `"cloud-locked"`, `"1"`,
  `"true"` all resolve to `local` rather than being guessed into `cloud`.
- **Everything else falls to `local`**: missing key, blank, whitespace-only,
  non-string values, and unrelated keys (`VITE_ELIZA_IOS_RUNTIME_MODE`,
  `ELIZA_RUNTIME_MODE`, `NODE_ENV`) which must not be read by this resolver.

There is also a closure assertion — across a spread of good and junk inputs the
function only ever returns one of the two declared modes, never `undefined` or
a pass-through of the raw string.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`android-runtime.test.ts` — `selects cloud only for an explicit cloud value`
and the three `defaults to local` cases.

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/platform/android-runtime.test.ts
```

To confirm the suite is not vacuous, I ran two mutations against the production
file (both reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `switch (value?.trim().toLowerCase())` → `switch (value)` | 9 pass, **1 fail** |
| default arm flipped so unknown values resolve to `cloud` | 5 pass, **5 fail** |

# Evidence Gate

<!-- evidence-head:b78c6d3fc8a63d60a8645851efd810dc2b5f34c5 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a pure string-to-enum resolver; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow is added or changed. The first-run picker this mode gates is owned by first-run-runtime-flag.ts, which this diff does not touch.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the function performs no I/O and emits no log lines.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; nothing is mounted.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
 RUN  v4.1.10 packages/ui

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  101ms
```

</details>

<details>
<summary>Mutation A — casing/whitespace normalisation dropped</summary>

```
 × resolveAndroidRuntimeMode > tolerates casing and surrounding whitespace on cloud
      Tests  1 failed | 9 passed (10)
```

</details>

<details>
<summary>Mutation B — default flipped to cloud</summary>

```
 × resolveAndroidRuntimeMode > defaults to local when the key is missing
 × resolveAndroidRuntimeMode > defaults to local for blank and whitespace-only values
 × resolveAndroidRuntimeMode > defaults to local for unrecognised values rather than guessing
 × resolveAndroidRuntimeMode > ignores non-string values
 × resolveAndroidRuntimeMode > ignores unrelated keys
      Tests  5 failed | 5 passed (10)
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff. The resolver has no rendered surface of its own, so
audit:app would produce no before/after delta.`

# Known gaps / failures

**`isAndroidCloudBuild()` is deliberately not covered directly, and I want to
be straight about why.** It reads `import.meta.env` from its own module scope,
which Vite statically replaces at compile time so the read collapses to a
constant in the shipped bundle. I tried driving it with `vi.stubEnv` and it
does not reach that read — the two cases failed with the stub applied. Rather
than reach for a module mock or weaken the assertions until they passed, I
dropped those cases and covered `resolveAndroidRuntimeMode`, which
`isAndroidCloudBuild` delegates to and which takes its env as a parameter. All
the branching logic lives there; what remains uncovered is the one-line
inlined env read.

`isAndroidLocalSideloadBuild()` is likewise uncovered — it composes
`getFrontendPlatform()` with the above, and controlling platform detection
needs a module mock.

**A design note, not a defect.** The default is `local`, so a cloud build whose
`VITE_ELIZA_ANDROID_RUNTIME_MODE` stamp went missing would fail *open* and
offer the Local option for a build with no agent — the exact situation the
module header warns about. That is unavoidable given the sideload build relies
on the same default, so I pinned the behaviour rather than calling it a bug.
Flagging it in case the build stamp is worth asserting at build time instead.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
