### PR TITLE
fix: keep realtime voice turns streaming

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
@@ -8,7 +8,6 @@ import {
   callOpeningPrompt,
   callStartedEvent,
   claimInboundCallOpeningContext,
-  ELIZA_AI_VOICE_DISCLOSURE,
   type InboundCallOpeningClaim,
   prewarmAndRecordVoiceCallStart,
   relativeInteractionAge,
@@ -19,12 +18,8 @@ describe("voice continuity", () => {
   const now = Date.UTC(2026, 7, 15, 12);
 
   test("uses an immediate deterministic greeting while the cold path prewarms", () => {
-    expect(callOpeningGreeting(false)).toBe(
-      `Hello? Who's this? ${ELIZA_AI_VOICE_DISCLOSURE}`,
-    );
-    expect(callOpeningGreeting(true)).toBe(
-      `Hey, what's up? ${ELIZA_AI_VOICE_DISCLOSURE}`,
-    );
+    expect(callOpeningGreeting(false)).toBe("Hey, how's it going?");
+    expect(callOpeningGreeting(true)).toBe("Hey, how's it going?");
   });
 
   test("describes first contact without inventing history", () => {
@@ -37,6 +32,12 @@ describe("voice continuity", () => {
     expect(relativeInteractionAge(now - 3 * 60 * 60_000, now)).toBe("3 hours");
     expect(callStartedEvent(true, now - 2 * 86_400_000, now)).toContain(
       "about 2 days ago",
+    );
+    expect(callStartedEvent(true, now - 2 * 86_400_000, now)).toContain(
+      "2026-08-13T12:00:00.000Z",
+    );
+    expect(callStartedEvent(true, now - 2 * 86_400_000, now)).toContain(
+      "2026-08-15T12:00:00.000Z",
     );
   });
 
@@ -162,8 +163,8 @@ describe("voice continuity", () => {
   });
 
   test("sanitizes teardown reasons", () => {
-    expect(callEndedEvent("client disconnect! token=secret")).toBe(
-      "Call lifecycle event: the phone call ended (client_disconnect__token_secret).",
+    expect(callEndedEvent("client disconnect! token=secret", now)).toBe(
+      "Call lifecycle event: the phone call ended at 2026-08-15T12:00:00.000Z (client_disconnect__token_secret).",
     );
   });
 

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
@@ -6,9 +6,6 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
-export const ELIZA_AI_VOICE_DISCLOSURE =
-  "Just so you know, I'm an AI assistant using an AI-generated voice.";
-
 export interface InboundCallOpeningClaim extends CallContinuityContext {
   id: string;
   receivedAt: Date;
@@ -102,6 +99,9 @@ function callRelationshipContext(
     return "This is their first recorded interaction with Eliza.";
   return [
     "They have prior private conversation history.",
+    previousInteractionAt
+      ? `Their last recorded interaction was at ${new Date(previousInteractionAt).toISOString()}.`
+      : "There is no reliable timestamp for that prior interaction.",
     age
       ? `Their last recorded interaction was about ${age} ago.`
       : "There is no reliable elapsed-time value for that prior interaction.",
@@ -114,7 +114,7 @@ export function callStartedEvent(
   now = Date.now(),
 ): string {
   return [
-    "Call lifecycle event: the user has called Eliza and is now connected.",
+    `Call lifecycle event: the user called Eliza and connected at ${new Date(now).toISOString()}.`,
     callRelationshipContext(returningCaller, previousInteractionAt, now),
   ].join(" ");
 }
@@ -125,8 +125,8 @@ export function callStartedEvent(
  * through the agent runtime puts its entire cold path before first audio.
  */
 export function callOpeningGreeting(returningCaller: boolean): string {
-  const greeting = returningCaller ? "Hey, what's up?" : "Hello? Who's this?";
-  return `${greeting} ${ELIZA_AI_VOICE_DISCLOSURE}`;
+  void returningCaller;
+  return "Hey, how's it going?";
 }
 
 /** Keeps variable history inside the canonical private turn while bounding its spoken output. */
@@ -153,12 +153,12 @@ export function callOpeningClientMessageId(callSid: string): string {
   return `twilio-call:${callSid}:opening`;
 }
 
-export function callEndedEvent(reason: string): string {
+export function callEndedEvent(reason: string, now = Date.now()): string {
   const normalized = reason
     .trim()
     .replace(/[^a-z_]/gi, "_")
     .slice(0, 40);
-  return `Call lifecycle event: the phone call ended (${normalized || "unknown"}).`;
+  return `Call lifecycle event: the phone call ended at ${new Date(now).toISOString()} (${normalized || "unknown"}).`;
 }
 
 /** Starts latency prewarm before lifecycle persistence and joins both tasks. */

--- a/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts
@@ -4,7 +4,7 @@
 
 import { expect, test } from "bun:test";
 import type { RuntimeDurableObjectStub } from "../../../types/cloud-worker-env";
-import { deadlineBoundCoordinatorStub } from "./coordinator-fetch";
+import { coordinatorFetch, deadlineBoundCoordinatorStub } from "./coordinator-fetch";
 
 test("deadline-bound coordinator stubs preserve Request inputs", async () => {
   const controller = new AbortController();
@@ -32,4 +32,50 @@ test("deadline-bound coordinator stubs preserve Request inputs", async () => {
   expect(seenSignal?.aborted).toBe(false);
   controller.abort();
   expect(seenSignal?.aborted).toBe(true);
+});
+
+test("coordinator deadline stops after streaming response headers arrive", async () => {
+  let seenSignal: AbortSignal | null | undefined;
+  const stub: RuntimeDurableObjectStub = {
+    fetch: async (_input, init) => {
+      seenSignal = init?.signal;
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            await Bun.sleep(30);
+            if (init?.signal?.aborted) {
+              controller.error(init.signal.reason);
+              return;
+            }
+            controller.enqueue(new TextEncoder().encode("complete"));
+            controller.close();
+          },
+        }),
+      );
+    },
+  };
+
+  const response = await coordinatorFetch(
+    stub,
+    "https://shared-runtime.internal/stream",
+    undefined,
+    10,
+  );
+  expect(await response.text()).toBe("complete");
+  expect(seenSignal?.aborted).toBe(false);
+});
+
+test("coordinator deadline still aborts before response headers", async () => {
+  const stub: RuntimeDurableObjectStub = {
+    fetch: (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+          once: true,
+        });
+      }),
+  };
+
+  await expect(
+    coordinatorFetch(stub, "https://shared-runtime.internal/stream", undefined, 10),
+  ).rejects.toMatchObject({ name: "TimeoutError" });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts
@@ -15,12 +15,19 @@ export function coordinatorFetch(
   init?: RequestInit,
   timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(
+    () =>
+      timeoutController.abort(
+        new DOMException("Shared runtime coordinator response headers timed out", "TimeoutError"),
+      ),
+    timeoutMs,
+  );
   const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
-  return stub.fetch(input, {
-    ...init,
-    signal: callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal,
-  });
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutController.signal])
+    : timeoutController.signal;
+  return stub.fetch(input, { ...init, signal }).finally(() => clearTimeout(timeout));
 }
 
 export function deadlineBoundCoordinatorStub(


### PR DESCRIPTION
## Summary

- clear the shared-runtime coordinator header deadline as soon as response headers arrive so it cannot abort a healthy SSE body mid-turn
- keep caller cancellation attached after headers
- replace the deterministic phone disclosure opener with `Hey, how's it going?`
- add exact connection/disconnection timestamps and natural elapsed-time context to durable callback lifecycle markers

Fixes #26722.

## Production diagnosis

The exact call `CAab62…dde1cc` completed in Twilio at 122 seconds with no Twilio media/application error. Worker telemetry showed `voice-sse-context` AbortError/TimeoutError failures before the caller disconnected; session teardown reason was `client_disconnect`, not `expired`. The Twilio media path already converts the 120-second, single-use bootstrap credential into a separate 30-minute admitted-call lease, and production has no `TWILIO_VOICE_MAX_CALL_SECONDS` override. This change therefore preserves the short replay-safe bootstrap and revocation polling while fixing the per-turn stream deadline that caused silence.

## Validation

- `bun test packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts` — 16 passed
- focused Biome check — passed
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `bun run verify` progressed through repository contracts and touched cloud lint lanes; stopped intentionally after decisive live correlation required re-checking the 120-second hypothesis. No touched-lane failure observed.
- API-only `tsc6 --noEmit` initially hit missing local `@elizaos/plugin-doordash` before the full workspace build materialized it; hosted CI remains authoritative.

## Required live acceptance after deploy

- sustain a real 808-forwarded call beyond 2 minutes and at least one deliberately slow (>10s) model turn
- hang up and call back; confirm prior conversation context plus timestamped call lifecycle markers
- confirm greeting is exactly natural and contains no AI disclosure
- record privacy-bounded close reason and turn/model/TTS timings