### PR TITLE
chore: restore the workspace lint closure (second pass)

### DIFF
--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -9,7 +9,9 @@
 import * as crypto from "node:crypto";
 import * as http from "node:http";
 import { sql } from "drizzle-orm";
-import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with { type: "json" };
+import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
+  type: "json",
+};
 
 const CLOUD_AGENT_RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 

--- a/packages/app-core/packaging/verify-snap-workspace-contract.mjs
+++ b/packages/app-core/packaging/verify-snap-workspace-contract.mjs
@@ -4,7 +4,7 @@
  * expensive architecture-specific build jobs.
  */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -79,7 +79,8 @@ const keptPluginDirectories = [...keepBlock[1].matchAll(/"([^"]+)"/g)].map(
   (match) => match[1],
 );
 const missingPluginDirectories = keptPluginDirectories.filter(
-  (directory) => !existsSync(join(repositoryRoot, "plugins", directory, "package.json")),
+  (directory) =>
+    !existsSync(join(repositoryRoot, "plugins", directory, "package.json")),
 );
 
 if (missingPluginDirectories.length > 0) {

--- a/packages/app-core/platforms/electrobun/.generated/brand-config.json
+++ b/packages/app-core/platforms/electrobun/.generated/brand-config.json
@@ -1,10 +1,10 @@
 {
-	"appName": "Eliza",
-	"appId": "ai.elizaos.app",
-	"namespace": "elizaos",
-	"urlScheme": "elizaos",
-	"configDirName": "Eliza",
-	"appDescription": "Open framework for autonomous agents",
-	"buildVariant": "direct",
-	"cloudOnly": true
+  "appName": "Eliza",
+  "appId": "ai.elizaos.app",
+  "namespace": "elizaos",
+  "urlScheme": "elizaos",
+  "configDirName": "Eliza",
+  "appDescription": "Open framework for autonomous agents",
+  "buildVariant": "direct",
+  "cloudOnly": true
 }

--- a/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
+++ b/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
@@ -1,47 +1,47 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../electrobun.config", () => ({
-	default: { app: { identifier: "x" } },
+  default: { app: { identifier: "x" } },
 }));
 vi.mock("../local-adhoc-sign-macos", () => ({ signLocalAppBundle: vi.fn() }));
 vi.mock("../postwrap-diagnostics", () => ({
-	resolveWrapperBundlePath: () => "/tmp/bundle.app",
+  resolveWrapperBundlePath: () => "/tmp/bundle.app",
 }));
 
 import { shouldSignDevMacApp } from "../sign-dev-macos-app.ts";
 
 const DEV_ENV = {
-	ELECTROBUN_BUILD_ENV: "dev",
-	ELECTROBUN_OS: "macos",
-	ELECTROBUN_SKIP_CODESIGN: "1",
+  ELECTROBUN_BUILD_ENV: "dev",
+  ELECTROBUN_OS: "macos",
+  ELECTROBUN_SKIP_CODESIGN: "1",
 };
 
 describe("shouldSignDevMacApp", () => {
-	it("signs only on darwin with dev/macos/skip-codesign env", () => {
-		expect(shouldSignDevMacApp(DEV_ENV, "darwin")).toBe(true);
-	});
+  it("signs only on darwin with dev/macos/skip-codesign env", () => {
+    expect(shouldSignDevMacApp(DEV_ENV, "darwin")).toBe(true);
+  });
 
-	it("refuses on non-darwin hosts", () => {
-		expect(shouldSignDevMacApp(DEV_ENV, "linux")).toBe(false);
-		expect(shouldSignDevMacApp(DEV_ENV, "win32")).toBe(false);
-	});
+  it("refuses on non-darwin hosts", () => {
+    expect(shouldSignDevMacApp(DEV_ENV, "linux")).toBe(false);
+    expect(shouldSignDevMacApp(DEV_ENV, "win32")).toBe(false);
+  });
 
-	it("refuses when env flags are missing", () => {
-		expect(shouldSignDevMacApp({}, "darwin")).toBe(false);
-		expect(
-			shouldSignDevMacApp(
-				{ ...DEV_ENV, ELECTROBUN_BUILD_ENV: "prod" },
-				"darwin",
-			),
-		).toBe(false);
-		expect(
-			shouldSignDevMacApp({ ...DEV_ENV, ELECTROBUN_OS: "ios" }, "darwin"),
-		).toBe(false);
-		expect(
-			shouldSignDevMacApp(
-				{ ...DEV_ENV, ELECTROBUN_SKIP_CODESIGN: "0" },
-				"darwin",
-			),
-		).toBe(false);
-	});
+  it("refuses when env flags are missing", () => {
+    expect(shouldSignDevMacApp({}, "darwin")).toBe(false);
+    expect(
+      shouldSignDevMacApp(
+        { ...DEV_ENV, ELECTROBUN_BUILD_ENV: "prod" },
+        "darwin",
+      ),
+    ).toBe(false);
+    expect(
+      shouldSignDevMacApp({ ...DEV_ENV, ELECTROBUN_OS: "ios" }, "darwin"),
+    ).toBe(false);
+    expect(
+      shouldSignDevMacApp(
+        { ...DEV_ENV, ELECTROBUN_SKIP_CODESIGN: "0" },
+        "darwin",
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/preload.js
+++ b/packages/app-core/platforms/electrobun/src/preload.js
@@ -1,1 +1,544 @@
-(()=>{function w(e,t){let r=e.map((n)=>`"${n}"`).join(", ");return Error(`This RPC instance cannot ${t} because the transport did not provide one or more of these methods: ${r}`)}function I(e={}){let t={},r={},n=void 0;function o(s){if(r.unregisterHandler)r.unregisterHandler();r=s,r.registerHandler?.(U)}function c(s){if(typeof s==="function"){n=s;return}n=(i,d)=>{let p=s[i];if(p)return p(d);let m=s._;if(!m)throw Error(`The requested method has no handler: ${String(i)}`);return m(i,d)}}let{maxRequestTime:a=1000}=e;if(e.transport)o(e.transport);if(e.requestHandler)c(e.requestHandler);if(e._debugHooks)t=e._debugHooks;let R=0;function g(){if(R<=10000000000)return++R;return R=0}let u=new Map,l=new Map;function S(s,...i){let d=i[0];return new Promise((p,m)=>{if(!r.send)throw w(["send"],"make requests");let f=g(),B={type:"request",id:f,method:s,params:d};if(u.set(f,{resolve:p,reject:m}),a!==1/0)l.set(f,setTimeout(()=>{l.delete(f),u.delete(f),m(Error("RPC request timed out."))},a));t.onSend?.(B),r.send(B)})}let q=new Proxy(S,{get:(s,i,d)=>{if(i in s)return Reflect.get(s,i,d);return(p)=>S(i,p)}}),x=q;function T(s,...i){let d=i[0];if(!r.send)throw w(["send"],"send messages");let p={type:"message",id:s,payload:d};t.onSend?.(p),r.send(p)}let v=new Proxy(T,{get:(s,i,d)=>{if(i in s)return Reflect.get(s,i,d);return(p)=>T(i,p)}}),O=v,h=new Map,b=new Set;function Y(s,i){if(!r.registerHandler)throw w(["registerHandler"],"register message listeners");if(s==="*"){b.add(i);return}if(!h.has(s))h.set(s,new Set);h.get(s).add(i)}function $(s,i){if(s==="*"){b.delete(i);return}if(h.get(s)?.delete(i),h.get(s)?.size===0)h.delete(s)}async function U(s){if(t.onReceive?.(s),!("type"in s))throw Error("Message does not contain a type.");if(s.type==="request"){if(!r.send||!n)throw w(["send","requestHandler"],"handle requests");let{id:i,method:d,params:p}=s,m;try{m={type:"response",id:i,success:!0,payload:await n(d,p)}}catch(f){if(!(f instanceof Error))throw f;m={type:"response",id:i,success:!1,error:f.message}}t.onSend?.(m),r.send(m);return}if(s.type==="response"){let i=l.get(s.id);if(i!=null)clearTimeout(i);l.delete(s.id);let{resolve:d,reject:p}=u.get(s.id)??{};if(u.delete(s.id),!s.success)p?.(Error(s.error));else d?.(s.payload);return}if(s.type==="message"){for(let d of b)d(s.id,s.payload);let i=h.get(s.id);if(!i)return;for(let d of i)d(s.payload);return}throw Error(`Unexpected RPC message type: ${s.type}`)}return{setTransport:o,setRequestHandler:c,request:q,requestProxy:x,send:v,sendProxy:O,addMessageListener:Y,removeMessageListener:$,proxy:{send:O,request:x}}}function H(e,t){let r={maxRequestTime:t.maxRequestTime,requestHandler:{...t.handlers.requests,...t.extraRequestHandlers},transport:{registerHandler:()=>{}}},n=I(r),o=t.handlers.messages;if(o)n.addMessageListener("*",(c,a)=>{let R=o["*"];if(R)R(c,a);let g=o[c];if(g)g(a)});return n}var{__electrobunWebviewId:L,__electrobunRpcSocketPort:A}=window;class _{bunSocket;rpc;rpcHandler;constructor(e){this.rpc=e.rpc,this.init()}init(){if(this.initSocketToBun(),window.__electrobun.receiveMessageFromBun=this.receiveMessageFromBun.bind(this),this.rpc)this.rpc.setTransport(this.createTransport())}initSocketToBun(){if(!A||!L)return;let e=new WebSocket(`ws://localhost:${A}/socket?webviewId=${L}`);this.bunSocket=e,e.addEventListener("open",()=>{}),e.addEventListener("message",async(t)=>{let r=t.data;if(typeof r==="string")try{let n=JSON.parse(r),o=await window.__electrobun_decrypt(n.encryptedData,n.iv,n.tag);this.rpcHandler?.(JSON.parse(o))}catch(n){console.error("Error parsing bun message:",n)}else if(r instanceof Blob);else console.error("UNKNOWN DATA TYPE RECEIVED:",t.data)}),e.addEventListener("error",(t)=>{console.error("Socket error:",t)}),e.addEventListener("close",(t)=>{})}createTransport(){let e=this;return{send(t){try{let r=JSON.stringify(t);e.bunBridge(r)}catch(r){console.error("bun: failed to serialize message to webview",r)}},registerHandler(t){e.rpcHandler=t}}}async bunBridge(e){if(this.bunSocket?.readyState===WebSocket.OPEN)try{let{encryptedData:t,iv:r,tag:n}=await window.__electrobun_encrypt(e),c=JSON.stringify({encryptedData:t,iv:r,tag:n});this.bunSocket.send(c);return}catch(t){console.error("Error sending message to bun via socket:",t)}window.__electrobunBunBridge?.postMessage(e)}receiveMessageFromBun(e){if(this.rpcHandler)this.rpcHandler(e)}static defineRPC(e){return H("webview",{...e,extraRequestHandlers:{evaluateJavascriptWithResponse:({script:t})=>new Promise((r)=>{try{let o=Function(t)();if(o instanceof Promise)o.then((c)=>{r(c)}).catch((c)=>{console.error("bun: async script execution failed",c),r(String(c))});else r(o)}catch(n){console.error("bun: failed to eval script",n),r(String(n))}})}})}}function C(e){return e>=500?"error":"warn"}var W={evaluate:async(e)=>({ok:!1,error:`BrowserWorkspaceView is not mounted — cannot evaluate tab ${e}`}),getTabRect:async()=>null};function E(){if(typeof window>"u")return W;return window.__ELIZA_BROWSER_TABS_REGISTRY__??W}var z=Symbol.for("elizaos.app.boot-config"),N=z;function F(e,t){let n={...e.__ELIZAOS_APP_BOOT_CONFIG__??e.__ELIZA_APP_BOOT_CONFIG__??e[N]?.current??{},...t};return e.__ELIZAOS_APP_BOOT_CONFIG__=n,e.__ELIZA_APP_BOOT_CONFIG__=n,e[N]={current:n},n}function D(){if(typeof window.__electrobun>"u")window.__electrobun={receiveMessageFromBun:(e)=>{},receiveInternalMessageFromBun:(e)=>{}}}var y={},K="__ELIZA_ELECTROBUN_LOG_MIRROR__";function G(e){if(!e||typeof e!=="object")throw Error("Electrobun RPC params must be an object");return e}function k(e,t){let r=e[t];if(typeof r!=="string")throw Error(`Electrobun RPC param "${t}" must be a string`);return r}function X(e,t){let r=e[t];if(typeof r!=="number"||!Number.isFinite(r))throw Error(`Electrobun RPC param "${t}" must be a finite number`);return r}D();function Z(e,t){if(e==="apiBaseUpdate"){let n=t;if(typeof n.externalApiBase==="string"&&n.externalApiBase.trim())window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__=n.externalApiBase.trim();else Reflect.deleteProperty(window,"__ELIZA_DESKTOP_EXTERNAL_API_BASE__");F(window,{apiBase:n.base,...n.token?{apiToken:n.token}:{}})}let r=y[e];if(!r)return;for(let n of Array.from(r))try{n(t)}catch(o){console.error(`[ElectrobunBridge] Listener error for ${e}:`,o)}}function j(e,t){if(typeof e==="string")Z(e,t)}var P=_.defineRPC({maxRequestTime:600000,handlers:{requests:{browserWorkspaceRendererEvaluate:async(e)=>{let t=G(e),r=k(t,"id"),n=k(t,"script"),o=X(t,"timeoutMs");return await E().evaluate(r,n,o)},browserWorkspaceRendererGetTabRect:async(e)=>{let t=G(e);return E().getTabRect(k(t,"id"))}},messages:{"*":j}}});new _({rpc:P});function M(e){if(e instanceof Error)return{name:e.name,message:e.message,stack:e.stack};return e}var J=new Proxy(P.request,{get(e,t,r){let n=Reflect.get(e,t,r);if(typeof n!=="function")return n;return async(o)=>{try{return await n.call(e,o)}catch(c){throw P.request.rendererReportDiagnostic({level:"error",source:"rpc",message:`Electrobun RPC request failed: ${String(t)}`,details:M(c)}).catch(()=>{}),c}}}}),V={request:J,onMessage:(e,t)=>{if(!y[e])y[e]=new Set;y[e].add(t)},offMessage:(e,t)=>{if(y[e]?.delete(t),y[e]?.size===0)delete y[e]}};window.__ELIZA_ELECTROBUN_RPC__=V;function Q(){let e=window;if(e[K])return;e[K]=!0;let t=(n,o,c,a)=>{P.request.rendererReportDiagnostic({level:n,source:o,message:c,details:a}).catch(()=>{})},r=["log","info","warn","error"];for(let n of r){let o=console[n].bind(console);console[n]=(...c)=>{o(...c),t(n,"console",c.map((a)=>{if(typeof a==="string")return a;try{return JSON.stringify(a)}catch{return String(a)}}).join(" "))}}if(window.addEventListener("error",(n)=>{let o=n.target;if(o&&(o.src||o.href)){t("error","resource","Failed to load resource",{tagName:o.tagName,src:o.src,href:o.href});return}t("error","window.onerror",n.message||"Unhandled window error",{filename:n.filename,lineno:n.lineno,colno:n.colno})},!0),window.addEventListener("unhandledrejection",(n)=>{t("error","unhandledrejection","Unhandled promise rejection",M(n.reason))}),typeof window.fetch==="function"){let n=window.fetch.bind(window);window.fetch=async(...o)=>{let c=Date.now(),a=o[0],R=o[1],g=typeof a==="string"?a:a instanceof Request?a.url:String(a),u=R?.method??(a instanceof Request?a.method:void 0)??"GET";try{let l=await n(...o),S=l.ok?null:C(l.status);if(S)t(S,"fetch",`HTTP ${l.status} ${l.statusText}`,{url:g,method:u,durationMs:Date.now()-c});return l}catch(l){throw t("error","fetch","Fetch failed",{url:g,method:u,durationMs:Date.now()-c,error:M(l)}),l}}}if(typeof XMLHttpRequest<"u"){let n=XMLHttpRequest.prototype.open,o=XMLHttpRequest.prototype.send;XMLHttpRequest.prototype.open=function(c,a,...R){return this.__elizaDiag={method:c,url:String(a),startedAt:Date.now()},n.call(this,c,a,...R)},XMLHttpRequest.prototype.send=function(...c){let a=this,R=()=>{let u=a.__elizaDiag;if(!u)return;let l=a.status>=400?C(a.status):null;if(l)t(l,"xhr",`HTTP ${a.status}`,{url:u.url,method:u.method,durationMs:Date.now()-u.startedAt})},g=()=>{let u=a.__elizaDiag;t("error","xhr","XMLHttpRequest failed",{url:u?.url,method:u?.method,durationMs:u?Date.now()-u.startedAt:void 0})};return a.addEventListener("loadend",R,{once:!0}),a.addEventListener("error",g,{once:!0}),o.call(this,...c)}}}Q();})();
+(() => {
+  function w(e, t) {
+    const r = e.map((n) => `"${n}"`).join(", ");
+    return Error(
+      `This RPC instance cannot ${t} because the transport did not provide one or more of these methods: ${r}`,
+    );
+  }
+  function I(e = {}) {
+    let t = {},
+      r = {},
+      n = void 0;
+    function o(s) {
+      if (r.unregisterHandler) r.unregisterHandler();
+      (r = s), r.registerHandler?.(U);
+    }
+    function c(s) {
+      if (typeof s === "function") {
+        n = s;
+        return;
+      }
+      n = (i, d) => {
+        const p = s[i];
+        if (p) return p(d);
+        const m = s._;
+        if (!m)
+          throw Error(`The requested method has no handler: ${String(i)}`);
+        return m(i, d);
+      };
+    }
+    const { maxRequestTime: a = 1000 } = e;
+    if (e.transport) o(e.transport);
+    if (e.requestHandler) c(e.requestHandler);
+    if (e._debugHooks) t = e._debugHooks;
+    let R = 0;
+    function g() {
+      if (R <= 10000000000) return ++R;
+      return (R = 0);
+    }
+    const u = new Map(),
+      l = new Map();
+    function S(s, ...i) {
+      const d = i[0];
+      return new Promise((p, m) => {
+        if (!r.send) throw w(["send"], "make requests");
+        const f = g(),
+          B = { type: "request", id: f, method: s, params: d };
+        if ((u.set(f, { resolve: p, reject: m }), a !== 1 / 0))
+          l.set(
+            f,
+            setTimeout(() => {
+              l.delete(f), u.delete(f), m(Error("RPC request timed out."));
+            }, a),
+          );
+        t.onSend?.(B), r.send(B);
+      });
+    }
+    const q = new Proxy(S, {
+        get: (s, i, d) => {
+          if (i in s) return Reflect.get(s, i, d);
+          return (p) => S(i, p);
+        },
+      }),
+      x = q;
+    function T(s, ...i) {
+      const d = i[0];
+      if (!r.send) throw w(["send"], "send messages");
+      const p = { type: "message", id: s, payload: d };
+      t.onSend?.(p), r.send(p);
+    }
+    const v = new Proxy(T, {
+        get: (s, i, d) => {
+          if (i in s) return Reflect.get(s, i, d);
+          return (p) => T(i, p);
+        },
+      }),
+      O = v,
+      h = new Map(),
+      b = new Set();
+    function Y(s, i) {
+      if (!r.registerHandler)
+        throw w(["registerHandler"], "register message listeners");
+      if (s === "*") {
+        b.add(i);
+        return;
+      }
+      if (!h.has(s)) h.set(s, new Set());
+      h.get(s).add(i);
+    }
+    function $(s, i) {
+      if (s === "*") {
+        b.delete(i);
+        return;
+      }
+      if ((h.get(s)?.delete(i), h.get(s)?.size === 0)) h.delete(s);
+    }
+    async function U(s) {
+      if ((t.onReceive?.(s), !("type" in s)))
+        throw Error("Message does not contain a type.");
+      if (s.type === "request") {
+        if (!r.send || !n)
+          throw w(["send", "requestHandler"], "handle requests");
+        let { id: i, method: d, params: p } = s,
+          m;
+        try {
+          m = { type: "response", id: i, success: !0, payload: await n(d, p) };
+        } catch (f) {
+          if (!(f instanceof Error)) throw f;
+          m = { type: "response", id: i, success: !1, error: f.message };
+        }
+        t.onSend?.(m), r.send(m);
+        return;
+      }
+      if (s.type === "response") {
+        const i = l.get(s.id);
+        if (i != null) clearTimeout(i);
+        l.delete(s.id);
+        const { resolve: d, reject: p } = u.get(s.id) ?? {};
+        if ((u.delete(s.id), !s.success)) p?.(Error(s.error));
+        else d?.(s.payload);
+        return;
+      }
+      if (s.type === "message") {
+        for (const d of b) d(s.id, s.payload);
+        const i = h.get(s.id);
+        if (!i) return;
+        for (const d of i) d(s.payload);
+        return;
+      }
+      throw Error(`Unexpected RPC message type: ${s.type}`);
+    }
+    return {
+      setTransport: o,
+      setRequestHandler: c,
+      request: q,
+      requestProxy: x,
+      send: v,
+      sendProxy: O,
+      addMessageListener: Y,
+      removeMessageListener: $,
+      proxy: { send: O, request: x },
+    };
+  }
+  function H(e, t) {
+    const r = {
+        maxRequestTime: t.maxRequestTime,
+        requestHandler: { ...t.handlers.requests, ...t.extraRequestHandlers },
+        transport: { registerHandler: () => {} },
+      },
+      n = I(r),
+      o = t.handlers.messages;
+    if (o)
+      n.addMessageListener("*", (c, a) => {
+        const R = o["*"];
+        if (R) R(c, a);
+        const g = o[c];
+        if (g) g(a);
+      });
+    return n;
+  }
+  var { __electrobunWebviewId: L, __electrobunRpcSocketPort: A } = window;
+  class _ {
+    bunSocket;
+    rpc;
+    rpcHandler;
+    constructor(e) {
+      (this.rpc = e.rpc), this.init();
+    }
+    init() {
+      if (
+        (this.initSocketToBun(),
+        (window.__electrobun.receiveMessageFromBun =
+          this.receiveMessageFromBun.bind(this)),
+        this.rpc)
+      )
+        this.rpc.setTransport(this.createTransport());
+    }
+    initSocketToBun() {
+      if (!A || !L) return;
+      const e = new WebSocket(`ws://localhost:${A}/socket?webviewId=${L}`);
+      (this.bunSocket = e),
+        e.addEventListener("open", () => {}),
+        e.addEventListener("message", async (t) => {
+          const r = t.data;
+          if (typeof r === "string")
+            try {
+              const n = JSON.parse(r),
+                o = await window.__electrobun_decrypt(
+                  n.encryptedData,
+                  n.iv,
+                  n.tag,
+                );
+              this.rpcHandler?.(JSON.parse(o));
+            } catch (n) {
+              console.error("Error parsing bun message:", n);
+            }
+          else if (r instanceof Blob);
+          else console.error("UNKNOWN DATA TYPE RECEIVED:", t.data);
+        }),
+        e.addEventListener("error", (t) => {
+          console.error("Socket error:", t);
+        }),
+        e.addEventListener("close", (t) => {});
+    }
+    createTransport() {
+      const e = this;
+      return {
+        send(t) {
+          try {
+            const r = JSON.stringify(t);
+            e.bunBridge(r);
+          } catch (r) {
+            console.error("bun: failed to serialize message to webview", r);
+          }
+        },
+        registerHandler(t) {
+          e.rpcHandler = t;
+        },
+      };
+    }
+    async bunBridge(e) {
+      if (this.bunSocket?.readyState === WebSocket.OPEN)
+        try {
+          const {
+              encryptedData: t,
+              iv: r,
+              tag: n,
+            } = await window.__electrobun_encrypt(e),
+            c = JSON.stringify({ encryptedData: t, iv: r, tag: n });
+          this.bunSocket.send(c);
+          return;
+        } catch (t) {
+          console.error("Error sending message to bun via socket:", t);
+        }
+      window.__electrobunBunBridge?.postMessage(e);
+    }
+    receiveMessageFromBun(e) {
+      if (this.rpcHandler) this.rpcHandler(e);
+    }
+    static defineRPC(e) {
+      return H("webview", {
+        ...e,
+        extraRequestHandlers: {
+          evaluateJavascriptWithResponse: ({ script: t }) =>
+            new Promise((r) => {
+              try {
+                const o = Function(t)();
+                if (o instanceof Promise)
+                  o.then((c) => {
+                    r(c);
+                  }).catch((c) => {
+                    console.error("bun: async script execution failed", c),
+                      r(String(c));
+                  });
+                else r(o);
+              } catch (n) {
+                console.error("bun: failed to eval script", n), r(String(n));
+              }
+            }),
+        },
+      });
+    }
+  }
+  function C(e) {
+    return e >= 500 ? "error" : "warn";
+  }
+  var W = {
+    evaluate: async (e) => ({
+      ok: !1,
+      error: `BrowserWorkspaceView is not mounted — cannot evaluate tab ${e}`,
+    }),
+    getTabRect: async () => null,
+  };
+  function E() {
+    if (typeof window > "u") return W;
+    return window.__ELIZA_BROWSER_TABS_REGISTRY__ ?? W;
+  }
+  var z = Symbol.for("elizaos.app.boot-config"),
+    N = z;
+  function F(e, t) {
+    const n = {
+      ...(e.__ELIZAOS_APP_BOOT_CONFIG__ ??
+        e.__ELIZA_APP_BOOT_CONFIG__ ??
+        e[N]?.current ??
+        {}),
+      ...t,
+    };
+    return (
+      (e.__ELIZAOS_APP_BOOT_CONFIG__ = n),
+      (e.__ELIZA_APP_BOOT_CONFIG__ = n),
+      (e[N] = { current: n }),
+      n
+    );
+  }
+  function D() {
+    if (typeof window.__electrobun > "u")
+      window.__electrobun = {
+        receiveMessageFromBun: (e) => {},
+        receiveInternalMessageFromBun: (e) => {},
+      };
+  }
+  var y = {},
+    K = "__ELIZA_ELECTROBUN_LOG_MIRROR__";
+  function G(e) {
+    if (!e || typeof e !== "object")
+      throw Error("Electrobun RPC params must be an object");
+    return e;
+  }
+  function k(e, t) {
+    const r = e[t];
+    if (typeof r !== "string")
+      throw Error(`Electrobun RPC param "${t}" must be a string`);
+    return r;
+  }
+  function X(e, t) {
+    const r = e[t];
+    if (typeof r !== "number" || !Number.isFinite(r))
+      throw Error(`Electrobun RPC param "${t}" must be a finite number`);
+    return r;
+  }
+  D();
+  function Z(e, t) {
+    if (e === "apiBaseUpdate") {
+      const n = t;
+      if (typeof n.externalApiBase === "string" && n.externalApiBase.trim())
+        window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__ = n.externalApiBase.trim();
+      else
+        Reflect.deleteProperty(window, "__ELIZA_DESKTOP_EXTERNAL_API_BASE__");
+      F(window, { apiBase: n.base, ...(n.token ? { apiToken: n.token } : {}) });
+    }
+    const r = y[e];
+    if (!r) return;
+    for (const n of Array.from(r))
+      try {
+        n(t);
+      } catch (o) {
+        console.error(`[ElectrobunBridge] Listener error for ${e}:`, o);
+      }
+  }
+  function j(e, t) {
+    if (typeof e === "string") Z(e, t);
+  }
+  var P = _.defineRPC({
+    maxRequestTime: 600000,
+    handlers: {
+      requests: {
+        browserWorkspaceRendererEvaluate: async (e) => {
+          const t = G(e),
+            r = k(t, "id"),
+            n = k(t, "script"),
+            o = X(t, "timeoutMs");
+          return await E().evaluate(r, n, o);
+        },
+        browserWorkspaceRendererGetTabRect: async (e) => {
+          const t = G(e);
+          return E().getTabRect(k(t, "id"));
+        },
+      },
+      messages: { "*": j },
+    },
+  });
+  new _({ rpc: P });
+  function M(e) {
+    if (e instanceof Error)
+      return { name: e.name, message: e.message, stack: e.stack };
+    return e;
+  }
+  var J = new Proxy(P.request, {
+      get(e, t, r) {
+        const n = Reflect.get(e, t, r);
+        if (typeof n !== "function") return n;
+        return async (o) => {
+          try {
+            return await n.call(e, o);
+          } catch (c) {
+            throw (
+              (P.request
+                .rendererReportDiagnostic({
+                  level: "error",
+                  source: "rpc",
+                  message: `Electrobun RPC request failed: ${String(t)}`,
+                  details: M(c),
+                })
+                .catch(() => {}),
+              c)
+            );
+          }
+        };
+      },
+    }),
+    V = {
+      request: J,
+      onMessage: (e, t) => {
+        if (!y[e]) y[e] = new Set();
+        y[e].add(t);
+      },
+      offMessage: (e, t) => {
+        if ((y[e]?.delete(t), y[e]?.size === 0)) delete y[e];
+      },
+    };
+  window.__ELIZA_ELECTROBUN_RPC__ = V;
+  function Q() {
+    const e = window;
+    if (e[K]) return;
+    e[K] = !0;
+    const t = (n, o, c, a) => {
+        P.request
+          .rendererReportDiagnostic({
+            level: n,
+            source: o,
+            message: c,
+            details: a,
+          })
+          .catch(() => {});
+      },
+      r = ["log", "info", "warn", "error"];
+    for (const n of r) {
+      const o = console[n].bind(console);
+      console[n] = (...c) => {
+        o(...c),
+          t(
+            n,
+            "console",
+            c
+              .map((a) => {
+                if (typeof a === "string") return a;
+                try {
+                  return JSON.stringify(a);
+                } catch {
+                  return String(a);
+                }
+              })
+              .join(" "),
+          );
+      };
+    }
+    if (
+      (window.addEventListener(
+        "error",
+        (n) => {
+          const o = n.target;
+          if (o && (o.src || o.href)) {
+            t("error", "resource", "Failed to load resource", {
+              tagName: o.tagName,
+              src: o.src,
+              href: o.href,
+            });
+            return;
+          }
+          t("error", "window.onerror", n.message || "Unhandled window error", {
+            filename: n.filename,
+            lineno: n.lineno,
+            colno: n.colno,
+          });
+        },
+        !0,
+      ),
+      window.addEventListener("unhandledrejection", (n) => {
+        t(
+          "error",
+          "unhandledrejection",
+          "Unhandled promise rejection",
+          M(n.reason),
+        );
+      }),
+      typeof window.fetch === "function")
+    ) {
+      const n = window.fetch.bind(window);
+      window.fetch = async (...o) => {
+        const c = Date.now(),
+          a = o[0],
+          R = o[1],
+          g =
+            typeof a === "string"
+              ? a
+              : a instanceof Request
+                ? a.url
+                : String(a),
+          u = R?.method ?? (a instanceof Request ? a.method : void 0) ?? "GET";
+        try {
+          const l = await n(...o),
+            S = l.ok ? null : C(l.status);
+          if (S)
+            t(S, "fetch", `HTTP ${l.status} ${l.statusText}`, {
+              url: g,
+              method: u,
+              durationMs: Date.now() - c,
+            });
+          return l;
+        } catch (l) {
+          throw (
+            (t("error", "fetch", "Fetch failed", {
+              url: g,
+              method: u,
+              durationMs: Date.now() - c,
+              error: M(l),
+            }),
+            l)
+          );
+        }
+      };
+    }
+    if (typeof XMLHttpRequest < "u") {
+      const n = XMLHttpRequest.prototype.open,
+        o = XMLHttpRequest.prototype.send;
+      (XMLHttpRequest.prototype.open = function (c, a, ...R) {
+        return (
+          (this.__elizaDiag = {
+            method: c,
+            url: String(a),
+            startedAt: Date.now(),
+          }),
+          n.call(this, c, a, ...R)
+        );
+      }),
+        (XMLHttpRequest.prototype.send = function (...c) {
+          const R = () => {
+              const u = this.__elizaDiag;
+              if (!u) return;
+              const l = this.status >= 400 ? C(this.status) : null;
+              if (l)
+                t(l, "xhr", `HTTP ${this.status}`, {
+                  url: u.url,
+                  method: u.method,
+                  durationMs: Date.now() - u.startedAt,
+                });
+            },
+            g = () => {
+              const u = this.__elizaDiag;
+              t("error", "xhr", "XMLHttpRequest failed", {
+                url: u?.url,
+                method: u?.method,
+                durationMs: u ? Date.now() - u.startedAt : void 0,
+              });
+            };
+          return (
+            this.addEventListener("loadend", R, { once: !0 }),
+            this.addEventListener("error", g, { once: !0 }),
+            o.call(this, ...c)
+          );
+        });
+    }
+  }
+  Q();
+})();

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -149,7 +149,7 @@ describe("Android periodic wake reconciliation (#17874)", () => {
   it("returns repeated service starts before the cold-boot process lock", () => {
     const service = source("ElizaAgentService.java");
     const requestStartBody = service.match(
-      /private void requestAgentStart\(boolean restartFirst\) \{([\s\S]*?)\n    \}\n\n    private void startAgentProcess/,
+      /private void requestAgentStart\(boolean restartFirst\) \{([\s\S]*?)\n {4}\}\n\n {4}private void startAgentProcess/,
     )?.[1];
 
     expect(service).toContain("private volatile Thread startWorker");
@@ -166,10 +166,10 @@ describe("Android periodic wake reconciliation (#17874)", () => {
     ]) {
       const service = source(name);
       const onCreateBody = service.match(
-        /public void onCreate\(\) \{([\s\S]*?)\n    \}\n\n    @Override\n    public int onStartCommand/,
+        /public void onCreate\(\) \{([\s\S]*?)\n {4}\}\n\n {4}@Override\n {4}public int onStartCommand/,
       )?.[1];
       const bootstrapBody = service.match(
-        /private Notification buildBootstrapNotification\([\s\S]*?\) \{([\s\S]*?)\n    \}/,
+        /private Notification buildBootstrapNotification\([\s\S]*?\) \{([\s\S]*?)\n {4}\}/,
       )?.[1];
 
       expect(onCreateBody).toContain("buildBootstrapNotification");

--- a/packages/app-core/scripts/codesign-mas.mjs
+++ b/packages/app-core/scripts/codesign-mas.mjs
@@ -33,8 +33,8 @@ import { spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
-  openSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   readSync,
@@ -60,20 +60,23 @@ const ENTITLEMENTS_DIR = path.resolve(
   "../platforms/electrobun/entitlements",
 );
 let PARENT_ENTITLEMENTS = path.join(ENTITLEMENTS_DIR, "mas.entitlements");
-let CHILD_ENTITLEMENTS = path.join(
-  ENTITLEMENTS_DIR,
-  "mas-child.entitlements",
-);
+let CHILD_ENTITLEMENTS = path.join(ENTITLEMENTS_DIR, "mas-child.entitlements");
 let BUN_ENTITLEMENTS = path.join(ENTITLEMENTS_DIR, "mas-bun.entitlements");
 
-export function resolveAppleSigningTeamId({ args, identity, env = process.env }) {
+export function resolveAppleSigningTeamId({
+  args,
+  identity,
+  env = process.env,
+}) {
   const identityTeam = identity?.match(/\(([A-Z0-9]{10})\)\s*$/)?.[1];
   const configured = [args["team-id"], env.ELIZA_APPLE_TEAM_ID, identityTeam]
     .map((value) => value?.trim())
     .filter(Boolean);
   const unique = [...new Set(configured)];
   if (unique.length !== 1 || !/^[A-Z0-9]{10}$/.test(unique[0])) {
-    throw new Error("MAS signing requires one matching 10-character Apple Team ID");
+    throw new Error(
+      "MAS signing requires one matching 10-character Apple Team ID",
+    );
   }
   return unique[0];
 }
@@ -99,7 +102,9 @@ function materializeConcreteEntitlements(teamId) {
     child: render(CHILD_ENTITLEMENTS),
     bun: render(BUN_ENTITLEMENTS),
   };
-  process.once("exit", () => rmSync(temporaryRoot, { force: true, recursive: true }));
+  process.once("exit", () =>
+    rmSync(temporaryRoot, { force: true, recursive: true }),
+  );
   return rendered;
 }
 

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -22,6 +22,7 @@ function envInt(raw: string | undefined, fallback: number): number {
   if (trimmed === "") return fallback;
   return /^\+?\d+$/.test(trimmed) ? Number(trimmed) : fallback;
 }
+
 import { fileURLToPath } from "node:url";
 
 import {

--- a/packages/app-core/scripts/lib/homepage-release-validation.mjs
+++ b/packages/app-core/scripts/lib/homepage-release-validation.mjs
@@ -5,7 +5,10 @@
  */
 
 export function unavailableReleaseFinding(release) {
-  if (release.publishedAtLabel !== "unavailable" || release.prerelease !== false) {
+  if (
+    release.publishedAtLabel !== "unavailable" ||
+    release.prerelease !== false
+  ) {
     return {
       message: "unavailable release must use canonical publication metadata",
       details: [],

--- a/packages/app-core/scripts/plugin-metadata-overrides.json
+++ b/packages/app-core/scripts/plugin-metadata-overrides.json
@@ -1,268 +1,127 @@
 {
   "anthropic": {
     "description": "Anthropic model provider for Claude chat and reasoning models.",
-    "tags": [
-      "ai-provider",
-      "llm",
-      "anthropic",
-      "chat"
-    ]
+    "tags": ["ai-provider", "llm", "anthropic", "chat"]
   },
   "blooio": {
     "description": "Integrates Blooio iMessage/SMS messaging into elizaOS with signed webhooks and outbound message sending.",
-    "tags": [
-      "connector",
-      "social",
-      "social-chat",
-      "messaging",
-      "blooio"
-    ]
+    "tags": ["connector", "social", "social-chat", "messaging", "blooio"]
   },
   "commands": {
     "description": "Chat command system for Eliza agents (/help, /status, /reset, etc.)",
-    "tags": [
-      "commands"
-    ]
+    "tags": ["commands"]
   },
   "directives": {
     "description": "Inline directive parsing for Eliza agents (@think, @model, @verbose, etc.)",
-    "tags": [
-      "directives"
-    ]
+    "tags": ["directives"]
   },
   "elevenlabs": {
     "description": "ElevenLabs voice plugin for text-to-speech generation and conversational audio output.",
-    "tags": [
-      "feature",
-      "voice",
-      "text-to-speech",
-      "audio"
-    ]
+    "tags": ["feature", "voice", "text-to-speech", "audio"]
   },
   "elizacloud": {
     "description": "elizaOS plugin to connect with elizaOS Cloud services",
-    "tags": [
-      "elizacloud"
-    ]
+    "tags": ["elizacloud"]
   },
   "farcaster": {
     "description": "Farcaster connector for publishing casts and responding to social conversations.",
-    "tags": [
-      "connector",
-      "social",
-      "farcaster",
-      "messaging"
-    ]
+    "tags": ["connector", "social", "farcaster", "messaging"]
   },
   "feishu": {
     "description": "Feishu connector for bots, chats, and workflow notifications on Lark/Feishu.",
-    "tags": [
-      "connector",
-      "messaging",
-      "feishu",
-      "productivity"
-    ]
+    "tags": ["connector", "messaging", "feishu", "productivity"]
   },
   "groq": {
     "description": "Groq model provider for low-latency chat and inference workloads.",
-    "tags": [
-      "ai-provider",
-      "llm",
-      "groq",
-      "chat"
-    ]
+    "tags": ["ai-provider", "llm", "groq", "chat"]
   },
   "imessage": {
     "description": "iMessage connector for Mac-based conversations and message automation.",
-    "tags": [
-      "connector",
-      "messaging",
-      "imessage",
-      "apple"
-    ]
+    "tags": ["connector", "messaging", "imessage", "apple"]
   },
   "iq": {
     "description": "IQ on-chain chat plugin for Eliza agents on Solana",
-    "tags": [
-      "connector",
-      "integration",
-      "iq"
-    ]
+    "tags": ["connector", "integration", "iq"]
   },
   "knowledge": {
     "description": "elizaOS RAG knowledge plugin",
-    "tags": [
-      "knowledge"
-    ]
+    "tags": ["knowledge"]
   },
   "line": {
     "description": "LINE connector for bot messaging and customer conversations.",
-    "tags": [
-      "connector",
-      "messaging",
-      "line",
-      "social"
-    ]
+    "tags": ["connector", "messaging", "line", "social"]
   },
   "local-ai": {
     "description": "LocalAI provider for self-hosted, OpenAI-compatible local model inference.",
-    "tags": [
-      "ai-provider",
-      "llm",
-      "local-models",
-      "self-hosted"
-    ]
+    "tags": ["ai-provider", "llm", "local-models", "self-hosted"]
   },
   "matrix": {
     "description": "Matrix connector for rooms, bots, and federated chat workflows.",
-    "tags": [
-      "connector",
-      "messaging",
-      "matrix",
-      "chat"
-    ]
+    "tags": ["connector", "messaging", "matrix", "chat"]
   },
   "minecraft": {
     "description": "Minecraft automation app for driving Mineflayer bots from Eliza agents.",
-    "tags": [
-      "app",
-      "games",
-      "minecraft",
-      "automation"
-    ]
+    "tags": ["app", "games", "minecraft", "automation"]
   },
   "moltbook": {
     "description": "Moltbook social plugin for Eliza agents - Reddit-style platform for AI agents",
-    "tags": [
-      "moltbook",
-      "social",
-      "reddit",
-      "agents",
-      "autonomous"
-    ]
+    "tags": ["moltbook", "social", "reddit", "agents", "autonomous"]
   },
   "nostr": {
     "description": "Nostr connector for relay-based social posting and conversation handling.",
-    "tags": [
-      "connector",
-      "social",
-      "nostr",
-      "relays"
-    ]
+    "tags": ["connector", "social", "nostr", "relays"]
   },
   "ollama": {
     "description": "Ollama provider for running local LLMs on your own machine.",
-    "tags": [
-      "ai-provider",
-      "llm",
-      "ollama",
-      "local-models"
-    ]
+    "tags": ["ai-provider", "llm", "ollama", "local-models"]
   },
   "openrouter": {
     "description": "OpenRouter provider for routing requests across many hosted models through one API.",
-    "tags": [
-      "ai-provider",
-      "llm",
-      "openrouter",
-      "routing"
-    ]
+    "tags": ["ai-provider", "llm", "openrouter", "routing"]
   },
   "pdf": {
     "description": "Core Node.js plugin for elizaOS that provides essential services and actions for file operations.",
-    "tags": [
-      "pdf"
-    ]
+    "tags": ["pdf"]
   },
   "s3-storage": {
     "description": "S3-compatible object storage plugin for saving files, media, and generated artifacts.",
-    "tags": [
-      "feature",
-      "storage",
-      "files",
-      "s3"
-    ]
+    "tags": ["feature", "storage", "files", "s3"]
   },
   "solana": {
     "description": "Core Solana blockchain plugin for elizaOS, enabling token operations, trading, and DeFi integrations.",
-    "tags": [
-      "crypto",
-      "solana"
-    ]
+    "tags": ["crypto", "solana"]
   },
   "sql": {
     "description": "SQL database adapter for persistent agent state, memory, and logs.",
-    "tags": [
-      "database",
-      "storage",
-      "sql",
-      "persistence"
-    ]
+    "tags": ["database", "storage", "sql", "persistence"]
   },
   "telegram": {
     "description": "Telegram connector for bot chats, groups, channels, and topic-based conversations.",
-    "tags": [
-      "connector",
-      "messaging",
-      "telegram",
-      "chat"
-    ]
+    "tags": ["connector", "messaging", "telegram", "chat"]
   },
   "tlon": {
     "description": "Tlon connector for Urbit chat and social interactions.",
-    "tags": [
-      "connector",
-      "social",
-      "urbit",
-      "chat"
-    ]
+    "tags": ["connector", "social", "urbit", "chat"]
   },
   "twitch": {
     "description": "Twitch connector for live chat, channel events, and audience interactions.",
-    "tags": [
-      "connector",
-      "streaming",
-      "twitch",
-      "chat"
-    ]
+    "tags": ["connector", "streaming", "twitch", "chat"]
   },
   "zalo": {
     "description": "Zalo connector for official account messaging and support workflows.",
-    "tags": [
-      "connector",
-      "messaging",
-      "zalo",
-      "chat"
-    ]
+    "tags": ["connector", "messaging", "zalo", "chat"]
   },
   "zalouser": {
     "description": "Zalo personal-account connector for one-to-one messaging workflows.",
-    "tags": [
-      "connector",
-      "messaging",
-      "zalo",
-      "personal-account"
-    ]
+    "tags": ["connector", "messaging", "zalo", "personal-account"]
   },
   "wechat": {
     "description": "WeChat connector for messaging via proxy API with QR code login.",
-    "tags": [
-      "connector",
-      "messaging",
-      "wechat",
-      "social"
-    ]
+    "tags": ["connector", "messaging", "wechat", "social"]
   },
   "music-library": {
     "description": "Music metadata, library storage, playlists, user preferences, analytics, and YouTube search for elizaOS agents.",
-    "tags": [
-      "feature",
-      "music",
-      "library",
-      "playlists",
-      "analytics",
-      "audio"
-    ],
+    "tags": ["feature", "music", "library", "playlists", "analytics", "audio"],
     "configKeys": [
       "MUSICBRAINZ_USER_AGENT",
       "LASTFM_API_KEY",
@@ -276,14 +135,7 @@
   },
   "music-player": {
     "description": "Music playback engine with queue management, cross-fading, HTTP streaming, and optional Discord voice integration.",
-    "tags": [
-      "feature",
-      "music",
-      "playback",
-      "streaming",
-      "audio",
-      "discord"
-    ],
+    "tags": ["feature", "music", "playback", "streaming", "audio", "discord"],
     "configKeys": [
       "AUDIO_CACHE_DIR",
       "AUDIO_CACHE_FORMAT",

--- a/packages/app-core/scripts/run-local-plugin-live-smoke.mjs
+++ b/packages/app-core/scripts/run-local-plugin-live-smoke.mjs
@@ -45,11 +45,7 @@ const runtimePackageBuildPrerequisites = [
   },
   {
     name: "@elizaos/plugin-personal-assistant",
-    packageRoot: path.join(
-      repoRoot,
-      "plugins",
-      "plugin-personal-assistant",
-    ),
+    packageRoot: path.join(repoRoot, "plugins", "plugin-personal-assistant"),
     requiredPaths: [path.join("dist", "plugin.js")],
   },
 ];

--- a/packages/app-core/scripts/runtime-package-manifest.test.ts
+++ b/packages/app-core/scripts/runtime-package-manifest.test.ts
@@ -19,7 +19,9 @@ const NO_PLUGINS_BUNDLED: ReadonlySet<string> = new Set<string>();
 describe("isRuntimePluginPackage", () => {
   it("recognizes elizaOS runtime plugins", () => {
     expect(isRuntimePluginPackage("@elizaos/plugin-sql")).toBe(true);
-    expect(isRuntimePluginPackage("@elizaos/plugin-local-inference")).toBe(true);
+    expect(isRuntimePluginPackage("@elizaos/plugin-local-inference")).toBe(
+      true,
+    );
     // Unscoped form used by local plugin projects.
     expect(isRuntimePluginPackage("plugin-my-project")).toBe(true);
   });
@@ -28,9 +30,9 @@ describe("isRuntimePluginPackage", () => {
     // Each of these is a hard dependency of a bundled package.
     expect(isRuntimePluginPackage("@octokit/plugin-request-log")).toBe(false);
     expect(isRuntimePluginPackage("@octokit/plugin-paginate-rest")).toBe(false);
-    expect(isRuntimePluginPackage("@octokit/plugin-rest-endpoint-methods")).toBe(
-      false,
-    );
+    expect(
+      isRuntimePluginPackage("@octokit/plugin-rest-endpoint-methods"),
+    ).toBe(false);
     expect(isRuntimePluginPackage("@jimp/plugin-resize")).toBe(false);
     expect(isRuntimePluginPackage("@milkdown/plugin-history")).toBe(false);
     expect(isRuntimePluginPackage("@solana/plugin-core")).toBe(false);
@@ -54,13 +56,18 @@ describe("shouldBundleDiscoveredPackage", () => {
       "@jimp/plugin-resize",
       "@milkdown/plugin-history",
     ]) {
-      expect(shouldBundleDiscoveredPackage(name, NO_PLUGINS_BUNDLED)).toBe(true);
+      expect(shouldBundleDiscoveredPackage(name, NO_PLUGINS_BUNDLED)).toBe(
+        true,
+      );
     }
   });
 
   it("still gates elizaOS plugins on the always-bundled set", () => {
     expect(
-      shouldBundleDiscoveredPackage("@elizaos/plugin-notes", NO_PLUGINS_BUNDLED),
+      shouldBundleDiscoveredPackage(
+        "@elizaos/plugin-notes",
+        NO_PLUGINS_BUNDLED,
+      ),
     ).toBe(false);
     expect(
       shouldBundleDiscoveredPackage(
@@ -81,8 +88,8 @@ describe("shouldBundleDiscoveredPackage", () => {
 
   it("bundles ordinary dependencies", () => {
     expect(shouldBundleDiscoveredPackage("zod", NO_PLUGINS_BUNDLED)).toBe(true);
-    expect(shouldBundleDiscoveredPackage("@octokit/rest", NO_PLUGINS_BUNDLED)).toBe(
-      true,
-    );
+    expect(
+      shouldBundleDiscoveredPackage("@octokit/rest", NO_PLUGINS_BUNDLED),
+    ).toBe(true);
   });
 });

--- a/packages/app-core/scripts/stage-elizavoice-lib.mjs
+++ b/packages/app-core/scripts/stage-elizavoice-lib.mjs
@@ -60,9 +60,7 @@ function resolveVulkanHostTooling(ndk) {
 
   const spirvHeadersDir =
     process.env.ELIZA_SPIRV_HEADERS_DIR ||
-    firstExisting([
-      "/tmp/spirv-headers-install/lib/cmake/SPIRV-Headers",
-    ]);
+    firstExisting(["/tmp/spirv-headers-install/lib/cmake/SPIRV-Headers"]);
   if (!spirvHeadersDir) {
     die(
       "SPIRV-Headers cmake dir not found (set ELIZA_SPIRV_HEADERS_DIR) — clone " +

--- a/packages/app-core/scripts/voice-attribution-smoke.ts
+++ b/packages/app-core/scripts/voice-attribution-smoke.ts
@@ -37,7 +37,6 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { buildVoiceTurnSignal } from "../../../packages/shared/src/voice/respond-gate.ts";
 import { handleLiveVoiceAttribution } from "@elizaos/plugin-local-inference/runtime/voice-entity-binding";
 import { resolveFusedLibraryPath } from "@elizaos/plugin-local-inference/services/desktop-fused-ffi-backend-runtime";
 import {
@@ -53,6 +52,7 @@ import {
   GgmlSileroVad,
   VadDetector,
 } from "@elizaos/plugin-local-inference/services/voice/vad";
+import { buildVoiceTurnSignal } from "../../../packages/shared/src/voice/respond-gate.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 const WAV = path.join(

--- a/packages/app-core/scripts/voice/__tests__/voice-openwakeword-eval.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-openwakeword-eval.test.ts
@@ -1,8 +1,9 @@
 // Exercises tests voice openwakeword eval.test automation behavior with deterministic script fixtures.
-import { describe, expect, test } from "vitest";
+
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, test } from "vitest";
 import {
   OPENWAKEWORD_SCHEMA,
   validateOpenWakeWordReport,

--- a/packages/app-core/scripts/voice/__tests__/voice-stage-b-eval.test.ts
+++ b/packages/app-core/scripts/voice/__tests__/voice-stage-b-eval.test.ts
@@ -1,8 +1,9 @@
 // Exercises tests voice stage b eval.test automation behavior with deterministic script fixtures.
-import { describe, expect, test } from "vitest";
+
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, test } from "vitest";
 import {
   STAGE_B_SCHEMA,
   validateStageBReport,

--- a/packages/app-core/test/helpers/real-runtime.ts
+++ b/packages/app-core/test/helpers/real-runtime.ts
@@ -504,9 +504,8 @@ export async function createRealTestRuntime(
     // are intentionally optional in a given test stay best-effort.
     for (const plugin of options?.plugins ?? []) {
       for (const service of plugin.services ?? []) {
-        const serviceType = (
-          service as unknown as { serviceType?: string }
-        ).serviceType;
+        const serviceType = (service as unknown as { serviceType?: string })
+          .serviceType;
         if (!serviceType) continue;
         try {
           await runtime.getServiceLoadPromise(serviceType);

--- a/packages/app-core/test/server-config-filter.test.ts
+++ b/packages/app-core/test/server-config-filter.test.ts
@@ -1,10 +1,11 @@
 /** Exercises server config filter behavior with deterministic app-core test fixtures. */
-import { describe, expect, test } from "vitest";
+
 import { ElizaError } from "@elizaos/core";
+import { describe, expect, test } from "vitest";
 import {
   CONFIG_FILTER_UNBOUNDED,
-  MAX_CONFIG_FILTER_DEPTH,
   filterConfigEnvForResponse,
+  MAX_CONFIG_FILTER_DEPTH,
 } from "../src/api/server-config-filter";
 
 describe("filterConfigEnvForResponse", () => {

--- a/packages/app/tsconfig.base.json
+++ b/packages/app/tsconfig.base.json
@@ -21,9 +21,6 @@
     "useUnknownInCatchVariables": true,
     "types": ["vite/client", "bun-types"]
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist", "ios", "android", "electrobun"]
 }


### PR DESCRIPTION
# Relates to

Follows #25816 (and #25333, #25700 before it). Currently blocking #25939, whose diff touches none of the offending packages.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`20f5fab88e6`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None.** `biome check --write` (safe fixes only): formatting and import order. `git diff -w` shows only wrapped lines and re-sorted imports.

# Background

## What does this PR do?

Six packages drifted back out of lint closure within hours of #25816 merging: `app`, `app-core`, `cloud-test-mocks`, `core`, `plugin-inbox`, `ui`. Because the lane runs the affected *closure*, a PR touching none of them still fails if its closure reaches one — which is what is blocking #25939 right now.

**This will keep recurring, and a third sweep should not be the answer.** The lane fails on the *next unrelated PR* rather than on the one that introduced the unformatted file, so the cost lands on whoever comes after. The durable fix is a required per-PR format gate — something that makes the introducing PR red — rather than repeated janitorial passes. I have not built that here because it is a CI-policy decision, not a code change I should make unilaterally, but it is the thing worth doing.

## What kind of change is this?

Chore (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`git diff -w` — if it shows only wrapped lines and re-sorted imports, the diff is doing exactly what it claims.

## Detailed testing steps

Enumerated by sweeping pristine develop first rather than guessing: `node packages/scripts/run-turbo.mjs run lint:check --concurrency=4 --continue` → the six packages above. After the pass, each one's own `bun run lint:check` reports clean (`No fixes applied`).

# Evidence Gate

<!-- evidence-head:ba24fcf5eeaaee7f872467082883171c25f0568e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - formatting only.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - formatting only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
N/A - formatting only.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Warnings untouched; only errors fail the lane.
- The recurrence itself is unaddressed by design — see the note above.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

