### PR TITLE
test(core): cover identity clusters

### DIFF
--- a/packages/core/src/identity-clusters.test.ts
+++ b/packages/core/src/identity-clusters.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for identity-clusters: validates entity expansion,
+ * verified identity authority validation, cache invalidation, and fallbacks.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "./errors.ts";
+import {
+	getRelatedEntityIds,
+	getVerifiedRelatedEntityIds,
+	invalidateRelatedEntityIds,
+	resolvePrimaryEntityId,
+} from "./identity-clusters.ts";
+import { type IAgentRuntime, ServiceType, type UUID } from "./types/index.ts";
+
+describe("identity-clusters", () => {
+	const mockAgentId = "00000000-0000-0000-0000-000000000000" as UUID;
+	const entity1 = "11111111-1111-1111-1111-111111111111" as UUID;
+	const entity2 = "22222222-2222-2222-2222-222222222222" as UUID;
+
+	function createRuntime(services: Record<string, any> = {}) {
+		return {
+			agentId: mockAgentId,
+			getService: (type: string) => services[type] ?? null,
+		} as unknown as IAgentRuntime;
+	}
+
+	describe("getRelatedEntityIds", () => {
+		it("returns [entityId] when relationships service is absent", async () => {
+			const runtime = createRuntime();
+			const result = await getRelatedEntityIds(runtime, entity1);
+			expect(result).toEqual([entity1]);
+		});
+
+		it("expands entity cluster via relationships service", async () => {
+			const runtime = createRuntime({
+				relationships: {
+					getMemberEntityIds: async (id: UUID) => [id, entity2],
+				},
+			});
+			const result = await getRelatedEntityIds(runtime, entity1);
+			expect(result).toEqual([entity1, entity2]);
+		});
+	});
+
+	describe("getVerifiedRelatedEntityIds", () => {
+		it("uses PrincipalService when available and validates cluster shape", async () => {
+			const runtime = createRuntime({
+				[ServiceType.PRINCIPAL]: {
+					getCluster: async () => ({
+						agentId: mockAgentId,
+						generation: 1,
+						canonicalPrincipalId: entity1,
+						principalIds: [entity1, entity2],
+					}),
+				},
+			});
+
+			const result = await getVerifiedRelatedEntityIds(runtime, entity1);
+			expect(result).toEqual([entity1, entity2]);
+		});
+
+		it("throws ElizaError on invalid cluster generation or mismatch", async () => {
+			const runtime = createRuntime({
+				[ServiceType.PRINCIPAL]: {
+					getCluster: async () => ({
+						agentId: mockAgentId,
+						generation: -1, // invalid generation
+						canonicalPrincipalId: entity1,
+						principalIds: [entity1],
+					}),
+				},
+			});
+
+			await expect(
+				getVerifiedRelatedEntityIds(runtime, entity1),
+			).rejects.toThrow(ElizaError);
+		});
+	});
+
+	describe("resolvePrimaryEntityId", () => {
+		it("returns original entityId when resolver is absent", async () => {
+			const runtime = createRuntime();
+			expect(await resolvePrimaryEntityId(runtime, entity1)).toBe(entity1);
+		});
+
+		it("resolves primary entity id when service provides it", async () => {
+			const runtime = createRuntime({
+				relationships: {
+					resolvePrimaryEntityId: async () => entity2,
+				},
+			});
+			expect(await resolvePrimaryEntityId(runtime, entity1)).toBe(entity2);
+		});
+	});
+
+	describe("invalidateRelatedEntityIds", () => {
+		it("runs without throwing for specific entity or all entities", () => {
+			const runtime = createRuntime();
+			expect(() => invalidateRelatedEntityIds(runtime, entity1)).not.toThrow();
+			expect(() => invalidateRelatedEntityIds(runtime)).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds comprehensive unit test coverage with no production code modifications.

# Background

## What does this PR do?
Adds unit tests for identity cluster expansion, verified principal checks, cache invalidation, and primary entity resolution.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/core/src/identity-clusters.test.ts`

## Detailed testing steps
Run:
```bash
node packages/scripts/run-vitest.mjs run packages/core/src/identity-clusters.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:278c5b862c6232df2018fe293e5a734abd15bb29 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.10 [39m[90m/private/tmp/wt-ship-lane-01[39m

 [32m✓[39m packages/core/src/identity-clusters.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 2[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m7 passed[39m[22m[90m (7)[39m
[2m   Start at [22m 06:48:06
[2m   Duration [22m 321ms[2m (transform 191ms, setup 0ms, import 262ms, tests 2ms, environment 0ms)[22m
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
