### PR TITLE
fix(app-core): correct auth-token test import path

### DIFF
--- a/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
+++ b/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
@@ -1,9 +1,10 @@
+/** Verifies deterministic API-token extraction and constant-time token comparison helpers. */
 import { describe, expect, it } from "vitest";
 import {
   extractHeaderValue,
   getProvidedApiToken,
   tokenMatches,
-} from "./tokens.ts";
+} from "../tokens.ts";
 
 describe("tokenMatches", () => {
   it("matches equal tokens", () => {


### PR DESCRIPTION
Closes #25549.

## What changed

- correct the auth-token unit test import from `./tokens.ts` to `../tokens.ts`
- add the repository-required maintained-source header to the touched test

## Verification

- `bun test packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts` — 6 passed, 0 failed; 100% line/function coverage for `tokens.ts`
- `biome check packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts` — passed
- `git diff --check` — passed
- composed root `bun run verify` previously reached 232/234 tasks and identified this import as the sole typecheck failure; the complete gate will be rerun with this commit composed

## Scope

Test-only import correction; no runtime or visual behavior changes. Visual evidence is N/A.

## Attribution

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
