### PR TITLE
test(scenarios): isolate the coding-tools fixture tree per runner process

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
@@ -18,9 +18,15 @@ import codingToolsPlugin from "../../../../plugins/plugin-coding-tools/src/index
 
 const execFileAsync = promisify(execFile);
 
+// Fixture tree for this scenario. Seed and cleanup both `rm -rf` this root,
+// so it must be unique per runner process: with a constant path, two
+// concurrent runners — separate worktrees, CI shards, or two developers on
+// one box — delete each other's tree mid-run. The victim then fails somewhere
+// unrelated-looking, e.g. the seeded repo is gone so SHELL runs in the
+// process cwd instead of the fixture repo.
 const tmpRoot = path.join(
   realpathSync(os.tmpdir()),
-  "eliza-scenario-coding-tools",
+  `eliza-scenario-coding-tools-${process.pid}`,
 );
 const repoRoot = path.join(tmpRoot, "repo");
 const blockedRoot = path.join(tmpRoot, "_blocked");


### PR DESCRIPTION
# Relates to

Completes #25758, which fixed the same hazard for the two app-control scenarios. This was the remaining destructive one. It also corrects a wrong note I left in #25932 — see Known gaps.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`20f5fab88e6`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** One scenario file: the fixture root gains a `process.pid` suffix, plus a comment.

# Background

## What does this PR do?

`deterministic-coding-tools-actions` pinned its fixture tree to a constant path under the system tmpdir and `rm -rf`'d it in **both** the seed and the cleanup step. Two runners executing this scenario concurrently — separate worktrees, CI shards, or two developers on one box — delete each other's tree mid-run, and the victim fails somewhere that looks nothing like a filesystem problem.

Reproduced deterministically with two runs staggered 4 seconds:

| fixture root | run A | run B |
|---|---|---|
| constant (today) | passed | **failed** — `assertTurn: expected SHELL cwd=<tmp>/eliza-scenario-coding-tools/repo, saw /Users/nubs/Gi…` (its seeded repo was gone, so the shell ran in the process cwd) |
| per-process (this PR) | passed | passed |

Eight sibling scenarios in this directory already derive their roots from `mkdtemp`/`os.tmpdir()`; this one and the two app-control scenarios were the outliers.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation; the fixture root carries a comment explaining why it is process-scoped and what the victim's failure looks like.

# Testing

## Where should a reviewer start?

The `tmpRoot` definition and the two `fs.rm(tmpRoot, …)` calls in the seed and cleanup steps that consume it.

## Detailed testing steps

- Standalone: **three consecutive passes**, ~7 s each.
- Concurrency: the staggered A/B pair above, run both ways on the same tree — constant path reproduces the failure, per-process does not.
- Biome clean.

# Evidence Gate

<!-- evidence-head:7dc1fee7a72a85cb93c1b8f58f86a2f4e11688e4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The runner's own assertion output for the victim run, quoted above — the expected fixture cwd versus the process cwd it fell back to once its tree was deleted.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The fixture trees themselves: previously one shared path, now one per runner process.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The runner's own assertion output for the victim run, quoted above — the expected fixture cwd versus the process cwd it fell back to once its tree was deleted.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- **Correcting my own earlier note.** #25932's body says this one-line fix "breaks this scenario", citing a 182 ms failure with `deterministic model fixtures were not consumed`. That conclusion was wrong: the failure came from the in-process plugin-union leak that #25932 itself fixes, not from the path. With #25932 on develop, the per-process root passes standalone three times over and under concurrent load. I have left the note in place rather than quietly editing a merged PR, so the correction is visible here.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

