### PR TITLE
fix(auth): recover orphaned passkey enrollment

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -167,6 +167,13 @@ describe("StewardLoginSection passkey capability gating", () => {
     stewardAuthSpies.getSession.mockReturnValue(null);
     stewardAuthSpies.refreshSession.mockResolvedValue(null);
     stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
+    stewardAuthSpies.verifyEmailOtp.mockResolvedValue({
+      emailGrant: "grant-default",
+    });
+    stewardAuthSpies.addPasskey.mockResolvedValue({
+      token: "registered-token",
+      refreshToken: null,
+    });
     passkeyHintSpies.has.mockResolvedValue(false);
     passkeyHintSpies.remember.mockResolvedValue(true);
     emailLoginSpies.start.mockResolvedValue({
@@ -586,15 +593,9 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
   });
 
-  it("rejects a too-short OTP code without calling the API and reports a cancelled passkey setup", async () => {
+  it("reuses the verified email grant after a cancelled passkey ceremony", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
-    stewardAuthSpies.signInWithPasskey.mockRejectedValue(
-      new StewardApiError(
-        "WebAuthn authentication cancelled or failed: NotAllowedError",
-        0,
-      ),
-    );
     stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
     stewardAuthSpies.verifyEmailOtp.mockResolvedValue({
       emailGrant: "grant-1",
@@ -610,13 +611,7 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Use an existing passkey" }),
-    );
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Set up passkey" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
 
     const codeInput = await screen.findByPlaceholderText("123456");
 
@@ -636,6 +631,133 @@ describe("StewardLoginSection passkey capability gating", () => {
         "Passkey setup was cancelled. Tap Create passkey to retry.",
       ),
     ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Use existing passkey" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Use Magic Link" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+
+    await waitFor(() => {
+      expect(stewardAuthSpies.addPasskey).toHaveBeenCalledTimes(2);
+    });
+    expect(stewardAuthSpies.verifyEmailOtp).toHaveBeenCalledTimes(1);
+    expect(stewardAuthSpies.addPasskey).toHaveBeenNthCalledWith(
+      1,
+      "person@example.com",
+      { emailGrant: "grant-1" },
+    );
+    expect(stewardAuthSpies.addPasskey).toHaveBeenNthCalledWith(
+      2,
+      "person@example.com",
+      { emailGrant: "grant-1" },
+    );
+  });
+
+  it.each([
+    [
+      "server conflict",
+      new StewardApiError(
+        "A passkey already exists for this email. Sign in with it instead.",
+        409,
+      ),
+    ],
+    [
+      "browser duplicate signal",
+      new StewardApiError(
+        "WebAuthn registration cancelled or failed: InvalidStateError: The authenticator was previously registered",
+        0,
+      ),
+    ],
+  ])(
+    "recovers an OTP-proven existing passkey from a %s",
+    async (_label, duplicateError) => {
+      capabilityRef.usable = true;
+      capabilityRef.reason = "available";
+      stewardAuthSpies.verifyEmailOtp.mockResolvedValue({
+        emailGrant: "grant-existing",
+      });
+      stewardAuthSpies.addPasskey.mockRejectedValue(duplicateError);
+
+      renderSection();
+
+      const input = await screen.findByPlaceholderText("you@example.com");
+      fireEvent.change(input, { target: { value: "person@example.com" } });
+      fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+
+      const codeInput = await screen.findByPlaceholderText("123456");
+      fireEvent.change(codeInput, { target: { value: "123456" } });
+      fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+
+      await waitFor(() => {
+        expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
+          "person@example.com",
+          { fallbackToRegistration: false },
+        );
+      });
+      expect(passkeyHintSpies.remember).toHaveBeenCalledWith(
+        "person@example.com",
+      );
+      expect(stewardAuthSpies.verifyEmailOtp).toHaveBeenCalledTimes(1);
+      expect(stewardAuthSpies.addPasskey).toHaveBeenCalledTimes(1);
+      expect(
+        screen.queryByText(
+          "Passkey setup was cancelled. Tap Create passkey to retry.",
+        ),
+      ).toBeNull();
+    },
+  );
+
+  it("clears the cached email grant when the user resends the OTP", async () => {
+    capabilityRef.usable = true;
+    capabilityRef.reason = "available";
+    stewardAuthSpies.verifyEmailOtp
+      .mockResolvedValueOnce({ emailGrant: "grant-1" })
+      .mockResolvedValueOnce({ emailGrant: "grant-2" });
+    stewardAuthSpies.addPasskey
+      .mockRejectedValueOnce(
+        new StewardApiError(
+          "WebAuthn registration cancelled or failed: NotAllowedError",
+          0,
+        ),
+      )
+      .mockResolvedValueOnce({
+        token: "registered-token",
+        refreshToken: null,
+      });
+
+    renderSection();
+
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: "person@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+
+    let codeInput = await screen.findByPlaceholderText("123456");
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+    expect(
+      await screen.findByText(
+        "Passkey setup was cancelled. Tap Create passkey to retry.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await waitFor(() => {
+      expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledTimes(2);
+    });
+
+    codeInput = screen.getByPlaceholderText("123456");
+    fireEvent.change(codeInput, { target: { value: "654321" } });
+    fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+
+    await waitFor(() => {
+      expect(stewardAuthSpies.verifyEmailOtp).toHaveBeenCalledTimes(2);
+    });
+    expect(stewardAuthSpies.addPasskey).toHaveBeenNthCalledWith(
+      2,
+      "person@example.com",
+      { emailGrant: "grant-2" },
+    );
   });
 
   it("requires an email before sending a magic link and surfaces send failures", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -584,6 +584,9 @@ export default function StewardLoginSection() {
   const [phone, setPhone] = useState("");
   const [smsCode, setSmsCode] = useState("");
   const [otpCode, setOtpCode] = useState("");
+  const [passkeyEmailGrant, setPasskeyEmailGrant] = useState<string | null>(
+    null,
+  );
   const [emailCode, setEmailCode] = useState("");
   const [emailChallenge, setEmailChallenge] =
     useState<StewardEmailLoginChallenge | null>(null);
@@ -599,6 +602,8 @@ export default function StewardLoginSection() {
   const [loading, setLoading] = useState<Provider | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showPasskeyRecovery, setShowPasskeyRecovery] = useState(false);
+  const [showPasskeyEnrollmentRecovery, setShowPasskeyEnrollmentRecovery] =
+    useState(false);
   const [telegramIntent, setTelegramIntent] = useState(false);
   const telegramIntentButtonRef = useRef<HTMLButtonElement>(null);
   const telegramRegionRef = useRef<HTMLFieldSetElement>(null);
@@ -1122,6 +1127,8 @@ export default function StewardLoginSection() {
     refreshToken?: string | null,
     options?: { verifiedPhone: string },
   ) {
+    setPasskeyEmailGrant(null);
+    setShowPasskeyEnrollmentRecovery(false);
     if (options) {
       await syncStewardSessionCookie(token, refreshToken, options);
     } else {
@@ -1205,6 +1212,26 @@ export default function StewardLoginSection() {
     );
   }
 
+  function isPasskeyAlreadyRegistered(e: unknown): boolean {
+    const msg = getErrorMessage(e, "").toLowerCase();
+    if (
+      e instanceof StewardApiError &&
+      e.status === 409 &&
+      (msg.includes("passkey already") ||
+        msg.includes("credential already") ||
+        msg.includes("already registered"))
+    ) {
+      return true;
+    }
+    if (!isBrowserOwnedWebAuthnFailure(e, msg)) return false;
+    return (
+      msg.includes("previously registered") ||
+      msg.includes("already registered") ||
+      msg.includes("invalidstateerror") ||
+      msg.includes("error_authenticator_previously_registered")
+    );
+  }
+
   // UV errors surface when the Steward server or browser WebAuthn layer requires
   // user verification (PIN/biometric) but the assertion didn't satisfy it. They
   // must NOT silently fall through to startPasskeySignup() — the user already
@@ -1241,6 +1268,7 @@ export default function StewardLoginSection() {
     setLoading("passkey");
     setError(null);
     setShowPasskeyRecovery(false);
+    setShowPasskeyEnrollmentRecovery(false);
     try {
       const result = requireCompletedAuth(
         await auth.signInWithPasskey(email.trim(), {
@@ -1295,6 +1323,8 @@ export default function StewardLoginSection() {
     setError(null);
     try {
       await auth.sendEmailOtp(email.trim());
+      setPasskeyEmailGrant(null);
+      setShowPasskeyEnrollmentRecovery(false);
       setOtpCode("");
       setShowPasskeyRecovery(false);
       setStep("otp-entry");
@@ -1313,21 +1343,47 @@ export default function StewardLoginSection() {
     }
     setLoading("passkey");
     setError(null);
+    setShowPasskeyEnrollmentRecovery(false);
     try {
-      const { emailGrant } = await auth.verifyEmailOtp(email.trim(), code);
+      let emailGrant = passkeyEmailGrant;
+      if (!emailGrant) {
+        ({ emailGrant } = await auth.verifyEmailOtp(email.trim(), code));
+        setPasskeyEmailGrant(emailGrant);
+      }
       const result = requireCompletedAuth(
         await auth.addPasskey(email.trim(), { emailGrant }),
       );
       await rememberPasskeyDeviceHint(email);
       await handleSuccess(result.token, result.refreshToken);
     } catch (e: unknown) {
+      // error-policy:J4 an OTP-proven account with a persisted credential
+      // recovers through authentication; ambiguous browser cancellation keeps
+      // registration retry plus explicit alternate sign-in choices visible.
+      if (isPasskeyAlreadyRegistered(e)) {
+        await rememberPasskeyDeviceHint(email);
+        setPasskeyEmailGrant(null);
+        setOtpCode("");
+        setShowPasskeyEnrollmentRecovery(false);
+        setStep("idle");
+        await runScopedPasskeyLogin();
+        return;
+      }
       if (isUserCancelled(e)) {
         setError("Passkey setup was cancelled. Tap Create passkey to retry.");
+        setShowPasskeyEnrollmentRecovery(true);
       } else {
         setError(getErrorMessage(e, "That code didn't work. Try again."));
       }
       setLoading(null);
     }
+  }
+
+  async function handleEnrollmentExistingPasskey() {
+    setPasskeyEmailGrant(null);
+    setOtpCode("");
+    setShowPasskeyEnrollmentRecovery(false);
+    setStep("idle");
+    await runScopedPasskeyLogin();
   }
 
   async function handleEmail() {
@@ -1337,6 +1393,8 @@ export default function StewardLoginSection() {
     }
     setLoading("email");
     setError(null);
+    setPasskeyEmailGrant(null);
+    setShowPasskeyEnrollmentRecovery(false);
     try {
       // The magic link can open in a new same-origin tab. Persist the pending
       // destination before asking Steward to send it so the callback can
@@ -1985,6 +2043,48 @@ export default function StewardLoginSection() {
           })}
         </Button>
 
+        {showPasskeyEnrollmentRecovery && (
+          <section
+            aria-label={t("cloud.login.otp.recoveryLabel", {
+              defaultValue: "Other passkey options",
+            })}
+            className="space-y-2 rounded-md border border-border-strong bg-bg-elevated p-3"
+          >
+            <p className="text-xs leading-relaxed text-muted">
+              {t("cloud.login.otp.recoveryMessage", {
+                defaultValue:
+                  "Already saved this passkey? Sign in with it, or use a Magic Link.",
+              })}
+            </p>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <Button
+                variant="ghost"
+                type="button"
+                onClick={handleEnrollmentExistingPasskey}
+                disabled={loading !== null}
+                className="min-h-touch rounded-md border border-border-strong px-3 py-2.5 text-sm font-semibold text-txt hover:border-border-hover hover:bg-bg-hover"
+              >
+                {t("cloud.login.button.existingPasskey", {
+                  defaultValue: "Use existing passkey",
+                })}
+              </Button>
+              {providers.email !== false && (
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={handleEmail}
+                  disabled={loading !== null}
+                  className="min-h-touch rounded-md border border-border-strong px-3 py-2.5 text-sm font-semibold text-txt hover:border-border-hover hover:bg-bg-hover"
+                >
+                  {t("cloud.login.passkeyRecovery.magicLink", {
+                    defaultValue: "Use Magic Link",
+                  })}
+                </Button>
+              )}
+            </div>
+          </section>
+        )}
+
         <div className="flex items-center justify-between text-sm">
           <Button
             variant="ghost"
@@ -1993,6 +2093,8 @@ export default function StewardLoginSection() {
             onClick={() => {
               setStep("idle");
               setOtpCode("");
+              setPasskeyEmailGrant(null);
+              setShowPasskeyEnrollmentRecovery(false);
               setError(null);
               setLoading(null);
             }}
@@ -2173,7 +2275,11 @@ export default function StewardLoginSection() {
             defaultValue: "you@example.com",
           })}
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            setPasskeyEmailGrant(null);
+            setShowPasskeyEnrollmentRecovery(false);
+          }}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               if (showPasskey) {


### PR DESCRIPTION
# Relates to

Follow-up to #24706. This handles the persisted-credential recovery case after an OTP-verified enrollment ceremony was interrupted after the authenticator had already been stored.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`20f5fab88e67bbe011ed5e5bfe370cc6c61e7f0e`).
- [x] Focused UI tests and `packages/ui` typecheck pass on the exact head.
- [x] A reviewer can confirm the state transition from the live staging trace below; visual evidence will be attached before this leaves draft.

# Sync with develop

- [x] Exact parent is current `origin/develop` (`20f5fab88e67bbe011ed5e5bfe370cc6c61e7f0e`); zero conflicts.
- [x] Focused suite: 22/22 pass.
- [x] `packages/ui` typecheck passes.
- [x] Cloud core build: 60/60 tasks.
- [x] Staging web build and byte verification pass.

# Risks

Medium. This changes the pre-auth passkey state machine and retry semantics. A false duplicate classification could send a user to existing-passkey login; the recovery panel retains explicit retry and Magic Link exits. The matching server response is ownership-bound to an OTP email grant. Production promotion is explicitly out of scope for this PR.

# Background

## What does this PR do?

- retains the one-time email verification grant across browser-owned registration retries;
- recognizes the ownership-bound `passkey_already_registered` response and browser duplicate-credential signals;
- immediately switches the same email to existing-passkey login instead of asking the browser to create the credential again;
- clears the grant on resend, Back, email change, Magic Link switch, or successful authentication;
- gives ambiguous cancellation a visible existing-passkey and Magic Link recovery path;
- adds regression coverage for grant reuse, server/browser duplicate recovery, and resend invalidation.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. The user-visible behavior is covered by regression tests and release evidence.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`
- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx`

## Detailed testing steps

1. Start from an email whose passkey registration previously persisted server-side but whose final session exchange failed.
2. Enter the email, choose Passkey, paste the emailed six-digit code, and submit once.
3. Verify the ownership-bound register/options response is recovered into existing-passkey login without `navigator.credentials.create` opening again.
4. Select the exact saved credential and complete Touch ID.
5. Verify the callback establishes the Steward session and lands in `/chat`, not billing.
6. Cancel a genuinely ambiguous browser ceremony and verify the retry, existing-passkey, and Magic Link exits remain visible.

# Evidence Gate

<!-- evidence-head:b1c85376e0bcb30ba37b816d6226fd2619715ffb -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page desktop/mobile screenshots: captured; upload pending before ready-for-review.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page desktop/mobile screenshots: captured; upload pending before ready-for-review.
<!-- evidence-row:walkthrough-video -->
- [ ] Exact-head MP4 walkthrough: pending before ready-for-review.
<!-- evidence-row:backend-logs -->
- [x] Real staging backend trace is summarized below; raw redacted receipt will be attached before ready-for-review.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend network/console bundle: pending before ready-for-review.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - authentication UI state-machine change; no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact staging build/deployment identifiers and server request ledger are recorded below.
<!-- evidence-row:ocr-review -->
- [ ] OCR review of exact-head screenshots: pending before ready-for-review.

# Evidence Details

## Backend + frontend logs

Exact staging head: `b1c85376e0bcb30ba37b816d6226fd2619715ffb`; Pages deployment `6248e24f-58f6-4d3d-9ec6-d1f7a63672b3`. All three staging hosts served the same manifest and all 592 JavaScript assets matched repository bytes.

Privacy-safe live request ledger (identifiers discarded):

- OTP send `200` (403 ms, thin path)
- OTP verify `200` (269 ms, thin path)
- passkey register/options expected recovery `409` (298 ms)
- passkey login/options `200` (140 ms, thin path), 91 ms after the recovery response
- passkey login/verify `200` (463 ms)
- Steward session exchange `200`; authenticated destination `/chat`
- no auth `500`; no passkey register/verify request occurred

## Screenshots (before / after) + video walkthrough

Captured against the exact staging build. Uploads are intentionally left as a draft gate and will be attached before requesting review.

## Known gaps / failures

- Draft-only until exact-head before/after screenshots, MP4, frontend network/console, and OCR artifacts are attached.
- The matching Steward recovery change must be promoted through its own reviewed main lineage and RP-scoped hardening. This PR must not be promoted independently.
- Public cold Worker evaluation still has an approximately 1.8-2.1 second p95 tail; warm passkey options are approximately 0.18-0.41 seconds.
- No production deployment or mutation was performed.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy Notes

Staging-only proof exists for this exact head. Do not promote until the companion Steward change is merged, rebuilt from main, and the complete auth matrix is rerun against one canonical certified staging tree.
