### PR TITLE
feat(core): deterministic CALCULATE action — chat arithmetic is computed, not recalled

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/calculate.ts
+++ b/packages/core/src/features/basic-capabilities/actions/calculate.ts
@@ -8,9 +8,9 @@
  * no eval/Function — so the result is arithmetic, not model recall.
  *
  * Integer-only expressions (+ - * % and non-negative integer ^) evaluate in
- * BigInt and are EXACT at any magnitude. Anything involving division or
- * decimals evaluates in floats and says so. Unsupported input is a typed
- * rejection naming the supported grammar — never a guess.
+ * BigInt and are exact within the explicit resource boundary below. Anything
+ * involving division or decimals evaluates in floats and says so. Unsupported
+ * or oversized input is a typed rejection — never a guess or partial result.
  */
 import type {
 	Action,
@@ -24,7 +24,20 @@ import { hasActionContext } from "../../../utils/action-validation.ts";
 
 type Num = { kind: "int"; value: bigint } | { kind: "float"; value: number };
 
-const int = (value: bigint): Num => ({ kind: "int", value });
+const MAX_EXPRESSION_CHARS = 10_000;
+const MAX_INTEGER_RESULT_DIGITS = 10_000;
+
+const integerDigits = (value: bigint): number =>
+	(value < 0n ? -value : value).toString().length;
+
+const int = (value: bigint): Num => {
+	if (integerDigits(value) > MAX_INTEGER_RESULT_DIGITS) {
+		throw new ExpressionError(
+			`Integer result is too large (max ${MAX_INTEGER_RESULT_DIGITS} digits)`,
+		);
+	}
+	return { kind: "int", value };
+};
 const flt = (value: number): Num => ({ kind: "float", value });
 const toFloat = (n: Num): number =>
 	n.kind === "int" ? Number(n.value) : n.value;
@@ -74,27 +87,27 @@ class Parser {
 	}
 
 	private term(): Num {
-		let left = this.power();
+		let left = this.unary();
 		for (;;) {
 			this.ws();
 			const op = this.src[this.pos];
 			const twoChar = this.src.slice(this.pos, this.pos + 2);
 			if (op === "*" && twoChar !== "**") {
 				this.pos++;
-				const right = this.power();
+				const right = this.unary();
 				left =
 					left.kind === "int" && right.kind === "int"
 						? int(left.value * right.value)
 						: flt(toFloat(left) * toFloat(right));
 			} else if (op === "/") {
 				this.pos++;
-				const right = this.power();
+				const right = this.unary();
 				const divisor = toFloat(right);
 				if (divisor === 0) throw new ExpressionError("Division by zero");
 				left = flt(toFloat(left) / divisor);
 			} else if (op === "%") {
 				this.pos++;
-				const right = this.power();
+				const right = this.unary();
 				if (left.kind === "int" && right.kind === "int") {
 					if (right.value === 0n) throw new ExpressionError("Division by zero");
 					left = int(left.value % right.value);
@@ -109,8 +122,23 @@ class Parser {
 		}
 	}
 
+	private unary(): Num {
+		this.ws();
+		const ch = this.src[this.pos];
+		if (ch === "-") {
+			this.pos++;
+			const value = this.unary();
+			return value.kind === "int" ? int(-value.value) : flt(-value.value);
+		}
+		if (ch === "+") {
+			this.pos++;
+			return this.unary();
+		}
+		return this.power();
+	}
+
 	private power(): Num {
-		const base = this.factor();
+		const base = this.primary();
 		this.ws();
 		const isCaret = this.src[this.pos] === "^";
 		const isStarStar = this.src.slice(this.pos, this.pos + 2) === "**";
@@ -118,7 +146,7 @@ class Parser {
 		this.pos += isStarStar ? 2 : 1;
 		// Right-associative; guard runaway integer exponents (10^6 digits is
 		// already far past anything a chat answer can carry).
-		const exponent = this.power();
+		const exponent = this.unary();
 		if (
 			base.kind === "int" &&
 			exponent.kind === "int" &&
@@ -127,12 +155,22 @@ class Parser {
 			if (exponent.value > 10_000n) {
 				throw new ExpressionError("Exponent too large (max 10000)");
 			}
+			const absoluteBase = base.value < 0n ? -base.value : base.value;
+			if (
+				absoluteBase > 1n &&
+				BigInt(integerDigits(absoluteBase)) * exponent.value >
+					BigInt(MAX_INTEGER_RESULT_DIGITS)
+			) {
+				throw new ExpressionError(
+					`Integer result is too large (max ${MAX_INTEGER_RESULT_DIGITS} digits)`,
+				);
+			}
 			return int(base.value ** exponent.value);
 		}
 		return flt(toFloat(base) ** toFloat(exponent));
 	}
 
-	private factor(): Num {
+	private primary(): Num {
 		this.ws();
 		const ch = this.src[this.pos];
 		if (ch === "(") {
@@ -145,16 +183,9 @@ class Parser {
 			this.pos++;
 			return inner;
 		}
-		if (ch === "-") {
-			this.pos++;
-			const inner = this.factor();
-			return inner.kind === "int" ? int(-inner.value) : flt(-inner.value);
-		}
-		if (ch === "+") {
-			this.pos++;
-			return this.factor();
-		}
-		const match = /^\d[\d_,]*(?:\.\d+)?/.exec(this.src.slice(this.pos));
+		const match = /^\d(?:\d|[,_](?=\d))*(?:\.\d+)?/.exec(
+			this.src.slice(this.pos),
+		);
 		if (!match) {
 			throw new ExpressionError(
 				`Expected a number at position ${this.pos + 1}`,
@@ -173,6 +204,11 @@ export function evaluateArithmetic(expression: string): {
 	text: string;
 	exact: boolean;
 } {
+	if (expression.length > MAX_EXPRESSION_CHARS) {
+		throw new ExpressionError(
+			`Expression is too large (max ${MAX_EXPRESSION_CHARS} characters)`,
+		);
+	}
 	const result = new Parser(expression).parse();
 	if (result.kind === "int") {
 		return { text: result.value.toString(), exact: true };
@@ -196,7 +232,7 @@ export const calculateAction: Action = {
 	name: "CALCULATE",
 	contexts: ["general"],
 	description:
-		"Exact arithmetic: evaluates a numeric expression (+ - * / % ^ parentheses, decimals, unary minus) deterministically. Use for ANY multi-digit arithmetic instead of computing in your head — model mental math is unreliable and this result is exact for integer expressions at any size.",
+		"Exact arithmetic: evaluates a numeric expression (+ - * / % ^ parentheses, decimals, unary minus) deterministically. Use for ANY multi-digit arithmetic instead of computing in your head — model mental math is unreliable and supported integer results are exact.",
 	descriptionCompressed:
 		"exact arithmetic eval; use for any multi-digit math instead of mental math",
 	similes: ["MATH", "COMPUTE", "ARITHMETIC", "MULTIPLY", "DIVIDE", "EVAL_MATH"],

--- a/packages/core/src/features/basic-capabilities/actions/calculate.ts
+++ b/packages/core/src/features/basic-capabilities/actions/calculate.ts
@@ -1,0 +1,262 @@
+/**
+ * CALCULATE — deterministic arithmetic for the chat surface. Language models
+ * reliably miscompute multi-digit arithmetic (live 2026-08-24: "3847 times
+ * 292" drew three different wrong products across the simple and planner
+ * paths), and the chat action surface carries no other compute tool: shell is
+ * gate-rejected from chat and a coding sub-agent is a build, not a
+ * calculator. The handler parses the expression itself — recursive descent,
+ * no eval/Function — so the result is arithmetic, not model recall.
+ *
+ * Integer-only expressions (+ - * % and non-negative integer ^) evaluate in
+ * BigInt and are EXACT at any magnitude. Anything involving division or
+ * decimals evaluates in floats and says so. Unsupported input is a typed
+ * rejection naming the supported grammar — never a guess.
+ */
+import type {
+	Action,
+	ActionResult,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "../../../types/index.ts";
+import { hasActionContext } from "../../../utils/action-validation.ts";
+
+type Num = { kind: "int"; value: bigint } | { kind: "float"; value: number };
+
+const int = (value: bigint): Num => ({ kind: "int", value });
+const flt = (value: number): Num => ({ kind: "float", value });
+const toFloat = (n: Num): number =>
+	n.kind === "int" ? Number(n.value) : n.value;
+
+class ExpressionError extends Error {}
+
+/** Recursive-descent evaluator over + - * / % ^ ( ) with unary minus. */
+class Parser {
+	private pos = 0;
+	constructor(private readonly src: string) {}
+
+	parse(): Num {
+		const value = this.expression();
+		this.ws();
+		if (this.pos < this.src.length) {
+			throw new ExpressionError(
+				`Unexpected "${this.src[this.pos]}" at position ${this.pos + 1}`,
+			);
+		}
+		return value;
+	}
+
+	private ws(): void {
+		while (this.pos < this.src.length && /\s/.test(this.src[this.pos] ?? "")) {
+			this.pos++;
+		}
+	}
+
+	private expression(): Num {
+		let left = this.term();
+		for (;;) {
+			this.ws();
+			const op = this.src[this.pos];
+			if (op !== "+" && op !== "-") return left;
+			this.pos++;
+			const right = this.term();
+			if (left.kind === "int" && right.kind === "int") {
+				left = int(
+					op === "+" ? left.value + right.value : left.value - right.value,
+				);
+			} else {
+				const l = toFloat(left);
+				const r = toFloat(right);
+				left = flt(op === "+" ? l + r : l - r);
+			}
+		}
+	}
+
+	private term(): Num {
+		let left = this.power();
+		for (;;) {
+			this.ws();
+			const op = this.src[this.pos];
+			const twoChar = this.src.slice(this.pos, this.pos + 2);
+			if (op === "*" && twoChar !== "**") {
+				this.pos++;
+				const right = this.power();
+				left =
+					left.kind === "int" && right.kind === "int"
+						? int(left.value * right.value)
+						: flt(toFloat(left) * toFloat(right));
+			} else if (op === "/") {
+				this.pos++;
+				const right = this.power();
+				const divisor = toFloat(right);
+				if (divisor === 0) throw new ExpressionError("Division by zero");
+				left = flt(toFloat(left) / divisor);
+			} else if (op === "%") {
+				this.pos++;
+				const right = this.power();
+				if (left.kind === "int" && right.kind === "int") {
+					if (right.value === 0n) throw new ExpressionError("Division by zero");
+					left = int(left.value % right.value);
+				} else {
+					const divisor = toFloat(right);
+					if (divisor === 0) throw new ExpressionError("Division by zero");
+					left = flt(toFloat(left) % divisor);
+				}
+			} else {
+				return left;
+			}
+		}
+	}
+
+	private power(): Num {
+		const base = this.factor();
+		this.ws();
+		const isCaret = this.src[this.pos] === "^";
+		const isStarStar = this.src.slice(this.pos, this.pos + 2) === "**";
+		if (!isCaret && !isStarStar) return base;
+		this.pos += isStarStar ? 2 : 1;
+		// Right-associative; guard runaway integer exponents (10^6 digits is
+		// already far past anything a chat answer can carry).
+		const exponent = this.power();
+		if (
+			base.kind === "int" &&
+			exponent.kind === "int" &&
+			exponent.value >= 0n
+		) {
+			if (exponent.value > 10_000n) {
+				throw new ExpressionError("Exponent too large (max 10000)");
+			}
+			return int(base.value ** exponent.value);
+		}
+		return flt(toFloat(base) ** toFloat(exponent));
+	}
+
+	private factor(): Num {
+		this.ws();
+		const ch = this.src[this.pos];
+		if (ch === "(") {
+			this.pos++;
+			const inner = this.expression();
+			this.ws();
+			if (this.src[this.pos] !== ")") {
+				throw new ExpressionError("Missing closing parenthesis");
+			}
+			this.pos++;
+			return inner;
+		}
+		if (ch === "-") {
+			this.pos++;
+			const inner = this.factor();
+			return inner.kind === "int" ? int(-inner.value) : flt(-inner.value);
+		}
+		if (ch === "+") {
+			this.pos++;
+			return this.factor();
+		}
+		const match = /^\d[\d_,]*(?:\.\d+)?/.exec(this.src.slice(this.pos));
+		if (!match) {
+			throw new ExpressionError(
+				`Expected a number at position ${this.pos + 1}`,
+			);
+		}
+		this.pos += match[0].length;
+		const literal = match[0].replace(/[_,]/g, "");
+		return literal.includes(".")
+			? flt(Number.parseFloat(literal))
+			: int(BigInt(literal));
+	}
+}
+
+/** Public for tests: evaluate one expression string. Throws ExpressionError. */
+export function evaluateArithmetic(expression: string): {
+	text: string;
+	exact: boolean;
+} {
+	const result = new Parser(expression).parse();
+	if (result.kind === "int") {
+		return { text: result.value.toString(), exact: true };
+	}
+	if (!Number.isFinite(result.value)) {
+		throw new ExpressionError("Result is not a finite number");
+	}
+	// 15 significant digits — the float's own faithful precision, disclosed.
+	return { text: String(Number(result.value.toPrecision(15))), exact: false };
+}
+
+function resolveExpression(options?: HandlerOptions): string | undefined {
+	const raw =
+		options?.parameters && typeof options.parameters === "object"
+			? (options.parameters as Record<string, unknown>).expression
+			: undefined;
+	return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+export const calculateAction: Action = {
+	name: "CALCULATE",
+	contexts: ["general"],
+	description:
+		"Exact arithmetic: evaluates a numeric expression (+ - * / % ^ parentheses, decimals, unary minus) deterministically. Use for ANY multi-digit arithmetic instead of computing in your head — model mental math is unreliable and this result is exact for integer expressions at any size.",
+	descriptionCompressed:
+		"exact arithmetic eval; use for any multi-digit math instead of mental math",
+	similes: ["MATH", "COMPUTE", "ARITHMETIC", "MULTIPLY", "DIVIDE", "EVAL_MATH"],
+	parameters: [
+		{
+			name: "expression",
+			description:
+				'The bare numeric expression to evaluate, e.g. "3847 * 292" or "(12.5 + 3) / 4". Numbers and + - * / % ^ ( ) only — no words, no variables.',
+			required: true,
+			schema: { type: "string" as const },
+		},
+	],
+	validate: async (
+		_runtime: IAgentRuntime,
+		message: Memory,
+		state?: State,
+	): Promise<boolean> =>
+		hasActionContext(message, state, { contexts: ["general"] }),
+	handler: async (
+		_runtime: IAgentRuntime,
+		_message: Memory,
+		_state?: State,
+		options?: HandlerOptions,
+	): Promise<ActionResult> => {
+		const expression = resolveExpression(options);
+		if (!expression) {
+			return {
+				success: false,
+				text: 'CALCULATE requires an `expression` parameter, e.g. "3847 * 292".',
+				values: { success: false },
+				data: {
+					actionName: "CALCULATE",
+					error: "CALCULATE_MISSING_EXPRESSION",
+				},
+			};
+		}
+		try {
+			const { text, exact } = evaluateArithmetic(expression);
+			return {
+				success: true,
+				text: `${expression} = ${text}${exact ? "" : " (floating-point; 15 significant digits)"}`,
+				values: { success: true, result: text, exact },
+				data: { actionName: "CALCULATE", expression, result: text, exact },
+			};
+		} catch (error) {
+			// error-policy:J3 untrusted expression text parses to an explicit
+			// invalid result — never a guessed number.
+			const reason =
+				error instanceof ExpressionError ? error.message : "unparseable input";
+			return {
+				success: false,
+				text: `CALCULATE could not evaluate "${expression}": ${reason}. Supported: numbers with + - * / % ^ and parentheses.`,
+				values: { success: false },
+				data: {
+					actionName: "CALCULATE",
+					error: "CALCULATE_INVALID_EXPRESSION",
+					expression,
+					reason,
+				},
+			};
+		}
+	},
+};

--- a/packages/core/src/features/basic-capabilities/actions/calculate.ts
+++ b/packages/core/src/features/basic-capabilities/actions/calculate.ts
@@ -26,6 +26,7 @@ type Num = { kind: "int"; value: bigint } | { kind: "float"; value: number };
 
 const MAX_EXPRESSION_CHARS = 10_000;
 const MAX_INTEGER_RESULT_DIGITS = 10_000;
+const MAX_PARSE_DEPTH = 256;
 
 const integerDigits = (value: bigint): number =>
 	(value < 0n ? -value : value).toString().length;
@@ -47,7 +48,22 @@ class ExpressionError extends Error {}
 /** Recursive-descent evaluator over + - * / % ^ ( ) with unary minus. */
 class Parser {
 	private pos = 0;
+	private depth = 0;
 	constructor(private readonly src: string) {}
+
+	private nested<T>(parse: () => T): T {
+		this.depth++;
+		if (this.depth > MAX_PARSE_DEPTH) {
+			throw new ExpressionError(
+				`Expression nesting is too deep (max ${MAX_PARSE_DEPTH})`,
+			);
+		}
+		try {
+			return parse();
+		} finally {
+			this.depth--;
+		}
+	}
 
 	parse(): Num {
 		const value = this.expression();
@@ -127,12 +143,12 @@ class Parser {
 		const ch = this.src[this.pos];
 		if (ch === "-") {
 			this.pos++;
-			const value = this.unary();
+			const value = this.nested(() => this.unary());
 			return value.kind === "int" ? int(-value.value) : flt(-value.value);
 		}
 		if (ch === "+") {
 			this.pos++;
-			return this.unary();
+			return this.nested(() => this.unary());
 		}
 		return this.power();
 	}
@@ -146,7 +162,7 @@ class Parser {
 		this.pos += isStarStar ? 2 : 1;
 		// Right-associative; guard runaway integer exponents (10^6 digits is
 		// already far past anything a chat answer can carry).
-		const exponent = this.unary();
+		const exponent = this.nested(() => this.unary());
 		if (
 			base.kind === "int" &&
 			exponent.kind === "int" &&
@@ -175,7 +191,7 @@ class Parser {
 		const ch = this.src[this.pos];
 		if (ch === "(") {
 			this.pos++;
-			const inner = this.expression();
+			const inner = this.nested(() => this.expression());
 			this.ws();
 			if (this.src[this.pos] !== ")") {
 				throw new ExpressionError("Missing closing parenthesis");

--- a/packages/core/src/features/basic-capabilities/actions/calculate.ts
+++ b/packages/core/src/features/basic-capabilities/actions/calculate.ts
@@ -174,7 +174,7 @@ class Parser {
 			const absoluteBase = base.value < 0n ? -base.value : base.value;
 			if (
 				absoluteBase > 1n &&
-				BigInt(integerDigits(absoluteBase)) * exponent.value >
+				(BigInt(integerDigits(absoluteBase)) - 1n) * exponent.value + 1n >
 					BigInt(MAX_INTEGER_RESULT_DIGITS)
 			) {
 				throw new ExpressionError(

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -60,6 +60,8 @@ describe("evaluateArithmetic", () => {
 			"99 ^ 10000",
 			"3 +",
 			"1".repeat(10_001),
+			`${"(".repeat(300)}1${")".repeat(300)}`,
+			`${"-".repeat(300)}1`,
 		]) {
 			expect(() => evaluateArithmetic(bad)).toThrow();
 		}
@@ -106,6 +108,9 @@ describe("deterministic arithmetic routing", () => {
 			"3847 * 292?",
 			"1,234 divided by 7 pls",
 			"what is 12345 plus 999",
+			"what is 3847 - 292",
+			"3847 / 292",
+			"3847 x 292?",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
 				"CALCULATE",
@@ -119,6 +124,13 @@ describe("deterministic arithmetic routing", () => {
 			"see you at 10 - 11 tomorrow",
 			"i walked 5 x this week",
 			"no math here at all",
+			"our 2024-2025 plan is attached",
+			"our 2024 - 2025 plan is attached",
+			"ISO 9001-2015 certification",
+			"call 555-1234 tomorrow",
+			"the 100-200 range",
+			"upgrade from version 100/200",
+			"use the 1920x1080 image",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual(
 				[],

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -38,6 +38,10 @@ describe("evaluateArithmetic", () => {
 			text: "24691357802469135780",
 			exact: true,
 		});
+		const power = evaluateArithmetic("10 ^ 5001");
+		expect(power.exact).toBe(true);
+		expect(power.text).toHaveLength(5002);
+		expect(power.text).toMatch(/^10+$/);
 	});
 
 	it("accepts digit separators", () => {

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -135,6 +135,11 @@ describe("deterministic arithmetic routing", () => {
 			"the 100-200 range",
 			"upgrade from version 100/200",
 			"use the 1920x1080 image",
+			"what is ISO 9001-2015 certification?",
+			"what is the 100-200 range?",
+			"what is 1920x1080 resolution?",
+			"what is version 100/200?",
+			"2024-2025",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual(
 				[],

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -115,6 +115,8 @@ describe("deterministic arithmetic routing", () => {
 			"what is 3847 - 292",
 			"3847 / 292",
 			"3847 x 292?",
+			"calculate 2024-2025",
+			"what is 2024-2025?",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
 				"CALCULATE",

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -24,6 +24,12 @@ describe("evaluateArithmetic", () => {
 		expect(evaluateArithmetic("-5 + 3").text).toBe("-2");
 		expect(evaluateArithmetic("2 ^ 10").text).toBe("1024");
 		expect(evaluateArithmetic("2 ** 10").text).toBe("1024");
+		expect(evaluateArithmetic("-2 ^ 2").text).toBe("-4");
+		expect(evaluateArithmetic("(-2) ^ 2").text).toBe("4");
+		expect(evaluateArithmetic("2 ^ -2")).toEqual({
+			text: "0.25",
+			exact: false,
+		});
 		expect(evaluateArithmetic("10 % 3").text).toBe("1");
 	});
 
@@ -44,8 +50,17 @@ describe("evaluateArithmetic", () => {
 		expect(evaluateArithmetic("0.1 + 0.2").text).toBe("0.3");
 	});
 
-	it("rejects words, variables, division by zero, and runaway exponents", () => {
-		for (const bad of ["two plus two", "x * 3", "5 / 0", "2 ^ 20000", "3 +"]) {
+	it("rejects invalid input and oversized work before returning a partial result", () => {
+		for (const bad of [
+			"two plus two",
+			"x * 3",
+			"1,,2 + 3",
+			"5 / 0",
+			"2 ^ 20000",
+			"99 ^ 10000",
+			"3 +",
+			"1".repeat(10_001),
+		]) {
 			expect(() => evaluateArithmetic(bad)).toThrow();
 		}
 	});

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -1,0 +1,113 @@
+/**
+ * CALCULATE action: deterministic recursive-descent arithmetic (BigInt-exact
+ * integer lane, disclosed float lane), typed rejection of unparseable input,
+ * and general-context reachability. Deterministic unit harness; no model.
+ */
+import { describe, expect, it } from "vitest";
+import { inferDirectCurrentRequestCandidateActions } from "../../services/message/direct-action-heuristics.ts";
+import type { ActionResult } from "../../types/index.ts";
+import { calculateAction, evaluateArithmetic } from "./actions/calculate.ts";
+import { basicActions } from "./index.ts";
+
+describe("evaluateArithmetic", () => {
+	it("computes the live-incident product exactly", () => {
+		// 2026-08-24: the model produced 1,123,186 / 1,122,824 for this ask.
+		expect(evaluateArithmetic("3847 * 292")).toEqual({
+			text: "1123324",
+			exact: true,
+		});
+	});
+
+	it("honors precedence, parentheses, and unary minus", () => {
+		expect(evaluateArithmetic("2 + 3 * 4").text).toBe("14");
+		expect(evaluateArithmetic("(2 + 3) * 4").text).toBe("20");
+		expect(evaluateArithmetic("-5 + 3").text).toBe("-2");
+		expect(evaluateArithmetic("2 ^ 10").text).toBe("1024");
+		expect(evaluateArithmetic("2 ** 10").text).toBe("1024");
+		expect(evaluateArithmetic("10 % 3").text).toBe("1");
+	});
+
+	it("is exact beyond float precision in the integer lane", () => {
+		expect(evaluateArithmetic("12345678901234567890 * 2")).toEqual({
+			text: "24691357802469135780",
+			exact: true,
+		});
+	});
+
+	it("accepts digit separators", () => {
+		expect(evaluateArithmetic("1,234 * 1_000").text).toBe("1234000");
+	});
+
+	it("division and decimals use the disclosed float lane", () => {
+		const r = evaluateArithmetic("847 / 7");
+		expect(r).toEqual({ text: "121", exact: false });
+		expect(evaluateArithmetic("0.1 + 0.2").text).toBe("0.3");
+	});
+
+	it("rejects words, variables, division by zero, and runaway exponents", () => {
+		for (const bad of ["two plus two", "x * 3", "5 / 0", "2 ^ 20000", "3 +"]) {
+			expect(() => evaluateArithmetic(bad)).toThrow();
+		}
+	});
+});
+
+describe("CALCULATE action", () => {
+	it("is registered in the basic bundle", () => {
+		expect(basicActions.some((a) => a.name === "CALCULATE")).toBe(true);
+	});
+
+	it("evaluates through the handler with a complete equation in text", async () => {
+		const result = (await calculateAction.handler(
+			{} as never,
+			{} as never,
+			undefined,
+			{ parameters: { expression: "3847 * 292" } },
+		)) as ActionResult;
+		expect(result.success).toBe(true);
+		expect(result.text).toBe("3847 * 292 = 1123324");
+	});
+
+	it("returns a typed rejection for unparseable input — never a guess", async () => {
+		const result = (await calculateAction.handler(
+			{} as never,
+			{} as never,
+			undefined,
+			{ parameters: { expression: "the meaning of life" } },
+		)) as ActionResult;
+		expect(result.success).toBe(false);
+		expect((result.data as { error: string }).error).toBe(
+			"CALCULATE_INVALID_EXPRESSION",
+		);
+		expect(result.text).not.toMatch(/= \d/);
+	});
+});
+
+describe("deterministic arithmetic routing", () => {
+	const actions = [{ name: "CALCULATE", similes: [], tags: [] }];
+
+	it("routes explicit multi-digit arithmetic to CALCULATE", () => {
+		for (const text of [
+			"whats 3847 times 292",
+			"3847 * 292?",
+			"1,234 divided by 7 pls",
+			"what is 12345 plus 999",
+		]) {
+			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
+				"CALCULATE",
+			]);
+		}
+	});
+
+	it("leaves two-digit mental math and ordinary prose on the simple path", () => {
+		for (const text of [
+			"whats 17 times 23",
+			"see you at 10 - 11 tomorrow",
+			"i walked 5 x this week",
+			"no math here at all",
+		]) {
+			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual(
+				[],
+			);
+		}
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -138,6 +138,7 @@ import { readAttachmentAction } from "../working-memory/readAttachmentAction.ts"
 // Direct leaf imports — see comment in
 // ../advanced-capabilities/index.ts for the Bun.build mis-rewrite that
 // requires bypassing barrels here too.
+import { calculateAction } from "./actions/calculate.ts";
 import { channelTopicSearchAction } from "./actions/channel-topic-search.ts";
 import { choiceAction } from "./actions/choice.ts";
 import { ignoreAction } from "./actions/ignore.ts";
@@ -1454,6 +1455,7 @@ export const basicActions = [
 	withCanonicalActionDocs(ignoreAction),
 	withCanonicalActionDocs(noneAction),
 	withCanonicalActionDocs(channelTopicSearchAction),
+	withCanonicalActionDocs(calculateAction),
 ];
 
 /**

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1187,6 +1187,16 @@ describe("candidate family hints: arithmetic", () => {
 			expect(parentAliasesForCandidateAction(name)).toEqual(["CALCULATE"]);
 		}
 	});
+
+	it("does not treat unrelated candidate-name substrings as arithmetic", () => {
+		for (const name of [
+			"MULTIPLATFORM_SETUP",
+			"CALCULUS_NOTES",
+			"MATHILDA_PROFILE",
+		]) {
+			expect(parentAliasesForCandidateAction(name)).not.toContain("CALCULATE");
+		}
+	});
 });
 
 describe("contact lookup candidate aliases", () => {

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1181,6 +1181,33 @@ describe("F21 alias rows: email + terminal candidates bind to real parents", () 
 	});
 });
 
+describe("candidate family hints: arithmetic and task acceptance", () => {
+	it("arithmetic-shaped inventions hint the deterministic evaluator", () => {
+		for (const name of ["CALC_RESULT", "DO_MATH", "MULTIPLY_NUMBERS"]) {
+			expect(parentAliasesForCandidateAction(name)).toEqual(["CALCULATE"]);
+		}
+	});
+
+	it("task-acceptance inventions hint the TASKS control surface", () => {
+		for (const name of [
+			"COMPLETE_TASK",
+			"ACCEPT_TASK",
+			"TASK_APPROVE",
+			"MARK_DONE",
+		]) {
+			expect(parentAliasesForCandidateAction(name)).toEqual([
+				"TASKS_CONTROL",
+				"TASKS",
+			]);
+		}
+	});
+
+	it("bare ACCEPT/APPROVE stay unhinted — lifeops approval territory", () => {
+		expect(parentAliasesForCandidateAction("APPROVE")).toEqual([]);
+		expect(parentAliasesForCandidateAction("ACCEPT_MESSAGE")).toEqual([]);
+	});
+});
+
 describe("contact lookup candidate aliases", () => {
 	it.each([
 		"CONTACTS_LOOKUP",

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1181,30 +1181,11 @@ describe("F21 alias rows: email + terminal candidates bind to real parents", () 
 	});
 });
 
-describe("candidate family hints: arithmetic and task acceptance", () => {
+describe("candidate family hints: arithmetic", () => {
 	it("arithmetic-shaped inventions hint the deterministic evaluator", () => {
 		for (const name of ["CALC_RESULT", "DO_MATH", "MULTIPLY_NUMBERS"]) {
 			expect(parentAliasesForCandidateAction(name)).toEqual(["CALCULATE"]);
 		}
-	});
-
-	it("task-acceptance inventions hint the TASKS control surface", () => {
-		for (const name of [
-			"COMPLETE_TASK",
-			"ACCEPT_TASK",
-			"TASK_APPROVE",
-			"MARK_DONE",
-		]) {
-			expect(parentAliasesForCandidateAction(name)).toEqual([
-				"TASKS_CONTROL",
-				"TASKS",
-			]);
-		}
-	});
-
-	it("bare ACCEPT/APPROVE stay unhinted — lifeops approval territory", () => {
-		expect(parentAliasesForCandidateAction("APPROVE")).toEqual([]);
-		expect(parentAliasesForCandidateAction("ACCEPT_MESSAGE")).toEqual([]);
 	});
 });
 

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1180,20 +1180,6 @@ function explicitParentAliasesForCandidateAction(actionName: string): string[] {
 	if (/CALC|MATH|ARITH|MULTIPL|DIVIDE/.test(normalized)) {
 		return ["CALCULATE"];
 	}
-	// Task-acceptance inventions (COMPLETE_TASK, ACCEPT_TASK, MARK_DONE …)
-	// hint the TASKS control surface, whose approve verb is the human
-	// override the park notice asks for (live 2026-08-24: candidate
-	// COMPLETE_TASK resolved to nothing, the planner fell back to a
-	// PAGE_DELEGATE guess, and the acceptance never landed). Bare
-	// ACCEPT/APPROVE stems stay unhinted — they belong to the lifeops
-	// approval queue, not task control.
-	if (
-		/(?:COMPLETE|ACCEPT|APPROVE|FINISH|MARK).*TASK|TASK.*(?:COMPLETE|ACCEPT|APPROVE|DONE)|MARK_?DONE|MARK_?COMPLETE/.test(
-			normalized,
-		)
-	) {
-		return ["TASKS_CONTROL", "TASKS"];
-	}
 	return [];
 }
 

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1180,6 +1180,20 @@ function explicitParentAliasesForCandidateAction(actionName: string): string[] {
 	if (/CALC|MATH|ARITH|MULTIPL|DIVIDE/.test(normalized)) {
 		return ["CALCULATE"];
 	}
+	// Task-acceptance inventions (COMPLETE_TASK, ACCEPT_TASK, MARK_DONE …)
+	// hint the TASKS control surface, whose approve verb is the human
+	// override the park notice asks for (live 2026-08-24: candidate
+	// COMPLETE_TASK resolved to nothing, the planner fell back to a
+	// PAGE_DELEGATE guess, and the acceptance never landed). Bare
+	// ACCEPT/APPROVE stems stay unhinted — they belong to the lifeops
+	// approval queue, not task control.
+	if (
+		/(?:COMPLETE|ACCEPT|APPROVE|FINISH|MARK).*TASK|TASK.*(?:COMPLETE|ACCEPT|APPROVE|DONE)|MARK_?DONE|MARK_?COMPLETE/.test(
+			normalized,
+		)
+	) {
+		return ["TASKS_CONTROL", "TASKS"];
+	}
 	return [];
 }
 

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1171,7 +1171,16 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 
 function explicitParentAliasesForCandidateAction(actionName: string): string[] {
 	const normalized = normalizeActionName(actionName);
-	return [...(CANDIDATE_ACTION_PARENT_ALIASES[normalized] ?? [])];
+	const explicit = CANDIDATE_ACTION_PARENT_ALIASES[normalized];
+	if (explicit) return [...explicit];
+	// Arithmetic-shaped inventions (CALC_RESULT, DO_MATH, MULTIPLY_NUMBERS …)
+	// are open-ended — Stage 1 produces a fresh spelling per turn — so they
+	// hint the deterministic evaluator by family; admission still passes
+	// through appendIfAllowed's role/context gates.
+	if (/CALC|MATH|ARITH|MULTIPL|DIVIDE/.test(normalized)) {
+		return ["CALCULATE"];
+	}
+	return [];
 }
 
 const APP_SURFACE_TOKENS = new Set([

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1142,7 +1142,7 @@ function dedupeNormalizedStrings(values: string[] | undefined): string[] {
 
 export function parentAliasesForCandidateAction(actionName: string): string[] {
 	const normalized = normalizeActionName(actionName);
-	const explicit = explicitParentAliasesForCandidateAction(normalized);
+	const explicit = explicitParentAliasesForCandidateAction(actionName);
 	if (explicit.length > 0) return explicit;
 	// Permission/access management is SETTINGS (grant/revoke an app's fs/net
 	// namespace, OS permission requests, shell access) — never view navigation.
@@ -1177,7 +1177,11 @@ function explicitParentAliasesForCandidateAction(actionName: string): string[] {
 	// are open-ended — Stage 1 produces a fresh spelling per turn — so they
 	// hint the deterministic evaluator by family; admission still passes
 	// through appendIfAllowed's role/context gates.
-	if (/CALC|MATH|ARITH|MULTIPL|DIVIDE/.test(normalized)) {
+	if (
+		/(?:^|[^A-Z0-9])(?:CALC(?:ULATE)?|MATH|ARITH(?:METIC)?|MULTIPLY|DIVIDE)(?:[^A-Z0-9]|$)/u.test(
+			actionName.toUpperCase(),
+		)
+	) {
 		return ["CALCULATE"];
 	}
 	return [];

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -465,7 +465,8 @@ export type DirectCurrentRequestCandidateKind =
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
-	| "web";
+	| "web"
+	| "calculate";
 
 export interface DirectCurrentRequestCandidateInference {
 	names: string[];
@@ -1139,6 +1140,36 @@ export function inferDirectCurrentRequestCandidateActions(
 	).names;
 }
 
+/**
+ * Explicit multi-digit arithmetic in the message ("whats 3847 times 292",
+ * "1,234 * 56"). Deterministically detectable, and worth routing: models
+ * reliably miscompute once any operand reaches three digits (live
+ * 2026-08-24: three different wrong products for one ask), while the
+ * CALCULATE action is exact. Two-digit mental math stays on the simple path
+ * — it is fast and demonstrated reliable — so the detector requires at
+ * least one operand of three or more digits (separators ignored).
+ */
+const ARITHMETIC_OPERAND = "\\d[\\d,_]*(?:\\.\\d+)?";
+const ARITHMETIC_OPERATOR =
+	"(?:[*×xX/÷^%]|\\*\\*|[+-]|plus|minus|times|multiplied\\s+by|divided\\s+by|over|mod(?:ulo)?|to\\s+the\\s+power\\s+of)";
+const ARITHMETIC_EXPRESSION_RE = new RegExp(
+	`(${ARITHMETIC_OPERAND})\\s*${ARITHMETIC_OPERATOR}\\s*(${ARITHMETIC_OPERAND})`,
+	"iu",
+);
+
+function looksLikeMultiDigitArithmetic(text: string): boolean {
+	const match = ARITHMETIC_EXPRESSION_RE.exec(text);
+	if (!match) return false;
+	const digits = (operand: string) => operand.replace(/[^\d]/g, "").length;
+	return digits(match[1] ?? "") >= 3 || digits(match[2] ?? "") >= 3;
+}
+
+function findCalculateActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+): string | undefined {
+	return findAvailableActionName(actions, ["CALCULATE"]);
+}
+
 export function inferDirectCurrentRequestCandidateInference(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
@@ -1147,6 +1178,12 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (looksLikeLocalShellRequest(messageText)) {
 		const shellAction = findShellDirectActionName(actions);
 		if (shellAction) return { names: [shellAction], kind: "shell" };
+	}
+	if (looksLikeMultiDigitArithmetic(messageText)) {
+		const calculateAction = findCalculateActionName(actions);
+		if (calculateAction) {
+			return { names: [calculateAction], kind: "calculate" };
+		}
 	}
 	if (hooks.looksLikeCodingWorkRequest?.(messageText)) {
 		const codingAction = hooks.findCodingDelegationActionName?.(actions);

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1202,7 +1202,11 @@ function looksLikeMultiDigitArithmetic(text: string): boolean {
 		Number(left) <= 2199 &&
 		Number(right) >= 1900 &&
 		Number(right) <= 2199;
-	if (isBareCalendarYearRange) {
+	if (
+		isBareCalendarYearRange &&
+		!EXPLICIT_ARITHMETIC_REQUEST_CUE_RE.test(text) &&
+		BARE_AMBIGUOUS_ARITHMETIC_RE.test(text)
+	) {
 		return false;
 	}
 

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1150,18 +1150,52 @@ export function inferDirectCurrentRequestCandidateActions(
  * least one operand of three or more digits (separators ignored).
  */
 const ARITHMETIC_OPERAND = "\\d[\\d,_]*(?:\\.\\d+)?";
-const ARITHMETIC_OPERATOR =
-	"(?:[*×xX/÷^%]|\\*\\*|[+-]|plus|minus|times|multiplied\\s+by|divided\\s+by|over|mod(?:ulo)?|to\\s+the\\s+power\\s+of)";
-const ARITHMETIC_EXPRESSION_RE = new RegExp(
-	`(${ARITHMETIC_OPERAND})\\s*${ARITHMETIC_OPERATOR}\\s*(${ARITHMETIC_OPERAND})`,
+const STRONG_ARITHMETIC_OPERATOR =
+	"(?:\\*\\*|[*×÷^%]|plus|minus|times|multiplied\\s+by|divided\\s+by|over|mod(?:ulo)?|to\\s+the\\s+power\\s+of)";
+const AMBIGUOUS_ARITHMETIC_OPERATOR = "(?:[+\\-/]|[xX])";
+const STRONG_ARITHMETIC_EXPRESSION_RE = new RegExp(
+	`(${ARITHMETIC_OPERAND})\\s*${STRONG_ARITHMETIC_OPERATOR}\\s*(${ARITHMETIC_OPERAND})`,
+	"iu",
+);
+const AMBIGUOUS_ARITHMETIC_EXPRESSION_RE = new RegExp(
+	`(${ARITHMETIC_OPERAND})(\\s*)(${AMBIGUOUS_ARITHMETIC_OPERATOR})(\\s*)(${ARITHMETIC_OPERAND})`,
+	"iu",
+);
+const ARITHMETIC_REQUEST_CUE_RE =
+	/\b(?:calculate|compute|evaluate|solve|what(?:'s|\s+is)|how\s+much|equals?|answer)\b/iu;
+const BARE_AMBIGUOUS_ARITHMETIC_RE = new RegExp(
+	`^\\s*[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*${AMBIGUOUS_ARITHMETIC_OPERATOR}\\s*[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*[?!.]?\\s*$`,
 	"iu",
 );
 
 function looksLikeMultiDigitArithmetic(text: string): boolean {
-	const match = ARITHMETIC_EXPRESSION_RE.exec(text);
-	if (!match) return false;
 	const digits = (operand: string) => operand.replace(/[^\d]/g, "").length;
-	return digits(match[1] ?? "") >= 3 || digits(match[2] ?? "") >= 3;
+	const hasLargeOperand = (left: string, right: string) =>
+		digits(left) >= 3 || digits(right) >= 3;
+	const strongMatch = STRONG_ARITHMETIC_EXPRESSION_RE.exec(text);
+	if (
+		strongMatch &&
+		hasLargeOperand(strongMatch[1] ?? "", strongMatch[2] ?? "")
+	) {
+		return true;
+	}
+
+	const ambiguousMatch = AMBIGUOUS_ARITHMETIC_EXPRESSION_RE.exec(text);
+	if (
+		!ambiguousMatch ||
+		!hasLargeOperand(ambiguousMatch[1] ?? "", ambiguousMatch[5] ?? "")
+	) {
+		return false;
+	}
+
+	// Hyphens, slashes, plus signs, and the letter x occur routinely in dates,
+	// ranges, phone numbers, versions, and dimensions. Treat them as arithmetic
+	// only when the user supplies a math cue or the complete message is the
+	// expression; spacing alone must not narrow the action catalog.
+	return (
+		ARITHMETIC_REQUEST_CUE_RE.test(text) ||
+		BARE_AMBIGUOUS_ARITHMETIC_RE.test(text)
+	);
 }
 
 function findCalculateActionName(

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1161,8 +1161,12 @@ const AMBIGUOUS_ARITHMETIC_EXPRESSION_RE = new RegExp(
 	`(${ARITHMETIC_OPERAND})(\\s*)(${AMBIGUOUS_ARITHMETIC_OPERATOR})(\\s*)(${ARITHMETIC_OPERAND})`,
 	"iu",
 );
-const ARITHMETIC_REQUEST_CUE_RE =
-	/\b(?:calculate|compute|evaluate|solve|what(?:'s|\s+is)|how\s+much|equals?|answer)\b/iu;
+const EXPLICIT_ARITHMETIC_REQUEST_CUE_RE =
+	/\b(?:calculate|compute|evaluate|solve|how\s+much|equals?|answer)\b/iu;
+const WHAT_IS_AMBIGUOUS_ARITHMETIC_RE = new RegExp(
+	`^\\s*what(?:'s|\\s+is)\\s+[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*${AMBIGUOUS_ARITHMETIC_OPERATOR}\\s*[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*[?!.]?\\s*$`,
+	"iu",
+);
 const BARE_AMBIGUOUS_ARITHMETIC_RE = new RegExp(
 	`^\\s*[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*${AMBIGUOUS_ARITHMETIC_OPERATOR}\\s*[+\\-]?(?:${ARITHMETIC_OPERAND})\\s*[?!.]?\\s*$`,
 	"iu",
@@ -1187,13 +1191,28 @@ function looksLikeMultiDigitArithmetic(text: string): boolean {
 	) {
 		return false;
 	}
+	const operator = ambiguousMatch[3] ?? "";
+	const left = ambiguousMatch[1] ?? "";
+	const right = ambiguousMatch[5] ?? "";
+	const isBareCalendarYearRange =
+		operator === "-" &&
+		/^\d{4}$/u.test(left) &&
+		/^\d{4}$/u.test(right) &&
+		Number(left) >= 1900 &&
+		Number(left) <= 2199 &&
+		Number(right) >= 1900 &&
+		Number(right) <= 2199;
+	if (isBareCalendarYearRange) {
+		return false;
+	}
 
 	// Hyphens, slashes, plus signs, and the letter x occur routinely in dates,
 	// ranges, phone numbers, versions, and dimensions. Treat them as arithmetic
 	// only when the user supplies a math cue or the complete message is the
 	// expression; spacing alone must not narrow the action catalog.
 	return (
-		ARITHMETIC_REQUEST_CUE_RE.test(text) ||
+		EXPLICIT_ARITHMETIC_REQUEST_CUE_RE.test(text) ||
+		WHAT_IS_AMBIGUOUS_ARITHMETIC_RE.test(text) ||
 		BARE_AMBIGUOUS_ARITHMETIC_RE.test(text)
 	);
 }


### PR DESCRIPTION
Live QA on the group-chat deployment (2026-08-24): "whats 3847 times 292" produced **three different wrong products** across the simple and planner paths (1,123,186 · 1,122,824 · a third on the explicit "use a tool" retry; correct is 1,123,324). Root cause is structural, not model-quality: the chat action surface has **no compute tool** — shell is gate-rejected from chat, and a coding sub-agent is a build, not a calculator — so every arithmetic ask is answered from model recall.

**CALCULATE** evaluates the expression itself — recursive-descent parser (no `eval`/`Function`) over `+ - * / % ^` with parentheses, decimals, unary minus, and digit separators. Integer-only expressions run in **BigInt and are exact within an explicit 10,000-digit result boundary**; anything with division/decimals uses floats and discloses it; unparseable input is a **typed rejection naming the grammar** — never a guessed number.

Routing is the other half (deploying the action alone changed nothing — same lesson as the channel-recap arc): the direct-action heuristic chain now surfaces CALCULATE deterministically when an explicit arithmetic expression has **any operand ≥ 3 digits**; two-digit mental math stays on the fast simple path, where it is demonstrated reliable (391, 121 both correct live). Arithmetic-shaped invented candidates (`CALC_RESULT`, `DO_MATH`, `MULTIPLY_NUMBERS` …) hint it by family, since exact-name alias tables lose to a generative router.

**Live proof after deploying both halves**: `whats 3847 times 292` → routed through CALCULATE → **1,123,324** (2.6s); `ok and 98765 * 43210?` → **4,267,635,650** — both exact.

Verification: focused calculator, routing, and candidate-family tests (evaluator incl. the incident product, precedence/parens/unary, beyond-float BigInt exactness, separators, float disclosure, malformed/zero-division/runaway-exponent rejection; registration; handler equation text; routing positives + simple-path negatives) plus the 74-test routing regression suite green; core typecheck and Biome clean.

cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)

