### PR TITLE
fix(scenario-runner): answer the post-turn evaluator call in the legacy lane

### DIFF
--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   clearLlmWireMockEnvForLiveProvider,
   deterministicScheduledDispatchRenderText,
+  isPostTurnEvaluationPrompt,
   isScheduledDispatchRenderPrompt,
   loadScenarioTestMocksForTests,
   resolveScenarioDeterministicModelCall,
@@ -219,6 +220,110 @@ describe("scenario runtime deterministic model mode", () => {
         latestUserText: "",
       }),
     ).toBe("Heads up: take a short walk.");
+  });
+
+  // `EvaluatorService` runs every active post-turn evaluator in one merged
+  // TEXT_SMALL call after EVERY turn, on the same runtime the scenario drives.
+  // It passes the prompt as `messages` with NO `prompt` param, so undeclared
+  // (legacy-fallback) scenarios saw it as an unexpected call and failed at
+  // `assertConsumed()` even though none of them assert evaluator output.
+  describe("post-turn evaluator model call", () => {
+    const postTurnEvaluationPrompt = [
+      "# Task: Post-turn evaluation",
+      "",
+      "Evaluate just-finished turn for TestAgent.",
+      "",
+      "## Shared Turn Context",
+      "",
+      "Room ID: 00000000-0000-0000-0000-000000000001",
+      "",
+      "Latest message:",
+      "open the media view",
+      "",
+      "## Active Evaluators",
+      "",
+      "### linkExtraction",
+      'Put result under "linkExtraction".',
+      "",
+    ].join("\n");
+
+    // The real call shape: `messages` only, plus a merged responseSchema.
+    const postTurnEvaluationCall = {
+      modelType: ModelType.TEXT_SMALL,
+      params: {
+        messages: [
+          { role: "user", content: postTurnEvaluationPrompt },
+        ] as never,
+        responseSchema: {
+          type: "object",
+          properties: { linkExtraction: { type: "object" } },
+          required: ["linkExtraction"],
+          additionalProperties: false,
+        },
+      },
+      latestUserText: postTurnEvaluationPrompt,
+    };
+
+    it("recognizes the merged post-turn evaluation prompt", () => {
+      expect(isPostTurnEvaluationPrompt(postTurnEvaluationPrompt)).toBe(true);
+      expect(isPostTurnEvaluationPrompt("ordinary TEXT_SMALL prompt")).toBe(
+        false,
+      );
+      // Conversation text that merely quotes the header is not an evaluator
+      // call: the `## Active Evaluators` section is what makes it one.
+      expect(
+        isPostTurnEvaluationPrompt(
+          "# Task: Post-turn evaluation is what I asked about",
+        ),
+      ).toBe(false);
+    });
+
+    it("answers the messages-shaped evaluator call with the empty shape", () => {
+      const resolved = resolveScenarioDeterministicModelCall(
+        postTurnEvaluationCall,
+      );
+      // "Nothing to record" — every section absent, so the evaluator skips each
+      // entry without recording a validation error.
+      expect(resolved).toBe("{}");
+      expect(JSON.parse(resolved as string)).toEqual({});
+    });
+
+    it("keeps the evaluator call out of unexpectedCalls for undeclared scenarios", async () => {
+      // Legacy-fallback wiring: an EMPTY registry plus the fallback resolver.
+      // The call must resolve AND leave the scenario assertable.
+      const plugin = createDeterministicModelPlugin({
+        resolve: (call) => resolveScenarioDeterministicModelCall(call),
+      });
+      await expect(
+        plugin.models?.[ModelType.TEXT_SMALL]?.(
+          {} as never,
+          postTurnEvaluationCall.params as never,
+        ),
+      ).resolves.toBe("{}");
+      expect(plugin.getFixtureDiagnostics().unexpectedCalls).toEqual([]);
+      expect(() => {
+        plugin.assertFixturesConsumed();
+      }).not.toThrow();
+    });
+
+    it("still fails closed when no fallback resolver is wired", async () => {
+      // Strict lanes (`mode: "fixtures"` / `"model-free"`) pass no `resolve`, so
+      // the same call must still be recorded and still fail the scenario. This
+      // pins that the fallback did not weaken strict-mode enforcement.
+      const strictPlugin = createDeterministicModelPlugin();
+      await expect(
+        strictPlugin.models?.[ModelType.TEXT_SMALL]?.(
+          {} as never,
+          postTurnEvaluationCall.params as never,
+        ),
+      ).rejects.toThrow(/no fixture matched/);
+      expect(strictPlugin.getFixtureDiagnostics().unexpectedCalls).toHaveLength(
+        1,
+      );
+      expect(() => {
+        strictPlugin.assertFixturesConsumed();
+      }).toThrow(/deterministic model calls were unexpected/);
+    });
   });
 });
 

--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -260,6 +260,8 @@ describe("scenario runtime deterministic model mode", () => {
           required: ["linkExtraction"],
           additionalProperties: false,
         },
+        responseFormat: { type: "json_object" },
+        temperature: 0,
       },
       latestUserText: postTurnEvaluationPrompt,
     };
@@ -286,6 +288,124 @@ describe("scenario runtime deterministic model mode", () => {
       // entry without recording a validation error.
       expect(resolved).toBe("{}");
       expect(JSON.parse(resolved as string)).toEqual({});
+    });
+
+    it("does not treat user-controlled marker text as an evaluator call without its schema", () => {
+      expect(
+        resolveScenarioDeterministicModelCall({
+          modelType: ModelType.TEXT_SMALL,
+          params: {
+            messages: [
+              { role: "user", content: postTurnEvaluationPrompt },
+            ] as never,
+          },
+          latestUserText: postTurnEvaluationPrompt,
+        }),
+      ).toBeNull();
+    });
+
+    it("does not trust evaluator markers from latestUserText or an unrelated message", async () => {
+      const adversarialCall = {
+        ...postTurnEvaluationCall,
+        params: {
+          ...postTurnEvaluationCall.params,
+          messages: [
+            { role: "user", content: "ordinary schema-bearing request" },
+          ] as never,
+        },
+        latestUserText: postTurnEvaluationPrompt,
+      };
+      expect(resolveScenarioDeterministicModelCall(adversarialCall)).toBeNull();
+
+      const plugin = createDeterministicModelPlugin({
+        resolve: (call) => resolveScenarioDeterministicModelCall(call),
+      });
+      await expect(
+        plugin.models?.[ModelType.TEXT_SMALL]?.(
+          {} as never,
+          adversarialCall.params as never,
+        ),
+      ).rejects.toThrow(/no fixture matched/);
+      expect(plugin.getFixtureDiagnostics().unexpectedCalls).toHaveLength(1);
+      expect(() => plugin.assertFixturesConsumed()).toThrow(
+        /deterministic model calls were unexpected/,
+      );
+    });
+
+    it.each([
+      [
+        "a prompt parameter",
+        { ...postTurnEvaluationCall.params, prompt: postTurnEvaluationPrompt },
+      ],
+      [
+        "multiple messages",
+        {
+          ...postTurnEvaluationCall.params,
+          messages: [
+            { role: "user", content: postTurnEvaluationPrompt },
+            { role: "user", content: "extra" },
+          ],
+        },
+      ],
+      [
+        "a non-user message",
+        {
+          ...postTurnEvaluationCall.params,
+          messages: [{ role: "assistant", content: postTurnEvaluationPrompt }],
+        },
+      ],
+      [
+        "a missing JSON response format",
+        { ...postTurnEvaluationCall.params, responseFormat: undefined },
+      ],
+      [
+        "a nonzero temperature",
+        { ...postTurnEvaluationCall.params, temperature: 0.1 },
+      ],
+      [
+        "an empty schema",
+        {
+          ...postTurnEvaluationCall.params,
+          responseSchema: {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ],
+      [
+        "mismatched required keys",
+        {
+          ...postTurnEvaluationCall.params,
+          responseSchema: {
+            type: "object",
+            properties: { linkExtraction: { type: "object" } },
+            required: ["differentEvaluator"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      [
+        "an open schema",
+        {
+          ...postTurnEvaluationCall.params,
+          responseSchema: {
+            type: "object",
+            properties: { linkExtraction: { type: "object" } },
+            required: ["linkExtraction"],
+            additionalProperties: true,
+          },
+        },
+      ],
+    ])("rejects marker text carried by %s", (_name, params) => {
+      expect(
+        resolveScenarioDeterministicModelCall({
+          modelType: ModelType.TEXT_SMALL,
+          params,
+          latestUserText: postTurnEvaluationPrompt,
+        }),
+      ).toBeNull();
     });
 
     it("keeps the evaluator call out of unexpectedCalls for undeclared scenarios", async () => {

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -606,6 +606,9 @@ type ScenarioDeterministicModelCall = {
   params?: {
     prompt?: unknown;
     messages?: unknown;
+    responseFormat?: unknown;
+    responseSchema?: unknown;
+    temperature?: unknown;
   };
 };
 
@@ -646,6 +649,50 @@ function deterministicCallTextCandidates(
   return candidates;
 }
 
+function isPostTurnEvaluationCall(
+  call: ScenarioDeterministicModelCall,
+): boolean {
+  if (call.modelType !== ModelType.TEXT_SMALL) return false;
+  const params = call.params;
+  if (!params || params.prompt !== undefined || params.temperature !== 0) {
+    return false;
+  }
+  if (!Array.isArray(params.messages) || params.messages.length !== 1) {
+    return false;
+  }
+  const message = params.messages[0];
+  if (
+    !isRecordLike(message) ||
+    message.role !== "user" ||
+    typeof message.content !== "string" ||
+    !isPostTurnEvaluationPrompt(message.content)
+  ) {
+    return false;
+  }
+  const responseFormat = params.responseFormat;
+  if (!isRecordLike(responseFormat) || responseFormat.type !== "json_object") {
+    return false;
+  }
+  const schema = params.responseSchema;
+  if (
+    !isRecordLike(schema) ||
+    schema.type !== "object" ||
+    !isRecordLike(schema.properties) ||
+    schema.additionalProperties !== false ||
+    !Array.isArray(schema.required)
+  ) {
+    return false;
+  }
+  const propertyKeys = Object.keys(schema.properties);
+  return (
+    propertyKeys.length > 0 &&
+    schema.required.length === propertyKeys.length &&
+    schema.required.every(
+      (requiredKey, index) => requiredKey === propertyKeys[index],
+    )
+  );
+}
+
 export function resolveScenarioDeterministicModelCall(
   call: ScenarioDeterministicModelCall,
 ): string | null {
@@ -661,8 +708,10 @@ export function resolveScenarioDeterministicModelCall(
   const candidates = deterministicCallTextCandidates(call);
   // Checked first: the evaluator prompt embeds the turn's provider context, so
   // a dispatch prompt delivered during the turn can appear INSIDE it. The
-  // post-turn header is the more specific signal.
-  if (candidates.some(isPostTurnEvaluationPrompt)) {
+  // post-turn header plus the evaluator's schema-bearing call shape are the
+  // more specific signal. Prompt text alone is untrusted scenario input and
+  // must not turn an ordinary model call into a fabricated empty evaluation.
+  if (isPostTurnEvaluationCall(call)) {
     // "Nothing to record" is the empty shape the evaluator prompt itself
     // prescribes. Every section is absent, so `processPreparedEntries` skips
     // each evaluator without an error. Scenarios that need real evaluator

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -89,6 +89,11 @@ const SCHEDULED_DISPATCH_RENDER_FIRED_AT_MARKER = "\n\nFired at:";
 const SCHEDULED_DISPATCH_TITLE_PROMPT_PREFIX =
   "You are the owner's personal assistant. Write a concise notification title for the scheduled message below.";
 const SCHEDULED_DISPATCH_TITLE_BODY_MARKER = "\nMessage body:\n";
+// `EvaluatorService` (packages/core/src/services/evaluator.ts) runs every active
+// post-turn evaluator in one merged TEXT_SMALL call after EVERY turn. It is
+// runtime-wide background work, not scenario-specific: the prompt header below
+// is emitted verbatim by `renderSharedContext`.
+const POST_TURN_EVALUATION_PROMPT_PREFIX = "# Task: Post-turn evaluation";
 
 async function createScenarioKnowledgeGraphPlugin(): Promise<Plugin> {
   const [knowledgeGraphModule, approvalModule] = await Promise.all([
@@ -488,6 +493,21 @@ function deterministicModelProviderConfig(): RuntimeFactoryResult["providerConfi
   };
 }
 
+// The merged post-turn evaluator call fires after every turn on the SAME
+// runtime the scenario drives, so it reaches the strict registry in scenarios
+// that never declared a model manifest. Left unanswered it is recorded as an
+// unexpected call and fails the whole scenario at `assertConsumed()`, even
+// though nothing in the scenario asserts evaluator output. Matched on the
+// header `renderSharedContext` emits plus the `## Active Evaluators` section
+// `renderPrompt` appends, so ordinary conversation text quoting the header
+// alone is never answered by this branch.
+export function isPostTurnEvaluationPrompt(prompt: string): boolean {
+  return (
+    prompt.startsWith(POST_TURN_EVALUATION_PROMPT_PREFIX) &&
+    prompt.includes("\n## Active Evaluators\n")
+  );
+}
+
 export function isScheduledDispatchRenderPrompt(prompt: string): boolean {
   return (
     prompt.startsWith(SCHEDULED_DISPATCH_RENDER_PROMPT_PREFIX) &&
@@ -639,6 +659,17 @@ export function resolveScenarioDeterministicModelCall(
     return null;
   }
   const candidates = deterministicCallTextCandidates(call);
+  // Checked first: the evaluator prompt embeds the turn's provider context, so
+  // a dispatch prompt delivered during the turn can appear INSIDE it. The
+  // post-turn header is the more specific signal.
+  if (candidates.some(isPostTurnEvaluationPrompt)) {
+    // "Nothing to record" is the empty shape the evaluator prompt itself
+    // prescribes. Every section is absent, so `processPreparedEntries` skips
+    // each evaluator without an error. Scenarios that need real evaluator
+    // output declare `modelFixtures: { mode: "fixtures" }`, which bypasses this
+    // resolver entirely and stays fail-closed.
+    return "{}";
+  }
   const bodyPrompt = candidates.find(isScheduledDispatchRenderPrompt);
   if (bodyPrompt) {
     return deterministicScheduledDispatchRenderText(bodyPrompt);


### PR DESCRIPTION
# Relates to

Seven of the ten failures in the `pr-deterministic` scenario lane on `develop`. Sibling of #25932 (scenario action scoping) and #26757 (fixture isolation) — all three are the lane becoming trustworthy again.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`21cbe704aba`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Low, and deliberately confined to the legacy lane.** The new branch is reached only when `modelFixtureMode === "legacy-fallback"`; scenarios that declare a model manifest (`mode: "fixtures"`) or run model-free bypass this resolver entirely and stay fail-closed. Strict-mode enforcement is untouched — a test pins that a plugin built without the fallback resolver still rejects the call and still fails `assertFixturesConsumed()`.

# Background

## What does this PR do?

The lane showed **32 passed / 10 failed**, and nine failures shared a signature: `deterministic model calls were unexpected: [{"modelType":"TEXT_SMALL", …}]`. They are not one cause — they are **7 + 1 + 1**.

The seven are `EvaluatorService`'s merged post-turn evaluation call: `generateEvaluationOutput` → `runtime.useModel(TEXT_SMALL, { messages, responseSchema, … })` in `packages/core/src/services/evaluator.ts`. It runs every active evaluator in one call after **every** turn, on the same runtime the scenario drives. It is runtime-wide background work that nothing in those scenarios asserts on, but it reaches the strict registry and fails the whole scenario at `assertConsumed()`.

**The call is legitimate and the scenarios were the ones missing a declaration.** The decisive evidence: two already-*passing* scenarios declare a fixture for this exact call — `deterministic-workflow-actions-routes.scenario.ts` (`input: { includes: "# Task: Post-turn evaluation" }`) and `deterministic-active-view-agent-surface.scenario.ts`. Scenarios that migrated to explicit manifests declare it; the seven that never declared one run in `legacy-fallback` and depend on `resolveScenarioDeterministicModelCall`, which only knew about scheduled-dispatch prompts.

The fix teaches that fallback resolver to answer the post-turn evaluator call with `"{}"` — the "nothing to record" empty shape the evaluator prompt itself prescribes, which `processPreparedEntries` skips section by section without error. It matches on **two** signals (the `# Task: Post-turn evaluation` header `renderSharedContext` emits, plus the `## Active Evaluators` section `renderPrompt` appends), so ordinary conversation text quoting the header alone is never answered, and it is checked before the dispatch branches because the evaluator prompt embeds the turn's provider context.

Incidental notes for the record: `promptLength: 0` in the diagnostic is not a defect — the evaluator passes `messages`, not `prompt`. And the evaluator prompt reaches roughly 1.1 MB, which follows from the deliberate "preserve complete model context" policy; left alone.

## What kind of change is this?

Bug fix (test harness; non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation; the new predicate and the branch each carry the reasoning in-code.

# Testing

## Where should a reviewer start?

`isPostTurnEvaluationPrompt` and the single branch that consumes it in `resolveScenarioDeterministicModelCall`, then the four tests in `runtime-factory.test.ts`.

## Detailed testing steps

- **Lane before: 32 passed / 10 failed. Lane after: 39 passed / 3 failed.** All seven evaluator failures green, zero regressions. `pgrep -f "cli.ts run test/scenarios"` verified clean before *and* after every measurement.
- `bunx vitest run src/runtime-factory.test.ts` → 22 pass (4 new). Mutation: disabling the branch → the two behavioural tests fail (`expected null to be '{}'`, `promise rejected … instead of resolving`); restored → 22/22.
- Independently re-verified after rebase onto current develop: `deterministic-media-actions` and `deterministic-agent-skills-actions` each 1 passed / 0 failed.
- Biome clean on both touched files. `typecheck`: 119 errors byte-identical before and after apart from one line-number shift on a pre-existing `TS2307` (all pre-existing unbuilt-sibling module resolution). `test:unit` 538 passed / 1 failed — `corpus-assertion-guard.test.ts`, reproduced on pristine files. `test:mocks` 21/21.

# Evidence Gate

<!-- evidence-head:13f8536ca072a7da8ba346e33568a83d990cb22b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The lane's own per-call diagnostics: the unexpected `TEXT_SMALL` entries carried a response schema and no prompt, and were attributed to `purpose=evaluation` by tagging the ambient trajectory purpose into the diagnostic (a throwaway probe, fully removed — `deterministic-model-plugin.ts` and `trajectory-context.ts` are byte-identical to develop).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Lane reports before and after (32/10 → 39/3).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The lane's own per-call diagnostics: the unexpected `TEXT_SMALL` entries carried a response schema and no prompt, and were attributed to `purpose=evaluation` by tagging the ambient trajectory purpose into the diagnostic (a throwaway probe, fully removed — `deterministic-model-plugin.ts` and `trajectory-context.ts` are byte-identical to develop).

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- **Three lane failures remain, each with a distinct cause**, deliberately not swept into this PR: `deterministic-lifeops-dispatch-retry` (`lifeops-priority-scoring` ×3 plus a `morning_brief` TEXT_LARGE ×3), `deterministic-sub-agent-credential-request` (`voice-gate-rephrase` ×3 via `ensureAgentVoice`), and `deterministic-progressive-content-actions` (a `FILE` mutation assertion, unrelated). The credential one needs a judgement call rather than a fixture: that scenario asserts on delivered literal text while the voice gate fails open, so any fixture there is either assertion-breaking or vacuous.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


