### PR TITLE
release: promote immutable develop snapshot to main

### DIFF
--- a/packages/cloud/shared/src/db/database-url.test.ts
+++ b/packages/cloud/shared/src/db/database-url.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Pins database URL resolution. The consequential property is the fail-closed
+ * one: production and CI must never silently fall back to a local file-backed
+ * PGlite store, and the opt-out kill switch must win over that fallback. Also
+ * covers explicit-URL precedence and the non-clobbering mutation contract of
+ * applyDatabaseUrlFallback. Every case injects its own env; process.env is
+ * never read or mutated.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import {
+  applyDatabaseUrlFallback,
+  getLocalPGliteDatabaseUrl,
+  resolveDatabaseUrl,
+} from "./database-url";
+
+const REMOTE = "postgres://user:pw@db.example.com:5432/prod";
+const TEST_REMOTE = "postgres://user:pw@db.example.com:5432/test";
+
+/** A local-dev env: not production, not CI. */
+const local = (over: Record<string, string | undefined> = {}) => ({
+  NODE_ENV: "development",
+  ...over,
+});
+
+describe("getLocalPGliteDatabaseUrl", () => {
+  test("resolves the default data dir to an absolute pglite url", () => {
+    const url = getLocalPGliteDatabaseUrl({});
+    expect(url.startsWith("pglite://")).toBe(true);
+    expect(path.isAbsolute(url.slice("pglite://".length))).toBe(true);
+  });
+
+  test("prefers PGLITE_DATA_DIR over LOCAL_DATABASE_PATH", () => {
+    const url = getLocalPGliteDatabaseUrl({
+      PGLITE_DATA_DIR: "/tmp/chosen",
+      LOCAL_DATABASE_PATH: "/tmp/ignored",
+    });
+    expect(url).toBe("pglite:///tmp/chosen");
+  });
+
+  test("falls back to LOCAL_DATABASE_PATH when PGLITE_DATA_DIR is absent", () => {
+    expect(getLocalPGliteDatabaseUrl({ LOCAL_DATABASE_PATH: "/tmp/fallback" })).toBe(
+      "pglite:///tmp/fallback",
+    );
+  });
+
+  test("treats a blank override as unset", () => {
+    const blank = getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: "" });
+    expect(blank).toBe(getLocalPGliteDatabaseUrl({}));
+  });
+
+  test("resolves a relative dir against the working directory", () => {
+    expect(getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: "relative/store" })).toBe(
+      `pglite://${path.resolve(process.cwd(), "relative/store")}`,
+    );
+  });
+
+  test("leaves an already-absolute dir untouched", () => {
+    expect(getLocalPGliteDatabaseUrl({ PGLITE_DATA_DIR: path.resolve("/var/data") })).toBe(
+      `pglite://${path.resolve("/var/data")}`,
+    );
+  });
+
+  test("is stable across calls with the same env", () => {
+    const env = local({ PGLITE_DATA_DIR: "some/dir" });
+    expect(getLocalPGliteDatabaseUrl(env)).toBe(getLocalPGliteDatabaseUrl(env));
+  });
+});
+
+describe("resolveDatabaseUrl — explicit URLs win", () => {
+  test("TEST_DATABASE_URL outranks DATABASE_URL", () => {
+    expect(resolveDatabaseUrl({ TEST_DATABASE_URL: TEST_REMOTE, DATABASE_URL: REMOTE })).toBe(
+      TEST_REMOTE,
+    );
+  });
+
+  test("DATABASE_URL is used when TEST_DATABASE_URL is absent or blank", () => {
+    expect(resolveDatabaseUrl({ DATABASE_URL: REMOTE })).toBe(REMOTE);
+    expect(resolveDatabaseUrl({ TEST_DATABASE_URL: "", DATABASE_URL: REMOTE })).toBe(REMOTE);
+  });
+
+  test("an explicit URL wins in production", () => {
+    expect(resolveDatabaseUrl({ NODE_ENV: "production", DATABASE_URL: REMOTE })).toBe(REMOTE);
+  });
+
+  test("an explicit URL wins over the kill switch", () => {
+    expect(
+      resolveDatabaseUrl({
+        DISABLE_LOCAL_PGLITE_FALLBACK: "1",
+        DATABASE_URL: REMOTE,
+      }),
+    ).toBe(REMOTE);
+  });
+});
+
+describe("resolveDatabaseUrl — fail closed", () => {
+  test("production never falls back to a local store", () => {
+    const url = resolveDatabaseUrl({ NODE_ENV: "production" });
+    expect(url).toBeNull();
+  });
+
+  test("CI never falls back to a local store", () => {
+    expect(resolveDatabaseUrl({ NODE_ENV: "development", CI: "true" })).toBeNull();
+    expect(resolveDatabaseUrl({ NODE_ENV: "test", CI: "true" })).toBeNull();
+  });
+
+  test("the kill switch suppresses the fallback in local execution", () => {
+    expect(resolveDatabaseUrl(local({ DISABLE_LOCAL_PGLITE_FALLBACK: "1" }))).toBeNull();
+  });
+
+  test("the kill switch is exact — only the string '1' disables", () => {
+    for (const value of ["0", "true", "yes", "", " 1", "1 "]) {
+      expect(resolveDatabaseUrl(local({ DISABLE_LOCAL_PGLITE_FALLBACK: value }))).not.toBeNull();
+    }
+  });
+
+  test("no resolved URL is ever a pglite store outside local execution", () => {
+    for (const env of [
+      { NODE_ENV: "production" },
+      { NODE_ENV: "production", CI: "true" },
+      { NODE_ENV: "development", CI: "true" },
+    ]) {
+      expect(resolveDatabaseUrl(env)).toBeNull();
+    }
+  });
+});
+
+describe("resolveDatabaseUrl — local fallback", () => {
+  test("falls back to PGlite in local development", () => {
+    expect(resolveDatabaseUrl(local())).toBe(getLocalPGliteDatabaseUrl(local()));
+  });
+
+  test("falls back for test and for an unset NODE_ENV", () => {
+    for (const env of [{ NODE_ENV: "test" }, {}]) {
+      expect(resolveDatabaseUrl(env)?.startsWith("pglite://")).toBe(true);
+    }
+  });
+
+  test("honours the data-dir override on the fallback path", () => {
+    expect(resolveDatabaseUrl(local({ PGLITE_DATA_DIR: "/tmp/x" }))).toBe("pglite:///tmp/x");
+  });
+
+  test("CI set to anything but 'true' is still local", () => {
+    expect(resolveDatabaseUrl(local({ CI: "false" }))?.startsWith("pglite://")).toBe(true);
+  });
+});
+
+describe("applyDatabaseUrlFallback", () => {
+  test("writes the resolved URL into DATABASE_URL", () => {
+    const env = local();
+    const url = applyDatabaseUrlFallback(env);
+    expect(url).not.toBeNull();
+    expect(env.DATABASE_URL).toBe(url as string);
+  });
+
+  test("never clobbers an existing DATABASE_URL", () => {
+    const env = local({ DATABASE_URL: REMOTE });
+    expect(applyDatabaseUrlFallback(env)).toBe(REMOTE);
+    expect(env.DATABASE_URL).toBe(REMOTE);
+  });
+
+  test("leaves DATABASE_URL alone even when the resolved URL differs", () => {
+    // TEST_DATABASE_URL outranks DATABASE_URL, so the resolved value is NOT
+    // the one already in DATABASE_URL. A plain assignment would overwrite the
+    // production handle with the test one; `??=` must not.
+    const env = local({
+      DATABASE_URL: REMOTE,
+      TEST_DATABASE_URL: TEST_REMOTE,
+    });
+    expect(applyDatabaseUrlFallback(env)).toBe(TEST_REMOTE);
+    expect(env.DATABASE_URL).toBe(REMOTE);
+  });
+
+  test("sets TEST_DATABASE_URL only under NODE_ENV=test", () => {
+    const testEnv: Record<string, string | undefined> = { NODE_ENV: "test" };
+    applyDatabaseUrlFallback(testEnv);
+    expect(testEnv.TEST_DATABASE_URL).toBe(testEnv.DATABASE_URL);
+
+    const devEnv: Record<string, string | undefined> = local();
+    applyDatabaseUrlFallback(devEnv);
+    expect(devEnv.TEST_DATABASE_URL).toBeUndefined();
+  });
+
+  test("never clobbers an existing TEST_DATABASE_URL", () => {
+    const env: Record<string, string | undefined> = {
+      NODE_ENV: "test",
+      TEST_DATABASE_URL: TEST_REMOTE,
+    };
+    applyDatabaseUrlFallback(env);
+    expect(env.TEST_DATABASE_URL).toBe(TEST_REMOTE);
+  });
+
+  test("leaves env untouched when nothing resolves", () => {
+    const env: Record<string, string | undefined> = { NODE_ENV: "production" };
+    expect(applyDatabaseUrlFallback(env)).toBeNull();
+    expect(env.DATABASE_URL).toBeUndefined();
+    expect(env.TEST_DATABASE_URL).toBeUndefined();
+  });
+
+  test("is idempotent", () => {
+    const env = local();
+    const first = applyDatabaseUrlFallback(env);
+    const snapshot = { ...env };
+    expect(applyDatabaseUrlFallback(env)).toBe(first as string);
+    expect(env).toEqual(snapshot);
+  });
+
+  test("agrees with resolveDatabaseUrl on a fresh env", () => {
+    for (const base of [
+      local(),
+      { NODE_ENV: "production" },
+      local({ DISABLE_LOCAL_PGLITE_FALLBACK: "1" }),
+      { DATABASE_URL: REMOTE },
+    ]) {
+      expect(applyDatabaseUrlFallback({ ...base })).toBe(resolveDatabaseUrl({ ...base }));
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/fragments/templates.test.ts
+++ b/packages/cloud/shared/src/lib/fragments/templates.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Pins fragment template id suffixing and the prompt renderer. The renderer
+ * builds model-facing content, so the repository prompt-integrity rule applies:
+ * every template must appear complete, with no cap or elision. The id helpers
+ * are an encode/decode pair and must round-trip. NODE_ENV is saved and restored
+ * per test; no harness.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import templates, {
+  getTemplateId,
+  getTemplateIdSuffix,
+  type Templates,
+  templatesToPrompt,
+} from "./templates";
+
+let savedNodeEnv: string | undefined;
+
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV;
+});
+
+afterEach(() => {
+  if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = savedNodeEnv;
+});
+
+describe("getTemplateIdSuffix", () => {
+  test("appends -dev only under NODE_ENV=development", () => {
+    process.env.NODE_ENV = "development";
+    expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer-dev");
+  });
+
+  test("returns the id unchanged in every other environment", () => {
+    for (const value of ["production", "test", "staging", ""]) {
+      process.env.NODE_ENV = value;
+      expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer");
+    }
+  });
+
+  test("returns the id unchanged when NODE_ENV is unset", () => {
+    delete process.env.NODE_ENV;
+    expect(getTemplateIdSuffix("nextjs-developer")).toBe("nextjs-developer");
+  });
+
+  test("matches NODE_ENV exactly — no casing or whitespace tolerance", () => {
+    for (const value of ["Development", "DEVELOPMENT", " development", "development "]) {
+      process.env.NODE_ENV = value;
+      expect(getTemplateIdSuffix("x")).toBe("x");
+    }
+  });
+});
+
+describe("getTemplateId", () => {
+  test("strips a trailing -dev", () => {
+    expect(getTemplateId("nextjs-developer-dev")).toBe("nextjs-developer");
+  });
+
+  test("leaves an id without the suffix alone", () => {
+    expect(getTemplateId("nextjs-developer")).toBe("nextjs-developer");
+    expect(getTemplateId("code-interpreter-v1")).toBe("code-interpreter-v1");
+  });
+
+  test("only strips at the end, not in the middle", () => {
+    expect(getTemplateId("my-dev-app")).toBe("my-dev-app");
+    expect(getTemplateId("dev-tools")).toBe("dev-tools");
+  });
+
+  test("strips exactly one suffix", () => {
+    expect(getTemplateId("x-dev-dev")).toBe("x-dev");
+  });
+
+  test("handles the empty string", () => {
+    expect(getTemplateId("")).toBe("");
+  });
+});
+
+describe("id round-trip", () => {
+  test("decode undoes encode in development", () => {
+    process.env.NODE_ENV = "development";
+    for (const id of [
+      "code-interpreter-v1",
+      "nextjs-developer",
+      "vue-developer",
+      "streamlit-developer",
+      "gradio-developer",
+    ]) {
+      expect(getTemplateId(getTemplateIdSuffix(id))).toBe(id);
+    }
+  });
+
+  test("decode undoes encode in production", () => {
+    process.env.NODE_ENV = "production";
+    for (const id of ["nextjs-developer", "vue-developer"]) {
+      expect(getTemplateId(getTemplateIdSuffix(id))).toBe(id);
+    }
+  });
+});
+
+describe("template catalog", () => {
+  const entries = Object.entries(templates);
+
+  test("is non-empty and every id is unique", () => {
+    expect(entries.length).toBeGreaterThan(0);
+    expect(new Set(Object.keys(templates)).size).toBe(entries.length);
+  });
+
+  test("every template carries a usable shape", () => {
+    for (const [id, t] of entries) {
+      expect(id.length).toBeGreaterThan(0);
+      expect(t.name.trim().length).toBeGreaterThan(0);
+      expect(t.instructions.trim().length).toBeGreaterThan(0);
+      expect(t.file.trim().length).toBeGreaterThan(0);
+      expect(Array.isArray(t.lib)).toBe(true);
+      expect(t.lib.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every port is either null or a valid TCP port", () => {
+    for (const [, t] of entries) {
+      if (t.port === null) continue;
+      expect(Number.isInteger(t.port)).toBe(true);
+      expect(t.port).toBeGreaterThan(0);
+      expect(t.port).toBeLessThanOrEqual(65535);
+    }
+  });
+
+  test("no dependency entry is blank", () => {
+    for (const [, t] of entries) {
+      for (const lib of t.lib) {
+        expect(typeof lib).toBe("string");
+        expect(lib.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("every catalog id decodes to a stable base id", () => {
+    for (const id of Object.keys(templates)) {
+      const base = getTemplateId(id);
+      expect(base.length).toBeGreaterThan(0);
+      expect(getTemplateId(base)).toBe(base);
+    }
+  });
+});
+
+describe("templatesToPrompt", () => {
+  const fixture = {
+    alpha: {
+      name: "Alpha",
+      lib: ["one", "two"],
+      file: "a.py",
+      instructions: "Does alpha things.",
+      port: 8501,
+    },
+    beta: {
+      name: "Beta",
+      lib: ["three"],
+      file: "",
+      instructions: "Does beta things.",
+      port: null,
+    },
+  } as unknown as Templates;
+
+  test("numbers entries from one, in insertion order", () => {
+    const lines = templatesToPromptLines(fixture);
+    expect(lines[0].startsWith("1. alpha:")).toBe(true);
+    expect(lines[1].startsWith("2. beta:")).toBe(true);
+  });
+
+  test("renders instructions, file, dependencies, and port", () => {
+    const [first] = templatesToPromptLines(fixture);
+    expect(first).toContain('"Does alpha things."');
+    expect(first).toContain("File: a.py");
+    expect(first).toContain("Dependencies installed: one, two");
+    expect(first).toContain("Port: 8501");
+  });
+
+  test("substitutes 'none' for a missing file or port", () => {
+    const [, second] = templatesToPromptLines(fixture);
+    expect(second).toContain("File: none");
+    expect(second).toContain("Port: none");
+  });
+
+  test("emits exactly one line per template, with no trailing newline", () => {
+    const rendered = templatesToPrompt(fixture);
+    expect(rendered.split("\n")).toHaveLength(2);
+    expect(rendered.endsWith("\n")).toBe(false);
+  });
+
+  test("renders the real catalog completely, with no elision", () => {
+    const rendered = templatesToPrompt(templates);
+    const ids = Object.keys(templates);
+    expect(rendered.split("\n")).toHaveLength(ids.length);
+    for (const id of ids) expect(rendered).toContain(`${id}:`);
+    expect(rendered).not.toContain("…");
+    expect(rendered).not.toMatch(/truncat/i);
+  });
+
+  test("carries every dependency of every template through", () => {
+    const rendered = templatesToPrompt(templates);
+    for (const t of Object.values(templates)) {
+      for (const lib of t.lib) expect(rendered).toContain(lib);
+    }
+  });
+
+  test("does not cap a long catalog", () => {
+    const many = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [
+        `tpl-${i}`,
+        {
+          name: `T${i}`,
+          lib: [`lib-${i}`],
+          file: `f${i}.py`,
+          instructions: `I${i}`,
+          port: null,
+        },
+      ]),
+    ) as unknown as Templates;
+    const rendered = templatesToPrompt(many);
+    expect(rendered.split("\n")).toHaveLength(200);
+    expect(rendered).toContain("200. tpl-199:");
+    expect(rendered).toContain("lib-199");
+  });
+
+  test("returns an empty string for an empty catalog", () => {
+    expect(templatesToPrompt({} as unknown as Templates)).toBe("");
+  });
+
+  test("is deterministic", () => {
+    expect(templatesToPrompt(templates)).toBe(templatesToPrompt(templates));
+  });
+});
+
+function templatesToPromptLines(input: Templates): string[] {
+  return templatesToPrompt(input).split("\n");
+}

--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -1,7 +1,8 @@
 /**
  * Exercises the read-side access-control filter — `actorFromAccessContext`,
- * `canReadScope`, and `filterByAccessContext` — as pure deterministic
- * functions, plus a verbatim cross-check against the documents read ladder.
+ * `canReadScope`, `filterByAccessContext`, and the adapter-bound location
+ * intersection as pure deterministic functions, plus a verbatim cross-check
+ * against the documents read ladder.
  */
 import { describe, expect, it } from "vitest";
 import type { AccessContext, Memory, MemoryScope, UUID } from "../types";
@@ -10,6 +11,7 @@ import {
 	actorFromAccessContext,
 	canReadScope,
 	filterByAccessContext,
+	filterMemoryReadByAccessContext,
 	type ScopeActor,
 } from "./filter";
 
@@ -265,6 +267,56 @@ describe("filterByAccessContext", () => {
 		const once = filterByAccessContext(corpus, ctx, AGENT);
 		const twice = filterByAccessContext(once, ctx, AGENT);
 		expect(twice).toEqual(once);
+	});
+
+	it("intersects world and authorized rooms with the scope ladder", () => {
+		const allowedWorld = "30000000-0000-0000-0000-000000000001" as UUID;
+		const otherWorld = "30000000-0000-0000-0000-000000000002" as UUID;
+		const allowedRoom = "40000000-0000-0000-0000-000000000001" as UUID;
+		const otherRoom = "40000000-0000-0000-0000-000000000002" as UUID;
+		const located = [
+			{
+				...mem("global", OTHER),
+				agentId: AGENT,
+				worldId: allowedWorld,
+				roomId: allowedRoom,
+			},
+			{ ...mem("global", OTHER), worldId: allowedWorld, roomId: otherRoom },
+			{ ...mem("global", OTHER), worldId: otherWorld, roomId: allowedRoom },
+			{
+				...mem("global", OTHER),
+				agentId: OTHER,
+				worldId: allowedWorld,
+				roomId: allowedRoom,
+			},
+		];
+
+		expect(
+			filterMemoryReadByAccessContext(
+				located,
+				{
+					requesterEntityId: SELF,
+					role: "USER",
+					worldId: allowedWorld,
+					authorizedRoomIds: [allowedRoom],
+				},
+				AGENT,
+			),
+		).toEqual([located[0]]);
+	});
+
+	it("an explicit empty authorized-room set denies all room memories", () => {
+		expect(
+			filterMemoryReadByAccessContext(
+				[{ ...mem("global", OTHER), roomId: SELF }],
+				{
+					requesterEntityId: SELF,
+					role: "USER",
+					authorizedRoomIds: [],
+				},
+				AGENT,
+			),
+		).toEqual([]);
 	});
 
 	describe("absent scope fails closed to private (author-scoped)", () => {

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -176,12 +176,17 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
  * also used after explicitly authorized cross-world recall, this variant
  * treats `worldId` and `authorizedRoomIds` as storage-query intersections and
  * rejects rows stamped for another agent. Adapters call it before any
- * ordering, ranking, cursor, offset, or limit operation.
+ * ordering, ranking, cursor, offset, or limit operation. Message-table callers
+ * with an explicit authorized-room set may pass `room` for `unstampedScope`:
+ * legacy transcript rows predate disclosure stamps, and verified room
+ * membership is their read boundary. Other tables retain author-private
+ * fail-closed behavior.
  */
 export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
 	memories: T[],
 	ctx: AccessContext,
 	agentId: UUID,
+	unstampedScope: MemoryScope = "private",
 ): T[] {
 	const authorizedRoomIds =
 		ctx.authorizedRoomIds === undefined
@@ -195,5 +200,19 @@ export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
 			return false;
 		return memory.roomId !== undefined && authorizedRoomIds.has(memory.roomId);
 	});
-	return filterByAccessContext(located, ctx, agentId);
+	if (unstampedScope === "private") {
+		return filterByAccessContext(located, ctx, agentId);
+	}
+	return filterByAccessContext(
+		located.map((memory) =>
+			memory.metadata?.scope === undefined
+				? {
+						...memory,
+						metadata: { ...memory.metadata, scope: unstampedScope },
+					}
+				: memory,
+		),
+		ctx,
+		agentId,
+	) as T[];
 }

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -1,8 +1,8 @@
 /**
- * Read-side access-control filter for memory-shaped retrieval records: maps an
- * {@link AccessContext} to a scope-ladder actor, decides whether that actor may
- * read a record of a given {@link MemoryScope}, and subtractively filters a
- * result array down to the readable set.
+ * Read-side access-control filters for memory-shaped retrieval records: the
+ * general disclosure filter applies the scope ladder, while the adapter-bound
+ * variant additionally intersects agent, world, and authorized-room bounds
+ * before ordering, ranking, or pagination.
  *
  * Composes with — never duplicates — Postgres RLS: RLS gates on
  * `entity_id`/`server_id`, this gates on `metadata.scope`. For the four
@@ -15,7 +15,10 @@ import type { RoleName } from "../roles";
 import type { AccessContext, MemoryScope, UUID } from "../types";
 
 interface AccessScopedRecord {
+	agentId?: UUID;
 	entityId?: UUID;
+	roomId?: UUID;
+	worldId?: UUID;
 	metadata?: {
 		scope?: unknown;
 		scopedToEntityId?: unknown;
@@ -123,10 +126,10 @@ export function canReadScope(
 }
 
 /**
- * Filter retrieval records down to those `ctx`'s requester may read. A pure,
- * strictly subtractive `.filter()`: it composes with (never duplicates)
- * Postgres RLS, which gates on `entity_id`/`server_id` while this gates on
- * `metadata.scope`. An ABSENT scope fails CLOSED to `private` (author-scoped):
+ * Filter retrieval records down to the disclosure scopes `ctx`'s requester may
+ * read. A pure, strictly subtractive `.filter()` that composes with (never
+ * duplicates) Postgres RLS and with the adapter-bound location filter below.
+ * An ABSENT scope fails CLOSED to `private` (author-scoped):
  * an unstamped legacy row must never be treated as globally readable, because
  * a write path that forgot to stamp a scope would otherwise silently publish
  * private data to every actor. `private` (rather than `owner-private`) keeps
@@ -166,4 +169,31 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
 					: memory.entityId;
 		return canReadScope(scope, scopedEntityId, actor);
 	});
+}
+
+/**
+ * Adapter-bound memory filter. Unlike {@link filterByAccessContext}, which is
+ * also used after explicitly authorized cross-world recall, this variant
+ * treats `worldId` and `authorizedRoomIds` as storage-query intersections and
+ * rejects rows stamped for another agent. Adapters call it before any
+ * ordering, ranking, cursor, offset, or limit operation.
+ */
+export function filterMemoryReadByAccessContext<T extends AccessScopedRecord>(
+	memories: T[],
+	ctx: AccessContext,
+	agentId: UUID,
+): T[] {
+	const authorizedRoomIds =
+		ctx.authorizedRoomIds === undefined
+			? undefined
+			: new Set<UUID>(ctx.authorizedRoomIds);
+	const located = memories.filter((memory) => {
+		if (memory.agentId !== undefined && memory.agentId !== agentId)
+			return false;
+		if (authorizedRoomIds === undefined) return true;
+		if (ctx.worldId !== undefined && memory.worldId !== ctx.worldId)
+			return false;
+		return memory.roomId !== undefined && authorizedRoomIds.has(memory.roomId);
+	});
+	return filterByAccessContext(located, ctx, agentId);
 }

--- a/packages/core/src/client-public.test.ts
+++ b/packages/core/src/client-public.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for client-public subpath: verifies duplicate-safe utility re-exports.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	formatError,
+	isElizaSettingsDebugEnabled,
+	isTruthyEnvValue,
+	resolveAliasedEnvValue,
+	sanitizeSpeechText,
+} from "./client-public.ts";
+
+describe("client-public", () => {
+	it("re-exports isTruthyEnvValue", () => {
+		expect(isTruthyEnvValue("true")).toBe(true);
+		expect(isTruthyEnvValue("1")).toBe(true);
+		expect(isTruthyEnvValue("false")).toBe(false);
+		expect(isTruthyEnvValue(undefined)).toBe(false);
+	});
+
+	it("re-exports sanitizeSpeechText", () => {
+		expect(sanitizeSpeechText("Hello world")).toBe("Hello world");
+	});
+
+	it("re-exports formatError", () => {
+		const formatted = formatError(new Error("sample error"));
+		expect(formatted).toContain("sample error");
+	});
+
+	it("re-exports resolveAliasedEnvValue", () => {
+		expect(typeof resolveAliasedEnvValue).toBe("function");
+	});
+
+	it("re-exports isElizaSettingsDebugEnabled", () => {
+		expect(typeof isElizaSettingsDebugEnabled).toBe("function");
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.access-context.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.access-context.test.ts
@@ -94,6 +94,16 @@ async function seededAdapter(): Promise<InMemoryDatabaseAdapter> {
 					embedding: vector(1, 0),
 				},
 			),
+			memory(
+				"30000000-0000-0000-0000-000000000006",
+				"needle allowed unstamped participant",
+				600,
+				{
+					entityId: STRANGER,
+					embedding: vector(1, 0),
+					metadata: { type: "custom" },
+				},
+			),
 		].map((entry) => ({ memory: entry, tableName: "messages" })),
 	);
 	return adapter;
@@ -109,7 +119,7 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(rows.map((row) => row.content.text)).toEqual([
-			"needle allowed private",
+			"needle allowed unstamped participant",
 		]);
 	});
 
@@ -122,6 +132,7 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed unstamped participant",
 			"needle allowed private",
 			"needle allowed global",
 		]);
@@ -145,7 +156,9 @@ describe("InMemoryDatabaseAdapter access context", () => {
 		});
 
 		expect(textRows[0]?.memory.content.text).toMatch(/^needle allowed /);
-		expect(vectorRows[0]?.content.text).toBe("needle allowed private");
+		expect(vectorRows[0]?.content.text).toBe(
+			"needle allowed unstamped participant",
+		);
 	});
 
 	it("denies every room-backed row for an explicit empty authorization", async () => {

--- a/packages/core/src/database/inMemoryAdapter.access-context.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.access-context.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Exercises adapter-boundary access-context enforcement in the core fallback
+ * store, including adversarial cross-world, cross-room, and pre-page filtering.
+ */
+import { describe, expect, it } from "vitest";
+import type { AccessContext, Memory, UUID } from "../types";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
+
+const AGENT = "00000000-0000-0000-0000-000000000001" as UUID;
+const REQUESTER = "00000000-0000-0000-0000-000000000002" as UUID;
+const STRANGER = "00000000-0000-0000-0000-000000000003" as UUID;
+const ALLOWED_WORLD = "10000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_WORLD = "10000000-0000-0000-0000-000000000002" as UUID;
+const ALLOWED_ROOM = "20000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_ROOM = "20000000-0000-0000-0000-000000000002" as UUID;
+const OTHER_WORLD_ROOM = "20000000-0000-0000-0000-000000000003" as UUID;
+
+const context: AccessContext = {
+	requesterEntityId: REQUESTER,
+	worldId: ALLOWED_WORLD,
+	authorizedRoomIds: [ALLOWED_ROOM],
+	role: "USER",
+};
+
+const vector = (first: number, second: number): number[] => [
+	first,
+	second,
+	...Array.from({ length: 382 }, () => 0),
+];
+
+function memory(
+	id: string,
+	text: string,
+	createdAt: number,
+	overrides: Partial<Memory>,
+): Memory {
+	return {
+		id: id as UUID,
+		agentId: AGENT,
+		entityId: REQUESTER,
+		roomId: ALLOWED_ROOM,
+		worldId: ALLOWED_WORLD,
+		createdAt,
+		content: { text },
+		embedding: vector(0.8, 0.2),
+		metadata: { type: "custom", scope: "global" },
+		...overrides,
+	};
+}
+
+async function seededAdapter(): Promise<InMemoryDatabaseAdapter> {
+	const adapter = new InMemoryDatabaseAdapter(AGENT);
+	await adapter.initialize();
+	await adapter.createMemories(
+		[
+			memory(
+				"30000000-0000-0000-0000-000000000001",
+				"needle allowed global",
+				100,
+				{},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000002",
+				"needle allowed private",
+				200,
+				{
+					embedding: vector(0.9, 0.1),
+					metadata: { type: "custom", scope: "private" },
+				},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000003",
+				"needle denied private",
+				500,
+				{
+					entityId: STRANGER,
+					embedding: vector(1, 0),
+					metadata: { type: "custom", scope: "private" },
+				},
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000004",
+				"needle denied room",
+				400,
+				{ roomId: OTHER_ROOM, embedding: vector(1, 0) },
+			),
+			memory(
+				"30000000-0000-0000-0000-000000000005",
+				"needle denied world",
+				300,
+				{
+					roomId: OTHER_WORLD_ROOM,
+					worldId: OTHER_WORLD,
+					embedding: vector(1, 0),
+				},
+			),
+		].map((entry) => ({ memory: entry, tableName: "messages" })),
+	);
+	return adapter;
+}
+
+describe("InMemoryDatabaseAdapter access context", () => {
+	it("filters scope, world, and room before list pagination", async () => {
+		const adapter = await seededAdapter();
+		const rows = await adapter.getMemories({
+			tableName: "messages",
+			accessContext: context,
+			limit: 1,
+		});
+
+		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed private",
+		]);
+	});
+
+	it("intersects caller room ids with authorized rooms", async () => {
+		const adapter = await seededAdapter();
+		const rows = await adapter.getMemoriesByRoomIds({
+			tableName: "messages",
+			roomIds: [ALLOWED_ROOM, OTHER_ROOM, OTHER_WORLD_ROOM],
+			accessContext: context,
+		});
+
+		expect(rows.map((row) => row.content.text)).toEqual([
+			"needle allowed private",
+			"needle allowed global",
+		]);
+	});
+
+	it("filters before message ranking and vector top-k", async () => {
+		const adapter = await seededAdapter();
+		const textRows = await adapter.searchMessages({
+			tableName: "messages",
+			roomIds: [ALLOWED_ROOM, OTHER_ROOM, OTHER_WORLD_ROOM],
+			query: "needle",
+			accessContext: context,
+			limit: 1,
+		});
+		const vectorRows = await adapter.searchMemories({
+			tableName: "messages",
+			embedding: vector(1, 0),
+			match_threshold: 0,
+			accessContext: context,
+			limit: 1,
+		});
+
+		expect(textRows[0]?.memory.content.text).toMatch(/^needle allowed /);
+		expect(vectorRows[0]?.content.text).toBe("needle allowed private");
+	});
+
+	it("denies every room-backed row for an explicit empty authorization", async () => {
+		const adapter = await seededAdapter();
+		await expect(
+			adapter.getMemories({
+				tableName: "messages",
+				accessContext: { ...context, authorizedRoomIds: [] },
+			}),
+		).resolves.toEqual([]);
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -13,6 +13,8 @@
  * containment all mirror the SQL adapters. Persistence is process-local and
  * lost on restart.
  */
+
+import { filterMemoryReadByAccessContext } from "../access-control/filter";
 import {
 	compareMemoryIds,
 	compareTasksForQuery,
@@ -303,6 +305,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
 	readonly documentRangeReadCapability = 1 as const;
 	db: Record<string, never> = {};
+	private readonly adapterAgentId: UUID;
+
+	constructor(agentId: UUID = DEFAULT_UUID) {
+		super();
+		this.adapterAgentId = agentId;
+	}
 
 	private ready = false;
 
@@ -1201,6 +1209,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			all = all.filter((memory) => memoryMatchesMetadata(memory, filterMeta));
 		}
 
+		if (params.accessContext) {
+			all = filterMemoryReadByAccessContext(
+				all,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
+
 		// Keyword filter — same case-insensitive `includes` semantics the SQL
 		// adapter pushes down as ILIKE.
 		const textContains = params.textContains?.trim().toLowerCase();
@@ -1289,12 +1305,23 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			all = filterMemoryReadByAccessContext(
+				all,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
 			const ta = typeof a.createdAt === "number" ? a.createdAt : 0;
 			const tb = typeof b.createdAt === "number" ? b.createdAt : 0;
-			return tb - ta;
+			if (ta !== tb) return tb - ta;
+			const aId = typeof a.id === "string" ? a.id : "";
+			const bId = typeof b.id === "string" ? b.id : "";
+			return compareMemoryIds(bId, aId);
 		});
 
 		const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1324,13 +1351,20 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		}
 		// The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
 		// adapters' created_at range conditions.
-		const windowed = candidates.filter((memory) =>
+		let windowed = candidates.filter((memory) =>
 			withinCreatedAtWindow(
 				typeof memory.createdAt === "number" ? memory.createdAt : undefined,
 				params.since,
 				params.until,
 			),
 		);
+		if (params.accessContext) {
+			windowed = filterMemoryReadByAccessContext(
+				windowed,
+				params.accessContext,
+				this.adapterAgentId,
+			);
+		}
 		const ranked = rankMessageSearch(windowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1214,6 +1214,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				all,
 				params.accessContext,
 				this.adapterAgentId,
+				params.tableName === "messages" &&
+					params.accessContext.authorizedRoomIds !== undefined
+					? "room"
+					: "private",
 			);
 		}
 
@@ -1310,6 +1314,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				all,
 				params.accessContext,
 				this.adapterAgentId,
+				params.tableName === "messages" &&
+					params.accessContext.authorizedRoomIds !== undefined
+					? "room"
+					: "private",
 			);
 		}
 
@@ -1363,6 +1371,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				windowed,
 				params.accessContext,
 				this.adapterAgentId,
+				"room",
 			);
 		}
 		const ranked = rankMessageSearch(windowed, params.query);

--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for factExtractor.schema: validates fact categories,
+ * discriminated op schemas, markdown fence stripping, and tolerant parsing.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	CurrentCategoryEnum,
+	DurableCategoryEnum,
+	OpSchema,
+	parseExtractorOutputTolerant,
+	VerificationStatusEnum,
+} from "./factExtractor.schema.ts";
+
+describe("factExtractor.schema", () => {
+	describe("Category Enums", () => {
+		it("validates durable categories", () => {
+			expect(DurableCategoryEnum.safeParse("identity").success).toBe(true);
+			expect(DurableCategoryEnum.safeParse("health").success).toBe(true);
+			expect(DurableCategoryEnum.safeParse("relationship").success).toBe(true);
+			expect(DurableCategoryEnum.safeParse("invalid_cat").success).toBe(false);
+		});
+
+		it("validates current categories", () => {
+			expect(CurrentCategoryEnum.safeParse("working_on").success).toBe(true);
+			expect(CurrentCategoryEnum.safeParse("feeling").success).toBe(true);
+			expect(CurrentCategoryEnum.safeParse("invalid_cat").success).toBe(false);
+		});
+
+		it("validates verification statuses", () => {
+			expect(VerificationStatusEnum.safeParse("self_reported").success).toBe(
+				true,
+			);
+			expect(VerificationStatusEnum.safeParse("confirmed").success).toBe(true);
+			expect(VerificationStatusEnum.safeParse("contradicted").success).toBe(
+				true,
+			);
+		});
+	});
+
+	describe("OpSchema", () => {
+		it("validates add_durable op", () => {
+			const res = OpSchema.safeParse({
+				op: "add_durable",
+				claim: "Lives in Seattle",
+				category: "identity",
+				keywords: ["seattle", "location"],
+			});
+			expect(res.success).toBe(true);
+			if (res.success && res.data.op === "add_durable") {
+				expect(res.data.structured_fields).toEqual({});
+			}
+		});
+
+		it("validates add_current op", () => {
+			const res = OpSchema.safeParse({
+				op: "add_current",
+				claim: "Working on compiler migration",
+				category: "working_on",
+				valid_at: "2026-08-24T00:00:00Z",
+			});
+			expect(res.success).toBe(true);
+		});
+
+		it("validates strengthen, decay, and contradict ops", () => {
+			expect(
+				OpSchema.safeParse({ op: "strengthen", factId: "fact-1" }).success,
+			).toBe(true);
+			expect(
+				OpSchema.safeParse({ op: "decay", factId: "fact-1" }).success,
+			).toBe(true);
+			expect(
+				OpSchema.safeParse({
+					op: "contradict",
+					factId: "fact-1",
+					reason: "Moved to Tokyo",
+				}).success,
+			).toBe(true);
+		});
+	});
+
+	describe("parseExtractorOutputTolerant", () => {
+		it("normalizes legacy type field to op", () => {
+			const raw = {
+				ops: [
+					{
+						type: "strengthen",
+						factId: "fact-123",
+					},
+				],
+			};
+			const res = parseExtractorOutputTolerant(raw);
+			expect(res?.ops.length).toBe(1);
+			expect(res?.ops[0].op).toBe("strengthen");
+		});
+
+		it("drops malformed ops and keeps valid ones", () => {
+			const raw = {
+				ops: [
+					{ op: "strengthen" },
+					{ op: "add_durable", claim: "Has a dog", category: "relationship" },
+				],
+			};
+			const res = parseExtractorOutputTolerant(raw);
+			expect(res?.ops.length).toBe(1);
+			expect(res?.ops[0].op).toBe("add_durable");
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for preference extractor schema: validates trait enums,
+ * discriminated union parsing, and tolerant output envelope parsing.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	PreferenceOpSchema,
+	PreferenceTraitEnum,
+	parsePreferenceOutputTolerant,
+} from "./preferenceExtractor.schema.ts";
+
+describe("preferenceExtractor.schema", () => {
+	describe("PreferenceTraitEnum", () => {
+		it("accepts valid traits", () => {
+			expect(PreferenceTraitEnum.safeParse("verbosity").success).toBe(true);
+			expect(PreferenceTraitEnum.safeParse("tone").success).toBe(true);
+			expect(PreferenceTraitEnum.safeParse("formality").success).toBe(true);
+		});
+
+		it("rejects unauthorized traits", () => {
+			expect(PreferenceTraitEnum.safeParse("reply_gate").success).toBe(false);
+			expect(PreferenceTraitEnum.safeParse("speed").success).toBe(false);
+		});
+	});
+
+	describe("PreferenceOpSchema", () => {
+		it("validates set_trait op", () => {
+			const res = PreferenceOpSchema.safeParse({
+				op: "set_trait",
+				trait: "verbosity",
+				value: "terse",
+				confidence: 0.9,
+				evidence: "user said be concise",
+			});
+			expect(res.success).toBe(true);
+		});
+
+		it("validates add_directive op", () => {
+			const res = PreferenceOpSchema.safeParse({
+				op: "add_directive",
+				text: "Always respond in bullet points",
+				confidence: 0.85,
+			});
+			expect(res.success).toBe(true);
+		});
+
+		it("validates add_preference_fact op", () => {
+			const res = PreferenceOpSchema.safeParse({
+				op: "add_preference_fact",
+				claim: "Prefers TypeScript over Python",
+				keywords: ["typescript", "preferences"],
+				confidence: 0.95,
+			});
+			expect(res.success).toBe(true);
+		});
+
+		it("validates retract_trait op", () => {
+			const res = PreferenceOpSchema.safeParse({
+				op: "retract_trait",
+				trait: "formality",
+				reason: "user requested default style",
+			});
+			expect(res.success).toBe(true);
+		});
+	});
+
+	describe("parsePreferenceOutputTolerant", () => {
+		it("returns null when envelope is not { ops: [...] }", () => {
+			expect(parsePreferenceOutputTolerant(null)).toBeNull();
+			expect(parsePreferenceOutputTolerant("not an object")).toBeNull();
+			expect(parsePreferenceOutputTolerant({ items: [] })).toBeNull();
+		});
+
+		it("tolerantly extracts valid ops and drops invalid traits or values", () => {
+			const res = parsePreferenceOutputTolerant({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "terse",
+						confidence: 0.9,
+					},
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "warm",
+						confidence: 0.9,
+					},
+					{
+						op: "unknown_op",
+						trait: "verbosity",
+					},
+					{
+						op: "add_directive",
+						text: "Do not use emojis",
+						confidence: 0.8,
+					},
+				],
+			});
+
+			expect(res).not.toBeNull();
+			expect(res?.ops.length).toBe(2);
+			expect(res?.ops[0].op).toBe("set_trait");
+			expect(res?.ops[1].op).toBe("add_directive");
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for trajectory evaluator utils: verifies JSON object parsing,
+ * trajectory service lookup, and prompt digest formatting.
+ */
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import {
+	formatTrajectoryForPrompt,
+	getTrajectoryService,
+	parseJsonObject,
+	type SkillTrajectory,
+} from "./trajectory-evaluator-utils.ts";
+
+describe("trajectory-evaluator-utils", () => {
+	describe("parseJsonObject", () => {
+		it("parses valid json object string", () => {
+			const res = parseJsonObject('{"key": "value", "count": 42}');
+			expect(res).toEqual({ key: "value", count: 42 });
+		});
+
+		it("returns null for malformed json or empty text", () => {
+			expect(parseJsonObject("")).toBeNull();
+			expect(parseJsonObject("   ")).toBeNull();
+			expect(parseJsonObject("{bad json}")).toBeNull();
+		});
+
+		it("returns null for non-object json values", () => {
+			expect(parseJsonObject('"a string"')).toBeNull();
+			expect(parseJsonObject("123")).toBeNull();
+			expect(parseJsonObject("null")).toBeNull();
+			expect(parseJsonObject("true")).toBeNull();
+		});
+	});
+
+	describe("getTrajectoryService", () => {
+		it("returns null when trajectories service is absent", () => {
+			const runtime = {
+				getService: () => null,
+			} as unknown as IAgentRuntime;
+			expect(getTrajectoryService(runtime)).toBeNull();
+		});
+
+		it("returns null when service does not implement required methods", () => {
+			const runtime = {
+				getService: () => ({
+					listTrajectories: () => {},
+				}),
+			} as unknown as IAgentRuntime;
+			expect(getTrajectoryService(runtime)).toBeNull();
+		});
+
+		it("returns typed service when valid methods exist", () => {
+			const service = {
+				listTrajectories: async () => ({ trajectories: [] }),
+				getTrajectoryDetail: async () => null,
+			};
+			const runtime = {
+				getService: () => service,
+			} as unknown as IAgentRuntime;
+			expect(getTrajectoryService(runtime)).toBe(service);
+		});
+	});
+
+	describe("formatTrajectoryForPrompt", () => {
+		it("formats minimal trajectory", () => {
+			const traj: SkillTrajectory = {
+				trajectoryId: "traj-123",
+				agentId: "agent-1",
+				startTime: 1000,
+			};
+			const out = formatTrajectoryForPrompt(traj);
+			expect(out).toContain("Trajectory: traj-123");
+			expect(out).toContain("Status: unknown");
+		});
+
+		it("formats trajectory with steps, llm calls, and custom options", () => {
+			const traj: SkillTrajectory = {
+				trajectoryId: "traj-456",
+				agentId: "agent-2",
+				startTime: 1000,
+				metrics: { finalStatus: "completed" },
+				steps: [
+					{
+						timestamp: 1010,
+						llmCalls: [
+							{
+								purpose: "search",
+								userPrompt: "Find documentation",
+								response: "Here is the doc",
+							},
+							{
+								actionType: "tool_use",
+								userPrompt: "Run command",
+								response: "Done",
+							},
+						],
+					},
+				],
+			};
+
+			const out = formatTrajectoryForPrompt(traj, {
+				statusLabel: "Final State",
+				includeStepCount: true,
+				blankLineAfterHeader: true,
+			});
+
+			expect(out).toContain("Trajectory: traj-456");
+			expect(out).toContain("Final State: completed");
+			expect(out).toContain("Step count: 1");
+			expect(out).toContain("--- Step 1 ---");
+			expect(out).toContain("[search]");
+			expect(out).toContain("USER: Find documentation");
+			expect(out).toContain("AGENT: Here is the doc");
+			expect(out).toContain("[tool_use]");
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/experience/generated/specs/spec-helpers.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/generated/specs/spec-helpers.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for spec-helpers: validates action and provider spec lookups,
+ * optional vs required retrieval, and not-found error handling.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	getActionSpec,
+	getProviderSpec,
+	requireActionSpec,
+	requireProviderSpec,
+} from "./spec-helpers.ts";
+
+describe("spec-helpers", () => {
+	describe("actions lookup", () => {
+		it("retrieves known action spec or undefined for unknown", () => {
+			expect(getActionSpec("UNKNOWN_ACTION_999")).toBeUndefined();
+		});
+
+		it("throws Error on requireActionSpec when not found", () => {
+			expect(() => requireActionSpec("NON_EXISTENT_ACTION")).toThrow(
+				"Action spec not found: NON_EXISTENT_ACTION",
+			);
+		});
+	});
+
+	describe("providers lookup", () => {
+		it("retrieves known provider spec or undefined for unknown", () => {
+			expect(getProviderSpec("UNKNOWN_PROVIDER_999")).toBeUndefined();
+		});
+
+		it("throws Error on requireProviderSpec when not found", () => {
+			expect(() => requireProviderSpec("NON_EXISTENT_PROVIDER")).toThrow(
+				"Provider spec not found: NON_EXISTENT_PROVIDER",
+			);
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/personality/reply-gate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/reply-gate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for personality reply gate: validates slot resolution order,
+ * lift phrases, on_mention gating, and never_until_lift mute decisions.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	decideReplyGate,
+	messageContainsLiftSignal,
+	resolveEffectiveReplyGate,
+} from "./reply-gate.ts";
+
+describe("reply-gate", () => {
+	describe("resolveEffectiveReplyGate", () => {
+		it("prioritizes user slot reply_gate over global slot", () => {
+			const res = resolveEffectiveReplyGate(
+				{ reply_gate: "on_mention" },
+				{ reply_gate: "always" },
+			);
+			expect(res).toEqual({ mode: "on_mention", scope: "user" });
+		});
+
+		it("falls back to global slot when user slot is unset", () => {
+			const res = resolveEffectiveReplyGate(null, {
+				reply_gate: "never_until_lift",
+			});
+			expect(res).toEqual({ mode: "never_until_lift", scope: "global" });
+		});
+
+		it("returns null when neither is set", () => {
+			expect(resolveEffectiveReplyGate(null, null)).toEqual({
+				mode: null,
+				scope: null,
+			});
+		});
+	});
+
+	describe("messageContainsLiftSignal", () => {
+		it("returns true when explicitly addressing agent", () => {
+			expect(messageContainsLiftSignal("hello", true)).toBe(true);
+		});
+
+		it("returns true on wake-up and lift phrases", () => {
+			expect(messageContainsLiftSignal("okay talk again", false)).toBe(true);
+			expect(messageContainsLiftSignal("you can talk", false)).toBe(true);
+			expect(messageContainsLiftSignal("please unmute", false)).toBe(true);
+			expect(messageContainsLiftSignal("lift the silence", false)).toBe(true);
+			expect(messageContainsLiftSignal("wake up", false)).toBe(true);
+			expect(messageContainsLiftSignal("start replying again", false)).toBe(
+				true,
+			);
+		});
+
+		it("returns false for casual mentions or unrelated text", () => {
+			expect(messageContainsLiftSignal("we should talk about it", false)).toBe(
+				false,
+			);
+			expect(messageContainsLiftSignal("", false)).toBe(false);
+			expect(messageContainsLiftSignal(undefined, false)).toBe(false);
+		});
+	});
+
+	describe("decideReplyGate", () => {
+		it("allows response when gate mode is unset or always", () => {
+			expect(
+				decideReplyGate({
+					userSlot: null,
+					globalSlot: null,
+					messageText: "hi",
+					explicitlyAddressesAgent: false,
+				}),
+			).toEqual({ allow: true, reason: "no_gate" });
+		});
+
+		it("allows response for addressed_or_ambient mode", () => {
+			expect(
+				decideReplyGate({
+					userSlot: { reply_gate: "addressed_or_ambient" },
+					globalSlot: null,
+					messageText: "hi",
+					explicitlyAddressesAgent: false,
+				}),
+			).toEqual({ allow: true, reason: "addressed_or_ambient" });
+		});
+
+		it("handles on_mention gate mode correctly", () => {
+			expect(
+				decideReplyGate({
+					userSlot: { reply_gate: "on_mention" },
+					globalSlot: null,
+					messageText: "@agent hi",
+					explicitlyAddressesAgent: true,
+				}),
+			).toEqual({ allow: true, reason: "on_mention_satisfied" });
+
+			expect(
+				decideReplyGate({
+					userSlot: { reply_gate: "on_mention" },
+					globalSlot: null,
+					messageText: "general message",
+					explicitlyAddressesAgent: false,
+				}),
+			).toEqual({
+				allow: false,
+				reason: "on_mention_not_addressed",
+				gateMode: "on_mention",
+				scope: "user",
+			});
+		});
+
+		it("handles never_until_lift gate mode correctly", () => {
+			expect(
+				decideReplyGate({
+					userSlot: { reply_gate: "never_until_lift" },
+					globalSlot: null,
+					messageText: "wake up",
+					explicitlyAddressesAgent: false,
+				}),
+			).toEqual({ allow: true, reason: "lift_signal" });
+
+			expect(
+				decideReplyGate({
+					userSlot: null,
+					globalSlot: { reply_gate: "never_until_lift" },
+					messageText: "random comment",
+					explicitlyAddressesAgent: false,
+				}),
+			).toEqual({
+				allow: false,
+				reason: "never_until_lift",
+				gateMode: "never_until_lift",
+				scope: "global",
+			});
+		});
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.edge.test.ts
+++ b/packages/core/src/features/basic-capabilities/index.edge.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit tests for basic-capabilities edge entrypoint: validates Workerd plugin
+ * assembly and unsupported capability error rejection.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	basicActions,
+	basicCapabilities,
+	basicProviders,
+	createBasicCapabilitiesPlugin,
+} from "./index.edge.ts";
+
+describe("basic-capabilities edge", () => {
+	it("exports default basic capabilities structure", () => {
+		expect(basicCapabilities.providers.length).toBeGreaterThan(0);
+		expect(basicCapabilities.actions.length).toBe(3);
+		expect(basicCapabilities.services.length).toBe(1);
+	});
+
+	it("creates basic capabilities plugin with default config", () => {
+		const plugin = createBasicCapabilitiesPlugin();
+		expect(plugin.name).toBe("basic-capabilities");
+		expect(plugin.actions.length).toBe(basicActions.length);
+		expect(plugin.providers.length).toBe(basicProviders.length);
+	});
+
+	it("throws error when unsupported capability flags are enabled in Workerd", () => {
+		expect(() =>
+			createBasicCapabilitiesPlugin({ enableAutonomy: true }),
+		).toThrow("Workerd runtime does not support core capability flags");
+	});
+});

--- a/packages/core/src/features/documents/provider.test.ts
+++ b/packages/core/src/features/documents/provider.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Behavior tests for renderPinnedDocuments — the DOCUMENTS provider's pinned
+ * document renderer. Covers the pinned-only filter, deterministic sort order,
+ * the fair-share token-budget truncation (with the explicit truncation marker),
+ * the identity-budget overflow guard, and the no-pinned-documents empty case.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../../errors.ts";
+import type { Memory } from "../../types/index.ts";
+import {
+	PINNED_DOCUMENT_TRUNCATION_MARKER,
+	renderPinnedDocuments,
+} from "./provider.ts";
+
+function pinnedMemory(
+	id: string,
+	text: string,
+	overrides: { title?: string; pinned?: boolean; type?: string } = {},
+): Memory {
+	return {
+		id,
+		content: { text },
+		createdAt: 0,
+		metadata: {
+			type: overrides.type ?? "document",
+			pinned: overrides.pinned ?? true,
+			...(overrides.title !== undefined ? { title: overrides.title } : {}),
+		},
+	} as Memory;
+}
+
+describe("renderPinnedDocuments", () => {
+	it("returns an empty payload when there are no pinned documents", () => {
+		const result = renderPinnedDocuments([]);
+		expect(result).toEqual({ text: "", truncated: false, includedIds: [] });
+	});
+
+	it("filters out non-document memories and unpinned documents", () => {
+		const documents = [
+			pinnedMemory("doc-1", "alpha", { pinned: true }),
+			pinnedMemory("doc-2", "beta", { pinned: false }),
+			pinnedMemory("frag-1", "gamma", { type: "fragment" }),
+			pinnedMemory("doc-3", "delta", { pinned: true }),
+		];
+		const result = renderPinnedDocuments(documents, 10_000);
+		expect(result.includedIds).toEqual(["doc-1", "doc-3"]);
+		expect(result.text).not.toContain("beta");
+		expect(result.text).not.toContain("gamma");
+	});
+
+	it("sorts pinned documents by title then id for a deterministic order", () => {
+		const documents = [
+			pinnedMemory("id-z", "zzz", { title: "zebra" }),
+			pinnedMemory("id-a", "aaa", { title: "alpha" }),
+			pinnedMemory("id-b", "bbb", { title: "bravo" }),
+			pinnedMemory("id-m", "mmm", { title: "zebra" }),
+		];
+		const result = renderPinnedDocuments(documents, 10_000);
+		// title primary (alpha < bravo < zebra), then id tiebreak on "zebra".
+		expect(result.includedIds).toEqual(["id-a", "id-b", "id-m", "id-z"]);
+	});
+
+	it("falls back to `Document N` for untitled pinned documents", () => {
+		const documents = [pinnedMemory("doc-1", "content", { title: "   " })];
+		const result = renderPinnedDocuments(documents, 10_000);
+		expect(result.text).toContain("## Document 1 (doc-1");
+	});
+
+	it("renders full content and no marker when the budget is not exceeded", () => {
+		const documents = [pinnedMemory("doc-1", "short content", { title: "T" })];
+		const result = renderPinnedDocuments(documents, 10_000);
+		expect(result.truncated).toBe(false);
+		expect(result.text).toContain("short content");
+		expect(result.text).not.toContain(PINNED_DOCUMENT_TRUNCATION_MARKER);
+		expect(result.includedIds).toEqual(["doc-1"]);
+	});
+
+	it("truncates long content to the fair share and appends the truncation marker", () => {
+		const documents = [
+			pinnedMemory("doc-1", "x".repeat(5_000), { title: "Long" }),
+			pinnedMemory("doc-2", "y".repeat(5_000), { title: "Longer" }),
+		];
+		// tokenBudget = 100 => 400 characters total, far below 10k of content.
+		const result = renderPinnedDocuments(documents, 100);
+		expect(result.truncated).toBe(true);
+		expect(result.text.endsWith(PINNED_DOCUMENT_TRUNCATION_MARKER)).toBe(true);
+		expect(result.includedIds).toEqual(["doc-1", "doc-2"]);
+		// The marker is only appended once, after all blocks.
+		expect(result.text.split(PINNED_DOCUMENT_TRUNCATION_MARKER)).toHaveLength(
+			2,
+		);
+	});
+
+	it("throws when the pinned identities alone exceed the token budget", () => {
+		const documents = [
+			pinnedMemory("doc-1", "content", {
+				title: "A".repeat(2_000),
+			}),
+		];
+		// tokenBudget = 1 => 4 chars total; headers alone are thousands of chars.
+		expect(() => renderPinnedDocuments(documents, 1)).toThrow(ElizaError);
+		try {
+			renderPinnedDocuments(documents, 1);
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(
+				"PINNED_DOCUMENT_IDENTITY_BUDGET_EXCEEDED",
+			);
+		}
+	});
+
+	it("includes a document with empty content as a header-only block", () => {
+		const documents = [pinnedMemory("doc-1", "", { title: "Empty" })];
+		const result = renderPinnedDocuments(documents, 10_000);
+		expect(result.truncated).toBe(false);
+		expect(result.text).toContain("## Empty (doc-1");
+		expect(result.includedIds).toEqual(["doc-1"]);
+	});
+});

--- a/packages/core/src/features/messaging/triage/deferred-send-scheduler.test.ts
+++ b/packages/core/src/features/messaging/triage/deferred-send-scheduler.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for deferred-send-scheduler: validates scheduler registration,
+ * duplicate rejection with ElizaError, retrieval, and teardown cleanup.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../../../errors.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import {
+	type DeferredMessageScheduler,
+	getDeferredMessageScheduler,
+	registerDeferredMessageScheduler,
+} from "./deferred-send-scheduler.ts";
+
+describe("deferred-send-scheduler", () => {
+	it("returns null when no scheduler is registered", () => {
+		const runtime = {} as IAgentRuntime;
+		expect(getDeferredMessageScheduler(runtime)).toBeNull();
+	});
+
+	it("registers and retrieves scheduler for a runtime", () => {
+		const runtime = {} as IAgentRuntime;
+		const mockScheduler: DeferredMessageScheduler = {
+			schedule: async () => ({
+				scheduledId: "sched-1",
+				scheduledForMs: Date.now() + 10000,
+				commit: {
+					kind: "durable",
+					id: "commit-1",
+					committedAt: new Date().toISOString(),
+					idempotencyKey: "idem-1",
+					replayed: false,
+				},
+			}),
+		};
+
+		const unregister = registerDeferredMessageScheduler(runtime, mockScheduler);
+		expect(getDeferredMessageScheduler(runtime)).toBe(mockScheduler);
+
+		unregister();
+		expect(getDeferredMessageScheduler(runtime)).toBeNull();
+	});
+
+	it("throws fatal ElizaError on duplicate registration", () => {
+		const runtime = {} as IAgentRuntime;
+		const mockScheduler: DeferredMessageScheduler = {
+			schedule: async () => ({}) as any,
+		};
+
+		registerDeferredMessageScheduler(runtime, mockScheduler);
+
+		expect(() => {
+			registerDeferredMessageScheduler(runtime, mockScheduler);
+		}).toThrow(ElizaError);
+
+		try {
+			registerDeferredMessageScheduler(runtime, mockScheduler);
+		} catch (err) {
+			expect((err as ElizaError).code).toBe(
+				"DEFERRED_MESSAGE_SCHEDULER_DUPLICATE",
+			);
+			expect((err as ElizaError).severity).toBe("fatal");
+		}
+	});
+});

--- a/packages/core/src/features/plugin-manager/coreExtensions.test.ts
+++ b/packages/core/src/features/plugin-manager/coreExtensions.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for coreExtensions: validates unregisterAction, unregisterProvider,
+ * and unregisterService extensions added to IAgentRuntime.
+ */
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "../../types/runtime.ts";
+import {
+	applyRuntimeExtensions,
+	type ExtendedRuntime,
+	extendRuntimeWithComponentUnregistration,
+} from "./coreExtensions.ts";
+
+describe("coreExtensions", () => {
+	function createMockRuntime() {
+		const servicesMap = new Map();
+		return {
+			actions: [
+				{ name: "ACTION_ONE", description: "First action" },
+				{ name: "ACTION_TWO", description: "Second action" },
+			],
+			providers: [
+				{ name: "PROVIDER_A", get: async () => ({ text: "A" }) },
+				{ name: "PROVIDER_B", get: async () => ({ text: "B" }) },
+			],
+			getServicesByType: (type: string) => {
+				return servicesMap.get(type) || [];
+			},
+			getAllServices: () => servicesMap,
+		} as unknown as IAgentRuntime;
+	}
+
+	it("extends runtime with unregisterAction and removes action", () => {
+		const runtime = createMockRuntime();
+		extendRuntimeWithComponentUnregistration(runtime);
+		const ext = runtime as ExtendedRuntime;
+
+		expect(ext.actions.length).toBe(2);
+		const removed = ext.unregisterAction("ACTION_ONE");
+		expect(removed).toBe(true);
+		expect(ext.actions.length).toBe(1);
+		expect(ext.actions[0].name).toBe("ACTION_TWO");
+
+		const removedAgain = ext.unregisterAction("ACTION_ONE");
+		expect(removedAgain).toBe(false);
+	});
+
+	it("extends runtime with unregisterProvider and removes provider", () => {
+		const runtime = createMockRuntime();
+		extendRuntimeWithComponentUnregistration(runtime);
+		const ext = runtime as ExtendedRuntime;
+
+		expect(ext.providers.length).toBe(2);
+		ext.unregisterProvider?.("PROVIDER_A");
+		expect(ext.providers.length).toBe(1);
+		expect(ext.providers[0].name).toBe("PROVIDER_B");
+	});
+
+	it("extends runtime with unregisterService and stops services", async () => {
+		const runtime = createMockRuntime();
+		let stopped = false;
+		const mockService = {
+			stop: async () => {
+				stopped = true;
+			},
+		};
+		runtime.getAllServices().set("CUSTOM_SERVICE", [mockService]);
+
+		applyRuntimeExtensions(runtime);
+		const ext = runtime as ExtendedRuntime;
+
+		await ext.unregisterService?.("CUSTOM_SERVICE");
+		expect(stopped).toBe(true);
+		expect(runtime.getAllServices().has("CUSTOM_SERVICE")).toBe(false);
+	});
+});

--- a/packages/core/src/features/secrets/storage/component-store.test.ts
+++ b/packages/core/src/features/secrets/storage/component-store.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for ComponentSecretStorage: validates secret storage backed
+ * by user runtime components.
+ */
+import { describe, expect, it } from "vitest";
+import type { Component, IAgentRuntime, UUID } from "../../../types/index.ts";
+import type { KeyManager } from "../crypto/encryption.ts";
+import type { SecretContext } from "../types.ts";
+import { ComponentSecretStorage } from "./component-store.ts";
+
+describe("ComponentSecretStorage", () => {
+	const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
+	const userId = "00000000-0000-0000-0000-000000000002" as UUID;
+	const mockKeyManager = {} as KeyManager;
+
+	function createStorage(components: Component[] = []) {
+		const runtime = {
+			agentId,
+			getComponents: async (_entityId: UUID) => components,
+			getComponent: async (_entityId: UUID, type: string) =>
+				components.find((c) => c.type === type) ?? null,
+			createComponent: async (c: Component) => {
+				components.push(c);
+			},
+		} as unknown as IAgentRuntime;
+
+		return {
+			storage: new ComponentSecretStorage(runtime, mockKeyManager),
+			runtime,
+			components,
+		};
+	}
+
+	const context: SecretContext = {
+		source: "user",
+		userId,
+		requesterId: userId,
+	};
+
+	it("returns false for exists when userId is missing", async () => {
+		const { storage } = createStorage();
+		expect(await storage.exists("KEY", { source: "agent" })).toBe(false);
+	});
+
+	it("retrieves plain string secret from component", async () => {
+		const { storage } = createStorage([
+			{
+				id: "comp-1" as UUID,
+				agentId,
+				entityId: userId,
+				type: "secret:GITHUB_TOKEN",
+				data: {
+					key: "GITHUB_TOKEN",
+					value: "ghp_12345",
+					config: { required: true },
+					updatedAt: Date.now(),
+				},
+				createdAt: Date.now(),
+			},
+		]);
+
+		expect(await storage.exists("GITHUB_TOKEN", context)).toBe(true);
+		const val = await storage.get("GITHUB_TOKEN", context);
+		expect(val).toBe("ghp_12345");
+	});
+});

--- a/packages/core/src/features/secrets/storage/world-store.test.ts
+++ b/packages/core/src/features/secrets/storage/world-store.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for WorldMetadataStorage: validates secrets stored in world.metadata.secrets.
+ */
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, UUID, World } from "../../../types/index.ts";
+import type { KeyManager } from "../crypto/encryption.ts";
+import type { SecretContext } from "../types.ts";
+import { WorldMetadataStorage } from "./world-store.ts";
+
+describe("WorldMetadataStorage", () => {
+	const worldId = "00000000-0000-0000-0000-000000000010" as UUID;
+	const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
+	const mockKeyManager = {} as KeyManager;
+
+	function createStorage(metadataSecrets: Record<string, any> = {}) {
+		const mockWorld: World = {
+			id: worldId,
+			name: "TestWorld",
+			agentId,
+			metadata: {
+				secrets: metadataSecrets,
+			},
+		} as World;
+
+		const runtime = {
+			agentId,
+			getWorld: async (_id: UUID) => mockWorld,
+			getRoom: async () => null,
+		} as unknown as IAgentRuntime;
+
+		return {
+			storage: new WorldMetadataStorage(runtime, mockKeyManager),
+			runtime,
+		};
+	}
+
+	const context: SecretContext = {
+		source: "agent",
+		worldId,
+		requesterId: agentId,
+	};
+
+	it("returns false for exists when worldId is missing", async () => {
+		const { storage } = createStorage();
+		expect(await storage.exists("KEY", { source: "agent" })).toBe(false);
+	});
+
+	it("retrieves plain string secret from world metadata", async () => {
+		const { storage } = createStorage({
+			DISCORD_BOT_TOKEN: "discord_secret_token_123",
+		});
+
+		expect(await storage.exists("DISCORD_BOT_TOKEN", context)).toBe(true);
+		const val = await storage.get("DISCORD_BOT_TOKEN", context);
+		expect(val).toBe("discord_secret_token_123");
+	});
+});

--- a/packages/core/src/features/working-memory/taskClipboardPersistence.test.ts
+++ b/packages/core/src/features/working-memory/taskClipboardPersistence.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for taskClipboardPersistence: verifies clipboard flag detection,
+ * title resolution priority, and maybeStoreTaskClipboardItem handling.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory } from "../../types/index.ts";
+import {
+	maybeStoreTaskClipboardItem,
+	resolveClipboardTitle,
+	shouldAddToClipboard,
+} from "./taskClipboardPersistence.ts";
+
+describe("taskClipboardPersistence", () => {
+	const baseMemory: Memory = {
+		id: "mem-1" as any,
+		roomId: "room-1" as any,
+		entityId: "entity-1" as any,
+		agentId: "agent-1" as any,
+		content: { text: "hello" },
+		createdAt: Date.now(),
+	};
+
+	describe("shouldAddToClipboard", () => {
+		it("returns false when no clipboard flags are set", () => {
+			expect(shouldAddToClipboard(baseMemory)).toBe(false);
+		});
+
+		it("returns true for boolean true flags", () => {
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", addToClipboard: true },
+				}),
+			).toBe(true);
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", persistToClipboard: true },
+				}),
+			).toBe(true);
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", saveToClipboard: true },
+				}),
+			).toBe(true);
+		});
+
+		it("returns true for string truthy flags", () => {
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", addToClipboard: "true" },
+				}),
+			).toBe(true);
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", persistToClipboard: "yes" },
+				}),
+			).toBe(true);
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", saveToClipboard: "1" },
+				}),
+			).toBe(true);
+		});
+
+		it("returns false for string falsy values", () => {
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", addToClipboard: "false" },
+				}),
+			).toBe(false);
+			expect(
+				shouldAddToClipboard({
+					...baseMemory,
+					content: { text: "", persistToClipboard: "no" },
+				}),
+			).toBe(false);
+		});
+	});
+
+	describe("resolveClipboardTitle", () => {
+		it("prioritizes clipboardTitle over title and fallback", () => {
+			const memory: Memory = {
+				...baseMemory,
+				content: {
+					text: "",
+					clipboardTitle: "Explicit Title",
+					title: "Content Title",
+				},
+			};
+			expect(resolveClipboardTitle(memory, "Fallback Title")).toBe(
+				"Explicit Title",
+			);
+		});
+
+		it("falls back to content.title when clipboardTitle is absent", () => {
+			const memory: Memory = {
+				...baseMemory,
+				content: { text: "", title: "Content Title" },
+			};
+			expect(resolveClipboardTitle(memory, "Fallback Title")).toBe(
+				"Content Title",
+			);
+		});
+
+		it("falls back to fallbackTitle when content titles are absent", () => {
+			expect(resolveClipboardTitle(baseMemory, "Fallback Title")).toBe(
+				"Fallback Title",
+			);
+		});
+
+		it("returns undefined when no valid titles exist", () => {
+			expect(resolveClipboardTitle(baseMemory)).toBeUndefined();
+			expect(resolveClipboardTitle(baseMemory, "   ")).toBeUndefined();
+		});
+	});
+
+	describe("maybeStoreTaskClipboardItem", () => {
+		it("returns requested: false when flag is not set", async () => {
+			const runtime = {} as IAgentRuntime;
+			const res = await maybeStoreTaskClipboardItem(runtime, baseMemory, {
+				content: "sample content",
+			});
+			expect(res).toEqual({ requested: false, stored: false });
+		});
+
+		it("returns requested: true, stored: false when content is empty", async () => {
+			const runtime = {} as IAgentRuntime;
+			const memory: Memory = {
+				...baseMemory,
+				content: { text: "", addToClipboard: true },
+			};
+			const res = await maybeStoreTaskClipboardItem(runtime, memory, {
+				content: "   ",
+			});
+			expect(res).toEqual({
+				requested: true,
+				stored: false,
+				reason: "No stored content was available to save in the clipboard.",
+			});
+		});
+	});
+});

--- a/packages/core/src/messaging/interactions/profile-catalog.test.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.test.ts
@@ -1,0 +1,729 @@
+/**
+ * Unit coverage for the published interaction templates, the mechanically
+ * audited first-party connector catalog, and the capability-matrix renderer:
+ * template inheritance boundaries, catalog invariants, and collaborator wiring
+ * are asserted against the real modules, whose exported spies delegate to the
+ * original implementations instead of fixtures.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	BUTTON_INTERACTION_PROFILE,
+	CONVERSATIONAL_INTERACTION_PROFILE,
+	FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT,
+	RICH_INTERACTION_PROFILE,
+	renderFirstPartyInteractionCapabilityMatrix,
+} from "./profile-catalog";
+import * as profiles from "./profiles";
+
+vi.mock("./profiles", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./profiles")>();
+	return {
+		...actual,
+		createConnectorInteractionCapabilityProfile: vi.fn(
+			actual.createConnectorInteractionCapabilityProfile,
+		),
+		renderInteractionCapabilityMatrix: vi.fn(
+			actual.renderInteractionCapabilityMatrix,
+		),
+	};
+});
+
+const createProfileSpy = vi.mocked(
+	profiles.createConnectorInteractionCapabilityProfile,
+);
+const renderMatrixSpy = vi.mocked(profiles.renderInteractionCapabilityMatrix);
+
+const CONVERSATIONAL_TTL_MS = 900_000;
+const TASK_TTL_MS = 21_600_000;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("CONVERSATIONAL_INTERACTION_PROFILE", () => {
+	it("declares the conversational-v1 template id and ordered block modes", () => {
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.templateId).toBe(
+			"conversational-v1",
+		);
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.choice).toEqual({
+			modes: ["conversational", "signed-hosted"],
+			maxSessionTtlMs: CONVERSATIONAL_TTL_MS,
+		});
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.form).toEqual({
+			modes: ["conversational", "signed-hosted"],
+			maxSessionTtlMs: CONVERSATIONAL_TTL_MS,
+		});
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.followups).toEqual({
+			modes: ["conversational"],
+			maxSessionTtlMs: CONVERSATIONAL_TTL_MS,
+		});
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.task).toEqual({
+			modes: ["signed-hosted", "conversational"],
+			maxSessionTtlMs: TASK_TTL_MS,
+		});
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.secret).toEqual({
+			modes: ["sensitive-request"],
+			maxSessionTtlMs: CONVERSATIONAL_TTL_MS,
+		});
+	});
+
+	it("uses a 15-minute session TTL everywhere except the 6-hour task block", () => {
+		expect(CONVERSATIONAL_TTL_MS).toBe(15 * 60 * 1_000);
+		expect(TASK_TTL_MS).toBe(24 * CONVERSATIONAL_TTL_MS);
+		expect(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.choice.maxSessionTtlMs,
+		).toBe(900_000);
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.blocks.task.maxSessionTtlMs).toBe(
+			21_600_000,
+		);
+	});
+
+	it("disables every native primitive except links and bounds text at 4,000 bytes", () => {
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.limits).toEqual({
+			buttons: {
+				supported: false,
+				maxPerRow: 0,
+				maxPerMessage: 0,
+				maxLabelBytes: 0,
+				maxCallbackBytes: 0,
+			},
+			lists: {
+				supported: false,
+				maxItems: 0,
+				maxLabelBytes: 0,
+				maxDescriptionBytes: 0,
+			},
+			modals: { supported: false, maxFields: 0, maxTitleBytes: 0 },
+			forms: { supported: false, maxFields: 0, maxOptionsPerField: 0 },
+			links: { supported: true, maxUrlBytes: 2_048 },
+			edits: { supported: false, windowMs: null },
+			threads: { supported: false, maxTitleBytes: 0 },
+			text: { maxMessageBytes: 4_000 },
+			attachments: {
+				supported: false,
+				maxCount: 0,
+				maxBytesEach: 0,
+				mimeTypes: [],
+			},
+		});
+	});
+
+	it("orders non-secret fallbacks conversational before signed-hosted", () => {
+		expect(CONVERSATIONAL_INTERACTION_PROFILE.nonSecretFallbacks).toEqual([
+			"conversational",
+			"signed-hosted",
+		]);
+	});
+
+	it("materializes into a valid version-1 capability profile", () => {
+		const materialized = profiles.createConnectorInteractionCapabilityProfile({
+			template: CONVERSATIONAL_INTERACTION_PROFILE,
+			source: "imessage",
+			accountId: "acct-conversational",
+			targetKind: "user",
+			targetId: "target-conversational",
+		});
+		expect(materialized.profileVersion).toBe(1);
+		expect(materialized.connector).toEqual({
+			source: "imessage",
+			accountId: "acct-conversational",
+		});
+		expect(materialized.target).toEqual({
+			kind: "user",
+			id: "target-conversational",
+		});
+		expect(materialized.profileId).toMatch(/^ip1:/);
+		expect(materialized.limits).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits,
+		);
+		expect(materialized.nonSecretFallbacks).toEqual([
+			"conversational",
+			"signed-hosted",
+		]);
+		expect(materialized.sensitiveFallback).toBe("sensitive-request");
+	});
+});
+
+describe("BUTTON_INTERACTION_PROFILE", () => {
+	it("keeps the conversational defaults it does not override", () => {
+		expect(BUTTON_INTERACTION_PROFILE.templateId).toBe("button-native-v1");
+		expect(BUTTON_INTERACTION_PROFILE.blocks.form).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.form,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.secret).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.secret,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.links).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.links,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.text).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.text,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.edits).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.edits,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.lists).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.lists,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.modals).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.modals,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.forms).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.forms,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.threads).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.threads,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.attachments).toEqual(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.attachments,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.task.maxSessionTtlMs).toBe(
+			TASK_TTL_MS,
+		);
+	});
+
+	it("prepends native to exactly choice, followups, and task", () => {
+		expect(BUTTON_INTERACTION_PROFILE.blocks.choice.modes).toEqual([
+			"native",
+			"conversational",
+			"signed-hosted",
+		]);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.followups.modes).toEqual([
+			"native",
+			"conversational",
+		]);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.task.modes).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.form.modes).not.toContain(
+			"native",
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.secret.modes).not.toContain(
+			"native",
+		);
+	});
+
+	it("enables buttons at the conservative 5/25/80/64 boundaries", () => {
+		expect(BUTTON_INTERACTION_PROFILE.limits.buttons).toEqual({
+			supported: true,
+			maxPerRow: 5,
+			maxPerMessage: 25,
+			maxLabelBytes: 80,
+			maxCallbackBytes: 64,
+		});
+	});
+
+	it("extends fallbacks to native first without dropping the conversational path", () => {
+		expect(BUTTON_INTERACTION_PROFILE.nonSecretFallbacks).toEqual([
+			"native",
+			"conversational",
+			"signed-hosted",
+		]);
+	});
+
+	it("copies overridden containers instead of aliasing the conversational ones", () => {
+		expect(BUTTON_INTERACTION_PROFILE).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.choice).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.choice,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.followups).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.followups,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.blocks.task).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.blocks.task,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.buttons).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.buttons,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.links).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.links,
+		);
+		expect(BUTTON_INTERACTION_PROFILE.limits.text).not.toBe(
+			CONVERSATIONAL_INTERACTION_PROFILE.limits.text,
+		);
+	});
+
+	it("materializes into a valid profile that keeps the button limits", () => {
+		const materialized = profiles.createConnectorInteractionCapabilityProfile({
+			template: BUTTON_INTERACTION_PROFILE,
+			source: "telegram",
+			accountId: "acct-button",
+			targetKind: "room",
+			targetId: "target-button",
+		});
+		expect(materialized.profileVersion).toBe(1);
+		expect(materialized.limits.buttons).toEqual(
+			BUTTON_INTERACTION_PROFILE.limits.buttons,
+		);
+		expect(materialized.blocks.choice.modes).toContain("native");
+		expect(materialized.nonSecretFallbacks).toEqual([
+			"native",
+			"conversational",
+			"signed-hosted",
+		]);
+	});
+});
+
+describe("RICH_INTERACTION_PROFILE", () => {
+	it("exposes the high-capability primitive boundaries", () => {
+		expect(RICH_INTERACTION_PROFILE.templateId).toBe("rich-native-v1");
+		expect(RICH_INTERACTION_PROFILE.limits.buttons).toEqual({
+			supported: true,
+			maxPerRow: 8,
+			maxPerMessage: 100,
+			maxLabelBytes: 256,
+			maxCallbackBytes: 256,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.lists).toEqual({
+			supported: true,
+			maxItems: 100,
+			maxLabelBytes: 256,
+			maxDescriptionBytes: 1_024,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.modals).toEqual({
+			supported: true,
+			maxFields: 20,
+			maxTitleBytes: 256,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.forms).toEqual({
+			supported: true,
+			maxFields: 20,
+			maxOptionsPerField: 100,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.links).toEqual({
+			supported: true,
+			maxUrlBytes: 8_192,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.threads).toEqual({
+			supported: true,
+			maxTitleBytes: 256,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.text).toEqual({
+			maxMessageBytes: 1_000_000,
+		});
+		expect(RICH_INTERACTION_PROFILE.limits.attachments).toEqual({
+			supported: true,
+			maxCount: 20,
+			maxBytesEach: 100_000_000,
+			mimeTypes: ["*/*"],
+		});
+	});
+
+	it("allows unbounded edit windows while keeping secrets on the sensitive flow", () => {
+		expect(RICH_INTERACTION_PROFILE.limits.edits).toEqual({
+			supported: true,
+			windowMs: null,
+		});
+		expect(RICH_INTERACTION_PROFILE.blocks.secret).toEqual({
+			modes: ["sensitive-request"],
+			maxSessionTtlMs: CONVERSATIONAL_TTL_MS,
+		});
+	});
+
+	it("adds native to every ordinary block with signed-hosted preferred over conversational", () => {
+		expect(RICH_INTERACTION_PROFILE.blocks.choice.modes).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+		expect(RICH_INTERACTION_PROFILE.blocks.form.modes).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+		expect(RICH_INTERACTION_PROFILE.blocks.followups.modes).toEqual([
+			"native",
+			"conversational",
+		]);
+		expect(RICH_INTERACTION_PROFILE.blocks.task.modes).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+		expect(RICH_INTERACTION_PROFILE.nonSecretFallbacks).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+	});
+
+	it("does not share overridden containers with the button template", () => {
+		expect(RICH_INTERACTION_PROFILE).not.toBe(BUTTON_INTERACTION_PROFILE);
+		expect(RICH_INTERACTION_PROFILE.blocks.choice).not.toBe(
+			BUTTON_INTERACTION_PROFILE.blocks.choice,
+		);
+		expect(RICH_INTERACTION_PROFILE.limits.buttons).not.toBe(
+			BUTTON_INTERACTION_PROFILE.limits.buttons,
+		);
+		expect(RICH_INTERACTION_PROFILE.limits).not.toBe(
+			BUTTON_INTERACTION_PROFILE.limits,
+		);
+	});
+
+	it("materializes into a valid profile carrying the rich limits", () => {
+		const materialized = profiles.createConnectorInteractionCapabilityProfile({
+			template: RICH_INTERACTION_PROFILE,
+			source: "matrix",
+			accountId: "acct-rich",
+			targetKind: "room",
+			targetId: "target-rich",
+		});
+		expect(materialized.profileVersion).toBe(1);
+		expect(materialized.limits.attachments).toEqual(
+			RICH_INTERACTION_PROFILE.limits.attachments,
+		);
+		expect(materialized.blocks.form.modes).toContain("native");
+		expect(materialized.nonSecretFallbacks).toEqual([
+			"native",
+			"signed-hosted",
+			"conversational",
+		]);
+	});
+});
+
+describe("FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT", () => {
+	it("lists exactly eleven connectors in declared order", () => {
+		expect(FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT).toHaveLength(11);
+		expect(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.source),
+		).toEqual([
+			"discord",
+			"gmail",
+			"google-chat",
+			"imessage",
+			"instagram",
+			"matrix",
+			"slack",
+			"telegram",
+			"wechat",
+			"whatsapp",
+			"x",
+		]);
+	});
+
+	it("never repeats a source", () => {
+		const sources = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map(
+			(entry) => entry.source,
+		);
+		expect(new Set(sources).size).toBe(sources.length);
+	});
+
+	it("fills every descriptive field on every entry", () => {
+		for (const entry of FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT) {
+			for (const field of [
+				"plugin",
+				"registrationSite",
+				"source",
+				"targetKind",
+				"note",
+			] as const) {
+				expect(entry[field].length, `${entry.source}.${field}`).toBeGreaterThan(
+					0,
+				);
+			}
+		}
+	});
+
+	it("reserves the button-native family for Discord and Telegram", () => {
+		const buttonNative = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.filter(
+			(entry) => entry.profileFamily === "button-native",
+		).map((entry) => entry.source);
+		expect(buttonNative).toEqual(["discord", "telegram"]);
+		expect(
+			new Set(
+				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map(
+					(entry) => entry.profileFamily,
+				),
+			),
+		).toEqual(new Set(["button-native", "conversational"]));
+	});
+
+	it("maps every source to its documented target kind", () => {
+		expect(
+			Object.fromEntries(
+				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => [
+					entry.source,
+					entry.targetKind,
+				]),
+			),
+		).toEqual({
+			discord: "channel",
+			gmail: "email",
+			"google-chat": "room",
+			imessage: "user",
+			instagram: "thread",
+			matrix: "room",
+			slack: "channel",
+			telegram: "room",
+			wechat: "room",
+			whatsapp: "phone",
+			x: "user",
+		});
+	});
+
+	it("attributes both Google surfaces to one registration site", () => {
+		const googleEntries = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.filter(
+			(entry) => entry.plugin === "plugin-google-workspace",
+		);
+		expect(googleEntries.map((entry) => entry.source)).toEqual([
+			"gmail",
+			"google-chat",
+		]);
+		expect(
+			new Set(googleEntries.map((entry) => entry.registrationSite)),
+		).toEqual(new Set(["plugin-google-workspace/src/chat/service.ts"]));
+	});
+
+	it("materializes every audited connector into a valid profile", () => {
+		for (const entry of FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT) {
+			const materialized = profiles.createConnectorInteractionCapabilityProfile(
+				{
+					template:
+						entry.profileFamily === "button-native"
+							? BUTTON_INTERACTION_PROFILE
+							: CONVERSATIONAL_INTERACTION_PROFILE,
+					source: entry.source,
+					accountId: `account:${entry.source}`,
+					targetKind: entry.targetKind,
+					targetId: `target:${entry.source}`,
+				},
+			);
+			expect(materialized.connector.source, entry.source).toBe(entry.source);
+			expect(materialized.target.kind, entry.source).toBe(entry.targetKind);
+			expect(materialized.sensitiveFallback, entry.source).toBe(
+				"sensitive-request",
+			);
+		}
+	});
+});
+
+describe("renderFirstPartyInteractionCapabilityMatrix output", () => {
+	function tableLinesOf(rendered: string): string[] {
+		return rendered.split("\n").slice(4);
+	}
+
+	function rowFor(tableLines: string[], source: string): string {
+		const row = tableLines.find((candidate) =>
+			candidate.startsWith(`| ${source} |`),
+		);
+		if (!row) throw new Error(`missing matrix row for source ${source}`);
+		return row;
+	}
+
+	it("is byte-deterministic across repeated calls", () => {
+		const first = renderFirstPartyInteractionCapabilityMatrix();
+		const second = renderFirstPartyInteractionCapabilityMatrix();
+		expect(first.length).toBeGreaterThan(0);
+		expect(second).toBe(first);
+	});
+
+	it("joins heading, blank separators, contract paragraph, and table with no trailing newline", () => {
+		const rendered = renderFirstPartyInteractionCapabilityMatrix();
+		const lines = rendered.split("\n");
+		expect(lines[0]).toBe("# First-party interaction capability baseline");
+		expect(lines[1]).toBe("");
+		expect(lines[2]).toBe(
+			"This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.",
+		);
+		expect(lines[3]).toBe("");
+		const tableLines = lines.slice(4);
+		expect(tableLines[0]).toBe(
+			"| Connector | Account | Target | Block delivery | Callback bytes | Attachments |",
+		);
+		expect(tableLines[1]).toBe("| --- | --- | --- | --- | ---: | --- |");
+		expect(tableLines).toHaveLength(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.length + 2,
+		);
+		expect(rendered.endsWith("\n")).toBe(false);
+	});
+
+	it("renders one placeholder-identified row per audited source in sorted order", () => {
+		const tableLines = tableLinesOf(
+			renderFirstPartyInteractionCapabilityMatrix(),
+		);
+		const rowSources = tableLines.slice(2).map((line) => {
+			const withoutLeadingPipe = line.replace(/^\| /, "");
+			return withoutLeadingPipe.slice(0, withoutLeadingPipe.indexOf(" |"));
+		});
+		expect(rowSources).toEqual(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.source).sort(
+				(a, b) => a.localeCompare(b),
+			),
+		);
+		for (const entry of FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT) {
+			const row = rowFor(tableLines, entry.source);
+			expect(
+				row.startsWith(
+					`| ${entry.source} | <account> | ${entry.targetKind}:<target> |`,
+				),
+				entry.source,
+			).toBe(true);
+		}
+	});
+
+	it("shows the button family delivery chains and 64-byte callbacks for Discord and Telegram", () => {
+		const tableLines = tableLinesOf(
+			renderFirstPartyInteractionCapabilityMatrix(),
+		);
+		expect(rowFor(tableLines, "discord")).toBe(
+			"| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |",
+		);
+		expect(rowFor(tableLines, "telegram")).toBe(
+			"| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |",
+		);
+	});
+
+	it("shows the conversational delivery chains and zero callbacks for every other family", () => {
+		const tableLines = tableLinesOf(
+			renderFirstPartyInteractionCapabilityMatrix(),
+		);
+		const conversationalSources =
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.filter(
+				(entry) => entry.profileFamily === "conversational",
+			).map((entry) => entry.source);
+		for (const source of conversationalSources) {
+			const cells = rowFor(tableLines, source).split(" | ");
+			const delivery = cells[3];
+			const callbackBytes = cells[4];
+			const attachments = cells[5];
+			if (!delivery || !callbackBytes || !attachments) {
+				throw new Error(`malformed matrix row for source ${source}`);
+			}
+			expect(delivery).toBe(
+				"choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request",
+			);
+			expect(callbackBytes).toBe("0");
+			expect(attachments).toBe("none |");
+		}
+	});
+});
+
+describe("renderFirstPartyInteractionCapabilityMatrix wiring", () => {
+	it("materializes one profile per audit entry in declared order", () => {
+		renderFirstPartyInteractionCapabilityMatrix();
+		expect(createProfileSpy).toHaveBeenCalledTimes(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.length,
+		);
+		for (const [index, call] of createProfileSpy.mock.calls.entries()) {
+			const args = call[0];
+			const entry = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT[index];
+			if (!args || !entry) {
+				throw new Error("recorded call missing arguments or audit entry");
+			}
+			expect(args.source, entry.source).toBe(entry.source);
+			expect(args.targetKind, entry.source).toBe(entry.targetKind);
+			expect(args.accountId, entry.source).toBe("<account>");
+			expect(args.targetId, entry.source).toBe("<target>");
+		}
+	});
+
+	it("selects the button template exactly for button-native families", () => {
+		renderFirstPartyInteractionCapabilityMatrix();
+		for (const call of createProfileSpy.mock.calls) {
+			const args = call[0];
+			if (!args) throw new Error("recorded call missing arguments");
+			const entry = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.find(
+				(candidate) => candidate.source === args.source,
+			);
+			if (!entry) throw new Error(`unexpected source ${args.source}`);
+			if (entry.profileFamily === "button-native") {
+				expect(args.template, entry.source).toBe(BUTTON_INTERACTION_PROFILE);
+			} else {
+				expect(args.template, entry.source).toBe(
+					CONVERSATIONAL_INTERACTION_PROFILE,
+				);
+			}
+		}
+	});
+
+	it("hands the renderer the complete ordered list of created profiles", () => {
+		renderFirstPartyInteractionCapabilityMatrix();
+		expect(renderMatrixSpy).toHaveBeenCalledTimes(1);
+		const handedProfiles = renderMatrixSpy.mock.calls[0]?.[0];
+		if (!handedProfiles) {
+			throw new Error("renderer was not called with a profile list");
+		}
+		expect(handedProfiles).toHaveLength(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.length,
+		);
+		handedProfiles.forEach((profile, index) => {
+			const entry = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT[index];
+			if (!entry) throw new Error(`unexpected extra profile at ${index}`);
+			const rematerialized =
+				profiles.createConnectorInteractionCapabilityProfile({
+					template:
+						entry.profileFamily === "button-native"
+							? BUTTON_INTERACTION_PROFILE
+							: CONVERSATIONAL_INTERACTION_PROFILE,
+					source: entry.source,
+					accountId: "<account>",
+					targetKind: entry.targetKind,
+					targetId: "<target>",
+				});
+			expect(profile, entry.source).toEqual(rematerialized);
+		});
+	});
+
+	it("propagates a mid-catalog materialization failure without rendering", () => {
+		const realCreate = createProfileSpy.getMockImplementation();
+		if (!realCreate) {
+			throw new Error("spy lost its delegating implementation");
+		}
+		const failure = new Error("profile factory exploded");
+		createProfileSpy.mockImplementation((args) => {
+			if (args.source === "slack") throw failure;
+			return realCreate(args);
+		});
+		let propagated: unknown = null;
+		try {
+			renderFirstPartyInteractionCapabilityMatrix();
+		} catch (caught) {
+			propagated = caught;
+		} finally {
+			createProfileSpy.mockImplementation(realCreate);
+		}
+		expect(propagated).toBe(failure);
+		expect(renderMatrixSpy).not.toHaveBeenCalled();
+		expect(createProfileSpy.mock.calls.map((call) => call[0]?.source)).toEqual([
+			"discord",
+			"gmail",
+			"google-chat",
+			"imessage",
+			"instagram",
+			"matrix",
+			"slack",
+		]);
+	});
+
+	it("propagates renderer failures after creating every profile", () => {
+		const realRender = renderMatrixSpy.getMockImplementation();
+		if (!realRender) {
+			throw new Error("spy lost its delegating implementation");
+		}
+		const failure = new Error("renderer exploded");
+		renderMatrixSpy.mockImplementationOnce(() => {
+			throw failure;
+		});
+		let propagated: unknown = null;
+		try {
+			renderFirstPartyInteractionCapabilityMatrix();
+		} catch (caught) {
+			propagated = caught;
+		}
+		expect(propagated).toBe(failure);
+		expect(createProfileSpy).toHaveBeenCalledTimes(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.length,
+		);
+	});
+});

--- a/packages/core/src/network/node-pinned-fetch.test.ts
+++ b/packages/core/src/network/node-pinned-fetch.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Behavioral suite for the Node pinned transport behind the SSRF fetch guard:
+ * `nodePinnedFetch` request construction and Web-Headers normalization, body
+ * buffering across every BodyInit shape, IncomingMessage → web Response
+ * conversion (streamed and null bodies), abort-signal wiring, once-only error
+ * settlement, and the `nodeLookupFn` resolver mapping contract. Deterministic —
+ * node:http, node:https and node:dns/promises are replaced at their module
+ * boundary; no sockets are opened, no DNS is resolved, no timers are used.
+ */
+import { Buffer } from "node:buffer";
+import { lookup as dnsLookup } from "node:dns/promises";
+import { EventEmitter } from "node:events";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nodeLookupFn, nodePinnedFetch } from "./node-pinned-fetch.ts";
+import type { LookupFn } from "./ssrf.ts";
+
+vi.mock("node:http", () => ({ request: vi.fn() }));
+vi.mock("node:https", () => ({ request: vi.fn() }));
+vi.mock("node:dns/promises", () => ({ lookup: vi.fn() }));
+
+type CapturedOptions = {
+	protocol: string;
+	hostname: string;
+	port?: number;
+	method: string;
+	path: string;
+	headers: Record<string, string>;
+	lookup?: unknown;
+	servername?: string;
+};
+
+type Deliver = (message: FakeIncomingMessage) => void;
+
+type RequestSpy = {
+	mock: {
+		calls: Array<[CapturedOptions, Deliver]>;
+		results: Array<{ value: FakeClientRequest }>;
+	};
+	mockImplementation(
+		impl: (options: CapturedOptions, callback: Deliver) => FakeClientRequest,
+	): void;
+};
+
+type DnsSpy = {
+	mock: { calls: Array<[string, { all: true }]> };
+	mockResolvedValue(entries: Array<{ address: string; family: number }>): void;
+	mockRejectedValue(error: Error): void;
+};
+
+const httpSpy = httpRequest as unknown as RequestSpy;
+const httpsSpy = httpsRequest as unknown as RequestSpy;
+const dnsSpy = dnsLookup as unknown as DnsSpy;
+
+const pinnedLookup: LookupFn = async () => [];
+
+class FakeClientRequest extends EventEmitter {
+	readonly options: CapturedOptions;
+	readonly writes: Buffer[] = [];
+	endCalls = 0;
+	destroyCalls: Array<Error | undefined> = [];
+
+	constructor(options: CapturedOptions) {
+		super();
+		this.options = options;
+	}
+
+	write(chunk: Buffer): boolean {
+		this.writes.push(Buffer.from(chunk));
+		return true;
+	}
+
+	end(): this {
+		this.endCalls += 1;
+		return this;
+	}
+
+	destroy(error?: Error): this {
+		this.destroyCalls.push(error);
+		if (error) {
+			queueMicrotask(() => this.emit("error", error));
+		}
+		return this;
+	}
+}
+
+class FakeIncomingMessage {
+	headers: Record<string, string | string[] | undefined>;
+	statusCode?: number;
+	statusMessage?: string;
+	chunks: Array<Buffer | Uint8Array | string> = [];
+	iteratorError?: Error;
+	destroyReasons: Array<Error | undefined> = [];
+	returnCalled = false;
+
+	constructor(
+		parts: {
+			headers?: Record<string, string | string[] | undefined>;
+			statusCode?: number;
+			statusMessage?: string;
+		} = {},
+	) {
+		this.headers = parts.headers ?? {};
+		this.statusCode = parts.statusCode;
+		this.statusMessage = parts.statusMessage;
+	}
+
+	destroy(reason?: Error): this {
+		this.destroyReasons.push(reason);
+		return this;
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<Buffer | Uint8Array | string> {
+		let index = 0;
+		const message = this;
+		return {
+			async next() {
+				if (index < message.chunks.length) {
+					const value = message.chunks[index];
+					index += 1;
+					return { done: false as const, value };
+				}
+				if (message.iteratorError) {
+					throw message.iteratorError;
+				}
+				return { done: true as const, value: undefined };
+			},
+			async return(value?: undefined) {
+				message.returnCalled = true;
+				return { done: true as const, value };
+			},
+		};
+	}
+}
+
+type FetchInit = {
+	method?: string;
+	headers?: HeadersInit;
+	body?: BodyInit | null;
+	signal?: AbortSignal | null;
+};
+
+function settleMicrotasks(): Promise<void> {
+	return new Promise((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+async function beginFetch(
+	init: FetchInit,
+	url = new URL("http://example.test/path"),
+): Promise<{
+	options: CapturedOptions;
+	deliver: Deliver;
+	request: FakeClientRequest;
+	pending: Promise<Response>;
+}> {
+	const spy = url.protocol === "https:" ? httpsSpy : httpSpy;
+	spy.mockImplementation((options) => new FakeClientRequest(options));
+	const pending = nodePinnedFetch({ url, init, lookup: pinnedLookup });
+	pending.catch(() => {});
+	await settleMicrotasks();
+	await settleMicrotasks();
+	const call = spy.mock.calls.at(-1);
+	if (!call) throw new Error("transport was never invoked");
+	const result = spy.mock.results.at(-1);
+	if (!result) throw new Error("transport returned no request handle");
+	return {
+		options: call[0],
+		deliver: call[1],
+		request: result.value,
+		pending,
+	};
+}
+
+function okMessage(): FakeIncomingMessage {
+	return new FakeIncomingMessage({
+		statusCode: 200,
+		statusMessage: "OK",
+	});
+}
+
+async function flushed<T>(promise: Promise<T>): Promise<T> {
+	await Promise.resolve();
+	await Promise.resolve();
+	return promise;
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("nodeLookupFn", () => {
+	it("passes hostname and options through unchanged and maps entries to { address, family }", async () => {
+		dnsSpy.mockResolvedValue([
+			{ address: "93.184.216.34", family: 4 },
+			{ address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+		]);
+
+		const results = await nodeLookupFn("example.test", { all: true });
+
+		expect(dnsSpy.mock.calls).toStrictEqual([["example.test", { all: true }]]);
+		expect(results).toStrictEqual([
+			{ address: "93.184.216.34", family: 4 },
+			{ address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+		]);
+	});
+
+	it("maps an empty resolver result to an empty array", async () => {
+		dnsSpy.mockResolvedValue([]);
+
+		await expect(
+			nodeLookupFn("empty.test", { all: true }),
+		).resolves.toStrictEqual([]);
+	});
+
+	it("propagates resolver rejection without conversion or fallback", async () => {
+		const failure = new Error("resolver down");
+		dnsSpy.mockRejectedValue(failure);
+
+		await expect(nodeLookupFn("broken.test", { all: true })).rejects.toBe(
+			failure,
+		);
+	});
+});
+
+describe("nodePinnedFetch request construction", () => {
+	it("builds an http request from the URL, init and pinned lookup", async () => {
+		const interaction = await beginFetch(
+			{
+				method: "post",
+				headers: { "x-token": "t" },
+				body: "payload",
+			},
+			new URL("http://example.test:8080/db/search?q=eliza"),
+		);
+
+		expect(interaction.options).toStrictEqual({
+			protocol: "http:",
+			hostname: "example.test",
+			port: 8080,
+			method: "POST",
+			path: "/db/search?q=eliza",
+			headers: { "x-token": "t", "content-length": "7" },
+			lookup: pinnedLookup,
+		});
+		expect("servername" in interaction.options).toBe(false);
+		expect(interaction.request.writes).toStrictEqual([Buffer.from("payload")]);
+		expect(interaction.request.endCalls).toBe(1);
+		expect(httpsSpy.mock.calls).toHaveLength(0);
+
+		interaction.deliver(okMessage());
+		const response = await interaction.pending;
+		expect(response.status).toBe(200);
+	});
+
+	it("selects node:https for https URLs and pins servername to the hostname", async () => {
+		const interaction = await beginFetch(
+			{},
+			new URL("https://example.test/secure"),
+		);
+
+		expect(httpsSpy.mock.calls).toHaveLength(1);
+		expect(httpSpy.mock.calls).toHaveLength(0);
+		expect(interaction.options.protocol).toBe("https:");
+		expect(interaction.options.servername).toBe("example.test");
+
+		interaction.deliver(okMessage());
+		const response = await interaction.pending;
+		expect(response.status).toBe(200);
+	});
+
+	it("defaults to GET, no numeric port and root path when the URL carries none", async () => {
+		const interaction = await beginFetch({}, new URL("http://defaults.test"));
+
+		expect(interaction.options.method).toBe("GET");
+		expect(interaction.options.port).toBeUndefined();
+		expect(interaction.options.path).toBe("/");
+
+		interaction.deliver(okMessage());
+		await interaction.pending;
+	});
+
+	it("normalizes input headers with Web Headers semantics", async () => {
+		const headers = new Headers();
+		headers.append("Set-Cookie", "a=1");
+		headers.append("set-cookie", "b=2");
+		headers.set("X-Case", "Up");
+
+		const interaction = await beginFetch({ headers });
+
+		expect(interaction.options.headers).toStrictEqual({
+			"set-cookie": "b=2",
+			"x-case": "Up",
+		});
+
+		interaction.deliver(okMessage());
+		await interaction.pending;
+	});
+});
+
+describe("nodePinnedFetch request bodies", () => {
+	async function bodyCase(init: FetchInit): Promise<{
+		options: CapturedOptions;
+		request: FakeClientRequest;
+	}> {
+		const interaction = await beginFetch(init);
+		interaction.deliver(okMessage());
+		const response = await interaction.pending;
+		await response.text();
+		return { options: interaction.options, request: interaction.request };
+	}
+
+	it("sends no bytes and synthesizes no content-length for an undefined body", async () => {
+		const { options, request } = await bodyCase({ method: "POST" });
+
+		expect(request.writes).toStrictEqual([]);
+		expect(options.headers["content-length"]).toBeUndefined();
+		expect(request.endCalls).toBe(1);
+	});
+
+	it("sends no bytes and synthesizes no content-length for a null body", async () => {
+		const { options, request } = await bodyCase({
+			method: "POST",
+			body: null,
+		});
+
+		expect(request.writes).toStrictEqual([]);
+		expect(options.headers["content-length"]).toBeUndefined();
+		expect(request.endCalls).toBe(1);
+	});
+
+	it("writes a zero-length buffer and content-length 0 for an empty string body", async () => {
+		const { options, request } = await bodyCase({
+			method: "PUT",
+			body: "",
+		});
+
+		expect(request.writes).toStrictEqual([Buffer.from("")]);
+		expect(options.headers["content-length"]).toBe("0");
+		expect(request.endCalls).toBe(1);
+	});
+
+	it("encodes string bodies as UTF-8 bytes with the byte-length header", async () => {
+		const text = "héllo ✅";
+		const { options, request } = await bodyCase({ body: text });
+
+		expect(request.writes).toStrictEqual([Buffer.from(text)]);
+		expect(options.headers["content-length"]).toBe(
+			String(Buffer.byteLength(text)),
+		);
+	});
+
+	it("copies ArrayBuffer bodies exactly", async () => {
+		const arrayBuffer = Uint8Array.from([1, 2, 3, 4]).buffer;
+		const { options, request } = await bodyCase({ body: arrayBuffer });
+
+		expect(request.writes).toStrictEqual([Buffer.from([1, 2, 3, 4])]);
+		expect(options.headers["content-length"]).toBe("4");
+	});
+
+	it("buffers only the byteOffset..byteLength window of a typed-array view", async () => {
+		const backing = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]);
+		const { options, request } = await bodyCase({
+			body: backing.subarray(2, 5),
+		});
+
+		expect(request.writes).toStrictEqual([Buffer.from([3, 4, 5])]);
+		expect(options.headers["content-length"]).toBe("3");
+	});
+
+	it("buffers only the DataView window over its backing buffer", async () => {
+		const backing = Uint8Array.from([9, 8, 7, 6, 5]);
+		const { request } = await bodyCase({
+			body: new DataView(backing.buffer, 1, 3),
+		});
+
+		expect(request.writes).toStrictEqual([Buffer.from([8, 7, 6])]);
+	});
+
+	it("serializes fallback bodies through Response(arrayBuffer), such as Blob", async () => {
+		const { options, request } = await bodyCase({
+			method: "POST",
+			body: new Blob(["hi"]),
+		});
+
+		expect(request.writes).toStrictEqual([Buffer.from("hi")]);
+		expect(options.headers["content-length"]).toBe("2");
+		expect(request.endCalls).toBe(1);
+	});
+
+	it.each(["0", "999"])(
+		"preserves an existing content-length of %s instead of recomputing it",
+		async (existing) => {
+			const { options, request } = await bodyCase({
+				method: "POST",
+				headers: { "content-length": existing },
+				body: "abc",
+			});
+
+			expect(options.headers["content-length"]).toBe(existing);
+			expect(request.writes).toStrictEqual([Buffer.from("abc")]);
+			expect(request.endCalls).toBe(1);
+		},
+	);
+});
+
+describe("nodePinnedFetch response conversion", () => {
+	async function beginResponse(message: FakeIncomingMessage) {
+		const interaction = await beginFetch({});
+		interaction.deliver(message);
+		return interaction;
+	}
+
+	it("converts status, statusText and header shapes into the web Response", async () => {
+		const interaction = await beginResponse(
+			new FakeIncomingMessage({
+				statusCode: 201,
+				statusMessage: "Created",
+				headers: {
+					"content-type": "text/plain",
+					"set-cookie": ["a=1", "b=2"],
+					"x-num": undefined,
+				},
+			}),
+		);
+
+		const response = await interaction.pending;
+		expect(response.status).toBe(201);
+		expect(response.statusText).toBe("Created");
+		expect(response.headers.get("content-type")).toBe("text/plain");
+		expect(response.headers.getSetCookie()).toStrictEqual(["a=1", "b=2"]);
+		expect(response.headers.get("x-num")).toBeNull();
+	});
+
+	it("falls back to status 500 when statusCode is missing", async () => {
+		const interaction = await beginResponse(new FakeIncomingMessage());
+
+		const response = await interaction.pending;
+		expect(response.status).toBe(500);
+	});
+
+	it("streams Buffer, Uint8Array and string chunks as concatenated body bytes", async () => {
+		const message = new FakeIncomingMessage({
+			statusCode: 200,
+			statusMessage: "OK",
+		});
+		message.chunks = [Buffer.from("he"), new TextEncoder().encode("ll"), "o!"];
+		const interaction = await beginResponse(message);
+
+		const response = await interaction.pending;
+		await expect(response.text()).resolves.toBe("hello!");
+	});
+
+	it("removes the abort listener once the streamed body completes", async () => {
+		const controller = new AbortController();
+		const interaction = await beginFetch({ signal: controller.signal });
+		const message = okMessage();
+		message.chunks = ["done"];
+		interaction.deliver(message);
+
+		const response = await interaction.pending;
+		await response.text();
+
+		controller.abort();
+		await flushed(Promise.resolve());
+		expect(interaction.request.destroyCalls).toHaveLength(0);
+	});
+
+	it.each([204, 205, 304])(
+		"gives %s responses a null body and cleans up without consuming the stream",
+		async (status) => {
+			const controller = new AbortController();
+			const interaction = await beginFetch({ signal: controller.signal });
+			const message = new FakeIncomingMessage({
+				statusCode: status,
+				statusMessage: "Null body",
+			});
+			message.chunks = ["never consumed"];
+			interaction.deliver(message);
+
+			const response = await interaction.pending;
+			expect(response.status).toBe(status);
+			expect(response.body).toBeNull();
+
+			controller.abort();
+			await flushed(Promise.resolve());
+			expect(interaction.request.destroyCalls).toHaveLength(0);
+		},
+	);
+
+	it("surfaces iterator failures through the body and cleans up", async () => {
+		const controller = new AbortController();
+		const interaction = await beginFetch({ signal: controller.signal });
+		const message = okMessage();
+		const failure = new Error("stream exploded");
+		message.chunks = ["partial"];
+		message.iteratorError = failure;
+		interaction.deliver(message);
+
+		const response = await interaction.pending;
+		await expect(response.text()).rejects.toBe(failure);
+
+		controller.abort();
+		await flushed(Promise.resolve());
+		expect(interaction.request.destroyCalls).toHaveLength(0);
+	});
+
+	it("destroys the Node stream with the Error reason when the body is cancelled", async () => {
+		const message = okMessage();
+		message.chunks = ["chunk-1", "chunk-2"];
+		const interaction = await beginResponse(message);
+
+		const response = await interaction.pending;
+		const reader = response.body?.getReader();
+		const first = await reader?.read();
+		expect(first?.done).toBe(false);
+
+		const reason = new Error("consumer cancelled");
+		await reader?.cancel(reason);
+		await flushed(Promise.resolve());
+
+		expect(message.returnCalled).toBe(true);
+		expect(message.destroyReasons).toStrictEqual([reason]);
+	});
+
+	it("destroys the Node stream without a reason for non-Error cancellation", async () => {
+		const message = okMessage();
+		message.chunks = ["chunk-1"];
+		const interaction = await beginResponse(message);
+
+		const response = await interaction.pending;
+		const reader = response.body?.getReader();
+		await reader?.read();
+
+		await reader?.cancel("just stop");
+		await flushed(Promise.resolve());
+
+		expect(message.returnCalled).toBe(true);
+		expect(message.destroyReasons).toStrictEqual([undefined]);
+	});
+});
+
+describe("nodePinnedFetch failures and aborts", () => {
+	it("rejects with the request error and detaches the abort listener", async () => {
+		const controller = new AbortController();
+		const interaction = await beginFetch({ signal: controller.signal });
+
+		const failure = new Error("connect ECONNREFUSED");
+		interaction.request.emit("error", failure);
+
+		await expect(interaction.pending).rejects.toBe(failure);
+
+		controller.abort();
+		await flushed(Promise.resolve());
+		expect(interaction.request.destroyCalls).toHaveLength(0);
+	});
+
+	it("settles exactly once when the request emits multiple errors", async () => {
+		const interaction = await beginFetch({});
+
+		const first = new Error("first failure");
+		interaction.request.emit("error", first);
+		interaction.request.emit("error", new Error("second failure"));
+
+		await expect(interaction.pending).rejects.toBe(first);
+	});
+
+	it("keeps the settled response valid when a late request error arrives", async () => {
+		const interaction = await beginFetch({});
+		const message = okMessage();
+		message.chunks = ["still good"];
+		interaction.deliver(message);
+
+		const response = await interaction.pending;
+		interaction.request.emit("error", new Error("late failure"));
+
+		expect(response.status).toBe(200);
+		await expect(response.text()).resolves.toBe("still good");
+	});
+
+	it("destroys an already-aborted request before sending", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const interaction = await beginFetch({ signal: controller.signal });
+
+		expect(interaction.request.destroyCalls).toHaveLength(1);
+		const abortError = interaction.request.destroyCalls[0];
+		expect(abortError).toBeInstanceOf(DOMException);
+		expect(abortError?.name).toBe("AbortError");
+
+		await expect(interaction.pending).rejects.toBe(abortError);
+		expect(interaction.request.endCalls).toBe(1);
+	});
+
+	it("destroys the request when aborted between send and response", async () => {
+		const controller = new AbortController();
+		const interaction = await beginFetch({ signal: controller.signal });
+
+		controller.abort();
+		expect(interaction.request.destroyCalls).toHaveLength(1);
+		const abortError = interaction.request.destroyCalls[0];
+		expect(abortError?.name).toBe("AbortError");
+
+		await expect(interaction.pending).rejects.toBe(abortError);
+	});
+});

--- a/packages/core/src/providers/skill-eligibility.test.ts
+++ b/packages/core/src/providers/skill-eligibility.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Tests for the skill eligibility providers: without AGENT_SKILLS_SERVICE they
+ * cost nothing, a fully-healthy install collapses to a one-line status, mixed
+ * installs render eligible/ineligible sections with reasons grouped into
+ * binary/env/config remedies, and a failing service degrades to an explicit
+ * unavailable state routed through reportError. Drives the real provider
+ * modules against a scripted service double — every rendering and grouping
+ * decision exercised here belongs to the module under test.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../types";
+import skillEligibilityDefault, {
+	skillEligibilityCompactProvider,
+	skillEligibilityProvider,
+} from "./skill-eligibility";
+
+type SkillFixture = {
+	slug: string;
+	name: string;
+	description: string;
+	source: string;
+	sourceDir: string;
+};
+
+type ReasonFixture = {
+	type: "bin" | "env" | "config";
+	missing: string;
+	message: string;
+	suggestion?: string;
+};
+
+type EligibilityFixture = {
+	slug: string;
+	eligible: boolean;
+	reasons: ReasonFixture[];
+	checkedAt: number;
+};
+
+type IneligibleEntryFixture = {
+	skill: SkillFixture;
+	eligibility: EligibilityFixture;
+};
+
+type ServiceDouble = {
+	getEligibleSkills: () => Promise<SkillFixture[]>;
+	getIneligibleSkills: () => Promise<IneligibleEntryFixture[]>;
+};
+
+const message = {} as Memory;
+const state = {} as State;
+
+function makeSkill(slug: string, name: string): SkillFixture {
+	return {
+		slug,
+		name,
+		description: `${name} capability`,
+		source: "bundled",
+		sourceDir: `/skills/${slug}`,
+	};
+}
+
+function makeReason(
+	type: ReasonFixture["type"],
+	missing: string,
+	suggestion?: string,
+): ReasonFixture {
+	return {
+		type,
+		missing,
+		message: `${missing} is required`,
+		...(suggestion ? { suggestion } : {}),
+	};
+}
+
+function makeEntry(
+	slug: string,
+	reasons: ReasonFixture[],
+): IneligibleEntryFixture {
+	const name = slug.charAt(0).toUpperCase() + slug.slice(1);
+	return {
+		skill: makeSkill(slug, name),
+		eligibility: { slug, eligible: false, reasons, checkedAt: 0 },
+	};
+}
+
+function harness(service: ServiceDouble | null) {
+	const reported: Array<{ scope: string; error: unknown }> = [];
+	const runtime = {
+		getService: () => service,
+		reportError: (scope: string, error: unknown) => {
+			reported.push({ scope, error });
+		},
+	} as unknown as IAgentRuntime;
+	return { runtime, reported };
+}
+
+function serviceDouble(
+	eligible: SkillFixture[],
+	ineligible: IneligibleEntryFixture[],
+): ServiceDouble {
+	return {
+		getEligibleSkills: () => Promise.resolve(eligible),
+		getIneligibleSkills: () => Promise.resolve(ineligible),
+	};
+}
+
+describe("skillEligibilityProvider", () => {
+	it("returns an empty result and reports nothing when the skills service is absent", async () => {
+		const { runtime, reported } = harness(null);
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.text).toBe("");
+		expect(result.values).toEqual({});
+		expect(result.data).toEqual({});
+		expect(reported).toEqual([]);
+	});
+
+	it("collapses an all-eligible install to the ready summary", async () => {
+		const eligible = [makeSkill("alpha", "Alpha"), makeSkill("beta", "Beta")];
+		const { runtime, reported } = harness(serviceDouble(eligible, []));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.text).toBe(
+			"**Skill Status:** All 2 installed skills are ready to use.",
+		);
+		expect(result.values).toEqual({
+			eligibleCount: 2,
+			ineligibleCount: 0,
+		});
+		expect(result.data).toEqual({
+			eligible: ["alpha", "beta"],
+			ineligible: [],
+		});
+		expect(reported).toEqual([]);
+	});
+
+	it("reports zero installed skills with zero counts on both sides", async () => {
+		const { runtime } = harness(serviceDouble([], []));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.text).toBe(
+			"**Skill Status:** All 0 installed skills are ready to use.",
+		);
+		expect(result.values).toEqual({ eligibleCount: 0, ineligibleCount: 0 });
+		expect(result.data).toEqual({ eligible: [], ineligible: [] });
+	});
+
+	it("renders eligible and ineligible sections with grouped reasons and remedies", async () => {
+		const eligible = [makeSkill("alpha", "Alpha"), makeSkill("beta", "Beta")];
+		const gamma = makeEntry("gamma", [
+			makeReason("bin", "ffmpeg", "brew install ffmpeg"),
+			makeReason("bin", "yt-dlp"),
+			makeReason("env", "GAMMA_TOKEN"),
+		]);
+		const delta = makeEntry("delta", [
+			makeReason("env", "DELTA_TOKEN"),
+			makeReason("config", "delta.apiKey"),
+		]);
+		const { runtime, reported } = harness(
+			serviceDouble(eligible, [gamma, delta]),
+		);
+
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		const text = result.text ?? "";
+
+		expect(text).toContain("## Skill Eligibility");
+		expect(text).toContain("### Ready to Use (2)");
+		expect(text).toContain("- **Alpha** (alpha)");
+		expect(text).toContain("- **Beta** (beta)");
+		expect(text).toContain("### Missing Dependencies (2)");
+		expect(text).toContain("#### Gamma (gamma)");
+		expect(text).toContain("- Missing binaries: ffmpeg, yt-dlp");
+		expect(text).toContain("  - brew install ffmpeg");
+		expect(text).toContain("- Missing env vars: GAMMA_TOKEN");
+		expect(text).toContain("#### Delta (delta)");
+		expect(text).toContain("- Missing env vars: DELTA_TOKEN");
+		expect(text).toContain("- Missing config: delta.apiKey");
+		expect(text).toContain("### To enable more skills:");
+		expect(text).toContain("- Install: ffmpeg, yt-dlp");
+		expect(text).toContain("- Set env: GAMMA_TOKEN, DELTA_TOKEN");
+
+		expect(result.values).toEqual({
+			eligibleCount: 2,
+			ineligibleCount: 2,
+			missingBinaries: ["ffmpeg", "yt-dlp"],
+			missingEnvVars: ["GAMMA_TOKEN", "DELTA_TOKEN"],
+		});
+		expect(result.data?.truncated).toBe(false);
+		expect(result.data?.eligible).toEqual(["alpha", "beta"]);
+		expect(result.data?.ineligible).toEqual([
+			{ slug: "gamma", reasons: gamma.eligibility.reasons },
+			{ slug: "delta", reasons: delta.eligibility.reasons },
+		]);
+		expect(reported).toEqual([]);
+	});
+
+	it("keeps the ineligible section when no skill is eligible", async () => {
+		const entry = makeEntry("lonely", [makeReason("bin", "sox")]);
+		const { runtime } = harness(serviceDouble([], [entry]));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		const text = result.text ?? "";
+		expect(text).not.toContain("Ready to Use");
+		expect(text).toContain("### Missing Dependencies (1)");
+		expect(text).toContain("#### Lonely (lonely)");
+		expect(text).toContain("- Missing binaries: sox");
+		expect(result.values?.eligibleCount).toBe(0);
+		expect(result.values?.ineligibleCount).toBe(1);
+	});
+
+	it("renders a suggestion line only for binary reasons that carry one", async () => {
+		const entry = makeEntry("tools", [
+			makeReason("bin", "rg", "brew install ripgrep"),
+			makeReason("bin", "fd"),
+		]);
+		const { runtime } = harness(serviceDouble([], [entry]));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		const text = result.text ?? "";
+		expect(text).toContain("- Missing binaries: rg, fd");
+		const suggestionLines = (result.text ?? "")
+			.split("\n")
+			.filter((line) => line.startsWith("  - "));
+		expect(suggestionLines).toEqual(["  - brew install ripgrep"]);
+	});
+
+	it("does not emit the remediation summary for config-only gaps", async () => {
+		const entry = makeEntry("cfgonly", [
+			makeReason("config", "cfgonly.endpoint"),
+		]);
+		const { runtime } = harness(
+			serviceDouble([makeSkill("ok", "Ok")], [entry]),
+		);
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		const text = result.text ?? "";
+		expect(text).toContain("- Missing config: cfgonly.endpoint");
+		expect(text).not.toContain("Missing binaries");
+		expect(text).not.toContain("Missing env vars");
+		expect(text).not.toContain("To enable more skills");
+		expect(result.values?.missingBinaries).toEqual([]);
+		expect(result.values?.missingEnvVars).toEqual([]);
+	});
+
+	it("leaves a zero-reason ineligible skill headed but unexplained", async () => {
+		const entry = makeEntry("mystery", []);
+		const { runtime } = harness(serviceDouble([], [entry]));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		const text = result.text ?? "";
+		expect(text).toContain("### Missing Dependencies (1)");
+		expect(text).toContain("#### Mystery (mystery)");
+		expect(text).not.toContain("Missing binaries");
+		expect(text).not.toContain("Missing env vars");
+		expect(text).not.toContain("Missing config");
+		expect(text).not.toContain("To enable more skills");
+		expect(result.values?.ineligibleCount).toBe(1);
+	});
+
+	it("dedupes repeated dependencies across skills preserving first-seen order", async () => {
+		const first = makeEntry("one", [
+			makeReason("bin", "ffmpeg"),
+			makeReason("env", "SHARED_TOKEN"),
+		]);
+		const second = makeEntry("two", [
+			makeReason("bin", "ffmpeg"),
+			makeReason("bin", "node"),
+			makeReason("env", "TWO_TOKEN"),
+			makeReason("env", "SHARED_TOKEN"),
+		]);
+		const { runtime } = harness(serviceDouble([], [first, second]));
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.values?.missingBinaries).toEqual(["ffmpeg", "node"]);
+		expect(result.values?.missingEnvVars).toEqual([
+			"SHARED_TOKEN",
+			"TWO_TOKEN",
+		]);
+		const text = result.text ?? "";
+		expect(text.match(/Install: ffmpeg/g)).toHaveLength(1);
+		expect(text).toContain("- Install: ffmpeg, node");
+		expect(text).toContain("- Set env: SHARED_TOKEN, TWO_TOKEN");
+	});
+
+	it("starts both service lookups before either settles", async () => {
+		let releaseEligible: ((skills: SkillFixture[]) => void) | undefined;
+		let releaseIneligible:
+			| ((entries: IneligibleEntryFixture[]) => void)
+			| undefined;
+		let eligibleCalls = 0;
+		let ineligibleCalls = 0;
+		const eligibleGate = new Promise<SkillFixture[]>((resolve) => {
+			releaseEligible = resolve;
+		});
+		const ineligibleGate = new Promise<IneligibleEntryFixture[]>((resolve) => {
+			releaseIneligible = resolve;
+		});
+		const service: ServiceDouble = {
+			getEligibleSkills: () => {
+				eligibleCalls += 1;
+				return eligibleGate;
+			},
+			getIneligibleSkills: () => {
+				ineligibleCalls += 1;
+				return ineligibleGate;
+			},
+		};
+		const { runtime } = harness(service);
+
+		const pending = skillEligibilityProvider.get(runtime, message, state);
+		if (!releaseEligible || !releaseIneligible) {
+			throw new Error("gates were not wired");
+		}
+		expect(eligibleCalls).toBe(1);
+		expect(ineligibleCalls).toBe(1);
+
+		releaseEligible([]);
+		releaseIneligible([makeEntry("late", [makeReason("env", "LATE_TOKEN")])]);
+		const result = await pending;
+		expect(result.values?.ineligibleCount).toBe(1);
+	});
+
+	it("degrades to an explicit unavailable state when the service throws an Error", async () => {
+		const failure = new Error("eligibility scan exploded");
+		const service: ServiceDouble = {
+			getEligibleSkills: () => Promise.resolve([]),
+			getIneligibleSkills: () => Promise.reject(failure),
+		};
+		const { runtime, reported } = harness(service);
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.text).toBe("Skill eligibility is unavailable.");
+		expect(result.values).toEqual({ skillEligibilityAvailable: false });
+		expect(result.data).toEqual({
+			available: false,
+			error: "eligibility scan exploded",
+		});
+		expect(reported).toHaveLength(1);
+		expect(reported[0].scope).toBe("SkillEligibilityProvider.get");
+		expect(reported[0].error).toBe(failure);
+	});
+
+	it("stringifies non-Error service failures into the unavailable payload", async () => {
+		const service: ServiceDouble = {
+			getEligibleSkills: () => Promise.reject("plain string failure"),
+			getIneligibleSkills: () => Promise.resolve([]),
+		};
+		const { runtime, reported } = harness(service);
+		const result = await skillEligibilityProvider.get(runtime, message, state);
+		expect(result.text).toBe("Skill eligibility is unavailable.");
+		expect(result.values).toEqual({ skillEligibilityAvailable: false });
+		expect(result.data).toEqual({
+			available: false,
+			error: "plain string failure",
+		});
+		expect(reported).toHaveLength(1);
+		expect(reported[0].error).toBe("plain string failure");
+	});
+});
+
+describe("skillEligibilityCompactProvider", () => {
+	it("returns an empty result without reporting when the service is absent", async () => {
+		const { runtime, reported } = harness(null);
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe("");
+		expect(result.values).toEqual({});
+		expect(result.data).toEqual({});
+		expect(reported).toEqual([]);
+	});
+
+	it("stays silent with an empty ineligible list when every skill is ready", async () => {
+		const eligible = [makeSkill("alpha", "Alpha")];
+		const { runtime } = harness(serviceDouble(eligible, []));
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe("");
+		expect(result.values).toEqual({});
+		expect(result.data).toEqual({ ineligible: [] });
+	});
+
+	it("lists a single non-binary gap without a missing-dependency suffix", async () => {
+		const entry = makeEntry("solo", [makeReason("env", "SOLO_TOKEN")]);
+		const { runtime } = harness(serviceDouble([], [entry]));
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe("⚠️ Skills unavailable: solo");
+		expect(result.values).toEqual({ ineligibleCount: 1 });
+		expect(result.data).toEqual({
+			ineligible: ["solo"],
+			missingBins: [],
+			omittedCount: 0,
+		});
+	});
+
+	it("lists every ineligible slug in service order with zero omissions", async () => {
+		const entries = [
+			makeEntry("gamma", [makeReason("bin", "ffmpeg")]),
+			makeEntry("alpha", [makeReason("env", "ALPHA_TOKEN")]),
+			makeEntry("beta", []),
+		];
+		const { runtime } = harness(serviceDouble([], entries));
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toContain("gamma, alpha, beta");
+		expect(result.values).toEqual({ ineligibleCount: 3 });
+		expect(result.data?.ineligible).toEqual(["gamma", "alpha", "beta"]);
+		expect(result.data?.omittedCount).toBe(0);
+	});
+
+	it("aggregates duplicated binary requirements once, in first-seen order", async () => {
+		const first = makeEntry("one", [
+			makeReason("bin", "ffmpeg"),
+			makeReason("bin", "yt-dlp"),
+			makeReason("bin", "ffmpeg"),
+		]);
+		const second = makeEntry("two", [
+			makeReason("bin", "node"),
+			makeReason("bin", "yt-dlp"),
+		]);
+		const { runtime } = harness(serviceDouble([], [first, second]));
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe(
+			"⚠️ Skills unavailable: one, two (missing: ffmpeg, yt-dlp, node)",
+		);
+		expect(result.data?.missingBins).toEqual(["ffmpeg", "yt-dlp", "node"]);
+	});
+
+	it("surfaces only binaries in the compact suffix even when env and config also miss", async () => {
+		const entry = makeEntry("mixed", [
+			makeReason("env", "MIXED_TOKEN"),
+			makeReason("bin", "jq"),
+			makeReason("config", "mixed.key"),
+		]);
+		const { runtime } = harness(serviceDouble([], [entry]));
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe("⚠️ Skills unavailable: mixed (missing: jq)");
+		expect(result.data?.missingBins).toEqual(["jq"]);
+		expect(result.text).not.toContain("MIXED_TOKEN");
+		expect(result.text).not.toContain("mixed.key");
+	});
+
+	it("degrades to the explicit unavailable state when the service fails with an Error", async () => {
+		const failure = new Error("compact scan failed");
+		const service: ServiceDouble = {
+			getEligibleSkills: () => Promise.resolve([]),
+			getIneligibleSkills: () => Promise.reject(failure),
+		};
+		const { runtime, reported } = harness(service);
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.text).toBe("Skill eligibility is unavailable.");
+		expect(result.values).toEqual({ skillEligibilityAvailable: false });
+		expect(result.data).toEqual({
+			available: false,
+			error: "compact scan failed",
+		});
+		expect(reported).toHaveLength(1);
+		expect(reported[0].scope).toBe("SkillEligibilityCompactProvider.get");
+		expect(reported[0].error).toBe(failure);
+	});
+
+	it("stringifies non-Error compact failures", async () => {
+		const service: ServiceDouble = {
+			getEligibleSkills: () => Promise.resolve([]),
+			getIneligibleSkills: () => Promise.reject({ code: 7 }),
+		};
+		const { runtime, reported } = harness(service);
+		const result = await skillEligibilityCompactProvider.get(
+			runtime,
+			message,
+			state,
+		);
+		expect(result.data).toEqual({
+			available: false,
+			error: "[object Object]",
+		});
+		expect(reported).toHaveLength(1);
+		expect(reported[0].error).toEqual({ code: 7 });
+	});
+});
+
+describe("skill eligibility provider metadata and exports", () => {
+	it("exposes invocation-controlling metadata on both providers", () => {
+		for (const provider of [
+			skillEligibilityProvider,
+			skillEligibilityCompactProvider,
+		]) {
+			expect(provider.position).toBe(-5);
+			expect(provider.dynamic).toBe(true);
+			expect(provider.contexts).toEqual(["general", "agent_internal"]);
+			expect(provider.contextGate).toEqual({
+				anyOf: ["general", "agent_internal"],
+			});
+			expect(provider.cacheStable).toBe(false);
+			expect(provider.cacheScope).toBe("turn");
+			expect(provider.roleGate).toEqual({ minRole: "USER" });
+		}
+		expect(skillEligibilityProvider.name).toBe("skill_eligibility");
+		expect(skillEligibilityProvider.description).toBe(
+			"Shows which skills are eligible and which have missing dependencies",
+		);
+		expect(skillEligibilityCompactProvider.name).toBe(
+			"skill_eligibility_compact",
+		);
+		expect(skillEligibilityCompactProvider.description).toBe(
+			"Compact view of ineligible skills only",
+		);
+	});
+
+	it("aliases the default export to the primary provider", () => {
+		expect(skillEligibilityDefault).toBe(skillEligibilityProvider);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3042,7 +3042,7 @@ export class AgentRuntime implements IAgentRuntime {
 					{ src: "agent", agentId: this.agentId },
 					"Database adapter not initialized; using in-memory adapter (ALLOW_NO_DATABASE)",
 				);
-				this.registerDatabaseAdapter(new InMemoryDatabaseAdapter());
+				this.registerDatabaseAdapter(new InMemoryDatabaseAdapter(this.agentId));
 			} else {
 				this.logger.error(
 					{ src: "agent", agentId: this.agentId },

--- a/packages/core/src/runtime/rlm.test.ts
+++ b/packages/core/src/runtime/rlm.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for RLM policy decision gate: validates budget allocation,
+ * task kind gating, token/char thresholds, and explicit request overrides.
+ */
+import { describe, expect, it } from "vitest";
+import { decideRLMUse } from "./rlm.ts";
+
+describe("rlm policy", () => {
+	it("enables RLM when explicitly requested regardless of task kind or size", () => {
+		const decision = decideRLMUse({
+			taskKind: "action-calling",
+			contextTokens: 100,
+			explicitlyRequested: true,
+			latencyBudgetMs: 5000,
+		});
+		expect(decision.enabled).toBe(true);
+		expect(decision.reason).toBe("explicitly_requested");
+		expect(decision.budget.maxLatencyMs).toBe(5000);
+	});
+
+	it("disables RLM for known short action task kinds", () => {
+		const kinds = [
+			"action-calling",
+			"bfcl",
+			"mind2web",
+			"vending_bench",
+			"voicebench",
+			"woobench",
+		];
+		for (const kind of kinds) {
+			const decision = decideRLMUse({ taskKind: kind });
+			expect(decision.enabled).toBe(false);
+			expect(decision.reason).toBe("short_action_task");
+		}
+	});
+
+	it("disables RLM when context is within direct model budget and not external", () => {
+		const decision = decideRLMUse({
+			taskKind: "general-reasoning",
+			contextTokens: 10000,
+			contextChars: 40000,
+			hasExternalContext: false,
+		});
+		expect(decision.enabled).toBe(false);
+		expect(decision.reason).toBe("context_within_direct_model_budget");
+	});
+
+	it("enables RLM when external context is present", () => {
+		const decision = decideRLMUse({
+			taskKind: "general-reasoning",
+			contextTokens: 500,
+			hasExternalContext: true,
+		});
+		expect(decision.enabled).toBe(true);
+		expect(decision.reason).toBe("large_external_context");
+	});
+
+	it("enables RLM when context exceeds token or character thresholds", () => {
+		const tokenDecision = decideRLMUse({
+			contextTokens: 35000,
+			contextChars: 50000,
+		});
+		expect(tokenDecision.enabled).toBe(true);
+		expect(tokenDecision.reason).toBe("large_external_context");
+
+		const charDecision = decideRLMUse({
+			contextTokens: 20000,
+			contextChars: 150000,
+		});
+		expect(charDecision.enabled).toBe(true);
+		expect(charDecision.reason).toBe("large_external_context");
+	});
+});

--- a/packages/core/src/testing/mock-runtime.test.ts
+++ b/packages/core/src/testing/mock-runtime.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for mock-runtime factory: validates default mock agent id,
+ * character structure, services and state maps, and override propagation.
+ */
+import { describe, expect, it } from "vitest";
+import { createMockRuntime, MOCK_AGENT_ID } from "./mock-runtime.ts";
+
+describe("mock-runtime", () => {
+	it("provides stable mock agent id constant", () => {
+		expect(MOCK_AGENT_ID).toBe("00000000-0000-0000-0000-000000000000");
+	});
+
+	it("creates default mock runtime with required structural fields", () => {
+		const runtime = createMockRuntime();
+
+		expect(runtime.agentId).toBe(MOCK_AGENT_ID);
+		expect(runtime.character.name).toBe("MockAgent");
+		expect(Array.isArray(runtime.providers)).toBe(true);
+		expect(Array.isArray(runtime.actions)).toBe(true);
+		expect(Array.isArray(runtime.evaluators)).toBe(true);
+		expect(Array.isArray(runtime.plugins)).toBe(true);
+		expect(runtime.services instanceof Map).toBe(true);
+		expect(runtime.stateCache instanceof Map).toBe(true);
+	});
+
+	it("applies overrides correctly", () => {
+		const customAgentId = "11111111-1111-1111-1111-111111111111" as any;
+		const runtime = createMockRuntime({
+			agentId: customAgentId,
+			getSetting: (k) => (k === "CUSTOM_KEY" ? "custom_value" : undefined),
+		});
+
+		expect(runtime.agentId).toBe(customAgentId);
+		expect(runtime.getSetting("CUSTOM_KEY")).toBe("custom_value");
+		expect(runtime.getSetting("UNKNOWN")).toBeUndefined();
+	});
+});

--- a/packages/core/src/testing/shared-test-utils.test.ts
+++ b/packages/core/src/testing/shared-test-utils.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for shared test utils: validates saveEnv, envSnapshot,
+ * withTimeout timeout handling, sleep delay, and createDeferred promises.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	createDeferred,
+	envSnapshot,
+	saveEnv,
+	sleep,
+	withTimeout,
+} from "./shared-test-utils.ts";
+
+describe("shared-test-utils", () => {
+	describe("saveEnv", () => {
+		it("restores original environment variable state", () => {
+			const testKey = "TEST_ENV_VAR_123";
+			process.env[testKey] = "original";
+
+			const env = saveEnv(testKey);
+			process.env[testKey] = "modified";
+			expect(process.env[testKey]).toBe("modified");
+
+			env.restore();
+			expect(process.env[testKey]).toBe("original");
+			delete process.env[testKey];
+		});
+	});
+
+	describe("envSnapshot", () => {
+		it("supports set, clear, and restore", () => {
+			const testKey = "SNAPSHOT_VAR_456";
+			delete process.env[testKey];
+
+			const snapshot = envSnapshot([testKey]);
+			snapshot.set(testKey, "temporary");
+			expect(process.env[testKey]).toBe("temporary");
+
+			snapshot.clear();
+			expect(process.env[testKey]).toBeUndefined();
+
+			snapshot.restore();
+			expect(process.env[testKey]).toBeUndefined();
+		});
+	});
+
+	describe("withTimeout", () => {
+		it("resolves when promise completes within duration", async () => {
+			const res = await withTimeout(Promise.resolve("success"), 500);
+			expect(res).toBe("success");
+		});
+
+		it("rejects when promise times out", async () => {
+			const slowPromise = new Promise((resolve) => setTimeout(resolve, 200));
+			await expect(withTimeout(slowPromise, 20, "SlowOp")).rejects.toThrow(
+				"SlowOp timed out after 20ms",
+			);
+		});
+	});
+
+	describe("sleep", () => {
+		it("resolves after delay", async () => {
+			const start = Date.now();
+			await sleep(20);
+			expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+		});
+	});
+
+	describe("createDeferred", () => {
+		it("creates a promise that can be resolved externally", async () => {
+			const deferred = createDeferred<string>();
+			deferred.resolve("resolved_value");
+			const val = await deferred.promise;
+			expect(val).toBe("resolved_value");
+		});
+
+		it("creates a promise that can be rejected externally", async () => {
+			const deferred = createDeferred<string>();
+			deferred.reject(new Error("rejected_error"));
+			await expect(deferred.promise).rejects.toThrow("rejected_error");
+		});
+	});
+});

--- a/packages/core/src/types/access-context.ts
+++ b/packages/core/src/types/access-context.ts
@@ -1,9 +1,10 @@
 /**
  * Access-control context threaded through memory reads: identifies the requester
- * a retrieval runs on behalf of so a database adapter can filter results down to
- * what that requester is permitted to see. Part of the canonical `@elizaos/core`
- * type system; enforcement composes with the opt-in Postgres RLS in `plugin-sql`
- * and is a no-op when omitted (single-tenant reads stay unfiltered).
+ * a retrieval runs on behalf of so a database adapter can intersect world,
+ * authorized rooms, and disclosure scope before pagination. Part of the
+ * canonical `@elizaos/core` type system; enforcement composes with the opt-in
+ * Postgres RLS in `plugin-sql` and is a no-op when omitted (single-tenant reads
+ * stay unfiltered).
  */
 import type { RoleName } from "../roles";
 import type { UUID } from "./primitives";
@@ -26,6 +27,15 @@ export interface AccessContext {
 	requesterEntityId: UUID;
 	/** World/tenant the request is scoped to. */
 	worldId?: UUID;
+	/**
+	 * Rooms whose membership/containment has already been authorized for this
+	 * read. When present, adapters intersect every memory query with this set and
+	 * with `worldId` (when supplied) before ordering, ranking, or pagination; an
+	 * empty set therefore denies all room-backed memories. Omission preserves the
+	 * legacy scope-only contract for callers that have not yet resolved room
+	 * authority, so topology-aware callers must never omit it accidentally.
+	 */
+	authorizedRoomIds?: readonly UUID[];
 	/** Requester's resolved role within `worldId`. */
 	role?: RoleName;
 	/** Whether the requester owns `worldId`. */

--- a/packages/core/src/types/action-failure.test.ts
+++ b/packages/core/src/types/action-failure.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for action-failure taxonomy: validates normalization
+ * for missing_capability, handler_error, and persistence_error,
+ * as well as reading provenance from thrown errors.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	normalizeActionFailureProvenance,
+	readActionFailureProvenance,
+} from "./action-failure.ts";
+
+describe("action-failure", () => {
+	describe("normalizeActionFailureProvenance", () => {
+		it("normalizes valid missing_capability provenance", () => {
+			const res = normalizeActionFailureProvenance({
+				kind: "missing_capability",
+				boundary: "capability",
+				code: "CAP_MISSING",
+				retryable: false,
+			});
+			expect(res).toEqual({
+				kind: "missing_capability",
+				boundary: "capability",
+				code: "CAP_MISSING",
+				retryable: false,
+			});
+		});
+
+		it("normalizes valid handler_error provenance", () => {
+			const res = normalizeActionFailureProvenance({
+				kind: "handler_error",
+				boundary: "handler",
+				code: "BAD_INPUT",
+				retryable: true,
+			});
+			expect(res).toEqual({
+				kind: "handler_error",
+				boundary: "handler",
+				code: "BAD_INPUT",
+				retryable: true,
+			});
+		});
+
+		it("normalizes valid persistence_error provenance", () => {
+			const res = normalizeActionFailureProvenance({
+				kind: "persistence_error",
+				boundary: "persistence",
+				code: "DB_TIMEOUT",
+				retryable: true,
+			});
+			expect(res).toEqual({
+				kind: "persistence_error",
+				boundary: "persistence",
+				code: "DB_TIMEOUT",
+				retryable: true,
+			});
+		});
+
+		it("throws TypeError on non-object or invalid fields", () => {
+			expect(() => normalizeActionFailureProvenance(null)).toThrow(TypeError);
+			expect(() => normalizeActionFailureProvenance("str")).toThrow(TypeError);
+			expect(() =>
+				normalizeActionFailureProvenance({
+					kind: "missing_capability",
+					code: "", // empty code
+					boundary: "capability",
+					retryable: false,
+				}),
+			).toThrow(TypeError);
+			expect(() =>
+				normalizeActionFailureProvenance({
+					kind: "missing_capability",
+					code: "CAP",
+					boundary: "handler", // wrong boundary
+					retryable: false,
+				}),
+			).toThrow(TypeError);
+		});
+	});
+
+	describe("readActionFailureProvenance", () => {
+		it("returns null for non-object errors or errors without provenance", () => {
+			expect(readActionFailureProvenance(null)).toBeNull();
+			expect(readActionFailureProvenance(new Error("simple error"))).toBeNull();
+		});
+
+		it("extracts provenance from error root or error.context", () => {
+			const errWithDirect = {
+				failureProvenance: {
+					kind: "handler_error",
+					boundary: "handler",
+					code: "HANDLER_ERR",
+					retryable: false,
+				},
+			};
+			expect(readActionFailureProvenance(errWithDirect)?.code).toBe(
+				"HANDLER_ERR",
+			);
+
+			const errWithContext = {
+				context: {
+					failureProvenance: {
+						kind: "persistence_error",
+						boundary: "persistence",
+						code: "STORE_ERR",
+						retryable: true,
+					},
+				},
+			};
+			expect(readActionFailureProvenance(errWithContext)?.code).toBe(
+				"STORE_ERR",
+			);
+		});
+	});
+});

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1147,8 +1147,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		 */
 		includeEmbedding?: boolean;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before ordering and pagination. When omitted,
+		 * no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
@@ -1235,8 +1236,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		textContains?: string;
 		includeEmbedding?: boolean;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before ordering and pagination. When omitted,
+		 * no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
@@ -1322,8 +1324,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		worldId?: UUID;
 		entityId?: UUID;
 		/**
-		 * Requester identity to scope retrieval to. When omitted, no
-		 * access-context filtering is applied (single-tenant behavior).
+		 * Requester authority used to intersect disclosure scope and any supplied
+		 * world/authorized-room bounds before vector ranking and pagination. When
+		 * omitted, no access-context filtering is applied (single-tenant behavior).
 		 */
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;

--- a/packages/core/src/types/tee.test.ts
+++ b/packages/core/src/types/tee.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Unit tests for legacy TEE contracts: validates TEEMode and TeeType enum objects.
+ */
+import { describe, expect, it } from "vitest";
+import { TEEMode, TeeType } from "./tee.ts";
+
+describe("tee constants", () => {
+	it("exports expected TEEMode values", () => {
+		expect(TEEMode.UNSPECIFIED).toBe("UNSPECIFIED");
+		expect(TEEMode.OFF).toBe("OFF");
+		expect(TEEMode.LOCAL).toBe("LOCAL");
+		expect(TEEMode.DOCKER).toBe("DOCKER");
+		expect(TEEMode.PRODUCTION).toBe("PRODUCTION");
+	});
+
+	it("exports expected TeeType values", () => {
+		expect(TeeType.UNSPECIFIED).toBe("UNSPECIFIED");
+		expect(TeeType.TDX_DSTACK).toBe("TDX_DSTACK");
+	});
+});

--- a/packages/examples/code/src/acp-terminal-failure.test.ts
+++ b/packages/examples/code/src/acp-terminal-failure.test.ts
@@ -1,0 +1,31 @@
+/** Tests the typed failure receipt exported by the eliza-code ACP boundary. */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { terminalFailureFromAgentClientError } from "./acp-terminal-failure.js";
+
+describe("terminalFailureFromAgentClientError", () => {
+  it("preserves kind, code, retryability, and complete message", () => {
+    const error = new ElizaError("Verification did not complete.", {
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: {
+        failureKind: "coding_mutation_unverified",
+        failureCode: "VERIFY_REQUIRED",
+        transient: false,
+      },
+      severity: "fatal",
+    });
+
+    expect(terminalFailureFromAgentClientError(error)).toEqual({
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Verification did not complete.",
+    });
+  });
+
+  it("does not translate unrelated failures", () => {
+    expect(
+      terminalFailureFromAgentClientError(new Error("transport failed")),
+    ).toBeUndefined();
+  });
+});

--- a/packages/examples/code/src/acp-terminal-failure.ts
+++ b/packages/examples/code/src/acp-terminal-failure.ts
@@ -1,0 +1,41 @@
+/**
+ * Converts the coding runtime's typed failed-turn exception into the ACP
+ * prompt-result extension consumed by the parent orchestrator.
+ */
+import { ElizaError } from "@elizaos/core";
+
+export interface AcpTerminalFailureReceipt {
+  kind: string;
+  code?: string;
+  transient: boolean;
+  message: string;
+}
+
+/** Preserve only the dedicated failed-turn exception; unrelated faults throw. */
+export function terminalFailureFromAgentClientError(
+  error: unknown,
+): AcpTerminalFailureReceipt | undefined {
+  if (
+    !(error instanceof ElizaError) ||
+    error.code !== "ELIZA_CODE_SYNTHETIC_TURN_FAILURE"
+  ) {
+    return undefined;
+  }
+  const context = error.context;
+  if (!context) return undefined;
+  const kind =
+    typeof context.failureKind === "string" && context.failureKind.trim()
+      ? context.failureKind.trim()
+      : undefined;
+  if (!kind || typeof context.transient !== "boolean") return undefined;
+  const code =
+    typeof context.failureCode === "string" && context.failureCode.trim()
+      ? context.failureCode.trim()
+      : undefined;
+  return {
+    kind,
+    ...(code ? { code } : {}),
+    transient: context.transient,
+    message: error.message,
+  };
+}

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -44,6 +44,7 @@ import {
 } from "@elizaos/plugin-coding-tools";
 import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { publishParsedReply } from "./acp-response.js";
+import { terminalFailureFromAgentClientError } from "./acp-terminal-failure.js";
 import { AcpActivePromptRegistry } from "./acp-active-prompts.js";
 import {
   type AcpToolCallUpdate,
@@ -378,21 +379,40 @@ const _connection = new AgentSideConnection(
         publish: (update: Parameters<typeof conn.sessionUpdate>[0]) =>
           conn.sessionUpdate(update),
       };
-      const response = await activePrompts.run(promptContext, (abortSignal) =>
-        getAgentClient().sendMessage({
-          room,
-          text,
-          identity: sessionIdentity,
-          source: "acp",
-          codingMode: true,
-          abortSignal,
-        }),
-      );
-      await publishParsedReply(params.sessionId, response, (update) =>
-        conn.sessionUpdate(update),
-      );
-      log("prompt done", { response: response.length });
-      return { stopReason: "end_turn" };
+      try {
+        const response = await activePrompts.run(promptContext, (abortSignal) =>
+          getAgentClient().sendMessage({
+            room,
+            text,
+            identity: sessionIdentity,
+            source: "acp",
+            codingMode: true,
+            abortSignal,
+          }),
+        );
+        await publishParsedReply(params.sessionId, response, (update) =>
+          conn.sessionUpdate(update),
+        );
+        log("prompt done", { response: response.length });
+        return { stopReason: "end_turn" };
+      } catch (error) {
+        // error-policy:J1 The ACP request boundary converts only the runtime's
+        // authoritative failed-turn receipt. Transport and programming faults
+        // still reject the JSON-RPC request normally.
+        const terminalFailure = terminalFailureFromAgentClientError(error);
+        if (!terminalFailure) throw error;
+        log("prompt terminal failure", {
+          kind: terminalFailure.kind,
+          transient: terminalFailure.transient,
+        });
+        return {
+          // ACP's standard StopReason union has no `error` member. The typed
+          // receipt is authoritative and the orchestrator maps it to its
+          // internal error stop reason without emitting an invalid ACP value.
+          stopReason: "end_turn",
+          _meta: { terminalFailure },
+        };
+      }
     },
     async cancel(params: { sessionId?: string }) {
       const sessionId = params?.sessionId;

--- a/packages/shared/src/views/shared-nav-targets.test.ts
+++ b/packages/shared/src/views/shared-nav-targets.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for shared-nav-targets: validates navigation vocabulary,
+ * localized labels across UI locales, and view ID translation targets.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DOCUMENTS_NAV_VOCABULARY,
+  SHARED_NAV_TARGETS,
+  SHARED_NAV_UI_LOCALES,
+} from "./shared-nav-targets.ts";
+
+describe("shared-nav-targets", () => {
+  it("maps standard navigation targets to routable view IDs", () => {
+    expect(SHARED_NAV_TARGETS.settings.viewId).toBe("settings");
+    expect(SHARED_NAV_TARGETS.vault.viewId).toBe("vault");
+    expect(SHARED_NAV_TARGETS.wallet.viewId).toBe("inventory"); // translated
+    expect(SHARED_NAV_TARGETS.calendar.viewId).toBe("calendar");
+    expect(SHARED_NAV_TARGETS.inbox.viewId).toBe("inbox");
+    expect(SHARED_NAV_TARGETS.finances.viewId).toBe("finances");
+    expect(SHARED_NAV_TARGETS.chat.viewId).toBe("chat");
+    expect(SHARED_NAV_TARGETS["cloud-apps"].viewPath).toBe("/cloud-apps");
+  });
+
+  it("omits native-only surfaces like camera from shared targets", () => {
+    expect(SHARED_NAV_TARGETS.camera).toBeUndefined();
+  });
+
+  it("provides complete localized labels for documents vocabulary", () => {
+    expect(DOCUMENTS_NAV_VOCABULARY.viewId).toBe("documents");
+    expect(DOCUMENTS_NAV_VOCABULARY.label).toBe("Knowledge");
+    expect(DOCUMENTS_NAV_VOCABULARY.aliases).toContain("knowledge base");
+
+    for (const locale of SHARED_NAV_UI_LOCALES) {
+      const label = DOCUMENTS_NAV_VOCABULARY.localizedLabels[locale];
+      expect(typeof label).toBe("string");
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/ui/src/chat/coding-agent-session-state.test.ts
+++ b/packages/ui/src/chat/coding-agent-session-state.test.ts
@@ -1,0 +1,196 @@
+/**
+ * coding-agent-session-state contract — real module, no mocks: STATUS_DOT /
+ * PULSE_STATUSES / TERMINAL_STATUSES membership, and every
+ * mapServerTasksToSessions branch (terminal filtering, per-field ?? defaults,
+ * order preservation, input immutability, empty input).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ServerTask } from "./coding-agent-session-state";
+import {
+  mapServerTasksToSessions,
+  PULSE_STATUSES,
+  STATUS_DOT,
+  TERMINAL_STATUSES,
+} from "./coding-agent-session-state";
+
+describe("STATUS_DOT", () => {
+  it("maps each known status to its dot utility class", () => {
+    expect(STATUS_DOT.active).toBe("bg-ok");
+    expect(STATUS_DOT.tool_running).toBe("bg-accent");
+    expect(STATUS_DOT.blocked).toBe("bg-warn");
+    expect(STATUS_DOT.error).toBe("bg-danger");
+  });
+
+  it("yields undefined for an unknown status key", () => {
+    expect(STATUS_DOT.nonexistent).toBeUndefined();
+  });
+});
+
+describe("PULSE_STATUSES", () => {
+  it("pulses only active and tool_running sessions", () => {
+    expect(PULSE_STATUSES.size).toBe(2);
+    expect(PULSE_STATUSES.has("active")).toBe(true);
+    expect(PULSE_STATUSES.has("tool_running")).toBe(true);
+  });
+
+  it("does not pulse blocked, completed, stopped, error, or interrupted", () => {
+    expect(PULSE_STATUSES.has("blocked")).toBe(false);
+    expect(PULSE_STATUSES.has("completed")).toBe(false);
+    expect(PULSE_STATUSES.has("stopped")).toBe(false);
+    expect(PULSE_STATUSES.has("error")).toBe(false);
+    expect(PULSE_STATUSES.has("interrupted")).toBe(false);
+  });
+});
+
+describe("TERMINAL_STATUSES", () => {
+  it("marks completed, stopped, error, and interrupted as terminal", () => {
+    expect(TERMINAL_STATUSES.size).toBe(4);
+    expect(TERMINAL_STATUSES.has("completed")).toBe(true);
+    expect(TERMINAL_STATUSES.has("stopped")).toBe(true);
+    expect(TERMINAL_STATUSES.has("error")).toBe(true);
+    expect(TERMINAL_STATUSES.has("interrupted")).toBe(true);
+  });
+
+  it("does not treat live statuses as terminal", () => {
+    expect(TERMINAL_STATUSES.has("active")).toBe(false);
+    expect(TERMINAL_STATUSES.has("blocked")).toBe(false);
+    expect(TERMINAL_STATUSES.has("tool_running")).toBe(false);
+  });
+
+  it("does not contain the nullish placeholder used by the filter", () => {
+    expect(TERMINAL_STATUSES.has("")).toBe(false);
+  });
+});
+
+describe("mapServerTasksToSessions", () => {
+  it("returns an empty array for an empty queue", () => {
+    expect(mapServerTasksToSessions([])).toEqual([]);
+  });
+
+  it("maps a fully populated task verbatim", () => {
+    const tasks: ServerTask[] = [
+      {
+        sessionId: "sess-1",
+        agentType: "codex",
+        label: "Refactor auth",
+        originalTask: "Refactor the auth module",
+        workdir: "/repo/auth",
+        status: "active",
+        decisionCount: 7,
+        autoResolvedCount: 3,
+      },
+    ];
+
+    expect(mapServerTasksToSessions(tasks)).toEqual([
+      {
+        sessionId: "sess-1",
+        agentType: "codex",
+        label: "Refactor auth",
+        originalTask: "Refactor the auth module",
+        workdir: "/repo/auth",
+        status: "active",
+        decisionCount: 7,
+        autoResolvedCount: 3,
+      },
+    ]);
+  });
+
+  it("applies defaults for every optional field when only sessionId is present", () => {
+    const tasks: ServerTask[] = [{ sessionId: "sess-2" }];
+
+    expect(mapServerTasksToSessions(tasks)).toEqual([
+      {
+        sessionId: "sess-2",
+        agentType: "claude",
+        label: "sess-2",
+        originalTask: "",
+        workdir: "",
+        status: "active",
+        decisionCount: 0,
+        autoResolvedCount: 0,
+      },
+    ]);
+  });
+
+  it("drops tasks whose status is terminal", () => {
+    expect(
+      mapServerTasksToSessions(
+        ["completed", "stopped", "error", "interrupted"].map((status) => ({
+          sessionId: `done-${status}`,
+          status,
+        })),
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps tasks whose status is live", () => {
+    expect(
+      mapServerTasksToSessions(
+        ["active", "blocked", "tool_running"].map((status) => ({
+          sessionId: `live-${status}`,
+          status,
+        })),
+      ).map((session) => session.sessionId),
+    ).toEqual(["live-active", "live-blocked", "live-tool_running"]);
+  });
+
+  it("keeps a task with no status and defaults it to active", () => {
+    const sessions = mapServerTasksToSessions([{ sessionId: "no-status" }]);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe("no-status");
+    expect(sessions[0]?.status).toBe("active");
+  });
+
+  it("filters by terminal-set membership, not by a known-status whitelist", () => {
+    const sessions = mapServerTasksToSessions([
+      { sessionId: "odd-live-a", status: "queued" },
+      { sessionId: "odd-live-b", status: "crashed" },
+    ]);
+
+    expect(sessions.map((session) => session.sessionId)).toEqual([
+      "odd-live-a",
+      "odd-live-b",
+    ]);
+  });
+
+  it("preserves input order across interleaved terminal and live tasks", () => {
+    const sessions = mapServerTasksToSessions([
+      { sessionId: "a", status: "active" },
+      { sessionId: "b", status: "completed" },
+      { sessionId: "c" },
+      { sessionId: "d", status: "interrupted" },
+      { sessionId: "e", status: "tool_running" },
+    ]);
+
+    expect(sessions.map((session) => session.sessionId)).toEqual([
+      "a",
+      "c",
+      "e",
+    ]);
+  });
+
+  it("resolves each task's label fallback independently", () => {
+    const sessions = mapServerTasksToSessions([
+      { sessionId: "x", label: "Named" },
+      { sessionId: "y" },
+    ]);
+
+    expect(sessions.map((session) => session.label)).toEqual(["Named", "y"]);
+  });
+
+  it("does not mutate the input tasks", () => {
+    const task: ServerTask = { sessionId: "sess-9" };
+
+    mapServerTasksToSessions([task]);
+
+    expect(task.agentType).toBeUndefined();
+    expect(task.label).toBeUndefined();
+    expect(task.originalTask).toBeUndefined();
+    expect(task.workdir).toBeUndefined();
+    expect(task.status).toBeUndefined();
+    expect(task.decisionCount).toBeUndefined();
+    expect(task.autoResolvedCount).toBeUndefined();
+  });
+});

--- a/packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.test.ts
+++ b/packages/ui/src/cloud-ui/components/brand/lock-on-button.variants.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the LockOnButton cva contract (`lockOnButtonVariants`):
+ * shared base classes, tone/size segments, default fallbacks, and
+ * unknown-key behaviour. Pure function, deterministic, no DOM.
+ */
+import { describe, expect, it } from "vitest";
+import { lockOnButtonVariants } from "./lock-on-button.variants";
+
+const BASE =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm border text-sm font-medium transition-colors    disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer";
+
+const TONE_SEGMENTS = {
+  primary:
+    "border-accent bg-accent text-accent-foreground hover:bg-accent-hover",
+  outline:
+    "border-border bg-bg-elevated text-txt hover:border-border-strong hover:bg-bg-hover",
+  ghost:
+    "border-transparent bg-transparent text-txt/70 hover:border-border hover:bg-bg-hover hover:text-txt",
+  hud: "border-accent/40 bg-accent-subtle text-accent hover:border-accent/70 hover:bg-accent/20",
+} as const;
+
+const SIZE_SEGMENTS = {
+  sm: "h-8 px-3 text-xs",
+  md: "h-10 px-4",
+  lg: "h-12 px-6",
+} as const;
+
+describe("lockOnButtonVariants", () => {
+  it("emits the shared base classes first, then tone, then size", () => {
+    const out = lockOnButtonVariants({ variant: "hud", size: "sm" });
+    expect(out.startsWith(`${BASE} `)).toBe(true);
+    expect(out.indexOf(TONE_SEGMENTS.hud)).toBeGreaterThan(0);
+    expect(out.indexOf(SIZE_SEGMENTS.sm)).toBeGreaterThan(
+      out.indexOf(TONE_SEGMENTS.hud),
+    );
+  });
+
+  it("defaults to the primary tone and md size when called with no arguments", () => {
+    const out = lockOnButtonVariants();
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.primary} ${SIZE_SEGMENTS.md}`);
+  });
+
+  it.each(Object.entries(TONE_SEGMENTS))(
+    "applies the %s tone segment and no other tone segment",
+    (tone, segment) => {
+      const out = lockOnButtonVariants({
+        variant: tone as keyof typeof TONE_SEGMENTS,
+      });
+      expect(out).toContain(` ${segment}`);
+      for (const [other, otherSegment] of Object.entries(TONE_SEGMENTS)) {
+        if (other !== tone) {
+          expect(out).not.toContain(otherSegment);
+        }
+      }
+    },
+  );
+
+  it.each(Object.entries(SIZE_SEGMENTS))(
+    "applies the %s size segment and no other size segment",
+    (size, segment) => {
+      const out = lockOnButtonVariants({
+        size: size as keyof typeof SIZE_SEGMENTS,
+      });
+      expect(out).toContain(` ${segment}`);
+      for (const [other, otherSegment] of Object.entries(SIZE_SEGMENTS)) {
+        if (other !== size) {
+          expect(out).not.toContain(otherSegment);
+        }
+      }
+    },
+  );
+
+  it("keeps the primary tone default when only a size override is given", () => {
+    const out = lockOnButtonVariants({ size: "lg" });
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.primary} ${SIZE_SEGMENTS.lg}`);
+  });
+
+  it("combines independent tone and size overrides", () => {
+    const out = lockOnButtonVariants({ variant: "outline", size: "sm" });
+    expect(out).toBe(`${BASE} ${TONE_SEGMENTS.outline} ${SIZE_SEGMENTS.sm}`);
+  });
+
+  it("falls back to both defaults when props are explicitly undefined", () => {
+    const out = lockOnButtonVariants({
+      variant: undefined,
+      size: undefined,
+    });
+    expect(out).toBe(lockOnButtonVariants());
+  });
+
+  it("emits no tone classes for an unknown tone instead of throwing", () => {
+    const out = lockOnButtonVariants({
+      variant: "bogus" as keyof typeof TONE_SEGMENTS,
+    });
+    expect(out).toBe(`${BASE} ${SIZE_SEGMENTS.md}`);
+  });
+
+  it("treats an empty props object exactly like no arguments", () => {
+    expect(lockOnButtonVariants({})).toBe(lockOnButtonVariants());
+  });
+});

--- a/packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts
+++ b/packages/ui/src/cloud-ui/components/dashboard/dashboard-route-error.helpers.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the dashboard route error message formatter
+ * (`formatDashboardRouteErrorMessage`): the pure branch table that maps an
+ * unknown route-error value to user-facing text. Deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { formatDashboardRouteErrorMessage } from "./dashboard-route-error.helpers";
+
+const FALLBACK = "An unexpected error occurred while loading this page.";
+
+describe("formatDashboardRouteErrorMessage", () => {
+  it("returns the message of a plain Error instance", () => {
+    expect(formatDashboardRouteErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns the message of an Error subclass via instanceof", () => {
+    expect(
+      formatDashboardRouteErrorMessage(new TypeError("not a function")),
+    ).toBe("not a function");
+  });
+
+  it("returns an empty string for an Error constructed with an empty message", () => {
+    expect(formatDashboardRouteErrorMessage(new Error(""))).toBe("");
+  });
+
+  it("passes a non-empty string through unchanged", () => {
+    expect(formatDashboardRouteErrorMessage("network unreachable")).toBe(
+      "network unreachable",
+    );
+  });
+
+  it("preserves whitespace and unicode in string input", () => {
+    expect(formatDashboardRouteErrorMessage("  402: 支払いが必要 🚧 ")).toBe(
+      "  402: 支払いが必要 🚧 ",
+    );
+  });
+
+  it("returns an empty string for empty-string input instead of the fallback", () => {
+    expect(formatDashboardRouteErrorMessage("")).toBe("");
+  });
+
+  it("falls back for null", () => {
+    expect(formatDashboardRouteErrorMessage(null)).toBe(FALLBACK);
+  });
+
+  it("falls back for undefined", () => {
+    expect(formatDashboardRouteErrorMessage(undefined)).toBe(FALLBACK);
+  });
+
+  it("uses one stable fallback string shared by both nullish branches", () => {
+    expect(formatDashboardRouteErrorMessage(null)).toBe(
+      formatDashboardRouteErrorMessage(undefined),
+    );
+  });
+});

--- a/packages/ui/src/cloud/applications/lib/native-cloud-nav.test.ts
+++ b/packages/ui/src/cloud/applications/lib/native-cloud-nav.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Unit tests for native-cloud-nav: validates cloud console URL resolution
+ * and external url filtering.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isNativeAppsStudioRuntime,
+  openExternalUrlOnNative,
+  resolveCloudConsoleUrl,
+} from "./native-cloud-nav.ts";
+
+describe("native-cloud-nav", () => {
+  it("reports false for native studio on standard node/web environment", () => {
+    expect(isNativeAppsStudioRuntime()).toBe(false);
+  });
+
+  it("resolves cloud console URL correctly", () => {
+    const url = resolveCloudConsoleUrl("apps/new");
+    expect(url).toContain("/apps/new");
+  });
+
+  it("returns false on web for openExternalUrlOnNative", () => {
+    expect(openExternalUrlOnNative("https://example.com")).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/settings/cloud-settings-group.test.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-group.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Pins the extra settings-group registry. Its store lives on a `Symbol.for`
+ * key so every bundle in the process shares one list, which means the registry
+ * is realm-global state: these cases save and restore it rather than assuming a
+ * clean slate. Covers last-write-wins, order-based listing, defensive copying,
+ * and the pinned group-id constants. No DOM, no runtime.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CLOUD_SETTINGS_GROUP_ID,
+  DEVELOPER_SETTINGS_GROUP_ID,
+  type ExtraSettingsGroupDef,
+  getExtraSettingsGroup,
+  listExtraSettingsGroups,
+  registerSettingsGroup,
+} from "./cloud-settings-group";
+
+const STORE_KEY = Symbol.for("elizaos.ui.cloud-settings-group-registry");
+
+type Store = { groups: Map<string, ExtraSettingsGroupDef> };
+
+function store(): Store | undefined {
+  return (globalThis as Record<PropertyKey, unknown>)[STORE_KEY] as
+    | Store
+    | undefined;
+}
+
+let saved: Array<[string, ExtraSettingsGroupDef]> = [];
+
+beforeEach(() => {
+  saved = [...(store()?.groups ?? new Map())];
+  store()?.groups.clear();
+});
+
+afterEach(() => {
+  const current = store();
+  if (!current) return;
+  current.groups.clear();
+  for (const [id, def] of saved) current.groups.set(id, def);
+});
+
+const group = (
+  id: string,
+  order: number,
+  label = `Label ${id}`,
+): ExtraSettingsGroupDef => ({ id, label, order });
+
+describe("registerSettingsGroup", () => {
+  it("makes a group retrievable by id", () => {
+    registerSettingsGroup(group("alpha", 1));
+    expect(getExtraSettingsGroup("alpha")).toEqual(group("alpha", 1));
+  });
+
+  it("last write for an id wins", () => {
+    registerSettingsGroup(group("alpha", 1, "First"));
+    registerSettingsGroup(group("alpha", 9, "Second"));
+    expect(getExtraSettingsGroup("alpha")).toEqual({
+      id: "alpha",
+      label: "Second",
+      order: 9,
+    });
+    expect(listExtraSettingsGroups()).toHaveLength(1);
+  });
+
+  it("stores a copy, so mutating the caller's object does not leak in", () => {
+    const def = group("alpha", 1);
+    registerSettingsGroup(def);
+    def.label = "mutated";
+    def.order = 99;
+    expect(getExtraSettingsGroup("alpha")).toEqual(group("alpha", 1));
+  });
+
+  it("keeps distinct ids separate", () => {
+    registerSettingsGroup(group("alpha", 1));
+    registerSettingsGroup(group("beta", 2));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});
+
+describe("getExtraSettingsGroup", () => {
+  it("returns undefined for an unregistered id", () => {
+    expect(getExtraSettingsGroup("nope")).toBeUndefined();
+  });
+
+  it("returns undefined for inherited Object.prototype keys", () => {
+    for (const key of [
+      "toString",
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      expect(getExtraSettingsGroup(key)).toBeUndefined();
+    }
+  });
+
+  it("is exact — no trimming or case folding", () => {
+    registerSettingsGroup(group("alpha", 1));
+    for (const key of ["Alpha", "ALPHA", " alpha", "alpha "]) {
+      expect(getExtraSettingsGroup(key)).toBeUndefined();
+    }
+  });
+});
+
+describe("listExtraSettingsGroups", () => {
+  it("is empty when nothing is registered", () => {
+    expect(listExtraSettingsGroups()).toEqual([]);
+  });
+
+  it("sorts by order, not by insertion or id", () => {
+    registerSettingsGroup(group("zeta", 3));
+    registerSettingsGroup(group("alpha", 1));
+    registerSettingsGroup(group("mid", 2));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "mid",
+      "zeta",
+    ]);
+  });
+
+  it("supports fractional orders that interleave with the built-in slots", () => {
+    // Built-ins occupy 0 (agent), 1 (system), 2 (security); 1.5 sits between.
+    registerSettingsGroup(group("security-ish", 2.5));
+    registerSettingsGroup(group("cloud", 1.5));
+    expect(listExtraSettingsGroups().map((g) => g.order)).toEqual([1.5, 2.5]);
+  });
+
+  it("supports negative orders sorting ahead of everything", () => {
+    registerSettingsGroup(group("late", 5));
+    registerSettingsGroup(group("early", -1));
+    expect(listExtraSettingsGroups()[0]?.id).toBe("early");
+  });
+
+  it("keeps registration order among equal orders", () => {
+    registerSettingsGroup(group("first", 1));
+    registerSettingsGroup(group("second", 1));
+    registerSettingsGroup(group("third", 1));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("returns a fresh array that callers cannot use to corrupt the registry", () => {
+    registerSettingsGroup(group("alpha", 1));
+    const listed = listExtraSettingsGroups();
+    listed.push(group("injected", 0));
+    listed.reverse();
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual(["alpha"]);
+  });
+
+  it("reflects a re-registration in the new position", () => {
+    registerSettingsGroup(group("alpha", 5));
+    registerSettingsGroup(group("beta", 1));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "beta",
+      "alpha",
+    ]);
+    registerSettingsGroup(group("alpha", 0));
+    expect(listExtraSettingsGroups().map((g) => g.id)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});
+
+describe("pinned group ids", () => {
+  it("are stable, distinct, non-empty slugs", () => {
+    expect(CLOUD_SETTINGS_GROUP_ID).toBe("cloud");
+    expect(DEVELOPER_SETTINGS_GROUP_ID).toBe("developer");
+    expect(CLOUD_SETTINGS_GROUP_ID).not.toBe(DEVELOPER_SETTINGS_GROUP_ID);
+    for (const id of [CLOUD_SETTINGS_GROUP_ID, DEVELOPER_SETTINGS_GROUP_ID]) {
+      expect(id).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+
+  it("do not collide with the pinned built-in group ids", () => {
+    for (const builtin of ["agent", "system", "security"]) {
+      expect(CLOUD_SETTINGS_GROUP_ID).not.toBe(builtin);
+      expect(DEVELOPER_SETTINGS_GROUP_ID).not.toBe(builtin);
+    }
+  });
+});
+
+describe("shared store identity", () => {
+  it("registers into the Symbol.for store every bundle reads", () => {
+    registerSettingsGroup(group("alpha", 1));
+    expect(store()?.groups.get("alpha")).toEqual(group("alpha", 1));
+  });
+});

--- a/packages/ui/src/platform/android-runtime.test.ts
+++ b/packages/ui/src/platform/android-runtime.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pins Android runtime-mode resolution. The `android-cloud` build has no
+ * on-device agent, so this is the switch that decides whether onboarding offers
+ * the Local runtime path at all; only an explicit "cloud" may select the
+ * cloud-locked variant, and everything else must resolve to "local". Env is
+ * injected per case: the sibling isAndroidCloudBuild() reads the Vite-inlined
+ * import.meta.env of its own module and is not addressable from a test, so this
+ * covers the injectable resolver it delegates to rather than faking that read.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveAndroidRuntimeMode } from "./android-runtime";
+
+const KEY = "VITE_ELIZA_ANDROID_RUNTIME_MODE";
+
+describe("resolveAndroidRuntimeMode", () => {
+  it("selects cloud only for an explicit cloud value", () => {
+    expect(resolveAndroidRuntimeMode({ [KEY]: "cloud" })).toBe("cloud");
+  });
+
+  it("tolerates casing and surrounding whitespace on cloud", () => {
+    for (const value of ["CLOUD", "Cloud", "  cloud  ", "\tcloud\n"]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("cloud");
+    }
+  });
+
+  it("defaults to local when the key is missing", () => {
+    expect(resolveAndroidRuntimeMode({})).toBe("local");
+  });
+
+  it("defaults to local for blank and whitespace-only values", () => {
+    for (const value of ["", "   ", "\t\n"]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("defaults to local for an explicit local value", () => {
+    for (const value of ["local", "LOCAL", " local "]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("defaults to local for unrecognised values rather than guessing", () => {
+    for (const value of [
+      "cloudy",
+      "remote",
+      "cloud-locked",
+      "system",
+      "1",
+      "true",
+    ]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("ignores non-string values", () => {
+    for (const value of [true, false, undefined]) {
+      expect(resolveAndroidRuntimeMode({ [KEY]: value })).toBe("local");
+    }
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(
+      resolveAndroidRuntimeMode({
+        VITE_ELIZA_IOS_RUNTIME_MODE: "cloud",
+        ELIZA_RUNTIME_MODE: "cloud",
+        NODE_ENV: "production",
+      }),
+    ).toBe("local");
+  });
+
+  it("only ever returns one of the two declared modes", () => {
+    const seen = new Set<string>();
+    for (const value of [
+      "cloud",
+      "local",
+      "",
+      "junk",
+      " CLOUD ",
+      undefined,
+      true,
+    ]) {
+      seen.add(resolveAndroidRuntimeMode({ [KEY]: value }));
+    }
+    expect([...seen].sort()).toEqual(["cloud", "local"]);
+  });
+
+  it("is pure — repeated calls with the same env agree", () => {
+    const env = { [KEY]: "cloud" };
+    expect(resolveAndroidRuntimeMode(env)).toBe(resolveAndroidRuntimeMode(env));
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -311,6 +311,63 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     await expect(cancelled).resolves.toEqual({ stopReason: "cancelled" });
   });
 
+  it("preserves an authoritative terminal failure from prompt metadata", async () => {
+    const { client, p } = await startClient();
+    const prompted = client.prompt("session-1", "change and verify it");
+    await waitForWrites(p, 2);
+
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        stopReason: "end_turn",
+        _meta: {
+          terminalFailure: {
+            kind: "coding_mutation_unverified",
+            code: "VERIFY_REQUIRED",
+            transient: false,
+            message: "The mutation was not verified.",
+          },
+        },
+      },
+    });
+
+    await expect(prompted).resolves.toEqual({
+      stopReason: "end_turn",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        code: "VERIFY_REQUIRED",
+        transient: false,
+        message: "The mutation was not verified.",
+      },
+    });
+  });
+
+  it("rejects malformed terminal failure metadata instead of dropping it", async () => {
+    const { client, p } = await startClient();
+    const prompted = client.prompt("session-1", "change and verify it");
+    await waitForWrites(p, 2);
+
+    emitJson(p, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        stopReason: "end_turn",
+        _meta: {
+          terminalFailure: {
+            kind: "coding_mutation_unverified",
+            transient: "no",
+            message: "The mutation was not verified.",
+          },
+        },
+      },
+    });
+
+    await expect(prompted).rejects.toThrow(
+      "ACP terminalFailure requires kind, message, transient",
+    );
+  });
+
   it("triggers cancellation when a prompt request times out", async () => {
     vi.useFakeTimers();
     const { client, p } = await startClient({ timeoutMs: 10 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -2109,6 +2109,273 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
+  it("CLI sendPrompt preserves the untyped error-with-deliverable completion heuristic", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-untyped-error-with-output",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "build it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-untyped-error",
+          result: {
+            stopReason: "error",
+            content: [{ type: "text", text: "Verified deliverable." }],
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    closeOk(prompt);
+
+    const result = await sent;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: "Verified deliverable.",
+    });
+    expect(result.error).toBeUndefined();
+    expect(events).toEqual(["task_complete"]);
+    expect((await service.getSession(sessionId))?.status).toBe("ready");
+  });
+
+  it("CLI typed failure suppresses generic auth/crash handling on nonzero exit", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-typed-terminal-failure",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Files changed, but verification did not complete.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-typed-failure",
+          result: {
+            stopReason: "end_turn",
+            content: [{ type: "text", text: terminalFailure.message }],
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    prompt.proc.stderr.emit(
+      "data",
+      Buffer.from("401 Unauthorized token expired"),
+    );
+    prompt.proc.emit("close", 1, null);
+
+    const result = await sent;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: terminalFailure.message,
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect(await service.getSession(sessionId)).toMatchObject({
+      status: "errored",
+      lastError: terminalFailure.message,
+    });
+  });
+
+  it("CLI protocol failure suppresses generic crash persistence on nonzero exit", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-malformed-terminal-failure",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    expect(() =>
+      prompt.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: "req-malformed-failure",
+            result: {
+              stopReason: "end_turn",
+              content: [{ type: "text", text: "Unverified prose." }],
+              _meta: {
+                terminalFailure: {
+                  kind: "coding_mutation_unverified",
+                  transient: "no",
+                  message: "Unverified prose.",
+                },
+              },
+            },
+            sessionId,
+          })}\n`,
+        ),
+      ),
+    ).not.toThrow();
+    prompt.proc.stderr.emit("data", Buffer.from("subprocess crashed"));
+    prompt.proc.emit("close", 2, null);
+
+    const result = await sent;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toMatchObject({
+      failureKind: "protocol_error",
+      stopReason: "error",
+    });
+    expect(await service.getSession(sessionId)).toMatchObject({
+      status: "errored",
+      lastError: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+  });
+
+  it.each([
+    {
+      label: "typed terminal failure",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        transient: false,
+        message: "Typed failure remains authoritative.",
+      },
+      expectedFailureKind: "coding_mutation_unverified",
+      expectedLastError: "Typed failure remains authoritative.",
+    },
+    {
+      label: "malformed terminal receipt",
+      terminalFailure: {
+        kind: "coding_mutation_unverified",
+        transient: "no",
+        message: "Malformed failure receipt.",
+      },
+      expectedFailureKind: "protocol_error",
+      expectedLastError:
+        "ACP terminalFailure requires kind, message, transient",
+    },
+  ])(
+    "keeps $label exactly once across an auth-like nonzero exit",
+    async ({
+      label,
+      terminalFailure,
+      expectedFailureKind,
+      expectedLastError,
+    }) => {
+      const create = nextProc();
+      const service = new AcpService(runtime());
+      const events: Array<{ event: string; payload: unknown }> = [];
+      service.onSessionEvent((_sid, event, payload) => {
+        events.push({ event, payload });
+      });
+      await service.start();
+      const spawned = service.spawnSession({
+        name: `exactly-once-${label.replaceAll(" ", "-")}`,
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+      await waitForSpawn(create);
+      closeOk(create);
+      const { sessionId } = await spawned;
+      events.length = 0;
+
+      const prompt = nextProc();
+      const sent = service.sendPrompt(sessionId, "verify it");
+      await waitForSpawn(prompt);
+      prompt.proc.stdout.emit(
+        "data",
+        Buffer.from(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: `req-${label}`,
+            result: {
+              stopReason: "end_turn",
+              _meta: { terminalFailure },
+            },
+            sessionId,
+          })}\n`,
+        ),
+      );
+      prompt.proc.stderr.emit(
+        "data",
+        Buffer.from("401 Unauthorized token expired"),
+      );
+      prompt.proc.emit("close", 3, null);
+
+      const result = await sent;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(result.stopReason).toBe("error");
+      expect(events.map(({ event }) => event)).toEqual(["error"]);
+      expect(events[0]?.payload).toMatchObject({
+        failureKind: expectedFailureKind,
+      });
+      expect(await service.getSession(sessionId)).toMatchObject({
+        status: "errored",
+        lastError: expect.stringContaining(expectedLastError),
+      });
+    },
+  );
+
   it("flushes raw stdout before advertising stdoutLogPath on task_complete", async () => {
     const priorTrajDir = process.env.ELIZA_TRAJECTORY_DIR;
     const priorRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
@@ -2346,6 +2613,59 @@ describe("AcpService", () => {
     expect(result.finalText).toBe("Deployed the site to https://x.io");
     // Durable store is NOT flipped to errored — the work succeeded for the user.
     expect((await service.getSession(sessionId))?.status).not.toBe("errored");
+  });
+
+  it("native sendPrompt never promotes a typed terminal failure with prose to task_complete", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-typed-error-with-output",
+      agentType: "elizaos",
+      workdir: "/tmp/acp-test",
+    });
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Files changed, but verification did not complete.",
+    };
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        sessionId: "protocol-session",
+        result: {
+          stopReason: "error",
+          content: [{ type: "text", text: terminalFailure.message }],
+          _meta: { terminalFailure },
+        },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn", terminalFailure };
+    });
+
+    const result = await service.sendPrompt(sessionId, "build it");
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      finalText: terminalFailure.message,
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map((event) => event.event)).toContain("error");
+    expect(events.map((event) => event.event)).not.toContain("task_complete");
+    expect(events.find((event) => event.event === "error")?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
   });
 
   // The other half of Fix #2: a true failure (stopReason error AND no captured
@@ -2587,8 +2907,8 @@ describe("AcpService", () => {
     await new Promise((resolve) => setImmediate(resolve));
     const cancelled = service.cancelSession(sessionId);
     resolvePrompt({ stopReason: "cancelled" });
-    await cancelled;
     const result = await sent;
+    await cancelled;
 
     expect(client.cancel).toHaveBeenCalledWith("protocol-session");
     expect(result.stopReason).toBe("cancelled");
@@ -2928,6 +3248,57 @@ describe("AcpService", () => {
     );
   });
 
+  it("cancels a CLI prompt during credential setup without spawning a prompt process", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cancel-during-credentials",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    let markCredentialsStarted: () => void = () => undefined;
+    const credentialsStarted = new Promise<void>((resolve) => {
+      markCredentialsStarted = resolve;
+    });
+    let releaseCredentials: (value: Record<string, string>) => void = () =>
+      undefined;
+    const delayedCredentials = new Promise<Record<string, string>>(
+      (resolve) => {
+        releaseCredentials = resolve;
+      },
+    );
+    const internal = service as unknown as {
+      accountCredentialsForSession(
+        session: unknown,
+      ): Promise<Record<string, string> | undefined>;
+    };
+    vi.spyOn(internal, "accountCredentialsForSession").mockImplementationOnce(
+      async () => {
+        markCredentialsStarted();
+        return delayedCredentials;
+      },
+    );
+    const spawnCountBeforePrompt = spawnMock.mock.calls.length;
+    const sent = service.sendPrompt(sessionId, "start slowly");
+    await credentialsStarted;
+    const cancelled = service.cancelSession(sessionId);
+
+    const [result] = await Promise.all([sent, cancelled.then(() => undefined)]);
+    releaseCredentials({});
+    expect(result).toMatchObject({ stopReason: "cancelled" });
+    expect(spawnMock.mock.calls).toHaveLength(spawnCountBeforePrompt);
+    expect(events).toEqual(["cancelled"]);
+    expect((await service.getSession(sessionId))?.status).toBe("cancelled");
+  });
+
   it("cancelSession sends SIGTERM then SIGKILL after grace", async () => {
     const create = nextProc();
     const service = new AcpService(runtime());
@@ -2982,6 +3353,253 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("cancelled");
     expect(events).toContain("cancelled");
     expect(events).not.toContain("error");
+  });
+
+  it("keeps a typed CLI terminal failure authoritative over a later cancellation", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "typed-failure-cancel-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const internalStore = (
+      service as unknown as {
+        store: {
+          updateStatus(
+            id: string,
+            status: string,
+            error?: string,
+          ): Promise<unknown>;
+        };
+      }
+    ).store;
+    const originalUpdateStatus = internalStore.updateStatus.bind(internalStore);
+    const statusWrites: string[] = [];
+    let releaseDelayedCancelledWrite: () => void = () => undefined;
+    const delayedCancelledWrite = new Promise<void>((resolve) => {
+      releaseDelayedCancelledWrite = resolve;
+    });
+    vi.spyOn(internalStore, "updateStatus").mockImplementation(
+      async (id, status, error) => {
+        statusWrites.push(status);
+        if (status === "cancelled") await delayedCancelledWrite;
+        return originalUpdateStatus(id, status, error);
+      },
+    );
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      code: "VERIFY_REQUIRED",
+      transient: false,
+      message: "Verification failed before cancellation arrived.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-typed-cancel-race",
+          result: {
+            stopReason: "end_turn",
+            content: [{ type: "text", text: terminalFailure.message }],
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    prompt.proc.emit("close", 130, "SIGTERM");
+
+    const result = await sent;
+    // If cancelSession started its own durable write, release it only after the
+    // prompt's errored write has landed. The old two-writer implementation then
+    // finished as cancelled and failed the assertions below.
+    releaseDelayedCancelledWrite();
+    await cancelled;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toEqual({
+      message: terminalFailure.message,
+      failureKind: terminalFailure.kind,
+      failureCode: terminalFailure.code,
+      transient: false,
+      stopReason: "error",
+    });
+    expect(statusWrites).not.toContain("cancelled");
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
+  });
+
+  it("keeps prompt ownership after process close until delayed error persistence settles", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "post-close-persistence-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const internalStore = (
+      service as unknown as {
+        store: {
+          updateStatus(
+            id: string,
+            status: string,
+            error?: string,
+          ): Promise<unknown>;
+        };
+      }
+    ).store;
+    const originalUpdateStatus = internalStore.updateStatus.bind(internalStore);
+    const statusWrites: string[] = [];
+    let markErroredWriteStarted: () => void = () => undefined;
+    const erroredWriteStarted = new Promise<void>((resolve) => {
+      markErroredWriteStarted = resolve;
+    });
+    let releaseErroredWrite: () => void = () => undefined;
+    const delayedErroredWrite = new Promise<void>((resolve) => {
+      releaseErroredWrite = resolve;
+    });
+    vi.spyOn(internalStore, "updateStatus").mockImplementation(
+      async (id, status, error) => {
+        statusWrites.push(status);
+        if (status === "errored") {
+          markErroredWriteStarted();
+          await delayedErroredWrite;
+        }
+        return originalUpdateStatus(id, status, error);
+      },
+    );
+
+    const terminalFailure = {
+      kind: "coding_mutation_unverified",
+      transient: false,
+      message: "The terminal receipt owns settlement.",
+    };
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "finish");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-post-close-race",
+          result: {
+            stopReason: "end_turn",
+            _meta: { terminalFailure },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    prompt.proc.emit("close", 0, null);
+    await erroredWriteStarted;
+    const spawnCountAtClose = spawnMock.mock.calls.length;
+    const fallbackCancel = nextProc();
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    if (spawnMock.mock.calls.length > spawnCountAtClose)
+      closeOk(fallbackCancel);
+    releaseErroredWrite();
+
+    const [result] = await Promise.all([sent, cancelled.then(() => undefined)]);
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: terminalFailure.message,
+      terminalFailure,
+    });
+    expect(spawnMock.mock.calls).toHaveLength(spawnCountAtClose);
+    expect(statusWrites).not.toContain("cancelled");
+    expect(events).toEqual(["error"]);
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
+  });
+
+  it("keeps a malformed CLI receipt error authoritative over a later cancellation", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: Array<{ event: string; payload: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      events.push({ event, payload });
+    });
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "protocol-error-cancel-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "change and verify it");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req-malformed-cancel-race",
+          result: {
+            stopReason: "end_turn",
+            _meta: {
+              terminalFailure: {
+                kind: "coding_mutation_unverified",
+                transient: "no",
+                message: "Malformed receipt.",
+              },
+            },
+          },
+          sessionId,
+        })}\n`,
+      ),
+    );
+    const cancelled = service.cancelSession(sessionId);
+    await new Promise((resolve) => setImmediate(resolve));
+    prompt.proc.emit("close", 130, "SIGTERM");
+
+    await cancelled;
+    const result = await sent;
+    expect(result).toMatchObject({
+      stopReason: "error",
+      error: expect.stringContaining(
+        "ACP terminalFailure requires kind, message, transient",
+      ),
+    });
+    expect(events.map(({ event }) => event)).toEqual(["error"]);
+    expect(events[0]?.payload).toMatchObject({
+      failureKind: "protocol_error",
+      stopReason: "error",
+    });
+    expect((await service.getSession(sessionId))?.status).toBe("errored");
   });
 
   it("ignores malformed NDJSON without crashing", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -10,7 +10,12 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
-import type { AcpJsonRpcMessage, ApprovalPreset } from "./types.js";
+import {
+  type AcpJsonRpcMessage,
+  type AcpTerminalFailure,
+  type ApprovalPreset,
+  readAcpTerminalFailure,
+} from "./types.js";
 
 export type NativeAcpEventCallback = (
   event: AcpJsonRpcMessage,
@@ -99,6 +104,7 @@ export type NativeAcpSessionClaim = {
 
 export type NativeAcpPromptResult = {
   stopReason: string;
+  terminalFailure?: AcpTerminalFailure;
 };
 
 type JsonRpcId = string | number | null;
@@ -308,8 +314,10 @@ export class NativeAcpClient {
       },
     ).then((value) => {
       const result = asRecord(value);
+      const terminalFailure = readAcpTerminalFailure(result);
       return {
         stopReason: stringValue(result?.stopReason) ?? "end_turn",
+        ...(terminalFailure ? { terminalFailure } : {}),
       };
     });
     this.activePrompts.set(sessionId, prompt);

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -134,11 +134,13 @@ import {
   type AcpCapacity,
   type AcpEventCallback,
   type AcpJsonRpcMessage,
+  type AcpTerminalFailure,
   type AcpToolCall,
   type AgentType,
   type ApprovalPreset,
   type AvailableAgentInfo,
   type PromptResult,
+  readAcpTerminalFailure,
   type SendOptions,
   SessionCapError,
   type SessionEventCallback,
@@ -230,6 +232,8 @@ type RunResult = {
   stderr: string;
   finalText: string;
   stopReason?: string;
+  terminalFailure?: AcpTerminalFailure;
+  protocolError?: string;
   cancelled?: boolean;
   durationMs: number;
 };
@@ -950,7 +954,15 @@ export class AcpService extends Service {
   // the completed turn through the session's next task metadata (#18490).
   private readonly promptTurns = new Map<
     string,
-    { id: string; sessionSnapshot: SessionInfo }
+    {
+      id: string;
+      sessionSnapshot: SessionInfo;
+      settled: Promise<void>;
+      resolveSettled: () => void;
+      cancelRequested: boolean;
+      cancellationRequested: Promise<void>;
+      resolveCancellationRequested: () => void;
+    }
   >();
   private readonly acpCallbacks: AcpEventCallback[] = [];
   private readonly activeProcesses = new Map<string, ProcessRecord>();
@@ -2388,17 +2400,31 @@ export class AcpService extends Service {
     if (this.promptTurns.has(sessionId)) {
       throw new Error(`ACP session is already busy: ${sessionId}`);
     }
+    let resolveSettled: () => void = () => undefined;
+    const settled = new Promise<void>((resolve) => {
+      resolveSettled = resolve;
+    });
+    let resolveCancellationRequested: () => void = () => undefined;
+    const cancellationRequested = new Promise<void>((resolve) => {
+      resolveCancellationRequested = resolve;
+    });
     const turn = {
       id: randomUUID(),
       sessionSnapshot: {
         ...session,
         metadata: session.metadata ? { ...session.metadata } : undefined,
       },
+      settled,
+      resolveSettled,
+      cancelRequested: false,
+      cancellationRequested,
+      resolveCancellationRequested,
     };
     this.promptTurns.set(sessionId, turn);
     try {
       return await this.sendPromptTurn(session, text, opts);
     } finally {
+      turn.resolveSettled();
       if (this.promptTurns.get(sessionId)?.id === turn.id) {
         this.promptTurns.delete(sessionId);
       }
@@ -2412,13 +2438,44 @@ export class AcpService extends Service {
   ): Promise<PromptResult> {
     const sessionId = session.id;
     const transportMode = sessionTransportMode(session, this.transportMode);
+    const startedAt = Date.now();
+    const settlePreProcessCancellation = async (): Promise<PromptResult> => {
+      await this.store.updateStatus(sessionId, "cancelled");
+      this.emitSessionEvent(sessionId, "cancelled", {
+        sessionId,
+        response: "",
+        exitCode: null,
+        signal: null,
+      });
+      return {
+        sessionId,
+        response: "",
+        finalText: "",
+        stopReason: "cancelled",
+        durationMs: Date.now() - startedAt,
+        exitCode: null,
+        signal: null,
+      };
+    };
+    const raceCancellation = async <T>(operation: Promise<T>) => {
+      const turn = this.promptTurns.get(sessionId);
+      if (!turn) return { cancelled: false as const, value: await operation };
+      if (turn.cancelRequested) return { cancelled: true as const };
+      return Promise.race([
+        operation.then((value) => ({ cancelled: false as const, value })),
+        turn.cancellationRequested.then(() => ({ cancelled: true as const })),
+      ]);
+    };
     if (
       transportMode !== "native" &&
       session.acpxSessionId &&
       !this.nativeClients.has(sessionId)
     ) {
-      const exists = await this.hasAcpxSessionState(session.acpxSessionId);
-      if (!exists) {
+      const stateCheck = await raceCancellation(
+        this.hasAcpxSessionState(session.acpxSessionId),
+      );
+      if (stateCheck.cancelled) return settlePreProcessCancellation();
+      if (!stateCheck.value) {
         this.logSubAgentStateLost(session, "send-prompt");
         const message =
           "Sub-agent state was lost (process exited without persisting). No automatic action taken.";
@@ -2430,7 +2487,6 @@ export class AcpService extends Service {
         throw new Error(message);
       }
     }
-    const startedAt = Date.now();
     const promptModel =
       session.agentType === "claude"
         ? normalizeClaudeAcpModelId(opts.model)
@@ -2463,7 +2519,6 @@ export class AcpService extends Service {
       }
     }
     this.turnOutputBuffers.set(sessionId, []);
-    await this.store.updateStatus(sessionId, "busy");
     const args = this.baseArgs({
       workdir: session.workdir,
       approvalPreset: session.approvalPreset,
@@ -2484,16 +2539,32 @@ export class AcpService extends Service {
     // session's selected-account credentials (the native transport keeps the
     // spawn-time client, which already has them) and the per-session git index
     // env that keeps same-repo sessions from sharing one mutable index file.
-    let promptCredentials: Record<string, string> | undefined;
-    try {
-      promptCredentials = await this.accountCredentialsForSession(session);
-    } catch (err) {
+    const credentialResult = await raceCancellation(
+      this.accountCredentialsForSession(session),
+    ).catch((error: unknown) => ({
+      cancelled: false as const,
+      error,
+    }));
+    if (credentialResult.cancelled) return settlePreProcessCancellation();
+    if ("error" in credentialResult) {
       // error-policy:J1 The CLI prompt boundary persists the typed account
       // failure before propagating it; no subprocess may inherit ambient
       // credentials after a session's pinned account pool is exhausted.
-      const message = errorMessage(err);
-      await this.recordAccountCredentialFailure(session, err, message);
-      throw err;
+      const message = errorMessage(credentialResult.error);
+      await this.recordAccountCredentialFailure(
+        session,
+        credentialResult.error,
+        message,
+      );
+      throw credentialResult.error;
+    }
+    const promptCredentials = credentialResult.value;
+    if (this.promptTurns.get(sessionId)?.cancelRequested) {
+      return settlePreProcessCancellation();
+    }
+    await this.store.updateStatus(sessionId, "busy");
+    if (this.promptTurns.get(sessionId)?.cancelRequested) {
+      return settlePreProcessCancellation();
     }
     const promptEnv: Record<string, string> = {
       ...(opts.env ?? {}),
@@ -2519,12 +2590,14 @@ export class AcpService extends Service {
     });
 
     const stopReason =
-      result.stopReason ??
-      (result.cancelled
-        ? "cancelled"
-        : result.code === 0
-          ? "end_turn"
-          : "error");
+      result.terminalFailure || result.protocolError
+        ? "error"
+        : (result.stopReason ??
+          (result.cancelled
+            ? "cancelled"
+            : result.code === 0
+              ? "end_turn"
+              : "error"));
     const promptResult: PromptResult = {
       sessionId,
       response: result.finalText,
@@ -2533,17 +2606,42 @@ export class AcpService extends Service {
       durationMs: result.durationMs || Date.now() - startedAt,
       exitCode: result.code,
       signal: result.signal,
-      ...(result.code !== 0 && !result.cancelled
-        ? { error: this.classifyExitError(result.code, result.stderr) }
-        : {}),
+      ...(result.terminalFailure
+        ? {
+            error: result.terminalFailure.message,
+            terminalFailure: result.terminalFailure,
+          }
+        : result.protocolError
+          ? { error: result.protocolError }
+          : result.code !== 0 && !result.cancelled
+            ? { error: this.classifyExitError(result.code, result.stderr) }
+            : {}),
     };
+
+    if (result.terminalFailure || result.protocolError) {
+      // An authoritative failed-turn receipt or invalid protocol result was
+      // observed before the subprocess closed. It outranks a later cancel race
+      // so the event, durable status, and returned result all remain an error.
+      await this.store.updateStatus(
+        sessionId,
+        "errored",
+        promptResult.error ?? "ACP prompt failed",
+      );
+      return promptResult;
+    }
 
     if (result.cancelled || stopReason === "cancelled") {
       await this.store.updateStatus(sessionId, "cancelled");
       return promptResult;
     }
 
-    if (result.code === 0 && stopReason !== "error") {
+    if (
+      (result.code === 0 || result.code === null) &&
+      (stopReason !== "error" || result.finalText.trim().length > 0)
+    ) {
+      // Preserve the legacy untyped ACP heuristic: an error stop reason after
+      // a captured deliverable remains a completion. Typed and malformed
+      // receipts returned above before they can enter this branch.
       await this.store.update(sessionId, {
         status: "ready",
         lastActivityAt: new Date(),
@@ -2565,6 +2663,32 @@ export class AcpService extends Service {
   }
 
   async cancelSession(sessionId: string): Promise<void> {
+    const ownedPromptTurn = this.promptTurns.get(sessionId);
+    if (
+      ownedPromptTurn &&
+      sessionTransportMode(
+        ownedPromptTurn.sessionSnapshot,
+        this.transportMode,
+      ) !== "native"
+    ) {
+      ownedPromptTurn.cancelRequested = true;
+      ownedPromptTurn.resolveCancellationRequested();
+      const active = this.activeProcesses.get(sessionId);
+      if (active) {
+        active.cancelled = true;
+        this.terminateProcess(sessionId, active);
+      }
+      // Consult prompt ownership before any store lookup or process lookup.
+      // The turn spans setup, child execution, close, and durable settlement,
+      // so no fallback acpx cancel or competing status write may begin here.
+      await ownedPromptTurn.settled;
+      this.workspaceRegistry.markTerminal(
+        ownedPromptTurn.sessionSnapshot.workdir,
+      );
+      void this.revokeModelLease(sessionId, "cancelSession");
+      await this.removeOwnedGitIndex(ownedPromptTurn.sessionSnapshot);
+      return;
+    }
     const session = await this.requireSession(sessionId);
     const transportMode = sessionTransportMode(session, this.transportMode);
     if (transportMode === "native") {
@@ -2608,23 +2732,17 @@ export class AcpService extends Service {
       await this.removeOwnedGitIndex(session);
       return;
     }
-    const active = this.activeProcesses.get(sessionId);
-    if (active) {
-      active.cancelled = true;
-      this.terminateProcess(sessionId, active);
-    } else {
-      const args = this.agentCommandArgs(session.agentType, [
-        "cancel",
-        "-s",
-        session.name ?? session.id,
-      ]);
-      await this.runAcpx({
-        sessionId,
-        agentType: session.agentType,
-        workdir: session.workdir,
-        args,
-      });
-    }
+    const args = this.agentCommandArgs(session.agentType, [
+      "cancel",
+      "-s",
+      session.name ?? session.id,
+    ]);
+    await this.runAcpx({
+      sessionId,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      args,
+    });
     await this.store.updateStatus(sessionId, "cancelled");
     this.workspaceRegistry.markTerminal(session.workdir);
     void this.revokeModelLease(sessionId, "cancelSession");
@@ -3587,29 +3705,39 @@ export class AcpService extends Service {
         : cancelled
           ? "cancelled"
           : stopReason;
+      const terminalFailure = result.terminalFailure;
+      const effectiveStopReason = terminalFailure ? "error" : finalStopReason;
       const promptResult: PromptResult = {
         sessionId: session.id,
         response: finalText,
         finalText,
-        stopReason: finalStopReason,
+        stopReason: effectiveStopReason,
         durationMs: Date.now() - startedAt,
         exitCode: 0,
         signal: null,
-        ...(finalStopReason === "error" && !finalText?.trim()
-          ? { error: "ACP prompt ended with stopReason error" }
-          : {}),
+        ...(terminalFailure
+          ? { error: terminalFailure.message, terminalFailure }
+          : effectiveStopReason === "error" && !finalText?.trim()
+            ? { error: "ACP prompt ended with stopReason error" }
+            : {}),
       };
-      if (stopped) {
+      if (terminalFailure) {
+        await this.store.updateStatus(
+          session.id,
+          "errored",
+          terminalFailure.message,
+        );
+        void this.revokeModelLease(session.id, "native_prompt:error");
+      } else if (stopped) {
         await this.store.updateStatus(session.id, "stopped");
         void this.revokeModelLease(session.id, "native_prompt:stopped");
       } else if (cancelled) {
         await this.store.updateStatus(session.id, "cancelled");
         void this.revokeModelLease(session.id, "native_prompt:cancelled");
-      } else if (finalStopReason === "error" && !finalText?.trim()) {
-        // Mirror the handleAcpEvent guard: a stopReason-error session that still
-        // captured a real deliverable is relayed as a completion, so don't mark
-        // it errored in the durable store — that would show a false-failed task
-        // in history/providers while the user actually got the result.
+      } else if (effectiveStopReason === "error" && !finalText?.trim()) {
+        // Untyped errors with a captured deliverable retain the legacy
+        // completion heuristic. An authoritative terminalFailure never reaches
+        // this branch and is always persisted as errored above.
         await this.store.updateStatus(
           session.id,
           "errored",
@@ -3949,7 +4077,23 @@ export class AcpService extends Service {
     const startedAt = Date.now();
     let finalText = "";
     let stopReason: string | undefined;
+    let terminalFailure: AcpTerminalFailure | undefined;
+    let protocolError: string | undefined;
     const capturedToolOutputs = new Set<string>();
+    const promptTurn = opts.sessionId
+      ? this.promptTurns.get(opts.sessionId)
+      : undefined;
+    if (opts.activeForSession && promptTurn?.cancelRequested) {
+      return Promise.resolve({
+        code: null,
+        signal: null,
+        stderr: "",
+        finalText: "",
+        stopReason: "cancelled",
+        cancelled: true,
+        durationMs: Date.now() - startedAt,
+      });
+    }
     const missingCliMessage = this.missingCliMessage();
     if (missingCliMessage) {
       if (opts.sessionId) {
@@ -3996,6 +4140,48 @@ export class AcpService extends Service {
       };
       if (opts.activeForSession && opts.sessionId)
         this.activeProcesses.set(opts.sessionId, record);
+      if (opts.activeForSession && promptTurn?.cancelRequested) {
+        record.cancelled = true;
+        this.terminateProcess(opts.sessionId ?? "", record);
+      }
+
+      const consumeAcpEvent = (parsed: AcpJsonRpcMessage): void => {
+        if (protocolError) return;
+        try {
+          const handled = this.handleAcpEvent(
+            parsed,
+            opts.sessionId,
+            finalText,
+            startedAt,
+            opts.activeForSession === true,
+            capturedToolOutputs,
+            opts.activeForSession === true,
+          );
+          finalText = handled.finalText;
+          stopReason = handled.stopReason ?? stopReason;
+          terminalFailure = handled.terminalFailure ?? terminalFailure;
+        } catch (err) {
+          // error-policy:J1 The CLI stdout boundary contains an invalid typed
+          // receipt and converts it to a structured failed prompt. Throwing
+          // from EventEmitter's data listener would crash the host process.
+          protocolError = errorMessage(err);
+          stopReason = "error";
+          record.stderr = capStderr(
+            `${record.stderr}\nACP protocol error: ${protocolError}`,
+          );
+          this.log("warn", "invalid acpx prompt result", {
+            sessionId: opts.sessionId,
+            error: protocolError,
+          });
+          if (opts.sessionId) {
+            this.emitSessionEvent(opts.sessionId, "error", {
+              message: protocolError,
+              failureKind: "protocol_error",
+              stopReason: "error",
+            });
+          }
+        }
+      };
 
       proc.stdout.on("data", (chunk: Buffer) => {
         const rawChunk = chunk.toString("utf8");
@@ -4007,19 +4193,7 @@ export class AcpService extends Service {
           record.stdoutBuffer = record.stdoutBuffer.slice(newlineIndex + 1);
           if (line) {
             const parsed = this.parseNdjson(line, opts.sessionId);
-            if (parsed) {
-              const handled = this.handleAcpEvent(
-                parsed,
-                opts.sessionId,
-                finalText,
-                startedAt,
-                opts.activeForSession === true,
-                capturedToolOutputs,
-                opts.activeForSession === true,
-              );
-              finalText = handled.finalText;
-              stopReason = handled.stopReason ?? stopReason;
-            }
+            if (parsed) consumeAcpEvent(parsed);
           }
           newlineIndex = record.stdoutBuffer.indexOf("\n");
         }
@@ -4049,19 +4223,7 @@ export class AcpService extends Service {
             record.stdoutBuffer.trim(),
             opts.sessionId,
           );
-          if (parsed) {
-            const handled = this.handleAcpEvent(
-              parsed,
-              opts.sessionId,
-              finalText,
-              startedAt,
-              opts.activeForSession === true,
-              capturedToolOutputs,
-              opts.activeForSession === true,
-            );
-            finalText = handled.finalText;
-            stopReason = handled.stopReason ?? stopReason;
-          }
+          if (parsed) consumeAcpEvent(parsed);
         }
         if (
           opts.sessionId &&
@@ -4073,6 +4235,8 @@ export class AcpService extends Service {
         if (
           opts.sessionId &&
           !record.cancelled &&
+          !terminalFailure &&
+          !protocolError &&
           code !== 0 &&
           // Emit for a 401/unauthorized auth failure OR an explicit token-expiry
           // exit (isAuthText alone misses a bare "token expired"), so a run that
@@ -4087,6 +4251,8 @@ export class AcpService extends Service {
         if (
           opts.sessionId &&
           !record.cancelled &&
+          !terminalFailure &&
+          !protocolError &&
           code !== 0 &&
           code !== null
         ) {
@@ -4137,7 +4303,19 @@ export class AcpService extends Service {
             (code === 0 || code === null) &&
             finalText.trim().length > 0 &&
             !isIncompletePromptStopReason(stopReason);
-          if (record.cancelled) {
+          if (terminalFailure) {
+            this.emitSessionEvent(opts.sessionId, "error", {
+              message: terminalFailure.message,
+              failureKind: terminalFailure.kind,
+              ...(terminalFailure.code
+                ? { failureCode: terminalFailure.code }
+                : {}),
+              transient: terminalFailure.transient,
+              stopReason: "error",
+            });
+          } else if (protocolError) {
+            // The data-listener boundary already emitted the structured error.
+          } else if (record.cancelled) {
             this.emitSessionEvent(opts.sessionId, "cancelled", {
               sessionId: opts.sessionId,
               response: finalText,
@@ -4175,7 +4353,14 @@ export class AcpService extends Service {
           signal,
           stderr: record.stderr,
           finalText,
-          stopReason: record.cancelled ? "cancelled" : stopReason,
+          stopReason:
+            terminalFailure || protocolError
+              ? "error"
+              : record.cancelled
+                ? "cancelled"
+                : stopReason,
+          ...(terminalFailure ? { terminalFailure } : {}),
+          ...(protocolError ? { protocolError } : {}),
           cancelled: record.cancelled,
           durationMs: Date.now() - startedAt,
         });
@@ -4214,9 +4399,14 @@ export class AcpService extends Service {
     emitPromptTerminalEvents: boolean,
     capturedToolOutputs: Set<string>,
     deferPromptTerminalEvent = false,
-  ): { finalText: string; stopReason?: string } {
+  ): {
+    finalText: string;
+    stopReason?: string;
+    terminalFailure?: AcpTerminalFailure;
+  } {
     const protocolSessionId = extractSessionId(event);
     const sessionId = localSessionId ?? protocolSessionId;
+    let terminalFailure: AcpTerminalFailure | undefined;
     if (
       localSessionId &&
       protocolSessionId &&
@@ -4473,7 +4663,8 @@ export class AcpService extends Service {
     }
 
     if (sessionId && result && typeof result.stopReason === "string") {
-      stopReason = result.stopReason;
+      terminalFailure = readAcpTerminalFailure(result);
+      stopReason = terminalFailure ? "error" : result.stopReason;
       if (emitPromptTerminalEvents) {
         // Per-turn token usage rides on the terminal result (claude-agent-acp
         // reports it under `result.usage` / `result._meta.usage`). Emit it once
@@ -4505,9 +4696,19 @@ export class AcpService extends Service {
         // NO captured output is a true, user-facing failure — otherwise the user
         // gets a false "hit a snag" for a build that actually succeeded.
         if (deferPromptTerminalEvent) {
-          return { finalText, stopReason };
+          return { finalText, stopReason, terminalFailure };
         }
-        if (!isIncompletePromptStopReason(stopReason)) {
+        if (terminalFailure) {
+          this.emitSessionEvent(sessionId, "error", {
+            message: terminalFailure.message,
+            failureKind: terminalFailure.kind,
+            ...(terminalFailure.code
+              ? { failureCode: terminalFailure.code }
+              : {}),
+            transient: terminalFailure.transient,
+            stopReason,
+          });
+        } else if (!isIncompletePromptStopReason(stopReason)) {
           if (stopReason === "cancelled") {
             this.emitSessionEvent(sessionId, "cancelled", {
               response: finalText,
@@ -4544,7 +4745,7 @@ export class AcpService extends Service {
       this.emitSessionEvent(sessionId, "error", { message });
     }
 
-    return { finalText, stopReason };
+    return { finalText, stopReason, terminalFailure };
   }
 
   emitSessionEvent(

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Unit tests for repository input normalizer: validates owner/repo expansion,
+ * HTTPS clone URL formatting, and SSH preservation.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeRepositoryInput } from "./repo-input.ts";
+
+describe("repo-input", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeRepositoryInput("")).toBe("");
+    expect(normalizeRepositoryInput("   ")).toBe("");
+  });
+
+  it("preserves SSH clone URLs unchanged", () => {
+    const ssh = "git@github.com:elizaOS/eliza.git";
+    expect(normalizeRepositoryInput(ssh)).toBe(ssh);
+  });
+
+  it("normalizes owner/repo shorthand to HTTPS clone URL", () => {
+    const res = normalizeRepositoryInput("elizaOS/eliza");
+    expect(res).toBe("https://github.com/elizaOS/eliza.git");
+  });
+
+  it("normalizes github.com/owner/repo without protocol", () => {
+    const res = normalizeRepositoryInput("github.com/elizaOS/eliza");
+    expect(res).toBe("https://github.com/elizaOS/eliza.git");
+  });
+
+  it("normalizes full HTTPS URLs by appending .git if missing", () => {
+    const res = normalizeRepositoryInput("https://github.com/elizaOS/eliza");
+    expect(res).toBe("https://github.com/elizaOS/eliza.git");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -295,6 +295,71 @@ export interface SendOptions {
   model?: string;
 }
 
+/** Authoritative failed-turn receipt carried by an ACP prompt result. */
+export interface AcpTerminalFailure {
+  kind: string;
+  code?: string;
+  transient: boolean;
+  message: string;
+}
+
+/**
+ * Read the elizaOS terminal-failure extension from an ACP prompt result.
+ * Presence is authoritative: malformed receipts fail the protocol boundary
+ * instead of being dropped and allowing surrounding prose to imply success.
+ */
+export function readAcpTerminalFailure(
+  promptResult: unknown,
+): AcpTerminalFailure | undefined {
+  if (
+    !promptResult ||
+    typeof promptResult !== "object" ||
+    Array.isArray(promptResult)
+  ) {
+    return undefined;
+  }
+  const metadata = (promptResult as Record<string, unknown>)._meta;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const candidate = (metadata as Record<string, unknown>).terminalFailure;
+  if (candidate === undefined) return undefined;
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new TypeError("ACP terminalFailure must be an object");
+  }
+  const record = candidate as Record<string, unknown>;
+  const kind =
+    typeof record.kind === "string" && record.kind.trim()
+      ? record.kind.trim()
+      : undefined;
+  const message =
+    typeof record.message === "string" && record.message.trim()
+      ? record.message
+      : undefined;
+  const code =
+    record.code === undefined
+      ? undefined
+      : typeof record.code === "string" && record.code.trim()
+        ? record.code.trim()
+        : null;
+  if (
+    !kind ||
+    !message ||
+    typeof record.transient !== "boolean" ||
+    code === null
+  ) {
+    throw new TypeError(
+      "ACP terminalFailure requires kind, message, transient, and an optional non-empty code",
+    );
+  }
+  return {
+    kind,
+    ...(code ? { code } : {}),
+    transient: record.transient,
+    message,
+  };
+}
+
 export interface PromptResult {
   sessionId: string;
   response: string;
@@ -304,6 +369,7 @@ export interface PromptResult {
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
   error?: string;
+  terminalFailure?: AcpTerminalFailure;
 }
 
 export interface AvailableAgentInfo {

--- a/plugins/plugin-agent-skills/src/actions/validators.test.ts
+++ b/plugins/plugin-agent-skills/src/actions/validators.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for agent skills action validators: validates service presence check.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { createAgentSkillsActionValidator } from "./validators.ts";
+
+describe("agent-skills validators", () => {
+	it("returns true when AGENT_SKILLS_SERVICE is registered on runtime", async () => {
+		const validator = createAgentSkillsActionValidator();
+		const runtime = {
+			getService: (name: string) =>
+				name === "AGENT_SKILLS_SERVICE" ? { listSkills: () => [] } : null,
+		} as unknown as IAgentRuntime;
+
+		const res = await validator(runtime, {} as any, {} as any);
+		expect(res).toBe(true);
+	});
+
+	it("returns false when AGENT_SKILLS_SERVICE is missing or throws", async () => {
+		const validator = createAgentSkillsActionValidator();
+		const runtimeMissing = {
+			getService: () => null,
+		} as unknown as IAgentRuntime;
+
+		expect(await validator(runtimeMissing, {} as any, {} as any)).toBe(false);
+
+		const runtimeThrowing = {
+			getService: () => {
+				throw new Error("Service lookup failed");
+			},
+		} as unknown as IAgentRuntime;
+
+		expect(await validator(runtimeThrowing, {} as any, {} as any)).toBe(false);
+	});
+});

--- a/plugins/plugin-agent-skills/src/commands.test.ts
+++ b/plugins/plugin-agent-skills/src/commands.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for commands registration: validates registering loaded skills
+ * as runtime slash commands.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { registerLoadedSkillCommands } from "./commands.ts";
+
+describe("agent-skills commands", () => {
+	it("returns 0 when commands service is null", () => {
+		const runtime = {
+			getService: () => null,
+		} as unknown as IAgentRuntime;
+		const service = {
+			getLoadedSkills: () => [{ slug: "code-review", description: "Review code" }],
+		} as any;
+
+		const count = registerLoadedSkillCommands(runtime, service, null);
+		expect(count).toBe(0);
+	});
+
+	it("registers loaded skills into commands service", () => {
+		const registeredCommands: any[] = [];
+		const commandsWriter = {
+			register: (cmd: any) => registeredCommands.push(cmd),
+		};
+		const runtime = {
+			getService: () => commandsWriter,
+		} as unknown as IAgentRuntime;
+
+		const service = {
+			getLoadedSkills: () => [
+				{ slug: "git-commit", description: "Create git commit" },
+				{ slug: "run-tests", description: "Run test suites" },
+			],
+		} as any;
+
+		const count = registerLoadedSkillCommands(runtime, service, commandsWriter as any);
+		expect(count).toBe(2);
+		expect(registeredCommands.length).toBe(2);
+		expect(registeredCommands[0].key).toBe("skill-git-commit");
+		expect(registeredCommands[0].textAliases).toEqual(["/git-commit"]);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/settings-subviews.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings-subviews.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Unit tests for settings-subviews: validates addressable subviews lookup.
+ */
+import { describe, expect, it } from "vitest";
+import { subviewsForView } from "./settings-subviews.ts";
+
+describe("settings-subviews", () => {
+	it("returns undefined for non-settings view IDs", () => {
+		expect(subviewsForView("chat")).toBeUndefined();
+		expect(subviewsForView("dashboard")).toBeUndefined();
+		expect(subviewsForView("")).toBeUndefined();
+	});
+
+	it("returns list of subviews for settings view", () => {
+		const subviews = subviewsForView("settings");
+		expect(Array.isArray(subviews)).toBe(true);
+		expect(subviews?.length).toBeGreaterThan(0);
+		for (const s of subviews ?? []) {
+			expect(typeof s.id).toBe("string");
+			expect(typeof s.label).toBe("string");
+		}
+	});
+});

--- a/plugins/plugin-inmemorydb/access-context.test.ts
+++ b/plugins/plugin-inmemorydb/access-context.test.ts
@@ -1,9 +1,6 @@
 /**
- * Pins the guarantee that the optional `accessContext` parameter on
- * `getMemories`/`getMemoriesByRoomIds`/`searchMemories` is accepted by the
- * types but does not (yet) filter results — permission-aware retrieval reads
- * it in a later stage. Runs against a real in-memory `InMemoryDatabaseAdapter`
- * + `MemoryStorage`, no mocks.
+ * Exercises access-context scope, world, and authorized-room enforcement
+ * against the real ephemeral adapter, including pagination and vector ranking.
  */
 import { randomUUID } from "node:crypto";
 import type { AccessContext, Memory, UUID } from "@elizaos/core";
@@ -11,24 +8,31 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
 
-describe("accessContext is a no-op on memory retrieval (PR 1)", () => {
+describe("access-context memory enforcement", () => {
   const agentId = randomUUID() as UUID;
-  const ownerEntity = randomUUID() as UUID;
-  const userEntity = randomUUID() as UUID;
-  const roomA = randomUUID() as UUID;
-  const roomB = randomUUID() as UUID;
-  const worldId = randomUUID() as UUID;
+  const requester = randomUUID() as UUID;
+  const stranger = randomUUID() as UUID;
+  const allowedRoom = randomUUID() as UUID;
+  const otherRoom = randomUUID() as UUID;
+  const otherWorldRoom = randomUUID() as UUID;
+  const allowedWorld = randomUUID() as UUID;
+  const otherWorld = randomUUID() as UUID;
 
   let adapter: InMemoryDatabaseAdapter;
 
-  const vector = (axis: number): number[] => {
-    const embedding = Array.from({ length: 384 }, () => 0);
-    embedding[axis] = 1;
-    return embedding;
-  };
+  const vector = (first: number, second: number): number[] => [
+    first,
+    second,
+    ...Array.from({ length: 382 }, () => 0),
+  ];
 
-  const sortById = (memories: Memory[]) =>
-    [...memories].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  const context: AccessContext = {
+    requesterEntityId: requester,
+    worldId: allowedWorld,
+    authorizedRoomIds: [allowedRoom],
+    role: "USER",
+    isOwner: false,
+  };
 
   beforeEach(async () => {
     const storage = new MemoryStorage();
@@ -38,80 +42,112 @@ describe("accessContext is a no-op on memory retrieval (PR 1)", () => {
 
     const seed: Memory[] = [
       {
-        entityId: ownerEntity,
-        roomId: roomA,
-        worldId,
-        content: { text: "owner in A" },
-        embedding: vector(0),
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 100,
+        content: { text: "needle allowed global" },
+        embedding: vector(0.8, 0.2),
+        metadata: { type: "custom", scope: "global" },
       },
       {
-        entityId: userEntity,
-        roomId: roomA,
-        worldId,
-        content: { text: "user in A" },
-        embedding: vector(1),
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 200,
+        content: { text: "needle allowed private" },
+        embedding: vector(0.9, 0.1),
+        metadata: { type: "custom", scope: "private" },
       },
       {
-        entityId: userEntity,
-        roomId: roomB,
-        worldId,
-        content: { text: "user in B" },
-        embedding: vector(2),
+        id: randomUUID() as UUID,
+        entityId: stranger,
+        roomId: allowedRoom,
+        worldId: allowedWorld,
+        createdAt: 500,
+        content: { text: "needle denied private" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "private" },
+      },
+      {
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: otherRoom,
+        worldId: allowedWorld,
+        createdAt: 400,
+        content: { text: "needle denied room" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "global" },
+      },
+      {
+        id: randomUUID() as UUID,
+        entityId: requester,
+        roomId: otherWorldRoom,
+        worldId: otherWorld,
+        createdAt: 300,
+        content: { text: "needle denied world" },
+        embedding: vector(1, 0),
+        metadata: { type: "custom", scope: "global" },
       },
     ];
-    await adapter.createMemories(seed.map((memory) => ({ memory, tableName: "memories" })));
+    await adapter.createMemories(seed.map((memory) => ({ memory, tableName: "messages" })));
   });
 
-  const requesterCtx: AccessContext = {
-    requesterEntityId: userEntity,
-    worldId,
-    role: "USER",
-    isOwner: false,
-  };
-
-  it("getMemories returns identical rows with and without accessContext", async () => {
-    const baseline = await adapter.getMemories({ tableName: "memories" });
-    const scoped = await adapter.getMemories({
-      tableName: "memories",
-      accessContext: requesterCtx,
+  it("intersects scope, world, and authorized rooms before list pagination", async () => {
+    const result = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: context,
+      limit: 1,
     });
 
-    expect(baseline).toHaveLength(3);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual(["needle allowed private"]);
   });
 
-  it("getMemoriesByRoomIds returns identical rows with and without accessContext", async () => {
-    const baseline = await adapter.getMemoriesByRoomIds({
-      tableName: "memories",
-      roomIds: [roomA],
-    });
-    const scoped = await adapter.getMemoriesByRoomIds({
-      tableName: "memories",
-      roomIds: [roomA],
-      accessContext: requesterCtx,
+  it("does not trust caller-supplied room ids as authorization", async () => {
+    const result = await adapter.getMemoriesByRoomIds({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      accessContext: context,
     });
 
-    expect(baseline).toHaveLength(2);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual([
+      "needle allowed private",
+      "needle allowed global",
+    ]);
   });
 
-  it("searchMemories returns identical rows with and without accessContext", async () => {
-    const query = vector(0);
-    const baseline = await adapter.searchMemories({
-      tableName: "memories",
-      embedding: query,
+  it("filters before full-text ranking and pagination", async () => {
+    const result = await adapter.searchMessages({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      query: "needle",
+      accessContext: context,
+      limit: 1,
+    });
+
+    expect(result[0]?.memory.content.text).toMatch(/^needle allowed /);
+  });
+
+  it("finds the top authorized vector when closer unauthorized rows exist", async () => {
+    const result = await adapter.searchMemories({
+      tableName: "messages",
+      embedding: vector(1, 0),
       match_threshold: 0,
-      limit: 3,
-    });
-    const scoped = await adapter.searchMemories({
-      tableName: "memories",
-      embedding: query,
-      match_threshold: 0,
-      limit: 3,
-      accessContext: requesterCtx,
+      accessContext: context,
+      limit: 1,
     });
 
-    expect(baseline).toHaveLength(3);
-    expect(sortById(scoped)).toEqual(sortById(baseline));
+    expect(result.map((memory) => memory.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("treats an explicit empty room authorization as deny-all", async () => {
+    const result = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: { ...context, authorizedRoomIds: [] },
+    });
+
+    expect(result).toEqual([]);
   });
 });

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -38,6 +38,7 @@ import {
   ElizaError,
   type EntitiesForRoomsResult,
   type Entity,
+  filterMemoryReadByAccessContext,
   type IDatabaseAdapter,
   isDocumentVisibleToRequester,
   type JsonValue,
@@ -1062,7 +1063,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       throw new Error("getMemories cursor and offset are mutually exclusive");
     }
     const textContains = params.textContains?.trim().toLowerCase();
-    let memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
+    const memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
       if (params.entityId && m.entityId !== params.entityId) return false;
       if (params.agentId && m.agentId !== params.agentId) return false;
       if (params.roomId && m.roomId !== params.roomId) return false;
@@ -1085,9 +1086,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       }
       return true;
     });
+    let readableMemories = memories.map(toMemory);
+    if (params.accessContext) {
+      readableMemories = filterMemoryReadByAccessContext(
+        readableMemories,
+        params.accessContext,
+        this.agentId
+      );
+    }
 
     const direction = params.orderDirection ?? "desc";
-    memories.sort((a, b) => {
+    readableMemories.sort((a, b) => {
       const ta = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0;
       const tb = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : 0;
       if (ta !== tb) return direction === "asc" ? ta - tb : tb - ta;
@@ -1098,7 +1107,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
     if (params.cursor) {
       const cursor = params.cursor;
-      memories = memories.filter((memory) => {
+      readableMemories = readableMemories.filter((memory) => {
         const createdAt = typeof memory.createdAt === "number" ? memory.createdAt : 0;
         const id = typeof memory.id === "string" ? memory.id : "";
         if (createdAt !== cursor.createdAt) {
@@ -1111,10 +1120,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? params.count;
-    if (offset > 0) memories = memories.slice(offset);
-    if (limit !== undefined) memories = memories.slice(0, limit);
+    if (offset > 0) readableMemories = readableMemories.slice(offset);
+    if (limit !== undefined) readableMemories = readableMemories.slice(0, limit);
 
-    return memories.map(toMemory);
+    return readableMemories;
   }
 
   async getMemoriesByRoomIds(params: {
@@ -1145,10 +1154,18 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       return true;
     });
     memories.sort(compareStoredMemoriesNewestFirst);
+    let readableMemories = memories.map(toMemory);
+    if (params.accessContext) {
+      readableMemories = filterMemoryReadByAccessContext(
+        readableMemories,
+        params.accessContext,
+        this.agentId
+      );
+    }
     const offset = typeof params.offset === "number" ? params.offset : 0;
-    let sliced = offset > 0 ? memories.slice(offset) : memories;
+    let sliced = offset > 0 ? readableMemories.slice(offset) : readableMemories;
     if (params.limit !== undefined) sliced = sliced.slice(0, params.limit);
-    return sliced.map(toMemory);
+    return sliced;
   }
 
   async searchMessages(params: {
@@ -1170,7 +1187,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     );
     // The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
     // adapters' created_at range conditions.
-    const candidates = stored
+    let candidates = stored
       .map(toMemory)
       .filter((memory) =>
         withinCreatedAtWindow(
@@ -1179,6 +1196,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
           params.until
         )
       );
+    if (params.accessContext) {
+      candidates = filterMemoryReadByAccessContext(candidates, params.accessContext, this.agentId);
+    }
     const ranked = rankMessageSearch(candidates, params.query);
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? 20;
@@ -1235,6 +1255,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     match_threshold?: number;
     count?: number;
     limit?: number;
+    offset?: number;
     unique?: boolean;
     query?: string;
     roomId?: UUID;
@@ -1245,6 +1266,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     return this.withDocumentMutationLock(async () => {
       const threshold = params.match_threshold ?? 0.5;
       const limit = params.count ?? params.limit ?? 10;
+      const offset = params.offset ?? 0;
 
       // Scope eligibility must be applied BEFORE the top-K cut so the result is
       // "top K among eligible memories". Mirrors the plugin-sql adapter, whose
@@ -1269,19 +1291,26 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
           (!params.entityId || memory.entityId === params.entityId) &&
           (!params.unique || !!memory.unique)
       );
+      const readableMemories = params.accessContext
+        ? filterMemoryReadByAccessContext(
+            eligibleMemories.map(toMemory),
+            params.accessContext,
+            this.agentId
+          )
+        : eligibleMemories.map(toMemory);
       const memoriesById = new Map(
-        eligibleMemories.flatMap((memory) => (memory.id ? [[memory.id, memory] as const] : []))
+        readableMemories.flatMap((memory) => (memory.id ? [[memory.id, memory] as const] : []))
       );
       const results = await this.vectorIndex.searchExact(
         params.embedding,
-        limit,
+        limit + offset,
         threshold,
         new Set(memoriesById.keys())
       );
 
-      return results.flatMap((result) => {
+      return results.slice(offset).flatMap((result) => {
         const memory = memoriesById.get(result.id);
-        return memory ? [{ ...toMemory(memory), similarity: result.similarity }] : [];
+        return memory ? [{ ...memory, similarity: result.similarity }] : [];
       });
     });
   }

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1091,7 +1091,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       readableMemories = filterMemoryReadByAccessContext(
         readableMemories,
         params.accessContext,
-        this.agentId
+        this.agentId,
+        params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+          ? "room"
+          : "private"
       );
     }
 
@@ -1159,7 +1162,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       readableMemories = filterMemoryReadByAccessContext(
         readableMemories,
         params.accessContext,
-        this.agentId
+        this.agentId,
+        params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+          ? "room"
+          : "private"
       );
     }
     const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1197,7 +1203,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         )
       );
     if (params.accessContext) {
-      candidates = filterMemoryReadByAccessContext(candidates, params.accessContext, this.agentId);
+      candidates = filterMemoryReadByAccessContext(
+        candidates,
+        params.accessContext,
+        this.agentId,
+        "room"
+      );
     }
     const ranked = rankMessageSearch(candidates, params.query);
     const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -1295,7 +1306,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         ? filterMemoryReadByAccessContext(
             eligibleMemories.map(toMemory),
             params.accessContext,
-            this.agentId
+            this.agentId,
+            params.tableName === "messages" && params.accessContext.authorizedRoomIds !== undefined
+              ? "room"
+              : "private"
           )
         : eligibleMemories.map(toMemory);
       const memoriesById = new Map(

--- a/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Verifies scope, world, and authorized-room memory enforcement inside real
+ * PGlite/Postgres queries before list pagination, text ranking, and vector top-k.
+ */
+import {
+  type AccessContext,
+  ChannelType,
+  type Entity,
+  type Memory,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+describe("memory access-context enforcement", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+
+  const requester = v4() as UUID;
+  const stranger = v4() as UUID;
+  const allowedWorld = v4() as UUID;
+  const otherWorld = v4() as UUID;
+  const allowedRoom = v4() as UUID;
+  const otherRoom = v4() as UUID;
+  const otherWorldRoom = v4() as UUID;
+
+  const vector = (first: number, second: number): number[] => [
+    first,
+    second,
+    ...Array.from({ length: 382 }, () => 0),
+  ];
+
+  const context = (): AccessContext => ({
+    requesterEntityId: requester,
+    worldId: allowedWorld,
+    authorizedRoomIds: [allowedRoom],
+    role: "USER",
+  });
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("memory_access_context");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+
+    await adapter.createWorld({
+      id: allowedWorld,
+      agentId,
+      name: "Allowed world",
+      serverId: "access-context-allowed",
+    } as World);
+    await adapter.createWorld({
+      id: otherWorld,
+      agentId,
+      name: "Other world",
+      serverId: "access-context-other",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: allowedRoom,
+        agentId,
+        worldId: allowedWorld,
+        name: "Allowed room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+      {
+        id: otherRoom,
+        agentId,
+        worldId: allowedWorld,
+        name: "Unauthorized room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+      {
+        id: otherWorldRoom,
+        agentId,
+        worldId: otherWorld,
+        name: "Other-world room",
+        source: "test",
+        type: ChannelType.GROUP,
+      },
+    ] as Room[]);
+    await adapter.createEntities([
+      { id: requester, agentId, names: ["Requester"] },
+      { id: stranger, agentId, names: ["Stranger"] },
+    ] as Entity[]);
+
+    const create = async (
+      text: string,
+      createdAt: number,
+      overrides: Partial<Memory>
+    ): Promise<void> => {
+      await adapter.createMemory(
+        {
+          id: v4() as UUID,
+          agentId,
+          entityId: requester,
+          roomId: allowedRoom,
+          worldId: allowedWorld,
+          createdAt,
+          content: { text },
+          embedding: vector(0.8, 0.2),
+          metadata: { type: "custom", scope: "global" },
+          ...overrides,
+        } as Memory,
+        "messages"
+      );
+    };
+
+    await create("needle allowed global", 100, {});
+    await create("needle allowed legacy private", 150, {
+      embedding: vector(0.7, 0.3),
+      metadata: { type: "custom" },
+    });
+    await create("needle allowed private", 200, {
+      embedding: vector(0.9, 0.1),
+      metadata: { type: "custom", scope: "private" },
+    });
+    await create("needle denied private", 500, {
+      entityId: stranger,
+      embedding: vector(1, 0),
+      metadata: { type: "custom", scope: "private" },
+    });
+    await create("needle denied legacy private", 600, {
+      entityId: stranger,
+      embedding: vector(1, 0),
+      metadata: { type: "custom" },
+    });
+    await create("needle denied room", 400, {
+      roomId: otherRoom,
+      embedding: vector(1, 0),
+    });
+    await create("needle denied world", 300, {
+      roomId: otherWorldRoom,
+      worldId: otherWorld,
+      embedding: vector(1, 0),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup?.();
+  });
+
+  it("filters scope, world, and room before list pagination", async () => {
+    const rows = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: context(),
+      includeEmbedding: false,
+      limit: 1,
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("intersects requested rooms with the authorized-room set", async () => {
+    const rows = await adapter.getMemoriesByRoomIds({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      accessContext: context(),
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual([
+      "needle allowed private",
+      "needle allowed legacy private",
+      "needle allowed global",
+    ]);
+  });
+
+  it("filters before text ranking and pagination", async () => {
+    const rows = await adapter.searchMessages({
+      tableName: "messages",
+      roomIds: [allowedRoom, otherRoom, otherWorldRoom],
+      query: "needle",
+      accessContext: context(),
+      limit: 1,
+    });
+
+    expect(rows[0]?.memory.content.text).toMatch(/^needle allowed /);
+  });
+
+  it("returns the top authorized vector despite closer unauthorized rows", async () => {
+    const rows = await adapter.searchMemories({
+      tableName: "messages",
+      embedding: vector(1, 0),
+      match_threshold: 0,
+      accessContext: context(),
+      limit: 1,
+    });
+
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+  });
+
+  it("treats an explicit empty authorized-room set as deny-all", async () => {
+    const rows = await adapter.getMemories({
+      tableName: "messages",
+      accessContext: { ...context(), authorizedRoomIds: [] },
+    });
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-access-context.real.test.ts
@@ -128,7 +128,7 @@ describe("memory access-context enforcement", () => {
       embedding: vector(1, 0),
       metadata: { type: "custom", scope: "private" },
     });
-    await create("needle denied legacy private", 600, {
+    await create("needle allowed unstamped participant", 600, {
       entityId: stranger,
       embedding: vector(1, 0),
       metadata: { type: "custom" },
@@ -156,7 +156,7 @@ describe("memory access-context enforcement", () => {
       limit: 1,
     });
 
-    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed unstamped participant"]);
   });
 
   it("intersects requested rooms with the authorized-room set", async () => {
@@ -167,6 +167,7 @@ describe("memory access-context enforcement", () => {
     });
 
     expect(rows.map((row) => row.content.text)).toEqual([
+      "needle allowed unstamped participant",
       "needle allowed private",
       "needle allowed legacy private",
       "needle allowed global",
@@ -194,7 +195,7 @@ describe("memory access-context enforcement", () => {
       limit: 1,
     });
 
-    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed private"]);
+    expect(rows.map((row) => row.content.text)).toEqual(["needle allowed unstamped participant"]);
   });
 
   it("treats an explicit empty authorized-room set as deny-all", async () => {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -216,7 +216,8 @@ function escapeIlikeLiteral(value: string): string {
  */
 function memoryAccessContextConditions(
   accessContext: AccessContext | undefined,
-  agentId: UUID
+  agentId: UUID,
+  tableName?: string
 ): SQL[] {
   if (!accessContext) return [];
 
@@ -246,8 +247,10 @@ function memoryAccessContextConditions(
       )
     )
   )`;
+  const unstampedScope =
+    tableName === "messages" && accessContext.authorizedRoomIds !== undefined ? "room" : "private";
   const scope = sql`CASE
-    WHEN NOT (${metadata} ? 'scope') THEN 'private'
+    WHEN NOT (${metadata} ? 'scope') THEN ${unstampedScope}
     ELSE ${metadata}->>'scope'
   END`;
   const scopedEntityId = sql`COALESCE(
@@ -2831,7 +2834,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withEntityContext(entityId ?? null, async (tx) => {
       const conditions = [eq(memoryTable.type, tableName)];
 
-      conditions.push(...memoryAccessContextConditions(params.accessContext, this.agentId));
+      conditions.push(
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName)
+      );
 
       if (start !== undefined) {
         conditions.push(gte(memoryTable.createdAt, new Date(start)));
@@ -3004,7 +3009,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const conditions = [
         eq(memoryTable.type, params.tableName),
         inArray(memoryTable.roomId, params.roomIds),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, params.tableName),
       ];
 
       conditions.push(eq(memoryTable.agentId, this.agentId));
@@ -3143,7 +3148,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName),
         ...timeConditions,
         sql`(${tsvector} @@ ${tsquery} OR ${literalMatch} OR ${trigramMatch})`,
       ];
@@ -3220,7 +3225,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               eq(memoryTable.type, tableName),
               eq(memoryTable.agentId, this.agentId),
               inArray(memoryTable.roomId, params.roomIds),
-              ...memoryAccessContextConditions(params.accessContext, this.agentId),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId, tableName),
               ...timeConditions,
               or(
                 sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
@@ -3929,7 +3934,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         isNotNull(activeColumn),
         eq(memoryTable.type, params.tableName),
         eq(memoryTable.agentId, this.agentId),
-        ...memoryAccessContextConditions(params.accessContext, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId, params.tableName),
       ];
 
       if (params.unique) {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -14,6 +14,7 @@ import {
   type AgentRunSummary,
   type AgentRunSummaryResult,
   type AppendConnectorAccountAuditEventParams,
+  actorFromAccessContext,
   ChannelType,
   type Component,
   type ConnectorAccountAuditEventRecord,
@@ -206,6 +207,97 @@ function normalizeAgentBio(value: unknown): string[] | undefined {
 /** Escape an ILIKE literal so user keywords match literally (no `%`/`_` wildcards). */
 function escapeIlikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+/**
+ * Storage-level memory authorization predicate. Every condition returned here
+ * is pushed into the same query that orders/ranks and paginates so ineligible
+ * rows can neither leak nor starve an authorized page.
+ */
+function memoryAccessContextConditions(
+  accessContext: AccessContext | undefined,
+  agentId: UUID
+): SQL[] {
+  if (!accessContext) return [];
+
+  const conditions: SQL[] = [eq(memoryTable.agentId, agentId)];
+  if (accessContext.authorizedRoomIds !== undefined) {
+    if (accessContext.worldId !== undefined) {
+      conditions.push(eq(memoryTable.worldId, accessContext.worldId));
+    }
+    const roomIds = [...new Set(accessContext.authorizedRoomIds)];
+    conditions.push(roomIds.length === 0 ? sql`false` : inArray(memoryTable.roomId, roomIds));
+  }
+
+  const actor = actorFromAccessContext(accessContext, agentId);
+  if (actor.role === "UNRESOLVED") {
+    conditions.push(sql`false`);
+    return conditions;
+  }
+
+  const metadata = memoryTable.metadata;
+  const validScope = sql`(
+    NOT (${metadata} ? 'scope')
+    OR (
+      jsonb_typeof(${metadata}->'scope') = 'string'
+      AND ${metadata}->>'scope' IN (
+        'shared', 'private', 'room', 'global', 'owner-private',
+        'user-private', 'agent-private'
+      )
+    )
+  )`;
+  const scope = sql`CASE
+    WHEN NOT (${metadata} ? 'scope') THEN 'private'
+    ELSE ${metadata}->>'scope'
+  END`;
+  const scopedEntityId = sql`COALESCE(
+    CASE
+      WHEN jsonb_typeof(${metadata}->'scopedToEntityId') = 'string'
+      THEN ${metadata}->>'scopedToEntityId'
+    END,
+    CASE
+      WHEN jsonb_typeof(${metadata}->'addedBy') = 'string'
+      THEN ${metadata}->>'addedBy'
+    END,
+    ${memoryTable.entityId}::text
+  )`;
+  const publicScope = sql`${scope} IN ('global', 'shared', 'room')`;
+
+  let visibility: SQL;
+  switch (actor.role) {
+    case "OWNER":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} IN ('owner-private', 'agent-private')
+        OR (${scope} IN ('private', 'user-private') AND ${scopedEntityId} = ${actor.entityId})
+      )`;
+      break;
+    case "AGENT":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} = 'agent-private'
+        OR ${scope} IN ('private', 'user-private')
+      )`;
+      break;
+    case "RUNTIME":
+      visibility = sql`(
+        ${publicScope}
+        OR ${scope} IN ('owner-private', 'agent-private', 'private', 'user-private')
+      )`;
+      break;
+    case "ADMIN":
+    case "USER":
+      visibility = sql`(
+        ${publicScope}
+        OR (${scope} IN ('private', 'user-private') AND ${scopedEntityId} = ${actor.entityId})
+      )`;
+      break;
+    case "GUEST":
+      visibility = publicScope;
+      break;
+  }
+  conditions.push(sql`(${validScope} AND ${visibility})`);
+  return conditions;
 }
 
 const DOCUMENT_UUID_PATTERN = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
@@ -2739,6 +2831,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withEntityContext(entityId ?? null, async (tx) => {
       const conditions = [eq(memoryTable.type, tableName)];
 
+      conditions.push(...memoryAccessContextConditions(params.accessContext, this.agentId));
+
       if (start !== undefined) {
         conditions.push(gte(memoryTable.createdAt, new Date(start)));
       }
@@ -2910,6 +3004,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const conditions = [
         eq(memoryTable.type, params.tableName),
         inArray(memoryTable.roomId, params.roomIds),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
       ];
 
       conditions.push(eq(memoryTable.agentId, this.agentId));
@@ -2940,7 +3035,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         })
         .from(memoryTable)
         .where(and(...conditions))
-        .orderBy(desc(memoryTable.createdAt));
+        .orderBy(desc(memoryTable.createdAt), desc(memoryTable.id));
 
       const { limit, offset } = params;
       const rows = await (async () => {
@@ -3048,6 +3143,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
         ...timeConditions,
         sql`(${tsvector} @@ ${tsquery} OR ${literalMatch} OR ${trigramMatch})`,
       ];
@@ -3124,6 +3220,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               eq(memoryTable.type, tableName),
               eq(memoryTable.agentId, this.agentId),
               inArray(memoryTable.roomId, params.roomIds),
+              ...memoryAccessContextConditions(params.accessContext, this.agentId),
               ...timeConditions,
               or(
                 sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
@@ -3767,6 +3864,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       entityId: params.entityId,
       unique: params.unique,
       tableName: params.tableName,
+      accessContext: params.accessContext,
     });
   }
 
@@ -3794,6 +3892,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       entityId?: UUID;
       unique?: boolean;
       tableName: string;
+      accessContext?: AccessContext;
     }
   ): Promise<Memory[]> {
     return this.withDatabase(async () => {
@@ -3830,6 +3929,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         isNotNull(activeColumn),
         eq(memoryTable.type, params.tableName),
         eq(memoryTable.agentId, this.agentId),
+        ...memoryAccessContextConditions(params.accessContext, this.agentId),
       ];
 
       if (params.unique) {


### PR DESCRIPTION
## Summary

Promote the immutable snapshot of current `develop` to `main`, including the realtime voice SSE timeout fix, natural greeting, callback continuity, prewarm instrumentation, and all subsequent develop merges through the snapshot.

## Exact refs

- develop snapshot: `0381388fdc3de3fadc8c983e74e7d5ef17fde9a7`
- current main: `e4a3330235cc7c81ce2ace1b54c18add96dfc74e`
- voice repair merge `21cbe704abaad415147579a87cea1c7281a0d9a5` is an ancestor (37 commits behind snapshot, zero divergence)

The user explicitly authorized merging without waiting for hosted runners. This immutable branch avoids racing a live develop head that was advancing every few seconds. Production deployment and live acceptance follow separately.