### PR TITLE
test(scripts): cover desktop clean-state entrypoint

### DIFF
--- a/packages/scripts/audit-scripts.self-test.mjs
+++ b/packages/scripts/audit-scripts.self-test.mjs
@@ -383,4 +383,21 @@ function hasFinding(report, fragment) {
   );
 }
 
+// 20. The macOS clean-install command is an intentional human entrypoint.
+{
+  const report = runAudit({
+    root: {
+      "desktop:clean-install-state":
+        "node scripts/desktop-clean-install-state.mjs",
+    },
+    files: {
+      "scripts/desktop-clean-install-state.mjs": "export function main() {}\n",
+    },
+  });
+  assert(
+    report.ok,
+    `desktop cleanup entrypoint should pass, got ${JSON.stringify(report.failures)}`,
+  );
+}
+
 console.log("audit-scripts self-test passed");


### PR DESCRIPTION
# Relates to

Fixes #26794.

# What changed

Adds a deterministic regression case proving `desktop:clean-install-state` remains an intentional exact human entrypoint in the repository script audit.

The production allowlist entry landed independently in #26780. Rebasing this branch onto current `develop` automatically dropped that duplicate hunk, so this PR is now test-only and does not broaden the accepted `desktop:*` namespace or change cleanup behavior.

# Validation

- `node packages/scripts/audit-scripts.self-test.mjs` — pass
- `node packages/scripts/audit-scripts.mjs` — pass (`OK — no orphan/no-op/broken scripts`)
- Rebased onto current `develop` without conflicts; hosted exact-head static smoke is required before merge.

# Evidence

Screenshots, video, runtime logs, and LLM trajectories are N/A because this changes only a deterministic repository-audit self-test.

<!-- evidence-head:359569d22c8bab1a7d9bfb5bebff5bd83d6f22b8 -->
