### PR TITLE
fix(plugin-native-canvas): bind CanvasWeb touch listeners once per attach

### DIFF
--- a/plugins/plugin-native-canvas/src/web-touch-reattach.test.ts
+++ b/plugins/plugin-native-canvas/src/web-touch-reattach.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for `CanvasWeb` touch/pointer listener lifecycle across
+ * attach/detach cycles. Runs a real `CanvasWeb` instance in jsdom with only the
+ * unavailable 2D context and `getBoundingClientRect` stubbed, then dispatches
+ * real `MouseEvent`s at the base canvas to count emitted `touch` events. Guards
+ * the contract that a detach->attach cycle (or a repeat attach() without an
+ * intervening detach) never stacks duplicate listeners — matching the native
+ * iOS (`touchesBegan`) and Android (view-intrinsic) bridges that bind once.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasWeb } from "./web";
+
+function createContextStub(): CanvasRenderingContext2D {
+  return {
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    getImageData: vi.fn(() => ({
+      data: new Uint8ClampedArray(4),
+      width: 1,
+      height: 1,
+    })),
+    putImageData: vi.fn(),
+    restore: vi.fn(),
+    save: vi.fn(),
+    setTransform: vi.fn(),
+    stroke: vi.fn(),
+    toDataURL: vi.fn(() => "data:image/png;base64,ZmFrZQ=="),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function stubBoundingRect(): void {
+  // jsdom returns a zero rect; supply a stable non-zero rect so the
+  // width/height coordinate scaling in setupTouchHandlers stays finite.
+  vi.spyOn(
+    HTMLCanvasElement.prototype,
+    "getBoundingClientRect",
+  ).mockReturnValue({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+function pressCanvas(host: HTMLElement): void {
+  const canvasEl = host.querySelector("canvas");
+  if (!canvasEl) throw new Error("Missing base canvas element");
+  // A single logical press: down then up. Duplicate listeners multiply the
+  // "start" emission, so counting "start" events isolates the leak.
+  canvasEl.dispatchEvent(
+    new MouseEvent("mousedown", {
+      clientX: 10,
+      clientY: 10,
+      bubbles: true,
+    }),
+  );
+  canvasEl.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+async function newAttachedCanvas(): Promise<{
+  canvas: CanvasWeb;
+  canvasId: string;
+  host: HTMLElement;
+  starts: () => number;
+}> {
+  const canvas = new CanvasWeb();
+  const { canvasId } = await canvas.create({
+    size: { width: 100, height: 100 },
+  });
+  const touchEvents: string[] = [];
+  await canvas.addListener("touch", (event) => {
+    touchEvents.push((event as { type: string }).type);
+  });
+  const host = document.createElement("div");
+  await canvas.attach({ canvasId, element: host });
+  await canvas.setTouchEnabled({ canvasId, enabled: true });
+  return {
+    canvas,
+    canvasId,
+    host,
+    starts: () => touchEvents.filter((t) => t === "start").length,
+  };
+}
+
+describe("CanvasWeb touch listener lifecycle", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      createContextStub(),
+    );
+    stubBoundingRect();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("emits exactly one touch per press after a single attach()", async () => {
+    const { host, starts } = await newAttachedCanvas();
+
+    pressCanvas(host);
+
+    expect(starts()).toBe(1);
+  });
+
+  it("emits exactly one touch per press after a detach()->attach() cycle", async () => {
+    const { canvas, canvasId, starts } = await newAttachedCanvas();
+
+    await canvas.detach({ canvasId });
+    const secondHost = document.createElement("div");
+    await canvas.attach({ canvasId, element: secondHost });
+
+    pressCanvas(secondHost);
+
+    // Pre-fix: detach() removed the element but not its listeners, and the
+    // re-attach bound a second set, so this press emitted 2 "start" events.
+    expect(starts()).toBe(1);
+  });
+
+  it("does not stack listeners across many detach()->attach() cycles", async () => {
+    const { canvas, canvasId, host, starts } = await newAttachedCanvas();
+
+    let latestHost = host;
+    for (let i = 0; i < 5; i++) {
+      await canvas.detach({ canvasId });
+      latestHost = document.createElement("div");
+      await canvas.attach({ canvasId, element: latestHost });
+    }
+
+    pressCanvas(latestHost);
+
+    expect(starts()).toBe(1);
+  });
+
+  it("emits exactly one touch per press after a second attach() without detach()", async () => {
+    const { canvas, canvasId, host, starts } = await newAttachedCanvas();
+
+    // Re-attaching to the same host without an intervening detach must not
+    // add a duplicate set of listeners to the same canvas element.
+    await canvas.attach({ canvasId, element: host });
+
+    pressCanvas(host);
+
+    expect(starts()).toBe(1);
+  });
+
+  it("removes listeners on detach so the retained element no longer emits", async () => {
+    const { canvas, canvasId, host, starts } = await newAttachedCanvas();
+    const canvasEl = host.querySelector("canvas");
+    if (!canvasEl) throw new Error("Missing base canvas element");
+
+    await canvas.detach({ canvasId });
+    // The element object is retained inside ManagedCanvas; dispatch directly at
+    // it (it is out of the DOM but still holds any bound listeners).
+    canvasEl.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: 5, clientY: 5 }),
+    );
+    canvasEl.dispatchEvent(new MouseEvent("mouseup"));
+
+    expect(starts()).toBe(0);
+  });
+
+  it("suppresses emission when touch is disabled via setTouchEnabled(false)", async () => {
+    const { canvas, canvasId, host, starts } = await newAttachedCanvas();
+
+    await canvas.setTouchEnabled({ canvasId, enabled: false });
+    pressCanvas(host);
+
+    expect(starts()).toBe(0);
+  });
+
+  it("suppresses emission after removeAllListeners()", async () => {
+    const { canvas, host, starts } = await newAttachedCanvas();
+
+    await canvas.removeAllListeners();
+    pressCanvas(host);
+
+    expect(starts()).toBe(0);
+  });
+});

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -71,6 +71,11 @@ interface WebViewIncomingMessage {
   result?: string;
 }
 
+interface BoundTouchHandler {
+  eventName: keyof HTMLElementEventMap;
+  handler: EventListener;
+}
+
 interface ManagedCanvas {
   id: string;
   canvas: HTMLCanvasElement;
@@ -79,6 +84,13 @@ interface ManagedCanvas {
   size: CanvasSize;
   transform: CanvasTransform;
   touchEnabled: boolean;
+  // The element the pointer listeners are currently bound to, plus the exact
+  // listener references needed to remove them. `null` means no listeners are
+  // attached, so a fresh `attach()` wires a single set. Tracking the bound
+  // element lets `setupTouchHandlers` short-circuit a repeat `attach()` on the
+  // same element instead of stacking a duplicate set of listeners.
+  touchTarget: HTMLCanvasElement | null;
+  touchHandlers: BoundTouchHandler[];
 }
 
 interface ManagedLayer {
@@ -212,6 +224,8 @@ export class CanvasWeb extends WebPlugin {
       size,
       transform: {},
       touchEnabled: false,
+      touchTarget: null,
+      touchHandlers: [],
     };
 
     this.canvases.set(canvasId, managedCanvas);
@@ -225,6 +239,7 @@ export class CanvasWeb extends WebPlugin {
     managed.layers.forEach((layer) => {
       layer.canvas.remove();
     });
+    this.teardownTouchHandlers(managed);
     managed.canvas.remove();
     this.canvases.delete(options.canvasId);
   }
@@ -251,6 +266,7 @@ export class CanvasWeb extends WebPlugin {
     for (const layer of managed.layers.values()) {
       layer.canvas.remove();
     }
+    this.teardownTouchHandlers(managed);
     managed.canvas.remove();
   }
 
@@ -1480,6 +1496,20 @@ export class CanvasWeb extends WebPlugin {
   }
 
   private setupTouchHandlers(managed: ManagedCanvas): void {
+    // Bind touch/pointer listeners at most once per element. `attach()` calls
+    // this unconditionally, and both `attach()` and `detach()` are public API,
+    // so a legitimate detach->attach cycle (or a repeat attach() without an
+    // intervening detach) would otherwise stack a second full set of anonymous
+    // listeners on the same canvas. Every pointer interaction would then emit N
+    // duplicate `touch` notifications, corrupting strokes and leaking DOM
+    // listeners. The native iOS (`touchesBegan` on the view) and Android
+    // (view-intrinsic touch handling) bridges bind once and never duplicate on
+    // re-attach; the web fallback must match that contract. Handlers bound to
+    // the current element are left in place; a different element (or none) is
+    // torn down first so exactly one fresh set is wired.
+    if (managed.touchTarget === managed.canvas) return;
+    this.teardownTouchHandlers(managed);
+
     const getScaledCoords = (clientX: number, clientY: number) => {
       const rect = managed.canvas.getBoundingClientRect();
       return {
@@ -1508,33 +1538,47 @@ export class CanvasWeb extends WebPlugin {
       emitTouch(type, touches);
     };
 
-    managed.canvas.addEventListener("touchstart", (e) =>
-      handleTouchEvent(e, "start"),
-    );
-    managed.canvas.addEventListener("touchmove", (e) =>
-      handleTouchEvent(e, "move"),
-    );
-    managed.canvas.addEventListener("touchend", (e) =>
-      handleTouchEvent(e, "end"),
-    );
-    managed.canvas.addEventListener("touchcancel", (e) =>
-      handleTouchEvent(e, "cancel"),
-    );
+    const bind = (
+      eventName: keyof HTMLElementEventMap,
+      handler: EventListener,
+    ) => {
+      managed.canvas.addEventListener(eventName, handler);
+      managed.touchHandlers.push({ eventName, handler });
+    };
 
-    managed.canvas.addEventListener("mousedown", (e) => {
+    bind("touchstart", (e) => handleTouchEvent(e as TouchEvent, "start"));
+    bind("touchmove", (e) => handleTouchEvent(e as TouchEvent, "move"));
+    bind("touchend", (e) => handleTouchEvent(e as TouchEvent, "end"));
+    bind("touchcancel", (e) => handleTouchEvent(e as TouchEvent, "cancel"));
+
+    bind("mousedown", (event) => {
+      const e = event as MouseEvent;
       if (!managed.touchEnabled) return;
       emitTouch("start", [{ id: 0, ...getScaledCoords(e.clientX, e.clientY) }]);
     });
 
-    managed.canvas.addEventListener("mousemove", (e) => {
+    bind("mousemove", (event) => {
+      const e = event as MouseEvent;
       if (!managed.touchEnabled || e.buttons !== 1) return;
       emitTouch("move", [{ id: 0, ...getScaledCoords(e.clientX, e.clientY) }]);
     });
 
-    managed.canvas.addEventListener("mouseup", () => {
+    bind("mouseup", () => {
       if (!managed.touchEnabled) return;
       emitTouch("end", []);
     });
+
+    managed.touchTarget = managed.canvas;
+  }
+
+  private teardownTouchHandlers(managed: ManagedCanvas): void {
+    const target = managed.touchTarget;
+    if (!target) return;
+    for (const { eventName, handler } of managed.touchHandlers) {
+      target.removeEventListener(eventName, handler);
+    }
+    managed.touchHandlers = [];
+    managed.touchTarget = null;
   }
 
   async addListener(


### PR DESCRIPTION
# Relates to

Closes #26710

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package test/typecheck/lint/build all pass (see logs). Full `bun run verify` is a long repo-wide gate; the owning-package gates were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts. The two new develop commits (`a83dd90847`, `874cd06b7a`) touch `packages/core` only — no overlap with `plugins/plugin-native-canvas`.
- [x] Owning-package gates (`test`, `typecheck`, `lint:check`, `build`) pass post-sync. See **Known gaps / failures** for the repo-wide `verify` note.

# Risks

Low. The change is local to the `CanvasWeb` class in `plugins/plugin-native-canvas/src/web.ts` (a Capacitor plugin web fallback, opt-in via `Canvas.*`). No public API, type, or native bridge changed. Listener wiring is now idempotent per element and cleaned up on `detach()`/`destroy()`; the observable `touch` event contract is unchanged except that duplicate emissions are eliminated.

# Background

## What does this PR do?

`CanvasWeb.attach()` unconditionally called `setupTouchHandlers()`, which added a fresh set of anonymous `touchstart`/`touchmove`/`touchend`/`touchcancel`/`mousedown`/`mousemove`/`mouseup` listeners to the canvas element. `detach()` only removed the element from the DOM (`managed.canvas.remove()`) and never removed those listeners, while the element object (with its listeners) was retained in `ManagedCanvas`.

Any legitimate `detach()` -> `attach()` cycle (both are public API), or a plain second `attach()` without an intervening `detach()`, stacked a second full set of listeners on the same element. Every subsequent pointer interaction then fired each handler N times, emitting N duplicate `touch`/`CanvasTouchEvent` notifications. For a drawing surface this corrupts strokes (each sampled point recorded 2x, 3x, ...) and leaks DOM event listeners.

The fix:
- `ManagedCanvas` now tracks the bound element (`touchTarget`) and the exact listener references (`touchHandlers`).
- `setupTouchHandlers()` short-circuits when the current element is already bound, and otherwise tears down any stale binding first, so at most one set of listeners is ever wired.
- `detach()` and `destroy()` call `removeEventListener` for each stored handler and clear the references, so a later `attach()` re-wires exactly one fresh set (this also fixes the listener leak).

This matches the native contract: the iOS bridge assigns a single `canvas.view.touchHandler` closure on `attach` (with view-intrinsic `touchesBegan`/`touchesMoved` overrides), and the Android bridge assigns a single `canvas.view.touchHandler` (view-intrinsic `onTouchEvent`). Both replace one handler slot on re-attach and never duplicate; the web fallback now matches.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change. The package `AGENTS.md` already documents "Touch handlers are set up on `attach()`" and that `setTouchEnabled` gates emission; both statements remain accurate.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-canvas/src/web-touch-reattach.test.ts` — a new jsdom vitest that runs a real `CanvasWeb`, dispatches real `MouseEvent`s at the base canvas, and counts emitted `touch` events across attach/detach cycles.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-native-canvas test        # 4 files, 47 tests pass
bun run --cwd plugins/plugin-native-canvas typecheck   # clean
bun run --cwd plugins/plugin-native-canvas lint:check  # clean
bun run --cwd plugins/plugin-native-canvas build       # dist/plugin.js + dist/plugin.cjs.js
```

The new test covers: (a) one emission per press after a single `attach()`; (b) one per press after a `detach()`->`attach()` cycle; (c) no stacking across 5 detach/attach cycles; (d) one per press after a second `attach()` without an intervening `detach()`; (e) the retained element no longer emits after `detach()` (listeners removed); (f) `setTouchEnabled(false)` suppresses; (g) `removeAllListeners()` suppresses. On the pre-fix code, (b)(c)(d)(e) fail (2 emissions / leaked listeners); after the fix all pass.

# Evidence Gate

<!-- evidence-head:d83cfc29d4a93c51d0cdfd0c32c590f0435defe1 -->

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change. This is a DOM event-listener lifecycle fix in a Capacitor plugin web fallback.

## Backend + frontend logs

This is a jsdom (browser-fallback) regression, so the "backend" and "frontend" logs are the same real vitest run: a live `CanvasWeb` in jsdom, dispatching real `MouseEvent`s at the base canvas and counting emitted `touch` events across attach/detach cycles. Complete, verbatim transcripts follow (`--reporter=verbose`), captured on the exact PR head `d83cfc29d4a93c51d0cdfd0c32c590f0435defe1`.

> Artifact hosting note: this branch is a fork contribution and `agent-cortex` has no push access to `elizaOS/eliza`, so neither the `pr-evidence` release (`gh release upload` → HTTP 404) nor programmatic `user-attachments` upload is available to the automated author. As `scripts/check-pr-evidence.mjs` itself documents (lines 170–177), the first-party route for a fork document artifact is a `user-attachments/files/...` link minted by GitHub's web uploader, which a headless PAT cannot mint. The complete transcripts are therefore embedded inline below as the immutable-in-git source evidence; each block is reproducible verbatim with the printed command.

<details><summary>Failing-before — regression reproduced on pre-fix <code>web.ts</code> (full vitest verbose output, 4 failed | 3 passed)</summary>

Procedure: `git show origin/develop:plugins/plugin-native-canvas/src/web.ts > plugins/plugin-native-canvas/src/web.ts` (restores the pre-fix listener wiring), then run the unchanged new test.

```
=== elizaOS/eliza PR #26835 :: FAILING-BEFORE (pre-fix web.ts from origin/develop) ===
=== web.ts restored to: origin/develop (65d589387dac89ce1d01ba5f16c8b6f68fd98445) ===
=== new regression test: src/web-touch-reattach.test.ts (unchanged from PR) ===

 RUN  v4.1.10 plugins/plugin-native-canvas

 ✓ CanvasWeb touch listener lifecycle > emits exactly one touch per press after a single attach() 30ms
 × CanvasWeb touch listener lifecycle > emits exactly one touch per press after a detach()->attach() cycle 17ms
   → expected 2 to be 1 // Object.is equality
 × CanvasWeb touch listener lifecycle > does not stack listeners across many detach()->attach() cycles 9ms
   → expected 6 to be 1 // Object.is equality
 × CanvasWeb touch listener lifecycle > emits exactly one touch per press after a second attach() without detach() 8ms
   → expected 2 to be 1 // Object.is equality
 × CanvasWeb touch listener lifecycle > removes listeners on detach so the retained element no longer emits 5ms
   → expected 1 to be +0 // Object.is equality
 ✓ CanvasWeb touch listener lifecycle > suppresses emission when touch is disabled via setTouchEnabled(false) 3ms
 ✓ CanvasWeb touch listener lifecycle > suppresses emission after removeAllListeners() 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  emits exactly one touch per press after a detach()->attach() cycle
 AssertionError: expected 2 to be 1 // Object.is equality
 - Expected  + Received
 - 1        + 2
 ❱ src/web-touch-reattach.test.ts:130:22

 FAIL  does not stack listeners across many detach()->attach() cycles
 AssertionError: expected 6 to be 1 // Object.is equality
 - Expected  + Received
 - 1        + 6
 ❱ src/web-touch-reattach.test.ts:145:22

 FAIL  emits exactly one touch per press after a second attach() without detach()
 AssertionError: expected 2 to be 1 // Object.is equality
 - Expected  + Received
 - 1        + 2
 ❱ src/web-touch-reattach.test.ts:157:22

 FAIL  removes listeners on detach so the retained element no longer emits
 AssertionError: expected 1 to be +0 // Object.is equality
 - Expected  + Received
 - 0        + 1
 ❱ src/web-touch-reattach.test.ts:173:22

 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

The emission counts are the domain artifact: a `detach()->attach()` press emits 2 `touch` starts, five cycles emit 6, a second `attach()` emits 2, and a detached-but-retained element still emits 1 (leaked listener). `web.ts` was then restored to the fixed revision.

</details>

<details><summary>Passing-after — fixed <code>web.ts</code> (full vitest verbose output, 7 passed)</summary>

```
=== elizaOS/eliza PR #26835 :: plugin-native-canvas touch-listener regression ===
=== HEAD: d83cfc29d4a93c51d0cdfd0c32c590f0435defe1 ===
=== Command: bun run --cwd plugins/plugin-native-canvas vitest run src/web-touch-reattach.test.ts --reporter=verbose ===

 RUN  v4.1.10 plugins/plugin-native-canvas

 ✓ CanvasWeb touch listener lifecycle > emits exactly one touch per press after a single attach() 27ms
 ✓ CanvasWeb touch listener lifecycle > emits exactly one touch per press after a detach()->attach() cycle 5ms
 ✓ CanvasWeb touch listener lifecycle > does not stack listeners across many detach()->attach() cycles 5ms
 ✓ CanvasWeb touch listener lifecycle > emits exactly one touch per press after a second attach() without detach() 2ms
 ✓ CanvasWeb touch listener lifecycle > removes listeners on detach so the retained element no longer emits 3ms
 ✓ CanvasWeb touch listener lifecycle > suppresses emission when touch is disabled via setTouchEnabled(false) 2ms
 ✓ CanvasWeb touch listener lifecycle > suppresses emission after removeAllListeners() 3ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Every emission count is now exactly 1 (or 0 for the detached/disabled cases): at most one listener set is ever bound.

</details>

<details><summary>Owning-package gates on the PR head — <code>test</code> / <code>typecheck</code> / <code>lint:check</code> (full output)</summary>

```
=== elizaOS/eliza PR #26835 :: owning-package gates (plugins/plugin-native-canvas) ===
=== HEAD: d83cfc29d4a93c51d0cdfd0c32c590f0435defe1 ===

########## bun run --cwd plugins/plugin-native-canvas test ##########
$ vitest run
 RUN  v4.1.10 plugins/plugin-native-canvas
 Test Files  4 passed (4)
      Tests  47 passed (47)

########## bun run --cwd plugins/plugin-native-canvas typecheck ##########
$ tsc --noEmit -p tsconfig.json
(no output — clean)

########## bun run --cwd plugins/plugin-native-canvas lint:check ##########
$ bunx @biomejs/biome check .
Checked 10 files in 77ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changes in this repo. The affected code is the touch/pointer event wiring of a Capacitor canvas web fallback; the fix is observable only as event-emission counts, which are asserted in the jsdom test above rather than pixels.

### Before

N/A - see above.

### After

N/A - see above.

### Walkthrough video

N/A - no UI surface; behavior verified via the jsdom regression test (failing-before / passing-after logs above).

## Audio / voice walkthrough

N/A - no voice/audio path.

## Known gaps / failures

Repo-wide `bun run verify` was not run to completion on this machine (it drives the full Turbo graph across all workspaces and is disproportionate to a single-file plugin fix). The owning-package gates that cover this change — `test`, `typecheck`, `lint:check`, and `build` — were all run and pass; outputs are attached. `bun install` completed after sync (the global bunfig `minimumReleaseAge` required `--minimum-release-age=0` for an unrelated freshly-published transitive dependency; this does not affect the change).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; fix is DOM event-listener wiring in a Capacitor canvas web fallback

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface; see jsdom regression test emission counts

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI flow; behavior is event-emission counts asserted in jsdom test

<!-- evidence-row:backend-logs -->
- [ ] N/A - no server path; failing-before/passing-after vitest logs are inline in the PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no app frontend; jsdom vitest MouseEvent dispatch counts are inline in the PR body

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/file/on-chain artifact; artifact is the touch-event emission count in the inline test logs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@d83cfc29d4a93c51d0cdfd0c32c590f0435defe1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@d83cfc29d4a93c51d0cdfd0c32c590f0435defe1:packages/skills/skills/contribute-to-eliza"} -->
