### PR TITLE
fix(sql): serialize membership TTL upgrade

### DIFF
--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -111,6 +111,8 @@ The Caddyfile at `plugins/plugin-sql/caddy/electric-proxy.Caddyfile` forwards ev
 | `ELIZA_SERVER_ID` | Conditional | — | Required when `ENABLE_DATA_ISOLATION=true`; becomes the RLS server UUID. |
 | `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS` | No | `false` | Allow column drops and other destructive schema changes at startup. |
 | `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS` | No | auto | Controls automatic install of the `message_search_document` generated column and message-search GIN indexes. Production Postgres adapters skip this DDL by default; set `true` after scheduling the generated-column/index migration. |
+| `ELIZA_MEMBERSHIP_TTL_DESTRUCTIVE_TEST` | Test-only | — | Must be exactly `1` before the real-PostgreSQL membership-TTL concurrency proof may execute destructive setup. |
+| `ELIZA_MEMBERSHIP_TTL_SCRATCH_DATABASE` | Test-only | — | Exact dedicated database name for that proof; must match `eliza_membership_ttl_test_<16-32 lowercase hex>`, be owned by the connected user, and contain no membership-authority relations. |
 | `NODE_ENV` | No | `development` | `production` disables verbose migration logging and tightens safety checks. |
 
 Settings are read via `runtime.getSetting(key)` inside `plugin.init`.

--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-concurrency.postgres.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-concurrency.postgres.real.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Real-PostgreSQL proof for the membership TTL post-schema guard. Independent
+ * pools exercise concurrent process startup, durable restart no-op behavior,
+ * and transactional rollback when the one-time repair fails.
+ */
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { applyMembershipAuthorityTtlConstraints } from "../../membership-authority-ttl-constraints";
+
+interface SnapshotRow extends Record<string, unknown> {
+  authority_constraint_id: number;
+  authority_expiry_ms: number | string;
+  authority_xmin: string;
+  scope_constraint_id: number;
+  scope_expiry_ms: number | string;
+  scope_xmin: string;
+  tagged_constraints: number | string;
+}
+
+const postgresUrl = process.env.POSTGRES_URL;
+
+describe.skipIf(!postgresUrl)("membership authority TTL PostgreSQL concurrency", () => {
+  const firstPool = new Pool({ connectionString: postgresUrl, max: 4 });
+  const secondPool = new Pool({ connectionString: postgresUrl, max: 4 });
+  const firstDb = drizzle(firstPool);
+  const secondDb = drizzle(secondPool);
+
+  async function installLegacySchema(): Promise<void> {
+    await firstDb.execute(sql`
+      DROP TABLE IF EXISTS membership_authority CASCADE;
+      DROP TABLE IF EXISTS membership_authority_scopes CASCADE;
+      CREATE TABLE membership_authority_scopes (
+        id integer PRIMARY KEY,
+        health text NOT NULL,
+        valid_until timestamptz,
+        observed_at timestamptz NOT NULL,
+        publisher_instance_id text,
+        source_version integer NOT NULL,
+        source_cursor text,
+        CONSTRAINT membership_authority_scope_current_check CHECK (
+          health <> 'current'
+          OR (
+            valid_until IS NOT NULL
+            AND valid_until > observed_at
+            AND publisher_instance_id IS NOT NULL
+            AND source_version >= 0
+            AND source_cursor IS NOT NULL
+          )
+        )
+      );
+      CREATE TABLE membership_authority (
+        id integer PRIMARY KEY,
+        generation integer NOT NULL,
+        source_version integer NOT NULL,
+        valid_until timestamptz NOT NULL,
+        observed_at timestamptz NOT NULL,
+        CONSTRAINT membership_authority_version_check CHECK (
+          generation > 0 AND source_version >= 0 AND valid_until > observed_at
+        )
+      );
+      INSERT INTO membership_authority_scopes
+        (id, health, valid_until, observed_at, publisher_instance_id, source_version, source_cursor)
+      VALUES
+        (1, 'current', TIMESTAMPTZ '2026-08-25 00:00:00+00',
+         TIMESTAMPTZ '2026-08-23 00:00:00+00', 'publisher', 0, 'cursor');
+      INSERT INTO membership_authority
+        (id, generation, source_version, valid_until, observed_at)
+      VALUES
+        (1, 1, 0, TIMESTAMPTZ '2026-08-25 00:00:00+00',
+         TIMESTAMPTZ '2026-08-23 00:00:00+00');
+    `);
+  }
+
+  async function snapshot(): Promise<SnapshotRow> {
+    const result = await firstDb.execute<SnapshotRow>(sql`
+      SELECT scope_constraint.oid::integer AS scope_constraint_id,
+             authority_constraint.oid::integer AS authority_constraint_id,
+             EXTRACT(EPOCH FROM scope.valid_until) * 1000 AS scope_expiry_ms,
+             EXTRACT(EPOCH FROM authority.valid_until) * 1000 AS authority_expiry_ms,
+             scope.xmin::text AS scope_xmin,
+             authority.xmin::text AS authority_xmin,
+             (
+               SELECT COUNT(*)
+                 FROM pg_constraint AS tagged
+                 JOIN pg_class AS relation ON relation.oid = tagged.conrelid
+                WHERE relation.relname IN (
+                        'membership_authority_scopes',
+                        'membership_authority'
+                      )
+                  AND tagged.conname IN (
+                        'membership_authority_scope_current_check',
+                        'membership_authority_version_check'
+                      )
+                  AND obj_description(tagged.oid, 'pg_constraint') =
+                        'elizaos:membership-authority-ttl:v1'
+             ) AS tagged_constraints
+        FROM membership_authority_scopes AS scope
+        CROSS JOIN membership_authority AS authority
+        CROSS JOIN pg_constraint AS scope_constraint
+        CROSS JOIN pg_constraint AS authority_constraint
+       WHERE scope.id = 1
+         AND authority.id = 1
+         AND scope_constraint.conname = 'membership_authority_scope_current_check'
+         AND authority_constraint.conname = 'membership_authority_version_check'
+    `);
+    const row = result.rows[0];
+    if (!row) throw new Error("membership TTL snapshot was unavailable");
+    return row;
+  }
+
+  beforeAll(async () => {
+    await Promise.all([
+      firstDb.execute(sql`SET statement_timeout = '15s'; SET lock_timeout = '10s'`),
+      secondDb.execute(sql`SET statement_timeout = '15s'; SET lock_timeout = '10s'`),
+    ]);
+  });
+
+  afterAll(async () => {
+    await firstDb.execute(sql`
+      DROP TABLE IF EXISTS membership_authority CASCADE;
+      DROP TABLE IF EXISTS membership_authority_scopes CASCADE;
+      DROP FUNCTION IF EXISTS slow_membership_ttl_upgrade();
+      DROP FUNCTION IF EXISTS reject_membership_ttl_upgrade()
+    `);
+    await Promise.all([firstPool.end(), secondPool.end()]);
+  });
+
+  it("serializes concurrent startups and makes every later startup a durable no-op", async () => {
+    await installLegacySchema();
+    await firstDb.execute(sql`
+      CREATE OR REPLACE FUNCTION slow_membership_ttl_upgrade() RETURNS trigger AS $$
+      BEGIN
+        PERFORM pg_sleep(0.15);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      CREATE TRIGGER slow_membership_ttl_upgrade
+        BEFORE UPDATE ON membership_authority_scopes
+        FOR EACH ROW EXECUTE FUNCTION slow_membership_ttl_upgrade()
+    `);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        applyMembershipAuthorityTtlConstraints(index % 2 === 0 ? firstDb : secondDb, "postgres")
+      )
+    );
+    expect(results).toEqual(Array.from({ length: 8 }, () => true));
+
+    const settled = await snapshot();
+    expect(Number(settled.tagged_constraints)).toBe(2);
+    expect(Number(settled.scope_expiry_ms)).toBe(new Date("2026-08-24T00:00:00.000Z").getTime());
+    expect(Number(settled.authority_expiry_ms)).toBe(
+      new Date("2026-08-24T00:00:00.000Z").getTime()
+    );
+
+    await applyMembershipAuthorityTtlConstraints(secondDb, "postgres");
+    expect(await snapshot()).toEqual(settled);
+  }, 30_000);
+
+  it("rolls back row clamps and DDL when the one-time repair fails", async () => {
+    await installLegacySchema();
+    await firstDb.execute(sql`
+      CREATE OR REPLACE FUNCTION reject_membership_ttl_upgrade() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'forced membership TTL upgrade failure';
+      END;
+      $$ LANGUAGE plpgsql;
+      CREATE TRIGGER reject_membership_ttl_upgrade
+        BEFORE UPDATE ON membership_authority
+        FOR EACH ROW EXECUTE FUNCTION reject_membership_ttl_upgrade()
+    `);
+
+    let failure: unknown;
+    try {
+      await applyMembershipAuthorityTtlConstraints(firstDb, "postgres");
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error & { cause?: Error }).cause?.message).toContain(
+      "forced membership TTL upgrade failure"
+    );
+
+    const rolledBack = await snapshot();
+    expect(Number(rolledBack.tagged_constraints)).toBe(0);
+    expect(Number(rolledBack.scope_expiry_ms)).toBe(new Date("2026-08-25T00:00:00.000Z").getTime());
+    expect(Number(rolledBack.authority_expiry_ms)).toBe(
+      new Date("2026-08-25T00:00:00.000Z").getTime()
+    );
+
+    await firstDb.execute(sql`DROP TRIGGER reject_membership_ttl_upgrade ON membership_authority`);
+    expect(await applyMembershipAuthorityTtlConstraints(secondDb, "postgres")).toBe(true);
+
+    const recovered = await snapshot();
+    expect(Number(recovered.tagged_constraints)).toBe(2);
+    expect(Number(recovered.scope_expiry_ms)).toBe(new Date("2026-08-24T00:00:00.000Z").getTime());
+    expect(Number(recovered.authority_expiry_ms)).toBe(
+      new Date("2026-08-24T00:00:00.000Z").getTime()
+    );
+    await expect(
+      firstDb.execute(sql`
+        UPDATE membership_authority
+           SET valid_until = observed_at + INTERVAL '48 hours'
+         WHERE id = 1
+      `)
+    ).rejects.toThrow();
+
+    await applyMembershipAuthorityTtlConstraints(firstDb, "postgres");
+    expect(await snapshot()).toEqual(recovered);
+  }, 30_000);
+});

--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-concurrency.postgres.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-concurrency.postgres.real.test.ts
@@ -1,13 +1,15 @@
 /**
  * Real-PostgreSQL proof for the membership TTL post-schema guard. Independent
  * pools exercise concurrent process startup, durable restart no-op behavior,
- * and transactional rollback when the one-time repair fails.
+ * and transactional rollback when the one-time repair fails. Destructive DDL
+ * is admitted only in a named, empty database owned by the connected user.
  */
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { applyMembershipAuthorityTtlConstraints } from "../../membership-authority-ttl-constraints";
+import { admitMembershipTtlPostgresScratch } from "./membership-authority-ttl-postgres-test-admission";
 
 interface SnapshotRow extends Record<string, unknown> {
   authority_constraint_id: number;
@@ -22,10 +24,11 @@ interface SnapshotRow extends Record<string, unknown> {
 const postgresUrl = process.env.POSTGRES_URL;
 
 describe.skipIf(!postgresUrl)("membership authority TTL PostgreSQL concurrency", () => {
-  const firstPool = new Pool({ connectionString: postgresUrl, max: 4 });
-  const secondPool = new Pool({ connectionString: postgresUrl, max: 4 });
-  const firstDb = drizzle(firstPool);
-  const secondDb = drizzle(secondPool);
+  let firstPool: Pool;
+  let secondPool: Pool;
+  let firstDb: ReturnType<typeof drizzle>;
+  let secondDb: ReturnType<typeof drizzle>;
+  let admitted = false;
 
   async function installLegacySchema(): Promise<void> {
     await firstDb.execute(sql`
@@ -111,6 +114,25 @@ describe.skipIf(!postgresUrl)("membership authority TTL PostgreSQL concurrency",
   }
 
   beforeAll(async () => {
+    const poolOptions = {
+      connectionString: postgresUrl,
+      max: 4,
+      options: "-c search_path=public,pg_catalog",
+    };
+    firstPool = new Pool(poolOptions);
+    try {
+      await admitMembershipTtlPostgresScratch(process.env, (text, values) =>
+        firstPool.query(text, [...values])
+      );
+      admitted = true;
+    } catch (error) {
+      await firstPool.end();
+      throw error;
+    }
+
+    secondPool = new Pool(poolOptions);
+    firstDb = drizzle(firstPool);
+    secondDb = drizzle(secondPool);
     await Promise.all([
       firstDb.execute(sql`SET statement_timeout = '15s'; SET lock_timeout = '10s'`),
       secondDb.execute(sql`SET statement_timeout = '15s'; SET lock_timeout = '10s'`),
@@ -118,13 +140,17 @@ describe.skipIf(!postgresUrl)("membership authority TTL PostgreSQL concurrency",
   });
 
   afterAll(async () => {
-    await firstDb.execute(sql`
-      DROP TABLE IF EXISTS membership_authority CASCADE;
-      DROP TABLE IF EXISTS membership_authority_scopes CASCADE;
-      DROP FUNCTION IF EXISTS slow_membership_ttl_upgrade();
-      DROP FUNCTION IF EXISTS reject_membership_ttl_upgrade()
-    `);
-    await Promise.all([firstPool.end(), secondPool.end()]);
+    if (!admitted) return;
+    try {
+      await firstDb.execute(sql`
+          DROP TABLE IF EXISTS membership_authority CASCADE;
+          DROP TABLE IF EXISTS membership_authority_scopes CASCADE;
+          DROP FUNCTION IF EXISTS slow_membership_ttl_upgrade();
+          DROP FUNCTION IF EXISTS reject_membership_ttl_upgrade()
+        `);
+    } finally {
+      await Promise.all([firstPool.end(), secondPool.end()]);
+    }
   });
 
   it("serializes concurrent startups and makes every later startup a durable no-op", async () => {

--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-postgres-test-admission.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-postgres-test-admission.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Deterministic admission coverage proves ordinary PostgreSQL configuration
+ * cannot reach the destructive membership-TTL test setup.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  admitMembershipTtlPostgresScratch,
+  MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV,
+  MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV,
+  type PostgresMetadataQuery,
+} from "./membership-authority-ttl-postgres-test-admission";
+
+const scratchDatabase = "eliza_membership_ttl_test_0123456789abcdef";
+
+function queryReturning(rows: Record<string, unknown>[]): PostgresMetadataQuery {
+  return vi.fn(async () => ({ rows })) as PostgresMetadataQuery;
+}
+
+describe("membership TTL destructive PostgreSQL test admission", () => {
+  it("rejects an ordinary POSTGRES_URL before executing any database query or DDL", async () => {
+    const query = queryReturning([]);
+
+    await expect(
+      admitMembershipTtlPostgresScratch({ POSTGRES_URL: "postgres://shared.example/eliza" }, query)
+    ).rejects.toThrow(`${MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV}=1 is required`);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing or unsafe scratch database before querying PostgreSQL", async () => {
+    for (const databaseName of [undefined, "postgres", "eliza_membership_ttl_test_short"]) {
+      const query = queryReturning([]);
+      await expect(
+        admitMembershipTtlPostgresScratch(
+          {
+            [MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV]: "1",
+            [MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV]: databaseName,
+          },
+          query
+        )
+      ).rejects.toThrow(`${MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV} must match`);
+      expect(query).not.toHaveBeenCalled();
+    }
+  });
+
+  it("requires the exact owner-operated database with no authority relations", async () => {
+    const base = {
+      current_database_name: scratchDatabase,
+      current_schema_name: "public",
+      current_user_name: "scratch_owner",
+      database_owner: "scratch_owner",
+      protected_relations: 0,
+    };
+    const environment = {
+      [MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV]: "1",
+      [MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV]: scratchDatabase,
+    };
+
+    await expect(
+      admitMembershipTtlPostgresScratch(
+        environment,
+        queryReturning([{ ...base, current_database_name: "shared_database" }])
+      )
+    ).rejects.toThrow("does not match the admitted scratch database");
+    await expect(
+      admitMembershipTtlPostgresScratch(
+        environment,
+        queryReturning([{ ...base, current_schema_name: "shared" }])
+      )
+    ).rejects.toThrow("must resolve DDL to public");
+    await expect(
+      admitMembershipTtlPostgresScratch(
+        environment,
+        queryReturning([{ ...base, database_owner: "other_owner" }])
+      )
+    ).rejects.toThrow("current user to own the scratch database");
+    await expect(
+      admitMembershipTtlPostgresScratch(
+        environment,
+        queryReturning([{ ...base, protected_relations: 1 }])
+      )
+    ).rejects.toThrow("already contains membership authority relations");
+  });
+
+  it("admits only the verified empty scratch database", async () => {
+    const admission = await admitMembershipTtlPostgresScratch(
+      {
+        [MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV]: "1",
+        [MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV]: scratchDatabase,
+      },
+      queryReturning([
+        {
+          current_database_name: scratchDatabase,
+          current_schema_name: "public",
+          current_user_name: "scratch_owner",
+          database_owner: "scratch_owner",
+          protected_relations: "0",
+        },
+      ])
+    );
+
+    expect(admission).toEqual({ databaseName: scratchDatabase });
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-postgres-test-admission.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-postgres-test-admission.ts
@@ -1,0 +1,88 @@
+/**
+ * Admits the destructive membership-TTL PostgreSQL proof only into an
+ * explicitly named, owner-operated scratch database with no authority tables.
+ */
+
+export const MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV = "ELIZA_MEMBERSHIP_TTL_DESTRUCTIVE_TEST";
+export const MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV = "ELIZA_MEMBERSHIP_TTL_SCRATCH_DATABASE";
+
+const SCRATCH_DATABASE_PATTERN = /^eliza_membership_ttl_test_[a-f0-9]{16,32}$/;
+
+interface ScratchDatabaseMetadata extends Record<string, unknown> {
+  current_database_name: string;
+  current_schema_name: string;
+  current_user_name: string;
+  database_owner: string;
+  protected_relations: number | string;
+}
+
+export type PostgresMetadataQuery = <Row extends Record<string, unknown>>(
+  text: string,
+  values: readonly unknown[]
+) => Promise<{ rows: Row[] }>;
+
+export interface MembershipTtlPostgresScratchAdmission {
+  databaseName: string;
+}
+
+/** Fails before querying PostgreSQL unless destructive execution is explicit. */
+export async function admitMembershipTtlPostgresScratch(
+  environment: NodeJS.ProcessEnv,
+  query: PostgresMetadataQuery
+): Promise<MembershipTtlPostgresScratchAdmission> {
+  if (environment[MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV] !== "1") {
+    throw new Error(
+      `${MEMBERSHIP_TTL_DESTRUCTIVE_TEST_ENV}=1 is required for the destructive membership TTL PostgreSQL test`
+    );
+  }
+
+  const databaseName = environment[MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV];
+  if (!databaseName || !SCRATCH_DATABASE_PATTERN.test(databaseName)) {
+    throw new Error(
+      `${MEMBERSHIP_TTL_SCRATCH_DATABASE_ENV} must match ${SCRATCH_DATABASE_PATTERN.source}`
+    );
+  }
+
+  const result = await query<ScratchDatabaseMetadata>(
+    `SELECT current_database() AS current_database_name,
+            current_schema() AS current_schema_name,
+            current_user AS current_user_name,
+            pg_get_userbyid(database.datdba) AS database_owner,
+            (
+              SELECT COUNT(*)
+                FROM pg_class AS relation
+                JOIN pg_namespace AS namespace
+                  ON namespace.oid = relation.relnamespace
+               WHERE namespace.nspname = 'public'
+                 AND relation.relname IN (
+                   'membership_authority',
+                   'membership_authority_scopes'
+                 )
+            ) AS protected_relations
+       FROM pg_database AS database
+      WHERE database.datname = current_database()`,
+    []
+  );
+  const metadata = result.rows[0];
+  if (!metadata) {
+    throw new Error("scratch database metadata was unavailable");
+  }
+  if (metadata.current_database_name !== databaseName) {
+    throw new Error("connected PostgreSQL database does not match the admitted scratch database");
+  }
+  if (metadata.current_schema_name !== "public") {
+    throw new Error("membership TTL PostgreSQL scratch database must resolve DDL to public");
+  }
+  if (metadata.current_user_name !== metadata.database_owner) {
+    throw new Error(
+      "membership TTL PostgreSQL test requires the current user to own the scratch database"
+    );
+  }
+  if (Number(metadata.protected_relations) !== 0) {
+    throw new Error(
+      "membership TTL PostgreSQL scratch database already contains membership authority relations"
+    );
+  }
+
+  return { databaseName };
+}

--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-upgrade.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-upgrade.real.test.ts
@@ -1,11 +1,13 @@
 /**
  * Real-PGlite upgrade coverage proving startup replaces the exact pre-#25474
- * membership TTL checks while preserving existing authority rows.
+ * membership TTL checks, preserves authority rows, skips dry runs and settled
+ * restarts, and defers until both authority tables exist.
  */
 import type { UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { plugin as sqlPlugin } from "../../index";
+import { applyMembershipAuthorityTtlConstraints } from "../../membership-authority-ttl-constraints";
 import { DatabaseMigrationService } from "../../migration-service";
 import { connectorAccountsTable } from "../../schema/connectorAccounts";
 import { entityTable } from "../../schema/entity";
@@ -17,9 +19,25 @@ import { type DrizzleDatabase, getDb } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 interface ConstraintRow {
+  [key: string]: unknown;
+  id: number;
   name: string;
   definition: string;
+  version: string | null;
 }
+
+const constraintQuery = sql`
+  SELECT oid::integer AS id,
+         conname AS name,
+         pg_get_constraintdef(oid) AS definition,
+         obj_description(oid, 'pg_constraint') AS version
+    FROM pg_constraint
+   WHERE conname IN (
+     'membership_authority_scope_current_check',
+     'membership_authority_version_check'
+   )
+   ORDER BY conname
+`;
 
 describe("membership authority TTL constraint upgrade", () => {
   let cleanup: () => Promise<void>;
@@ -121,34 +139,32 @@ describe("membership authority TTL constraint upgrade", () => {
   });
 
   it("replaces same-named legacy checks on restart without deleting or fabricating rows", async () => {
-    const before = await db.execute<ConstraintRow>(sql`
-      SELECT conname AS name, pg_get_constraintdef(oid) AS definition
-        FROM pg_constraint
-       WHERE conname IN (
-         'membership_authority_scope_current_check',
-         'membership_authority_version_check'
-       )
-       ORDER BY conname
-    `);
+    const before = await db.execute<ConstraintRow>(constraintQuery);
     expect(before.rows).toHaveLength(2);
     expect(before.rows.every((row) => !row.definition.includes("24:00:00"))).toBe(true);
+
+    const dryRunService = new DatabaseMigrationService({ databaseBackend: "pglite" });
+    await dryRunService.initializeWithDatabase(db);
+    dryRunService.discoverAndRegisterPluginSchemas([sqlPlugin]);
+    await dryRunService.runAllPluginMigrations({ dryRun: true, verbose: false });
+
+    const afterDryRun = await db.execute<ConstraintRow>(constraintQuery);
+    expect(afterDryRun.rows).toEqual(before.rows);
+    expect((await db.select().from(membershipAuthorityTable))[0]?.validUntil.getTime()).toBe(
+      legacyValidUntil.getTime()
+    );
 
     const migrationService = new DatabaseMigrationService({ databaseBackend: "pglite" });
     await migrationService.initializeWithDatabase(db);
     migrationService.discoverAndRegisterPluginSchemas([sqlPlugin]);
     await migrationService.runAllPluginMigrations({ verbose: false });
 
-    const after = await db.execute<ConstraintRow>(sql`
-      SELECT conname AS name, pg_get_constraintdef(oid) AS definition
-        FROM pg_constraint
-       WHERE conname IN (
-         'membership_authority_scope_current_check',
-         'membership_authority_version_check'
-       )
-       ORDER BY conname
-    `);
+    const after = await db.execute<ConstraintRow>(constraintQuery);
     expect(after.rows).toHaveLength(2);
     expect(after.rows.every((row) => row.definition.includes("24:00:00"))).toBe(true);
+    expect(after.rows.every((row) => row.version === "elizaos:membership-authority-ttl:v1")).toBe(
+      true
+    );
 
     const scopes = await db.select().from(membershipAuthorityScopeTable);
     const memberships = await db.select().from(membershipAuthorityTable);
@@ -189,5 +205,110 @@ describe("membership authority TTL constraint upgrade", () => {
          WHERE canonical_principal_id = ${principalId}
       `)
     ).rejects.toThrow();
+
+    const restartService = new DatabaseMigrationService({ databaseBackend: "pglite" });
+    await restartService.initializeWithDatabase(db);
+    restartService.discoverAndRegisterPluginSchemas([sqlPlugin]);
+    await restartService.runAllPluginMigrations({ verbose: false });
+    expect((await db.execute<ConstraintRow>(constraintQuery)).rows).toEqual(after.rows);
   }, 30_000);
+
+  it("defers without mutation when either authority table is absent", async () => {
+    for (const retainedTable of ["membership_authority", "membership_authority_scopes"] as const) {
+      const setup = await createIsolatedTestDatabase(`membership_ttl_partial_${retainedTable}`);
+      try {
+        const partialDb = getDb(setup.adapter);
+        const partialAccountId = crypto.randomUUID() as UUID;
+        const partialPrincipalId = crypto.randomUUID() as UUID;
+        const droppedTable =
+          retainedTable === "membership_authority"
+            ? "membership_authority_scopes"
+            : "membership_authority";
+        await partialDb.execute(sql.raw(`DROP TABLE ${droppedTable} CASCADE`));
+        await partialDb.insert(connectorAccountsTable).values({
+          id: partialAccountId,
+          agentId: setup.testAgentId,
+          provider: "partial-upgrade-test",
+          accountKey: retainedTable,
+        });
+        const partialScope = {
+          agentId: setup.testAgentId,
+          connectorId: "partial-upgrade-test",
+          connectorAccountId: partialAccountId,
+          externalWorldId: "partial-world",
+          externalRoomId: "partial-room",
+        };
+        if (retainedTable === "membership_authority_scopes") {
+          await partialDb.insert(membershipAuthorityScopeTable).values({
+            ...partialScope,
+            health: "stale",
+            reason: "publisher_not_registered",
+            generation: 0,
+            sourceVersion: -1,
+            observedAt,
+            updatedAt: observedAt,
+          });
+        } else {
+          await partialDb.insert(entityTable).values({
+            id: partialPrincipalId,
+            agentId: setup.testAgentId,
+            names: ["Partial retained principal"],
+          });
+          await partialDb.insert(membershipAuthorityTable).values({
+            ...partialScope,
+            canonicalPrincipalId: partialPrincipalId,
+            state: "active",
+            reason: "reconciled_present",
+            roles: ["member"],
+            permissionSnapshot: { canRead: true },
+            publisherInstanceId: "partial-publisher",
+            publisherGeneration: 0,
+            evidenceMode: "complete_snapshot",
+            generation: 1,
+            sourceVersion: 0,
+            sourceCursor: "partial-cursor",
+            observedAt,
+            validUntil: new Date("2026-08-23T12:00:00.000Z"),
+            createdAt: observedAt,
+            updatedAt: observedAt,
+          });
+        }
+
+        const retainedRowsBefore =
+          retainedTable === "membership_authority"
+            ? await partialDb.select().from(membershipAuthorityTable)
+            : await partialDb.select().from(membershipAuthorityScopeTable);
+        const retainedConstraintsBefore = await partialDb.execute<ConstraintRow>(sql`
+          SELECT constraint_record.oid::integer AS id,
+                 constraint_record.conname AS name,
+                 pg_get_constraintdef(constraint_record.oid) AS definition,
+                 obj_description(constraint_record.oid, 'pg_constraint') AS version
+            FROM pg_constraint AS constraint_record
+            JOIN pg_class AS relation ON relation.oid = constraint_record.conrelid
+           WHERE relation.relname = ${retainedTable}
+           ORDER BY constraint_record.conname
+        `);
+
+        expect(await applyMembershipAuthorityTtlConstraints(partialDb, "pglite")).toBe(false);
+        const retainedRowsAfter =
+          retainedTable === "membership_authority"
+            ? await partialDb.select().from(membershipAuthorityTable)
+            : await partialDb.select().from(membershipAuthorityScopeTable);
+        const retainedConstraintsAfter = await partialDb.execute<ConstraintRow>(sql`
+          SELECT constraint_record.oid::integer AS id,
+                 constraint_record.conname AS name,
+                 pg_get_constraintdef(constraint_record.oid) AS definition,
+                 obj_description(constraint_record.oid, 'pg_constraint') AS version
+            FROM pg_constraint AS constraint_record
+            JOIN pg_class AS relation ON relation.oid = constraint_record.conrelid
+           WHERE relation.relname = ${retainedTable}
+           ORDER BY constraint_record.conname
+        `);
+        expect(retainedRowsAfter).toEqual(retainedRowsBefore);
+        expect(retainedConstraintsAfter.rows).toEqual(retainedConstraintsBefore.rows);
+      } finally {
+        await setup.cleanup();
+      }
+    }
+  }, 60_000);
 });

--- a/plugins/plugin-sql/src/membership-authority-ttl-constraints.ts
+++ b/plugins/plugin-sql/src/membership-authority-ttl-constraints.ts
@@ -1,9 +1,20 @@
 /**
  * Repairs membership authority freshness checks that runtime schema diffing
- * cannot update when an existing constraint keeps the same name.
+ * cannot update when an existing constraint keeps the same name. A durable
+ * constraint comment is the restart fast path; PostgreSQL upgrades serialize
+ * with a transaction-scoped advisory lock before taking table locks.
  */
 import { sql } from "drizzle-orm";
 import type { DrizzleDatabase } from "./types";
+
+const CONSTRAINT_VERSION = "elizaos:membership-authority-ttl:v1";
+
+type DatabaseBackend = "postgres" | "pglite" | "unknown";
+
+interface CountRow {
+  [key: string]: unknown;
+  count: number | string;
+}
 
 function rows(value: unknown): readonly unknown[] {
   if (Array.isArray(value)) return value;
@@ -12,19 +23,71 @@ function rows(value: unknown): readonly unknown[] {
   return Array.isArray(resultRows) ? resultRows : [];
 }
 
-/** Atomically enforce observation-relative 24-hour membership evidence windows. */
-export async function applyMembershipAuthorityTtlConstraints(
-  db: DrizzleDatabase
-): Promise<boolean> {
-  const tables = await db.execute(sql`
+async function hasCurrentConstraints(db: DrizzleDatabase): Promise<boolean> {
+  const result = await db.execute<CountRow>(sql`
+    SELECT COUNT(*) AS count
+      FROM pg_constraint AS constraint_record
+      JOIN pg_class AS relation
+        ON relation.oid = constraint_record.conrelid
+     WHERE relation.relnamespace = 'public'::regnamespace
+       AND (
+         (
+           relation.relname = 'membership_authority_scopes'
+           AND constraint_record.conname = 'membership_authority_scope_current_check'
+         )
+         OR (
+           relation.relname = 'membership_authority'
+           AND constraint_record.conname = 'membership_authority_version_check'
+         )
+       )
+       AND obj_description(constraint_record.oid, 'pg_constraint') = ${CONSTRAINT_VERSION}
+  `);
+  return Number(result.rows[0]?.count ?? 0) === 2;
+}
+
+async function bothAuthorityTablesExist(db: DrizzleDatabase): Promise<boolean> {
+  const result = await db.execute(sql`
     SELECT table_name
       FROM information_schema.tables
      WHERE table_schema = 'public'
        AND table_name IN ('membership_authority_scopes', 'membership_authority')
   `);
-  if (rows(tables).length !== 2) return false;
+  return rows(result).length === 2;
+}
 
-  await db.transaction(async (tx) => {
+/** Atomically enforce observation-relative 24-hour membership evidence windows. */
+export async function applyMembershipAuthorityTtlConstraints(
+  db: DrizzleDatabase,
+  databaseBackend: DatabaseBackend
+): Promise<boolean> {
+  if (await hasCurrentConstraints(db)) return true;
+  if (!(await bothAuthorityTablesExist(db))) return false;
+
+  return db.transaction(async (tx) => {
+    if (databaseBackend === "postgres") {
+      await tx.execute(sql`
+        SELECT pg_advisory_xact_lock(
+          hashtext('elizaos.plugin-sql'),
+          hashtext('membership-authority-ttl-v1')
+        )
+      `);
+    }
+
+    // A process may have completed the upgrade while this transaction waited
+    // for the advisory lock. Rechecking avoids all authority-table work.
+    if (await hasCurrentConstraints(tx)) return true;
+    if (!(await bothAuthorityTablesExist(tx))) return false;
+
+    if (databaseBackend === "postgres") {
+      // Acquire the strongest locks in one fixed order before any UPDATE. This
+      // prevents the RowExclusive -> AccessExclusive lock-upgrade deadlock
+      // that concurrent startups could trigger in the original repair.
+      await tx.execute(sql`
+        LOCK TABLE membership_authority_scopes, membership_authority
+          IN ACCESS EXCLUSIVE MODE
+      `);
+    }
+
     // Evidence that exceeded the newly bounded contract was never safe to keep
     // authoritative. Shorten only its expiry; preserve the retained fact.
     await tx.execute(sql`
@@ -71,7 +134,20 @@ export async function applyMembershipAuthorityTtlConstraints(
           AND valid_until <= observed_at + INTERVAL '24 hours'
         )
     `);
-  });
 
-  return true;
+    await tx.execute(
+      sql.raw(`
+      COMMENT ON CONSTRAINT membership_authority_scope_current_check
+        ON membership_authority_scopes IS '${CONSTRAINT_VERSION}'
+    `)
+    );
+    await tx.execute(
+      sql.raw(`
+      COMMENT ON CONSTRAINT membership_authority_version_check
+        ON membership_authority IS '${CONSTRAINT_VERSION}'
+    `)
+    );
+
+    return true;
+  });
 }

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -156,7 +156,7 @@ export class DatabaseMigrationService {
 
       if (!migrationOptions.dryRun && !this.membershipAuthorityTtlConstraintsSettled) {
         this.membershipAuthorityTtlConstraintsSettled =
-          await applyMembershipAuthorityTtlConstraints(this.db);
+          await applyMembershipAuthorityTtlConstraints(this.db, this.databaseBackend);
       }
 
       if (!this.identityPersonLinkGuardSettled) {


### PR DESCRIPTION
Closes #26758.

Concurrent PostgreSQL startups now serialize the membership authority TTL upgrade with a transaction-scoped advisory lock and recheck the installed constraints after acquiring it. The upgrade clamps existing expirations to 24 hours, replaces both checks atomically, and records their version. Later startups preserve the existing constraints and rows without repeating DDL. PGlite follows the same data upgrade without PostgreSQL advisory locks.

Validated head: `c20ab4a4df2d0df79a96229e99c9f391e163e51b`  
Validated develop: `755a8213f0e165628a90ba0b573f6527f42037e5`

- Rebased and installed with Bun 1.3.14; Node 24.15.0 pinned throughout validation.
- Complete SQL package suite: 181 passed, 3 opt-in tests skipped, no failures.
- Real PostgreSQL 16 concurrency suite: 2 passed. Eight concurrent transactions converge; subsequent startups preserve constraint OIDs and row versions. Failed transactions roll back and can retry.
- Real PGlite upgrade suite: 2 passed. Legacy checks upgrade without deleting or fabricating rows; an incomplete schema remains untouched.
- Owning typecheck/lint and root `bun run verify`: 376/376 workspace tasks and all repository audits passed.
- Reviewed the resulting database constraints and rows through the real integration harnesses. Temporary PostgreSQL and PGlite databases were cleaned up.

<!-- evidence-head:c20ab4a4df2d0df79a96229e99c9f391e163e51b -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - database migration only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no renderer changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction changes.
<!-- evidence-row:backend-logs -->
- [x] PostgreSQL and PGlite execution results below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend execution changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real database row and constraint identity checks passed, including concurrent startup and restart.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text.

```text
PostgreSQL:
  serializes concurrent startups and makes every later startup a durable no-op
  2 passed, 0 failed
PGlite:
  replaces same-named legacy checks on restart without deleting or fabricating rows
  defers without mutation when either authority table is absent
  2 passed, 0 failed
Full package: 181 passed, 3 skipped, 0 failed
Root verify: 376 successful, 376 total; all repository audits passed
```

Fresh hosted checks must pass on the final head before merge.
