### PR TITLE
test(agent): cover index

### DIFF
--- a/packages/agent/src/actions/index.test.ts
+++ b/packages/agent/src/actions/index.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Verifies that the action barrel exposes the complete runtime surface of its
+ * source modules without wrapping or replacing any exported value.
+ */
+import { describe, expect, it } from "vitest";
+import * as connectAccount from "./connect-account.ts";
+import * as contact from "./contact.ts";
+import * as contextSignal from "./context-signal.ts";
+import * as contextSignalLexicon from "./context-signal-lexicon.ts";
+import * as database from "./database.ts";
+import * as extractParams from "./extract-params.ts";
+import * as groundedActionReply from "./grounded-action-reply.ts";
+import * as actionIndex from "./index.ts";
+import * as logs from "./logs.ts";
+import * as memories from "./memories.ts";
+import * as pageActionGroups from "./page-action-groups.ts";
+import * as plugin from "./plugin.ts";
+import * as recentConversationTexts from "./recent-conversation-texts.ts";
+import * as runtime from "./runtime.ts";
+import * as settingsActions from "./settings-actions.ts";
+import * as terminal from "./terminal.ts";
+import * as trigger from "./trigger.ts";
+
+const directExports = {
+  ...connectAccount,
+  ...contact,
+  ...contextSignal,
+  ...contextSignalLexicon,
+  ...database,
+  ...extractParams,
+  ...groundedActionReply,
+  ...logs,
+  ...memories,
+  ...pageActionGroups,
+  ...plugin,
+  ...recentConversationTexts,
+  ...runtime,
+  ...settingsActions,
+  ...terminal,
+  ...trigger,
+};
+
+describe("actions index", () => {
+  it("re-exports the complete runtime surface of every action module", () => {
+    expect(Object.keys(actionIndex).sort()).toEqual(
+      Object.keys(directExports).sort(),
+    );
+  });
+
+  it("preserves the identity of every re-exported value", () => {
+    for (const [name, value] of Object.entries(directExports)) {
+      expect(Reflect.get(actionIndex, name), name).toBe(value);
+    }
+  });
+});


### PR DESCRIPTION

## Summary

- add runtime coverage for the `packages/agent/src/actions/index.ts` barrel
- verify that its export surface exactly matches all 16 source action modules
- verify that every re-export preserves the original runtime value identity

## Validation

- `bunx vitest run packages/agent/src/actions/index.test.ts`: 1 test file passed, 2 tests passed
- `bunx biome check --write packages/agent/src/actions/index.test.ts`: 1 file checked, no fixes applied
- `cd packages/agent && bunx tsc --noEmit`: exited 1 with 44 pre-existing diagnostics; 0 diagnostics reference `index.test.ts` (`grep` exit 1)
- the diff adds only `packages/agent/src/actions/index.test.ts` (55 additions, 0 deletions)

This is a fork contribution, so hosted CI does not run on this pull request.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:eccbc2ddb25b067509184d09d43d5cece83ad723 -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
