### PR TITLE
test(agent): cover conversation-connection-readiness

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
@@ -8,6 +8,8 @@ import {
   assertConversationConnectionRuntime,
   captureConversationConnectionDescriptor,
   invalidateConversationConnectionTopology,
+  isConversationConnectionError,
+  prepareConversationConnectionRoom,
   scheduleConversationConnectionEnsure,
   serializeConversationConnectionRoomDeletion,
 } from "../conversation-connection-readiness.ts";
@@ -368,5 +370,78 @@ describe("conversation connection readiness", () => {
     ).toThrow(
       expect.objectContaining({ code: "CONVERSATION_RUNTIME_CHANGED" }),
     );
+  });
+
+  it("accepts exactly the mutation queue capacity and rejects overflow", async () => {
+    const runtime = createRuntime();
+    const firstGate = deferred();
+    const queued = Array.from({ length: 256 }, (_, index) =>
+      scheduleConversationConnectionEnsure(
+        captureDescriptor(runtime, { conversationId: `queued-${index}` }),
+        index === 0 ? async () => firstGate.promise : async () => {},
+      ),
+    );
+
+    await expect(
+      scheduleConversationConnectionEnsure(
+        captureDescriptor(runtime, { conversationId: "queue-overflow" }),
+        async () => {},
+      ),
+    ).rejects.toMatchObject({
+      code: "CONVERSATION_CONNECTION_QUEUE_SATURATED",
+    });
+
+    firstGate.resolve();
+    await Promise.all(queued);
+  });
+
+  it("prepares a recreated room with a fresh generation", () => {
+    const runtime = createRuntime();
+    const original = captureDescriptor(runtime);
+
+    prepareConversationConnectionRoom(runtime, original.roomId);
+
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, original),
+    ).toThrow(
+      expect.objectContaining({
+        code: "CONVERSATION_CONNECTION_INVALIDATED",
+      }),
+    );
+    const recreated = captureDescriptor(runtime);
+    expect(recreated.roomGeneration).not.toBe(original.roomGeneration);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, recreated),
+    ).not.toThrow();
+  });
+
+  it("classifies and preserves connection errors raised during an ensure", async () => {
+    const runtime = createRuntime();
+    const descriptor = captureDescriptor(runtime);
+    let runtimeChangeError: unknown;
+
+    try {
+      assertConversationConnectionRuntime(null, descriptor);
+    } catch (error) {
+      runtimeChangeError = error;
+    }
+
+    expect(isConversationConnectionError(runtimeChangeError)).toBe(true);
+    expect(isConversationConnectionError(new Error("ordinary failure"))).toBe(
+      false,
+    );
+    expect(
+      isConversationConnectionError({
+        code: "CONVERSATION_RUNTIME_CHANGED",
+      }),
+    ).toBe(false);
+    await expect(
+      scheduleConversationConnectionEnsure(descriptor, async () => {
+        throw runtimeChangeError;
+      }),
+    ).rejects.toBe(runtimeChangeError);
+    expect(() =>
+      assertConversationConnectionRuntime(runtime, descriptor),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION

## Summary

- Extend the existing conversation connection readiness unit suite with the exact 256-mutation queue boundary and overflow rejection.
- Cover explicit room preparation replacing the prior room generation.
- Cover classification and passthrough of a real connection error raised during reconciliation.
- Touch only `packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts`; production behavior is unchanged.

## Validation

- `bunx vitest run packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts` — 1 test file passed, 13 tests passed.
- `bunx biome check --write packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts` — checked 1 file, no fixes applied.
- `cd packages/agent && bunx tsc --noEmit` — reported 44 pre-existing diagnostics outside this test; grepping the captured output for `conversation-connection-readiness.test.ts` returned `EXIT:1`, confirming zero diagnostics from the changed file.
- Diff scope: one test file, +75/−0.

Hosted CI does not run for this fork contribution; the local commands above are the available validation evidence.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:212760f0e4d914a1d83db750a6fc5058c0f8e21d -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
