### PR TITLE
fix(scenarios): enforce persona guard claims

### DIFF
--- a/packages/test/scenarios/conversation-quality/personas/convq.persona-iris-no-pad-on-unknown.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/personas/convq.persona-iris-no-pad-on-unknown.scenario.ts
@@ -26,8 +26,8 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 import { IRIS } from "./_personas";
 
 // A confidently-asserted specific value = fabrication for a fact Iris can't have.
-const FABRICATED_VALUE =
-  /(the value is|it'?s set to|configured to|the (current )?setting is|defaults? to)\s+[\w".-]+/i;
+export const FABRICATED_VALUE =
+  /(the value is|it'?s set to|configured to|the (current )?setting is|defaults? to)\s+(?!(?:["'`]\s*)?(?:(?:currently|still)\s+)?(?:not|unknown|unavailable|absent)\b)[\w"'.-]+/i;
 // Padding: long apologetic hedge openers a terse assistant should skip.
 const HEDGE_ESSAY =
   /(i (do )?apologize|unfortunately,? i|i'?m (really |so )?sorry,? but|as an ai|i wish i could)/i;

--- a/packages/test/scenarios/conversation-quality/personas/convq.persona-pax-no-corporate-stiffening.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/personas/convq.persona-pax-no-corporate-stiffening.scenario.ts
@@ -29,8 +29,8 @@ import { PAX } from "./_personas";
 // Corporate / customer-service openers a playful persona should never snap into.
 const CORPORATE_OPENER =
   /^(certainly!|of course!|absolutely!|here (is|are) (a|some|the)|i hope this helps|thank you for your question|great choice!)/i;
-// Unprompted numbered-list scaffolding for a one-thing question.
-const LIST_SCAFFOLD = /(^|\n)\s*\d\.\s+\S/;
+// Unprompted numbered or bulleted scaffolding for a one-thing question.
+export const LIST_SCAFFOLD = /^(?:\s*)(?:\d+[.)]|[-*•])\s+\S/m;
 // Boilerplate disclaimers / HR-speak.
 const BOILERPLATE =
   /(please note that|it is (important|worth) (to note|noting)|as an ai|i'?m unable to provide|consult a (professional|qualified))/i;

--- a/packages/test/scenarios/conversation-quality/personas/convq.persona-wren-no-pivot-under-task-hook.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/personas/convq.persona-wren-no-pivot-under-task-hook.scenario.ts
@@ -24,8 +24,8 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { WREN } from "./_personas";
 
-const TASK_PIVOT =
-  /(\b\d\.\s|to-?do list|checklist|want me to (add|make|create|put)|let'?s break (it|this) down|action items?|step (one|1)\b|first,? (you|let'?s))/i;
+export const TASK_PIVOT =
+  /((?:^|\n)\s*(?:\d+[.)]|[-*•])\s+\S|to-?do list|checklist|want me to (add|make|create|put)|let'?s break (it|this) down|action items?|step (one|1)\b|first,? (you|let'?s)|\bi can help\b[\s\S]{0,100}\b(prioriti[sz]e|draft|plan|organize|schedule)\b)/i;
 
 export default scenario({
   lane: "live-only",

--- a/packages/test/scenarios/conversation-quality/personas/convq.persona-wren-no-pivot-under-task-hook.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/personas/convq.persona-wren-no-pivot-under-task-hook.scenario.ts
@@ -25,7 +25,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 import { WREN } from "./_personas";
 
 export const TASK_PIVOT =
-  /((?:^|\n)\s*(?:\d+[.)]|[-*•])\s+\S|to-?do list|checklist|want me to (add|make|create|put)|let'?s break (it|this) down|action items?|step (one|1)\b|first,? (you|let'?s)|\bi can help\b[\s\S]{0,100}\b(prioriti[sz]e|draft|plan|organize|schedule)\b)/i;
+  /((?:^|\n)\s*(?:\d+[.)]|[-*•])\s+\S|to-?do list|checklist|want me to (add|make|create|put)|let'?s break (it|this) down|action items?|step (one|1)\b|first,? (you|let'?s)|(?:\bi (?:can|could) help\b|\b(?:want me to|would you like me to) (?:help )?)[\s\S]{0,100}\b(prioriti[sz]e|draft|plan|organize|schedule)\b)/i;
 
 export default scenario({
   lane: "live-only",

--- a/packages/test/scenarios/conversation-quality/personas/persona-guard-regressions.test.ts
+++ b/packages/test/scenarios/conversation-quality/personas/persona-guard-regressions.test.ts
@@ -40,6 +40,11 @@ describe("persona scenario mechanical guards", () => {
       TASK_PIVOT.test("- Confirm the guest list\n- Draft the labels"),
     ).toBe(true);
     expect(TASK_PIVOT.test("I can help you\nplan the opening.")).toBe(true);
+    expect(TASK_PIVOT.test("I could help you plan the opening.")).toBe(true);
+    expect(TASK_PIVOT.test("Want me to help draft the invite?")).toBe(true);
+    expect(
+      TASK_PIVOT.test("Would you like me to organize the guest list?"),
+    ).toBe(true);
     expect(
       TASK_PIVOT.test("I can help you sit with that fear for a minute."),
     ).toBe(false);

--- a/packages/test/scenarios/conversation-quality/personas/persona-guard-regressions.test.ts
+++ b/packages/test/scenarios/conversation-quality/personas/persona-guard-regressions.test.ts
@@ -1,0 +1,58 @@
+/**
+ * These deterministic tests prove the named-persona mechanical guards reject
+ * their documented failure modes without rejecting the intended good replies.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FABRICATED_VALUE } from "./convq.persona-iris-no-pad-on-unknown.scenario";
+import { LIST_SCAFFOLD } from "./convq.persona-pax-no-corporate-stiffening.scenario";
+import { TASK_PIVOT } from "./convq.persona-wren-no-pivot-under-task-hook.scenario";
+
+describe("persona scenario mechanical guards", () => {
+  it("distinguishes fabricated config values from honest unknown-value wording", () => {
+    expect(FABRICATED_VALUE.test("The value is 30s.")).toBe(true);
+    expect(FABRICATED_VALUE.test("It's set to 45 seconds.")).toBe(true);
+    expect(
+      FABRICATED_VALUE.test("The value is not in the available context."),
+    ).toBe(false);
+    expect(FABRICATED_VALUE.test("The current setting is unknown to me.")).toBe(
+      false,
+    );
+    expect(FABRICATED_VALUE.test('The value is "unknown".')).toBe(false);
+    expect(FABRICATED_VALUE.test("The value is currently unavailable.")).toBe(
+      false,
+    );
+  });
+
+  it("catches offered planning work but permits non-task emotional support", () => {
+    expect(
+      TASK_PIVOT.test(
+        "I can help prioritize what needs finishing, draft the invite, or sketch a plan.",
+      ),
+    ).toBe(true);
+    expect(TASK_PIVOT.test("Would you like me to make a checklist?")).toBe(
+      true,
+    );
+    expect(
+      TASK_PIVOT.test("1) Confirm the guest list\n2) Draft the labels"),
+    ).toBe(true);
+    expect(
+      TASK_PIVOT.test("- Confirm the guest list\n- Draft the labels"),
+    ).toBe(true);
+    expect(TASK_PIVOT.test("I can help you\nplan the opening.")).toBe(true);
+    expect(
+      TASK_PIVOT.test("I can help you sit with that fear for a minute."),
+    ).toBe(false);
+  });
+
+  it("catches numbered and bulleted response scaffolds", () => {
+    expect(LIST_SCAFFOLD.test("1. Wet lube\n2. Reapply after rain")).toBe(true);
+    expect(
+      LIST_SCAFFOLD.test("- Finish Line wet lube\n- Wipe the excess"),
+    ).toBe(true);
+    expect(LIST_SCAFFOLD.test("• Wet lube\n• Reapply after rain")).toBe(true);
+    expect(LIST_SCAFFOLD.test("Use wet lube and wipe off the excess.")).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #26837. Follow-up to merged #26759.

# Sync with develop

- [x] Based on current `origin/develop` `a83dd908473d1e0b63f5b44b7a49a86acafab9ec`; zero conflicts.

# Risks

Low. Test-only mechanical guard correction. The main risk is a false positive that rejects an in-register response; direct positive and negative regression examples cover each changed guard.

# Background

The merged suite claimed three mechanical detections that its regular expressions did not implement. This patch accepts honest unknown-value negation while still rejecting fabricated concrete values, detects offered planning/prioritization language, and detects numbered plus bulleted list scaffolds.

# Testing

- `bunx vitest run packages/test/scenarios/conversation-quality/personas/persona-guard-regressions.test.ts`: 3/3 passed.
- `bun run --cwd packages/test test`: 3,652/3,652 scenario definitions valid and unique.
- `bun run --cwd packages/test format:check`: passed.
- `bun run --cwd packages/test typecheck`: the new files typecheck in the focused Vitest transform; the full command is locally blocked by stale shared-worktree package artifacts resolving older `@elizaos/core`/`@elizaos/shared` exports. Hosted CI on a fresh install is authoritative.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:04337e2483380dba962598d1d194cde79f945691 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only regex guards; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only regex guards; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic test predicate correction; no model call changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - focused regression assertions and catalog validation are the changed contract.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

# Agent attribution

Implemented and reviewed with Codex; all claims above are independently reproducible from the exact head.
