### PR TITLE
fix(ui): catalog OTP recovery copy

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8470,6 +8470,8 @@
   "cloud.login.loadingOptions.aria": "Loading sign-in options",
   "cloud.login.metaTitle": "Sign In | Eliza",
   "cloud.login.otp.createPasskey": "Create passkey",
+  "cloud.login.otp.recoveryLabel": "Other passkey options",
+  "cloud.login.otp.recoveryMessage": "Already saved this passkey? Sign in with it, or use a Magic Link.",
   "cloud.login.otp.resend": "Resend code",
   "cloud.login.otp.subtitle": "Enter the 6-digit code we sent to",
   "cloud.login.otp.title": "Set up your passkey",

--- a/packages/ui/src/i18n/messages.test.ts
+++ b/packages/ui/src/i18n/messages.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit coverage asserting the startup-shell keys exist across the loaded
- * language catalogs. Pure data, no runtime.
+ * Unit coverage asserting required interface copy exists in the canonical
+ * English catalog and startup-shell keys exist across all loaded catalogs.
  */
 import { describe, expect, it } from "vitest";
 import englishMessages from "./locales/en.json" with { type: "json" };
@@ -26,7 +26,17 @@ const PERMISSION_PRIMING_RECOVERY_MESSAGES = {
     "Couldn’t open Settings. Open System Settings manually, then re-check.",
 } as const;
 
+const PASSKEY_ENROLLMENT_RECOVERY_MESSAGES = {
+  "cloud.login.otp.recoveryLabel": "Other passkey options",
+  "cloud.login.otp.recoveryMessage":
+    "Already saved this passkey? Sign in with it, or use a Magic Link.",
+} as const;
+
 describe("i18n messages", () => {
+  it("keeps passkey enrollment recovery copy in the English locale", () => {
+    expect(englishMessages).toMatchObject(PASSKEY_ENROLLMENT_RECOVERY_MESSAGES);
+  });
+
   it("keeps permission recovery copy in the English locale", () => {
     expect(englishMessages).toMatchObject(PERMISSION_PRIMING_RECOVERY_MESSAGES);
   });


### PR DESCRIPTION
# Relates to

Closes #26836

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the unrelated root verification failure is recorded below.
- [x] A reviewer can confirm the catalog contract through the focused test and `check:i18n` results below.

# Sync with develop

- [x] Rebased onto `aec34df6fa4237c474fbadbcbb0458cabf19226f`; zero conflicts.
- [x] `bun run verify` passes `check:i18n` and reaches the repository Turbo lane; the unrelated blocker is documented below.

# Risks

Low. This adds two English source-catalog entries that exactly match the existing call-site defaults and adds a catalog-only regression assertion. No rendered markup, behavior, or non-English translation changes.

# Background

## What does this PR do?

- Catalogs `cloud.login.otp.recoveryLabel` as `Other passkey options`.
- Catalogs `cloud.login.otp.recoveryMessage` as `Already saved this passkey? Sign in with it, or use a Magic Link.`
- Pins both strings in focused English-catalog coverage so the accessible recovery section cannot drift uncataloged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this repairs the canonical source catalog.

# Testing

## Where should a reviewer start?

Review `packages/ui/src/i18n/locales/en.json` and `packages/ui/src/i18n/messages.test.ts`.

## Detailed testing steps

- `bun run check:i18n` — pass (non-English fallback summaries are warnings).
- `bun run --cwd packages/ui test src/i18n/messages.test.ts` — pass, 3 tests.
- `bun run --cwd packages/ui typecheck` — pass.
- `bun run --cwd packages/ui lint:check` — pass with 9 pre-existing warnings outside the touched files.
- `bunx @biomejs/biome check packages/ui/src/i18n/messages.test.ts packages/ui/src/i18n/locales/en.json` — pass.
- `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:438d09909ddf5e9d15e503b64739576fa2f47ed8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - source-catalog and data-test change only; no rendered layout or styling changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - source-catalog and data-test change only; existing English call-site defaults are preserved exactly.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interaction or runtime behavior changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no request, response, or frontend state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI file changed; the canonical catalog values exactly match the existing English defaults.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

N/A - catalog-only change with no network or backend path.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI, layout, behavior, or styling changed.

## Audio / voice walkthrough

N/A - no audio or voice path changed.

## Known gaps / failures

`bun run verify` passes `check:i18n` and progresses through 213 of 215 Turbo tasks, then fails in unrelated existing cloud shared test typing consumed by `@elizaos/cloud-api#typecheck`:

- `packages/cloud/shared/src/db/database-url.test.ts:154`
- `packages/cloud/shared/src/db/database-url.test.ts:160`
- `packages/cloud/shared/src/db/database-url.test.ts:172`

Each reports `TS2339: Property 'DATABASE_URL' does not exist on type '{ NODE_ENV: string; }'`. The failing file is outside this PR's diff.

## Maintainer CI exception record

N/A - no exception requested.
