### PR TITLE
fix(auth): require structured passkey recovery code

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
@@ -9,8 +9,12 @@
 import { StewardApiError, StewardAuth } from "@stwd/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-function jsonResponse(status: number, error: string): Response {
-  return new Response(JSON.stringify({ ok: false, error }), {
+function jsonResponse(
+  status: number,
+  error: string,
+  details: Record<string, unknown> = {},
+): Response {
+  return new Response(JSON.stringify({ ok: false, error, ...details }), {
     status,
     headers: { "Content-Type": "application/json" },
   });
@@ -142,6 +146,34 @@ describe("StewardAuth passkey ceremony boundaries", () => {
     ).rejects.toMatchObject({
       status: 500,
       message: "Passkey service unavailable",
+    });
+    expect(recorder.callCount()).toBe(1);
+  });
+
+  it("preserves structured registration errors through the real SDK", async () => {
+    const recorder = recordFetch([
+      jsonResponse(
+        409,
+        "A passkey already exists for this email. Sign in with it instead.",
+        { code: "passkey_already_registered" },
+      ),
+    ]);
+    vi.stubGlobal("fetch", recorder.fetch);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+
+    const error = await auth
+      .addPasskey("person@example.com", { emailGrant: "email-grant" })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(StewardApiError);
+    expect(error).toMatchObject({
+      status: 409,
+      data: {
+        ok: false,
+        error:
+          "A passkey already exists for this email. Sign in with it instead.",
+        code: "passkey_already_registered",
+      },
     });
     expect(recorder.callCount()).toBe(1);
   });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -70,10 +70,12 @@ vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
 vi.mock("@stwd/sdk", () => ({
   StewardApiError: class StewardApiError extends Error {
     status: number;
-    constructor(message: string, status: number) {
+    data: unknown;
+    constructor(message: string, status: number, data?: unknown) {
       super(message);
       this.name = "StewardApiError";
       this.status = status;
+      this.data = data;
     }
   },
   StewardAuth: class {
@@ -660,6 +662,12 @@ describe("StewardLoginSection passkey capability gating", () => {
       new StewardApiError(
         "A passkey already exists for this email. Sign in with it instead.",
         409,
+        {
+          ok: false,
+          error:
+            "A passkey already exists for this email. Sign in with it instead.",
+          code: "passkey_already_registered",
+        },
       ),
     ],
     [
@@ -707,6 +715,38 @@ describe("StewardLoginSection passkey capability gating", () => {
       ).toBeNull();
     },
   );
+
+  it("does not treat an untyped server conflict as an existing passkey", async () => {
+    capabilityRef.usable = true;
+    capabilityRef.reason = "available";
+    stewardAuthSpies.verifyEmailOtp.mockResolvedValue({
+      emailGrant: "grant-conflict",
+    });
+    stewardAuthSpies.addPasskey.mockRejectedValue(
+      new StewardApiError(
+        "A passkey already exists for this email. Sign in with it instead.",
+        409,
+      ),
+    );
+
+    renderSection();
+
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: "person@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+
+    const codeInput = await screen.findByPlaceholderText("123456");
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Create passkey/i }));
+
+    expect(
+      await screen.findByText(
+        "A passkey already exists for this email. Sign in with it instead.",
+      ),
+    ).toBeTruthy();
+    expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
+    expect(stewardAuthSpies.addPasskey).toHaveBeenCalledTimes(1);
+  });
 
   it("clears the cached email grant when the user resends the OTP", async () => {
     capabilityRef.usable = true;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1214,14 +1214,16 @@ export default function StewardLoginSection() {
 
   function isPasskeyAlreadyRegistered(e: unknown): boolean {
     const msg = getErrorMessage(e, "").toLowerCase();
-    if (
-      e instanceof StewardApiError &&
-      e.status === 409 &&
-      (msg.includes("passkey already") ||
-        msg.includes("credential already") ||
-        msg.includes("already registered"))
-    ) {
-      return true;
+    if (e instanceof StewardApiError && e.status === 409) {
+      const data = e.data;
+      if (
+        typeof data === "object" &&
+        data !== null &&
+        "code" in data &&
+        data.code === "passkey_already_registered"
+      ) {
+        return true;
+      }
     }
     if (!isBrowserOwnedWebAuthnFailure(e, msg)) return false;
     return (

--- a/patches/@stwd%2Fsdk@0.11.0.patch
+++ b/patches/@stwd%2Fsdk@0.11.0.patch
@@ -1,6 +1,8 @@
+diff --git a/dist/auth.d.ts b/dist/auth.d.ts
+index 5555cf294d4b123575e30f35c18d23f9055c8c07..cecb720957d99e4425d7e318e420d4d2403c9a46 100644
 --- a/dist/auth.d.ts
 +++ b/dist/auth.d.ts
-@@ -109,7 +109,9 @@
+@@ -109,7 +109,9 @@ export declare class StewardAuth {
       * Requires a browser environment and `@simplewebauthn/browser` installed.
       * Throws `StewardApiError` in Node or when the dependency is missing.
       */
@@ -11,9 +13,20 @@
      /**
       * Register a new passkey for the given email, regardless of whether the
       * user already has other passkeys on other relying parties (RPs).
+diff --git a/dist/auth.js b/dist/auth.js
+index 50f91554ab7333b11689341f6be543bd3fa68090..96e3e11036e82ef3340e05b8efefd52d21feaeaf 100644
 --- a/dist/auth.js
 +++ b/dist/auth.js
-@@ -540,7 +540,7 @@
+@@ -191,7 +191,7 @@ async function authRequest(baseUrl, path, init = {}, token) {
+         const errMsg = typeof payload.error === "string"
+             ? payload.error
+             : `Request failed with status ${response.status}`;
+-        return { ok: false, status: response.status, error: errMsg };
++        return { ok: false, status: response.status, error: errMsg, data: payload };
+     }
+     return { ok: true, status: response.status, data: payload };
+ }
+@@ -540,7 +540,7 @@ export class StewardAuth {
       * Requires a browser environment and `@simplewebauthn/browser` installed.
       * Throws `StewardApiError` in Node or when the dependency is missing.
       */
@@ -22,7 +35,7 @@
          if (!isBrowser()) {
              throw new StewardApiError("Passkeys require a browser environment. Use signInWithEmail or signInWithSIWE in Node.", 0);
          }
-@@ -564,8 +564,9 @@
+@@ -564,8 +564,9 @@ export class StewardAuth {
              // User exists with passkeys — run authentication flow
              return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
          }
@@ -34,7 +47,7 @@
              return this.completePasskeyRegister(email, browserLib);
          }
          throw new StewardApiError(loginOptsRes.error, loginOptsRes.status);
-@@ -609,7 +610,7 @@
+@@ -609,7 +610,7 @@ export class StewardAuth {
          let authResponse;
          try {
              // Server-provided options; types are validated by the WebAuthn browser library.
@@ -43,7 +56,13 @@
          }
          catch (err) {
              throw new StewardApiError(`WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`, 0);
-@@ -648,7 +649,7 @@
+@@ -643,12 +644,12 @@ export class StewardAuth {
+             }),
+         });
+         if (!regOptsRes.ok) {
+-            throw new StewardApiError(regOptsRes.error, regOptsRes.status);
++            throw new StewardApiError(regOptsRes.error, regOptsRes.status, regOptsRes.data);
+         }
          let regResponse;
          try {
              // Server-provided options; types are validated by the WebAuthn browser library.
@@ -52,7 +71,16 @@
          }
          catch (err) {
              throw new StewardApiError(`WebAuthn registration cancelled or failed: ${err instanceof Error ? err.message : String(err)}`, 0);
-@@ -1092,7 +1093,7 @@
+@@ -663,7 +664,7 @@ export class StewardAuth {
+             }),
+         });
+         if (!verifyRes.ok) {
+-            throw new StewardApiError(verifyRes.error, verifyRes.status);
++            throw new StewardApiError(verifyRes.error, verifyRes.status, verifyRes.data);
+         }
+         return this.storeExchangeResponse(verifyRes.data);
+     }
+@@ -1092,7 +1093,7 @@ export class StewardAuth {
          }
          let authResponse;
          try {
@@ -61,9 +89,11 @@
          }
          catch (err) {
              throw new StewardApiError(`WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`, 0);
+diff --git a/dist/client.d.ts b/dist/client.d.ts
+index d3ce2d1a0490833f09470cec693cef155dba259d..f41bb345dad3f3083dbc191f80c2ac29328651b7 100644
 --- a/dist/client.d.ts
 +++ b/dist/client.d.ts
-@@ -1421,5 +1421,15 @@
+@@ -1421,6 +1421,16 @@ export declare class StewardClient {
      revokeTenantRequestSigningKey(tenantId: string, keyId: string): Promise<TenantRequestSigningKey>;
      /** Get the aggregated dashboard for an agent (balance, spend, policies, recent tx, pending approvals). */
      getAgentDashboard(agentId: string): Promise<AgentDashboardResponse>;
@@ -79,12 +109,15 @@
 +    }>>;
      /** Get on-chain and realtime spend accounting for an agent. */
      getAgentSpend(agentId: string): Promise<AgentSpendSummary>;
+     /** Get the aggregated digital asset account for an agent. */
+diff --git a/dist/client.js b/dist/client.js
+index 9381d508632049ed24e8bbf0530ec8d68bca61b4..da03dda10271d5d00cdbde1f4657ffb27a5b70db 100644
 --- a/dist/client.js
 +++ b/dist/client.js
-@@ -2032,6 +2032,26 @@
-             throw new StewardApiError(response.error, response.status, response.data);
+@@ -2032,6 +2032,26 @@ export class StewardClient {
          return response.data;
      }
+     /** Get on-chain and realtime spend accounting for an agent. */
 +    /** List the agent-scoped pending approval page. */
 +    async listPendingApprovals(agentId, opts = {}) {
 +        const params = new URLSearchParams();
@@ -105,6 +138,6 @@
 +            throw new StewardApiError("Steward pending approvals response is invalid", 502, response.data);
 +        return response.data.approvals;
 +    }
-     /** Get on-chain and realtime spend accounting for an agent. */
      async getAgentSpend(agentId) {
          const response = await this.request(`/agents/${encodeURIComponent(agentId)}/spend`);
+         if (!response.ok)


### PR DESCRIPTION
## Summary

- require Steward's stable `passkey_already_registered` response code before entering existing-passkey recovery
- preserve browser-owned WebAuthn duplicate handling
- prove a misleading untyped HTTP 409 cannot trigger authentication

Closes #26842.

## Verification

- Exact head: `ec3de4a12b34b75d48cfc214f5575db7d28f9c04`
- `bunx biome check packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx`
- `bunx vitest run packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx` — 23 passed

## Evidence

This is a state-machine correction with no visual change. The protected static smoke and app audit are being completed on this exact head before merge.

<!-- evidence-head: ec3de4a12b34b75d48cfc214f5575db7d28f9c04 -->