### PR TITLE
test(agent): cover server helpers mcp configuration validation

### DIFF
--- a/packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts
+++ b/packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for MCP server configuration validation and terminal authorization helpers.
+ * Exercises blocked key filtering, stdio detection, and terminal auth resolution.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mcpServersIncludeStdio,
+  resolveMcpServersRejection,
+  resolveMcpTerminalAuthorizationRejection,
+} from "../server-helpers-mcp.ts";
+
+describe("server-helpers-mcp", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe("mcpServersIncludeStdio", () => {
+    it("returns false for empty servers map", () => {
+      expect(mcpServersIncludeStdio({})).toBe(false);
+    });
+
+    it("returns false for non-stdio server configurations", () => {
+      const servers = {
+        weather: { type: "sse", url: "https://api.example.com/sse" },
+        search: { type: "http", url: "https://api.example.com/mcp" },
+      };
+      expect(mcpServersIncludeStdio(servers)).toBe(false);
+    });
+
+    it("returns true when at least one server is stdio", () => {
+      const servers = {
+        remote: { type: "sse", url: "https://api.example.com/sse" },
+        localGit: { type: "stdio", command: "git-mcp", args: [] },
+      };
+      expect(mcpServersIncludeStdio(servers)).toBe(true);
+    });
+
+    it("safely ignores non-object or invalid configs", () => {
+      const servers = {
+        invalid1: null,
+        invalid2: "string-config",
+        invalid3: ["array", "config"],
+      };
+      expect(mcpServersIncludeStdio(servers)).toBe(false);
+    });
+  });
+
+  describe("resolveMcpServersRejection", () => {
+    it("rejects blocked server names", async () => {
+      const rejection = await resolveMcpServersRejection({
+        __proto__: { type: "sse", url: "https://example.com" },
+        constructor: { type: "sse", url: "https://example.com" },
+      });
+      expect(rejection).toMatch(/Invalid server name/);
+    });
+
+    it("rejects non-object server configs", async () => {
+      const rejection = await resolveMcpServersRejection({
+        invalidServer: "not-an-object",
+      });
+      expect(rejection).toBe(
+        'Server "invalidServer" config must be a JSON object',
+      );
+    });
+
+    it("rejects array server configs", async () => {
+      const rejection = await resolveMcpServersRejection({
+        invalidArray: [{ type: "stdio" }],
+      });
+      expect(rejection).toBe(
+        'Server "invalidArray" config must be a JSON object',
+      );
+    });
+
+    it("rejects configs with blocked keys deep", async () => {
+      const serverPayload = JSON.parse(
+        '{"badServer": {"type": "sse", "url": "https://example.com", "__proto__": {"polluted": true}}}',
+      );
+      const rejection = await resolveMcpServersRejection(serverPayload);
+      expect(rejection).toBe('Server "badServer" contains blocked object keys');
+    });
+
+    it("returns null for valid server configs", async () => {
+      const rejection = await resolveMcpServersRejection({
+        github: {
+          type: "sse",
+          url: "https://api.github.com/mcp",
+        },
+      });
+      expect(rejection).toBeNull();
+    });
+  });
+
+  describe("resolveMcpTerminalAuthorizationRejection", () => {
+    it("returns null if servers do not include stdio", () => {
+      const req = { headers: {} };
+      const servers = {
+        sseServer: { type: "sse", url: "https://example.com" },
+      };
+      const result = resolveMcpTerminalAuthorizationRejection(req, servers, {});
+      expect(result).toBeNull();
+    });
+
+    it("rejects with 403 when stdio is configured without terminal token or dev override", () => {
+      delete process.env.ELIZA_TERMINAL_RUN_TOKEN;
+      delete process.env.ELIZA_ALLOW_UNAUTHENTICATED_STDIO_MCP;
+
+      const req = { headers: {} };
+      const servers = {
+        localTool: { type: "stdio", command: "node", args: ["tool.js"] },
+      };
+      const result = resolveMcpTerminalAuthorizationRejection(req, servers, {});
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
+      expect(result?.reason).toContain("ELIZA_TERMINAL_RUN_TOKEN");
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for MCP server configuration validation and terminal authorization helpers with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `resolveMcpServersRejection`, `mcpServersIncludeStdio`, and `resolveMcpTerminalAuthorizationRejection` helpers in `@elizaos/agent`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts`

## Detailed testing steps
Run:
```bash
node packages/scripts/run-vitest.mjs run packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1b3b834304eebf06385b7d4f559b0e95eeba4d79 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
node packages/scripts/run-vitest.mjs run packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/.worktrees/wt-ship

 ✓ packages/agent/src/api/__tests__/server-helpers-mcp-suite.test.ts (11 tests) 9ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:27:46
   Duration  3.38s (transform 2.63s, setup 0ms, import 3.31s, tests 9ms, environment 0ms)
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
