### PR TITLE
test(core): cover browser streaming context manager

### DIFF
--- a/packages/core/src/__tests__/streaming-context-browser-suite.test.ts
+++ b/packages/core/src/__tests__/streaming-context-browser-suite.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for browser streaming context manager.
+ * Exercises stack-based context propagation, active context isolation, and nested scopes.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	createBrowserStreamingContextManager,
+	StackContextManager,
+	type StreamingContext,
+} from "../streaming-context.browser.ts";
+
+describe("streaming-context.browser", () => {
+	describe("createBrowserStreamingContextManager", () => {
+		it("creates an instance of StackContextManager", () => {
+			const manager = createBrowserStreamingContextManager();
+			expect(manager).toBeInstanceOf(StackContextManager);
+		});
+	});
+
+	describe("StackContextManager", () => {
+		it("returns undefined when no context is active", () => {
+			const manager = new StackContextManager();
+			expect(manager.active()).toBeUndefined();
+		});
+
+		it("binds active context during run execution and restores prior context", () => {
+			const manager = new StackContextManager();
+			const contextA: StreamingContext = {
+				runtimeId: "agent-1",
+				messageId: "msg-100",
+				roomId: "room-abc",
+			};
+
+			const result = manager.run(contextA, () => {
+				expect(manager.active()).toEqual(contextA);
+				return "completed-a";
+			});
+
+			expect(result).toBe("completed-a");
+			expect(manager.active()).toBeUndefined();
+		});
+
+		it("supports nested context stacks cleanly", () => {
+			const manager = new StackContextManager();
+			const outerCtx: StreamingContext = {
+				runtimeId: "outer-agent",
+				messageId: "outer-msg",
+				roomId: "outer-room",
+			};
+			const innerCtx: StreamingContext = {
+				runtimeId: "inner-agent",
+				messageId: "inner-msg",
+				roomId: "inner-room",
+			};
+
+			manager.run(outerCtx, () => {
+				expect(manager.active()).toEqual(outerCtx);
+				manager.run(innerCtx, () => {
+					expect(manager.active()).toEqual(innerCtx);
+				});
+				expect(manager.active()).toEqual(outerCtx);
+			});
+
+			expect(manager.active()).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for browser streaming context manager with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `createBrowserStreamingContextManager` and `StackContextManager` in `@elizaos/core`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/core/src/__tests__/streaming-context-browser-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/core/src/__tests__/streaming-context-browser-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f3ace0fa2adcc90b5b174eb408dd0669fb34d280 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/core/src/__tests__/streaming-context-browser-suite.test.ts
bun test v1.3.11 (af24e281)

packages/core/src/__tests__/streaming-context-browser-suite.test.ts:
(pass) streaming-context.browser > createBrowserStreamingContextManager > creates an instance of StackContextManager [0.38ms]
(pass) streaming-context.browser > StackContextManager > returns undefined when no context is active [0.11ms]
(pass) streaming-context.browser > StackContextManager > binds active context during run execution and restores prior context [0.05ms]
(pass) streaming-context.browser > StackContextManager > supports nested context stacks cleanly
--------------------------------------------------|---------|---------|-------------------
File                                              | % Funcs | % Lines | Uncovered Line #s
--------------------------------------------------|---------|---------|-------------------
All files                                         |   58.33 |  100.00 |
 packages/core/src/streaming-context.browser.ts   |   50.00 |  100.00 | 
 packages/core/src/utils/stack-context-manager.ts |   66.67 |  100.00 | 
--------------------------------------------------|---------|---------|-------------------

 4 pass
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [99.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
