### PR TITLE
[cloud] Isolate app analytics sessions by visitor

### DIFF
--- a/packages/cloud/shared/src/lib/services/app-analytics.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.test.ts
@@ -142,6 +142,34 @@ describe("AppAnalyticsService.buildSessionAnalytics", () => {
     expect(analytics.funnel.steps[2]?.conversionFromPreviousPercent).toBe(50);
   });
 
+  test("keeps visitors separate when they reuse the same session id", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics(
+      [
+        request("00000000-0000-4000-8000-000000000037", "2026-07-02T12:00:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "shared-session",
+          page_url: "/",
+        }),
+        request("00000000-0000-4000-8000-000000000038", "2026-07-02T12:01:00Z", {
+          visitor_id: "visitor-b",
+          session_id: "shared-session",
+          page_url: "/checkout",
+        }),
+      ],
+      ["/", "/checkout"],
+    );
+
+    expect(analytics.summary.totalSessions).toBe(2);
+    expect(analytics.summary.uniqueVisitors).toBe(2);
+    expect(analytics.summary.bounceRatePercent).toBe(100);
+    expect(analytics.sessions.map((session) => session.visitorId).sort()).toEqual([
+      "visitor-a",
+      "visitor-b",
+    ]);
+    expect(analytics.funnel.steps.map((step) => step.sessions)).toEqual([1, 0]);
+  });
+
   test("splits legacy fallback sessions at the hour-bucket window boundary", () => {
     const service = new AppAnalyticsService();
     const analytics = service.buildSessionAnalytics([

--- a/packages/cloud/shared/src/lib/services/app-analytics.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.ts
@@ -51,6 +51,13 @@ type AppAnalyticsRepository = Pick<
   "findById" | "getRecentRequests" | "incrementUsage" | "trackAppUserActivity"
 >;
 
+interface AggregatedSession {
+  aggregationKey: string;
+  sessionId: string;
+  visitorId: string;
+  pages: Array<{ path: string; at: Date }>;
+}
+
 function metadataString(
   metadata: Record<string, unknown> | null | undefined,
   key: string,
@@ -208,14 +215,7 @@ export class AppAnalyticsService {
     const ordered = validRequests
       .slice()
       .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
-    const sessions = new Map<
-      string,
-      {
-        sessionId: string;
-        visitorId: string;
-        pages: Array<{ path: string; at: Date }>;
-      }
-    >();
+    const sessions = new Map<string, AggregatedSession>();
 
     for (const request of ordered) {
       const metadata = request.metadata;
@@ -227,22 +227,20 @@ export class AppAnalyticsService {
       const sessionId =
         metadataString(metadata, "session_id") ??
         `${visitorId}:${request.created_at.toISOString().slice(0, 13)}`;
+      const aggregationKey = JSON.stringify([visitorId, sessionId]);
       const path = normalizePath(
         metadataString(metadata, "pathname") ?? metadataString(metadata, "page_url"),
       );
       const existing =
-        sessions.get(sessionId) ??
+        sessions.get(aggregationKey) ??
         ({
+          aggregationKey,
           sessionId,
           visitorId,
           pages: [],
-        } satisfies {
-          sessionId: string;
-          visitorId: string;
-          pages: Array<{ path: string; at: Date }>;
-        });
+        } satisfies AggregatedSession);
       existing.pages.push({ path, at: request.created_at });
-      sessions.set(sessionId, existing);
+      sessions.set(aggregationKey, existing);
     }
 
     const sessionRows = [...sessions.values()]
@@ -314,15 +312,11 @@ export class AppAnalyticsService {
   }
 
   private buildFunnel(
-    sessions: Array<{
-      sessionId: string;
-      visitorId: string;
-      pages: Array<{ path: string; at: Date }>;
-    }>,
+    sessions: AggregatedSession[],
     steps: string[],
   ): AppSessionAnalytics["funnel"] {
     let previousSessions: Map<string, number> = new Map(
-      sessions.map((session) => [session.sessionId, -1] as const),
+      sessions.map((session) => [session.aggregationKey, -1] as const),
     );
     const startCount = previousSessions.size;
     const stepRows: AppFunnelStep[] = [];
@@ -331,13 +325,13 @@ export class AppAnalyticsService {
       const matchedSessions = new Map<string, number>();
       const matchedVisitors = new Set<string>();
       for (const session of sessions) {
-        const previousIndex = previousSessions.get(session.sessionId);
+        const previousIndex = previousSessions.get(session.aggregationKey);
         if (previousIndex === undefined) continue;
         const matchedIndex = session.pages.findIndex(
           (page, index) => index > previousIndex && page.path === step,
         );
         if (matchedIndex >= 0) {
-          matchedSessions.set(session.sessionId, matchedIndex);
+          matchedSessions.set(session.aggregationKey, matchedIndex);
           matchedVisitors.add(session.visitorId);
         }
       }

--- a/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
@@ -53,6 +53,7 @@ import { AppAnalytics } from "./app-analytics";
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   apiMock.mockReset();
   toastErrorMock.mockReset();
 });
@@ -102,7 +103,7 @@ function mockAnalyticsResponses() {
           },
           sessions: [
             {
-              sessionId: "session-a",
+              sessionId: "shared-session",
               visitorId: "visitor-a",
               startedAt: "2026-07-02T12:00:00.000Z",
               endedAt: "2026-07-02T12:04:00.000Z",
@@ -110,6 +111,16 @@ function mockAnalyticsResponses() {
               pageViews: 3,
               entryPath: "/",
               exitPath: "/checkout",
+            },
+            {
+              sessionId: "shared-session",
+              visitorId: "visitor-b",
+              startedAt: "2026-07-02T12:01:00.000Z",
+              endedAt: "2026-07-02T12:01:00.000Z",
+              durationMs: 0,
+              pageViews: 1,
+              entryPath: "/pricing",
+              exitPath: "/pricing",
             },
           ],
           funnel: {
@@ -143,6 +154,9 @@ function mockAnalyticsResponses() {
 describe("AppAnalytics sessions tab (#11349)", () => {
   it("loads and renders session summary, funnel, and recent sessions from the DTO", async () => {
     mockAnalyticsResponses();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const user = userEvent.setup({ delay: null });
     render(<AppAnalytics appId="app_1" />);
 
@@ -158,6 +172,11 @@ describe("AppAnalytics sessions tab (#11349)", () => {
     expect(screen.getByText("2.5")).toBeTruthy();
     expect(screen.getByText("Checkout")).toBeTruthy();
     expect(screen.getAllByText("/checkout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("/pricing")).toHaveLength(2);
     expect(screen.getByText("3")).toBeTruthy();
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+      "Encountered two children with the same key",
+    );
+    consoleError.mockRestore();
   });
 });

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -906,7 +906,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                         <tbody>
                           {sessionAnalytics.sessions.slice(0, 10).map((s) => (
                             <tr
-                              key={s.sessionId}
+                              key={JSON.stringify([s.visitorId, s.sessionId])}
                               className="border-b border-border hover:bg-bg-hover"
                             >
                               <td className="py-2 px-3 text-txt text-xs max-w-[180px] truncate">


### PR DESCRIPTION
# Relates to

Fixes #26506

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused tests, typechecks, and touched-file Biome checks were run after sync; the unavailable post-sync root verification is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the evidence attached below.

# Sync with develop

- [x] Rebased onto `a83dd908473d1e0b63f5b44b7a49a86acafab9ec`; zero conflicts.
- [ ] `bun run verify` was not rerun post-sync because Bun became unavailable in the publication shell; focused exact-head verification passed and the gap is documented below.

# Risks

Low. The change only affects in-memory analytics aggregation when different visitors reuse the same public session ID, plus the React key used for those rows. Public session IDs and response shapes are unchanged.

# Background

## What does this PR do?

- Keys internal app-analytics session aggregation by the `(visitorId, sessionId)` pair instead of `sessionId` alone.
- Uses the same pair for funnel bookkeeping, preventing page views from different visitors from completing a false cross-visitor funnel.
- Keeps the public `sessionId` unchanged and uses a collision-safe composite React row key.
- Adds backend and UI regressions for two visitors that reuse one session ID.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required; this restores the documented visitor/session semantics without changing the API.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/services/app-analytics.test.ts`, particularly the shared-session-ID regression, then inspect `AppAnalyticsService.getAnalytics()`.

## Detailed testing steps

Exact head: `8894bcf3b5b979ce3f8701ce60e06e696ad9c352`

- `bun --config=/tmp/eliza-app-analytics-bunfig.toml test packages/cloud/shared/src/lib/services/app-analytics.test.ts` — 10 passed, 0 failed, 45 assertions.
- `bun run --cwd packages/ui test -- src/cloud/applications/components/app-analytics.test.tsx` — 1 file and 1 test passed.
- `bun run --cwd packages/cloud/shared typecheck` — passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `node_modules/.bin/biome check` on the four changed files under Node 24 — passed, no fixes applied.

# Evidence Gate

<!-- evidence-head:8894bcf3b5b979ce3f8701ce60e06e696ad9c352 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/user-attachments/assets/5716948e-1cd6-4282-8ce5-356e1765aeca)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/user-attachments/assets/98011927-3e64-4844-9eb0-466bcb8b7c96)
<!-- evidence-row:walkthrough-video -->
- [x] [db80cd0e-b636-44f0-bbb4-cbe9a6e8b47a](https://github.com/user-attachments/assets/db80cd0e-b636-44f0-bbb4-cbe9a6e8b47a)
<!-- evidence-row:backend-logs -->
- [x] [26873-backend-regression.log](https://github.com/user-attachments/files/31358073/26873-backend-regression.log)
<!-- evidence-row:frontend-logs -->
- [x] [26873-frontend-regression.log](https://github.com/user-attachments/files/31358074/26873-frontend-regression.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, persistent domain state, wallet, memory, or scheduled-task changes.
<!-- evidence-row:ocr-review -->
- [x] [26873-ocr-tesseract-review.json](https://github.com/user-attachments/files/31358076/26873-ocr-tesseract-review.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

The attached backend log runs the production aggregation service regression. The frontend log renders the production component with the corrected response, and the captured browser console reports zero errors and zero warnings.

## Screenshots (before / after) + video walkthrough

The deterministic evidence harness renders the actual `AppAnalytics` component against before/after server-response fixtures for the reported collision. It is not a live Cloud-tenant capture. The before state shows one merged session, zero bounce, and a false 100% checkout conversion; the after state shows two sessions/two visitors, 100% bounce, and zero checkout conversion on desktop and mobile. The MP4 walks through the corrected Overview and Sessions tabs.

## Audio / voice walkthrough

N/A - this change does not affect voice, transcript, TTS, STT, or omnivoice behavior.

## Known gaps / failures

- Post-sync focused tests, both affected-package typechecks, and touched-file Biome checks pass at the evidence head.
- `bun run verify` was not rerun after the final rebase because Bun was no longer available on `PATH` in the publication shell (`zsh: command not found: bun`). CI remains the authoritative broad exact-head verification.
- The repository is Bun-managed; requested `pnpm lint` / `pnpm test` attempts were rejected by the workspace toolchain (and the system pnpm first encountered Node 14). No dependencies were added.
- An earlier broad UI-suite diagnostic on the prior `develop` base contained unrelated existing failures; it is not presented as exact-head evidence.
- UI evidence uses deterministic response fixtures through the real production component rather than a live Cloud tenant or production database.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [mysteryjax-issue-fix-3]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@64105d7b2636478b39f7a5677999adc963d30863:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0QVHVQPPBCP917DXTWK0MVJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T17:44:04.087Z","completed_at":"2026-08-24T01:13:23.477Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEASLwS0eshLeA4cpT_vbS3lnzrnGRmGrX8f03fEtMmqdA","device_key_id":"3d2067bc23a0d32e00b5dcb579c70fa9f982894b17fdb1dfe2497057f9d99324","device_signature":"-eqjmgdE0xfEPKkeqR45gIUt5_2swq2OqbNyAAhP06htf2D8bFUuVVEaHyAOyLQz8iOsJlWlmgfwLTs2UX-DCQ"}} -->



