### PR TITLE
test(core): cover channel topic search action

### DIFF
--- a/packages/core/src/__tests__/channel-topic-search-suite.test.ts
+++ b/packages/core/src/__tests__/channel-topic-search-suite.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for SEARCH_CHANNEL_TOPICS action handler and validation logic.
+ * Exercises query resolution, service availability checks, matching formatting,
+ * and scope reporting.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { channelTopicSearchAction } from "../features/basic-capabilities/actions/channel-topic-search.ts";
+import type { IAgentRuntime, Memory } from "../types/index.ts";
+
+describe("channel-topic-search action", () => {
+	describe("validate", () => {
+		it("returns false when channel_topics service is not registered", async () => {
+			const runtime = {
+				getService: vi.fn().mockReturnValue(null),
+			} as unknown as IAgentRuntime;
+
+			const valid = await channelTopicSearchAction.validate(
+				runtime,
+				{} as Memory,
+			);
+			expect(valid).toBe(false);
+		});
+
+		it("returns true when channel_topics service with searchTopics is registered", async () => {
+			const runtime = {
+				getService: vi.fn().mockReturnValue({
+					searchTopics: vi.fn(),
+				}),
+			} as unknown as IAgentRuntime;
+
+			const valid = await channelTopicSearchAction.validate(
+				runtime,
+				{} as Memory,
+			);
+			expect(valid).toBe(true);
+		});
+	});
+
+	describe("handler", () => {
+		it("returns failure when channel_topics service is unavailable", async () => {
+			const runtime = {
+				getService: vi.fn().mockReturnValue(null),
+			} as unknown as IAgentRuntime;
+
+			const message = {
+				content: { text: "search query" },
+			} as unknown as Memory;
+			const result = await channelTopicSearchAction.handler(runtime, message);
+
+			expect(result.success).toBe(false);
+			expect(result.text).toBe("Channel topic search is unavailable.");
+		});
+
+		it("returns failure when search query is empty", async () => {
+			const runtime = {
+				getService: vi.fn().mockReturnValue({
+					searchTopics: vi.fn(),
+				}),
+			} as unknown as IAgentRuntime;
+
+			const message = { content: { text: "" } } as unknown as Memory;
+			const result = await channelTopicSearchAction.handler(runtime, message);
+
+			expect(result.success).toBe(false);
+			expect(result.text).toBe("Provide a topic to search for.");
+		});
+
+		it("searches topics using explicit parameter and returns formatted hits", async () => {
+			const searchTopicsMock = vi
+				.fn()
+				.mockReturnValue([
+					{ roomId: "room-crypto", matchedTopics: ["solana", "trading"] },
+				]);
+			const getTopicsForAllRoomsMock = vi.fn().mockReturnValue({
+				"room-crypto": ["solana", "trading"],
+				"room-general": ["chat"],
+			});
+
+			const runtime = {
+				getService: vi.fn().mockReturnValue({
+					searchTopics: searchTopicsMock,
+					getTopicsForAllRooms: getTopicsForAllRoomsMock,
+				}),
+			} as unknown as IAgentRuntime;
+
+			const message = {
+				content: { text: "fallback text" },
+			} as unknown as Memory;
+			const options = { parameters: { query: "solana" } };
+			const result = await channelTopicSearchAction.handler(
+				runtime,
+				message,
+				undefined,
+				options,
+			);
+
+			expect(searchTopicsMock).toHaveBeenCalledWith("solana");
+			expect(result.success).toBe(true);
+			expect(result.values?.matchCount).toBe(1);
+			expect(result.text).toContain("Channels discussing");
+			expect(result.text).toContain("room-crypto: solana, trading");
+		});
+
+		it("formats cleanly when zero hits are found", async () => {
+			const runtime = {
+				getService: vi.fn().mockReturnValue({
+					searchTopics: vi.fn().mockReturnValue([]),
+					getTopicsForAllRooms: vi.fn().mockReturnValue({}),
+				}),
+			} as unknown as IAgentRuntime;
+
+			const message = {
+				content: { text: "quantum-physics" },
+			} as unknown as Memory;
+			const result = await channelTopicSearchAction.handler(runtime, message);
+
+			expect(result.success).toBe(true);
+			expect(result.values?.matchCount).toBe(0);
+			expect(result.text).toContain(
+				"No channels in 0 active or hydrated room(s) in memory",
+			);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for the SEARCH_CHANNEL_TOPICS action handler and validation logic with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `channelTopicSearchAction` in `@elizaos/core`, verifying validation, query resolution, and search hit formatting.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/core/src/__tests__/channel-topic-search-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/core/src/__tests__/channel-topic-search-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a4c5e56b200c04e34519c7cbfec6c5852917356e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/core/src/__tests__/channel-topic-search-suite.test.ts
bun test v1.3.11 (af24e281)

packages/core/src/__tests__/channel-topic-search-suite.test.ts:
(pass) channel-topic-search action > validate > returns false when channel_topics service is not registered
(pass) channel-topic-search action > validate > returns true when channel_topics service with searchTopics is registered
(pass) channel-topic-search action > handler > returns failure when channel_topics service is unavailable
(pass) channel-topic-search action > handler > returns failure when search query is empty
(pass) channel-topic-search action > handler > searches topics using explicit parameter and returns formatted hits
(pass) channel-topic-search action > handler > formats cleanly when zero hits are found
-------------------------------------------------------------------------------|---------|---------|-------------------
File                                                                           | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------------------------------------------|---------|---------|-------------------
All files                                                                      |   34.63 |   52.67 |
 packages/core/src/features/basic-capabilities/actions/channel-topic-search.ts |  100.00 |  100.00 | 
-------------------------------------------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 14 expect() calls
Ran 6 tests across 1 file. [114.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
