### PR TITLE
test(cloud): cover persistence-guard

### DIFF
--- a/packages/cloud/shared/src/lib/utils/persistence-guard.test.ts
+++ b/packages/cloud/shared/src/lib/utils/persistence-guard.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  allowEphemeralCloudStateFallback,
+  assertPersistentCloudStateConfigured,
+} from "./persistence-guard.js";
+
+describe("persistence-guard", () => {
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env = { ...orig };
+  });
+
+  it("allows fallback when flag set", () => {
+    process.env.AGENT_ALLOW_EPHEMERAL_CLOUD_STATE = "true";
+    expect(allowEphemeralCloudStateFallback()).toBe(true);
+  });
+
+  it("disallows in production without flag", () => {
+    delete process.env.AGENT_ALLOW_EPHEMERAL_CLOUD_STATE;
+    process.env.NODE_ENV = "production";
+    process.env.ENVIRONMENT = "production";
+    expect(allowEphemeralCloudStateFallback()).toBe(false);
+  });
+
+  it("throws when persistent not configured in prod", () => {
+    delete process.env.AGENT_ALLOW_EPHEMERAL_CLOUD_STATE;
+    process.env.NODE_ENV = "production";
+    process.env.ENVIRONMENT = "production";
+    expect(() => assertPersistentCloudStateConfigured("test", false)).toThrow(/Redis/);
+  });
+
+  it("does not throw when backend present", () => {
+    delete process.env.AGENT_ALLOW_EPHEMERAL_CLOUD_STATE;
+    process.env.NODE_ENV = "production";
+    expect(() => assertPersistentCloudStateConfigured("test", true)).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:00beccc3f8f88af4ad36c3b484754a03be9f3ab0 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/utils/persistence-guard.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/utils/persistence-guard.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/utils/persistence-guard.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/utils/persistence-guard.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop; verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) -> Green (restored)

**Red — proves non-vacuous (imports real export):**
```
     23|   });
     24|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  packages/cloud/shared/src/lib/utils/persistence-guard.test.ts > persistence-guard > throws when persistent not configured in prod
AssertionError: expected [Function] to throw an error

- Expected:
null

+ Received:
undefined

 ❯ packages/cloud/shared/src/lib/utils/persistence-guard.test.ts:29:71
     27|     process.env.NODE_ENV = "production";
     28|     process.env.ENVIRONMENT = "production";
     29|     expect(() => assertPersistentCloudStateConfigured("test", false)).…
       |                                                                       ^
     30|   });
     31|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
   Start at  08:34:13
   Duration  101ms (transform 22ms, setup 0ms, import 27ms, tests 4ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:34:12
   Duration  90ms (transform 21ms, setup 0ms, import 27ms, tests 2ms, environment 0ms)
```

