### PR TITLE
fix(cloud): unblock cold voice turns during prewarm

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -35,6 +35,10 @@ const repositoryHistoryLengths: number[] = [];
 const repositoryHistories: unknown[][] = [];
 let streamMergeGate: Promise<void> | null = null;
 let resolveStreamMergeGate = () => {};
+let runtimePrewarmGate: Promise<void> | null = null;
+let resolveRuntimePrewarmGate = () => {};
+let runtimePrewarmEntered: Promise<void> | null = null;
+let markRuntimePrewarmEntered = () => {};
 let rehydrateCalls = 0;
 let bridgeFunding: unknown;
 let recoveredCutoverTargetId: string | null = null;
@@ -253,6 +257,12 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
     },
   },
 }));
+mock.module("@/lib/services/shared-runtime/shared-eliza-runtime", () => ({
+  prewarmSharedElizaRuntime: async () => {
+    markRuntimePrewarmEntered();
+    if (runtimePrewarmGate) await runtimePrewarmGate;
+  },
+}));
 mock.module("@/lib/mobile-push/apns-provider", () => ({
   resolveCloudApnsConfig: (env: { ELIZA_APNS_KEY?: string }) =>
     env.ELIZA_APNS_KEY ? { configured: true } : null,
@@ -290,6 +300,10 @@ beforeEach(() => {
   repositoryDeletes = 0;
   streamMergeGate = null;
   resolveStreamMergeGate = () => {};
+  runtimePrewarmGate = null;
+  resolveRuntimePrewarmGate = () => {};
+  runtimePrewarmEntered = null;
+  markRuntimePrewarmEntered = () => {};
   rehydrateCalls = 0;
   bridgeFunding = undefined;
   recoveredCutoverTargetId = null;
@@ -874,6 +888,115 @@ test("prewarm joins cold hydration without writing a conversation turn", async (
   const result = await makeInvoke(object)("first-real-turn");
   expect(result).toMatchObject({ result: { historyLength: 2 } });
   expect(repositoryReads).toBe(1);
+});
+
+test("slow prewarm returns headers and releases the room queue before completion", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [{ role: "assistant", content: "migrated" }];
+  runtimePrewarmGate = new Promise<void>((resolve) => {
+    resolveRuntimePrewarmGate = resolve;
+  });
+  runtimePrewarmEntered = new Promise<void>((resolve) => {
+    markRuntimePrewarmEntered = resolve;
+  });
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  const prewarmResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  await runtimePrewarmEntered;
+
+  const historyResult = await Promise.race([
+    object
+      .fetch(
+        new Request("https://shared-runtime.internal/history", {
+          method: "POST",
+          body: JSON.stringify({
+            operation: "history",
+            agentId: AGENT_FIXTURE.id,
+            roomId: "room-1",
+          }),
+        }),
+      )
+      .then(async (response) => ({
+        status: response.status,
+        body: await response.json(),
+      })),
+    new Promise<"queue-blocked">((resolve) =>
+      setTimeout(() => resolve("queue-blocked"), 100),
+    ),
+  ]);
+
+  expect(historyResult).not.toBe("queue-blocked");
+  expect(historyResult).toMatchObject({
+    status: 200,
+    body: { history: repositoryRow },
+  });
+  expect(prewarmResponse.headers.has("X-Eliza-Release-Coordinator-Queue")).toBe(
+    false,
+  );
+
+  resolveRuntimePrewarmGate();
+  await expect(prewarmResponse.json()).resolves.toEqual({ success: true });
+  await Promise.all(background.splice(0));
+  expect(repositoryReads).toBe(1);
+  expect(repositoryWrites).toBe(0);
+});
+
+test("canceling the prewarm response does not cancel background readiness", async () => {
+  runtimePrewarmGate = new Promise<void>((resolve) => {
+    resolveRuntimePrewarmGate = resolve;
+  });
+  runtimePrewarmEntered = new Promise<void>((resolve) => {
+    markRuntimePrewarmEntered = resolve;
+  });
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  await runtimePrewarmEntered;
+  await response.body?.cancel();
+
+  resolveRuntimePrewarmGate();
+  await Promise.all(background.splice(0));
+
+  const warmResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  await expect(warmResponse.json()).resolves.toEqual({ success: true });
 });
 
 test("fresh-room prewarm skips a legacy history query", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -32,6 +32,8 @@ import type {
 import { mergeSharedRuntimeHistoryMessages } from "@/lib/services/shared-runtime/shared-runtime-history-policy";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const RELEASE_QUEUE_BEFORE_BODY_HEADER = "X-Eliza-Release-Coordinator-Queue";
+
 // The agent row crosses the Durable Object boundary as JSON, so its Drizzle
 // `Date` columns arrive as ISO strings; `handle` rehydrates them before any
 // service consumes the row (the CONVERSATIONS-500 defect class).
@@ -350,6 +352,7 @@ export class SharedRuntimeConversation {
   private conversation: StoredConversation | null | undefined;
   private hydration: Promise<void> | undefined;
   private prewarmReady = false;
+  private prewarm: Promise<void> | undefined;
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
   private alarmMutationQueue: Promise<void> = Promise.resolve();
@@ -503,6 +506,59 @@ export class SharedRuntimeConversation {
         );
       }),
     );
+  }
+
+  /**
+   * Starts one room warmup without holding the serialized turn queue.
+   *
+   * The response body remains pending until the warmup finishes, so callers
+   * still observe truthful completion. Response headers are returned
+   * immediately and the Durable Object queue is released before that body is
+   * consumed; otherwise a cold runtime build can head-of-line block the first
+   * live voice turn behind the caller's coordinator header deadline.
+   */
+  private deferredPrewarmResponse(
+    agentId: string,
+    channelId: string,
+    startEmpty: boolean,
+  ): Response {
+    if (!this.prewarmReady && !this.prewarm) {
+      const prewarm = this.prewarmConversation(agentId, channelId, startEmpty);
+      this.prewarm = prewarm;
+      const clearPrewarm = () => {
+        if (this.prewarm === prewarm) this.prewarm = undefined;
+      };
+      void prewarm.then(clearPrewarm, clearPrewarm);
+      this.state.waitUntil(prewarm);
+    }
+
+    const completion = this.prewarm ?? Promise.resolve();
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        void completion.then(
+          () => {
+            if (canceled) return;
+            controller.enqueue(
+              new TextEncoder().encode(JSON.stringify({ success: true })),
+            );
+            controller.close();
+          },
+          (error) => {
+            if (!canceled) controller.error(error);
+          },
+        );
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    return new Response(body, {
+      headers: {
+        "Content-Type": "application/json",
+        [RELEASE_QUEUE_BEFORE_BODY_HEADER]: "before-body",
+      },
+    });
   }
 
   /**
@@ -1595,12 +1651,11 @@ export class SharedRuntimeConversation {
       return Response.json({ success: true });
     }
     if (payload.operation === "prewarm") {
-      await this.prewarmConversation(
+      return this.deferredPrewarmResponse(
         payload.agentId,
         payload.roomId,
         payload.startEmpty === true,
       );
-      return Response.json({ success: true });
     }
     if (payload.operation === "cutover-seal") {
       const existing = await this.activeCutoverSeal();
@@ -1868,6 +1923,13 @@ export class SharedRuntimeConversation {
 
     try {
       const response = await this.handle(request);
+      if (
+        response.headers.get(RELEASE_QUEUE_BEFORE_BODY_HEADER) === "before-body"
+      ) {
+        response.headers.delete(RELEASE_QUEUE_BEFORE_BODY_HEADER);
+        release();
+        return response;
+      }
       return this.releaseWhenConsumed(response, release);
     } catch (error) {
       // error-policy:J1 the Durable Object transport boundary translates cache


### PR DESCRIPTION
Closes #26722

## What changed

- Start shared-runtime conversation prewarm as a single-flight background task.
- Return prewarm response headers immediately and release the Durable Object room queue before the truthful completion body settles.
- Keep the warmup alive if its HTTP response consumer disconnects.
- Preserve the existing serialized-body lock for real conversation turns and all other operations.

## Why

Production call `CA296d...` remained connected for 167 seconds with no Twilio media/application error, while the Worker repeatedly logged `Shared runtime coordinator response headers timed out`. The cold conversation prewarm held the same room queue while history and full runtime initialization ran, so the first live voice turn queued behind prewarm and crossed the 10-second coordinator header deadline.

## Validation (exact head `b11279b7c48ff62cfc7aecccae647c80d6649a65`, base `417a22e36d91442a0c61254862c43f309c74f453`)

- `bun test packages/cloud/api/src/shared-runtime-conversation.test.ts` — 36 pass, 0 fail.
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts` — 3 pass, 0 fail.
- `bunx biome check packages/cloud/api/src/shared-runtime-conversation.ts packages/cloud/api/src/shared-runtime-conversation.test.ts` — pass.
- `git diff --check` — pass.
- `bun run verify` — blocked before affected checks by current-base i18n drift: missing locale keys and two missing English OTP recovery keys. No changed file is in the i18n surface.
- `bun run --cwd packages/cloud/api typecheck` — blocked by current workspace errors in `database-url.test.ts` and missing built `@elizaos/plugin-doordash` types.

The deterministic regression stalls runtime prewarm, proves a concurrent request for the same room receives headers and completes instead of queue-blocking, then proves truthful prewarm completion. A second regression cancels the response body and proves background readiness still completes.

## Evidence

- Production runtime logs and privacy-bounded Twilio ledger correlation are recorded on #26722.
- UI screenshots: N/A - server-side Durable Object coordination only.
- Walkthrough video: N/A - real behavior requires a deployed PSTN call and will be attached after production acceptance.
- Live audio: pending exact-head deployment; acceptance requires cold and warm calls exceeding 3 minutes plus callback continuity.
