### PR TITLE
test(ui): cover api response and error response helpers

### DIFF
--- a/packages/ui/src/api/__tests__/response-suite.test.ts
+++ b/packages/ui/src/api/__tests__/response-suite.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for UI HTTP JSON response helpers.
+ * Validates sendJson, sendJsonError, stack trace sanitization, and headersSent guard.
+ */
+
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { sendJson, sendJsonError } from "../response.ts";
+
+function createMockResponse(headersSent = false): {
+  res: http.ServerResponse;
+  headers: Record<string, string>;
+  endBody: string;
+} {
+  const headers: Record<string, string> = {};
+  let endBody = "";
+
+  const res = {
+    headersSent,
+    statusCode: 200,
+    setHeader: vi.fn((key: string, val: string) => {
+      headers[key.toLowerCase()] = val;
+    }),
+    end: vi.fn((payload?: string) => {
+      if (payload) endBody = payload;
+    }),
+  } as unknown as http.ServerResponse;
+
+  return {
+    res,
+    headers,
+    get endBody() {
+      return endBody;
+    },
+  };
+}
+
+describe("api response helpers", () => {
+  describe("sendJson", () => {
+    it("sets status, content-type header, and writes JSON payload", () => {
+      const mock = createMockResponse();
+      const res = mock.res;
+      const headers = mock.headers;
+      sendJson(res, 200, { ok: true, data: "hello" });
+
+      expect(res.statusCode).toBe(200);
+      expect(headers["content-type"]).toBe("application/json; charset=utf-8");
+      expect(JSON.parse(mock.endBody)).toEqual({
+        ok: true,
+        data: "hello",
+      });
+    });
+
+    it("scrubs stack and stackTrace fields from objects and nested structures", () => {
+      const mock = createMockResponse();
+      const res = mock.res;
+      const body = {
+        status: "error",
+        stack: "Error: at foo.ts:10",
+        stackTrace: "trace-info",
+        details: {
+          nested: "value",
+          stack: "inner stack",
+        },
+        list: [
+          { id: 1, stack: "item stack" },
+          new Error("Nested error message"),
+        ],
+      };
+
+      sendJson(res, 500, body);
+      const parsed = JSON.parse(mock.endBody);
+
+      expect(parsed.stack).toBeUndefined();
+      expect(parsed.stackTrace).toBeUndefined();
+      expect(parsed.details.stack).toBeUndefined();
+      expect(parsed.details.nested).toBe("value");
+      expect(parsed.list[0].stack).toBeUndefined();
+      expect(parsed.list[1]).toEqual({ error: "Nested error message" });
+    });
+
+    it("does not write if headersSent is true", () => {
+      const mock = createMockResponse(true);
+      const res = mock.res;
+      sendJson(res, 200, { ok: true });
+
+      expect(res.setHeader).not.toHaveBeenCalled();
+      expect(res.end).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendJsonError", () => {
+    it("sends structured error message with status", () => {
+      const mock = createMockResponse();
+      const res = mock.res;
+      sendJsonError(res, 404, "Resource not found");
+
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(mock.endBody)).toEqual({
+        error: "Resource not found",
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for API JSON response helpers, error formatting, and stack sanitization with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `sendJson` and `sendJsonError` in `@elizaos/ui`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/ui/src/api/__tests__/response-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/ui/src/api/__tests__/response-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:40f7c00687585db8a179017201bd9eb65e3b3f68 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/ui/src/api/__tests__/response-suite.test.ts
bun test v1.3.11 (af24e281)

packages/ui/src/api/__tests__/response-suite.test.ts:
(pass) api response helpers > sendJson > sets status, content-type header, and writes JSON payload
(pass) api response helpers > sendJson > scrubs stack and stackTrace fields from objects and nested structures
(pass) api response helpers > sendJson > does not write if headersSent is true
(pass) api response helpers > sendJsonError > sends structured error message with status
---------------------------------|---------|---------|-------------------
File                             | % Funcs | % Lines | Uncovered Line #s
---------------------------------|---------|---------|-------------------
All files                        |  100.00 |  100.00 |
 packages/ui/src/api/response.ts |  100.00 |  100.00 | 
---------------------------------|---------|---------|-------------------

 4 pass
 0 fail
 13 expect() calls
Ran 4 tests across 1 file. [83.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
