### PR TITLE
test(ui): cover api transport and request parsing helpers

### DIFF
--- a/packages/ui/src/api/__tests__/transport-suite.test.ts
+++ b/packages/ui/src/api/__tests__/transport-suite.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for UI HTTP request transport and parsing helpers.
+ * Validates headers conversion, HTTP method body rules, body coercion, and streaming detection.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bodyToString,
+  fetchAgentTransport,
+  headersToRecord,
+  isStreamingRequest,
+  methodAllowsBody,
+} from "../transport.ts";
+
+describe("transport helpers", () => {
+  describe("headersToRecord", () => {
+    it("returns empty object for undefined headers", () => {
+      expect(headersToRecord(undefined)).toEqual({});
+    });
+
+    it("converts record object to key-value pairs", () => {
+      const headers = {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      };
+      const record = headersToRecord(headers);
+      expect(record["content-type"]).toBe("application/json");
+      expect(record.authorization).toBe("Bearer token");
+    });
+
+    it("converts Headers instance to record", () => {
+      const headers = new Headers();
+      headers.set("X-Custom-Header", "custom-val");
+      const record = headersToRecord(headers);
+      expect(record["x-custom-header"]).toBe("custom-val");
+    });
+  });
+
+  describe("methodAllowsBody", () => {
+    it("rejects GET and HEAD methods case-insensitively", () => {
+      expect(methodAllowsBody("GET")).toBe(false);
+      expect(methodAllowsBody("get")).toBe(false);
+      expect(methodAllowsBody("HEAD")).toBe(false);
+      expect(methodAllowsBody("head")).toBe(false);
+    });
+
+    it("allows POST, PUT, PATCH, DELETE methods", () => {
+      expect(methodAllowsBody("POST")).toBe(true);
+      expect(methodAllowsBody("PUT")).toBe(true);
+      expect(methodAllowsBody("PATCH")).toBe(true);
+      expect(methodAllowsBody("DELETE")).toBe(true);
+    });
+  });
+
+  describe("bodyToString", () => {
+    it("preserves null and undefined as distinct values", () => {
+      expect(bodyToString(null)).toBeNull();
+      expect(bodyToString(undefined)).toBeUndefined();
+    });
+
+    it("returns raw strings unmodified", () => {
+      expect(bodyToString("test payload")).toBe("test payload");
+    });
+
+    it("converts URLSearchParams to string representation", () => {
+      const params = new URLSearchParams({ key: "val", tag: "123" });
+      expect(bodyToString(params)).toBe("key=val&tag=123");
+    });
+
+    it("returns undefined for unsupported body types", () => {
+      expect(bodyToString({} as unknown as BodyInit)).toBeUndefined();
+    });
+  });
+
+  describe("isStreamingRequest", () => {
+    it("detects streaming via Accept header", () => {
+      expect(
+        isStreamingRequest("/api/chat", { Accept: "text/event-stream" }),
+      ).toBe(true);
+      expect(
+        isStreamingRequest("/api/chat", {
+          accept: "TEXT/EVENT-STREAM; charset=utf-8",
+        }),
+      ).toBe(true);
+    });
+
+    it("detects streaming via /stream URL endpoint path", () => {
+      expect(isStreamingRequest("/api/v1/chat/stream", undefined)).toBe(true);
+      expect(
+        isStreamingRequest("https://example.com/api/stream", undefined),
+      ).toBe(true);
+    });
+
+    it("returns false for non-streaming endpoints and headers", () => {
+      expect(
+        isStreamingRequest("/api/v1/chat", { Accept: "application/json" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("fetchAgentTransport", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("delegates to global fetch", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("ok"));
+      const res = await fetchAgentTransport.request(
+        "https://api.example.com/test",
+        { method: "GET" },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/test", {
+        method: "GET",
+      });
+      expect(await res.text()).toBe("ok");
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for API transport abstractions, HTTP method rules, header normalization, and body coercion with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `fetchAgentTransport`, `headersToRecord`, `methodAllowsBody`, `bodyToString`, and `isStreamingRequest` in `@elizaos/ui`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/ui/src/api/__tests__/transport-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/ui/src/api/__tests__/transport-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2beb1b1d221e1fce29eae8878758ba4893b5dd8d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/ui/src/api/__tests__/transport-suite.test.ts
bun test v1.3.11 (af24e281)

packages/ui/src/api/__tests__/transport-suite.test.ts:
(pass) transport helpers > headersToRecord > returns empty object for undefined headers
(pass) transport helpers > headersToRecord > converts record object to key-value pairs
(pass) transport helpers > headersToRecord > converts Headers instance to record
(pass) transport helpers > methodAllowsBody > rejects GET and HEAD methods case-insensitively
(pass) transport helpers > methodAllowsBody > allows POST, PUT, PATCH, DELETE methods
(pass) transport helpers > bodyToString > preserves null and undefined as distinct values
(pass) transport helpers > bodyToString > returns raw strings unmodified
(pass) transport helpers > bodyToString > converts URLSearchParams to string representation
(pass) transport helpers > bodyToString > returns undefined for unsupported body types
(pass) transport helpers > isStreamingRequest > detects streaming via Accept header
(pass) transport helpers > isStreamingRequest > detects streaming via /stream URL endpoint path
(pass) transport helpers > isStreamingRequest > returns false for non-streaming endpoints and headers
(pass) transport helpers > fetchAgentTransport > delegates to global fetch
----------------------------------|---------|---------|-------------------
File                              | % Funcs | % Lines | Uncovered Line #s
----------------------------------|---------|---------|-------------------
All files                         |  100.00 |   94.12 |
 packages/ui/src/api/transport.ts |  100.00 |   94.12 | 74-75
----------------------------------|---------|---------|-------------------

 13 pass
 0 fail
 24 expect() calls
Ran 13 tests across 1 file. [95.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
