### PR TITLE
test(core): cover sandbox-policy

### DIFF
--- a/packages/core/src/sandbox-policy.test.ts
+++ b/packages/core/src/sandbox-policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./build-variant.js", () => ({
+	getBuildVariant: vi.fn(() => "direct"),
+	getDirectDownloadUrl: vi.fn(() => "https://example.com/download"),
+}));
+
+import { getBuildVariant } from "./build-variant.js";
+import {
+	buildStoreVariantBlockedMessage,
+	isLocalCodeExecutionAllowed,
+} from "./sandbox-policy.js";
+
+describe("sandbox-policy", () => {
+	it("allows when direct", () => {
+		vi.mocked(getBuildVariant).mockReturnValue("direct");
+		expect(isLocalCodeExecutionAllowed()).toBe(true);
+	});
+
+	it("blocks when not direct", () => {
+		vi.mocked(getBuildVariant).mockReturnValue("store" as never);
+		expect(isLocalCodeExecutionAllowed()).toBe(false);
+	});
+
+	it("builds blocked message", () => {
+		const msg = buildStoreVariantBlockedMessage("Tool");
+		expect(msg).toContain("Tool requires");
+		expect(msg).toContain("https://example.com/download");
+	});
+});


### PR DESCRIPTION
<!-- evidence-head:b60ec77286a8e6d41e596cae82179d3254410992 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/core/src/sandbox-policy.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/core/src/sandbox-policy.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/core/src/sandbox-policy.test.ts`

## Detailed testing steps
`bunx vitest run packages/core/src/sandbox-policy.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop; verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) -> Green (restored)

**Red — proves non-vacuous (imports real export):**
```
     18|  });
     19|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  packages/core/src/sandbox-policy.test.ts > sandbox-policy > blocks when not direct
AssertionError: expected 'bad' to be false // Object.is equality

- Expected:
false

+ Received:
"bad"

 ❯ packages/core/src/sandbox-policy.test.ts:22:41
     20|  it("blocks when not direct", () => {
     21|   vi.mocked(getBuildVariant).mockReturnValue("store" as never);
     22|   expect(isLocalCodeExecutionAllowed()).toBe(false);
       |                                         ^
     23|  });
     24|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
   Start at  08:37:20
   Duration  94ms (transform 22ms, setup 0ms, import 29ms, tests 3ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:37:19
   Duration  88ms (transform 21ms, setup 0ms, import 27ms, tests 1ms, environment 0ms)
```

