### PR TITLE
test(cloud): cover hono-root-request

### DIFF
--- a/packages/cloud/shared/src/lib/api/hono-root-request.test.ts
+++ b/packages/cloud/shared/src/lib/api/hono-root-request.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchHonoRoot, toHonoRootRequest } from "./hono-root-request.js";
+
+describe("hono-root-request", () => {
+  it("rewrites pathname to root", () => {
+    const req = new Request("https://example.com/api/foo?x=1");
+    const rooted = toHonoRootRequest(req);
+    expect(new URL(rooted.url).pathname).toBe("/");
+    expect(new URL(rooted.url).search).toBe("?x=1");
+  });
+
+  it("fetchHonoRoot delegates to app", async () => {
+    const app = { fetch: vi.fn().mockResolvedValue(new Response("ok")) };
+    const req = new Request("https://example.com/some/path");
+    const res = await fetchHonoRoot(app, req);
+    expect(app.fetch).toHaveBeenCalled();
+    const calledReq = app.fetch.mock.calls[0][0] as Request;
+    expect(new URL(calledReq.url).pathname).toBe("/");
+    expect(await (res as Response).text()).toBe("ok");
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:1f9263c235dac658f746f86ac91c831f34283722 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/api/hono-root-request.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/api/hono-root-request.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/api/hono-root-request.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/api/hono-root-request.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop; verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) -> Green (restored)

**Red — proves non-vacuous (imports real export):**
```
 FAIL  packages/cloud/shared/src/lib/api/hono-root-request.test.ts > hono-root-request > rewrites pathname to root
TypeError: Invalid URL
 ❯ packages/cloud/shared/src/lib/api/hono-root-request.test.ts:8:12
      6|     const req = new Request("https://example.com/api/foo?x=1");
      7|     const rooted = toHonoRootRequest(req);
      8|     expect(new URL(rooted.url).pathname).toBe("/");
       |            ^
      9|     expect(new URL(rooted.url).search).toBe("?x=1");
     10|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  packages/cloud/shared/src/lib/api/hono-root-request.test.ts > hono-root-request > fetchHonoRoot delegates to app
TypeError: Invalid URL
 ❯ packages/cloud/shared/src/lib/api/hono-root-request.test.ts:18:12
     16|     expect(app.fetch).toHaveBeenCalled();
     17|     const calledReq = app.fetch.mock.calls[0][0] as Request;
     18|     expect(new URL(calledReq.url).pathname).toBe("/");
       |            ^
     19|     expect(await (res as Response).text()).toBe("ok");
     20|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed (2)
   Start at  08:37:54
   Duration  96ms (transform 20ms, setup 0ms, import 24ms, tests 11ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  08:37:53
   Duration  99ms (transform 19ms, setup 0ms, import 25ms, tests 13ms, environment 0ms)
```

