### PR TITLE
test(shared): cover gpu profile schema and catalog mapping

### DIFF
--- a/packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts
+++ b/packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for GPU YAML profile schemas and catalog compatibility validators.
+ * Tests schema parsing, tier ID catalog validation, and recommendation filtering.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BundleRecommendation,
+  bundleIdsInProfileMatchCatalog,
+  GpuYamlId,
+  GpuYamlProfile,
+  getRecommendationsByTier,
+} from "../gpu-profile-schema.ts";
+
+describe("gpu-profile-schema", () => {
+  describe("GpuYamlId", () => {
+    it("accepts supported GPU identifiers", () => {
+      expect(GpuYamlId.safeParse("rtx-3090").success).toBe(true);
+      expect(GpuYamlId.safeParse("rtx-4090").success).toBe(true);
+      expect(GpuYamlId.safeParse("rtx-5090").success).toBe(true);
+      expect(GpuYamlId.safeParse("h200").success).toBe(true);
+    });
+
+    it("rejects unknown GPU identifiers", () => {
+      expect(GpuYamlId.safeParse("gtx-1080").success).toBe(false);
+      expect(GpuYamlId.safeParse("").success).toBe(false);
+    });
+  });
+
+  describe("BundleRecommendation", () => {
+    it("validates a complete bundle recommendation", () => {
+      const valid = {
+        n_gpu_layers: 33,
+        ctx_size: 8192,
+        parallel: 1,
+        batch_size: 512,
+        ubatch_size: 512,
+        kv_cache_k: "f16",
+        kv_cache_v: "f16",
+        flash_attention: true,
+        estimated_decode_tps: 85.5,
+        estimated_prefill_tps: 450.0,
+      };
+      expect(BundleRecommendation.safeParse(valid).success).toBe(true);
+    });
+  });
+
+  describe("GpuYamlProfile", () => {
+    it("enforces sm_XX architecture format", () => {
+      const profile = {
+        gpu_id: "rtx-4090",
+        gpu_arch: "sm_89",
+        vram_gb: 24,
+        mem_bandwidth_gbps: 1008,
+        fp8_supported: true,
+        fp4_supported: false,
+        nvlink: false,
+        bundle_recommendations: {},
+        mtp: {
+          enabled: false,
+          draft_min: 1,
+          draft_max: 5,
+          draft_gpu_layers: 0,
+        },
+        verify_recipe: {
+          build_target: "cuda",
+          cuda_arch: 89,
+          cmake_flags: ["-DGGML_CUDA=ON"],
+          expected_kernels: ["turbo3"],
+          smoke_bundle: "small",
+          tolerance_pct: 10,
+        },
+      };
+      expect(GpuYamlProfile.safeParse(profile).success).toBe(true);
+
+      const invalidArch = { ...profile, gpu_arch: "invalid_arch" };
+      expect(GpuYamlProfile.safeParse(invalidArch).success).toBe(false);
+    });
+  });
+
+  describe("bundleIdsInProfileMatchCatalog", () => {
+    it("reports unknown bundle recommendations", () => {
+      const profile = {
+        bundle_recommendations: {
+          "eliza-1-2b": {} as unknown as BundleRecommendation,
+          "nonexistent-bundle": {} as unknown as BundleRecommendation,
+        },
+      } as unknown as GpuYamlProfile;
+
+      const result = bundleIdsInProfileMatchCatalog(profile);
+      expect(result.ok).toBe(false);
+      expect(result.unknown).toContain("nonexistent-bundle");
+    });
+  });
+
+  describe("getRecommendationsByTier", () => {
+    it("filters map down to known tier IDs", () => {
+      const rec = {
+        n_gpu_layers: 33,
+        ctx_size: 8192,
+        parallel: 1,
+        batch_size: 512,
+        ubatch_size: 512,
+        kv_cache_k: "f16" as const,
+        kv_cache_v: "f16" as const,
+        flash_attention: true,
+        estimated_decode_tps: 85,
+        estimated_prefill_tps: 450,
+      };
+
+      const profile = {
+        bundle_recommendations: {
+          "eliza-1-2b": rec,
+          "invalid-tier": rec,
+        },
+      } as unknown as GpuYamlProfile;
+
+      const filtered = getRecommendationsByTier(profile);
+      expect(filtered["eliza-1-2b"]).toEqual(rec);
+      expect(
+        filtered["invalid-tier" as unknown as keyof typeof filtered],
+      ).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for GPU YAML profile schema validation and Eliza-1 catalog recommendation filtering with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `GpuYamlProfile`, `BundleRecommendation`, `GpuYamlId`, `bundleIdsInProfileMatchCatalog`, and `getRecommendationsByTier` in `@elizaos/shared`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:89480c2b417454f9d8e349ffe455b98861daabde -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts
bun test v1.3.11 (af24e281)

packages/shared/src/local-inference-gpu/__tests__/gpu-profile-schema-suite.test.ts:
(pass) gpu-profile-schema > GpuYamlId > accepts supported GPU identifiers
(pass) gpu-profile-schema > GpuYamlId > rejects unknown GPU identifiers
(pass) gpu-profile-schema > BundleRecommendation > validates a complete bundle recommendation
(pass) gpu-profile-schema > GpuYamlProfile > enforces sm_XX architecture format
(pass) gpu-profile-schema > bundleIdsInProfileMatchCatalog > reports unknown bundle recommendations
(pass) gpu-profile-schema > getRecommendationsByTier > filters map down to known tier IDs
---------------------------------------------------------------|---------|---------|-------------------
File                                                           | % Funcs | % Lines | Uncovered Line #s
---------------------------------------------------------------|---------|---------|-------------------
All files                                                      |   18.62 |   34.82 |
 packages/shared/src/local-inference-gpu/gpu-profile-schema.ts |  100.00 |  100.00 | 
---------------------------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [120.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
