### PR TITLE
test(shared): cover gpu hardware profiles and matcher heuristics

### DIFF
--- a/packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts
+++ b/packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for GPU inference hardware profiles and name matching.
+ * Validates card profile specifications, headroom calculation, and name matcher heuristics.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GPU_PROFILE_IDS,
+  GPU_PROFILES,
+  matchGpuProfile,
+  reservedHeadroomGb,
+} from "../gpu-profiles.ts";
+
+describe("gpu-profiles", () => {
+  describe("GPU_PROFILES and GPU_PROFILE_IDS", () => {
+    it("registers all 4 supported GPU profiles", () => {
+      expect(GPU_PROFILE_IDS).toEqual([
+        "rtx-3090",
+        "rtx-4090",
+        "rtx-5090",
+        "h200",
+      ]);
+      expect(Object.keys(GPU_PROFILES)).toHaveLength(4);
+    });
+
+    it("has correct hardware attributes for RTX 4090", () => {
+      const rtx4090 = GPU_PROFILES["rtx-4090"];
+      expect(rtx4090.displayName).toBe("NVIDIA GeForce RTX 4090");
+      expect(rtx4090.vramGb).toBe(24);
+      expect(rtx4090.computeCapability).toBe("sm_89");
+      expect(rtx4090.fp8).toBe(true);
+      expect(rtx4090.recommendedBundles).toContain("eliza-1-27b");
+    });
+
+    it("has correct hardware attributes for H200", () => {
+      const h200 = GPU_PROFILES.h200;
+      expect(h200.displayName).toBe("NVIDIA H200 (SXM 141 GiB)");
+      expect(h200.vramGb).toBe(141);
+      expect(h200.computeCapability).toBe("sm_90");
+      expect(h200.memoryBandwidthGBs).toBe(4800);
+    });
+  });
+
+  describe("matchGpuProfile", () => {
+    it("matches NVIDIA card names correctly", () => {
+      expect(matchGpuProfile("NVIDIA GeForce RTX 4090")).toBe("rtx-4090");
+      expect(matchGpuProfile("NVIDIA GeForce RTX 3090 Ti")).toBe("rtx-3090");
+      expect(matchGpuProfile("NVIDIA GeForce RTX 5090")).toBe("rtx-5090");
+      expect(matchGpuProfile("NVIDIA H200 141GB HBM3e")).toBe("h200");
+      expect(matchGpuProfile("rtx4090")).toBe("rtx-4090");
+    });
+
+    it("returns null for unsupported or non-matching card names", () => {
+      expect(matchGpuProfile("NVIDIA GeForce GTX 1080")).toBeNull();
+      expect(matchGpuProfile("NVIDIA RTX A6000")).toBeNull();
+      expect(matchGpuProfile("Apple M2 Max")).toBeNull();
+      expect(matchGpuProfile("")).toBeNull();
+    });
+  });
+
+  describe("reservedHeadroomGb", () => {
+    it("returns correct headroom reserve for each profile", () => {
+      expect(reservedHeadroomGb(GPU_PROFILES["rtx-3090"])).toBe(3);
+      expect(reservedHeadroomGb(GPU_PROFILES["rtx-4090"])).toBe(3);
+      expect(reservedHeadroomGb(GPU_PROFILES["rtx-5090"])).toBe(4);
+      expect(reservedHeadroomGb(GPU_PROFILES.h200)).toBe(6);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for GPU hardware profile specifications, headroom calculation, and card matcher logic with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `GPU_PROFILES`, `GPU_PROFILE_IDS`, `matchGpuProfile`, and `reservedHeadroomGb` in `@elizaos/shared`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:eb25969f432dbe6d6e0ff28dfaded482b9e2a8e1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts
bun test v1.3.11 (af24e281)

packages/shared/src/local-inference/__tests__/gpu-profiles-suite.test.ts:
(pass) gpu-profiles > GPU_PROFILES and GPU_PROFILE_IDS > registers all 4 supported GPU profiles
(pass) gpu-profiles > GPU_PROFILES and GPU_PROFILE_IDS > has correct hardware attributes for RTX 4090
(pass) gpu-profiles > GPU_PROFILES and GPU_PROFILE_IDS > has correct hardware attributes for H200
(pass) gpu-profiles > matchGpuProfile > matches NVIDIA card names correctly
(pass) gpu-profiles > matchGpuProfile > returns null for unsupported or non-matching card names
(pass) gpu-profiles > reservedHeadroomGb > returns correct headroom reserve for each profile
-----------------------------------------------------|---------|---------|-------------------
File                                                 | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------------|---------|---------|-------------------
All files                                            |  100.00 |  100.00 |
 packages/shared/src/local-inference/gpu-profiles.ts |  100.00 |  100.00 | 
-----------------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 24 expect() calls
Ran 6 tests across 1 file. [94.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
