### PR TITLE
test(core): cover settings-debug

### DIFF
--- a/packages/core/src/settings-debug.test.ts
+++ b/packages/core/src/settings-debug.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	isElizaSettingsDebugEnabled,
+	MAX_STRING,
+	sanitizeDebugString,
+} from "./settings-debug.js";
+
+describe("settings-debug", () => {
+	it("exposes MAX_STRING constant", () => {
+		expect(MAX_STRING).toBe(120);
+	});
+
+	it("detects enabled via env", () => {
+		expect(
+			isElizaSettingsDebugEnabled({ env: { ELIZA_SETTINGS_DEBUG: "1" } }),
+		).toBe(true);
+		expect(
+			isElizaSettingsDebugEnabled({
+				env: { VITE_ELIZA_SETTINGS_DEBUG: "true" },
+			}),
+		).toBe(true);
+		expect(isElizaSettingsDebugEnabled({ env: {} })).toBe(false);
+	});
+
+	it("detects enabled via importMetaEnv", () => {
+		expect(
+			isElizaSettingsDebugEnabled({
+				importMetaEnv: { ELIZA_SETTINGS_DEBUG: "1" },
+			}),
+		).toBe(true);
+		expect(
+			isElizaSettingsDebugEnabled({
+				importMetaEnv: { VITE_ELIZA_SETTINGS_DEBUG: "on" },
+			}),
+		).toBe(true);
+		expect(isElizaSettingsDebugEnabled({ importMetaEnv: {} })).toBe(false);
+	});
+
+	it("sanitizes strings", () => {
+		expect(sanitizeDebugString("")).toBe("");
+		expect(sanitizeDebugString("[REDACTED]")).toBe("[REDACTED]");
+		expect(sanitizeDebugString("  hello  ")).toBe("hello");
+		const long = `sk-${"a".repeat(60)}`;
+		const masked = sanitizeDebugString(long);
+		expect(masked).toContain("chars)");
+		expect(masked).not.toBe(long);
+	});
+});


### PR DESCRIPTION
<!-- evidence-head:4318b2ec5c6804304d51b3eea6663df173aaf396 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/core/src/settings-debug.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/core/src/settings-debug.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/core/src/settings-debug.test.ts`

## Detailed testing steps
`bunx vitest run packages/core/src/settings-debug.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Backend + frontend logs
N/A - test-only. See red->green below.

## Screenshots (before / after) + video walkthrough
N/A - no UI.

## Audio / voice walkthrough
N/A - no voice.

## Known gaps / failures
Typecheck: pre-existing failures may exist on develop; verified not introduced by this PR via revert check.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (production broken, keep test) -> Green (restored)

**Red — proves non-vacuous (imports real export):**
```
 ❯ packages/core/src/settings-debug.test.ts (4 tests | 1 failed) 3ms
     × exposes MAX_STRING constant 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/core/src/settings-debug.test.ts > settings-debug > exposes MAX_STRING constant
AssertionError: expected 'bad' to be 120 // Object.is equality

- Expected:
120

+ Received:
"bad"

 ❯ packages/core/src/settings-debug.test.ts:10:22
      8| describe("settings-debug", () => {
      9|  it("exposes MAX_STRING constant", () => {
     10|   expect(MAX_STRING).toBe(120);
       |                      ^
     11|  });
     12|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
   Start at  08:41:52
   Duration  115ms (transform 43ms, setup 0ms, import 50ms, tests 3ms, environment 0ms)
```

**Green:**
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:41:51
   Duration  110ms (transform 42ms, setup 0ms, import 49ms, tests 2ms, environment 0ms)
```

