### PR TITLE
test(core): cover wallet rpc provider contracts and normalizers

### DIFF
--- a/packages/core/src/__tests__/wallet-contracts-suite.test.ts
+++ b/packages/core/src/__tests__/wallet-contracts-suite.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for wallet RPC configuration contracts and normalizers.
+ * Validates RPC provider options, aliases resolution, and selection normalizers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_WALLET_RPC_SELECTIONS,
+	normalizeWalletRpcProviderId,
+	normalizeWalletRpcSelections,
+	WALLET_RPC_PROVIDER_OPTIONS,
+} from "../contracts/wallet.ts";
+
+describe("wallet contracts", () => {
+	describe("constants", () => {
+		it("defines default wallet RPC selections", () => {
+			expect(DEFAULT_WALLET_RPC_SELECTIONS).toEqual({
+				evm: "eliza-cloud",
+				bsc: "eliza-cloud",
+				solana: "eliza-cloud",
+			});
+		});
+
+		it("registers provider options for EVM, BSC, and Solana chains", () => {
+			expect(WALLET_RPC_PROVIDER_OPTIONS.evm.map((o) => o.id)).toContain(
+				"eliza-cloud",
+			);
+			expect(WALLET_RPC_PROVIDER_OPTIONS.evm.map((o) => o.id)).toContain(
+				"alchemy",
+			);
+			expect(WALLET_RPC_PROVIDER_OPTIONS.bsc.map((o) => o.id)).toContain(
+				"nodereal",
+			);
+			expect(WALLET_RPC_PROVIDER_OPTIONS.solana.map((o) => o.id)).toContain(
+				"helius-birdeye",
+			);
+		});
+	});
+
+	describe("normalizeWalletRpcProviderId", () => {
+		it("resolves valid provider IDs across chains", () => {
+			expect(normalizeWalletRpcProviderId("evm", "alchemy")).toBe("alchemy");
+			expect(normalizeWalletRpcProviderId("evm", "infura")).toBe("infura");
+			expect(normalizeWalletRpcProviderId("bsc", "quicknode")).toBe(
+				"quicknode",
+			);
+			expect(normalizeWalletRpcProviderId("solana", "helius-birdeye")).toBe(
+				"helius-birdeye",
+			);
+		});
+
+		it("resolves aliases correctly", () => {
+			expect(normalizeWalletRpcProviderId("evm", "elizacloud")).toBe(
+				"eliza-cloud",
+			);
+			expect(normalizeWalletRpcProviderId("bsc", "elizacloud")).toBe(
+				"eliza-cloud",
+			);
+			expect(normalizeWalletRpcProviderId("solana", "helius")).toBe(
+				"helius-birdeye",
+			);
+		});
+
+		it("returns null for mismatched chains or invalid provider IDs", () => {
+			expect(normalizeWalletRpcProviderId("evm", "nodereal")).toBeNull();
+			expect(normalizeWalletRpcProviderId("solana", "alchemy")).toBeNull();
+			expect(
+				normalizeWalletRpcProviderId("evm", "unknown-provider"),
+			).toBeNull();
+			expect(normalizeWalletRpcProviderId("evm", "")).toBeNull();
+			expect(normalizeWalletRpcProviderId("evm", null)).toBeNull();
+			expect(normalizeWalletRpcProviderId("evm", undefined)).toBeNull();
+		});
+	});
+
+	describe("normalizeWalletRpcSelections", () => {
+		it("normalizes valid selections and applies defaults for missing fields", () => {
+			const selections = normalizeWalletRpcSelections({
+				evm: "alchemy",
+				solana: "helius",
+			});
+
+			expect(selections).toEqual({
+				evm: "alchemy",
+				bsc: "eliza-cloud",
+				solana: "helius-birdeye",
+			});
+		});
+
+		it("falls back to full default selection when input is empty or null", () => {
+			expect(normalizeWalletRpcSelections(null)).toEqual(
+				DEFAULT_WALLET_RPC_SELECTIONS,
+			);
+			expect(normalizeWalletRpcSelections(undefined)).toEqual(
+				DEFAULT_WALLET_RPC_SELECTIONS,
+			);
+			expect(normalizeWalletRpcSelections({})).toEqual(
+				DEFAULT_WALLET_RPC_SELECTIONS,
+			);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for wallet RPC provider configuration constants and normalizers with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `DEFAULT_WALLET_RPC_SELECTIONS`, `WALLET_RPC_PROVIDER_OPTIONS`, `normalizeWalletRpcProviderId`, and `normalizeWalletRpcSelections` in `@elizaos/core`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/core/src/__tests__/wallet-contracts-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/core/src/__tests__/wallet-contracts-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:66ace2de79d22d0831ed639f2a2ef1a3cf617440 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/core/src/__tests__/wallet-contracts-suite.test.ts
bun test v1.3.11 (af24e281)

packages/core/src/__tests__/wallet-contracts-suite.test.ts:
(pass) wallet contracts > constants > defines default wallet RPC selections
(pass) wallet contracts > constants > registers provider options for EVM, BSC, and Solana chains
(pass) wallet contracts > normalizeWalletRpcProviderId > resolves valid provider IDs across chains
(pass) wallet contracts > normalizeWalletRpcProviderId > resolves aliases correctly
(pass) wallet contracts > normalizeWalletRpcProviderId > returns null for mismatched chains or invalid provider IDs
(pass) wallet contracts > normalizeWalletRpcSelections > normalizes valid selections and applies defaults for missing fields
(pass) wallet contracts > normalizeWalletRpcSelections > falls back to full default selection when input is empty or null
---------------------------------------|---------|---------|-------------------
File                                   | % Funcs | % Lines | Uncovered Line #s
---------------------------------------|---------|---------|-------------------
All files                              |  100.00 |  100.00 |
 packages/core/src/contracts/wallet.ts |  100.00 |  100.00 | 
---------------------------------------|---------|---------|-------------------

 7 pass
 0 fail
 22 expect() calls
Ran 7 tests across 1 file. [94.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
