### PR TITLE
test(context): prove cross-world recall revocation

### DIFF
--- a/packages/agent/src/providers/recent-conversations.access-context.test.ts
+++ b/packages/agent/src/providers/recent-conversations.access-context.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Deterministic integration coverage for cross-world recent-conversation
+ * authorization. The production provider, access-context helper, AgentRuntime,
+ * and in-memory adapter execute together; only live membership changes between
+ * reads, proving a revoked room is removed before storage disclosure.
+ */
+import {
+  AgentRuntime,
+  attestDeliveryAudienceFromCanonicalRoom,
+  buildCrossWorldConversationAccessContext,
+  ChannelType,
+  createCharacter,
+  createMessageMemory,
+  InMemoryDatabaseAdapter,
+  type Memory,
+  revalidateOwnerExclusiveDisclosure,
+  type State,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { recentConversationsProvider } from "./recent-conversations.ts";
+
+const OWNER = stringToUuid("recent-conversations-access-owner");
+const CURRENT_ROOM = stringToUuid("recent-conversations-access-current-room");
+const RETAINED_ROOM = stringToUuid("recent-conversations-access-retained-room");
+const REVOKED_ROOM = stringToUuid("recent-conversations-access-revoked-room");
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+const activeRuntimes: AgentRuntime[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    activeRuntimes.splice(0).map(async (runtime) => {
+      await runtime.stop();
+      await runtime.close();
+    }),
+  );
+});
+
+async function createRuntime(): Promise<{
+  runtime: AgentRuntime;
+  adapter: InMemoryDatabaseAdapter;
+}> {
+  const character = createCharacter({ name: "RecentConversationAccessAgent" });
+  const agentId = stringToUuid("recent-conversations-access-agent");
+  const adapter = new InMemoryDatabaseAdapter(agentId);
+  const runtime = new AgentRuntime({
+    character,
+    agentId,
+    adapter,
+    enableAutonomy: false,
+    logLevel: "fatal",
+  });
+  activeRuntimes.push(runtime);
+  await runtime.initialize();
+  runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", OWNER);
+  return { runtime, adapter };
+}
+
+async function ensureOwnerDm(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  source: string,
+): Promise<void> {
+  const worldId = stringToUuid(`recent-conversations-world:${source}`);
+  await runtime.ensureConnection({
+    entityId: OWNER,
+    roomId,
+    worldId,
+    worldName: `${source} world`,
+    userName: "owner",
+    source,
+    channelId: `${source}:${roomId}`,
+    type: ChannelType.DM,
+  });
+  const world = await runtime.getWorld(worldId);
+  if (!world) throw new Error(`missing ${source} test world`);
+  world.metadata = {
+    ...world.metadata,
+    ownership: { ownerId: OWNER },
+    roles: { ...world.metadata?.roles, [OWNER]: "OWNER" },
+    roleSources: { [OWNER]: "manual" },
+  };
+  await runtime.updateWorld(world);
+}
+
+function storedMessage(
+  runtime: AgentRuntime,
+  roomId: UUID,
+  source: string,
+  text: string,
+  createdAt: number,
+): Memory {
+  const memory = createMessageMemory({
+    id: stringToUuid(`recent-conversations-message:${roomId}`),
+    agentId: runtime.agentId,
+    entityId: OWNER,
+    roomId,
+    content: { text, source, channelType: ChannelType.DM },
+  });
+  memory.createdAt = createdAt;
+  memory.metadata = { type: "message", scope: "global" };
+  return memory;
+}
+
+async function ownerTurn(
+  runtime: AgentRuntime,
+  sequence: number,
+): Promise<Memory> {
+  const turn = createMessageMemory({
+    id: stringToUuid(`recent-conversations-turn:${sequence}`),
+    agentId: runtime.agentId,
+    entityId: OWNER,
+    roomId: CURRENT_ROOM,
+    content: {
+      text: "What did I say elsewhere?",
+      source: "discord",
+      channelType: ChannelType.DM,
+    },
+  });
+  await attestDeliveryAudienceFromCanonicalRoom(runtime, turn);
+  return turn;
+}
+
+describe("recentConversationsProvider access-context integration", () => {
+  it("removes a cross-world room from recall immediately after membership is revoked", async () => {
+    const { runtime, adapter } = await createRuntime();
+    await ensureOwnerDm(runtime, CURRENT_ROOM, "discord");
+    await ensureOwnerDm(runtime, RETAINED_ROOM, "telegram");
+    await ensureOwnerDm(runtime, REVOKED_ROOM, "x");
+
+    await runtime.createMemory(
+      storedMessage(
+        runtime,
+        RETAINED_ROOM,
+        "telegram",
+        "retained cross-world message",
+        100,
+      ),
+      "messages",
+    );
+    await runtime.createMemory(
+      storedMessage(
+        runtime,
+        REVOKED_ROOM,
+        "x",
+        "revoked cross-world message",
+        200,
+      ),
+      "messages",
+    );
+
+    const storageRead = vi.spyOn(adapter, "getMemoriesByRoomIds");
+    const firstTurn = await ownerTurn(runtime, 1);
+    expect(
+      await revalidateOwnerExclusiveDisclosure(runtime, firstTurn),
+    ).toMatchObject({ allowed: true, basis: "owner_private_destination" });
+    const firstAccessContext = await buildCrossWorldConversationAccessContext(
+      runtime,
+      firstTurn,
+    );
+    expect(firstAccessContext).toMatchObject({
+      role: "OWNER",
+      isOwner: true,
+      authorizedRoomIds: expect.arrayContaining([RETAINED_ROOM, REVOKED_ROOM]),
+    });
+    expect(
+      await runtime.getMemoriesByRoomIds({
+        tableName: "messages",
+        roomIds: [RETAINED_ROOM, REVOKED_ROOM],
+        accessContext: firstAccessContext,
+      }),
+    ).toHaveLength(2);
+    const beforeRevocation = await recentConversationsProvider.get(
+      runtime,
+      firstTurn,
+      EMPTY_STATE,
+    );
+
+    expect(beforeRevocation.text).toContain("retained cross-world message");
+    expect(beforeRevocation.text).toContain("revoked cross-world message");
+    expect(beforeRevocation.values?.recentConversationCount).toBe(2);
+    expect(storageRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        roomIds: expect.arrayContaining([RETAINED_ROOM, REVOKED_ROOM]),
+        accessContext: expect.objectContaining({
+          authorizedRoomIds: expect.arrayContaining([
+            RETAINED_ROOM,
+            REVOKED_ROOM,
+          ]),
+        }),
+      }),
+    );
+
+    await runtime.removeParticipant(OWNER, REVOKED_ROOM);
+    const afterRevocation = await recentConversationsProvider.get(
+      runtime,
+      await ownerTurn(runtime, 2),
+      EMPTY_STATE,
+    );
+
+    expect(afterRevocation.text).toContain("retained cross-world message");
+    expect(afterRevocation.text).not.toContain("revoked cross-world message");
+    expect(afterRevocation.values?.recentConversationCount).toBe(1);
+    const finalRead = storageRead.mock.calls.at(-1)?.[0];
+    expect(finalRead?.roomIds).toContain(RETAINED_ROOM);
+    expect(finalRead?.roomIds).not.toContain(REVOKED_ROOM);
+    expect(finalRead?.accessContext?.authorizedRoomIds).toContain(
+      RETAINED_ROOM,
+    );
+    expect(finalRead?.accessContext?.authorizedRoomIds).not.toContain(
+      REVOKED_ROOM,
+    );
+  });
+});

--- a/packages/core/src/access-context.test.ts
+++ b/packages/core/src/access-context.test.ts
@@ -6,13 +6,18 @@
  * resolvable worldId) role/owner are undefined — callers must read that as "no
  * elevated access", never "unrestricted".
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	buildAccessContext,
 	buildCrossWorldConversationAccessContext,
 } from "./access-context";
 import { createUniqueUuid } from "./entities";
-import type { IAgentRuntime, Memory, UUID } from "./types";
+import {
+	type IAgentRuntime,
+	type Memory,
+	ServiceType,
+	type UUID,
+} from "./types";
 
 const AGENT = "00000000-0000-0000-0000-0000000000a9" as UUID;
 const USER = "00000000-0000-0000-0000-0000000000u5" as UUID;
@@ -148,5 +153,45 @@ describe("buildCrossWorldConversationAccessContext", () => {
 		expect(ctx.isOwner).toBe(true);
 		expect(ctx.worldId).toBeUndefined();
 		expect(ctx.authorizedRoomIds).toEqual([OTHER_ROOM]);
+	});
+
+	it("returns an explicit empty authorization set when requester and agent rooms do not intersect", async () => {
+		const runtime = runtimeWithRoles({ [USER]: "OWNER" }, WORLD, {
+			[USER]: "manual",
+		});
+		runtime.getRoomsForParticipants = async () => [ROOM];
+		runtime.getRoomsForParticipant = async () => [OTHER_ROOM];
+
+		const ctx = await buildCrossWorldConversationAccessContext(
+			runtime,
+			message("discord"),
+		);
+
+		expect(ctx.worldId).toBeUndefined();
+		expect(ctx.authorizedRoomIds).toEqual([]);
+	});
+
+	it("fails closed before room discovery when the identity authority fails", async () => {
+		const runtime = runtimeWithRoles({ [USER]: "OWNER" }, WORLD, {
+			[USER]: "manual",
+		});
+		const getRoomsForParticipants = vi.fn(async () => [ROOM]);
+		const getRoomsForParticipant = vi.fn(async () => [ROOM]);
+		runtime.getRoomsForParticipants = getRoomsForParticipants;
+		runtime.getRoomsForParticipant = getRoomsForParticipant;
+		runtime.getService = ((serviceType: string) =>
+			serviceType === ServiceType.PRINCIPAL
+				? {
+						getCluster: async () => {
+							throw new Error("identity authority unavailable");
+						},
+					}
+				: null) as IAgentRuntime["getService"];
+
+		await expect(
+			buildCrossWorldConversationAccessContext(runtime, message("discord")),
+		).rejects.toThrow("identity authority unavailable");
+		expect(getRoomsForParticipants).not.toHaveBeenCalled();
+		expect(getRoomsForParticipant).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Fixes #26937.

## What changed

- Proves an empty requester/agent room intersection produces an explicit deny-all `authorizedRoomIds` set.
- Proves identity-authority failure stops before either room-discovery call.
- Adds an integration-style test using the production recent-conversations provider, real cross-world access helper, canonical private-audience attestation, `AgentRuntime`, and `InMemoryDatabaseAdapter`.
- Seeds Discord, Telegram, and X rooms, then revokes the owner’s X-room membership and proves the next provider/storage read excludes both the room and its message.

## Validation

- Core access-context tests: 8/8 pass.
- New and existing recent-conversations tests: 9/9 pass.
- Core typecheck: pass.
- Biome exact files: pass.
- `git diff --check`: pass.

The agent-wide typecheck is not claimed from the sparse worktree because unrelated workspace sources are intentionally absent there; hosted exact-head Static Smoke remains required. This PR is tests only and has no migration or UI evidence requirements.

<!-- evidence-head:99b80441787e681f426aa9485948fc55a6791639 -->
