### PR TITLE
test(shared): cover hardware product catalog and lookup helpers

### DIFF
--- a/packages/cloud/shared/src/db/__tests__/execute-helpers-suite.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/execute-helpers-suite.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for cloud DB execute helper utilities.
+ * Validates driver rows extraction and row count normalization.
+ */
+
+import type { SQLWrapper } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { mutateRowCount, type SqlExecutor, sqlRows } from "../execute-helpers.ts";
+
+describe("execute-helpers", () => {
+  describe("sqlRows", () => {
+    it("extracts rows array from valid database execution result", async () => {
+      const fakeDb: SqlExecutor = {
+        execute: async () => ({
+          rows: [
+            { id: 1, name: "Alice" },
+            { id: 2, name: "Bob" },
+          ],
+        }),
+      };
+      const dummyQuery = {} as SQLWrapper;
+      const rows = await sqlRows<{ id: number; name: string }>(fakeDb, dummyQuery);
+      expect(rows).toEqual([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]);
+    });
+
+    it("throws error if execute result is not an object with rows", async () => {
+      const fakeDb: SqlExecutor = {
+        execute: async () => null,
+      };
+      const dummyQuery = {} as SQLWrapper;
+      await expect(sqlRows(fakeDb, dummyQuery)).rejects.toThrow(
+        "[sqlRows] execute() did not return an object with rows",
+      );
+    });
+
+    it("throws error if rows property is not an array", async () => {
+      const fakeDb: SqlExecutor = {
+        execute: async () => ({ rows: "not-an-array" }),
+      };
+      const dummyQuery = {} as SQLWrapper;
+      await expect(sqlRows(fakeDb, dummyQuery)).rejects.toThrow(
+        "[sqlRows] execute().rows is not an array",
+      );
+    });
+  });
+
+  describe("mutateRowCount", () => {
+    it("extracts valid numeric rowCount", () => {
+      expect(mutateRowCount({ rowCount: 5 })).toBe(5);
+      expect(mutateRowCount({ rowCount: 0 })).toBe(0);
+    });
+
+    it("returns 0 for missing or non-numeric rowCount", () => {
+      expect(mutateRowCount({})).toBe(0);
+      expect(mutateRowCount({ rowCount: "5" })).toBe(0);
+      expect(mutateRowCount(null)).toBe(0);
+      expect(mutateRowCount(undefined)).toBe(0);
+      expect(mutateRowCount("string-result")).toBe(0);
+    });
+  });
+});

--- a/packages/cloud/shared/src/db/__tests__/mobile-app-auth-credential-policy-suite.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/mobile-app-auth-credential-policy-suite.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for mobile app auth credential provenance policy.
+ * Validates canonical credential naming, description formatting, and composite provenance builders.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildMobileAppAuthCredentialDescription,
+  buildMobileAppAuthCredentialName,
+  buildMobileAppAuthCredentialProvenance,
+  MOBILE_APP_AUTH_CREDENTIAL_DESCRIPTION_PREFIX,
+  MOBILE_APP_AUTH_CREDENTIAL_NAME_PREFIX,
+} from "../mobile-app-auth-credential-policy.ts";
+
+describe("mobile-app-auth-credential-policy", () => {
+  describe("constants", () => {
+    it("defines canonical prefixes", () => {
+      expect(MOBILE_APP_AUTH_CREDENTIAL_NAME_PREFIX).toBe("Eliza mobile");
+      expect(MOBILE_APP_AUTH_CREDENTIAL_DESCRIPTION_PREFIX).toBe("First-party mobile credential");
+    });
+  });
+
+  describe("buildMobileAppAuthCredentialName", () => {
+    it("includes deviceName when present", () => {
+      const name = buildMobileAppAuthCredentialName({
+        deviceName: "iPhone 16 Pro",
+        environment: "production",
+        grantId: "grant-uuid-1234",
+      });
+      expect(name).toBe("Eliza mobile - iPhone 16 Pro - production - grant-uuid-1234");
+    });
+
+    it("omits deviceName when null or undefined", () => {
+      const name = buildMobileAppAuthCredentialName({
+        deviceName: null,
+        environment: "staging",
+        grantId: "grant-uuid-5678",
+      });
+      expect(name).toBe("Eliza mobile - staging - grant-uuid-5678");
+    });
+  });
+
+  describe("buildMobileAppAuthCredentialDescription", () => {
+    it("formats client ID and space-separated scopes", () => {
+      const desc = buildMobileAppAuthCredentialDescription({
+        clientId: "mobile-app-client",
+        scopes: ["offline_access", "read:agents", "write:messages"],
+      });
+      expect(desc).toBe(
+        "First-party mobile credential; client=mobile-app-client; scope=offline_access read:agents write:messages",
+      );
+    });
+  });
+
+  describe("buildMobileAppAuthCredentialProvenance", () => {
+    it("builds composite name and description bundle", () => {
+      const prov = buildMobileAppAuthCredentialProvenance({
+        deviceName: "Pixel 9",
+        environment: "production",
+        grantId: "grant-001",
+        clientId: "client-android",
+        scopes: ["read", "write"],
+      });
+      expect(prov).toEqual({
+        name: "Eliza mobile - Pixel 9 - production - grant-001",
+        description: "First-party mobile credential; client=client-android; scope=read write",
+      });
+    });
+  });
+});

--- a/packages/core/src/__tests__/code-fence-suite.test.ts
+++ b/packages/core/src/__tests__/code-fence-suite.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for code fence unwrapping and language delimiter parsing.
+ * Validates whole code fence unwrapping, unsupported language rejection, and whitespace trimming.
+ */
+import { describe, expect, it } from "vitest";
+import { unwrapWholeCodeFence } from "../utils/code-fence.ts";
+
+describe("code-fence", () => {
+	it("returns null for non-fence or malformed strings", () => {
+		expect(unwrapWholeCodeFence("plain text", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```json", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("hello```", ["json"])).toBeNull();
+	});
+
+	it("unwraps matching language fences cleanly", () => {
+		const jsonFence = '```json\n{"foo": "bar"}\n```';
+		expect(unwrapWholeCodeFence(jsonFence, ["json"])).toBe('{"foo": "bar"}');
+
+		const upperJsonFence = '```JSON\n{"foo": "bar"}\n```';
+		expect(unwrapWholeCodeFence(upperJsonFence, ["json"])).toBe(
+			'{"foo": "bar"}',
+		);
+	});
+
+	it("unwraps bare code fences without language tags", () => {
+		const bareFence = "```\nhello world\n```";
+		expect(unwrapWholeCodeFence(bareFence, ["json"])).toBe("hello world");
+
+		const compactBare = "```true```";
+		expect(unwrapWholeCodeFence(compactBare, ["json"])).toBe("true");
+	});
+
+	it("rejects fences with unsupported explicit language identifiers", () => {
+		const xmlFence = "```xml\n<data></data>\n```";
+		expect(unwrapWholeCodeFence(xmlFence, ["json"])).toBeNull();
+	});
+});

--- a/packages/core/src/__tests__/schema-builder-suite.test.ts
+++ b/packages/core/src/__tests__/schema-builder-suite.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit tests for schema builder dialect utilities.
+ * Validates snake_case to camelCase conversion for table column identifiers.
+ */
+import { describe, expect, it } from "vitest";
+import { snakeToCamel } from "../types/schema-builder.ts";
+
+describe("schema-builder", () => {
+	describe("snakeToCamel", () => {
+		it("converts simple snake_case strings to camelCase", () => {
+			expect(snakeToCamel("agent_id")).toBe("agentId");
+			expect(snakeToCamel("created_at")).toBe("createdAt");
+			expect(snakeToCamel("user_first_name")).toBe("userFirstName");
+		});
+
+		it("handles alphanumeric tokens with numbers correctly", () => {
+			expect(snakeToCamel("dim_384")).toBe("dim384");
+			expect(snakeToCamel("field_1_value")).toBe("field1Value");
+		});
+
+		it("leaves strings without underscores unchanged", () => {
+			expect(snakeToCamel("alreadyCamel")).toBe("alreadyCamel");
+			expect(snakeToCamel("name")).toBe("name");
+			expect(snakeToCamel("")).toBe("");
+		});
+	});
+});

--- a/packages/shared/src/brand-classic/__tests__/brand-classic-suite.test.ts
+++ b/packages/shared/src/brand-classic/__tests__/brand-classic-suite.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for Eliza Classic brand tokens and asset path resolution.
+ * Validates path formatting, color palette values, and logo/favicon registries.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BRAND_ASSET_BASE_PATH,
+  brandAssetPath,
+  brandColors,
+  brandFavicons,
+  brandLogos,
+} from "../index.ts";
+
+describe("brand-classic", () => {
+  describe("brandAssetPath", () => {
+    it("resolves asset paths with default /brand base path", () => {
+      expect(BRAND_ASSET_BASE_PATH).toBe("/brand");
+      expect(brandAssetPath("logos/logo.svg")).toBe("/brand/logos/logo.svg");
+      expect(brandAssetPath("/logos/logo.svg")).toBe("/brand/logos/logo.svg");
+    });
+  });
+
+  describe("brandColors", () => {
+    it("defines expected canonical brand hex values", () => {
+      expect(brandColors.orange).toBe("#FF5800");
+      expect(brandColors.blue).toBe("#0B35F1");
+      expect(brandColors.black).toBe("#000000");
+      expect(brandColors.white).toBe("#FFFFFF");
+    });
+  });
+
+  describe("brandLogos and brandFavicons", () => {
+    it("ensures all logo paths begin with /brand/", () => {
+      for (const path of Object.values(brandLogos)) {
+        expect(path).toMatch(/^\/brand\//);
+      }
+    });
+
+    it("ensures all favicon paths begin with /brand/", () => {
+      for (const path of Object.values(brandFavicons)) {
+        expect(path).toMatch(/^\/brand\//);
+      }
+    });
+  });
+});

--- a/packages/shared/src/checkout/__tests__/checkout-suite.test.ts
+++ b/packages/shared/src/checkout/__tests__/checkout-suite.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for shared hardware checkout client and error formatting.
+ * Validates Stripe checkout session payload creation, token headers, and error handling.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createStripeCheckoutSession,
+  StripeCheckoutError,
+  startStripeCheckout,
+} from "../index.ts";
+
+describe("checkout", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("StripeCheckoutError", () => {
+    it("sets error properties and custom name correctly", () => {
+      const err = new StripeCheckoutError("Payment failed", 402);
+      expect(err.message).toBe("Payment failed");
+      expect(err.status).toBe(402);
+      expect(err.name).toBe("StripeCheckoutError");
+    });
+  });
+
+  describe("createStripeCheckoutSession", () => {
+    it("sends request with headers and bearer token and returns session url on success", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          url: "https://checkout.stripe.com/c/pay/cs_test_12345",
+        }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const url = await createStripeCheckoutSession(
+        {
+          hardwareSku: "eliza-hw-1",
+          hardwareColor: "black",
+          returnUrl: "https://eliza.app/checkout/complete",
+        },
+        {
+          apiBaseUrl: "https://api.eliza.app",
+          bearerToken: "steward-session-token",
+        },
+      );
+
+      expect(url).toBe("https://checkout.stripe.com/c/pay/cs_test_12345");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.eliza.app/api/stripe/create-checkout-session",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer steward-session-token",
+          },
+        }),
+      );
+    });
+
+    it("throws StripeCheckoutError on non-OK response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Invalid hardware SKU" }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(
+        createStripeCheckoutSession(
+          {
+            hardwareSku: "invalid-sku",
+            hardwareColor: "black",
+            returnUrl: "https://eliza.app/checkout/complete",
+          },
+          {
+            apiBaseUrl: "",
+          },
+        ),
+      ).rejects.toThrow("Invalid hardware SKU");
+    });
+
+    it("throws StripeCheckoutError when response body is missing url", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(
+        createStripeCheckoutSession(
+          {
+            hardwareSku: "eliza-hw-1",
+            hardwareColor: "black",
+            returnUrl: "https://eliza.app/checkout/complete",
+          },
+          {
+            apiBaseUrl: "https://api.eliza.app",
+          },
+        ),
+      ).rejects.toThrow("Could not start checkout.");
+    });
+  });
+
+  describe("startStripeCheckout", () => {
+    it("redirects window.location to checkout url", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ url: "https://checkout.stripe.com/pay/cs_999" }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+      const originalWindow = globalThis.window;
+      const mockLocation = { href: "" };
+      globalThis.window = { location: mockLocation } as unknown as Window &
+        typeof globalThis;
+
+      try {
+        await startStripeCheckout(
+          {
+            hardwareSku: "eliza-hw-1",
+            hardwareColor: "black",
+            returnUrl: "https://eliza.app/checkout/complete",
+          },
+          {
+            apiBaseUrl: "https://api.eliza.app",
+          },
+        );
+        expect(mockLocation.href).toBe(
+          "https://checkout.stripe.com/pay/cs_999",
+        );
+      } finally {
+        globalThis.window = originalWindow;
+      }
+    });
+  });
+});

--- a/packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts
+++ b/packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for hardware product catalog and lookup helpers.
+ * Validates SKU mappings, slug index lookups, and product specification data.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  findBySku,
+  findBySlug,
+  HARDWARE_PRODUCTS,
+  HARDWARE_SKUS,
+} from "../index.ts";
+
+describe("hardware-catalog", () => {
+  describe("HARDWARE_PRODUCTS and HARDWARE_SKUS", () => {
+    it("registers all 8 hardware catalog products", () => {
+      expect(HARDWARE_PRODUCTS).toHaveLength(8);
+      expect(HARDWARE_SKUS).toHaveLength(8);
+      expect(HARDWARE_SKUS).toContain("elizaos-usb");
+      expect(HARDWARE_SKUS).toContain("elizaos-phone");
+      expect(HARDWARE_SKUS).toContain("elizaos-box");
+      expect(HARDWARE_SKUS).toContain("elizaos-mini-pc");
+    });
+
+    it("has required price and marketing metadata on every product", () => {
+      for (const product of HARDWARE_PRODUCTS) {
+        expect(product.priceUsd).toBeGreaterThan(0);
+        expect(product.colors.length).toBeGreaterThan(0);
+        expect(product.stripeName.length).toBeGreaterThan(0);
+        expect(product.stripeDescription.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("findBySku", () => {
+    it("returns product when matching SKU exists", () => {
+      const product = findBySku("elizaos-phone");
+      expect(product).toBeDefined();
+      expect(product?.name).toBe("ElizaOS Phone");
+      expect(product?.kind).toBe("phone");
+    });
+
+    it("returns undefined for unknown SKU", () => {
+      expect(findBySku("non-existent-sku")).toBeUndefined();
+    });
+  });
+
+  describe("findBySlug", () => {
+    it("returns product when matching slug exists", () => {
+      const product = findBySlug("usb");
+      expect(product).toBeDefined();
+      expect(product?.sku).toBe("elizaos-usb");
+    });
+
+    it("returns undefined for unknown slug", () => {
+      expect(findBySlug("unknown-slug")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for `HARDWARE_PRODUCTS`, `HARDWARE_SKUS`, `findBySku`, and `findBySlug` with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `HARDWARE_PRODUCTS`, `HARDWARE_SKUS`, `findBySku`, and `findBySlug` in `@elizaos/shared`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts`

## Detailed testing steps
Run:
```bash
bun test packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:305e6661fcc9f6f2b45098a62858a89e9413e038 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
bun test packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts
bun test v1.3.11 (af24e281)

packages/shared/src/hardware-catalog/__tests__/hardware-catalog-suite.test.ts:
(pass) hardware-catalog > HARDWARE_PRODUCTS and HARDWARE_SKUS > registers all 8 hardware catalog products
(pass) hardware-catalog > HARDWARE_PRODUCTS and HARDWARE_SKUS > has required price and marketing metadata on every product
(pass) hardware-catalog > findBySku > returns product when matching SKU exists
(pass) hardware-catalog > findBySku > returns undefined for unknown SKU
(pass) hardware-catalog > findBySlug > returns product when matching slug exists
(pass) hardware-catalog > findBySlug > returns undefined for unknown slug
-----------------------------------------------|---------|---------|-------------------
File                                           | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------------|---------|---------|-------------------
All files                                      |  100.00 |  100.00 |
 packages/shared/src/brand/index.ts            |  100.00 |  100.00 | 
 packages/shared/src/hardware-catalog/index.ts |  100.00 |  100.00 | 
-----------------------------------------------|---------|---------|-------------------

 6 pass
 0 fail
 45 expect() calls
Ran 6 tests across 1 file. [97.00ms]
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
