### PR TITLE
test(cloud): cover app-url

### DIFF
--- a/packages/cloud/shared/src/lib/services/app-url.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/containers-env.js", () => ({
+  containersEnv: { appsPublicBaseDomain: vi.fn() },
+}));
+
+import { containersEnv } from "../config/containers-env.js";
+import { deriveAppPublicUrl } from "./app-url.js";
+
+describe("deriveAppPublicUrl", () => {
+  it("returns null when domain not configured", () => {
+    vi.mocked(containersEnv.appsPublicBaseDomain).mockReturnValue("");
+    expect(deriveAppPublicUrl("123e4567-e89b-12d3-a456-426614174000")).toBeNull();
+  });
+
+  it("derives hostname and url from containerId", () => {
+    vi.mocked(containersEnv.appsPublicBaseDomain).mockReturnValue("apps.eliza.app");
+    const res = deriveAppPublicUrl("123e4567-e89b-12d3-a456-426614174000");
+    expect(res).toEqual({
+      hostname: "123e4567.apps.eliza.app",
+      url: "https://123e4567.apps.eliza.app",
+    });
+  });
+
+  it("handles short id without dashes", () => {
+    vi.mocked(containersEnv.appsPublicBaseDomain).mockReturnValue("example.com");
+    const res = deriveAppPublicUrl("abcdef1234567890");
+    expect(res?.hostname).toBe("abcdef12.example.com");
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:4e05841251935fc90d92746de69027d2b02d10d1 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/lib/services/app-url.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/lib/services/app-url.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/lib/services/app-url.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/lib/services/app-url.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Testing evidence
## Green (with production code)
```
 Test Files  1 passed (1);      Tests  3 passed (3);
```
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  09:14:34
   Duration  98ms (transform 21ms, setup 0ms, import 27ms, tests 2ms, environment 0ms)
```

## Red (production file broken, test must fail)
```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯; FAIL  packages/cloud/shared/src/lib/services/app-url.test.ts > deriveAppPublicUrl > returns null when domain not configured;AssertionError: expected 'bad' to be null; FAIL  packages/cloud/shared/src/lib/services/app-url.test.ts > deriveAppPublicUrl > derives hostname and url from containerId;AssertionError: expected 'bad' to deeply equal { …(2) }; FAIL  packages/cloud/shared/src/lib/services/app-url.test.ts > deriveAppPublicUrl > handles short id without dashes;AssertionError: expected undefined to be 'abcdef12.example.com' // Object.is equality; Test Files  1 failed (1);      Tests  3 failed (3);
```
```
     26|     vi.mocked(containersEnv.appsPublicBaseDomain).mockReturnValue("exa…
     27|     const res = deriveAppPublicUrl("abcdef1234567890");
     28|     expect(res?.hostname).toBe("abcdef12.example.com");
       |                           ^
     29|   });
     30| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed (3)
   Start at  09:14:35
   Duration  92ms (transform 20ms, setup 0ms, import 27ms, tests 4ms, environment 0ms)
```

## Existing suites
N/A - isolated new file.

## Biome
`biome check --write` clean on changed file.

## Typecheck
N/A - test-only, no production types changed. `bun run --cwd packages/app typecheck` baseline unchanged (verified via `bun run typecheck` on develop).

# Known gaps / failures
N/A - no unrelated failures observed.

# Maintainer CI exception record
N/A - no exception requested.

