### PR TITLE
fix(examples): type dual-runner test APIs

### DIFF
--- a/packages/examples/code/src/components/task-pane.test.ts
+++ b/packages/examples/code/src/components/task-pane.test.ts
@@ -9,9 +9,15 @@ import { VirtualTerminal } from "../testing/virtual-terminal.test.js";
 import type { CodeTask } from "../types.js";
 import { TaskPane } from "./TaskPane.js";
 
-const { beforeEach, describe, expect, it } = process.env.VITEST
+type TestApi = Pick<
+  typeof import("vitest"),
+  "beforeEach" | "describe" | "expect" | "it"
+>;
+
+const runnerApi = process.env.VITEST
   ? await import("vitest")
   : await import("bun:test");
+const { beforeEach, describe, expect, it } = runnerApi as unknown as TestApi;
 
 function codeTask(): CodeTask {
   return {

--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -18,9 +18,15 @@ import type { ChatRoom } from "../types.js";
 import { getAgentClient, resetAgentClient } from "./agent-client.js";
 import type { SessionIdentity } from "./identity.js";
 
-const { beforeEach, describe, expect, it } = process.env.VITEST
+type TestApi = Pick<
+  typeof import("vitest"),
+  "beforeEach" | "describe" | "expect" | "it"
+>;
+
+const runnerApi = process.env.VITEST
   ? await import("vitest")
   : await import("bun:test");
+const { beforeEach, describe, expect, it } = runnerApi as unknown as TestApi;
 
 interface HandleMessageOptions {
   codingMode?: boolean;


### PR DESCRIPTION
Fixes #26956.

## What changed

Both affected tests intentionally run under Bun in the package lane and Vitest in isolated merge-readiness lanes. Their conditional imports previously produced an incompatible `bun:test | vitest` union, so TypeScript rejected every `describe`, `it`, and `expect` call.

This change gives the shared runtime-compatible subset one explicit `TestApi` type while preserving the conditional runtime import.

## Validation

- Biome on both files: pass.
- Bun execution: 43/43 tests passed across `task-pane.test.ts` and `agent-client.streaming.test.ts`.
- Package typecheck no longer reports any diagnostic in either changed test; the sparse worktree still reports unrelated missing built workspace exports.
- `git diff --check`: pass.
- The root verification failure reproduced on unchanged `develop`; the cross-world integration branch has no diff in either file.

No production, UI, model, or provider behavior changes; visual and live-model evidence are N/A.

<!-- evidence-head:8a95932bb412f50e9adeb07955a62feaa090aeef -->
