### PR TITLE
test(cloud): cover agent-billing-numeric

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseOrgCreditBalance } from "./agent-billing-numeric.js";
+
+describe("parseOrgCreditBalance", () => {
+  it("parses numeric string and number", () => {
+    expect(parseOrgCreditBalance("25.00")).toBe(25);
+    expect(parseOrgCreditBalance(42)).toBe(42);
+    expect(parseOrgCreditBalance("0")).toBe(0);
+  });
+
+  it("throws on empty or missing", () => {
+    expect(() => parseOrgCreditBalance(null)).toThrow(/empty or missing/);
+    expect(() => parseOrgCreditBalance(undefined)).toThrow(/empty or missing/);
+    expect(() => parseOrgCreditBalance("")).toThrow(/empty or missing/);
+    expect(() => parseOrgCreditBalance("   ")).toThrow(/empty or missing/);
+  });
+
+  it("throws on non-finite", () => {
+    expect(() => parseOrgCreditBalance("NaN")).toThrow(/finite/);
+    expect(() => parseOrgCreditBalance("Infinity")).toThrow(/finite/);
+    expect(() => parseOrgCreditBalance("bad")).toThrow(/finite/);
+  });
+
+  it("uses custom fieldName in message", () => {
+    expect(() => parseOrgCreditBalance(null, "my_field")).toThrow(/my_field/);
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:1a4cbcdd39703d6f6596d64f382731cb458dd694 -->

# Relates to
N/A - coverage for module with no existing test file.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop
- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, single new file `packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts`. No production code changed.

# Background
## What does this PR do?
Adds Vitest coverage for `packages/cloud/shared/src/db/repositories/agent-billing-numeric.ts` which had no test file.

## What kind of change is this?
Test coverage (non-breaking).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts`

## Detailed testing steps
`bunx vitest run packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts --run --coverage=false`

# Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only, Vitest output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM path.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Testing evidence
## Green (with production code)
```
 Test Files  1 passed (1);      Tests  4 passed (4);
```
```

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  09:18:24
   Duration  82ms (transform 18ms, setup 0ms, import 23ms, tests 2ms, environment 0ms)
```

## Red (production file broken, test must fail)
```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯; FAIL  packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts > parseOrgCreditBalance > parses numeric string and number;AssertionError: expected 'bad' to be 25 // Object.is equality; FAIL  packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts > parseOrgCreditBalance > throws on empty or missing;AssertionError: expected [Function] to throw an error; FAIL  packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts > parseOrgCreditBalance > throws on non-finite;AssertionError: expected [Function] to throw an error; FAIL  packages/cloud/shared/src/db/repositories/agent-billing-numeric.test.ts > parseOrgCreditBalance > uses custom fieldName in message;AssertionError: expected [Function] to throw an error; Test Files  1 failed (1);
```
```
     23|
     24|   it("uses custom fieldName in message", () => {
     25|     expect(() => parseOrgCreditBalance(null, "my_field")).toThrow(/my_…
       |                                                           ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯


 Test Files  1 failed (1)
      Tests  4 failed (4)
   Start at  09:18:25
   Duration  92ms (transform 18ms, setup 0ms, import 23ms, tests 4ms, environment 0ms)
```

## Existing suites
N/A - isolated new file.

## Biome
`biome check --write` clean on changed file.

## Typecheck
N/A - test-only, no production types changed. `bun run --cwd packages/app typecheck` baseline unchanged (verified via `bun run typecheck` on develop).

# Known gaps / failures
N/A - no unrelated failures observed.

# Maintainer CI exception record
N/A - no exception requested.

