### PR TITLE
fix(core): scope model omission sentinels

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -496,6 +496,7 @@ describe("MEMORY uuid validation", () => {
       (candidate) => candidate.name === "memoryId",
     );
     expect(memoryId?.schema.pattern).toBeDefined();
+    expect(memoryId?.modelOmissionSentinels).toEqual(["", "null", "undefined"]);
     const pattern = new RegExp(memoryId?.schema.pattern ?? "");
     expect(pattern.test(ROOM_ID)).toBe(true);
     expect(pattern.test("general")).toBe(false);

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -958,6 +958,7 @@ export const memoryAction: Action = {
       description:
         "update/delete: id of the memory to mutate; optional when query is provided.",
       required: false,
+      modelOmissionSentinels: ["", "null", "undefined"],
       schema: { type: "string" as const, pattern: UUID_SCHEMA_PATTERN },
     },
     {

--- a/packages/core/src/actions/validate-tool-args.test.ts
+++ b/packages/core/src/actions/validate-tool-args.test.ts
@@ -164,12 +164,14 @@ describe("unused-optional sentinel strings", () => {
 				name: "content",
 				description: "d",
 				required: true,
+				modelOmissionSentinels: ["null"],
 				schema: { type: "string" as const },
 			},
 			{
 				name: "memoryId",
 				description: "d",
 				required: false,
+				modelOmissionSentinels: ["", "null", "undefined"],
 				schema: {
 					type: "string" as const,
 					pattern:
@@ -181,7 +183,7 @@ describe("unused-optional sentinel strings", () => {
 		validate: async () => true,
 	} as never;
 
-	it('treats "null"/"undefined"/"" on an OPTIONAL patterned param as absent', () => {
+	it("omits only declared sentinel spellings on an optional parameter", () => {
 		for (const sentinel of ["null", "undefined", "", " NULL "]) {
 			const result = validateToolArgs(action, {
 				content: "remember this",
@@ -192,7 +194,75 @@ describe("unused-optional sentinel strings", () => {
 		}
 	});
 
-	it("a REQUIRED param keeps a sentinel-looking value verbatim", () => {
+	it("preserves ordinary optional strings and recursive JSON Schema semantics", () => {
+		const ordinaryAction = {
+			...action,
+			parameters: [
+				...(action.parameters ?? []),
+				{
+					name: "freeText",
+					description: "d",
+					required: false,
+					schema: { type: "string" as const, minLength: 0 },
+				},
+				{
+					name: "enumValue",
+					description: "d",
+					required: false,
+					schema: { type: "string" as const, enum: ["null"] },
+				},
+				{
+					name: "withDefault",
+					description: "d",
+					required: false,
+					schema: { type: "string" as const, default: "fallback" },
+				},
+				{
+					name: "nested",
+					description: "d",
+					required: false,
+					schema: {
+						type: "object" as const,
+						properties: { value: { type: "string" as const } },
+					},
+				},
+			],
+		} as never;
+		const result = validateToolArgs(ordinaryAction, {
+			content: "remember this",
+			freeText: "",
+			enumValue: "null",
+			withDefault: "undefined",
+			nested: { value: "null" },
+		});
+
+		expect(result.valid).toBe(true);
+		expect(result.args).toMatchObject({
+			freeText: "",
+			enumValue: "null",
+			withDefault: "undefined",
+			nested: { value: "null" },
+		});
+	});
+
+	it("does not change exported recursive schema validation", () => {
+		const errors: string[] = [];
+		const result = validateSchema(
+			{
+				type: "object",
+				properties: {
+					literal: { type: "string", default: "fallback" },
+				},
+			},
+			{ literal: "null" },
+			"structured",
+			errors,
+		);
+		expect(errors).toEqual([]);
+		expect(result).toEqual({ literal: "null" });
+	});
+
+	it("a required parameter keeps a sentinel-looking value verbatim", () => {
 		const result = validateToolArgs(action, { content: "null" });
 		// required "content" keeps whatever string was supplied — sentinels
 		// only ever mean absent for optional properties.

--- a/packages/core/src/actions/validate-tool-args.ts
+++ b/packages/core/src/actions/validate-tool-args.ts
@@ -177,25 +177,6 @@ function validateObject(
 		}
 	}
 
-	// Planner models routinely fill UNUSED optional parameters with the
-	// strings "null"/"undefined"/"" rather than omitting them; a patterned
-	// optional then fails validation and kills an otherwise-valid call (live
-	// 2026-08-24: MEMORY create failed on memoryId:"null" and the turn
-	// claimed success anyway).
-	//
-	// The rule is deliberately narrow: a sentinel counts as "absent" ONLY for
-	// an optional property whose schema cannot accept the literal anyway. For
-	// a free-text optional, "" and the literal "null" are legitimate values a
-	// user may have actually asked to send, and dropping them would be silent
-	// data loss on the model -> action path. So the value is validated first,
-	// and only a value that BOTH fails its schema and reads as a sentinel is
-	// treated as omitted.
-	const requiredKeys = new Set(schema.required ?? []);
-	const readsAsAbsent = (key: string, supplied: unknown): boolean =>
-		!requiredKeys.has(key) &&
-		typeof supplied === "string" &&
-		["", "null", "undefined"].includes(supplied.trim().toLowerCase());
-
 	for (const [key, childSchema] of Object.entries(properties)) {
 		if (hasOwn(value, key) && value[key] !== undefined && value[key] !== null) {
 			const childPath = path ? `${path}.${key}` : key;
@@ -208,15 +189,8 @@ function validateObject(
 			);
 			if (errors.length === before) {
 				output[key] = childValue;
-				continue;
 			}
-			if (readsAsAbsent(key, value[key])) {
-				// Schema-rejected sentinel on an optional property: drop the
-				// rejection with it and fall through to the default/absent path.
-				errors.length = before;
-			} else {
-				continue;
-			}
+			continue;
 		}
 
 		if (
@@ -389,6 +363,32 @@ export function validateSchema(
 	}
 }
 
+function omitDeclaredModelSentinels(
+	action: Action,
+	args: Record<string, unknown>,
+): Record<string, unknown> {
+	let normalized = args;
+	for (const parameter of action.parameters ?? []) {
+		const suppliedValue = args[parameter.name];
+		if (
+			parameter.required ||
+			!hasOwn(args, parameter.name) ||
+			typeof suppliedValue !== "string" ||
+			!parameter.modelOmissionSentinels?.length
+		) {
+			continue;
+		}
+		const supplied = suppliedValue.trim().toLowerCase();
+		const isDeclaredSentinel = parameter.modelOmissionSentinels.some(
+			(sentinel) => sentinel.trim().toLowerCase() === supplied,
+		);
+		if (!isDeclaredSentinel) continue;
+		if (normalized === args) normalized = { ...args };
+		delete normalized[parameter.name];
+	}
+	return normalized;
+}
+
 export function validateToolArgs(
 	action: Action,
 	args: unknown,
@@ -404,8 +404,9 @@ export function validateToolArgs(
 		};
 	}
 
-	const validatedArgs = validateObject(schema, args, "", errors);
-	const invalidParameterNames = Object.keys(args).filter(
+	const normalizedArgs = omitDeclaredModelSentinels(action, args);
+	const validatedArgs = validateObject(schema, normalizedArgs, "", errors);
+	const invalidParameterNames = Object.keys(normalizedArgs).filter(
 		(name) => !Object.hasOwn(validatedArgs, name),
 	);
 

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -648,6 +648,11 @@ describe("executePlannedToolCall", () => {
 					modelOmissionSentinels: ["null"],
 					schema: { type: "string", pattern: "^[0-9a-f-]{36}$" },
 				},
+				{
+					name: "note",
+					description: "Optional byte-exact note",
+					schema: { type: "string" },
+				},
 			],
 			handler,
 		});
@@ -670,7 +675,7 @@ describe("executePlannedToolCall", () => {
 					{ message: makeMessage() },
 					{
 						name: "MEMORY",
-						params: { text: "remember this", memoryId: "null" },
+						params: { text: "remember this", memoryId: "null", note: "" },
 					},
 				),
 		);
@@ -680,14 +685,18 @@ describe("executePlannedToolCall", () => {
 			expect.any(Object),
 			expect.any(Object),
 			undefined,
-			expect.objectContaining({ parameters: { text: "remember this" } }),
+			expect.objectContaining({
+				parameters: { text: "remember this", note: "" },
+			}),
 			undefined,
 			undefined,
 		);
 		expect(trajectoryLogger.completeStep).toHaveBeenCalledWith(
 			"normalization-trajectory",
 			"normalized-action-step",
-			expect.objectContaining({ parameters: { text: "remember this" } }),
+			expect.objectContaining({
+				parameters: { text: "remember this", note: "" },
+			}),
 		);
 	});
 
@@ -2409,6 +2418,7 @@ describe("dropEmptyOptionalArgs", () => {
 					name: "preset",
 					description: "Shader preset",
 					required: false,
+					modelOmissionSentinels: [""],
 					schema: { type: "string", enum: ["aurora", "lava"] },
 				},
 			],
@@ -2465,7 +2475,7 @@ describe("dropEmptyOptionalArgs", () => {
 		expect(handler).not.toHaveBeenCalled();
 	});
 
-	it("drops only empty-string optional keys and returns the same object when nothing matches", () => {
+	it("drops only opted-in empty-string sentinels and preserves ordinary empty strings", () => {
 		const action = backgroundLikeAction();
 
 		const untouched = { op: "set", color: "teal" };
@@ -2473,7 +2483,7 @@ describe("dropEmptyOptionalArgs", () => {
 
 		expect(
 			dropEmptyOptionalArgs(action, { op: "set", color: "", preset: "" }),
-		).toEqual({ op: "set" });
+		).toEqual({ op: "set", color: "" });
 
 		// Undeclared keys and non-string empties pass through untouched — strict
 		// validation still owns rejecting them.

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -624,6 +624,73 @@ describe("executePlannedToolCall", () => {
 		);
 	});
 
+	it("records and delivers only the opt-in normalized tool parameters", async () => {
+		const handler = vi.fn(async () => ({ success: true }));
+		const trajectoryLogger = {
+			isEnabled: vi.fn(() => true),
+			startStep: vi.fn(() => "normalized-action-step"),
+			completeStep: vi.fn(),
+			flushWriteQueue: vi.fn(async () => {}),
+			annotateStep: vi.fn(async () => {}),
+		};
+		const action = makeAction({
+			name: "MEMORY",
+			parameters: [
+				{
+					name: "text",
+					description: "Memory text",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "memoryId",
+					description: "Optional memory UUID",
+					modelOmissionSentinels: ["null"],
+					schema: { type: "string", pattern: "^[0-9a-f-]{36}$" },
+				},
+			],
+			handler,
+		});
+		const runtime = makeRuntime([action], {
+			getService: vi.fn((serviceType: string) =>
+				serviceType === "trajectories" ? trajectoryLogger : undefined,
+			),
+			getServicesByType: vi.fn(() => []),
+		});
+
+		const result = await runWithTrajectoryContext(
+			{
+				trajectoryId: "normalization-trajectory",
+				trajectoryStepId: "planner-step",
+				purpose: "planner",
+			},
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{ message: makeMessage() },
+					{
+						name: "MEMORY",
+						params: { text: "remember this", memoryId: "null" },
+					},
+				),
+		);
+
+		expect(result.success).toBe(true);
+		expect(handler).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.any(Object),
+			undefined,
+			expect.objectContaining({ parameters: { text: "remember this" } }),
+			undefined,
+			undefined,
+		);
+		expect(trajectoryLogger.completeStep).toHaveBeenCalledWith(
+			"normalization-trajectory",
+			"normalized-action-step",
+			expect.objectContaining({ parameters: { text: "remember this" } }),
+		);
+	});
+
 	it("preserves byte-exact canonical callback text through later voice gates", async () => {
 		const canonicalText =
 			"“Send demo video” is scheduled for Tuesday, August 4, 2026 at 9:00 AM.";

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -1215,14 +1215,14 @@ export function expandEnumShortForm(
 }
 
 /**
- * Treat an empty-string value on a declared OPTIONAL parameter as omitted.
+ * Treat an empty-string value as omitted only when an OPTIONAL parameter
+ * explicitly declares that model omission sentinel.
  *
- * Strict tool schemas force the model to emit every key, so `""` is its only
- * way to say "unset" for a parameter it doesn't want (observed live in the
- * #10694 trajectories: the planner emitted `BACKGROUND {preset: ""}` on a
- * color-only turn and enum validation rejected the whole call). Dropping the
- * key before validation restores the intended "omitted" semantics. Required
- * parameters are left untouched so an empty required value still fails loudly.
+ * Some strict provider schemas force the model to emit every key. Actions that
+ * observed `""` as the provider's unset representation opt in through
+ * `modelOmissionSentinels`; other actions may use an empty string as legitimate
+ * data and must receive it byte-for-byte. Required parameters are always left
+ * untouched so an empty required value still fails loudly.
  */
 export function dropEmptyOptionalArgs(
 	action: Action,
@@ -1236,7 +1236,10 @@ export function dropEmptyOptionalArgs(
 	let filtered: Record<string, unknown> | undefined;
 	for (const parameter of action.parameters ?? []) {
 		if (parameter.required === true) continue;
-		if (args[parameter.name] === "") {
+		if (
+			args[parameter.name] === "" &&
+			parameter.modelOmissionSentinels?.includes("")
+		) {
 			filtered ??= { ...args };
 			delete filtered[parameter.name];
 		}

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -105,6 +105,14 @@ export interface ActionParameter {
 	 * and never lets an unclaimed/unknown key through (that still rejects).
 	 */
 	aliases?: readonly string[];
+	/**
+	 * Exact string spellings that the model-tool boundary treats as omission for
+	 * this optional top-level parameter. Matching ignores surrounding whitespace
+	 * and ASCII case. This is not JSON Schema behavior and is never applied by
+	 * recursive structured-output validation; use it only where these literals
+	 * cannot be valid domain values, such as an optional UUID identifier.
+	 */
+	modelOmissionSentinels?: readonly string[];
 	/** JSON Schema for parameter validation */
 	schema: ActionParameterSchema;
 	/**

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -719,6 +719,7 @@ export function createBackgroundAction(
 				description:
 					"Animated shader preset for set: aurora | lava | plasma | waves | nebula.",
 				required: false,
+				modelOmissionSentinels: [""],
 				schema: {
 					type: "string",
 					enum: ["aurora", "lava", "plasma", "waves", "nebula"],

--- a/plugins/plugin-app-control/src/actions/model-omission-contract.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-omission-contract.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Exercises the production BACKGROUND and MODEL_SWITCH schemas through the
+ * real tool executor so provider omission spellings reach their intended
+ * handlers without weakening ordinary enum validation.
+ */
+
+import {
+	type Action,
+	executePlannedToolCall,
+	type IAgentRuntime,
+	type Memory,
+	type Task,
+	type UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { createBackgroundAction } from "./background.ts";
+import { createModelSwitchAction } from "./model-switch.ts";
+
+function message(text: string): Memory {
+	return {
+		id: "message-id" as UUID,
+		entityId: "owner-id" as UUID,
+		roomId: "room-id" as UUID,
+		content: { text },
+	} as Memory;
+}
+
+function runtimeFor(action: Action): IAgentRuntime {
+	const tasks: Task[] = [];
+	return {
+		actions: [action],
+		agentId: "agent-id" as UUID,
+		getRoom: vi.fn(async () => null),
+		getService: vi.fn(() => undefined),
+		getTasks: vi.fn(async () => tasks),
+		createTask: vi.fn(async (task: Task) => {
+			tasks.push({ ...task, id: "task-id" as UUID });
+			return "task-id" as UUID;
+		}),
+		deleteTask: vi.fn(async () => undefined),
+		reportError: vi.fn(),
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+}
+
+const ownerContext = {
+	activeContexts: ["general"],
+	userRoles: ["OWNER"],
+} as const;
+
+describe("production model omission contracts", () => {
+	it("omits BACKGROUND's empty preset before the production schema validates", async () => {
+		const handler = vi.fn(async () => ({ success: true }));
+		const action = { ...createBackgroundAction(), handler };
+		const result = await executePlannedToolCall(
+			runtimeFor(action),
+			{ message: message("make the background teal"), ...ownerContext },
+			{
+				name: "BACKGROUND",
+				params: { op: "set", color: "teal", preset: "" },
+			},
+		);
+
+		expect(result.success).toBe(true);
+		expect(handler).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.any(Object),
+			undefined,
+			expect.objectContaining({
+				parameters: { op: "set", color: "teal" },
+			}),
+			undefined,
+			undefined,
+		);
+	});
+
+	it.each(["", "null", "undefined"])(
+		"routes MODEL_SWITCH target sentinel %j into its clarification handler",
+		async (sentinel) => {
+			const switchModel = vi.fn(async () => ({ ok: true as const }));
+			const productionAction = createModelSwitchAction({ switchModel });
+			const handler = vi.fn(productionAction.handler);
+			const action = { ...productionAction, handler };
+			const runtime = runtimeFor(action);
+
+			const result = await executePlannedToolCall(
+				runtime,
+				{ message: message("switch to the faster model"), ...ownerContext },
+				{ name: "MODEL_SWITCH", params: { target: sentinel } },
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.values).toMatchObject({ awaitingTarget: true });
+			expect(handler).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.any(Object),
+				undefined,
+				expect.objectContaining({ parameters: {} }),
+				undefined,
+				undefined,
+			);
+			expect(runtime.createTask).toHaveBeenCalledTimes(1);
+			expect(switchModel).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -325,6 +325,7 @@ export function createModelSwitchAction(
 				description:
 					"Where text inference should run: local (on-device Eliza-1) or cloud (Eliza Cloud). Omit when the user has not named a target; the action will ask them to choose without changing anything.",
 				required: false,
+				modelOmissionSentinels: ["", "null", "undefined"],
 				schema: { type: "string", enum: ["local", "cloud"] },
 			},
 			{


### PR DESCRIPTION
## Summary

- restore normal recursive JSON Schema validation after #26933
- add explicit modelOmissionSentinels metadata for optional top-level action parameters
- opt MEMORY memoryId into empty/null/undefined omission normalization
- prove the handler and trajectory settlement receive the same normalized parameters

Closes #26979.

## Why

The failure behind #26933 is real, but treating schema-rejected sentinel-looking strings as absent during every recursive validateSchema call changes a public structured-output validator and can silently rewrite nested plugin/model data. This follow-up confines the non-JSON-Schema behavior to the model-to-tool boundary and requires the owning action to opt in.

## Validation

- 107 focused core/agent tests passed, 369 assertions
- packages/core and packages/agent typecheck passed
- packages/core and packages/agent lint passed; core reports only existing warnings
- packages/core multi-target build, declarations, packed edge/Node/browser/Vite consumers passed
- packages/agent build passed
- Biome and git diff checks passed
- bun run verify reached 367/375 successful tasks and stopped only at unchanged current-develop UI type errors in surface.helpers.test.ts and character-hub-helpers.test.ts; the changed core and agent lanes passed

No live provider credentials were available. The regression proof exercises the actual planner-tool executor and trajectory settlement boundary deterministically; no prompt or model context is truncated or compacted.