### PR TITLE
fix(coding): attest foreground shell workspace mutations

### DIFF
--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -377,6 +377,30 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  windows-runtime-installation-identity:
+    name: Windows runtime installation identity
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows'
+    runs-on: windows-2025
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install workspace
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Prove Windows identity storage fails closed
+        run: bunx vitest run packages/agent/src/runtime/runtime-installation-id.test.ts --config packages/agent/vitest.config.ts -t "real Windows"
+
   windows-computeruse-evidence:
     name: Windows computer-use evidence
     if: github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'windows')

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -138,6 +138,7 @@
       "import": "./dist/runtime/index.js",
       "default": "./dist/runtime/index.js"
     },
+    "./runtime/runtime-installation-id": null,
     "./runtime/*": {
       "types": "./src/runtime/*.ts",
       "eliza-source": {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -255,7 +255,7 @@ import {
   resolvePreferredProviderPluginName,
   resolvePrimaryModel,
 } from "./model-resolution.ts";
-import { loadOrCreateRuntimeInstallationId } from "./runtime-installation-id.ts";
+import { constructWithRuntimeInstallationIdentity } from "./runtime-installation-id.ts";
 
 type RemoteCodingRunnerModule =
   typeof import("../services/remote-coding-runner.ts");
@@ -4824,43 +4824,49 @@ export async function startEliza(
   await configureLocalEmbeddingEnvEarlyIfNeeded(config);
   opts?.abortSignal?.throwIfAborted();
   bootContext.enterPhase("construct-runtime");
-  const runtimeInstanceId = await loadOrCreateRuntimeInstallationId(
-    resolveStateDir(),
-  );
-  let runtime = new AgentRuntime({
-    character,
-    runtimeInstanceId,
-    // advancedCapabilities: true,
-    actionPlanning: true,
-    // advancedMemory is enabled via character.advancedMemory
-    enableSecretsManager: true,
-    plugins: [...subAgentCredentialPlugins, elizaPlugin, ...pluginsForRuntime],
-    ...(runtimeLogLevel ? { logLevel: runtimeLogLevel } : {}),
-    // Sandbox options — only active when mode != "off"
-    ...(isSandboxActive
-      ? {
-          sandboxMode: true,
-          sandboxAuditHandler: sandboxAuditLog
-            ? (event: SandboxFetchAuditEvent) => {
-                sandboxAuditLog.recordTokenReplacement(
-                  event.direction,
-                  event.url,
-                  event.tokenIds,
-                );
-              }
-            : undefined,
-        }
-      : {}),
-    settings: buildRuntimeSettings(config, {
-      preferredProviderId,
-      brainProviderName: preferredTextRuntimeProviderName,
-      embeddingProviderName: preferredEmbeddingRuntimeProviderName,
-      visionModeSetting,
-      managedSkillsDir,
-      bundledSkillsDir,
-      workspaceSkillsDir,
-      connectorSecretsOverlay,
-    }),
+  let runtime = await constructWithRuntimeInstallationIdentity({
+    stateDirectory: resolveStateDir(),
+    abortSignal: opts?.abortSignal,
+    construct: (runtimeInstanceId) =>
+      new AgentRuntime({
+        character,
+        runtimeInstanceId,
+        // advancedCapabilities: true,
+        actionPlanning: true,
+        // advancedMemory is enabled via character.advancedMemory
+        enableSecretsManager: true,
+        plugins: [
+          ...subAgentCredentialPlugins,
+          elizaPlugin,
+          ...pluginsForRuntime,
+        ],
+        ...(runtimeLogLevel ? { logLevel: runtimeLogLevel } : {}),
+        // Sandbox options — only active when mode != "off"
+        ...(isSandboxActive
+          ? {
+              sandboxMode: true,
+              sandboxAuditHandler: sandboxAuditLog
+                ? (event: SandboxFetchAuditEvent) => {
+                    sandboxAuditLog.recordTokenReplacement(
+                      event.direction,
+                      event.url,
+                      event.tokenIds,
+                    );
+                  }
+                : undefined,
+            }
+          : {}),
+        settings: buildRuntimeSettings(config, {
+          preferredProviderId,
+          brainProviderName: preferredTextRuntimeProviderName,
+          embeddingProviderName: preferredEmbeddingRuntimeProviderName,
+          visionModeSetting,
+          managedSkillsDir,
+          bundledSkillsDir,
+          workspaceSkillsDir,
+          connectorSecretsOverlay,
+        }),
+      }),
   });
   installRuntimeMethodBindings(runtime);
   opts?.onRuntimeCreated?.(runtime);

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -255,6 +255,7 @@ import {
   resolvePreferredProviderPluginName,
   resolvePrimaryModel,
 } from "./model-resolution.ts";
+import { loadOrCreateRuntimeInstallationId } from "./runtime-installation-id.ts";
 
 type RemoteCodingRunnerModule =
   typeof import("../services/remote-coding-runner.ts");
@@ -4823,8 +4824,12 @@ export async function startEliza(
   await configureLocalEmbeddingEnvEarlyIfNeeded(config);
   opts?.abortSignal?.throwIfAborted();
   bootContext.enterPhase("construct-runtime");
+  const runtimeInstanceId = await loadOrCreateRuntimeInstallationId(
+    resolveStateDir(),
+  );
   let runtime = new AgentRuntime({
     character,
+    runtimeInstanceId,
     // advancedCapabilities: true,
     actionPlanning: true,
     // advancedMemory is enabled via character.advancedMemory

--- a/packages/agent/src/runtime/runtime-installation-id.race.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.race.test.ts
@@ -1,0 +1,252 @@
+/** Exercises runtime identity races by faulting real filesystem calls outside production. */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FileHandle = Awaited<ReturnType<typeof fs.open>>;
+
+const faults = vi.hoisted(() => ({
+  afterLstat: undefined as
+    | ((
+        target: string,
+        stat: Awaited<ReturnType<typeof fs.lstat>>,
+      ) => Promise<void>)
+    | undefined,
+  afterOpen: undefined as
+    | ((target: string, handle: FileHandle) => Promise<void>)
+    | undefined,
+  afterLink: undefined as
+    | ((source: string, target: string) => Promise<void>)
+    | undefined,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      const stat = await actual.lstat(...args);
+      await faults.afterLstat?.(String(args[0]), stat);
+      return stat;
+    },
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const handle = await actual.open(...args);
+      await faults.afterOpen?.(String(args[0]), handle);
+      return handle;
+    },
+    link: async (...args: Parameters<typeof actual.link>) => {
+      await actual.link(...args);
+      await faults.afterLink?.(String(args[0]), String(args[1]));
+    },
+  };
+});
+
+const {
+  loadOrCreateRuntimeInstallationId,
+  RuntimeInstallationIdentityRecoveryError,
+} = await import("./runtime-installation-id.ts");
+const cleanup: string[] = [];
+
+async function expectNoIdentityArtifacts(directory: string): Promise<void> {
+  expect(
+    (await fs.readdir(directory)).filter(
+      (name) =>
+        name === "runtime-installation-id" ||
+        name.startsWith(".runtime-installation-id."),
+    ),
+  ).toEqual([]);
+}
+
+afterEach(async () => {
+  faults.afterLstat = undefined;
+  faults.afterOpen = undefined;
+  faults.afterLink = undefined;
+  await Promise.all(
+    cleanup
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("runtime installation identity filesystem races", () => {
+  it("rejects link injection between identity lstat and open", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-lstat-link-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const canonicalRoot = await fs.realpath(root);
+    const target = path.join(canonicalRoot, "runtime-installation-id");
+    faults.afterLstat = async (observed) => {
+      if (observed !== target) return;
+      faults.afterLstat = undefined;
+      await fs.link(target, path.join(root, "racing-link"));
+    };
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "must not have multiple links",
+    );
+  });
+
+  it("rejects link injection after the identity descriptor opens", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-open-link-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const canonicalRoot = await fs.realpath(root);
+    const target = path.join(canonicalRoot, "runtime-installation-id");
+    faults.afterOpen = async (observed) => {
+      if (observed !== target) return;
+      faults.afterOpen = undefined;
+      await fs.link(target, path.join(root, "racing-link"));
+    };
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "must not have multiple links",
+    );
+  });
+
+  it("rejects target replacement between lstat and open", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-open-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const canonicalRoot = await fs.realpath(root);
+    const target = path.join(canonicalRoot, "runtime-installation-id");
+    faults.afterLstat = async (observed) => {
+      if (observed !== target) return;
+      faults.afterLstat = undefined;
+      await fs.rename(target, path.join(root, "original-id"));
+      await fs.writeFile(target, "66666666-6666-4666-8666-666666666666\n", {
+        mode: 0o600,
+      });
+    };
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "changed during validation",
+    );
+  });
+
+  it("rejects target replacement after its descriptor opens", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-return-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const canonicalRoot = await fs.realpath(root);
+    const target = path.join(canonicalRoot, "runtime-installation-id");
+    faults.afterOpen = async (observed) => {
+      if (observed !== target) return;
+      faults.afterOpen = undefined;
+      await fs.rename(target, path.join(canonicalRoot, "opened-id"));
+      await fs.writeFile(target, "77777777-7777-4777-8777-777777777777\n", {
+        mode: 0o600,
+      });
+    };
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "changed during validation",
+    );
+  });
+
+  it("cleans both directory inodes after each publication substitution phase", async () => {
+    for (const phase of ["pre-create", "temporary", "published"] as const) {
+      const parent = await fs.mkdtemp(
+        path.join(os.tmpdir(), `runtime-id-${phase}-`),
+      );
+      cleanup.push(parent);
+      const root = path.join(parent, "state");
+      const moved = path.join(parent, "moved-state");
+      const canonicalParent = await fs.realpath(parent);
+      const canonicalRoot = path.join(canonicalParent, "state");
+      const canonicalMoved = path.join(canonicalParent, "moved-state");
+      let stateLstats = 0;
+      const substitute = async () => {
+        await fs.rename(canonicalRoot, canonicalMoved);
+        await fs.mkdir(canonicalRoot, { mode: 0o700 });
+      };
+      if (phase === "pre-create") {
+        faults.afterLstat = async (observed) => {
+          if (observed !== canonicalRoot || ++stateLstats !== 3) return;
+          faults.afterLstat = undefined;
+          await substitute();
+        };
+      } else if (phase === "temporary") {
+        faults.afterLstat = async (observed) => {
+          if (!path.basename(observed).startsWith(".runtime-installation-id."))
+            return;
+          faults.afterLstat = undefined;
+          await substitute();
+        };
+      } else {
+        faults.afterLink = async () => {
+          faults.afterLink = undefined;
+          await substitute();
+        };
+      }
+      await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+        "state directory changed during validation",
+      );
+      await expectNoIdentityArtifacts(root);
+      await expectNoIdentityArtifacts(moved);
+    }
+  });
+
+  it("closes and durably cleans a candidate whose descriptor stat fails", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-stat-fail-"),
+    );
+    cleanup.push(parent);
+    const root = path.join(parent, "state");
+    let closeCount = 0;
+    faults.afterOpen = async (observed, handle) => {
+      if (!path.basename(observed).startsWith(".runtime-installation-id."))
+        return;
+      faults.afterOpen = undefined;
+      const close = handle.close.bind(handle);
+      handle.close = async () => {
+        closeCount += 1;
+        await close();
+      };
+      handle.stat = async () => {
+        throw new Error("injected candidate stat failure");
+      };
+    };
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "injected candidate stat failure",
+    );
+    expect(closeCount).toBeGreaterThan(0);
+    await expectNoIdentityArtifacts(root);
+  });
+
+  it("reports ambiguous recovery only after post-link cleanup attempts directory sync", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-sync-fail-"),
+    );
+    cleanup.push(parent);
+    const root = path.join(parent, "state");
+    const moved = path.join(parent, "moved-state");
+    const canonicalParent = await fs.realpath(parent);
+    const canonicalRoot = path.join(canonicalParent, "state");
+    const events: string[] = [];
+    faults.afterOpen = async (observed, handle) => {
+      if (observed !== canonicalRoot) return;
+      faults.afterOpen = undefined;
+      handle.sync = async () => {
+        events.push("sync");
+        throw new Error("injected directory sync failure");
+      };
+    };
+    faults.afterLink = async () => {
+      faults.afterLink = undefined;
+      await fs.rename(canonicalRoot, path.join(canonicalParent, "moved-state"));
+      await fs.mkdir(canonicalRoot, { mode: 0o700 });
+      events.push("substituted");
+    };
+    await expect(
+      loadOrCreateRuntimeInstallationId(root),
+    ).rejects.toBeInstanceOf(RuntimeInstallationIdentityRecoveryError);
+    expect(events).toEqual(["substituted", "sync"]);
+    await expectNoIdentityArtifacts(root);
+    await expectNoIdentityArtifacts(moved);
+  });
+});

--- a/packages/agent/src/runtime/runtime-installation-id.race.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.race.test.ts
@@ -19,6 +19,7 @@ const faults = vi.hoisted(() => ({
   afterLink: undefined as
     | ((source: string, target: string) => Promise<void>)
     | undefined,
+  afterUnlink: undefined as ((target: string) => Promise<void>) | undefined,
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -38,6 +39,10 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     link: async (...args: Parameters<typeof actual.link>) => {
       await actual.link(...args);
       await faults.afterLink?.(String(args[0]), String(args[1]));
+    },
+    unlink: async (...args: Parameters<typeof actual.unlink>) => {
+      await actual.unlink(...args);
+      await faults.afterUnlink?.(String(args[0]));
     },
   };
 });
@@ -62,6 +67,7 @@ afterEach(async () => {
   faults.afterLstat = undefined;
   faults.afterOpen = undefined;
   faults.afterLink = undefined;
+  faults.afterUnlink = undefined;
   await Promise.all(
     cleanup
       .splice(0)
@@ -198,7 +204,17 @@ describe("runtime installation identity filesystem races", () => {
     cleanup.push(parent);
     const root = path.join(parent, "state");
     let closeCount = 0;
+    const durabilityEvents: string[] = [];
     faults.afterOpen = async (observed, handle) => {
+      const canonicalRoot = path.join(await fs.realpath(parent), "state");
+      if (observed === canonicalRoot) {
+        const sync = handle.sync.bind(handle);
+        handle.sync = async () => {
+          durabilityEvents.push("sync");
+          await sync();
+        };
+        return;
+      }
       if (!path.basename(observed).startsWith(".runtime-installation-id."))
         return;
       faults.afterOpen = undefined;
@@ -211,10 +227,16 @@ describe("runtime installation identity filesystem races", () => {
         throw new Error("injected candidate stat failure");
       };
     };
+    faults.afterUnlink = async (observed) => {
+      if (!path.basename(observed).startsWith(".runtime-installation-id."))
+        return;
+      durabilityEvents.push("unlink");
+    };
     await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
       "injected candidate stat failure",
     );
     expect(closeCount).toBeGreaterThan(0);
+    expect(durabilityEvents).toEqual(["unlink", "sync"]);
     await expectNoIdentityArtifacts(root);
   });
 
@@ -248,5 +270,40 @@ describe("runtime installation identity filesystem races", () => {
     expect(events).toEqual(["substituted", "sync"]);
     await expectNoIdentityArtifacts(root);
     await expectNoIdentityArtifacts(moved);
+  });
+
+  it("preserves typed recovery when cleanup sync and state close both fail", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-sync-close-fail-"),
+    );
+    cleanup.push(parent);
+    const root = path.join(parent, "state");
+    const canonicalParent = await fs.realpath(parent);
+    const canonicalRoot = path.join(canonicalParent, "state");
+    faults.afterOpen = async (observed, handle) => {
+      if (observed !== canonicalRoot) return;
+      faults.afterOpen = undefined;
+      const close = handle.close.bind(handle);
+      handle.sync = async () => {
+        throw new Error("injected cleanup sync failure");
+      };
+      handle.close = async () => {
+        await close();
+        throw new Error("injected state close failure");
+      };
+    };
+    faults.afterLink = async () => {
+      faults.afterLink = undefined;
+      await fs.rename(canonicalRoot, path.join(canonicalParent, "moved-state"));
+      await fs.mkdir(canonicalRoot, { mode: 0o700 });
+    };
+    const failure = await loadOrCreateRuntimeInstallationId(root).catch(
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(RuntimeInstallationIdentityRecoveryError);
+    expect(failure).toMatchObject({
+      code: "RUNTIME_INSTALLATION_ID_RECOVERY_AMBIGUOUS",
+      cause: expect.any(AggregateError),
+    });
   });
 });

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -164,6 +164,50 @@ describe("runtime installation identity", () => {
     await expectNoIdentityArtifacts(safeParent);
   });
 
+  it("rejects an attacker-writable lexical ancestor before following its redirect", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-lexical-"),
+    );
+    const hostile = path.join(root, "hostile");
+    const safe = path.join(root, "safe");
+    const safeParent = path.join(safe, "parent");
+    const redirect = path.join(hostile, "redirect");
+    const requestedState = path.join(redirect, "parent", "state");
+    const resolvedState = path.join(safeParent, "state");
+    cleanup.push(root);
+    await fs.mkdir(hostile, { mode: 0o700 });
+    await fs.chmod(hostile, 0o777);
+    await fs.mkdir(safeParent, { recursive: true, mode: 0o700 });
+    await fs.symlink(safe, redirect);
+    await expect(
+      loadOrCreateRuntimeInstallationId(requestedState),
+    ).rejects.toThrow("replaceable by another user");
+    await expect(fs.access(requestedState)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fs.access(resolvedState)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expectNoIdentityArtifacts(safeParent);
+  });
+
+  it("accepts an intermediate redirect controlled by a trusted ancestor", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-safe-redirect-"),
+    );
+    const controlled = path.join(root, "controlled");
+    const destination = path.join(root, "destination");
+    const destinationParent = path.join(destination, "parent");
+    const redirect = path.join(controlled, "redirect");
+    cleanup.push(root);
+    await fs.mkdir(controlled, { mode: 0o700 });
+    await fs.mkdir(destinationParent, { recursive: true, mode: 0o700 });
+    await fs.symlink(destination, redirect);
+    await expect(
+      loadOrCreateRuntimeInstallationId(path.join(redirect, "parent", "state")),
+    ).resolves.toMatch(/^[a-f0-9-]{36}$/);
+  });
+
   it("does not expose test controls to a real Bun sibling consumer", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "runtime-id-consumer-"),

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -1,0 +1,52 @@
+/** Exercises durable runtime installation identity against real temporary directories. */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadOrCreateRuntimeInstallationId } from "./runtime-installation-id.ts";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanup
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("runtime installation identity", () => {
+  it("survives host reconstruction and concurrent boot in one state directory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-owner-one-"));
+    cleanup.push(root);
+    const concurrent = await Promise.all(
+      Array.from({ length: 8 }, () => loadOrCreateRuntimeInstallationId(root)),
+    );
+    expect(new Set(concurrent)).toHaveLength(1);
+    expect(await loadOrCreateRuntimeInstallationId(root)).toBe(concurrent[0]);
+    expect(
+      (await fs.stat(path.join(root, "runtime-installation-id"))).mode & 0o777,
+    ).toBe(0o600);
+  });
+
+  it("gives independent installations distinct identities", async () => {
+    const first = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-owner-a-"));
+    const second = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-owner-b-"));
+    cleanup.push(first, second);
+    expect(await loadOrCreateRuntimeInstallationId(first)).not.toBe(
+      await loadOrCreateRuntimeInstallationId(second),
+    );
+  });
+
+  it("fails closed when a persisted identity is corrupt", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-owner-bad-"));
+    cleanup.push(root);
+    await fs.writeFile(
+      path.join(root, "runtime-installation-id"),
+      "not-a-uuid\n",
+    );
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "Runtime installation identity is corrupt",
+    );
+  });
+});

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -146,4 +146,243 @@ describe("runtime installation identity", () => {
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(construct).not.toHaveBeenCalled();
   });
+
+  it("rejects an existing hard-linked identity", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-hardlink-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    await fs.link(target, path.join(root, "second-link"));
+    await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
+      "must not have multiple links",
+    );
+  });
+
+  it("rejects link injection after the identity descriptor opens", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-link-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    let injected = false;
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        afterIdentityOpen: async () => {
+          if (injected) return;
+          injected = true;
+          await fs.link(target, path.join(root, "racing-link"));
+        },
+      }),
+    ).rejects.toThrow("must not have multiple links");
+  });
+
+  it("rejects link injection between identity lstat and open", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-lstat-link-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    let injected = false;
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        afterIdentityLstat: async () => {
+          if (injected) return;
+          injected = true;
+          await fs.link(target, path.join(root, "lstat-racing-link"));
+        },
+      }),
+    ).rejects.toThrow("must not have multiple links");
+  });
+
+  it("rejects target replacement between lstat and open", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-open-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    let replaced = false;
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        afterIdentityLstat: async () => {
+          if (replaced) return;
+          replaced = true;
+          await fs.rename(target, path.join(root, "original-id"));
+          await fs.writeFile(target, "66666666-6666-4666-8666-666666666666\n", {
+            mode: 0o600,
+          });
+        },
+      }),
+    ).rejects.toThrow("changed during validation");
+  });
+
+  it("rejects target replacement after its descriptor opens", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-return-race-"),
+    );
+    cleanup.push(root);
+    await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    let replaced = false;
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        afterIdentityOpen: async () => {
+          if (replaced) return;
+          replaced = true;
+          await fs.rename(target, path.join(root, "opened-id"));
+          await fs.writeFile(target, "77777777-7777-4777-8777-777777777777\n", {
+            mode: 0o600,
+          });
+        },
+      }),
+    ).rejects.toThrow("changed during validation");
+  });
+
+  it("rejects state-directory replacement before publication", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-dir-race-"),
+    );
+    const root = path.join(parent, "state");
+    const moved = path.join(parent, "moved-state");
+    cleanup.push(parent);
+    let replaced = false;
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        afterDirectoryValidation: async () => {
+          if (replaced) return;
+          replaced = true;
+          await fs.rename(root, moved);
+          await fs.mkdir(root, { mode: 0o700 });
+        },
+      }),
+    ).rejects.toThrow("state directory changed during validation");
+    await expect(
+      fs.access(path.join(root, "runtime-installation-id")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.access(path.join(moved, "runtime-installation-id")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects state-directory replacement at the publication boundary", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-publish-race-"),
+    );
+    const root = path.join(parent, "state");
+    const moved = path.join(parent, "moved-state");
+    cleanup.push(parent);
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, {
+        beforeIdentityPublication: async () => {
+          await fs.rename(root, moved);
+          await fs.mkdir(root, { mode: 0o700 });
+        },
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.access(path.join(root, "runtime-installation-id")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.access(path.join(moved, "runtime-installation-id")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["EINVAL", "EPERM"])(
+    "degrades only unsupported Windows directory-open %s",
+    async (code) => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "runtime-owner-win-open-"),
+      );
+      cleanup.push(root);
+      await expect(
+        loadOrCreateRuntimeInstallationId(root, {
+          platform: "win32",
+          openDirectory: async () => {
+            throw Object.assign(new Error("unsupported directory open"), {
+              code,
+            });
+          },
+        }),
+      ).resolves.toMatch(/^[a-f0-9-]{36}$/);
+    },
+  );
+
+  it.each(["EINVAL", "EPERM"])(
+    "degrades only unsupported Windows directory-sync %s",
+    async (code) => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "runtime-owner-win-sync-"),
+      );
+      cleanup.push(root);
+      await expect(
+        loadOrCreateRuntimeInstallationId(root, {
+          platform: "win32",
+          syncDirectory: async () => {
+            throw Object.assign(new Error("unsupported directory sync"), {
+              code,
+            });
+          },
+        }),
+      ).resolves.toMatch(/^[a-f0-9-]{36}$/);
+    },
+  );
+
+  it.each(["open", "sync"] as const)(
+    "propagates real Windows directory %s failures",
+    async (operation) => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "runtime-owner-win-io-"),
+      );
+      cleanup.push(root);
+      const failure = Object.assign(new Error("real directory I/O failure"), {
+        code: "EIO",
+      });
+      await expect(
+        loadOrCreateRuntimeInstallationId(root, {
+          platform: "win32",
+          ...(operation === "open"
+            ? { openDirectory: async () => await Promise.reject(failure) }
+            : { syncDirectory: async () => await Promise.reject(failure) }),
+        }),
+      ).rejects.toBe(failure);
+    },
+  );
+
+  it("supports existing/new Windows identities while rejecting corrupt and symlink paths", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-win-valid-"),
+    );
+    const corrupt = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-win-bad-"),
+    );
+    const linked = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-win-link-"),
+    );
+    cleanup.push(root, corrupt, linked);
+    const created = await loadOrCreateRuntimeInstallationId(root, {
+      platform: "win32",
+    });
+    const target = path.join(root, "runtime-installation-id");
+    await fs.chmod(target, 0o644);
+    await expect(
+      loadOrCreateRuntimeInstallationId(root, { platform: "win32" }),
+    ).resolves.toBe(created);
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
+    await fs.writeFile(path.join(corrupt, "runtime-installation-id"), "bad\n");
+    await fs.writeFile(path.join(linked, "external"), `${created}\n`);
+    await fs.symlink(
+      path.join(linked, "external"),
+      path.join(linked, "runtime-installation-id"),
+    );
+    await expect(
+      loadOrCreateRuntimeInstallationId(corrupt, { platform: "win32" }),
+    ).rejects.toThrow("corrupt");
+    await expect(
+      loadOrCreateRuntimeInstallationId(linked, { platform: "win32" }),
+    ).rejects.toThrow("regular file");
+  });
 });

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -2,8 +2,12 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { loadOrCreateRuntimeInstallationId } from "./runtime-installation-id.ts";
+import type { UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  constructWithRuntimeInstallationIdentity,
+  loadOrCreateRuntimeInstallationId,
+} from "./runtime-installation-id.ts";
 
 const cleanup: string[] = [];
 
@@ -48,5 +52,98 @@ describe("runtime installation identity", () => {
     await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
       "Runtime installation identity is corrupt",
     );
+  });
+
+  it("repairs a valid identity whose permissions are too broad", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-mode-"),
+    );
+    cleanup.push(root);
+    const expected = await loadOrCreateRuntimeInstallationId(root);
+    const target = path.join(root, "runtime-installation-id");
+    await fs.chmod(target, 0o644);
+    await expect(loadOrCreateRuntimeInstallationId(root)).resolves.toBe(
+      expected,
+    );
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects symlink and nonregular identity paths", async () => {
+    const symlinkRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-link-"),
+    );
+    const directoryRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-nonregular-"),
+    );
+    const external = path.join(symlinkRoot, "external");
+    cleanup.push(symlinkRoot, directoryRoot);
+    await fs.writeFile(external, "55555555-5555-4555-8555-555555555555\n");
+    await fs.symlink(
+      external,
+      path.join(symlinkRoot, "runtime-installation-id"),
+    );
+    await fs.mkdir(path.join(directoryRoot, "runtime-installation-id"));
+    await expect(
+      loadOrCreateRuntimeInstallationId(symlinkRoot),
+    ).rejects.toThrow("must be a regular file");
+    await expect(
+      loadOrCreateRuntimeInstallationId(directoryRoot),
+    ).rejects.toThrow("must be a regular file");
+  });
+
+  it("rejects symlinked and attacker-writable state directories", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-dir-"),
+    );
+    const real = path.join(parent, "real");
+    const linked = path.join(parent, "linked");
+    const hostile = path.join(parent, "hostile");
+    cleanup.push(parent);
+    await fs.mkdir(real, { mode: 0o700 });
+    await fs.symlink(real, linked);
+    await fs.mkdir(hostile, { mode: 0o777 });
+    await fs.chmod(hostile, 0o777);
+    await expect(loadOrCreateRuntimeInstallationId(linked)).rejects.toThrow(
+      "must be a real directory",
+    );
+    await expect(loadOrCreateRuntimeInstallationId(hostile)).rejects.toThrow(
+      "writable by another user",
+    );
+  });
+
+  it("accepts a trusted pre-existing state directory", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-existing-"),
+    );
+    cleanup.push(root);
+    await fs.chmod(root, 0o755);
+    await expect(loadOrCreateRuntimeInstallationId(root)).resolves.toMatch(
+      /^[a-f0-9-]{36}$/,
+    );
+  });
+
+  it("rechecks cancellation after delayed identity I/O before construction", async () => {
+    const controller = new AbortController();
+    let release: ((value: UUID) => void) | undefined;
+    const load = vi.fn(
+      async () =>
+        await new Promise<UUID>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const construct = vi.fn(() => ({ constructed: true }));
+    const pending = constructWithRuntimeInstallationIdentity({
+      stateDirectory: "/unused",
+      abortSignal: controller.signal,
+      load,
+      construct,
+    });
+    await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
+    controller.abort(
+      new DOMException("cancelled during identity load", "AbortError"),
+    );
+    release?.("55555555-5555-4555-8555-555555555555" as UUID);
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(construct).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -1,17 +1,20 @@
 /** Exercises durable runtime installation identity against real temporary directories. */
+
+import { execFile } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { promisify } from "node:util";
 import type { UUID } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  __createRuntimeInstallationIdLoaderForTests,
   constructWithRuntimeInstallationIdentity,
   loadOrCreateRuntimeInstallationId,
   RuntimeInstallationIdentityUnsupportedError,
 } from "./runtime-installation-id.ts";
 
 const cleanup: string[] = [];
+const execFileAsync = promisify(execFile);
 
 async function expectNoIdentityArtifacts(directory: string): Promise<void> {
   const names = await fs.readdir(directory);
@@ -144,6 +147,54 @@ describe("runtime installation identity", () => {
     ).rejects.toThrow("parent must be a real directory");
   });
 
+  it("rejects an attacker-writable grandparent before creating state", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-grandparent-"),
+    );
+    const hostileGrandparent = path.join(root, "hostile");
+    const safeParent = path.join(hostileGrandparent, "safe");
+    const state = path.join(safeParent, "state");
+    cleanup.push(root);
+    await fs.mkdir(safeParent, { recursive: true, mode: 0o700 });
+    await fs.chmod(hostileGrandparent, 0o777);
+    await expect(loadOrCreateRuntimeInstallationId(state)).rejects.toThrow(
+      "replaceable by another user",
+    );
+    await expect(fs.access(state)).rejects.toMatchObject({ code: "ENOENT" });
+    await expectNoIdentityArtifacts(safeParent);
+  });
+
+  it("does not expose test controls to a real Bun sibling consumer", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-id-consumer-"),
+    );
+    const nodeModules = path.join(root, "node_modules", "@elizaos");
+    cleanup.push(root);
+    await fs.mkdir(nodeModules, { recursive: true });
+    await fs.symlink(
+      path.resolve(import.meta.dirname, "../.."),
+      path.join(nodeModules, "agent"),
+      "dir",
+    );
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "identity-sibling-consumer", type: "module" }),
+    );
+    const script = [
+      'const specifier = "@elizaos/agent/runtime/runtime-installation-id";',
+      "try {",
+      "  const loaded = await import(specifier);",
+      '  if ("__createRuntimeInstallationIdLoaderForTests" in loaded) process.exit(7);',
+      "} catch (error) {",
+      '  const expected = error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED" || String(error).includes("Cannot find module");',
+      "  if (!expected) throw error;",
+      "}",
+    ].join("\n");
+    await expect(
+      execFileAsync("bun", ["--eval", script], { cwd: root }),
+    ).resolves.toMatchObject({ stderr: "" });
+  });
+
   it("accepts a trusted pre-existing state directory", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "runtime-owner-existing-"),
@@ -191,148 +242,6 @@ describe("runtime installation identity", () => {
     await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toThrow(
       "must not have multiple links",
     );
-  });
-
-  it("rejects link injection after the identity descriptor opens", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-link-race-"),
-    );
-    cleanup.push(root);
-    await loadOrCreateRuntimeInstallationId(root);
-    const target = path.join(root, "runtime-installation-id");
-    let injected = false;
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterIdentityOpen: async () => {
-          if (injected) return;
-          injected = true;
-          await fs.link(target, path.join(root, "racing-link"));
-        },
-      })(root),
-    ).rejects.toThrow("must not have multiple links");
-  });
-
-  it("rejects link injection between identity lstat and open", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-lstat-link-race-"),
-    );
-    cleanup.push(root);
-    await loadOrCreateRuntimeInstallationId(root);
-    const target = path.join(root, "runtime-installation-id");
-    let injected = false;
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterIdentityLstat: async () => {
-          if (injected) return;
-          injected = true;
-          await fs.link(target, path.join(root, "lstat-racing-link"));
-        },
-      })(root),
-    ).rejects.toThrow("must not have multiple links");
-  });
-
-  it("rejects target replacement between lstat and open", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-open-race-"),
-    );
-    cleanup.push(root);
-    await loadOrCreateRuntimeInstallationId(root);
-    const target = path.join(root, "runtime-installation-id");
-    let replaced = false;
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterIdentityLstat: async () => {
-          if (replaced) return;
-          replaced = true;
-          await fs.rename(target, path.join(root, "original-id"));
-          await fs.writeFile(target, "66666666-6666-4666-8666-666666666666\n", {
-            mode: 0o600,
-          });
-        },
-      })(root),
-    ).rejects.toThrow("changed during validation");
-  });
-
-  it("rejects target replacement after its descriptor opens", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-return-race-"),
-    );
-    cleanup.push(root);
-    await loadOrCreateRuntimeInstallationId(root);
-    const target = path.join(root, "runtime-installation-id");
-    let replaced = false;
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterIdentityOpen: async () => {
-          if (replaced) return;
-          replaced = true;
-          await fs.rename(target, path.join(root, "opened-id"));
-          await fs.writeFile(target, "77777777-7777-4777-8777-777777777777\n", {
-            mode: 0o600,
-          });
-        },
-      })(root),
-    ).rejects.toThrow("changed during validation");
-  });
-
-  it("cleans both directory inodes after substitution following pre-create validation", async () => {
-    const parent = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-dir-race-"),
-    );
-    const root = path.join(parent, "state");
-    const moved = path.join(parent, "moved-state");
-    cleanup.push(parent);
-    let replaced = false;
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterPreCreateValidation: async () => {
-          if (replaced) return;
-          replaced = true;
-          await fs.rename(root, moved);
-          await fs.mkdir(root, { mode: 0o700 });
-        },
-      })(root),
-    ).rejects.toThrow("state directory changed during validation");
-    await expectNoIdentityArtifacts(root);
-    await expectNoIdentityArtifacts(moved);
-  });
-
-  it("cleans both directory inodes after substitution following temporary creation", async () => {
-    const parent = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-publish-race-"),
-    );
-    const root = path.join(parent, "state");
-    const moved = path.join(parent, "moved-state");
-    cleanup.push(parent);
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterTemporaryCreate: async () => {
-          await fs.rename(root, moved);
-          await fs.mkdir(root, { mode: 0o700 });
-        },
-      })(root),
-    ).rejects.toThrow("state directory changed during validation");
-    await expectNoIdentityArtifacts(root);
-    await expectNoIdentityArtifacts(moved);
-  });
-
-  it("cleans both directory inodes after substitution immediately after publication", async () => {
-    const parent = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-linked-race-"),
-    );
-    const root = path.join(parent, "state");
-    const moved = path.join(parent, "moved-state");
-    cleanup.push(parent);
-    await expect(
-      __createRuntimeInstallationIdLoaderForTests({
-        afterIdentityPublication: async () => {
-          await fs.rename(root, moved);
-          await fs.mkdir(root, { mode: 0o700 });
-        },
-      })(root),
-    ).rejects.toThrow("state directory changed during validation");
-    await expectNoIdentityArtifacts(root);
-    await expectNoIdentityArtifacts(moved);
   });
 
   it.runIf(process.platform === "win32")(

--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -5,11 +5,24 @@ import * as path from "node:path";
 import type { UUID } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  __createRuntimeInstallationIdLoaderForTests,
   constructWithRuntimeInstallationIdentity,
   loadOrCreateRuntimeInstallationId,
+  RuntimeInstallationIdentityUnsupportedError,
 } from "./runtime-installation-id.ts";
 
 const cleanup: string[] = [];
+
+async function expectNoIdentityArtifacts(directory: string): Promise<void> {
+  const names = await fs.readdir(directory);
+  expect(
+    names.filter(
+      (name) =>
+        name === "runtime-installation-id" ||
+        name.startsWith(".runtime-installation-id."),
+    ),
+  ).toEqual([]);
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -111,6 +124,26 @@ describe("runtime installation identity", () => {
     );
   });
 
+  it("rejects symlinked and attacker-writable state parents", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-parent-"),
+    );
+    const hostileParent = path.join(root, "hostile");
+    const realParent = path.join(root, "real");
+    const linkedParent = path.join(root, "linked");
+    cleanup.push(root);
+    await fs.mkdir(hostileParent, { mode: 0o777 });
+    await fs.chmod(hostileParent, 0o777);
+    await fs.mkdir(realParent, { mode: 0o700 });
+    await fs.symlink(realParent, linkedParent);
+    await expect(
+      loadOrCreateRuntimeInstallationId(path.join(hostileParent, "state")),
+    ).rejects.toThrow("replaceable by another user");
+    await expect(
+      loadOrCreateRuntimeInstallationId(path.join(linkedParent, "state")),
+    ).rejects.toThrow("parent must be a real directory");
+  });
+
   it("accepts a trusted pre-existing state directory", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "runtime-owner-existing-"),
@@ -169,13 +202,13 @@ describe("runtime installation identity", () => {
     const target = path.join(root, "runtime-installation-id");
     let injected = false;
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
+      __createRuntimeInstallationIdLoaderForTests({
         afterIdentityOpen: async () => {
           if (injected) return;
           injected = true;
           await fs.link(target, path.join(root, "racing-link"));
         },
-      }),
+      })(root),
     ).rejects.toThrow("must not have multiple links");
   });
 
@@ -188,13 +221,13 @@ describe("runtime installation identity", () => {
     const target = path.join(root, "runtime-installation-id");
     let injected = false;
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
+      __createRuntimeInstallationIdLoaderForTests({
         afterIdentityLstat: async () => {
           if (injected) return;
           injected = true;
           await fs.link(target, path.join(root, "lstat-racing-link"));
         },
-      }),
+      })(root),
     ).rejects.toThrow("must not have multiple links");
   });
 
@@ -207,7 +240,7 @@ describe("runtime installation identity", () => {
     const target = path.join(root, "runtime-installation-id");
     let replaced = false;
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
+      __createRuntimeInstallationIdLoaderForTests({
         afterIdentityLstat: async () => {
           if (replaced) return;
           replaced = true;
@@ -216,7 +249,7 @@ describe("runtime installation identity", () => {
             mode: 0o600,
           });
         },
-      }),
+      })(root),
     ).rejects.toThrow("changed during validation");
   });
 
@@ -229,7 +262,7 @@ describe("runtime installation identity", () => {
     const target = path.join(root, "runtime-installation-id");
     let replaced = false;
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
+      __createRuntimeInstallationIdLoaderForTests({
         afterIdentityOpen: async () => {
           if (replaced) return;
           replaced = true;
@@ -238,11 +271,11 @@ describe("runtime installation identity", () => {
             mode: 0o600,
           });
         },
-      }),
+      })(root),
     ).rejects.toThrow("changed during validation");
   });
 
-  it("rejects state-directory replacement before publication", async () => {
+  it("cleans both directory inodes after substitution following pre-create validation", async () => {
     const parent = await fs.mkdtemp(
       path.join(os.tmpdir(), "runtime-owner-dir-race-"),
     );
@@ -251,24 +284,20 @@ describe("runtime installation identity", () => {
     cleanup.push(parent);
     let replaced = false;
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
-        afterDirectoryValidation: async () => {
+      __createRuntimeInstallationIdLoaderForTests({
+        afterPreCreateValidation: async () => {
           if (replaced) return;
           replaced = true;
           await fs.rename(root, moved);
           await fs.mkdir(root, { mode: 0o700 });
         },
-      }),
+      })(root),
     ).rejects.toThrow("state directory changed during validation");
-    await expect(
-      fs.access(path.join(root, "runtime-installation-id")),
-    ).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(
-      fs.access(path.join(moved, "runtime-installation-id")),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expectNoIdentityArtifacts(root);
+    await expectNoIdentityArtifacts(moved);
   });
 
-  it("rejects state-directory replacement at the publication boundary", async () => {
+  it("cleans both directory inodes after substitution following temporary creation", async () => {
     const parent = await fs.mkdtemp(
       path.join(os.tmpdir(), "runtime-owner-publish-race-"),
     );
@@ -276,113 +305,50 @@ describe("runtime installation identity", () => {
     const moved = path.join(parent, "moved-state");
     cleanup.push(parent);
     await expect(
-      loadOrCreateRuntimeInstallationId(root, {
-        beforeIdentityPublication: async () => {
+      __createRuntimeInstallationIdLoaderForTests({
+        afterTemporaryCreate: async () => {
           await fs.rename(root, moved);
           await fs.mkdir(root, { mode: 0o700 });
         },
-      }),
-    ).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(
-      fs.access(path.join(root, "runtime-installation-id")),
-    ).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(
-      fs.access(path.join(moved, "runtime-installation-id")),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+      })(root),
+    ).rejects.toThrow("state directory changed during validation");
+    await expectNoIdentityArtifacts(root);
+    await expectNoIdentityArtifacts(moved);
   });
 
-  it.each(["EINVAL", "EPERM"])(
-    "degrades only unsupported Windows directory-open %s",
-    async (code) => {
-      const root = await fs.mkdtemp(
-        path.join(os.tmpdir(), "runtime-owner-win-open-"),
-      );
-      cleanup.push(root);
-      await expect(
-        loadOrCreateRuntimeInstallationId(root, {
-          platform: "win32",
-          openDirectory: async () => {
-            throw Object.assign(new Error("unsupported directory open"), {
-              code,
-            });
-          },
-        }),
-      ).resolves.toMatch(/^[a-f0-9-]{36}$/);
-    },
-  );
-
-  it.each(["EINVAL", "EPERM"])(
-    "degrades only unsupported Windows directory-sync %s",
-    async (code) => {
-      const root = await fs.mkdtemp(
-        path.join(os.tmpdir(), "runtime-owner-win-sync-"),
-      );
-      cleanup.push(root);
-      await expect(
-        loadOrCreateRuntimeInstallationId(root, {
-          platform: "win32",
-          syncDirectory: async () => {
-            throw Object.assign(new Error("unsupported directory sync"), {
-              code,
-            });
-          },
-        }),
-      ).resolves.toMatch(/^[a-f0-9-]{36}$/);
-    },
-  );
-
-  it.each(["open", "sync"] as const)(
-    "propagates real Windows directory %s failures",
-    async (operation) => {
-      const root = await fs.mkdtemp(
-        path.join(os.tmpdir(), "runtime-owner-win-io-"),
-      );
-      cleanup.push(root);
-      const failure = Object.assign(new Error("real directory I/O failure"), {
-        code: "EIO",
-      });
-      await expect(
-        loadOrCreateRuntimeInstallationId(root, {
-          platform: "win32",
-          ...(operation === "open"
-            ? { openDirectory: async () => await Promise.reject(failure) }
-            : { syncDirectory: async () => await Promise.reject(failure) }),
-        }),
-      ).rejects.toBe(failure);
-    },
-  );
-
-  it("supports existing/new Windows identities while rejecting corrupt and symlink paths", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-win-valid-"),
+  it("cleans both directory inodes after substitution immediately after publication", async () => {
+    const parent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "runtime-owner-linked-race-"),
     );
-    const corrupt = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-win-bad-"),
-    );
-    const linked = await fs.mkdtemp(
-      path.join(os.tmpdir(), "runtime-owner-win-link-"),
-    );
-    cleanup.push(root, corrupt, linked);
-    const created = await loadOrCreateRuntimeInstallationId(root, {
-      platform: "win32",
-    });
-    const target = path.join(root, "runtime-installation-id");
-    await fs.chmod(target, 0o644);
+    const root = path.join(parent, "state");
+    const moved = path.join(parent, "moved-state");
+    cleanup.push(parent);
     await expect(
-      loadOrCreateRuntimeInstallationId(root, { platform: "win32" }),
-    ).resolves.toBe(created);
-    expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
-    await fs.writeFile(path.join(corrupt, "runtime-installation-id"), "bad\n");
-    await fs.writeFile(path.join(linked, "external"), `${created}\n`);
-    await fs.symlink(
-      path.join(linked, "external"),
-      path.join(linked, "runtime-installation-id"),
-    );
-    await expect(
-      loadOrCreateRuntimeInstallationId(corrupt, { platform: "win32" }),
-    ).rejects.toThrow("corrupt");
-    await expect(
-      loadOrCreateRuntimeInstallationId(linked, { platform: "win32" }),
-    ).rejects.toThrow("regular file");
+      __createRuntimeInstallationIdLoaderForTests({
+        afterIdentityPublication: async () => {
+          await fs.rename(root, moved);
+          await fs.mkdir(root, { mode: 0o700 });
+        },
+      })(root),
+    ).rejects.toThrow("state directory changed during validation");
+    await expectNoIdentityArtifacts(root);
+    await expectNoIdentityArtifacts(moved);
   });
+
+  it.runIf(process.platform === "win32")(
+    "fails closed with a typed unsupported contract on real Windows",
+    async () => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "runtime-owner-win-unsupported-"),
+      );
+      cleanup.push(root);
+      await expect(loadOrCreateRuntimeInstallationId(root)).rejects.toEqual(
+        expect.objectContaining({
+          code: "RUNTIME_INSTALLATION_ID_PLATFORM_UNSUPPORTED",
+          name: RuntimeInstallationIdentityUnsupportedError.name,
+        }),
+      );
+      await expectNoIdentityArtifacts(root);
+    },
+  );
 });

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -1,4 +1,13 @@
-/** Persists the standalone host identity used to scope runtime-owned effects. */
+/**
+ * Persists the standalone host identity used to scope runtime-owned effects.
+ *
+ * POSIX ownership is the trust boundary: the state directory and its parent
+ * must exclude writes by other users (a sticky root-owned parent is allowed),
+ * and every candidate cleanup matches device/inode before unlinking. Same-UID
+ * processes are therefore inside the runtime installation's trust domain.
+ * Windows fails closed because this package has no ACL primitive that can prove
+ * the equivalent boundary.
+ */
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import * as fs from "node:fs/promises";
@@ -11,21 +20,36 @@ const UUID_PATTERN =
 type FileHandle = Awaited<ReturnType<typeof fs.open>>;
 type FileStat = Awaited<ReturnType<typeof fs.lstat>>;
 
-/** Test-only phase controls for deterministic filesystem race and platform probes. */
-export interface RuntimeInstallationIdTestControls {
-  platform?: NodeJS.Platform;
-  openDirectory?: (directory: string, flags: number) => Promise<FileHandle>;
-  syncDirectory?: (directory: FileHandle) => Promise<void>;
-  afterDirectoryValidation?: () => void | Promise<void>;
+/** Test-only phase controls for deterministic filesystem race probes. */
+interface RuntimeInstallationIdTestControls {
+  afterPreCreateValidation?: () => void | Promise<void>;
   afterIdentityLstat?: () => void | Promise<void>;
   afterIdentityOpen?: () => void | Promise<void>;
   beforeIdentityReturn?: () => void | Promise<void>;
   beforeIdentityPublication?: () => void | Promise<void>;
+  afterTemporaryCreate?: () => void | Promise<void>;
+  afterIdentityPublication?: () => void | Promise<void>;
 }
 
 interface TrustedDirectory {
-  handle?: FileHandle;
+  handle: FileHandle;
   stat: FileStat;
+  parent: TrustedParentDirectory;
+}
+
+interface TrustedParentDirectory {
+  handle: FileHandle;
+  path: string;
+  stat: FileStat;
+}
+
+export class RuntimeInstallationIdentityUnsupportedError extends Error {
+  readonly code = "RUNTIME_INSTALLATION_ID_PLATFORM_UNSUPPORTED";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeInstallationIdentityUnsupportedError";
+  }
 }
 
 function currentUid(): number | undefined {
@@ -46,83 +70,109 @@ function sameIdentity(left: FileStat, right: FileStat): boolean {
   );
 }
 
-function assertTrustedDirectoryStat(
-  stat: FileStat,
-  platform: NodeJS.Platform,
-): void {
+function assertTrustedDirectoryStat(stat: FileStat): void {
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new Error("Runtime state directory must be a real directory.");
   }
   assertOwnedByRuntime(stat, "Runtime state directory");
-  // POSIX mode bits are meaningful here. Windows trust is supplied by its ACL;
-  // treating emulated mode bits as an ACL proof would reject or bless paths falsely.
-  if (platform !== "win32" && (Number(stat.mode) & 0o022) !== 0) {
+  if ((Number(stat.mode) & 0o022) !== 0) {
     throw new Error("Runtime state directory is writable by another user.");
+  }
+}
+
+function assertTrustedParentDirectoryStat(stat: FileStat): void {
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Runtime state parent must be a real directory.");
+  }
+  const uid = currentUid();
+  const mode = Number(stat.mode) & 0o7777;
+  const isRuntimeOwned = uid === undefined || Number(stat.uid) === uid;
+  const isRootOwnedStickyDirectory =
+    Number(stat.uid) === 0 && (mode & 0o1000) !== 0;
+  if (!isRuntimeOwned && !isRootOwnedStickyDirectory) {
+    throw new Error("Runtime state parent is not owned by a trusted user.");
+  }
+  if ((mode & 0o022) !== 0 && (mode & 0o1000) === 0) {
+    throw new Error("Runtime state parent is replaceable by another user.");
+  }
+}
+
+async function revalidateParentPath(
+  trusted: TrustedParentDirectory,
+): Promise<void> {
+  const [pathStat, descriptorStat] = await Promise.all([
+    fs.lstat(trusted.path),
+    trusted.handle.stat(),
+  ]);
+  assertTrustedParentDirectoryStat(pathStat);
+  assertTrustedParentDirectoryStat(descriptorStat);
+  if (
+    !sameIdentity(pathStat, trusted.stat) ||
+    !sameIdentity(descriptorStat, trusted.stat)
+  ) {
+    throw new Error("Runtime state parent changed during validation.");
   }
 }
 
 async function revalidateDirectoryPath(
   stateDirectory: string,
   trusted: TrustedDirectory,
-  platform: NodeJS.Platform,
 ): Promise<void> {
   const pathStat = await fs.lstat(stateDirectory);
-  assertTrustedDirectoryStat(pathStat, platform);
+  assertTrustedDirectoryStat(pathStat);
   if (!sameIdentity(pathStat, trusted.stat)) {
     throw new Error("Runtime state directory changed during validation.");
   }
-  if (trusted.handle) {
-    const openedStat = await trusted.handle.stat();
-    if (!openedStat.isDirectory() || !sameIdentity(openedStat, pathStat)) {
-      throw new Error("Runtime state directory changed during validation.");
-    }
+  const openedStat = await trusted.handle.stat();
+  if (!openedStat.isDirectory() || !sameIdentity(openedStat, pathStat)) {
+    throw new Error("Runtime state directory changed during validation.");
   }
-}
-
-function isUnsupportedWindowsDirectoryIo(
-  error: unknown,
-  platform: NodeJS.Platform,
-): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return platform === "win32" && (code === "EINVAL" || code === "EPERM");
 }
 
 async function openTrustedStateDirectory(
   stateDirectory: string,
-  controls: RuntimeInstallationIdTestControls,
 ): Promise<TrustedDirectory> {
-  const platform = controls.platform ?? process.platform;
-  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
-  const pathStat = await fs.lstat(stateDirectory);
-  assertTrustedDirectoryStat(pathStat, platform);
-  const openDirectory = controls.openDirectory ?? fs.open;
-  const flags =
-    platform === "win32"
-      ? constants.O_RDONLY
-      : constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW;
-  let handle: FileHandle | undefined;
+  const parentPath = path.dirname(stateDirectory);
+  const parentPathStat = await fs.lstat(parentPath);
+  assertTrustedParentDirectoryStat(parentPathStat);
+  const parentHandle = await fs.open(
+    parentPath,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  const parent = {
+    path: parentPath,
+    stat: parentPathStat,
+    handle: parentHandle,
+  };
   try {
-    handle = await openDirectory(stateDirectory, flags);
+    await revalidateParentPath(parent);
+    try {
+      await fs.mkdir(stateDirectory, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    const pathStat = await fs.lstat(stateDirectory);
+    assertTrustedDirectoryStat(pathStat);
+    const handle = await fs.open(
+      stateDirectory,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+    const trusted = { stat: pathStat, handle, parent };
+    try {
+      await revalidateDirectoryPath(stateDirectory, trusted);
+      await revalidateParentPath(parent);
+      return trusted;
+    } catch (error) {
+      await handle.close();
+      throw error;
+    }
   } catch (error) {
-    // error-policy:J4 Windows may reject opening a directory descriptor with
-    // EINVAL/EPERM. Path identity is still revalidated before every commit/return.
-    if (!isUnsupportedWindowsDirectoryIo(error, platform)) throw error;
-  }
-  const trusted = { stat: pathStat, ...(handle ? { handle } : {}) };
-  try {
-    await revalidateDirectoryPath(stateDirectory, trusted, platform);
-    await controls.afterDirectoryValidation?.();
-    return trusted;
-  } catch (error) {
-    await handle?.close();
+    await parentHandle.close();
     throw error;
   }
 }
 
-function assertTrustedIdentityStat(
-  stat: FileStat,
-  platform: NodeJS.Platform,
-): void {
+function assertTrustedIdentityStat(stat: FileStat): void {
   if (!stat.isFile() || stat.isSymbolicLink()) {
     throw new Error("Runtime installation identity must be a regular file.");
   }
@@ -132,7 +182,7 @@ function assertTrustedIdentityStat(
       "Runtime installation identity must not have multiple links.",
     );
   }
-  if (platform !== "win32" && (Number(stat.mode) & 0o777) !== 0o600) {
+  if ((Number(stat.mode) & 0o777) !== 0o600) {
     throw new Error("Runtime installation identity permissions are insecure.");
   }
 }
@@ -145,21 +195,20 @@ async function finalIdentityRevalidation(
   trustedDirectory: TrustedDirectory,
   controls: RuntimeInstallationIdTestControls,
 ): Promise<void> {
-  const platform = controls.platform ?? process.platform;
   await controls.beforeIdentityReturn?.();
   const [descriptorStat, pathStat] = await Promise.all([
     file.stat(),
     fs.lstat(target),
   ]);
-  assertTrustedIdentityStat(descriptorStat, platform);
-  assertTrustedIdentityStat(pathStat, platform);
+  assertTrustedIdentityStat(descriptorStat);
+  assertTrustedIdentityStat(pathStat);
   if (
     !sameIdentity(descriptorStat, openedStat) ||
     !sameIdentity(pathStat, descriptorStat)
   ) {
     throw new Error("Runtime installation identity changed during validation.");
   }
-  await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
+  await revalidateDirectoryPath(stateDirectory, trustedDirectory);
 }
 
 async function readInstallationId(
@@ -168,7 +217,6 @@ async function readInstallationId(
   trustedDirectory: TrustedDirectory,
   controls: RuntimeInstallationIdTestControls,
 ): Promise<UUID | undefined> {
-  const platform = controls.platform ?? process.platform;
   let pathStat: FileStat;
   try {
     pathStat = await fs.lstat(target);
@@ -186,11 +234,7 @@ async function readInstallationId(
     );
   }
   await controls.afterIdentityLstat?.();
-  const fileFlags =
-    platform === "win32"
-      ? constants.O_RDONLY
-      : constants.O_RDONLY | constants.O_NOFOLLOW;
-  const file = await fs.open(target, fileFlags);
+  const file = await fs.open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const openedStat = await file.stat();
     if (!openedStat.isFile() || !sameIdentity(openedStat, pathStat)) {
@@ -204,7 +248,7 @@ async function readInstallationId(
         "Runtime installation identity must not have multiple links.",
       );
     }
-    if (platform !== "win32" && (Number(openedStat.mode) & 0o777) !== 0o600) {
+    if ((Number(openedStat.mode) & 0o777) !== 0o600) {
       await file.chmod(0o600);
       await file.sync();
     }
@@ -227,113 +271,216 @@ async function readInstallationId(
   }
 }
 
-async function syncStateDirectory(
-  trusted: TrustedDirectory,
-  controls: RuntimeInstallationIdTestControls,
-): Promise<void> {
-  if (!trusted.handle) return;
-  const platform = controls.platform ?? process.platform;
-  const syncDirectory = controls.syncDirectory ?? ((handle) => handle.sync());
-  try {
-    await syncDirectory(trusted.handle);
-  } catch (error) {
-    // error-policy:J4 Only Windows' documented unsupported-directory errors
-    // degrade after the identity file itself has been synced.
-    if (!isUnsupportedWindowsDirectoryIo(error, platform)) throw error;
-  }
+async function syncStateDirectory(trusted: TrustedDirectory): Promise<void> {
+  await trusted.handle.sync();
 }
 
-async function removePublishedCandidate(
-  target: string,
+async function pathsForTrustedDirectory(
+  stateDirectory: string,
+  trusted: TrustedDirectory,
+): Promise<string[]> {
+  await revalidateParentPath(trusted.parent);
+  try {
+    const currentStat = await fs.lstat(stateDirectory);
+    if (
+      currentStat.isDirectory() &&
+      !currentStat.isSymbolicLink() &&
+      sameIdentity(currentStat, trusted.stat)
+    ) {
+      return [stateDirectory];
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const paths: string[] = [];
+  // A same-UID fault may rename the directory despite the ownership boundary.
+  // Locate its still-open inode under the trusted, identity-checked parent so
+  // rollback can clean the moved directory without touching a replacement.
+  const entries = await fs.opendir(trusted.parent.path);
+  try {
+    for await (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const candidatePath = path.join(trusted.parent.path, entry.name);
+      let candidateStat: FileStat;
+      try {
+        candidateStat = await fs.lstat(candidatePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+      if (
+        candidateStat.isDirectory() &&
+        !candidateStat.isSymbolicLink() &&
+        sameIdentity(candidateStat, trusted.stat)
+      ) {
+        paths.push(candidatePath);
+      }
+    }
+  } finally {
+    await entries.close().catch((error: NodeJS.ErrnoException) => {
+      // error-policy:J2 Directory enumeration cleanup is part of secure identity
+      // cleanup, so a close failure remains fatal at the boot boundary.
+      if (error.code !== "ERR_DIR_CLOSED") throw error;
+    });
+  }
+  await revalidateParentPath(trusted.parent);
+  return paths;
+}
+
+async function removeCandidateName(
+  directory: string,
+  name: string,
   candidateStat: FileStat,
 ): Promise<void> {
+  const candidatePath = path.join(directory, name);
   try {
-    const targetStat = await fs.lstat(target);
-    if (targetStat.isFile() && sameIdentity(targetStat, candidateStat)) {
-      await fs.unlink(target);
+    const targetStat = await fs.lstat(candidatePath);
+    if (
+      targetStat.isFile() &&
+      !targetStat.isSymbolicLink() &&
+      sameIdentity(targetStat, candidateStat)
+    ) {
+      await fs.unlink(candidatePath);
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 
+async function cleanupCandidate(
+  stateDirectory: string,
+  trusted: TrustedDirectory,
+  temporaryName: string,
+  candidateStat: FileStat,
+  removePublishedIdentity: boolean,
+): Promise<void> {
+  const directories = await pathsForTrustedDirectory(stateDirectory, trusted);
+  for (const directory of directories) {
+    if (removePublishedIdentity) {
+      await removeCandidateName(
+        directory,
+        INSTALLATION_ID_FILENAME,
+        candidateStat,
+      );
+    }
+    await removeCandidateName(directory, temporaryName, candidateStat);
+  }
+}
+
 /** Loads one durable UUID per trusted state directory without following links. */
-export async function loadOrCreateRuntimeInstallationId(
+async function loadOrCreateRuntimeInstallationIdImpl(
   stateDirectory: string,
   controls: RuntimeInstallationIdTestControls = {},
 ): Promise<UUID> {
-  const platform = controls.platform ?? process.platform;
+  const resolvedStateDirectory = path.resolve(stateDirectory);
   const trustedDirectory = await openTrustedStateDirectory(
-    stateDirectory,
-    controls,
+    resolvedStateDirectory,
   );
-  const target = path.join(stateDirectory, INSTALLATION_ID_FILENAME);
+  const target = path.join(resolvedStateDirectory, INSTALLATION_ID_FILENAME);
   try {
     const existing = await readInstallationId(
       target,
-      stateDirectory,
+      resolvedStateDirectory,
       trustedDirectory,
       controls,
     );
     if (existing) return existing;
 
-    await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
+    await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
+    await revalidateParentPath(trustedDirectory.parent);
+    await controls.afterPreCreateValidation?.();
+    await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
     const candidate = randomUUID() as UUID;
-    const temporary = path.join(
-      stateDirectory,
-      `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`,
-    );
+    const temporaryName = `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`;
+    const temporary = path.join(resolvedStateDirectory, temporaryName);
     const file = await fs.open(temporary, "wx", 0o600);
-    try {
-      await file.writeFile(`${candidate}\n`, "utf8");
-      await file.sync();
-    } finally {
-      await file.close();
-    }
-    const candidateStat = await fs.lstat(temporary);
-    await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
-    await controls.beforeIdentityPublication?.();
+    const candidateStat = await file.stat();
     let publishedCandidate = false;
     try {
+      try {
+        await file.writeFile(`${candidate}\n`, "utf8");
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+      const temporaryPathStat = await fs.lstat(temporary);
+      if (!sameIdentity(temporaryPathStat, candidateStat)) {
+        throw new Error(
+          "Runtime installation identity candidate changed during creation.",
+        );
+      }
+      await controls.afterTemporaryCreate?.();
+      await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
+      await controls.beforeIdentityPublication?.();
+      await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
       try {
         await fs.link(temporary, target);
         publishedCandidate = true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
-      try {
-        await revalidateDirectoryPath(
-          stateDirectory,
-          trustedDirectory,
-          platform,
-        );
-      } catch (error) {
-        if (publishedCandidate) {
-          await removePublishedCandidate(target, candidateStat);
-        }
-        throw error;
+      await controls.afterIdentityPublication?.();
+      await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
+      await cleanupCandidate(
+        resolvedStateDirectory,
+        trustedDirectory,
+        temporaryName,
+        candidateStat,
+        false,
+      );
+      await syncStateDirectory(trustedDirectory);
+      const published = await readInstallationId(
+        target,
+        resolvedStateDirectory,
+        trustedDirectory,
+        controls,
+      );
+      if (!published) {
+        throw new Error("Runtime installation identity was not published.");
       }
-    } finally {
-      await fs.unlink(temporary).catch((error: NodeJS.ErrnoException) => {
-        // error-policy:J2 A cleanup failure makes publication durability
-        // ambiguous, so retain the original filesystem error for the boot boundary.
-        if (error.code !== "ENOENT") throw error;
+      return published;
+    } catch (error) {
+      await file.close().catch((closeError: NodeJS.ErrnoException) => {
+        // error-policy:J2 The creation error remains authoritative when its
+        // descriptor was already closed; any other close error is fail-closed.
+        if (closeError.code !== "EBADF") throw closeError;
       });
+      await cleanupCandidate(
+        resolvedStateDirectory,
+        trustedDirectory,
+        temporaryName,
+        candidateStat,
+        publishedCandidate,
+      );
+      throw error;
     }
-    await syncStateDirectory(trustedDirectory, controls);
-    const published = await readInstallationId(
-      target,
-      stateDirectory,
-      trustedDirectory,
-      controls,
-    );
-    if (!published) {
-      throw new Error("Runtime installation identity was not published.");
-    }
-    return published;
   } finally {
-    await trustedDirectory.handle?.close();
+    try {
+      await trustedDirectory.handle.close();
+    } finally {
+      await trustedDirectory.parent.handle.close();
+    }
   }
+}
+
+/** Loads the host identity with production-fixed platform and filesystem policy. */
+export async function loadOrCreateRuntimeInstallationId(
+  stateDirectory: string,
+): Promise<UUID> {
+  if (process.platform === "win32") {
+    throw new RuntimeInstallationIdentityUnsupportedError(
+      "Secure runtime installation identity storage is unavailable on Windows.",
+    );
+  }
+  return await loadOrCreateRuntimeInstallationIdImpl(stateDirectory);
+}
+
+/** @internal Test-only factory; stripped from production declarations. */
+export function __createRuntimeInstallationIdLoaderForTests(
+  controls: RuntimeInstallationIdTestControls,
+): (stateDirectory: string) => Promise<UUID> {
+  return async (stateDirectory) =>
+    await loadOrCreateRuntimeInstallationIdImpl(stateDirectory, controls);
 }
 
 /** Loads identity, rechecks cancellation, and only then invokes the constructor. */

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -1,5 +1,6 @@
 /** Persists the standalone host identity used to scope runtime-owned effects. */
 import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { UUID } from "@elizaos/core";
@@ -8,60 +9,172 @@ const INSTALLATION_ID_FILENAME = "runtime-installation-id";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-async function readInstallationId(target: string): Promise<UUID | undefined> {
+function currentUid(): number | undefined {
+  return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+function assertOwnedByRuntime(
+  stat: Awaited<ReturnType<typeof fs.lstat>>,
+  label: string,
+): void {
+  const uid = currentUid();
+  if (uid !== undefined && stat.uid !== uid) {
+    throw new Error(`${label} is not owned by the runtime user.`);
+  }
+}
+
+async function openTrustedStateDirectory(stateDirectory: string) {
+  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+  const pathStat = await fs.lstat(stateDirectory);
+  if (!pathStat.isDirectory() || pathStat.isSymbolicLink()) {
+    throw new Error("Runtime state directory must be a real directory.");
+  }
+  assertOwnedByRuntime(pathStat, "Runtime state directory");
+  if ((pathStat.mode & 0o022) !== 0) {
+    throw new Error("Runtime state directory is writable by another user.");
+  }
+  const directory = await fs.open(
+    stateDirectory,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
   try {
-    const value = (await fs.readFile(target, "utf8")).trim();
-    if (!UUID_PATTERN.test(value)) {
-      throw new Error(`Runtime installation identity is corrupt: ${target}`);
+    const openedStat = await directory.stat();
+    if (
+      !openedStat.isDirectory() ||
+      openedStat.dev !== pathStat.dev ||
+      openedStat.ino !== pathStat.ino
+    ) {
+      throw new Error("Runtime state directory changed during validation.");
     }
-    return value.toLowerCase() as UUID;
+    return directory;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    await directory.close();
     throw error;
   }
 }
 
-/** Loads one durable UUID per state directory, publishing it without replacement. */
-export async function loadOrCreateRuntimeInstallationId(
-  stateDirectory: string,
-): Promise<UUID> {
-  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
-  const target = path.join(stateDirectory, INSTALLATION_ID_FILENAME);
-  const existing = await readInstallationId(target);
-  if (existing) return existing;
-
-  const candidate = randomUUID() as UUID;
-  const temporary = path.join(
-    stateDirectory,
-    `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`,
-  );
-  const file = await fs.open(temporary, "wx", 0o600);
+async function readInstallationId(target: string): Promise<UUID | undefined> {
+  let pathStat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
-    await file.writeFile(`${candidate}\n`, "utf8");
-    await file.sync();
+    pathStat = await fs.lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (!pathStat.isFile() || pathStat.isSymbolicLink()) {
+    throw new Error("Runtime installation identity must be a regular file.");
+  }
+  assertOwnedByRuntime(pathStat, "Runtime installation identity");
+  if (pathStat.nlink !== 1) {
+    throw new Error(
+      "Runtime installation identity must not have multiple links.",
+    );
+  }
+  const file = await fs.open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedStat = await file.stat();
+    if (
+      !openedStat.isFile() ||
+      openedStat.dev !== pathStat.dev ||
+      openedStat.ino !== pathStat.ino
+    ) {
+      throw new Error(
+        "Runtime installation identity changed during validation.",
+      );
+    }
+    assertOwnedByRuntime(openedStat, "Runtime installation identity");
+    if ((openedStat.mode & 0o777) !== 0o600) {
+      await file.chmod(0o600);
+      await file.sync();
+      const repaired = await file.stat();
+      if ((repaired.mode & 0o777) !== 0o600) {
+        throw new Error(
+          "Runtime installation identity permissions are insecure.",
+        );
+      }
+    }
+    const value = (await file.readFile("utf8")).trim();
+    if (!UUID_PATTERN.test(value)) {
+      throw new Error(`Runtime installation identity is corrupt: ${target}`);
+    }
+    return value.toLowerCase() as UUID;
   } finally {
     await file.close();
   }
-  try {
-    await fs.link(temporary, target);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-  } finally {
-    await fs.unlink(temporary).catch((error: NodeJS.ErrnoException) => {
-      // error-policy:J2 A cleanup failure makes publication durability
-      // ambiguous, so retain the original filesystem error for the boot boundary.
-      if (error.code !== "ENOENT") throw error;
-    });
-  }
-  await fs.chmod(target, 0o600);
-  const directory = await fs.open(stateDirectory, "r");
+}
+
+async function syncStateDirectory(
+  directory: Awaited<ReturnType<typeof fs.open>>,
+): Promise<void> {
   try {
     await directory.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // error-policy:J4 Node documents directory fsync as unsupported on Windows;
+    // only those platform-specific errors degrade after the file itself is synced.
+    if (
+      process.platform !== "win32" ||
+      (code !== "EINVAL" && code !== "EPERM")
+    ) {
+      throw error;
+    }
+  }
+}
+
+/** Loads one durable UUID per trusted state directory without following links. */
+export async function loadOrCreateRuntimeInstallationId(
+  stateDirectory: string,
+): Promise<UUID> {
+  const directory = await openTrustedStateDirectory(stateDirectory);
+  const target = path.join(stateDirectory, INSTALLATION_ID_FILENAME);
+  try {
+    const existing = await readInstallationId(target);
+    if (existing) return existing;
+
+    const candidate = randomUUID() as UUID;
+    const temporary = path.join(
+      stateDirectory,
+      `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`,
+    );
+    const file = await fs.open(temporary, "wx", 0o600);
+    try {
+      await file.writeFile(`${candidate}\n`, "utf8");
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    try {
+      await fs.link(temporary, target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    } finally {
+      await fs.unlink(temporary).catch((error: NodeJS.ErrnoException) => {
+        // error-policy:J2 A cleanup failure makes publication durability
+        // ambiguous, so retain the original filesystem error for the boot boundary.
+        if (error.code !== "ENOENT") throw error;
+      });
+    }
+    await syncStateDirectory(directory);
+    const published = await readInstallationId(target);
+    if (!published) {
+      throw new Error("Runtime installation identity was not published.");
+    }
+    return published;
   } finally {
     await directory.close();
   }
-  const published = await readInstallationId(target);
-  if (!published)
-    throw new Error("Runtime installation identity was not published.");
-  return published;
+}
+
+/** Loads identity, rechecks cancellation, and only then invokes the constructor. */
+export async function constructWithRuntimeInstallationIdentity<T>(options: {
+  stateDirectory: string;
+  abortSignal?: AbortSignal;
+  construct: (runtimeInstanceId: UUID) => T;
+  load?: (stateDirectory: string) => Promise<UUID>;
+}): Promise<T> {
+  const runtimeInstanceId = await (
+    options.load ?? loadOrCreateRuntimeInstallationId
+  )(options.stateDirectory);
+  options.abortSignal?.throwIfAborted();
+  return options.construct(runtimeInstanceId);
 }

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -1,9 +1,10 @@
 /**
  * Persists the standalone host identity used to scope runtime-owned effects.
  *
- * POSIX ownership is the trust boundary: the state directory and its parent
- * must exclude writes by other users (a sticky root-owned parent is allowed),
- * and every candidate cleanup matches device/inode before unlinking. Same-UID
+ * POSIX ownership is the trust boundary: the state directory and every
+ * controlling ancestor must exclude replacement by other users (a sticky
+ * root-owned ancestor is allowed), and every candidate cleanup matches
+ * device/inode before unlinking. Same-UID
  * processes are therefore inside the runtime installation's trust domain.
  * Windows fails closed because this package has no ACL primitive that can prove
  * the equivalent boundary.
@@ -20,21 +21,11 @@ const UUID_PATTERN =
 type FileHandle = Awaited<ReturnType<typeof fs.open>>;
 type FileStat = Awaited<ReturnType<typeof fs.lstat>>;
 
-/** Test-only phase controls for deterministic filesystem race probes. */
-interface RuntimeInstallationIdTestControls {
-  afterPreCreateValidation?: () => void | Promise<void>;
-  afterIdentityLstat?: () => void | Promise<void>;
-  afterIdentityOpen?: () => void | Promise<void>;
-  beforeIdentityReturn?: () => void | Promise<void>;
-  beforeIdentityPublication?: () => void | Promise<void>;
-  afterTemporaryCreate?: () => void | Promise<void>;
-  afterIdentityPublication?: () => void | Promise<void>;
-}
-
 interface TrustedDirectory {
   handle: FileHandle;
   stat: FileStat;
   parent: TrustedParentDirectory;
+  ancestors: TrustedParentDirectory[];
 }
 
 interface TrustedParentDirectory {
@@ -49,6 +40,15 @@ export class RuntimeInstallationIdentityUnsupportedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "RuntimeInstallationIdentityUnsupportedError";
+  }
+}
+
+export class RuntimeInstallationIdentityRecoveryError extends Error {
+  readonly code = "RUNTIME_INSTALLATION_ID_RECOVERY_AMBIGUOUS";
+
+  constructor(message: string, options: ErrorOptions) {
+    super(message, options);
+    this.name = "RuntimeInstallationIdentityRecoveryError";
   }
 }
 
@@ -86,15 +86,49 @@ function assertTrustedParentDirectoryStat(stat: FileStat): void {
   }
   const uid = currentUid();
   const mode = Number(stat.mode) & 0o7777;
-  const isRuntimeOwned = uid === undefined || Number(stat.uid) === uid;
-  const isRootOwnedStickyDirectory =
-    Number(stat.uid) === 0 && (mode & 0o1000) !== 0;
-  if (!isRuntimeOwned && !isRootOwnedStickyDirectory) {
+  const isTrustedOwner =
+    uid === undefined || Number(stat.uid) === uid || Number(stat.uid) === 0;
+  if (!isTrustedOwner) {
     throw new Error("Runtime state parent is not owned by a trusted user.");
   }
   if ((mode & 0o022) !== 0 && (mode & 0o1000) === 0) {
     throw new Error("Runtime state parent is replaceable by another user.");
   }
+}
+
+function ancestorPaths(directory: string): string[] {
+  const root = path.parse(directory).root;
+  const relativeParts = path
+    .relative(root, directory)
+    .split(path.sep)
+    .filter(Boolean);
+  const paths = [root];
+  let current = root;
+  for (const part of relativeParts) {
+    current = path.join(current, part);
+    paths.push(current);
+  }
+  return paths;
+}
+
+async function closeAncestors(
+  ancestors: TrustedParentDirectory[],
+): Promise<void> {
+  let failure: unknown;
+  for (const ancestor of [...ancestors].reverse()) {
+    try {
+      await ancestor.handle.close();
+    } catch (error) {
+      failure ??= error;
+    }
+  }
+  if (failure) throw failure;
+}
+
+async function revalidateAncestorChain(
+  ancestors: TrustedParentDirectory[],
+): Promise<void> {
+  for (const ancestor of ancestors) await revalidateParentPath(ancestor);
 }
 
 async function revalidateParentPath(
@@ -133,19 +167,20 @@ async function openTrustedStateDirectory(
   stateDirectory: string,
 ): Promise<TrustedDirectory> {
   const parentPath = path.dirname(stateDirectory);
-  const parentPathStat = await fs.lstat(parentPath);
-  assertTrustedParentDirectoryStat(parentPathStat);
-  const parentHandle = await fs.open(
-    parentPath,
-    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
-  );
-  const parent = {
-    path: parentPath,
-    stat: parentPathStat,
-    handle: parentHandle,
-  };
+  const ancestors: TrustedParentDirectory[] = [];
   try {
-    await revalidateParentPath(parent);
+    for (const ancestorPath of ancestorPaths(parentPath)) {
+      const ancestorStat = await fs.lstat(ancestorPath);
+      assertTrustedParentDirectoryStat(ancestorStat);
+      const handle = await fs.open(
+        ancestorPath,
+        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+      );
+      ancestors.push({ path: ancestorPath, stat: ancestorStat, handle });
+    }
+    const parent = ancestors.at(-1);
+    if (!parent) throw new Error("Runtime state parent chain is empty.");
+    await revalidateAncestorChain(ancestors);
     try {
       await fs.mkdir(stateDirectory, { mode: 0o700 });
     } catch (error) {
@@ -157,17 +192,17 @@ async function openTrustedStateDirectory(
       stateDirectory,
       constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
     );
-    const trusted = { stat: pathStat, handle, parent };
+    const trusted = { stat: pathStat, handle, parent, ancestors };
     try {
       await revalidateDirectoryPath(stateDirectory, trusted);
-      await revalidateParentPath(parent);
+      await revalidateAncestorChain(ancestors);
       return trusted;
     } catch (error) {
       await handle.close();
       throw error;
     }
   } catch (error) {
-    await parentHandle.close();
+    await closeAncestors(ancestors);
     throw error;
   }
 }
@@ -193,9 +228,7 @@ async function finalIdentityRevalidation(
   openedStat: FileStat,
   stateDirectory: string,
   trustedDirectory: TrustedDirectory,
-  controls: RuntimeInstallationIdTestControls,
 ): Promise<void> {
-  await controls.beforeIdentityReturn?.();
   const [descriptorStat, pathStat] = await Promise.all([
     file.stat(),
     fs.lstat(target),
@@ -215,7 +248,6 @@ async function readInstallationId(
   target: string,
   stateDirectory: string,
   trustedDirectory: TrustedDirectory,
-  controls: RuntimeInstallationIdTestControls,
 ): Promise<UUID | undefined> {
   let pathStat: FileStat;
   try {
@@ -233,7 +265,6 @@ async function readInstallationId(
       "Runtime installation identity must not have multiple links.",
     );
   }
-  await controls.afterIdentityLstat?.();
   const file = await fs.open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const openedStat = await file.stat();
@@ -252,7 +283,6 @@ async function readInstallationId(
       await file.chmod(0o600);
       await file.sync();
     }
-    await controls.afterIdentityOpen?.();
     const value = (await file.readFile("utf8")).trim();
     if (!UUID_PATTERN.test(value)) {
       throw new Error(`Runtime installation identity is corrupt: ${target}`);
@@ -263,7 +293,6 @@ async function readInstallationId(
       openedStat,
       stateDirectory,
       trustedDirectory,
-      controls,
     );
     return value.toLowerCase() as UUID;
   } finally {
@@ -354,25 +383,41 @@ async function cleanupCandidate(
   candidateStat: FileStat,
   removePublishedIdentity: boolean,
 ): Promise<void> {
-  const directories = await pathsForTrustedDirectory(stateDirectory, trusted);
-  for (const directory of directories) {
-    if (removePublishedIdentity) {
-      await removeCandidateName(
-        directory,
-        INSTALLATION_ID_FILENAME,
-        candidateStat,
-      );
+  try {
+    const directories = await pathsForTrustedDirectory(stateDirectory, trusted);
+    for (const directory of directories) {
+      if (removePublishedIdentity) {
+        await removeCandidateName(
+          directory,
+          INSTALLATION_ID_FILENAME,
+          candidateStat,
+        );
+      }
+      await removeCandidateName(directory, temporaryName, candidateStat);
     }
-    await removeCandidateName(directory, temporaryName, candidateStat);
+    await trusted.handle.sync();
+  } catch (error) {
+    throw new RuntimeInstallationIdentityRecoveryError(
+      "Runtime installation identity rollback could not be durably confirmed.",
+      { cause: error },
+    );
   }
 }
 
 /** Loads one durable UUID per trusted state directory without following links. */
 async function loadOrCreateRuntimeInstallationIdImpl(
   stateDirectory: string,
-  controls: RuntimeInstallationIdTestControls = {},
 ): Promise<UUID> {
-  const resolvedStateDirectory = path.resolve(stateDirectory);
+  const requestedStateDirectory = path.resolve(stateDirectory);
+  const requestedParent = path.dirname(requestedStateDirectory);
+  const requestedParentStat = await fs.lstat(requestedParent);
+  if (requestedParentStat.isSymbolicLink()) {
+    throw new Error("Runtime state parent must be a real directory.");
+  }
+  const resolvedStateDirectory = path.join(
+    await fs.realpath(requestedParent),
+    path.basename(requestedStateDirectory),
+  );
   const trustedDirectory = await openTrustedStateDirectory(
     resolvedStateDirectory,
   );
@@ -382,21 +427,20 @@ async function loadOrCreateRuntimeInstallationIdImpl(
       target,
       resolvedStateDirectory,
       trustedDirectory,
-      controls,
     );
     if (existing) return existing;
 
     await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
-    await revalidateParentPath(trustedDirectory.parent);
-    await controls.afterPreCreateValidation?.();
+    await revalidateAncestorChain(trustedDirectory.ancestors);
     await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
     const candidate = randomUUID() as UUID;
     const temporaryName = `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`;
     const temporary = path.join(resolvedStateDirectory, temporaryName);
     const file = await fs.open(temporary, "wx", 0o600);
-    const candidateStat = await file.stat();
+    let candidateStat: FileStat | undefined;
     let publishedCandidate = false;
     try {
+      candidateStat = await file.stat();
       try {
         await file.writeFile(`${candidate}\n`, "utf8");
         await file.sync();
@@ -409,9 +453,7 @@ async function loadOrCreateRuntimeInstallationIdImpl(
           "Runtime installation identity candidate changed during creation.",
         );
       }
-      await controls.afterTemporaryCreate?.();
       await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
-      await controls.beforeIdentityPublication?.();
       await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
       try {
         await fs.link(temporary, target);
@@ -419,7 +461,6 @@ async function loadOrCreateRuntimeInstallationIdImpl(
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
-      await controls.afterIdentityPublication?.();
       await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
       await cleanupCandidate(
         resolvedStateDirectory,
@@ -433,32 +474,62 @@ async function loadOrCreateRuntimeInstallationIdImpl(
         target,
         resolvedStateDirectory,
         trustedDirectory,
-        controls,
       );
       if (!published) {
         throw new Error("Runtime installation identity was not published.");
       }
       return published;
     } catch (error) {
-      await file.close().catch((closeError: NodeJS.ErrnoException) => {
-        // error-policy:J2 The creation error remains authoritative when its
-        // descriptor was already closed; any other close error is fail-closed.
-        if (closeError.code !== "EBADF") throw closeError;
-      });
-      await cleanupCandidate(
-        resolvedStateDirectory,
-        trustedDirectory,
-        temporaryName,
-        candidateStat,
-        publishedCandidate,
-      );
+      let closeFailure: unknown;
+      try {
+        await file.close();
+      } catch (closeError) {
+        if ((closeError as NodeJS.ErrnoException).code !== "EBADF") {
+          closeFailure = closeError;
+        }
+      }
+      try {
+        if (candidateStat) {
+          await cleanupCandidate(
+            resolvedStateDirectory,
+            trustedDirectory,
+            temporaryName,
+            candidateStat,
+            publishedCandidate,
+          );
+        } else {
+          await revalidateDirectoryPath(
+            resolvedStateDirectory,
+            trustedDirectory,
+          );
+          await fs.unlink(temporary);
+          await trustedDirectory.handle.sync();
+        }
+      } catch (cleanupError) {
+        throw new RuntimeInstallationIdentityRecoveryError(
+          "Runtime installation identity candidate cleanup is ambiguous.",
+          {
+            cause: new AggregateError(
+              [error, closeFailure, cleanupError].filter(
+                (failure) => failure !== undefined,
+              ),
+            ),
+          },
+        );
+      }
+      if (closeFailure) {
+        throw new RuntimeInstallationIdentityRecoveryError(
+          "Runtime installation identity candidate descriptor did not close cleanly.",
+          { cause: new AggregateError([error, closeFailure]) },
+        );
+      }
       throw error;
     }
   } finally {
     try {
       await trustedDirectory.handle.close();
     } finally {
-      await trustedDirectory.parent.handle.close();
+      await closeAncestors(trustedDirectory.ancestors);
     }
   }
 }
@@ -473,14 +544,6 @@ export async function loadOrCreateRuntimeInstallationId(
     );
   }
   return await loadOrCreateRuntimeInstallationIdImpl(stateDirectory);
-}
-
-/** @internal Test-only factory; stripped from production declarations. */
-export function __createRuntimeInstallationIdLoaderForTests(
-  controls: RuntimeInstallationIdTestControls,
-): (stateDirectory: string) => Promise<UUID> {
-  return async (stateDirectory) =>
-    await loadOrCreateRuntimeInstallationIdImpl(stateDirectory, controls);
 }
 
 /** Loads identity, rechecks cancellation, and only then invokes the constructor. */

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -8,53 +8,168 @@ import type { UUID } from "@elizaos/core";
 const INSTALLATION_ID_FILENAME = "runtime-installation-id";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+type FileHandle = Awaited<ReturnType<typeof fs.open>>;
+type FileStat = Awaited<ReturnType<typeof fs.lstat>>;
+
+/** Test-only phase controls for deterministic filesystem race and platform probes. */
+export interface RuntimeInstallationIdTestControls {
+  platform?: NodeJS.Platform;
+  openDirectory?: (directory: string, flags: number) => Promise<FileHandle>;
+  syncDirectory?: (directory: FileHandle) => Promise<void>;
+  afterDirectoryValidation?: () => void | Promise<void>;
+  afterIdentityLstat?: () => void | Promise<void>;
+  afterIdentityOpen?: () => void | Promise<void>;
+  beforeIdentityReturn?: () => void | Promise<void>;
+  beforeIdentityPublication?: () => void | Promise<void>;
+}
+
+interface TrustedDirectory {
+  handle?: FileHandle;
+  stat: FileStat;
+}
 
 function currentUid(): number | undefined {
   return typeof process.getuid === "function" ? process.getuid() : undefined;
 }
 
-function assertOwnedByRuntime(
-  stat: Awaited<ReturnType<typeof fs.lstat>>,
-  label: string,
-): void {
+function assertOwnedByRuntime(stat: FileStat, label: string): void {
   const uid = currentUid();
-  if (uid !== undefined && stat.uid !== uid) {
+  if (uid !== undefined && Number(stat.uid) !== uid) {
     throw new Error(`${label} is not owned by the runtime user.`);
   }
 }
 
-async function openTrustedStateDirectory(stateDirectory: string) {
-  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
-  const pathStat = await fs.lstat(stateDirectory);
-  if (!pathStat.isDirectory() || pathStat.isSymbolicLink()) {
+function sameIdentity(left: FileStat, right: FileStat): boolean {
+  return (
+    String(left.dev) === String(right.dev) &&
+    String(left.ino) === String(right.ino)
+  );
+}
+
+function assertTrustedDirectoryStat(
+  stat: FileStat,
+  platform: NodeJS.Platform,
+): void {
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new Error("Runtime state directory must be a real directory.");
   }
-  assertOwnedByRuntime(pathStat, "Runtime state directory");
-  if ((pathStat.mode & 0o022) !== 0) {
+  assertOwnedByRuntime(stat, "Runtime state directory");
+  // POSIX mode bits are meaningful here. Windows trust is supplied by its ACL;
+  // treating emulated mode bits as an ACL proof would reject or bless paths falsely.
+  if (platform !== "win32" && (Number(stat.mode) & 0o022) !== 0) {
     throw new Error("Runtime state directory is writable by another user.");
   }
-  const directory = await fs.open(
-    stateDirectory,
-    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
-  );
-  try {
-    const openedStat = await directory.stat();
-    if (
-      !openedStat.isDirectory() ||
-      openedStat.dev !== pathStat.dev ||
-      openedStat.ino !== pathStat.ino
-    ) {
+}
+
+async function revalidateDirectoryPath(
+  stateDirectory: string,
+  trusted: TrustedDirectory,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  const pathStat = await fs.lstat(stateDirectory);
+  assertTrustedDirectoryStat(pathStat, platform);
+  if (!sameIdentity(pathStat, trusted.stat)) {
+    throw new Error("Runtime state directory changed during validation.");
+  }
+  if (trusted.handle) {
+    const openedStat = await trusted.handle.stat();
+    if (!openedStat.isDirectory() || !sameIdentity(openedStat, pathStat)) {
       throw new Error("Runtime state directory changed during validation.");
     }
-    return directory;
+  }
+}
+
+function isUnsupportedWindowsDirectoryIo(
+  error: unknown,
+  platform: NodeJS.Platform,
+): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return platform === "win32" && (code === "EINVAL" || code === "EPERM");
+}
+
+async function openTrustedStateDirectory(
+  stateDirectory: string,
+  controls: RuntimeInstallationIdTestControls,
+): Promise<TrustedDirectory> {
+  const platform = controls.platform ?? process.platform;
+  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+  const pathStat = await fs.lstat(stateDirectory);
+  assertTrustedDirectoryStat(pathStat, platform);
+  const openDirectory = controls.openDirectory ?? fs.open;
+  const flags =
+    platform === "win32"
+      ? constants.O_RDONLY
+      : constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW;
+  let handle: FileHandle | undefined;
+  try {
+    handle = await openDirectory(stateDirectory, flags);
   } catch (error) {
-    await directory.close();
+    // error-policy:J4 Windows may reject opening a directory descriptor with
+    // EINVAL/EPERM. Path identity is still revalidated before every commit/return.
+    if (!isUnsupportedWindowsDirectoryIo(error, platform)) throw error;
+  }
+  const trusted = { stat: pathStat, ...(handle ? { handle } : {}) };
+  try {
+    await revalidateDirectoryPath(stateDirectory, trusted, platform);
+    await controls.afterDirectoryValidation?.();
+    return trusted;
+  } catch (error) {
+    await handle?.close();
     throw error;
   }
 }
 
-async function readInstallationId(target: string): Promise<UUID | undefined> {
-  let pathStat: Awaited<ReturnType<typeof fs.lstat>>;
+function assertTrustedIdentityStat(
+  stat: FileStat,
+  platform: NodeJS.Platform,
+): void {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("Runtime installation identity must be a regular file.");
+  }
+  assertOwnedByRuntime(stat, "Runtime installation identity");
+  if (Number(stat.nlink) !== 1) {
+    throw new Error(
+      "Runtime installation identity must not have multiple links.",
+    );
+  }
+  if (platform !== "win32" && (Number(stat.mode) & 0o777) !== 0o600) {
+    throw new Error("Runtime installation identity permissions are insecure.");
+  }
+}
+
+async function finalIdentityRevalidation(
+  target: string,
+  file: FileHandle,
+  openedStat: FileStat,
+  stateDirectory: string,
+  trustedDirectory: TrustedDirectory,
+  controls: RuntimeInstallationIdTestControls,
+): Promise<void> {
+  const platform = controls.platform ?? process.platform;
+  await controls.beforeIdentityReturn?.();
+  const [descriptorStat, pathStat] = await Promise.all([
+    file.stat(),
+    fs.lstat(target),
+  ]);
+  assertTrustedIdentityStat(descriptorStat, platform);
+  assertTrustedIdentityStat(pathStat, platform);
+  if (
+    !sameIdentity(descriptorStat, openedStat) ||
+    !sameIdentity(pathStat, descriptorStat)
+  ) {
+    throw new Error("Runtime installation identity changed during validation.");
+  }
+  await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
+}
+
+async function readInstallationId(
+  target: string,
+  stateDirectory: string,
+  trustedDirectory: TrustedDirectory,
+  controls: RuntimeInstallationIdTestControls,
+): Promise<UUID | undefined> {
+  const platform = controls.platform ?? process.platform;
+  let pathStat: FileStat;
   try {
     pathStat = await fs.lstat(target);
   } catch (error) {
@@ -65,38 +180,47 @@ async function readInstallationId(target: string): Promise<UUID | undefined> {
     throw new Error("Runtime installation identity must be a regular file.");
   }
   assertOwnedByRuntime(pathStat, "Runtime installation identity");
-  if (pathStat.nlink !== 1) {
+  if (Number(pathStat.nlink) !== 1) {
     throw new Error(
       "Runtime installation identity must not have multiple links.",
     );
   }
-  const file = await fs.open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
+  await controls.afterIdentityLstat?.();
+  const fileFlags =
+    platform === "win32"
+      ? constants.O_RDONLY
+      : constants.O_RDONLY | constants.O_NOFOLLOW;
+  const file = await fs.open(target, fileFlags);
   try {
     const openedStat = await file.stat();
-    if (
-      !openedStat.isFile() ||
-      openedStat.dev !== pathStat.dev ||
-      openedStat.ino !== pathStat.ino
-    ) {
+    if (!openedStat.isFile() || !sameIdentity(openedStat, pathStat)) {
       throw new Error(
         "Runtime installation identity changed during validation.",
       );
     }
     assertOwnedByRuntime(openedStat, "Runtime installation identity");
-    if ((openedStat.mode & 0o777) !== 0o600) {
+    if (Number(openedStat.nlink) !== 1) {
+      throw new Error(
+        "Runtime installation identity must not have multiple links.",
+      );
+    }
+    if (platform !== "win32" && (Number(openedStat.mode) & 0o777) !== 0o600) {
       await file.chmod(0o600);
       await file.sync();
-      const repaired = await file.stat();
-      if ((repaired.mode & 0o777) !== 0o600) {
-        throw new Error(
-          "Runtime installation identity permissions are insecure.",
-        );
-      }
     }
+    await controls.afterIdentityOpen?.();
     const value = (await file.readFile("utf8")).trim();
     if (!UUID_PATTERN.test(value)) {
       throw new Error(`Runtime installation identity is corrupt: ${target}`);
     }
+    await finalIdentityRevalidation(
+      target,
+      file,
+      openedStat,
+      stateDirectory,
+      trustedDirectory,
+      controls,
+    );
     return value.toLowerCase() as UUID;
   } finally {
     await file.close();
@@ -104,33 +228,56 @@ async function readInstallationId(target: string): Promise<UUID | undefined> {
 }
 
 async function syncStateDirectory(
-  directory: Awaited<ReturnType<typeof fs.open>>,
+  trusted: TrustedDirectory,
+  controls: RuntimeInstallationIdTestControls,
+): Promise<void> {
+  if (!trusted.handle) return;
+  const platform = controls.platform ?? process.platform;
+  const syncDirectory = controls.syncDirectory ?? ((handle) => handle.sync());
+  try {
+    await syncDirectory(trusted.handle);
+  } catch (error) {
+    // error-policy:J4 Only Windows' documented unsupported-directory errors
+    // degrade after the identity file itself has been synced.
+    if (!isUnsupportedWindowsDirectoryIo(error, platform)) throw error;
+  }
+}
+
+async function removePublishedCandidate(
+  target: string,
+  candidateStat: FileStat,
 ): Promise<void> {
   try {
-    await directory.sync();
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    // error-policy:J4 Node documents directory fsync as unsupported on Windows;
-    // only those platform-specific errors degrade after the file itself is synced.
-    if (
-      process.platform !== "win32" ||
-      (code !== "EINVAL" && code !== "EPERM")
-    ) {
-      throw error;
+    const targetStat = await fs.lstat(target);
+    if (targetStat.isFile() && sameIdentity(targetStat, candidateStat)) {
+      await fs.unlink(target);
     }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 
 /** Loads one durable UUID per trusted state directory without following links. */
 export async function loadOrCreateRuntimeInstallationId(
   stateDirectory: string,
+  controls: RuntimeInstallationIdTestControls = {},
 ): Promise<UUID> {
-  const directory = await openTrustedStateDirectory(stateDirectory);
+  const platform = controls.platform ?? process.platform;
+  const trustedDirectory = await openTrustedStateDirectory(
+    stateDirectory,
+    controls,
+  );
   const target = path.join(stateDirectory, INSTALLATION_ID_FILENAME);
   try {
-    const existing = await readInstallationId(target);
+    const existing = await readInstallationId(
+      target,
+      stateDirectory,
+      trustedDirectory,
+      controls,
+    );
     if (existing) return existing;
 
+    await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
     const candidate = randomUUID() as UUID;
     const temporary = path.join(
       stateDirectory,
@@ -143,10 +290,29 @@ export async function loadOrCreateRuntimeInstallationId(
     } finally {
       await file.close();
     }
+    const candidateStat = await fs.lstat(temporary);
+    await revalidateDirectoryPath(stateDirectory, trustedDirectory, platform);
+    await controls.beforeIdentityPublication?.();
+    let publishedCandidate = false;
     try {
-      await fs.link(temporary, target);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        await fs.link(temporary, target);
+        publishedCandidate = true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+      try {
+        await revalidateDirectoryPath(
+          stateDirectory,
+          trustedDirectory,
+          platform,
+        );
+      } catch (error) {
+        if (publishedCandidate) {
+          await removePublishedCandidate(target, candidateStat);
+        }
+        throw error;
+      }
     } finally {
       await fs.unlink(temporary).catch((error: NodeJS.ErrnoException) => {
         // error-policy:J2 A cleanup failure makes publication durability
@@ -154,14 +320,19 @@ export async function loadOrCreateRuntimeInstallationId(
         if (error.code !== "ENOENT") throw error;
       });
     }
-    await syncStateDirectory(directory);
-    const published = await readInstallationId(target);
+    await syncStateDirectory(trustedDirectory, controls);
+    const published = await readInstallationId(
+      target,
+      stateDirectory,
+      trustedDirectory,
+      controls,
+    );
     if (!published) {
       throw new Error("Runtime installation identity was not published.");
     }
     return published;
   } finally {
-    await directory.close();
+    await trustedDirectory.handle?.close();
   }
 }
 

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -26,10 +26,17 @@ interface TrustedDirectory {
   stat: FileStat;
   parent: TrustedParentDirectory;
   ancestors: TrustedParentDirectory[];
+  lexicalAncestors: TrustedLexicalEntry[];
 }
 
 interface TrustedParentDirectory {
   handle: FileHandle;
+  path: string;
+  stat: FileStat;
+}
+
+interface TrustedLexicalEntry {
+  handle?: FileHandle;
   path: string;
   stat: FileStat;
 }
@@ -125,6 +132,81 @@ async function closeAncestors(
   if (failure) throw failure;
 }
 
+async function closeLexicalAncestors(
+  ancestors: TrustedLexicalEntry[],
+): Promise<void> {
+  await closeAncestors(
+    ancestors.filter(
+      (ancestor): ancestor is TrustedParentDirectory =>
+        ancestor.handle !== undefined,
+    ),
+  );
+}
+
+function assertTrustedSymlinkStat(stat: FileStat): void {
+  if (!stat.isSymbolicLink()) {
+    throw new Error(
+      "Runtime state lexical redirect changed during validation.",
+    );
+  }
+  const uid = currentUid();
+  if (uid !== undefined && Number(stat.uid) !== uid && Number(stat.uid) !== 0) {
+    throw new Error("Runtime state lexical redirect has an untrusted owner.");
+  }
+}
+
+async function openTrustedLexicalChain(
+  directory: string,
+): Promise<TrustedLexicalEntry[]> {
+  const paths = ancestorPaths(directory);
+  const trusted: TrustedLexicalEntry[] = [];
+  try {
+    for (const [index, entryPath] of paths.entries()) {
+      const stat = await fs.lstat(entryPath);
+      if (stat.isSymbolicLink()) {
+        if (index === paths.length - 1) {
+          throw new Error("Runtime state parent must be a real directory.");
+        }
+        assertTrustedSymlinkStat(stat);
+        trusted.push({ path: entryPath, stat });
+        continue;
+      }
+      assertTrustedParentDirectoryStat(stat);
+      const handle = await fs.open(
+        entryPath,
+        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+      );
+      trusted.push({ path: entryPath, stat, handle });
+    }
+    await revalidateLexicalChain(trusted);
+    return trusted;
+  } catch (error) {
+    await closeLexicalAncestors(trusted);
+    throw error;
+  }
+}
+
+async function revalidateLexicalChain(
+  ancestors: TrustedLexicalEntry[],
+): Promise<void> {
+  for (const ancestor of ancestors) {
+    const pathStat = await fs.lstat(ancestor.path);
+    if (!sameIdentity(pathStat, ancestor.stat)) {
+      throw new Error("Runtime state lexical path changed during validation.");
+    }
+    if (!ancestor.handle) {
+      assertTrustedSymlinkStat(pathStat);
+      continue;
+    }
+    assertTrustedParentDirectoryStat(pathStat);
+    const descriptorStat = await ancestor.handle.stat();
+    assertTrustedParentDirectoryStat(descriptorStat);
+    if (!sameIdentity(descriptorStat, ancestor.stat)) {
+      throw new Error("Runtime state lexical path changed during validation.");
+    }
+  }
+}
+
 async function revalidateAncestorChain(
   ancestors: TrustedParentDirectory[],
 ): Promise<void> {
@@ -165,6 +247,7 @@ async function revalidateDirectoryPath(
 
 async function openTrustedStateDirectory(
   stateDirectory: string,
+  lexicalAncestors: TrustedLexicalEntry[],
 ): Promise<TrustedDirectory> {
   const parentPath = path.dirname(stateDirectory);
   const ancestors: TrustedParentDirectory[] = [];
@@ -192,10 +275,17 @@ async function openTrustedStateDirectory(
       stateDirectory,
       constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
     );
-    const trusted = { stat: pathStat, handle, parent, ancestors };
+    const trusted = {
+      stat: pathStat,
+      handle,
+      parent,
+      ancestors,
+      lexicalAncestors,
+    };
     try {
       await revalidateDirectoryPath(stateDirectory, trusted);
       await revalidateAncestorChain(ancestors);
+      await revalidateLexicalChain(lexicalAncestors);
       return trusted;
     } catch (error) {
       await handle.close();
@@ -410,19 +500,24 @@ async function loadOrCreateRuntimeInstallationIdImpl(
 ): Promise<UUID> {
   const requestedStateDirectory = path.resolve(stateDirectory);
   const requestedParent = path.dirname(requestedStateDirectory);
-  const requestedParentStat = await fs.lstat(requestedParent);
-  if (requestedParentStat.isSymbolicLink()) {
-    throw new Error("Runtime state parent must be a real directory.");
-  }
-  const resolvedStateDirectory = path.join(
-    await fs.realpath(requestedParent),
-    path.basename(requestedStateDirectory),
-  );
-  const trustedDirectory = await openTrustedStateDirectory(
-    resolvedStateDirectory,
-  );
-  const target = path.join(resolvedStateDirectory, INSTALLATION_ID_FILENAME);
+  const lexicalAncestors = await openTrustedLexicalChain(requestedParent);
+  let trustedDirectory: TrustedDirectory;
+  let resolvedStateDirectory: string;
   try {
+    resolvedStateDirectory = path.join(
+      await fs.realpath(requestedParent),
+      path.basename(requestedStateDirectory),
+    );
+    trustedDirectory = await openTrustedStateDirectory(
+      resolvedStateDirectory,
+      lexicalAncestors,
+    );
+  } catch (error) {
+    await closeLexicalAncestors(lexicalAncestors);
+    throw error;
+  }
+  const target = path.join(resolvedStateDirectory, INSTALLATION_ID_FILENAME);
+  const execute = async (): Promise<UUID> => {
     const existing = await readInstallationId(
       target,
       resolvedStateDirectory,
@@ -432,6 +527,7 @@ async function loadOrCreateRuntimeInstallationIdImpl(
 
     await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
     await revalidateAncestorChain(trustedDirectory.ancestors);
+    await revalidateLexicalChain(trustedDirectory.lexicalAncestors);
     await revalidateDirectoryPath(resolvedStateDirectory, trustedDirectory);
     const candidate = randomUUID() as UUID;
     const temporaryName = `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`;
@@ -525,13 +621,43 @@ async function loadOrCreateRuntimeInstallationIdImpl(
       }
       throw error;
     }
-  } finally {
-    try {
-      await trustedDirectory.handle.close();
-    } finally {
-      await closeAncestors(trustedDirectory.ancestors);
-    }
+  };
+  let result: UUID | undefined;
+  let operationError: unknown;
+  try {
+    result = await execute();
+  } catch (error) {
+    operationError = error;
   }
+  let closeError: unknown;
+  try {
+    await trustedDirectory.handle.close();
+  } catch (failure) {
+    closeError = failure;
+  }
+  try {
+    await closeAncestors(trustedDirectory.ancestors);
+  } catch (failure) {
+    closeError ??= failure;
+  }
+  try {
+    await closeLexicalAncestors(trustedDirectory.lexicalAncestors);
+  } catch (failure) {
+    closeError ??= failure;
+  }
+  if (
+    operationError instanceof RuntimeInstallationIdentityRecoveryError &&
+    closeError
+  ) {
+    throw new RuntimeInstallationIdentityRecoveryError(operationError.message, {
+      cause: new AggregateError([operationError, closeError]),
+    });
+  }
+  if (operationError) throw operationError;
+  if (closeError) throw closeError;
+  if (!result)
+    throw new Error("Runtime installation identity was unavailable.");
+  return result;
 }
 
 /** Loads the host identity with production-fixed platform and filesystem policy. */

--- a/packages/agent/src/runtime/runtime-installation-id.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.ts
@@ -1,0 +1,67 @@
+/** Persists the standalone host identity used to scope runtime-owned effects. */
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { UUID } from "@elizaos/core";
+
+const INSTALLATION_ID_FILENAME = "runtime-installation-id";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function readInstallationId(target: string): Promise<UUID | undefined> {
+  try {
+    const value = (await fs.readFile(target, "utf8")).trim();
+    if (!UUID_PATTERN.test(value)) {
+      throw new Error(`Runtime installation identity is corrupt: ${target}`);
+    }
+    return value.toLowerCase() as UUID;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+/** Loads one durable UUID per state directory, publishing it without replacement. */
+export async function loadOrCreateRuntimeInstallationId(
+  stateDirectory: string,
+): Promise<UUID> {
+  await fs.mkdir(stateDirectory, { recursive: true, mode: 0o700 });
+  const target = path.join(stateDirectory, INSTALLATION_ID_FILENAME);
+  const existing = await readInstallationId(target);
+  if (existing) return existing;
+
+  const candidate = randomUUID() as UUID;
+  const temporary = path.join(
+    stateDirectory,
+    `.${INSTALLATION_ID_FILENAME}.${randomUUID()}.tmp`,
+  );
+  const file = await fs.open(temporary, "wx", 0o600);
+  try {
+    await file.writeFile(`${candidate}\n`, "utf8");
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+  try {
+    await fs.link(temporary, target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  } finally {
+    await fs.unlink(temporary).catch((error: NodeJS.ErrnoException) => {
+      // error-policy:J2 A cleanup failure makes publication durability
+      // ambiguous, so retain the original filesystem error for the boot boundary.
+      if (error.code !== "ENOENT") throw error;
+    });
+  }
+  await fs.chmod(target, 0o600);
+  const directory = await fs.open(stateDirectory, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+  const published = await readInstallationId(target);
+  if (!published)
+    throw new Error("Runtime installation identity was not published.");
+  return published;
+}

--- a/packages/agent/src/services/remote-capability-router.ts
+++ b/packages/agent/src/services/remote-capability-router.ts
@@ -559,7 +559,7 @@ async function invokeLocalRouter(
     case "pty.command.run":
       return (await router.pty.runCommand(
         params as TerminalRunParams,
-      )) as JsonValue;
+      )) as unknown as JsonValue;
     case "git.status":
       return (await router.git.status(params as GitStatusParams)) as JsonValue;
     case "git.diff":

--- a/packages/agent/src/services/remote-coding-runner.test.ts
+++ b/packages/agent/src/services/remote-coding-runner.test.ts
@@ -5,8 +5,29 @@
  * host↔sandbox path mapping, and cloud coding-container provisioning. Uses fake
  * sandbox factories and fetch-mocked remote-runner / cloud HTTP servers.
  */
-import { CapabilityError, type IAgentRuntime, type UUID } from "@elizaos/core";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import {
+  AgentRuntime,
+  CAPABILITY_ROUTER_SERVICE_TYPE,
+  CapabilityError,
+  type ElizaCapabilityRouter,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+  type WorkspaceDeltaReceipt,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import codingToolsPlugin, {
+  SANDBOX_SERVICE,
+  SandboxService,
+  SESSION_CWD_SERVICE,
+  SessionCwdService,
+} from "../../../../plugins/plugin-coding-tools/src/index.ts";
+import { __codingMutationRequiresVerificationForTests } from "../../../core/src/runtime/planner-loop.ts";
 import {
   DEFAULT_ELIZA_CLOUD_API_BASE_URL,
   RemoteCodingCapabilityRouterService,
@@ -17,6 +38,8 @@ import {
   type SandboxCommandResult,
   type SandboxEntryInfo,
 } from "./remote-coding-runner.ts";
+
+const execFileAsync = promisify(execFile);
 
 class FakeFiles {
   readonly listCalls: string[] = [];
@@ -674,10 +697,188 @@ describe("RemoteCodingCapabilityRouterService", () => {
       timedOut: false,
     });
     expect(result.output).toContain("ran npm 'test'");
-    expect(sandbox.commands.runCalls[1]).toMatchObject({
+    expect(
+      sandbox.commands.runCalls.find((call) => call.cmd === "npm 'test'"),
+    ).toMatchObject({
       cmd: "npm 'test'",
       cwd: "/workspace/src",
     });
+  });
+
+  it("observes and emits changed then unchanged receipts at the production PTY endpoint", async () => {
+    const sandbox = new FakeSandbox();
+    let remoteFingerprint = "1".repeat(40);
+    vi.spyOn(sandbox.commands, "run").mockImplementation(
+      async (cmd, opts = {}) => {
+        sandbox.commands.runCalls.push({ cmd, cwd: opts.cwd });
+        if (cmd.startsWith("bash -lc ")) {
+          return { exitCode: 0, stdout: `${remoteFingerprint}\n`, stderr: "" };
+        }
+        if (cmd.includes("mutate")) remoteFingerprint = "2".repeat(40);
+        return { exitCode: 0, stdout: `ran ${cmd}\n`, stderr: "" };
+      },
+    );
+    const service = new RemoteCodingCapabilityRouterService(
+      makeRuntime(),
+      makeConfig(),
+      new FakeFactory(sandbox),
+    );
+
+    const changed = await service.pty.runCommand({
+      command: "node mutate.js",
+      cwd: "/repo",
+    });
+    const unchanged = await service.pty.runCommand({
+      command: "bun test",
+      cwd: "/repo",
+    });
+
+    expect(changed.workspaceDeltaReceipt).toMatchObject({
+      outcome: "changed",
+      scope: changed.workspaceExecution,
+    });
+    expect(unchanged.workspaceDeltaReceipt).toMatchObject({
+      outcome: "unchanged",
+      scope: changed.workspaceExecution,
+    });
+    expect(changed.workspaceExecution).toMatchObject({
+      root: "/workspace",
+      rootId: expect.stringMatching(/^[a-f0-9]{64}$/),
+      executionDomainId: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+  });
+
+  it("carries production endpoint receipts through RuntimeBroker, SHELL, and planner scope matching", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "remote-receipt-e2e-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      const sandbox = new FakeSandbox();
+      let remoteFingerprint = "1".repeat(40);
+      vi.spyOn(sandbox.commands, "run").mockImplementation(
+        async (cmd, opts = {}) => {
+          sandbox.commands.runCalls.push({ cmd, cwd: opts.cwd });
+          if (cmd.startsWith("bash -lc ")) {
+            return {
+              exitCode: 0,
+              stdout: `${remoteFingerprint}\n`,
+              stderr: "",
+            };
+          }
+          if (cmd.includes("mutate")) remoteFingerprint = "2".repeat(40);
+          return { exitCode: 0, stdout: `ran ${cmd}\n`, stderr: "" };
+        },
+      );
+      const endpoint = new RemoteCodingCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({ hostWorkspaceRoot: root }),
+        new FakeFactory(sandbox),
+      );
+      let routedCalls = 0;
+      const router: ElizaCapabilityRouter = {
+        environment: endpoint.environment,
+        fs: endpoint.fs,
+        git: endpoint.git,
+        model: endpoint.model,
+        plugin: endpoint.plugin,
+        availability: () => endpoint.availability(),
+        pty: {
+          runCommand: async (params) => {
+            routedCalls += 1;
+            if (routedCalls === 2) {
+              throw new CapabilityError({
+                code: "CAPABILITY_UNAVAILABLE",
+                capability: "pty",
+                method: "pty.command.run",
+                message: "exercise local fallback",
+              });
+            }
+            const result = await endpoint.pty.runCommand(params);
+            return result;
+          },
+        },
+      };
+      const action = codingToolsPlugin.actions?.find(
+        (candidate) => candidate.name === "SHELL",
+      );
+      if (!action?.handler) throw new Error("SHELL action unavailable");
+      const owner = new AgentRuntime({
+        character: { name: "remote-receipt-conformance" } as never,
+      });
+      const services = new Map<string, unknown>();
+      const runtime = {
+        agentId: owner.agentId,
+        runtimeInstanceId: "55555555-5555-4555-8555-555555555555" as UUID,
+        actions: [action],
+        character: owner.character,
+        getSetting: (key: string) =>
+          key === "CODING_TOOLS_WORKSPACE_ROOTS" ? root : undefined,
+        getService: <T>(type: string) => (services.get(type) as T) ?? null,
+        redactSecrets: (text: string) => text,
+        locateConfiguredSecretFragmentTaint:
+          owner.locateConfiguredSecretFragmentTaint.bind(owner),
+        logger: owner.logger,
+      } as IAgentRuntime;
+      const sandboxService = await SandboxService.start(runtime);
+      const sessionService = await SessionCwdService.start(runtime);
+      services.set(SANDBOX_SERVICE, sandboxService);
+      services.set(SESSION_CWD_SERVICE, sessionService);
+      services.set(CAPABILITY_ROUTER_SERVICE_TYPE, router);
+      const roomId = "22222222-2222-2222-2222-222222222222" as UUID;
+      sessionService.setCwd(String(roomId), root);
+      const message = {
+        id: "33333333-3333-3333-3333-333333333333" as UUID,
+        roomId,
+        entityId: "44444444-4444-4444-4444-444444444444" as UUID,
+        content: { text: "mutate and verify" },
+      } as Memory;
+      const run = async (command: string) =>
+        await action.handler?.(runtime, message, undefined, { command });
+      const changed = await run("printf mutate");
+      const local = await run("true");
+      const remoteUnchanged = await run("bun test");
+      const steps = [changed, local, remoteUnchanged].map((result, index) => ({
+        toolCall: {
+          name: "SHELL",
+          params: {
+            command: ["printf mutate", "true", "bun test"][index],
+          },
+        },
+        result,
+      }));
+      const trajectorySteps = steps.slice(0, 1);
+      const trajectory = {
+        steps: trajectorySteps,
+        archivedSteps: [],
+      } as unknown as Parameters<
+        typeof __codingMutationRequiresVerificationForTests
+      >[0];
+      const changedReceipt = changed?.data?.workspaceDeltaReceipt as
+        | WorkspaceDeltaReceipt
+        | undefined;
+      expect(changedReceipt).toMatchObject({
+        outcome: "changed",
+      });
+      if (!changedReceipt) throw new Error("changed receipt unavailable");
+      expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+        true,
+      );
+      trajectorySteps.push(steps[1]);
+      expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+        true,
+      );
+      trajectorySteps.push(steps[2]);
+      expect(remoteUnchanged?.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "unchanged",
+        scope: changedReceipt.scope,
+      });
+      expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("retries runner creation after a transient failure instead of caching the rejection", async () => {
@@ -804,7 +1005,11 @@ describe("RemoteCodingCapabilityRouterService", () => {
     });
 
     expect(result.operation.status).toBe("completed");
-    expect(sandbox.commands.runCalls.at(-1)).toMatchObject({
+    expect(
+      sandbox.commands.runCalls.find(
+        (call) => call.cmd === "git 'status' '--short'",
+      ),
+    ).toMatchObject({
       cmd: "git 'status' '--short'",
       cwd: "/workspace",
     });
@@ -929,6 +1134,10 @@ describe("RemoteCodingCapabilityRouterService", () => {
           "/v1/fs/entries",
           "/v1/fs/file",
           "/v1/fs/file",
+          "/v1/processes/run",
+          "/v1/processes/run",
+          "/v1/processes/run",
+          "/v1/processes/run",
           "/v1/processes/run",
           "/v1/processes/run",
         ]);
@@ -1475,6 +1684,9 @@ describe("RemoteCodingCapabilityRouterService", () => {
         output: "partial output\ncommand deadline reached",
         exitCode: 124,
         timedOut: true,
+        workspaceExecution: expect.objectContaining({
+          root: "/workspace",
+        }),
       });
     } finally {
       replaceGlobalFetch(originalFetch);

--- a/packages/agent/src/services/remote-coding-runner.test.ts
+++ b/packages/agent/src/services/remote-coding-runner.test.ts
@@ -109,10 +109,108 @@ class FakeSandbox implements RemoteRunnerClient {
   }
 }
 
+class LocalProcessSandbox implements RemoteRunnerClient {
+  readonly sandboxId: string;
+  readonly workspacePrepared = true;
+
+  constructor(
+    readonly root: string,
+    sandboxId = `local-${path.basename(root)}`,
+  ) {
+    this.sandboxId = sandboxId;
+  }
+
+  readonly commands = {
+    run: async (
+      cmd: string,
+      opts: {
+        cwd?: string;
+        timeoutMs?: number;
+        envs?: Record<string, string>;
+      } = {},
+    ): Promise<SandboxCommandResult> => {
+      try {
+        const result = await execFileAsync(
+          "/bin/bash",
+          ["--noprofile", "--norc", "-o", "pipefail", "-c", cmd],
+          {
+            cwd: opts.cwd ?? this.root,
+            env: { ...process.env, ...opts.envs },
+            encoding: "utf8",
+            timeout: opts.timeoutMs,
+            maxBuffer: 4 * 1024 * 1024,
+          },
+        );
+        return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+      } catch (error) {
+        const failure = error as Error & {
+          code?: number | string;
+          stdout?: string;
+          stderr?: string;
+          killed?: boolean;
+        };
+        return {
+          exitCode:
+            typeof failure.code === "number"
+              ? failure.code
+              : failure.killed
+                ? 137
+                : 1,
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? failure.message,
+          timedOut: failure.killed === true,
+        };
+      }
+    },
+  };
+
+  readonly files = {
+    list: async (target: string): Promise<SandboxEntryInfo[]> => {
+      const directory = await fs.opendir(target);
+      const entries: SandboxEntryInfo[] = [];
+      for await (const item of directory) {
+        const absolute = path.join(target, item.name);
+        const stat = await fs.lstat(absolute);
+        entries.push({
+          path: absolute,
+          name: item.name,
+          type: item.isFile()
+            ? "file"
+            : item.isDirectory()
+              ? "dir"
+              : item.isSymbolicLink()
+                ? "symlink"
+                : "other",
+          size: stat.size,
+          mode: stat.mode,
+          modifiedTime: stat.mtime,
+          ...(item.isSymbolicLink()
+            ? { symlinkTarget: await fs.readlink(absolute) }
+            : {}),
+        });
+      }
+      return entries;
+    },
+    read: async (
+      target: string,
+      opts?: { format?: "text" | "bytes" },
+    ): Promise<string | Uint8Array> =>
+      opts?.format === "bytes"
+        ? new Uint8Array(await fs.readFile(target))
+        : await fs.readFile(target, "utf8"),
+    write: async (target: string, data: string) => {
+      await fs.writeFile(target, data);
+      return { path: target, name: path.basename(target) };
+    },
+  };
+
+  readonly kill = vi.fn(async () => {});
+}
+
 class FakeFactory implements RemoteRunnerFactory {
   readonly configs: RemoteCodingRunnerConfig[] = [];
 
-  constructor(readonly sandbox = new FakeSandbox()) {}
+  constructor(readonly sandbox: RemoteRunnerClient = new FakeSandbox()) {}
 
   async create(config: RemoteCodingRunnerConfig): Promise<RemoteRunnerClient> {
     this.configs.push(config);
@@ -705,48 +803,246 @@ describe("RemoteCodingCapabilityRouterService", () => {
     });
   });
 
-  it("observes and emits changed then unchanged receipts at the production PTY endpoint", async () => {
-    const sandbox = new FakeSandbox();
-    let remoteFingerprint = "1".repeat(40);
-    vi.spyOn(sandbox.commands, "run").mockImplementation(
-      async (cmd, opts = {}) => {
-        sandbox.commands.runCalls.push({ cmd, cwd: opts.cwd });
-        if (cmd.startsWith("bash -lc ")) {
-          return { exitCode: 0, stdout: `${remoteFingerprint}\n`, stderr: "" };
-        }
-        if (cmd.includes("mutate")) remoteFingerprint = "2".repeat(40);
-        return { exitCode: 0, stdout: `ran ${cmd}\n`, stderr: "" };
-      },
-    );
-    const service = new RemoteCodingCapabilityRouterService(
-      makeRuntime(),
-      makeConfig(),
-      new FakeFactory(sandbox),
-    );
+  it("observes the canonical remote Git root through the production PTY endpoint", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remote-observer-"));
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      await fs.writeFile(path.join(root, "tracked.txt"), "before\n");
+      await fs.mkdir(path.join(root, "nested"));
+      await execFileAsync("git", ["add", "."], { cwd: root });
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "user.name=test",
+          "-c",
+          "user.email=test@example.com",
+          "commit",
+          "-qm",
+          "initial",
+        ],
+        { cwd: root },
+      );
+      const sandbox = new LocalProcessSandbox(root);
+      const service = new RemoteCodingCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({ workdir: root, hostWorkspaceRoot: root }),
+        new FakeFactory(sandbox),
+      );
 
-    const changed = await service.pty.runCommand({
-      command: "node mutate.js",
-      cwd: "/repo",
-    });
-    const unchanged = await service.pty.runCommand({
-      command: "bun test",
-      cwd: "/repo",
-    });
+      const changed = await service.pty.runCommand({
+        command: "printf 'after\\n' > ../tracked.txt",
+        cwd: path.join(root, "nested"),
+      });
+      const unchanged = await service.pty.runCommand({
+        command: "true",
+        cwd: path.join(root, "nested"),
+      });
 
-    expect(changed.workspaceDeltaReceipt).toMatchObject({
-      outcome: "changed",
-      scope: changed.workspaceExecution,
-    });
-    expect(unchanged.workspaceDeltaReceipt).toMatchObject({
-      outcome: "unchanged",
-      scope: changed.workspaceExecution,
-    });
-    expect(changed.workspaceExecution).toMatchObject({
-      root: "/workspace",
-      rootId: expect.stringMatching(/^[a-f0-9]{64}$/),
-      executionDomainId: expect.stringMatching(/^[a-f0-9]{64}$/),
-    });
+      expect(changed.workspaceDeltaReceipt).toMatchObject({
+        outcome: "changed",
+        scope: changed.workspaceExecution,
+      });
+      expect(unchanged.workspaceDeltaReceipt).toMatchObject({
+        outcome: "unchanged",
+        scope: changed.workspaceExecution,
+      });
+      expect(changed.workspaceExecution).toMatchObject({
+        root: await fs.realpath(root),
+        rootId: expect.stringMatching(/^[a-f0-9]{64}$/),
+        executionDomainId: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
+
+  it("detects remote index exceptions, nested symlinks, modes, and dirty submodules", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "remote-special-"));
+    const child = await fs.mkdtemp(path.join(os.tmpdir(), "remote-submodule-"));
+    const commit = async (cwd: string, message: string) => {
+      await execFileAsync("git", ["add", "."], { cwd });
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "user.name=test",
+          "-c",
+          "user.email=test@example.com",
+          "commit",
+          "-qm",
+          message,
+        ],
+        { cwd },
+      );
+    };
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      await fs.writeFile(path.join(root, "tracked.txt"), "initial\n");
+      await fs.writeFile(path.join(root, "verify.js"), "export {};\n");
+      await commit(root, "initial");
+      const service = new RemoteCodingCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({ workdir: root, hostWorkspaceRoot: root }),
+        new FakeFactory(new LocalProcessSandbox(root)),
+      );
+
+      await execFileAsync(
+        "git",
+        ["update-index", "--assume-unchanged", "tracked.txt"],
+        { cwd: root },
+      );
+      expect(
+        (
+          await service.pty.runCommand({
+            command: "printf assume > tracked.txt",
+            cwd: root,
+          })
+        ).workspaceDeltaReceipt,
+      ).toMatchObject({ outcome: "changed" });
+      await execFileAsync(
+        "git",
+        ["update-index", "--no-assume-unchanged", "tracked.txt"],
+        { cwd: root },
+      );
+      await execFileAsync("git", ["checkout", "--", "tracked.txt"], {
+        cwd: root,
+      });
+
+      await execFileAsync(
+        "git",
+        ["update-index", "--skip-worktree", "tracked.txt"],
+        { cwd: root },
+      );
+      expect(
+        (
+          await service.pty.runCommand({
+            command: "printf skip > tracked.txt",
+            cwd: root,
+          })
+        ).workspaceDeltaReceipt,
+      ).toMatchObject({ outcome: "changed" });
+      await execFileAsync(
+        "git",
+        ["update-index", "--no-skip-worktree", "tracked.txt"],
+        { cwd: root },
+      );
+      await execFileAsync("git", ["checkout", "--", "tracked.txt"], {
+        cwd: root,
+      });
+
+      await fs.mkdir(path.join(root, "untracked", "nested"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(root, "untracked", "nested", "mode.txt"),
+        "mode\n",
+      );
+      await fs.symlink(
+        "mode.txt",
+        path.join(root, "untracked", "nested", "link"),
+      );
+      expect(
+        (
+          await service.pty.runCommand({
+            command:
+              "chmod 700 untracked/nested/mode.txt && ln -snf ../mode.txt untracked/nested/link",
+            cwd: root,
+          })
+        ).workspaceDeltaReceipt,
+      ).toMatchObject({ outcome: "changed" });
+
+      await execFileAsync("git", ["init", "-q"], { cwd: child });
+      await fs.writeFile(path.join(child, "child.txt"), "initial\n");
+      await commit(child, "child");
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "protocol.file.allow=always",
+          "submodule",
+          "add",
+          "-q",
+          child,
+          "submodule",
+        ],
+        { cwd: root },
+      );
+      await commit(root, "submodule");
+      await fs.writeFile(
+        path.join(root, "submodule", "child.txt"),
+        "dirty-before\n",
+      );
+      expect(
+        (
+          await service.pty.runCommand({
+            command: "printf dirty-after > submodule/child.txt",
+            cwd: root,
+          })
+        ).workspaceDeltaReceipt,
+      ).toMatchObject({ outcome: "changed" });
+    } finally {
+      await Promise.all([
+        fs.rm(root, { recursive: true, force: true }),
+        fs.rm(child, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it.each([
+    ["file bytes", { maxFileBytes: 1 }, "OBSERVATION_BYTE_BUDGET_EXCEEDED"],
+    [
+      "Git output",
+      { maxGitOutputBytes: 1 },
+      "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
+    ],
+    [
+      "directory entries",
+      { maxDirectoryEntries: 1 },
+      "OBSERVATION_BYTE_BUDGET_EXCEEDED",
+    ],
+    [
+      "directory names",
+      { maxDirectoryNameBytes: 1 },
+      "OBSERVATION_BYTE_BUDGET_EXCEEDED",
+    ],
+    ["wall clock", { maxObservationMs: 1 }, "OBSERVATION_TIME_BUDGET_EXCEEDED"],
+  ] as const)(
+    "fails closed at the remote %s observation budget",
+    async (_name, limits, reasonCode) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "remote-budget-"));
+      try {
+        await execFileAsync("git", ["init", "-q"], { cwd: root });
+        const embedded = path.join(root, "embedded");
+        await fs.mkdir(embedded);
+        await execFileAsync("git", ["init", "-q"], { cwd: embedded });
+        await fs.writeFile(
+          path.join(embedded, "long-entry-one.txt"),
+          "payload\n",
+        );
+        await fs.writeFile(
+          path.join(embedded, "long-entry-two.txt"),
+          "payload\n",
+        );
+        const service = new RemoteCodingCapabilityRouterService(
+          makeRuntime(),
+          makeConfig({ workdir: root, hostWorkspaceRoot: root }),
+          new FakeFactory(new LocalProcessSandbox(root)),
+          limits,
+        );
+        const result = await service.pty.runCommand({
+          command: "true",
+          cwd: root,
+        });
+        expect(result.workspaceDeltaReceipt).toMatchObject({
+          outcome: "indeterminate",
+          reasonCode,
+        });
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("carries production endpoint receipts through RuntimeBroker, SHELL, and planner scope matching", async () => {
     const root = await fs.mkdtemp(
@@ -754,25 +1050,26 @@ describe("RemoteCodingCapabilityRouterService", () => {
     );
     try {
       await execFileAsync("git", ["init", "-q"], { cwd: root });
-      const sandbox = new FakeSandbox();
-      let remoteFingerprint = "1".repeat(40);
-      vi.spyOn(sandbox.commands, "run").mockImplementation(
-        async (cmd, opts = {}) => {
-          sandbox.commands.runCalls.push({ cmd, cwd: opts.cwd });
-          if (cmd.startsWith("bash -lc ")) {
-            return {
-              exitCode: 0,
-              stdout: `${remoteFingerprint}\n`,
-              stderr: "",
-            };
-          }
-          if (cmd.includes("mutate")) remoteFingerprint = "2".repeat(40);
-          return { exitCode: 0, stdout: `ran ${cmd}\n`, stderr: "" };
-        },
+      await fs.writeFile(path.join(root, "tracked.txt"), "initial\n");
+      await fs.writeFile(path.join(root, "verify.js"), "export {};\n");
+      await execFileAsync("git", ["add", "."], { cwd: root });
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "user.name=test",
+          "-c",
+          "user.email=test@example.com",
+          "commit",
+          "-qm",
+          "initial",
+        ],
+        { cwd: root },
       );
+      const sandbox = new LocalProcessSandbox(root, "conformance-sandbox");
       const endpoint = new RemoteCodingCapabilityRouterService(
         makeRuntime(),
-        makeConfig({ hostWorkspaceRoot: root }),
+        makeConfig({ hostWorkspaceRoot: root, workdir: root }),
         new FakeFactory(sandbox),
       );
       let routedCalls = 0;
@@ -835,14 +1132,18 @@ describe("RemoteCodingCapabilityRouterService", () => {
       } as Memory;
       const run = async (command: string) =>
         await action.handler?.(runtime, message, undefined, { command });
-      const changed = await run("printf mutate");
+      const changed = await run("printf mutate > remote.txt");
       const local = await run("true");
-      const remoteUnchanged = await run("bun test");
+      const remoteUnchanged = await run("node --check verify.js");
       const steps = [changed, local, remoteUnchanged].map((result, index) => ({
         toolCall: {
           name: "SHELL",
           params: {
-            command: ["printf mutate", "true", "bun test"][index],
+            command: [
+              "printf mutate > remote.txt",
+              "true",
+              "node --check verify.js",
+            ][index],
           },
         },
         result,
@@ -1684,9 +1985,6 @@ describe("RemoteCodingCapabilityRouterService", () => {
         output: "partial output\ncommand deadline reached",
         exitCode: 124,
         timedOut: true,
-        workspaceExecution: expect.objectContaining({
-          root: "/workspace",
-        }),
       });
     } finally {
       replaceGlobalFetch(originalFetch);

--- a/packages/agent/src/services/remote-coding-runner.test.ts
+++ b/packages/agent/src/services/remote-coding-runner.test.ts
@@ -14,9 +14,10 @@ import {
   AgentRuntime,
   CAPABILITY_ROUTER_SERVICE_TYPE,
   CapabilityError,
-  type ElizaCapabilityRouter,
   type IAgentRuntime,
+  type JsonValue,
   type Memory,
+  RuntimeBrokerCapabilityRouter,
   type UUID,
   type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
@@ -1072,30 +1073,46 @@ describe("RemoteCodingCapabilityRouterService", () => {
         makeConfig({ hostWorkspaceRoot: root, workdir: root }),
         new FakeFactory(sandbox),
       );
-      let routedCalls = 0;
-      const router: ElizaCapabilityRouter = {
+      let brokerMode: "normal" | "unavailable" | "malformed" | "mismatch" =
+        "normal";
+      const router = new RuntimeBrokerCapabilityRouter({
         environment: endpoint.environment,
-        fs: endpoint.fs,
-        git: endpoint.git,
-        model: endpoint.model,
-        plugin: endpoint.plugin,
-        availability: () => endpoint.availability(),
-        pty: {
-          runCommand: async (params) => {
-            routedCalls += 1;
-            if (routedCalls === 2) {
-              throw new CapabilityError({
-                code: "CAPABILITY_UNAVAILABLE",
-                capability: "pty",
-                method: "pty.command.run",
-                message: "exercise local fallback",
-              });
-            }
-            const result = await endpoint.pty.runCommand(params);
-            return result;
-          },
+        invokeRuntime: async (method, params) => {
+          if (method !== "pty.command.run") {
+            throw new Error(`Unexpected broker method: ${method}`);
+          }
+          if (brokerMode === "unavailable") {
+            throw new CapabilityError({
+              code: "CAPABILITY_UNAVAILABLE",
+              capability: "pty",
+              method: "pty.command.run",
+              message: "exercise local fallback",
+            });
+          }
+          const produced = await endpoint.pty.runCommand(params as never);
+          if (brokerMode === "malformed") {
+            return {
+              ...produced,
+              workspaceDeltaReceipt: {
+                ...produced.workspaceDeltaReceipt,
+                unexpected: true,
+              },
+            } as unknown as JsonValue;
+          }
+          if (brokerMode === "mismatch") {
+            return {
+              ...produced,
+              workspaceExecution: produced.workspaceExecution
+                ? {
+                    ...produced.workspaceExecution,
+                    rootId: "f".repeat(64),
+                  }
+                : undefined,
+            } as unknown as JsonValue;
+          }
+          return produced as unknown as JsonValue;
         },
-      };
+      });
       const action = codingToolsPlugin.actions?.find(
         (candidate) => candidate.name === "SHELL",
       );
@@ -1133,22 +1150,31 @@ describe("RemoteCodingCapabilityRouterService", () => {
       const run = async (command: string) =>
         await action.handler?.(runtime, message, undefined, { command });
       const changed = await run("printf mutate > remote.txt");
+      brokerMode = "malformed";
+      const malformed = await run("node --check verify.js");
+      brokerMode = "mismatch";
+      const mismatch = await run("node --check verify.js");
+      brokerMode = "unavailable";
       const local = await run("true");
+      brokerMode = "normal";
       const remoteUnchanged = await run("node --check verify.js");
-      const steps = [changed, local, remoteUnchanged].map((result, index) => ({
-        toolCall: {
-          name: "SHELL",
-          params: {
-            command: [
-              "printf mutate > remote.txt",
-              "true",
-              "node --check verify.js",
-            ][index],
+      const commands = [
+        "printf mutate > remote.txt",
+        "node --check verify.js",
+        "node --check verify.js",
+        "true",
+        "node --check verify.js",
+      ];
+      const steps = [changed, malformed, mismatch, local, remoteUnchanged].map(
+        (result, index) => ({
+          toolCall: {
+            name: "SHELL",
+            params: { command: commands[index] },
           },
-        },
-        result,
-      }));
-      const trajectorySteps = steps.slice(0, 1);
+          result,
+        }),
+      );
+      const trajectorySteps = [steps[0]];
       const trajectory = {
         steps: trajectorySteps,
         archivedSteps: [],
@@ -1162,14 +1188,33 @@ describe("RemoteCodingCapabilityRouterService", () => {
         outcome: "changed",
       });
       if (!changedReceipt) throw new Error("changed receipt unavailable");
+      expect(malformed?.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "indeterminate",
+        reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+      });
+      expect(mismatch?.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "indeterminate",
+        reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+      });
+      for (const negative of [steps[1], steps[2]]) {
+        const negativeTrajectory = {
+          steps: [steps[0], negative, steps[4]],
+          archivedSteps: [],
+        } as unknown as Parameters<
+          typeof __codingMutationRequiresVerificationForTests
+        >[0];
+        expect(
+          __codingMutationRequiresVerificationForTests(negativeTrajectory),
+        ).toBe(true);
+      }
       expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
         true,
       );
-      trajectorySteps.push(steps[1]);
+      trajectorySteps.push(steps[3]);
       expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
         true,
       );
-      trajectorySteps.push(steps[2]);
+      trajectorySteps.push(steps[4]);
       expect(remoteUnchanged?.data?.workspaceDeltaReceipt).toMatchObject({
         outcome: "unchanged",
         scope: changedReceipt.scope,

--- a/packages/agent/src/services/remote-coding-runner.ts
+++ b/packages/agent/src/services/remote-coding-runner.ts
@@ -47,8 +47,14 @@ import {
   Service,
   type TerminalRunParams,
   type TerminalRunResult,
-  type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
+import {
+  beginLocalWorkspaceDeltaObservation,
+  finishLocalWorkspaceDeltaObservation,
+  type LocalWorkspaceDeltaDependencies,
+  type LocalWorkspaceDeltaObservation,
+  type WorkspaceDeltaFs,
+} from "@elizaos/plugin-coding-tools/lib/workspace-delta";
 
 export type {
   RemoteRunnerClient,
@@ -61,7 +67,11 @@ const LOG_CONTEXT = { src: "service:remote_coding_capability_router" } as const;
 const DEFAULT_REMOTE_WORKDIR = "/workspace";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
-const REMOTE_WORKSPACE_OBSERVATION_TIMEOUT_MS = 900;
+const REMOTE_WORKSPACE_OBSERVATION_TIMEOUT_MS = 6_000;
+const REMOTE_WORKSPACE_FILE_BYTE_BUDGET = 512 * 1024;
+const REMOTE_WORKSPACE_GIT_OUTPUT_BUDGET = 384 * 1024;
+const REMOTE_WORKSPACE_DIRECTORY_ENTRY_BUDGET = 10_000;
+const REMOTE_WORKSPACE_DIRECTORY_NAME_BYTE_BUDGET = 256 * 1024;
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 const MAX_REMOTE_JSON_BYTES = 1024 * 1024;
 const MAX_REMOTE_ERROR_BYTES = 16 * 1024;
@@ -114,6 +124,17 @@ export interface RemoteCodingRunnerConfig {
 export interface RemoteRunnerFactory {
   create(config: RemoteCodingRunnerConfig): Promise<RemoteRunnerClient>;
 }
+
+type RemoteWorkspaceObservationLimits = Partial<
+  Pick<
+    LocalWorkspaceDeltaDependencies,
+    | "maxObservationMs"
+    | "maxFileBytes"
+    | "maxGitOutputBytes"
+    | "maxDirectoryEntries"
+    | "maxDirectoryNameBytes"
+  >
+>;
 
 class DefaultRemoteRunnerFactory implements RemoteRunnerFactory {
   private readonly remoteHttpFactory = new RemoteRunnerHttpFactory();
@@ -582,11 +603,13 @@ export class RemoteCodingCapabilityRouterService
   private createdRunner = false;
   private readonly routerConfig: RemoteCodingRunnerConfig;
   private readonly factory: RemoteRunnerFactory;
+  private readonly workspaceObservationLimits: RemoteWorkspaceObservationLimits;
 
   constructor(
     runtime?: IAgentRuntime,
     routerConfig?: RemoteCodingRunnerConfig,
     factory?: RemoteRunnerFactory,
+    workspaceObservationLimits: RemoteWorkspaceObservationLimits = {},
   ) {
     if (!runtime) {
       throw new Error(
@@ -597,6 +620,7 @@ export class RemoteCodingCapabilityRouterService
     this.routerConfig =
       routerConfig ?? resolveRemoteCodingRunnerConfig(runtime);
     this.factory = factory ?? new DefaultRemoteRunnerFactory();
+    this.workspaceObservationLimits = workspaceObservationLimits;
   }
 
   static async start(runtime: IAgentRuntime): Promise<Service> {
@@ -737,6 +761,19 @@ export class RemoteCodingCapabilityRouterService
     params: TerminalRunParams,
   ): Promise<TerminalRunResult> {
     await this.requireAvailable("pty", "pty.command.run");
+    if (
+      params.timeoutMs !== undefined &&
+      (!Number.isInteger(params.timeoutMs) ||
+        params.timeoutMs <= 0 ||
+        params.timeoutMs > MAX_TIMER_DELAY_MS)
+    ) {
+      throw new CapabilityError({
+        code: "CAPABILITY_REQUEST_FAILED",
+        capability: "pty",
+        method: "pty.command.run",
+        message: `Duration must be an integer between 1 and ${MAX_TIMER_DELAY_MS}ms.`,
+      });
+    }
     const sandbox = await this.getRunner();
     const command = commandLine(params.command, params.args ?? []);
     const cwd = this.mapPath(params.cwd ?? this.routerConfig.workdir);
@@ -750,24 +787,24 @@ export class RemoteCodingCapabilityRouterService
       requestTimeoutMs: params.timeoutMs ?? this.routerConfig.requestTimeoutMs,
       ...(params.env === undefined ? {} : { envs: params.env }),
     };
-    const workspaceExecution = remoteWorkspaceExecution(
-      remoteExecutionOwnerIdentity(this.routerConfig, sandbox.sandboxId),
+    const observation = await beginLocalWorkspaceDeltaObservation(
       cwd,
-    );
-    const beforeFingerprint = await remoteWorkspaceFingerprint(
-      sandbox,
-      cwd,
-      observationTimeoutMs,
+      remoteWorkspaceObservationDependencies(
+        sandbox,
+        remoteExecutionDomainId(
+          remoteExecutionOwnerIdentity(this.routerConfig, sandbox.sandboxId),
+        ),
+        observationTimeoutMs,
+        this.routerConfig.requestTimeoutMs,
+        this.workspaceObservationLimits,
+      ),
     );
     try {
       const result = await sandbox.commands.run(command, opts);
       return await commandRunResultWithWorkspaceObservation(
-        sandbox,
         result,
         result.timedOut === true,
-        workspaceExecution,
-        beforeFingerprint,
-        observationTimeoutMs,
+        observation,
       );
     } catch (error) {
       const normalized =
@@ -775,20 +812,17 @@ export class RemoteCodingCapabilityRouterService
       const commandResult = commandResultFromError(normalized);
       if (commandResult) {
         return await commandRunResultWithWorkspaceObservation(
-          sandbox,
           commandResult,
           commandResult.timedOut === true,
-          workspaceExecution,
-          beforeFingerprint,
-          observationTimeoutMs,
+          observation,
         );
       }
       if (isTimeoutError(normalized)) {
-        return {
-          output: normalized.message,
-          exitCode: null,
-          timedOut: true,
-        };
+        return await terminalFailureWithWorkspaceObservation(
+          normalized.message,
+          true,
+          observation,
+        );
       }
       throw new CapabilityError({
         code: "CAPABILITY_REQUEST_FAILED",
@@ -1895,33 +1929,11 @@ function commandRunResult(
   };
 }
 
-const REMOTE_WORKSPACE_FINGERPRINT_COMMAND =
-  "set -euo pipefail; git rev-parse --is-inside-work-tree >/dev/null 2>&1 && " +
-  "{ git rev-parse --verify HEAD 2>/dev/null || printf unborn; " +
-  "git symbolic-ref --quiet HEAD 2>/dev/null || true; " +
-  "git status --porcelain=v2 -z --untracked-files=all; " +
-  "git diff --binary; git diff --cached --binary; " +
-  "git ls-files --others --exclude-standard -z | " +
-  "while IFS= read -r -d '' p; do printf '%s\\0' \"$p\"; " +
-  'if [ -d "$p" ]; then find "$p" -type f -print0 | sort -z | ' +
-  "while IFS= read -r -d '' f; do printf '%s\\0' \"$f\"; git hash-object --no-filters -- \"$f\"; done; " +
-  'else git hash-object --no-filters -- "$p"; fi; done; } | git hash-object --stdin';
-
-function remoteWorkspaceExecution(
-  ownerIdentity: string,
-  root: string,
-): NonNullable<TerminalRunResult["workspaceExecution"]> {
-  const executionDomainId = createHash("sha256")
+function remoteExecutionDomainId(ownerIdentity: string): string {
+  return createHash("sha256")
     .update("eliza-remote-coding-execution-domain-v1\0")
     .update(ownerIdentity)
     .digest("hex");
-  const rootId = createHash("sha256")
-    .update("eliza-workspace-root-v1\0")
-    .update(executionDomainId)
-    .update("\0")
-    .update(root)
-    .digest("hex");
-  return { root, rootId, executionDomainId };
 }
 
 function remoteExecutionOwnerIdentity(
@@ -1935,60 +1947,407 @@ function remoteExecutionOwnerIdentity(
   });
 }
 
-async function remoteWorkspaceFingerprint(
-  sandbox: RemoteRunnerClient,
-  cwd: string,
-  requestTimeoutMs: number,
-): Promise<string | undefined> {
-  try {
-    const result = await sandbox.commands.run(
-      `bash -lc ${shellQuote(REMOTE_WORKSPACE_FINGERPRINT_COMMAND)}`,
-      { cwd, timeoutMs: requestTimeoutMs, requestTimeoutMs },
-    );
-    const fingerprint = result.stdout.trim();
-    return result.exitCode === 0 && /^[a-f0-9]{40,64}$/.test(fingerprint)
-      ? createHash("sha256").update(fingerprint).digest("hex")
-      : undefined;
-  } catch {
-    // error-policy:J4 remote observation failure stays visibly unobserved; the
-    // command result is still returned but cannot clear mutation verification.
-    return undefined;
+const REMOTE_GIT_OBSERVER_SCRIPT = `
+const { spawn } = require("node:child_process");
+const limit = Number(process.argv[1]);
+const timeout = Number(process.argv[2]);
+const cwd = process.argv[3];
+const args = JSON.parse(process.argv[4]);
+const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+const stdoutChunks = [];
+const stderrChunks = [];
+let bytes = 0;
+let overflow = false;
+let emitted = false;
+const take = (kind, chunk) => {
+  bytes += chunk.length;
+  if (bytes > limit) { overflow = true; child.kill("SIGKILL"); return; }
+  if (kind === "stdout") stdoutChunks.push(chunk);
+  else stderrChunks.push(chunk);
+};
+child.stdout.on("data", chunk => take("stdout", chunk));
+child.stderr.on("data", chunk => take("stderr", chunk));
+const timer = setTimeout(() => child.kill("SIGKILL"), timeout);
+child.on("error", error => { clearTimeout(timer); emitted = true; process.stdout.write(JSON.stringify({ spawnError: error.message })); });
+child.on("close", (code, signal) => {
+  clearTimeout(timer);
+  if (emitted) return;
+  const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+  const stderr = Buffer.concat(stderrChunks).toString("utf8");
+  process.stdout.write(JSON.stringify({ stdout, stderr, code, signal, overflow }));
+});`;
+
+const REMOTE_FS_OBSERVER_SCRIPT = `
+const fs = require("node:fs/promises");
+const op = process.argv[1];
+const target = process.argv[2];
+const entryLimit = Number(process.argv[3]);
+const nameLimit = Number(process.argv[4]);
+const fileLimit = Number(process.argv[5]);
+(async () => {
+  if (op === "realpath") return await fs.realpath(target);
+  if (op === "readlink") return await fs.readlink(target);
+  if (op === "lstat") {
+    const value = await fs.lstat(target);
+    return { mode: value.mode, size: value.size, mtimeMs: value.mtimeMs,
+      kind: value.isFile() ? "file" : value.isSymbolicLink() ? "symlink" : value.isDirectory() ? "directory" : "other" };
   }
+  if (op === "read") {
+    const handle = await fs.open(target, "r");
+    const chunks = [];
+    let bytes = 0;
+    try {
+      for await (const chunk of handle.createReadStream()) {
+        bytes += chunk.length;
+        if (bytes > fileLimit) throw Object.assign(new Error("remote file observation budget exceeded"), { code: "EOBSERVATIONBYTE" });
+        chunks.push(chunk);
+      }
+    } finally { await handle.close().catch(() => undefined); }
+    return { bytes: Buffer.concat(chunks).toString("base64") };
+  }
+  if (op === "opendir") {
+    const directory = await fs.opendir(target);
+    const names = [];
+    let nameBytes = 0;
+    try {
+      for await (const entry of directory) {
+        nameBytes += Buffer.byteLength(entry.name);
+        if (names.length >= entryLimit || nameBytes > nameLimit) throw Object.assign(new Error("remote directory observation budget exceeded"), { code: "EOBSERVATIONBYTE" });
+        names.push(entry.name);
+      }
+    } finally { await directory.close().catch(() => undefined); }
+    return names;
+  }
+  throw new Error("unsupported remote filesystem observation operation");
+})().then(value => process.stdout.write(JSON.stringify({ value }))).catch(error => {
+  process.stdout.write(JSON.stringify({ error: error.message, code: error.code || "EIO" }));
+});`;
+
+type RemoteFsMetadata =
+  | string
+  | string[]
+  | { bytes: string }
+  | { mode: number; size: number; mtimeMs: number; kind: string };
+
+async function runRemoteObserverCommand(
+  sandbox: RemoteRunnerClient,
+  command: string,
+  requestTimeoutMs: number,
+): Promise<string> {
+  const result = await sandbox.commands.run(command, {
+    timeoutMs: requestTimeoutMs,
+    requestTimeoutMs,
+  });
+  if (result.timedOut) {
+    const error = new Error("Remote workspace observer timed out.") as Error & {
+      killed?: boolean;
+      signal?: string;
+    };
+    error.killed = true;
+    error.signal = "SIGTERM";
+    throw error;
+  }
+  if (result.exitCode !== 0) {
+    const error = new Error(
+      result.stderr || "Remote workspace observer failed.",
+    );
+    Object.assign(error, {
+      code: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+    throw error;
+  }
+  return result.stdout;
+}
+
+async function remoteFsMetadata(
+  sandbox: RemoteRunnerClient,
+  operation: "realpath" | "lstat" | "readlink" | "opendir" | "read",
+  target: string,
+  requestTimeoutMs: number,
+  limits: Required<RemoteWorkspaceObservationLimits>,
+): Promise<RemoteFsMetadata> {
+  const raw = await runRemoteObserverCommand(
+    sandbox,
+    commandLine("node", [
+      "-e",
+      REMOTE_FS_OBSERVER_SCRIPT,
+      operation,
+      target,
+      String(limits.maxDirectoryEntries),
+      String(limits.maxDirectoryNameBytes),
+      String(limits.maxFileBytes),
+    ]),
+    requestTimeoutMs,
+  );
+  const parsed = JSON.parse(raw) as {
+    value?: RemoteFsMetadata;
+    error?: string;
+    code?: string;
+  };
+  if (parsed.error) {
+    const error = new Error(parsed.error) as Error & { code?: string };
+    error.code = parsed.code;
+    throw error;
+  }
+  if (parsed.value === undefined)
+    throw new Error("Remote observer returned no value.");
+  return parsed.value;
+}
+
+function remoteWorkspaceObservationDependencies(
+  sandbox: RemoteRunnerClient,
+  executionDomainId: string,
+  maxObservationMs: number,
+  requestTimeoutMs: number,
+  overrides: RemoteWorkspaceObservationLimits,
+): LocalWorkspaceDeltaDependencies {
+  const limits: Required<RemoteWorkspaceObservationLimits> = {
+    maxObservationMs: overrides.maxObservationMs ?? maxObservationMs,
+    maxFileBytes: overrides.maxFileBytes ?? REMOTE_WORKSPACE_FILE_BYTE_BUDGET,
+    maxGitOutputBytes:
+      overrides.maxGitOutputBytes ?? REMOTE_WORKSPACE_GIT_OUTPUT_BUDGET,
+    maxDirectoryEntries:
+      overrides.maxDirectoryEntries ?? REMOTE_WORKSPACE_DIRECTORY_ENTRY_BUDGET,
+    maxDirectoryNameBytes:
+      overrides.maxDirectoryNameBytes ??
+      REMOTE_WORKSPACE_DIRECTORY_NAME_BYTE_BUDGET,
+  };
+  const observerRequestTimeoutMs = Math.min(
+    requestTimeoutMs,
+    limits.maxObservationMs,
+  );
+  const fsAdapter: WorkspaceDeltaFs = {
+    realpath: async (value) =>
+      String(
+        await remoteFsMetadata(
+          sandbox,
+          "realpath",
+          value,
+          observerRequestTimeoutMs,
+          limits,
+        ),
+      ),
+    readlink: async (value) =>
+      String(
+        await remoteFsMetadata(
+          sandbox,
+          "readlink",
+          value,
+          observerRequestTimeoutMs,
+          limits,
+        ),
+      ),
+    lstat: async (value) => {
+      const metadata = await remoteFsMetadata(
+        sandbox,
+        "lstat",
+        value,
+        observerRequestTimeoutMs,
+        limits,
+      );
+      if (
+        typeof metadata !== "object" ||
+        Array.isArray(metadata) ||
+        !("kind" in metadata)
+      ) {
+        throw new Error("Remote observer returned invalid lstat metadata.");
+      }
+      return {
+        mode: metadata.mode,
+        size: metadata.size,
+        mtimeMs: metadata.mtimeMs,
+        isFile: () => metadata.kind === "file",
+        isSymbolicLink: () => metadata.kind === "symlink",
+        isDirectory: () => metadata.kind === "directory",
+      } as Awaited<ReturnType<WorkspaceDeltaFs["lstat"]>>;
+    },
+    opendir: ((value: string) =>
+      remoteFsMetadata(
+        sandbox,
+        "opendir",
+        value,
+        observerRequestTimeoutMs,
+        limits,
+      ).then((metadata) => {
+        if (!Array.isArray(metadata)) {
+          throw new Error(
+            "Remote observer returned invalid directory metadata.",
+          );
+        }
+        let index = 0;
+        let closed = false;
+        const directory = {
+          close: async () => {
+            closed = true;
+          },
+          [Symbol.asyncIterator]() {
+            return {
+              next: async () => {
+                if (closed || index >= metadata.length) {
+                  return { done: true as const, value: undefined };
+                }
+                return {
+                  done: false as const,
+                  value: { name: metadata[index++] },
+                };
+              },
+            };
+          },
+        };
+        return directory;
+      })) as WorkspaceDeltaFs["opendir"],
+    createReadStream: ((value: string) => {
+      let delivered = false;
+      let destroyed = false;
+      const stream = {
+        destroy: () => {
+          destroyed = true;
+        },
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              if (delivered || destroyed) {
+                return { done: true as const, value: undefined };
+              }
+              delivered = true;
+              const content = await remoteFsMetadata(
+                sandbox,
+                "read",
+                value,
+                observerRequestTimeoutMs,
+                limits,
+              );
+              if (
+                typeof content !== "object" ||
+                Array.isArray(content) ||
+                !("bytes" in content) ||
+                typeof content.bytes !== "string"
+              ) {
+                throw new Error("Remote observer returned invalid file bytes.");
+              }
+              return {
+                done: false as const,
+                value: Buffer.from(content.bytes, "base64"),
+              };
+            },
+          };
+        },
+      };
+      return stream;
+    }) as WorkspaceDeltaFs["createReadStream"],
+  };
+  return {
+    ...limits,
+    executionDomainId,
+    fs: fsAdapter,
+    runGit: async (cwd, args, gitLimits) => {
+      const aggregateLimit = Math.min(
+        gitLimits?.maxOutputBytes ?? limits.maxGitOutputBytes,
+        limits.maxGitOutputBytes,
+      );
+      const timeoutMs = Math.min(
+        gitLimits?.timeoutMs ?? limits.maxObservationMs,
+        limits.maxObservationMs,
+      );
+      const raw = await runRemoteObserverCommand(
+        sandbox,
+        commandLine("node", [
+          "-e",
+          REMOTE_GIT_OBSERVER_SCRIPT,
+          String(aggregateLimit),
+          String(timeoutMs),
+          cwd,
+          JSON.stringify(args),
+        ]),
+        Math.min(observerRequestTimeoutMs, timeoutMs),
+      );
+      const parsed = JSON.parse(raw) as {
+        stdout?: string;
+        stderr?: string;
+        code?: number | null;
+        signal?: string | null;
+        overflow?: boolean;
+        spawnError?: string;
+      };
+      if (parsed.overflow) {
+        const error = new Error("Remote Git observer maxBuffer exceeded.");
+        Object.assign(error, {
+          code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+          stdout: parsed.stdout ?? "",
+          stderr: parsed.stderr ?? "",
+        });
+        throw error;
+      }
+      if (parsed.spawnError) throw new Error(parsed.spawnError);
+      if (parsed.signal) {
+        const error = new Error("Remote Git observer timed out.");
+        Object.assign(error, {
+          killed: true,
+          signal: parsed.signal,
+          stdout: parsed.stdout ?? "",
+          stderr: parsed.stderr ?? "",
+        });
+        throw error;
+      }
+      if (parsed.code !== 0) {
+        const error = new Error(parsed.stderr || "Remote Git observer failed.");
+        Object.assign(error, {
+          code: parsed.code,
+          stdout: parsed.stdout ?? "",
+          stderr: parsed.stderr ?? "",
+        });
+        throw error;
+      }
+      return { stdout: parsed.stdout ?? "", stderr: parsed.stderr ?? "" };
+    },
+  };
 }
 
 async function commandRunResultWithWorkspaceObservation(
-  sandbox: RemoteRunnerClient,
   result: SandboxCommandResult,
   timedOut: boolean,
-  workspaceExecution: NonNullable<TerminalRunResult["workspaceExecution"]>,
-  beforeFingerprint: string | undefined,
-  requestTimeoutMs: number,
+  observation: LocalWorkspaceDeltaObservation | undefined,
 ): Promise<TerminalRunResult> {
   const base = commandRunResult(result, timedOut);
-  const afterFingerprint = await remoteWorkspaceFingerprint(
-    sandbox,
-    workspaceExecution.root,
-    requestTimeoutMs,
-  );
-  let workspaceDeltaReceipt: WorkspaceDeltaReceipt | undefined;
-  if (beforeFingerprint && afterFingerprint) {
-    workspaceDeltaReceipt = {
-      version: 1,
-      kind: "workspace_delta",
-      scope: {
-        kind: "git_worktree",
-        ...workspaceExecution,
-        coverage: "tracked_and_untracked_nonignored",
-      },
-      outcome: beforeFingerprint === afterFingerprint ? "unchanged" : "changed",
-      beforeFingerprint,
-      afterFingerprint,
-      observedAt: new Date().toISOString(),
-    };
-  }
+  const workspaceDeltaReceipt =
+    await finishLocalWorkspaceDeltaObservation(observation);
   return {
     ...base,
-    workspaceExecution,
+    ...(observation
+      ? {
+          workspaceExecution: {
+            root: observation.root,
+            rootId: observation.rootId,
+            executionDomainId: observation.executionDomainId,
+          },
+        }
+      : {}),
+    ...(workspaceDeltaReceipt ? { workspaceDeltaReceipt } : {}),
+  };
+}
+
+async function terminalFailureWithWorkspaceObservation(
+  output: string,
+  timedOut: boolean,
+  observation: LocalWorkspaceDeltaObservation | undefined,
+): Promise<TerminalRunResult> {
+  const workspaceDeltaReceipt =
+    await finishLocalWorkspaceDeltaObservation(observation);
+  return {
+    output,
+    exitCode: null,
+    timedOut,
+    ...(observation
+      ? {
+          workspaceExecution: {
+            root: observation.root,
+            rootId: observation.rootId,
+            executionDomainId: observation.executionDomainId,
+          },
+        }
+      : {}),
     ...(workspaceDeltaReceipt ? { workspaceDeltaReceipt } : {}),
   };
 }

--- a/packages/agent/src/services/remote-coding-runner.ts
+++ b/packages/agent/src/services/remote-coding-runner.ts
@@ -10,7 +10,7 @@
  * root into the remote workdir and rejected if it escapes that root; model and
  * remote-plugin capabilities are intentionally unavailable on this router.
  */
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import nodePath from "node:path";
 import {
   CAPABILITY_ROUTER_SERVICE_TYPE,
@@ -47,6 +47,7 @@ import {
   Service,
   type TerminalRunParams,
   type TerminalRunResult,
+  type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
 
 export type {
@@ -60,6 +61,7 @@ const LOG_CONTEXT = { src: "service:remote_coding_capability_router" } as const;
 const DEFAULT_REMOTE_WORKDIR = "/workspace";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
+const REMOTE_WORKSPACE_OBSERVATION_TIMEOUT_MS = 900;
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 const MAX_REMOTE_JSON_BYTES = 1024 * 1024;
 const MAX_REMOTE_ERROR_BYTES = 16 * 1024;
@@ -738,21 +740,48 @@ export class RemoteCodingCapabilityRouterService
     const sandbox = await this.getRunner();
     const command = commandLine(params.command, params.args ?? []);
     const cwd = this.mapPath(params.cwd ?? this.routerConfig.workdir);
+    const observationTimeoutMs = Math.min(
+      params.timeoutMs ?? this.routerConfig.requestTimeoutMs,
+      REMOTE_WORKSPACE_OBSERVATION_TIMEOUT_MS,
+    );
     const opts: SandboxCommandRunOptions = {
       cwd,
       timeoutMs: params.timeoutMs ?? this.routerConfig.timeoutMs,
       requestTimeoutMs: params.timeoutMs ?? this.routerConfig.requestTimeoutMs,
       ...(params.env === undefined ? {} : { envs: params.env }),
     };
+    const workspaceExecution = remoteWorkspaceExecution(
+      remoteExecutionOwnerIdentity(this.routerConfig, sandbox.sandboxId),
+      cwd,
+    );
+    const beforeFingerprint = await remoteWorkspaceFingerprint(
+      sandbox,
+      cwd,
+      observationTimeoutMs,
+    );
     try {
       const result = await sandbox.commands.run(command, opts);
-      return commandRunResult(result, result.timedOut === true);
+      return await commandRunResultWithWorkspaceObservation(
+        sandbox,
+        result,
+        result.timedOut === true,
+        workspaceExecution,
+        beforeFingerprint,
+        observationTimeoutMs,
+      );
     } catch (error) {
       const normalized =
         error instanceof Error ? error : new Error(String(error));
       const commandResult = commandResultFromError(normalized);
       if (commandResult) {
-        return commandRunResult(commandResult, commandResult.timedOut === true);
+        return await commandRunResultWithWorkspaceObservation(
+          sandbox,
+          commandResult,
+          commandResult.timedOut === true,
+          workspaceExecution,
+          beforeFingerprint,
+          observationTimeoutMs,
+        );
       }
       if (isTimeoutError(normalized)) {
         return {
@@ -1863,6 +1892,104 @@ function commandRunResult(
     output: `${result.stdout}${stderr}`,
     exitCode: result.exitCode,
     timedOut,
+  };
+}
+
+const REMOTE_WORKSPACE_FINGERPRINT_COMMAND =
+  "set -euo pipefail; git rev-parse --is-inside-work-tree >/dev/null 2>&1 && " +
+  "{ git rev-parse --verify HEAD 2>/dev/null || printf unborn; " +
+  "git symbolic-ref --quiet HEAD 2>/dev/null || true; " +
+  "git status --porcelain=v2 -z --untracked-files=all; " +
+  "git diff --binary; git diff --cached --binary; " +
+  "git ls-files --others --exclude-standard -z | " +
+  "while IFS= read -r -d '' p; do printf '%s\\0' \"$p\"; " +
+  'if [ -d "$p" ]; then find "$p" -type f -print0 | sort -z | ' +
+  "while IFS= read -r -d '' f; do printf '%s\\0' \"$f\"; git hash-object --no-filters -- \"$f\"; done; " +
+  'else git hash-object --no-filters -- "$p"; fi; done; } | git hash-object --stdin';
+
+function remoteWorkspaceExecution(
+  ownerIdentity: string,
+  root: string,
+): NonNullable<TerminalRunResult["workspaceExecution"]> {
+  const executionDomainId = createHash("sha256")
+    .update("eliza-remote-coding-execution-domain-v1\0")
+    .update(ownerIdentity)
+    .digest("hex");
+  const rootId = createHash("sha256")
+    .update("eliza-workspace-root-v1\0")
+    .update(executionDomainId)
+    .update("\0")
+    .update(root)
+    .digest("hex");
+  return { root, rootId, executionDomainId };
+}
+
+function remoteExecutionOwnerIdentity(
+  config: RemoteCodingRunnerConfig,
+  runnerSandboxId: string,
+): string {
+  return JSON.stringify({
+    provider: config.provider,
+    endpoint: config.remoteHttpBaseUrl ?? config.cloudApiBaseUrl ?? null,
+    sandboxId: config.sandboxId ?? runnerSandboxId,
+  });
+}
+
+async function remoteWorkspaceFingerprint(
+  sandbox: RemoteRunnerClient,
+  cwd: string,
+  requestTimeoutMs: number,
+): Promise<string | undefined> {
+  try {
+    const result = await sandbox.commands.run(
+      `bash -lc ${shellQuote(REMOTE_WORKSPACE_FINGERPRINT_COMMAND)}`,
+      { cwd, timeoutMs: requestTimeoutMs, requestTimeoutMs },
+    );
+    const fingerprint = result.stdout.trim();
+    return result.exitCode === 0 && /^[a-f0-9]{40,64}$/.test(fingerprint)
+      ? createHash("sha256").update(fingerprint).digest("hex")
+      : undefined;
+  } catch {
+    // error-policy:J4 remote observation failure stays visibly unobserved; the
+    // command result is still returned but cannot clear mutation verification.
+    return undefined;
+  }
+}
+
+async function commandRunResultWithWorkspaceObservation(
+  sandbox: RemoteRunnerClient,
+  result: SandboxCommandResult,
+  timedOut: boolean,
+  workspaceExecution: NonNullable<TerminalRunResult["workspaceExecution"]>,
+  beforeFingerprint: string | undefined,
+  requestTimeoutMs: number,
+): Promise<TerminalRunResult> {
+  const base = commandRunResult(result, timedOut);
+  const afterFingerprint = await remoteWorkspaceFingerprint(
+    sandbox,
+    workspaceExecution.root,
+    requestTimeoutMs,
+  );
+  let workspaceDeltaReceipt: WorkspaceDeltaReceipt | undefined;
+  if (beforeFingerprint && afterFingerprint) {
+    workspaceDeltaReceipt = {
+      version: 1,
+      kind: "workspace_delta",
+      scope: {
+        kind: "git_worktree",
+        ...workspaceExecution,
+        coverage: "tracked_and_untracked_nonignored",
+      },
+      outcome: beforeFingerprint === afterFingerprint ? "unchanged" : "changed",
+      beforeFingerprint,
+      afterFingerprint,
+      observedAt: new Date().toISOString(),
+    };
+  }
+  return {
+    ...base,
+    workspaceExecution,
+    ...(workspaceDeltaReceipt ? { workspaceDeltaReceipt } : {}),
   };
 }
 

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -40,6 +40,9 @@
       ],
       "@elizaos/plugin-phone": ["../../plugins/plugin-phone/src/index.ts"],
       "@elizaos/plugin-phone/*": ["../../plugins/plugin-phone/src/*"],
+      "@elizaos/plugin-coding-tools/*": [
+        "../../plugins/plugin-coding-tools/src/*"
+      ],
       "@elizaos/plugin-form": ["../../plugins/plugin-form/src/index.ts"],
       "@elizaos/plugin-agent-skills": [
         "../../plugins/plugin-agent-skills/src/index.ts"

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -18,9 +18,16 @@ const srcRoot = path.join(packageRoot, "src");
 const requireFromOrchestrator = createRequire(
   path.join(monorepoRoot, "plugins/plugin-agent-orchestrator/package.json"),
 );
-const octokitRestEntry = realpathSync(
-  requireFromOrchestrator.resolve("@octokit/rest"),
-);
+let octokitRestEntry: string | undefined;
+try {
+  octokitRestEntry = realpathSync(
+    requireFromOrchestrator.resolve("@octokit/rest"),
+  );
+} catch (error) {
+  // error-policy:J4 Suites which do not import Octokit remain runnable in a
+  // light install; suites that require it still fail visibly at import time.
+  if ((error as NodeJS.ErrnoException).code !== "MODULE_NOT_FOUND") throw error;
+}
 
 export default defineConfig({
   ...baseConfig,
@@ -34,10 +41,14 @@ export default defineConfig({
     alias: [
       // Resolve Octokit from its physical Bun store path so its own transitive
       // dependencies remain visible while workspace source aliases preserve symlinks.
-      {
-        find: /^@octokit\/rest$/,
-        replacement: octokitRestEntry,
-      },
+      ...(octokitRestEntry
+        ? [
+            {
+              find: /^@octokit\/rest$/,
+              replacement: octokitRestEntry,
+            },
+          ]
+        : []),
       {
         find: /^@elizaos\/agent$/,
         replacement: path.join(srcRoot, "index.ts"),
@@ -45,6 +56,13 @@ export default defineConfig({
       {
         find: /^@elizaos\/agent\/(.+)$/,
         replacement: path.join(srcRoot, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-coding-tools\/(.+)$/,
+        replacement: path.join(
+          monorepoRoot,
+          "plugins/plugin-coding-tools/src/$1",
+        ),
       },
       {
         find: /^@elizaos\/ui$/,

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -166,6 +166,42 @@ describe("capability router", () => {
 		]);
 	});
 
+	it("strictly decodes opaque workspace execution attestations", async () => {
+		const workspaceExecution = {
+			root: "/remote/repo",
+			rootId: "a".repeat(64),
+			executionDomainId: "b".repeat(64),
+		};
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				output: "ok",
+				exitCode: 0,
+				timedOut: false,
+				workspaceExecution,
+			}),
+		});
+		await expect(
+			router.pty.runCommand({ command: "npm test" }),
+		).resolves.toMatchObject({ workspaceExecution });
+
+		for (const malformed of [
+			{ ...workspaceExecution, rootId: "short" },
+			{ ...workspaceExecution, extra: true },
+		]) {
+			const invalid = new RuntimeBrokerCapabilityRouter({
+				invokeRuntime: async () => ({
+					output: "ok",
+					exitCode: 0,
+					timedOut: false,
+					workspaceExecution: malformed,
+				}),
+			});
+			await expect(
+				invalid.pty.runCommand({ command: "npm test" }),
+			).rejects.toMatchObject({ code: "CAPABILITY_DECODE_FAILED" });
+		}
+	});
+
 	it("wraps broker failures as capability request failures", async () => {
 		const router = new RuntimeBrokerCapabilityRouter({
 			invokeRuntime: async () => {

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -202,6 +202,65 @@ describe("capability router", () => {
 		}
 	});
 
+	it("accepts only full workspace receipts bound to the attested routed scope", async () => {
+		const workspaceExecution = {
+			root: "/remote/repo",
+			rootId: "a".repeat(64),
+			executionDomainId: "b".repeat(64),
+		};
+		const workspaceDeltaReceipt = {
+			version: 1,
+			kind: "workspace_delta",
+			scope: {
+				kind: "git_worktree",
+				...workspaceExecution,
+				coverage: "tracked_and_untracked_nonignored",
+			},
+			outcome: "unchanged",
+			beforeFingerprint: "c".repeat(64),
+			afterFingerprint: "c".repeat(64),
+			observedAt: "2026-08-23T12:00:00.000Z",
+		};
+		const router = new RuntimeBrokerCapabilityRouter({
+			invokeRuntime: async () => ({
+				output: "ok",
+				exitCode: 0,
+				timedOut: false,
+				workspaceExecution,
+				workspaceDeltaReceipt,
+			}),
+		});
+		await expect(
+			router.pty.runCommand({ command: "npm test" }),
+		).resolves.toMatchObject({
+			workspaceExecution,
+			workspaceDeltaReceipt,
+		});
+
+		for (const invalidReceipt of [
+			{ ...workspaceDeltaReceipt, extra: true },
+			{
+				...workspaceDeltaReceipt,
+				scope: { ...workspaceDeltaReceipt.scope, rootId: "d".repeat(64) },
+			},
+		]) {
+			const invalid = new RuntimeBrokerCapabilityRouter({
+				invokeRuntime: async () => ({
+					output: "ok",
+					exitCode: 0,
+					timedOut: false,
+					workspaceExecution,
+					workspaceDeltaReceipt: invalidReceipt,
+				}),
+			});
+			await expect(
+				invalid.pty.runCommand({ command: "npm test" }),
+			).rejects.toMatchObject({
+				code: "CAPABILITY_DECODE_FAILED",
+			});
+		}
+	});
+
 	it("wraps broker failures as capability request failures", async () => {
 		const router = new RuntimeBrokerCapabilityRouter({
 			invokeRuntime: async () => {

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -16,6 +16,10 @@
  */
 import type { JsonObject, JsonValue } from "../types/primitives";
 import type { SurfaceCapability } from "../types/surface-manifest";
+import {
+	normalizeWorkspaceDeltaReceipt,
+	type WorkspaceDeltaReceipt,
+} from "../types/workspace-delta";
 
 export * from "./remote-runner";
 
@@ -155,6 +159,7 @@ export type TerminalRunResult = {
 		rootId: string;
 		executionDomainId: string;
 	};
+	workspaceDeltaReceipt?: WorkspaceDeltaReceipt;
 };
 
 export type GitStatusParams = CapabilityEndpointSelection & {
@@ -1445,6 +1450,33 @@ export class RuntimeBrokerCapabilityRouter implements ElizaCapabilityRouter {
 			}
 			normalizedWorkspaceExecution = { root, rootId, executionDomainId };
 		}
+		let workspaceDeltaReceipt: WorkspaceDeltaReceipt | undefined;
+		if (object.workspaceDeltaReceipt !== undefined) {
+			try {
+				workspaceDeltaReceipt = normalizeWorkspaceDeltaReceipt(
+					object.workspaceDeltaReceipt,
+				);
+			} catch (error) {
+				throw decodeError(
+					"pty.command.run",
+					`workspaceDeltaReceipt is invalid: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			if (
+				!normalizedWorkspaceExecution ||
+				workspaceDeltaReceipt.scope.root !==
+					normalizedWorkspaceExecution.root ||
+				workspaceDeltaReceipt.scope.rootId !==
+					normalizedWorkspaceExecution.rootId ||
+				workspaceDeltaReceipt.scope.executionDomainId !==
+					normalizedWorkspaceExecution.executionDomainId
+			) {
+				throw decodeError(
+					"pty.command.run",
+					"workspaceDeltaReceipt must bind exactly to the attested workspaceExecution scope.",
+				);
+			}
+		}
 		return {
 			output: requireString(object, "output", "pty.command.run"),
 			exitCode: nullableNumber(object, "exitCode", "pty.command.run"),
@@ -1452,6 +1484,7 @@ export class RuntimeBrokerCapabilityRouter implements ElizaCapabilityRouter {
 			...(normalizedWorkspaceExecution
 				? { workspaceExecution: normalizedWorkspaceExecution }
 				: {}),
+			...(workspaceDeltaReceipt ? { workspaceDeltaReceipt } : {}),
 		};
 	}
 

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -150,6 +150,11 @@ export type TerminalRunResult = {
 	output: string;
 	exitCode: number | null;
 	timedOut: boolean;
+	workspaceExecution?: {
+		root: string;
+		rootId: string;
+		executionDomainId: string;
+	};
 };
 
 export type GitStatusParams = CapabilityEndpointSelection & {
@@ -1396,10 +1401,57 @@ export class RuntimeBrokerCapabilityRouter implements ElizaCapabilityRouter {
 				: { endpointId: params.endpointId }),
 		});
 		const object = requireObject(result, "pty.command.run");
+		const workspaceExecution = optionalJsonObject(
+			object,
+			"workspaceExecution",
+			"pty.command.run",
+		);
+		let normalizedWorkspaceExecution: TerminalRunResult["workspaceExecution"];
+		if (workspaceExecution) {
+			const unexpectedWorkspaceKeys = Object.keys(workspaceExecution).filter(
+				(key) => !["root", "rootId", "executionDomainId"].includes(key),
+			);
+			if (unexpectedWorkspaceKeys.length > 0) {
+				throw decodeError(
+					"pty.command.run",
+					`workspaceExecution has unexpected fields: ${unexpectedWorkspaceKeys.join(", ")}.`,
+				);
+			}
+			const root = requireNonEmptyString(
+				workspaceExecution,
+				"root",
+				"pty.command.run.workspaceExecution",
+			);
+			const rootId = requireString(
+				workspaceExecution,
+				"rootId",
+				"pty.command.run.workspaceExecution",
+			);
+			const executionDomainId = requireString(
+				workspaceExecution,
+				"executionDomainId",
+				"pty.command.run.workspaceExecution",
+			);
+			if (
+				root.trim() !== root ||
+				/[\0\r\n]/.test(root) ||
+				!/^[a-f0-9]{64}$/.test(rootId) ||
+				!/^[a-f0-9]{64}$/.test(executionDomainId)
+			) {
+				throw decodeError(
+					"pty.command.run",
+					"workspaceExecution must contain a safe root and canonical opaque identities.",
+				);
+			}
+			normalizedWorkspaceExecution = { root, rootId, executionDomainId };
+		}
 		return {
 			output: requireString(object, "output", "pty.command.run"),
 			exitCode: nullableNumber(object, "exitCode", "pty.command.run"),
 			timedOut: requireBoolean(object, "timedOut", "pty.command.run"),
+			...(normalizedWorkspaceExecution
+				? { workspaceExecution: normalizedWorkspaceExecution }
+				: {}),
 		};
 	}
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1457,7 +1457,7 @@ export class AgentRuntime implements IAgentRuntime {
 	constructor(opts: {
 		conversationLength?: number;
 		agentId?: UUID;
-		/** Host-persisted installation identity, or a fresh identity for this runtime. */
+		/** Host-persisted installation identity. Omitted only by ephemeral/test runtimes. */
 		runtimeInstanceId?: UUID;
 		/** Optional character configuration. If not provided, an anonymous character is created. */
 		character?: Character;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1247,6 +1247,7 @@ export class AgentRuntime implements IAgentRuntime {
 	readonly supportsModelAttemptPreparation = true;
 	#conversationLength = 100;
 	readonly agentId: UUID;
+	readonly runtimeInstanceId: UUID;
 	readonly character: Character;
 	public adapter!: IDatabaseAdapter;
 	static #anonymousAgentCounter = 0;
@@ -1456,6 +1457,8 @@ export class AgentRuntime implements IAgentRuntime {
 	constructor(opts: {
 		conversationLength?: number;
 		agentId?: UUID;
+		/** Host-persisted installation identity, or a fresh identity for this runtime. */
+		runtimeInstanceId?: UUID;
 		/** Optional character configuration. If not provided, an anonymous character is created. */
 		character?: Character;
 		plugins?: Plugin[];
@@ -1572,6 +1575,7 @@ export class AgentRuntime implements IAgentRuntime {
 		// Falls back to random UUID only if no character name is provided
 		this.agentId =
 			character.id ?? opts.agentId ?? stringToUuid(character.name ?? uuidv4());
+		this.runtimeInstanceId = opts.runtimeInstanceId ?? (uuidv4() as UUID);
 		this.character = character;
 
 		this.initPromise = new Promise((resolve) => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -2294,7 +2294,7 @@ describe("v5 planner loop skeleton", () => {
 					};
 				}
 			).providerOptions?.eliza?.modelInputBudget?.shouldReject,
-		).toBe(true);
+		).toBe(false);
 	});
 
 	it("retries premature terminal output when a non-terminal tool call is required", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -12,6 +12,7 @@ import { plannerTemplate } from "../../prompts/planner";
 import { ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
 import {
+	__codingMutationRequiresVerificationForTests,
 	__renderRoutingHintsBlockForTests,
 	actionResultToPlannerToolResult,
 	FAILED_TOOL_FALLBACK_MESSAGE,
@@ -556,10 +557,25 @@ describe("v5 planner loop skeleton", () => {
 			rootId?: string;
 			executionDomainId?: string;
 			backgroundHandle?: string;
+			backgroundStatus?:
+				| "running"
+				| "terminating"
+				| "exited"
+				| "killed"
+				| "error";
 			reasonCode?: "WORKTREE_PROBE_FAILED" | "BACKGROUND_RECEIPT_PENDING";
 		} = {},
 	) => ({
-		...(options.backgroundHandle ? { handle: options.backgroundHandle } : {}),
+		...(options.backgroundHandle
+			? {
+					handle: options.backgroundHandle,
+					status:
+						options.backgroundStatus ??
+						(options.reasonCode === "BACKGROUND_RECEIPT_PENDING"
+							? "running"
+							: "exited"),
+				}
+			: {}),
 		workspaceDeltaReceipt: {
 			version: 1,
 			kind: "workspace_delta",
@@ -582,6 +598,11 @@ describe("v5 planner loop skeleton", () => {
 						operation: {
 							kind: "background_shell",
 							handle: options.backgroundHandle,
+							status:
+								options.backgroundStatus ??
+								(options.reasonCode === "BACKGROUND_RECEIPT_PENDING"
+									? "running"
+									: "exited"),
 						},
 					}
 				: {}),
@@ -1361,6 +1382,86 @@ describe("v5 planner loop skeleton", () => {
 			});
 			expect(result.finalMessage).toContain("coding task is incomplete");
 		});
+	});
+
+	it("preserves an exact background handle through running operations and resolves only a proven terminal poll", async () => {
+		const running = (status: "running" | "terminating") =>
+			workspaceDelta("indeterminate", "/workspace", {
+				backgroundHandle: "bg-1",
+				backgroundStatus: status,
+				reasonCode: "BACKGROUND_RECEIPT_PENDING",
+			});
+		const steps: Array<Record<string, unknown>> = [];
+		const trajectory = { steps, archivedSteps: [] } as unknown as Parameters<
+			typeof __codingMutationRequiresVerificationForTests
+		>[0];
+		const append = (
+			action: string,
+			data: Record<string, unknown> | undefined,
+			handle?: string,
+			success = true,
+		) => {
+			steps.push({
+				toolCall: {
+					name: "SHELL",
+					params: {
+						action,
+						...(handle ? { handle } : { command: "npm test" }),
+					},
+				},
+				result: { success, text: action, ...(data ? { data } : {}) },
+			});
+		};
+
+		append("start_background", running("running"), undefined, false);
+		expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(true);
+		append("poll_background", running("running"), "bg-1");
+		append("write_background", running("running"), "bg-1");
+		append("kill_background", running("terminating"), "bg-1", false);
+		append("poll_background", undefined, "unknown", false);
+		expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(true);
+		append(
+			"poll_background",
+			workspaceDelta("unchanged", "/workspace", {
+				backgroundHandle: "bg-1",
+				backgroundStatus: "error",
+			}),
+			"bg-1",
+			false,
+		);
+		expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+			false,
+		);
+	});
+
+	it("keeps a fast terminal start owned until a later terminal poll", async () => {
+		const terminal = workspaceDelta("unchanged", "/workspace", {
+			backgroundHandle: "bg-fast",
+			backgroundStatus: "exited",
+		});
+		const steps = [
+			{
+				toolCall: {
+					name: "SHELL",
+					params: { action: "start_background", command: "true" },
+				},
+				result: { success: false, text: "callback failed", data: terminal },
+			},
+		];
+		const trajectory = { steps, archivedSteps: [] } as unknown as Parameters<
+			typeof __codingMutationRequiresVerificationForTests
+		>[0];
+		expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(true);
+		steps.push({
+			toolCall: {
+				name: "SHELL",
+				params: { action: "poll_background", handle: "bg-fast" },
+			},
+			result: { success: true, text: "exited", data: terminal },
+		});
+		expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+			false,
+		);
 	});
 
 	it("does not treat a successful inspection command as coding verification", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -552,18 +552,42 @@ describe("v5 planner loop skeleton", () => {
 	const workspaceDelta = (
 		outcome: "changed" | "unchanged" | "indeterminate",
 		root = "/workspace",
+		options: {
+			rootId?: string;
+			executionDomainId?: string;
+			backgroundHandle?: string;
+			reasonCode?: "WORKTREE_PROBE_FAILED" | "BACKGROUND_RECEIPT_PENDING";
+		} = {},
 	) => ({
+		...(options.backgroundHandle ? { handle: options.backgroundHandle } : {}),
 		workspaceDeltaReceipt: {
 			version: 1,
 			kind: "workspace_delta",
 			scope: {
 				kind: "git_worktree",
 				root,
+				rootId:
+					options.rootId ??
+					(root === "/workspace-a"
+						? "a"
+						: root === "/workspace-b"
+							? "b"
+							: "c"
+					).repeat(64),
+				executionDomainId: options.executionDomainId ?? "d".repeat(64),
 				coverage: "tracked_and_untracked_nonignored",
 			},
+			...(options.backgroundHandle
+				? {
+						operation: {
+							kind: "background_shell",
+							handle: options.backgroundHandle,
+						},
+					}
+				: {}),
 			outcome,
 			...(outcome === "indeterminate"
-				? { reasonCode: "WORKTREE_PROBE_FAILED" }
+				? { reasonCode: options.reasonCode ?? "WORKTREE_PROBE_FAILED" }
 				: {
 						beforeFingerprint: "a".repeat(64),
 						afterFingerprint: (outcome === "changed" ? "b" : "a").repeat(64),
@@ -1007,7 +1031,7 @@ describe("v5 planner loop skeleton", () => {
 		},
 	);
 
-	it("requires verification from the exact mutation receipt scope", async () => {
+	it("matches opaque root and execution-domain identities instead of redacted display roots", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const runtime = {
 				useModel: vi
@@ -1053,17 +1077,23 @@ describe("v5 planner loop skeleton", () => {
 				.mockResolvedValueOnce({
 					success: true,
 					text: "generated",
-					data: workspaceDelta("changed", "/workspace-a"),
+					data: workspaceDelta("changed", "[private]", {
+						rootId: "a".repeat(64),
+					}),
 				})
 				.mockResolvedValueOnce({
 					success: true,
 					text: "wrong workspace passed",
-					data: workspaceDelta("unchanged", "/workspace-b"),
+					data: workspaceDelta("unchanged", "[private]", {
+						rootId: "b".repeat(64),
+					}),
 				})
 				.mockResolvedValueOnce({
 					success: true,
 					text: "right workspace passed",
-					data: workspaceDelta("unchanged", "/workspace-a"),
+					data: workspaceDelta("unchanged", "[private]", {
+						rootId: "a".repeat(64),
+					}),
 				});
 
 			const result = await runPlannerLoop({
@@ -1080,6 +1110,62 @@ describe("v5 planner loop skeleton", () => {
 
 			expect(result.finalMessage).toBe("Verified in the changed workspace.");
 			expect(executeToolCall).toHaveBeenCalledTimes(3);
+		});
+	});
+
+	it("does not let a local-domain receipt clear a remote-domain mutation", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const shell = (id: string, command = "npm test") => ({
+				text: "",
+				toolCalls: [{ id, name: "SHELL", arguments: { command } }],
+			});
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce(shell("mutate-remote", "node generate.js"))
+					.mockResolvedValueOnce(shell("verify-local"))
+					.mockResolvedValueOnce(codingReply("early", "Verified."))
+					.mockResolvedValueOnce(shell("verify-remote", "npm run typecheck"))
+					.mockResolvedValueOnce(codingReply("done", "Remote scope verified."))
+					.mockResolvedValue(codingReply("fallback", "Still pending.")),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: true,
+					text: "remote mutation",
+					data: workspaceDelta("changed", "[private]", {
+						executionDomainId: "e".repeat(64),
+					}),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "local pass",
+					data: workspaceDelta("unchanged", "[private]"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "remote pass",
+					data: workspaceDelta("unchanged", "[private]", {
+						executionDomainId: "e".repeat(64),
+					}),
+				});
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run." },
+					{ name: "REPLY", description: "Reply." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+			expect(executeToolCall).toHaveBeenCalledTimes(3);
+			expect(runtime.useModel).toHaveBeenCalledTimes(5);
+			expect(result.finalMessage).toBe("Remote scope verified.");
 		});
 	});
 
@@ -1143,6 +1229,137 @@ describe("v5 planner loop skeleton", () => {
 
 			expect(result.finalMessage).toBe("Verified in foreground.");
 			expect(executeToolCall).toHaveBeenCalledTimes(3);
+		});
+	});
+
+	it("keeps same-root background handles independent until each exact terminal action resolves", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const call = (id: string, action: string, handle?: string) => ({
+				text: "",
+				toolCalls: [
+					{
+						id,
+						name: "SHELL",
+						arguments: {
+							action,
+							...(handle ? { handle } : { command: "npm test" }),
+						},
+					},
+				],
+			});
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							...call("start-one", "start_background").toolCalls,
+							...call("start-two", "start_background").toolCalls,
+						],
+					})
+					.mockResolvedValueOnce(call("poll-one", "poll_background", "bg-one"))
+					.mockResolvedValueOnce(call("foreground", "run"))
+					.mockResolvedValueOnce(codingReply("launder", "Both done."))
+					.mockResolvedValueOnce(call("kill-two", "kill_background", "bg-two"))
+					.mockResolvedValueOnce(codingReply("done", "Both handles settled.")),
+				logger: { warn: vi.fn() },
+			};
+			const pending = (handle: string) =>
+				workspaceDelta("indeterminate", "/workspace", {
+					backgroundHandle: handle,
+					reasonCode: "BACKGROUND_RECEIPT_PENDING",
+				});
+			const terminal = (handle: string, outcome: "changed" | "unchanged") =>
+				workspaceDelta(outcome, "/workspace", {
+					backgroundHandle: handle,
+				});
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: true,
+					text: "one",
+					data: pending("bg-one"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "two",
+					data: pending("bg-two"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "one done",
+					data: terminal("bg-one", "changed"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "tests pass",
+					data: workspaceDelta("unchanged"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "two killed",
+					data: terminal("bg-two", "unchanged"),
+				});
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run." },
+					{ name: "REPLY", description: "Reply." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Both handles settled.");
+			expect(executeToolCall).toHaveBeenCalledTimes(5);
+		});
+	});
+
+	it("fails closed when a pending receipt does not bind the generated handle", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "start",
+								name: "SHELL",
+								arguments: {
+									action: "start_background",
+									command: "npm test",
+								},
+							},
+						],
+					})
+					.mockResolvedValue(codingReply("claim", "Finished.")),
+				logger: { warn: vi.fn() },
+			};
+			const data = workspaceDelta("indeterminate", "/workspace", {
+				backgroundHandle: "claimed-handle",
+				reasonCode: "BACKGROUND_RECEIPT_PENDING",
+			});
+			data.handle = "actual-handle";
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run." },
+					{ name: "REPLY", description: "Reply." },
+				],
+				executeToolCall: vi.fn(async () => ({
+					success: true,
+					text: "started",
+					data,
+				})),
+				evaluate: vi.fn(),
+			});
+			expect(result.finalMessage).toContain("coding task is incomplete");
 		});
 	});
 

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -551,13 +551,14 @@ describe("v5 planner loop skeleton", () => {
 	});
 	const workspaceDelta = (
 		outcome: "changed" | "unchanged" | "indeterminate",
+		root = "/workspace",
 	) => ({
 		workspaceDeltaReceipt: {
 			version: 1,
 			kind: "workspace_delta",
 			scope: {
 				kind: "git_worktree",
-				root: "/workspace",
+				root,
 				coverage: "tracked_and_untracked_nonignored",
 			},
 			outcome,
@@ -1005,6 +1006,145 @@ describe("v5 planner loop skeleton", () => {
 			});
 		},
 	);
+
+	it("requires verification from the exact mutation receipt scope", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "mutate-a",
+								name: "SHELL",
+								arguments: { command: "node generate.js" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "verify-b",
+								name: "SHELL",
+								arguments: { command: "npm test", cwd: "/workspace-b" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(codingReply("wrong-root", "Verified."))
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "verify-a",
+								name: "SHELL",
+								arguments: { command: "npm test", cwd: "/workspace-a" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("right-root", "Verified in the changed workspace."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: true,
+					text: "generated",
+					data: workspaceDelta("changed", "/workspace-a"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "wrong workspace passed",
+					data: workspaceDelta("unchanged", "/workspace-b"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "right workspace passed",
+					data: workspaceDelta("unchanged", "/workspace-a"),
+				});
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Verified in the changed workspace.");
+			expect(executeToolCall).toHaveBeenCalledTimes(3);
+		});
+	});
+
+	it("does not accept start_background as completed verification", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write",
+								name: "WRITE",
+								arguments: { path: "file.ts", content: "ok" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "background-test",
+								name: "SHELL",
+								arguments: { action: "start_background", command: "npm test" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(codingReply("too-early", "Verified."))
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "foreground-test",
+								name: "SHELL",
+								arguments: { command: "npm test" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("done", "Verified in foreground."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async () => ({
+				success: true,
+				text: "ok",
+			}));
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write." },
+					{ name: "SHELL", description: "Run." },
+					{ name: "REPLY", description: "Reply." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Verified in foreground.");
+			expect(executeToolCall).toHaveBeenCalledTimes(3);
+		});
+	});
 
 	it("does not treat a successful inspection command as coding verification", async () => {
 		await withCodingRequiredToolDefaults(async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -549,6 +549,27 @@ describe("v5 planner loop skeleton", () => {
 		text: "",
 		toolCalls: [{ id, name: "REPLY", arguments: { text } }],
 	});
+	const workspaceDelta = (
+		outcome: "changed" | "unchanged" | "indeterminate",
+	) => ({
+		workspaceDeltaReceipt: {
+			version: 1,
+			kind: "workspace_delta",
+			scope: {
+				kind: "git_worktree",
+				root: "/workspace",
+				coverage: "tracked_and_untracked_nonignored",
+			},
+			outcome,
+			...(outcome === "indeterminate"
+				? { reasonCode: "WORKTREE_PROBE_FAILED" }
+				: {
+						beforeFingerprint: "a".repeat(64),
+						afterFingerprint: (outcome === "changed" ? "b" : "a").repeat(64),
+					}),
+			observedAt: "2026-08-22T12:00:00.000Z",
+		},
+	});
 	const codingFileWrite = () => ({
 		text: "",
 		toolCalls: [
@@ -776,6 +797,214 @@ describe("v5 planner loop skeleton", () => {
 			);
 		});
 	});
+
+	it("requires clean verification after an observed shell mutation", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "generate-1",
+								name: "SHELL",
+								arguments: { command: "node generate.js" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(codingReply("reply-1", "Generated files."))
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "verify-clean",
+								name: "SHELL",
+								arguments: { command: "npm test" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-2", "Generated and verified files."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: true,
+					text: "generated",
+					data: workspaceDelta("changed"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "tests passed cleanly",
+					data: workspaceDelta("unchanged"),
+				});
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Generated and verified files.");
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+			expect(
+				result.trajectory.evaluatorOutputs.filter(
+					(output) => output.decision === "CONTINUE",
+				),
+			).toHaveLength(1);
+		});
+	});
+
+	it("treats an indeterminate shell receipt as a mutation requiring verification", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "generate-unknown",
+								name: "SHELL",
+								arguments: { command: "node generate.js" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(codingReply("reply-1", "Generated files."))
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "verify-clean",
+								name: "SHELL",
+								arguments: { command: "npm test" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-2", "Generated and verified files."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: true,
+					text: "generation status unknown",
+					data: workspaceDelta("indeterminate"),
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					text: "tests passed cleanly",
+					data: workspaceDelta("unchanged"),
+				});
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Generated and verified files.");
+			expect(runtime.useModel).toHaveBeenCalledTimes(4);
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	it.each(["changed", "indeterminate"] as const)(
+		"does not let a verifier with a %s receipt clear pending mutation",
+		async (verifierOutcome) => {
+			await withCodingRequiredToolDefaults(async () => {
+				const runtime = {
+					useModel: vi
+						.fn()
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "generate-1",
+									name: "SHELL",
+									arguments: { command: "node generate.js" },
+								},
+							],
+						})
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "verify-mutating",
+									name: "SHELL",
+									arguments: { command: "npm test" },
+								},
+							],
+						})
+						.mockResolvedValueOnce(codingReply("reply-1", "Verified."))
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "verify-clean",
+									name: "SHELL",
+									arguments: { command: "npm run typecheck" },
+								},
+							],
+						})
+						.mockResolvedValueOnce(
+							codingReply("reply-2", "Verified without further mutation."),
+						),
+					logger: { warn: vi.fn() },
+				};
+				const executeToolCall = vi
+					.fn()
+					.mockResolvedValueOnce({
+						success: true,
+						text: "generated",
+						data: workspaceDelta("changed"),
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						text: "tests passed but mutated the workspace",
+						data: workspaceDelta(verifierOutcome),
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						text: "tests passed cleanly",
+						data: workspaceDelta("unchanged"),
+					});
+
+				const result = await runPlannerLoop({
+					runtime,
+					context: codingPlannerContext,
+					codingMode: true,
+					tools: [
+						{ name: "SHELL", description: "Run a command." },
+						{ name: "REPLY", description: "Reply to the user." },
+					],
+					executeToolCall,
+					evaluate: vi.fn(),
+				});
+
+				expect(result.finalMessage).toBe("Verified without further mutation.");
+				expect(runtime.useModel).toHaveBeenCalledTimes(5);
+				expect(executeToolCall).toHaveBeenCalledTimes(3);
+			});
+		},
+	);
 
 	it("does not treat a successful inspection command as coding verification", async () => {
 		await withCodingRequiredToolDefaults(async () => {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3777,29 +3777,67 @@ function codingMutationRequiresVerification(
 				: undefined;
 			if (receipt.reasonCode === "BACKGROUND_RECEIPT_PENDING") {
 				const generatedHandle = String(step.result?.data?.handle ?? "");
-				if (
-					subaction !== "start_background" ||
-					!operationKey ||
-					generatedHandle !== receipt.operation?.handle
-				) {
+				const requestedHandle = String(
+					(step.toolCall?.params as Record<string, unknown> | undefined)
+						?.handle ?? "",
+				);
+				if (!operationKey) {
 					pending.set(malformedKey, { kind: "malformed" });
-				} else {
+				} else if (subaction === "start_background") {
+					if (generatedHandle !== receipt.operation?.handle) {
+						pending.set(malformedKey, { kind: "malformed" });
+						continue;
+					}
 					pending.set(operationKey, {
 						kind: "background_pending",
 						scopeKey,
 					});
+				} else if (
+					(subaction === "poll_background" ||
+						subaction === "write_background" ||
+						subaction === "kill_background") &&
+					requestedHandle === receipt.operation?.handle
+				) {
+					// A running poll/write or failed/in-flight kill can only preserve a
+					// handle established by its exact start; it never creates ownership.
+					if (!pending.has(operationKey)) {
+						pending.set(malformedKey, { kind: "malformed" });
+					}
+				} else {
+					pending.set(malformedKey, { kind: "malformed" });
 				}
 			} else if (operationKey) {
+				const generatedHandle = String(step.result?.data?.handle ?? "");
+				if (
+					subaction === "start_background" &&
+					generatedHandle === receipt.operation?.handle
+				) {
+					// Even a very fast process may finish before a throwing start callback
+					// returns. Start establishes ownership; only a later terminal poll/kill
+					// is allowed to resolve it.
+					pending.set(operationKey, {
+						kind: "background_pending",
+						scopeKey,
+					});
+					continue;
+				}
 				const requestedHandle = String(
 					(step.toolCall?.params as Record<string, unknown> | undefined)
 						?.handle ?? "",
 				);
 				const returnedHandle = String(step.result?.data?.handle ?? "");
+				const returnedStatus = String(step.result?.data?.status ?? "");
+				const terminalStatus = receipt.operation?.status;
 				if (
 					(subaction !== "poll_background" &&
 						subaction !== "kill_background") ||
 					requestedHandle !== receipt.operation?.handle ||
-					returnedHandle !== receipt.operation?.handle
+					returnedHandle !== receipt.operation?.handle ||
+					returnedStatus !== terminalStatus ||
+					(terminalStatus !== "exited" &&
+						terminalStatus !== "killed" &&
+						terminalStatus !== "error") ||
+					!pending.has(operationKey)
 				) {
 					pending.set(malformedKey, { kind: "malformed" });
 				} else {
@@ -3830,6 +3868,13 @@ function codingMutationRequiresVerification(
 		}
 	}
 	return pending.size > 0;
+}
+
+/** Test seam for the receipt lifecycle gate without invoking model retries. */
+export function __codingMutationRequiresVerificationForTests(
+	trajectory: PlannerTrajectory,
+): boolean {
+	return codingMutationRequiresVerification(trajectory);
 }
 
 function workspaceDeltaReceipt(step: PlannerStep): {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -53,7 +53,7 @@ import {
 } from "../types/model";
 import {
 	readWorkspaceDeltaReceipt,
-	type WorkspaceDeltaOutcome,
+	type WorkspaceDeltaReceipt,
 } from "../types/workspace-delta";
 import {
 	isModelProviderError,
@@ -3725,11 +3725,17 @@ function deferCodingCompletionUntilMutationVerified(args: {
 function codingMutationRequiresVerification(
 	trajectory: PlannerTrajectory,
 ): boolean {
-	let latestMutationIndex = -1;
+	type PendingMutation =
+		| { kind: "typed" }
+		| { kind: "background_pending" }
+		| { kind: "legacy" }
+		| { kind: "malformed" };
+	const pending = new Map<string, PendingMutation>();
+	const legacyKey = "legacy:unscoped";
+	const malformedKey = "malformed:unscoped";
 	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
-	for (let index = 0; index < steps.length; index++) {
-		const step = steps[index];
-		const workspaceDelta = workspaceDeltaOutcome(step);
+	for (const step of steps) {
+		const workspaceDelta = workspaceDeltaReceipt(step);
 		const name = step?.toolCall?.name.toUpperCase();
 		const fileMutation =
 			name === "FILE" &&
@@ -3753,33 +3759,66 @@ function codingMutationRequiresVerification(
 					.trim()
 					.toLowerCase(),
 			);
+		if (workspaceDelta.malformed) {
+			pending.set(malformedKey, { kind: "malformed" });
+		} else if (workspaceDelta.receipt) {
+			const receipt = workspaceDelta.receipt;
+			const key = workspaceDeltaScopeKey(receipt);
+			if (receipt.outcome === "changed") {
+				pending.set(key, { kind: "typed" });
+			} else if (receipt.outcome === "indeterminate") {
+				const existing = pending.get(key);
+				if (receipt.reasonCode === "BACKGROUND_RECEIPT_PENDING") {
+					if (!existing) pending.set(key, { kind: "background_pending" });
+				} else {
+					pending.set(key, { kind: "typed" });
+				}
+			} else if (pending.get(key)?.kind === "background_pending") {
+				// A terminal background observation resolves only its own provisional
+				// start receipt. It is not semantic test evidence for older mutations.
+				pending.delete(key);
+			}
+		}
 		if (
-			workspaceDelta === "changed" ||
-			workspaceDelta === "indeterminate" ||
-			((name === "WRITE" || name === "EDIT" || fileMutation) &&
-				step.result?.success === true)
+			(name === "WRITE" || name === "EDIT" || fileMutation) &&
+			step.result?.success === true
 		) {
-			latestMutationIndex = index;
+			pending.set(legacyKey, { kind: "legacy" });
+		}
+		if (isSuccessfulCodingVerificationStep(step)) {
+			if (workspaceDelta.receipt?.outcome === "unchanged") {
+				pending.delete(workspaceDeltaScopeKey(workspaceDelta.receipt));
+				// Receipt-less file tools predate typed scopes. Preserve their existing
+				// compatibility contract while never letting them clear another typed root.
+				pending.delete(legacyKey);
+			} else if (!workspaceDelta.receipt && !workspaceDelta.malformed) {
+				pending.delete(legacyKey);
+			}
 		}
 	}
-	if (latestMutationIndex < 0) return false;
-
-	const verified = steps
-		.slice(latestMutationIndex + 1)
-		.some((step) => isSuccessfulCodingVerificationStep(step));
-	return !verified;
+	return pending.size > 0;
 }
 
-function workspaceDeltaOutcome(
-	step: PlannerStep,
-): WorkspaceDeltaOutcome | undefined {
+function workspaceDeltaReceipt(step: PlannerStep): {
+	receipt?: WorkspaceDeltaReceipt;
+	malformed: boolean;
+} {
 	try {
-		return readWorkspaceDeltaReceipt(step.result?.data)?.outcome;
+		return {
+			receipt: readWorkspaceDeltaReceipt(step.result?.data),
+			malformed: false,
+		};
 	} catch {
 		// A malformed receipt is not allowed to suppress the completion gate. Its
 		// mutation outcome is unknown, which is conservatively indeterminate.
-		return "indeterminate";
+		return { malformed: true };
 	}
+}
+
+function workspaceDeltaScopeKey(receipt: WorkspaceDeltaReceipt): string {
+	return [receipt.scope.kind, receipt.scope.coverage, receipt.scope.root].join(
+		"\0",
+	);
 }
 
 /**
@@ -3798,8 +3837,21 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 	) {
 		return false;
 	}
-	const workspaceDelta = workspaceDeltaOutcome(step);
-	if (workspaceDelta === "changed" || workspaceDelta === "indeterminate") {
+	const subaction = String(
+		(step.toolCall.params as Record<string, unknown> | undefined)?.action ??
+			(step.toolCall.params as Record<string, unknown> | undefined)
+				?.operation ??
+			"run",
+	)
+		.trim()
+		.toLowerCase();
+	if (subaction !== "run") return false;
+	const workspaceDelta = workspaceDeltaReceipt(step);
+	if (
+		workspaceDelta.malformed ||
+		workspaceDelta.receipt?.outcome === "changed" ||
+		workspaceDelta.receipt?.outcome === "indeterminate"
+	) {
 		return false;
 	}
 	if (

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -52,6 +52,10 @@ import {
 	type ToolDefinition,
 } from "../types/model";
 import {
+	readWorkspaceDeltaReceipt,
+	type WorkspaceDeltaOutcome,
+} from "../types/workspace-delta";
+import {
 	isModelProviderError,
 	modelProviderErrorDetail,
 } from "../utils/model-errors";
@@ -3725,6 +3729,7 @@ function codingMutationRequiresVerification(
 	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
 	for (let index = 0; index < steps.length; index++) {
 		const step = steps[index];
+		const workspaceDelta = workspaceDeltaOutcome(step);
 		const name = step?.toolCall?.name.toUpperCase();
 		const fileMutation =
 			name === "FILE" &&
@@ -3749,8 +3754,10 @@ function codingMutationRequiresVerification(
 					.toLowerCase(),
 			);
 		if (
-			(name === "WRITE" || name === "EDIT" || fileMutation) &&
-			step.result?.success === true
+			workspaceDelta === "changed" ||
+			workspaceDelta === "indeterminate" ||
+			((name === "WRITE" || name === "EDIT" || fileMutation) &&
+				step.result?.success === true)
 		) {
 			latestMutationIndex = index;
 		}
@@ -3761,6 +3768,18 @@ function codingMutationRequiresVerification(
 		.slice(latestMutationIndex + 1)
 		.some((step) => isSuccessfulCodingVerificationStep(step));
 	return !verified;
+}
+
+function workspaceDeltaOutcome(
+	step: PlannerStep,
+): WorkspaceDeltaOutcome | undefined {
+	try {
+		return readWorkspaceDeltaReceipt(step.result?.data)?.outcome;
+	} catch {
+		// A malformed receipt is not allowed to suppress the completion gate. Its
+		// mutation outcome is unknown, which is conservatively indeterminate.
+		return "indeterminate";
+	}
 }
 
 /**
@@ -3777,6 +3796,10 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 		step.toolCall?.name.toUpperCase() !== "SHELL" ||
 		step.result?.success !== true
 	) {
+		return false;
+	}
+	const workspaceDelta = workspaceDeltaOutcome(step);
+	if (workspaceDelta === "changed" || workspaceDelta === "indeterminate") {
 		return false;
 	}
 	if (

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3727,7 +3727,7 @@ function codingMutationRequiresVerification(
 ): boolean {
 	type PendingMutation =
 		| { kind: "typed" }
-		| { kind: "background_pending" }
+		| { kind: "background_pending"; scopeKey: string }
 		| { kind: "legacy" }
 		| { kind: "malformed" };
 	const pending = new Map<string, PendingMutation>();
@@ -3737,6 +3737,14 @@ function codingMutationRequiresVerification(
 	for (const step of steps) {
 		const workspaceDelta = workspaceDeltaReceipt(step);
 		const name = step?.toolCall?.name.toUpperCase();
+		const subaction = String(
+			(step.toolCall?.params as Record<string, unknown> | undefined)?.action ??
+				(step.toolCall?.params as Record<string, unknown> | undefined)
+					?.operation ??
+				"run",
+		)
+			.trim()
+			.toLowerCase();
 		const fileMutation =
 			name === "FILE" &&
 			[
@@ -3763,20 +3771,45 @@ function codingMutationRequiresVerification(
 			pending.set(malformedKey, { kind: "malformed" });
 		} else if (workspaceDelta.receipt) {
 			const receipt = workspaceDelta.receipt;
-			const key = workspaceDeltaScopeKey(receipt);
-			if (receipt.outcome === "changed") {
-				pending.set(key, { kind: "typed" });
-			} else if (receipt.outcome === "indeterminate") {
-				const existing = pending.get(key);
-				if (receipt.reasonCode === "BACKGROUND_RECEIPT_PENDING") {
-					if (!existing) pending.set(key, { kind: "background_pending" });
+			const scopeKey = workspaceDeltaScopeKey(receipt);
+			const operationKey = receipt.operation
+				? workspaceDeltaOperationKey(receipt)
+				: undefined;
+			if (receipt.reasonCode === "BACKGROUND_RECEIPT_PENDING") {
+				const generatedHandle = String(step.result?.data?.handle ?? "");
+				if (
+					subaction !== "start_background" ||
+					!operationKey ||
+					generatedHandle !== receipt.operation?.handle
+				) {
+					pending.set(malformedKey, { kind: "malformed" });
 				} else {
-					pending.set(key, { kind: "typed" });
+					pending.set(operationKey, {
+						kind: "background_pending",
+						scopeKey,
+					});
 				}
-			} else if (pending.get(key)?.kind === "background_pending") {
-				// A terminal background observation resolves only its own provisional
-				// start receipt. It is not semantic test evidence for older mutations.
-				pending.delete(key);
+			} else if (operationKey) {
+				const requestedHandle = String(
+					(step.toolCall?.params as Record<string, unknown> | undefined)
+						?.handle ?? "",
+				);
+				const returnedHandle = String(step.result?.data?.handle ?? "");
+				if (
+					(subaction !== "poll_background" &&
+						subaction !== "kill_background") ||
+					requestedHandle !== receipt.operation?.handle ||
+					returnedHandle !== receipt.operation?.handle
+				) {
+					pending.set(malformedKey, { kind: "malformed" });
+				} else {
+					pending.delete(operationKey);
+					if (receipt.outcome !== "unchanged") {
+						pending.set(scopeKey, { kind: "typed" });
+					}
+				}
+			} else if (receipt.outcome !== "unchanged") {
+				pending.set(scopeKey, { kind: "typed" });
 			}
 		}
 		if (
@@ -3816,9 +3849,21 @@ function workspaceDeltaReceipt(step: PlannerStep): {
 }
 
 function workspaceDeltaScopeKey(receipt: WorkspaceDeltaReceipt): string {
-	return [receipt.scope.kind, receipt.scope.coverage, receipt.scope.root].join(
-		"\0",
-	);
+	return [
+		receipt.scope.kind,
+		receipt.scope.coverage,
+		receipt.scope.executionDomainId,
+		receipt.scope.rootId,
+	].join("\0");
+}
+
+function workspaceDeltaOperationKey(receipt: WorkspaceDeltaReceipt): string {
+	return [
+		"background",
+		receipt.scope.executionDomainId,
+		receipt.scope.rootId,
+		receipt.operation?.handle ?? "",
+	].join("\0");
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -123,3 +123,4 @@ export {
 	VIEW_KIND_META,
 	VIEW_KINDS,
 } from "./view-kind";
+export * from "./workspace-delta";

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -573,6 +573,8 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	/** Database adapter. Set in constructor; required. */
 	adapter: IDatabaseAdapter;
 	agentId: UUID;
+	/** Opaque identity of this concrete runtime instance, never character-derived. */
+	runtimeInstanceId: UUID;
 	character: Character;
 	enableAutonomy: boolean;
 	/** When true, TaskService does not start a timer; host drives via runDueTasks(). WHY: no long-lived process in serverless. */

--- a/packages/core/src/types/workspace-delta.test.ts
+++ b/packages/core/src/types/workspace-delta.test.ts
@@ -61,10 +61,29 @@ describe("WorkspaceDeltaReceipt", () => {
 		{ ...observed("changed"), outcome: "maybe" },
 		{ ...observed("changed"), beforeFingerprint: "short" },
 		{ ...observed("changed"), observedAt: "not-a-time" },
+		{ ...observed("changed"), observedAt: "2026-08-22" },
+		{ ...observed("changed"), afterFingerprint: HASH_A },
+		{ ...observed("unchanged"), afterFingerprint: HASH_B },
+		{ ...observed("changed"), extra: true },
+		{
+			...observed("changed"),
+			scope: { ...observed("changed").scope, extra: true },
+		},
 		{
 			...observed("changed"),
 			outcome: "indeterminate",
 			afterFingerprint: undefined,
+		},
+		{
+			...observed("changed"),
+			outcome: "indeterminate",
+			afterFingerprint: undefined,
+			reasonCode: "arbitrary prose",
+		},
+		{
+			...observed("changed"),
+			outcome: "indeterminate",
+			reasonCode: "POST_SNAPSHOT_FAILED",
 		},
 	])("rejects malformed receipt %#", (value) => {
 		expect(() => normalizeWorkspaceDeltaReceipt(value)).toThrow(TypeError);

--- a/packages/core/src/types/workspace-delta.test.ts
+++ b/packages/core/src/types/workspace-delta.test.ts
@@ -77,6 +77,34 @@ describe("WorkspaceDeltaReceipt", () => {
 		});
 	});
 
+	it("requires pending and terminal background receipts to carry matching lifecycle status", () => {
+		const pending = {
+			...observed("unchanged"),
+			outcome: "indeterminate",
+			afterFingerprint: undefined,
+			reasonCode: "BACKGROUND_RECEIPT_PENDING",
+			operation: {
+				kind: "background_shell",
+				handle: "bg-1",
+				status: "terminating",
+			},
+		};
+		expect(normalizeWorkspaceDeltaReceipt(pending)).toMatchObject({
+			outcome: "indeterminate",
+			operation: { handle: "bg-1", status: "terminating" },
+		});
+		expect(() =>
+			normalizeWorkspaceDeltaReceipt({
+				...observed("unchanged"),
+				operation: {
+					kind: "background_shell",
+					handle: "bg-1",
+					status: "running",
+				},
+			}),
+		).toThrow(/terminal status/);
+	});
+
 	it.each([
 		{ ...observed("changed"), version: 2 },
 		{ ...observed("changed"), outcome: "maybe" },
@@ -112,6 +140,7 @@ describe("WorkspaceDeltaReceipt", () => {
 			operation: {
 				kind: "background_shell",
 				handle: "bg-1",
+				status: "exited",
 				extra: true,
 			},
 		},

--- a/packages/core/src/types/workspace-delta.test.ts
+++ b/packages/core/src/types/workspace-delta.test.ts
@@ -9,6 +9,8 @@ import {
 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
+const ROOT_ID = "c".repeat(64);
+const DOMAIN_ID = "d".repeat(64);
 
 function observed(outcome: "changed" | "unchanged") {
 	return {
@@ -17,6 +19,8 @@ function observed(outcome: "changed" | "unchanged") {
 		scope: {
 			kind: "git_worktree",
 			root: "/workspace",
+			rootId: ROOT_ID,
+			executionDomainId: DOMAIN_ID,
 			coverage: "tracked_and_untracked_nonignored",
 		},
 		outcome,
@@ -56,12 +60,40 @@ describe("WorkspaceDeltaReceipt", () => {
 		);
 	});
 
+	it("preserves display roots separately from canonical opaque identities", () => {
+		const receipt = normalizeWorkspaceDeltaReceipt({
+			...observed("unchanged"),
+			scope: {
+				...observed("unchanged").scope,
+				root: "[redacted]",
+			},
+		});
+		expect(receipt.scope).toEqual({
+			kind: "git_worktree",
+			root: "[redacted]",
+			rootId: ROOT_ID,
+			executionDomainId: DOMAIN_ID,
+			coverage: "tracked_and_untracked_nonignored",
+		});
+	});
+
 	it.each([
 		{ ...observed("changed"), version: 2 },
 		{ ...observed("changed"), outcome: "maybe" },
 		{ ...observed("changed"), beforeFingerprint: "short" },
 		{ ...observed("changed"), observedAt: "not-a-time" },
 		{ ...observed("changed"), observedAt: "2026-08-22" },
+		{
+			...observed("changed"),
+			scope: { ...observed("changed").scope, rootId: "short" },
+		},
+		{
+			...observed("changed"),
+			scope: {
+				...observed("changed").scope,
+				executionDomainId: undefined,
+			},
+		},
 		{ ...observed("changed"), afterFingerprint: HASH_A },
 		{ ...observed("unchanged"), afterFingerprint: HASH_B },
 		{ ...observed("changed"), extra: true },
@@ -73,6 +105,15 @@ describe("WorkspaceDeltaReceipt", () => {
 			...observed("changed"),
 			outcome: "indeterminate",
 			afterFingerprint: undefined,
+			reasonCode: "BACKGROUND_RECEIPT_PENDING",
+		},
+		{
+			...observed("changed"),
+			operation: {
+				kind: "background_shell",
+				handle: "bg-1",
+				extra: true,
+			},
 		},
 		{
 			...observed("changed"),

--- a/packages/core/src/types/workspace-delta.test.ts
+++ b/packages/core/src/types/workspace-delta.test.ts
@@ -1,0 +1,72 @@
+/** Tests the pure workspace-delta receipt validator with deterministic fixtures. */
+
+import { describe, expect, it } from "vitest";
+import {
+	normalizeWorkspaceDeltaReceipt,
+	readWorkspaceDeltaReceipt,
+	WORKSPACE_DELTA_RECEIPT_DATA_KEY,
+} from "./workspace-delta";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+function observed(outcome: "changed" | "unchanged") {
+	return {
+		version: 1,
+		kind: "workspace_delta",
+		scope: {
+			kind: "git_worktree",
+			root: "/workspace",
+			coverage: "tracked_and_untracked_nonignored",
+		},
+		outcome,
+		beforeFingerprint: HASH_A,
+		afterFingerprint: outcome === "changed" ? HASH_B : HASH_A,
+		observedAt: "2026-08-22T12:00:00.000Z",
+	};
+}
+
+describe("WorkspaceDeltaReceipt", () => {
+	it("normalizes observed and indeterminate receipts", () => {
+		expect(normalizeWorkspaceDeltaReceipt(observed("changed"))).toEqual(
+			observed("changed"),
+		);
+		expect(
+			normalizeWorkspaceDeltaReceipt({
+				...observed("unchanged"),
+				outcome: "indeterminate",
+				afterFingerprint: undefined,
+				reasonCode: "POST_SNAPSHOT_FAILED",
+			}),
+		).toMatchObject({
+			outcome: "indeterminate",
+			reasonCode: "POST_SNAPSHOT_FAILED",
+			beforeFingerprint: HASH_A,
+		});
+	});
+
+	it("reads only the canonical ActionResult.data key", () => {
+		expect(
+			readWorkspaceDeltaReceipt({
+				[WORKSPACE_DELTA_RECEIPT_DATA_KEY]: observed("unchanged"),
+			}),
+		).toMatchObject({ outcome: "unchanged" });
+		expect(readWorkspaceDeltaReceipt({ unrelated: observed("changed") })).toBe(
+			undefined,
+		);
+	});
+
+	it.each([
+		{ ...observed("changed"), version: 2 },
+		{ ...observed("changed"), outcome: "maybe" },
+		{ ...observed("changed"), beforeFingerprint: "short" },
+		{ ...observed("changed"), observedAt: "not-a-time" },
+		{
+			...observed("changed"),
+			outcome: "indeterminate",
+			afterFingerprint: undefined,
+		},
+	])("rejects malformed receipt %#", (value) => {
+		expect(() => normalizeWorkspaceDeltaReceipt(value)).toThrow(TypeError);
+	});
+});

--- a/packages/core/src/types/workspace-delta.ts
+++ b/packages/core/src/types/workspace-delta.ts
@@ -10,6 +10,20 @@ export const WORKSPACE_DELTA_RECEIPT_DATA_KEY =
 
 export type WorkspaceDeltaOutcome = "changed" | "unchanged" | "indeterminate";
 
+export const WORKSPACE_DELTA_INDETERMINATE_REASON_CODES = [
+	"WORKTREE_PROBE_FAILED",
+	"BASELINE_SNAPSHOT_FAILED",
+	"POST_SNAPSHOT_FAILED",
+	"OBSERVATION_TIME_BUDGET_EXCEEDED",
+	"OBSERVATION_BYTE_BUDGET_EXCEEDED",
+	"OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
+	"REMOTE_EXECUTION_UNOBSERVED",
+	"BACKGROUND_RECEIPT_PENDING",
+] as const;
+
+export type WorkspaceDeltaIndeterminateReasonCode =
+	(typeof WORKSPACE_DELTA_INDETERMINATE_REASON_CODES)[number];
+
 export interface WorkspaceDeltaReceipt {
 	version: 1;
 	kind: "workspace_delta";
@@ -25,7 +39,23 @@ export interface WorkspaceDeltaReceipt {
 	afterFingerprint?: string;
 	observedAt: string;
 	/** Stable machine-readable reason required for indeterminate observations. */
-	reasonCode?: string;
+	reasonCode?: WorkspaceDeltaIndeterminateReasonCode;
+}
+
+const BASE_KEYS = ["version", "kind", "scope", "outcome", "observedAt"];
+
+function assertExactKeys(
+	value: Record<string, unknown>,
+	allowed: readonly string[],
+	label: string,
+): void {
+	const allowedKeys = new Set(allowed);
+	const unexpected = Object.keys(value).filter((key) => !allowedKeys.has(key));
+	if (unexpected.length > 0) {
+		throw new TypeError(
+			`${label} has unexpected fields: ${unexpected.join(", ")}.`,
+		);
+	}
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {
@@ -49,13 +79,29 @@ export function normalizeWorkspaceDeltaReceipt(
 ): WorkspaceDeltaReceipt {
 	const raw = record(value);
 	const scope = record(raw?.scope);
+	if (raw) {
+		assertExactKeys(
+			raw,
+			[...BASE_KEYS, "beforeFingerprint", "afterFingerprint", "reasonCode"],
+			"WorkspaceDeltaReceipt",
+		);
+	}
+	if (scope) {
+		assertExactKeys(
+			scope,
+			["kind", "root", "coverage"],
+			"WorkspaceDeltaReceipt.scope",
+		);
+	}
 	if (
 		raw?.version !== 1 ||
 		raw.kind !== "workspace_delta" ||
 		scope?.kind !== "git_worktree" ||
 		scope.coverage !== "tracked_and_untracked_nonignored" ||
 		typeof scope.root !== "string" ||
-		scope.root.trim().length === 0
+		scope.root.length === 0 ||
+		scope.root.trim() !== scope.root ||
+		/[\0\r\n]/.test(scope.root)
 	) {
 		throw new TypeError(
 			"WorkspaceDeltaReceipt has an invalid envelope or scope.",
@@ -70,7 +116,8 @@ export function normalizeWorkspaceDeltaReceipt(
 	}
 	if (
 		typeof raw.observedAt !== "string" ||
-		!Number.isFinite(Date.parse(raw.observedAt))
+		!Number.isFinite(Date.parse(raw.observedAt)) ||
+		new Date(raw.observedAt).toISOString() !== raw.observedAt
 	) {
 		throw new TypeError(
 			"WorkspaceDeltaReceipt.observedAt must be an ISO timestamp.",
@@ -78,9 +125,19 @@ export function normalizeWorkspaceDeltaReceipt(
 	}
 
 	if (raw.outcome === "indeterminate") {
-		if (typeof raw.reasonCode !== "string" || raw.reasonCode.length === 0) {
+		if (
+			typeof raw.reasonCode !== "string" ||
+			!WORKSPACE_DELTA_INDETERMINATE_REASON_CODES.includes(
+				raw.reasonCode as WorkspaceDeltaIndeterminateReasonCode,
+			)
+		) {
 			throw new TypeError(
-				"Indeterminate WorkspaceDeltaReceipt values require reasonCode.",
+				"Indeterminate WorkspaceDeltaReceipt values require a canonical reasonCode.",
+			);
+		}
+		if (raw.afterFingerprint !== undefined) {
+			throw new TypeError(
+				"Indeterminate WorkspaceDeltaReceipt values cannot include afterFingerprint.",
 			);
 		}
 		return {
@@ -101,8 +158,29 @@ export function normalizeWorkspaceDeltaReceipt(
 						),
 					}),
 			observedAt: raw.observedAt,
-			reasonCode: raw.reasonCode,
+			reasonCode: raw.reasonCode as WorkspaceDeltaIndeterminateReasonCode,
 		};
+	}
+	if (raw.reasonCode !== undefined) {
+		throw new TypeError(
+			"Observed WorkspaceDeltaReceipt values cannot include reasonCode.",
+		);
+	}
+	const beforeFingerprint = fingerprint(
+		raw.beforeFingerprint,
+		"beforeFingerprint",
+	);
+	const afterFingerprint = fingerprint(
+		raw.afterFingerprint,
+		"afterFingerprint",
+	);
+	if (
+		(raw.outcome === "changed" && beforeFingerprint === afterFingerprint) ||
+		(raw.outcome === "unchanged" && beforeFingerprint !== afterFingerprint)
+	) {
+		throw new TypeError(
+			`WorkspaceDeltaReceipt fingerprints contradict outcome ${raw.outcome}.`,
+		);
 	}
 
 	return {
@@ -114,8 +192,8 @@ export function normalizeWorkspaceDeltaReceipt(
 			coverage: "tracked_and_untracked_nonignored",
 		},
 		outcome: raw.outcome,
-		beforeFingerprint: fingerprint(raw.beforeFingerprint, "beforeFingerprint"),
-		afterFingerprint: fingerprint(raw.afterFingerprint, "afterFingerprint"),
+		beforeFingerprint,
+		afterFingerprint,
 		observedAt: raw.observedAt,
 	};
 }

--- a/packages/core/src/types/workspace-delta.ts
+++ b/packages/core/src/types/workspace-delta.ts
@@ -29,8 +29,15 @@ export interface WorkspaceDeltaReceipt {
 	kind: "workspace_delta";
 	scope: {
 		kind: "git_worktree";
+		/** Display-only root; machine matching uses the opaque identities. */
 		root: string;
+		rootId: string;
+		executionDomainId: string;
 		coverage: "tracked_and_untracked_nonignored";
+	};
+	operation?: {
+		kind: "background_shell";
+		handle: string;
 	};
 	outcome: WorkspaceDeltaOutcome;
 	/** SHA-256 of the complete observed baseline state, when available. */
@@ -82,14 +89,20 @@ export function normalizeWorkspaceDeltaReceipt(
 	if (raw) {
 		assertExactKeys(
 			raw,
-			[...BASE_KEYS, "beforeFingerprint", "afterFingerprint", "reasonCode"],
+			[
+				...BASE_KEYS,
+				"operation",
+				"beforeFingerprint",
+				"afterFingerprint",
+				"reasonCode",
+			],
 			"WorkspaceDeltaReceipt",
 		);
 	}
 	if (scope) {
 		assertExactKeys(
 			scope,
-			["kind", "root", "coverage"],
+			["kind", "root", "rootId", "executionDomainId", "coverage"],
 			"WorkspaceDeltaReceipt.scope",
 		);
 	}
@@ -106,6 +119,31 @@ export function normalizeWorkspaceDeltaReceipt(
 		throw new TypeError(
 			"WorkspaceDeltaReceipt has an invalid envelope or scope.",
 		);
+	}
+	const rootId = fingerprint(scope.rootId, "scope.rootId");
+	const executionDomainId = fingerprint(
+		scope.executionDomainId,
+		"scope.executionDomainId",
+	);
+	const operation = record(raw.operation);
+	if (operation) {
+		assertExactKeys(
+			operation,
+			["kind", "handle"],
+			"WorkspaceDeltaReceipt.operation",
+		);
+		if (
+			operation.kind !== "background_shell" ||
+			typeof operation.handle !== "string" ||
+			operation.handle.length === 0 ||
+			operation.handle.length > 200 ||
+			operation.handle.trim() !== operation.handle ||
+			/[\0\r\n]/.test(operation.handle)
+		) {
+			throw new TypeError("WorkspaceDeltaReceipt has an invalid operation.");
+		}
+	} else if (raw.operation !== undefined) {
+		throw new TypeError("WorkspaceDeltaReceipt has an invalid operation.");
 	}
 	if (
 		raw.outcome !== "changed" &&
@@ -140,14 +178,32 @@ export function normalizeWorkspaceDeltaReceipt(
 				"Indeterminate WorkspaceDeltaReceipt values cannot include afterFingerprint.",
 			);
 		}
+		if (
+			raw.reasonCode === "BACKGROUND_RECEIPT_PENDING" &&
+			operation === undefined
+		) {
+			throw new TypeError(
+				"A pending background WorkspaceDeltaReceipt requires its operation handle.",
+			);
+		}
 		return {
 			version: 1,
 			kind: "workspace_delta",
 			scope: {
 				kind: "git_worktree",
 				root: scope.root,
+				rootId,
+				executionDomainId,
 				coverage: "tracked_and_untracked_nonignored",
 			},
+			...(operation
+				? {
+						operation: {
+							kind: "background_shell" as const,
+							handle: operation.handle as string,
+						},
+					}
+				: {}),
 			outcome: "indeterminate",
 			...(raw.beforeFingerprint === undefined
 				? {}
@@ -189,8 +245,18 @@ export function normalizeWorkspaceDeltaReceipt(
 		scope: {
 			kind: "git_worktree",
 			root: scope.root,
+			rootId,
+			executionDomainId,
 			coverage: "tracked_and_untracked_nonignored",
 		},
+		...(operation
+			? {
+					operation: {
+						kind: "background_shell" as const,
+						handle: operation.handle as string,
+					},
+				}
+			: {}),
 		outcome: raw.outcome,
 		beforeFingerprint,
 		afterFingerprint,

--- a/packages/core/src/types/workspace-delta.ts
+++ b/packages/core/src/types/workspace-delta.ts
@@ -38,6 +38,7 @@ export interface WorkspaceDeltaReceipt {
 	operation?: {
 		kind: "background_shell";
 		handle: string;
+		status: "running" | "terminating" | "exited" | "killed" | "error";
 	};
 	outcome: WorkspaceDeltaOutcome;
 	/** SHA-256 of the complete observed baseline state, when available. */
@@ -129,7 +130,7 @@ export function normalizeWorkspaceDeltaReceipt(
 	if (operation) {
 		assertExactKeys(
 			operation,
-			["kind", "handle"],
+			["kind", "handle", "status"],
 			"WorkspaceDeltaReceipt.operation",
 		);
 		if (
@@ -138,7 +139,10 @@ export function normalizeWorkspaceDeltaReceipt(
 			operation.handle.length === 0 ||
 			operation.handle.length > 200 ||
 			operation.handle.trim() !== operation.handle ||
-			/[\0\r\n]/.test(operation.handle)
+			/[\0\r\n]/.test(operation.handle) ||
+			!["running", "terminating", "exited", "killed", "error"].includes(
+				String(operation.status),
+			)
 		) {
 			throw new TypeError("WorkspaceDeltaReceipt has an invalid operation.");
 		}
@@ -186,6 +190,18 @@ export function normalizeWorkspaceDeltaReceipt(
 				"A pending background WorkspaceDeltaReceipt requires its operation handle.",
 			);
 		}
+		if (
+			operation &&
+			(raw.reasonCode === "BACKGROUND_RECEIPT_PENDING"
+				? operation.status !== "running" && operation.status !== "terminating"
+				: operation.status !== "exited" &&
+					operation.status !== "killed" &&
+					operation.status !== "error")
+		) {
+			throw new TypeError(
+				"WorkspaceDeltaReceipt operation status contradicts its observation state.",
+			);
+		}
 		return {
 			version: 1,
 			kind: "workspace_delta",
@@ -201,6 +217,12 @@ export function normalizeWorkspaceDeltaReceipt(
 						operation: {
 							kind: "background_shell" as const,
 							handle: operation.handle as string,
+							status: operation.status as
+								| "running"
+								| "terminating"
+								| "exited"
+								| "killed"
+								| "error",
 						},
 					}
 				: {}),
@@ -220,6 +242,16 @@ export function normalizeWorkspaceDeltaReceipt(
 	if (raw.reasonCode !== undefined) {
 		throw new TypeError(
 			"Observed WorkspaceDeltaReceipt values cannot include reasonCode.",
+		);
+	}
+	if (
+		operation &&
+		operation.status !== "exited" &&
+		operation.status !== "killed" &&
+		operation.status !== "error"
+	) {
+		throw new TypeError(
+			"Observed WorkspaceDeltaReceipt operations require a terminal status.",
 		);
 	}
 	const beforeFingerprint = fingerprint(
@@ -254,6 +286,12 @@ export function normalizeWorkspaceDeltaReceipt(
 					operation: {
 						kind: "background_shell" as const,
 						handle: operation.handle as string,
+						status: operation.status as
+							| "running"
+							| "terminating"
+							| "exited"
+							| "killed"
+							| "error",
 					},
 				}
 			: {}),

--- a/packages/core/src/types/workspace-delta.ts
+++ b/packages/core/src/types/workspace-delta.ts
@@ -1,0 +1,131 @@
+/**
+ * Typed, content-free observations of net workspace changes made by a tool.
+ * Receipts live under the canonical ActionResult.data key so existing action,
+ * streaming, trajectory, and planner transports preserve them unchanged.
+ */
+
+/** Canonical ActionResult.data key for a workspace delta observation. */
+export const WORKSPACE_DELTA_RECEIPT_DATA_KEY =
+	"workspaceDeltaReceipt" as const;
+
+export type WorkspaceDeltaOutcome = "changed" | "unchanged" | "indeterminate";
+
+export interface WorkspaceDeltaReceipt {
+	version: 1;
+	kind: "workspace_delta";
+	scope: {
+		kind: "git_worktree";
+		root: string;
+		coverage: "tracked_and_untracked_nonignored";
+	};
+	outcome: WorkspaceDeltaOutcome;
+	/** SHA-256 of the complete observed baseline state, when available. */
+	beforeFingerprint?: string;
+	/** SHA-256 of the complete observed final state, when available. */
+	afterFingerprint?: string;
+	observedAt: string;
+	/** Stable machine-readable reason required for indeterminate observations. */
+	reasonCode?: string;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function fingerprint(value: unknown, field: string): string {
+	if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) {
+		throw new TypeError(
+			`WorkspaceDeltaReceipt.${field} must be a lowercase SHA-256 hex string.`,
+		);
+	}
+	return value;
+}
+
+/** Strictly validates an untrusted workspace-delta receipt. */
+export function normalizeWorkspaceDeltaReceipt(
+	value: unknown,
+): WorkspaceDeltaReceipt {
+	const raw = record(value);
+	const scope = record(raw?.scope);
+	if (
+		raw?.version !== 1 ||
+		raw.kind !== "workspace_delta" ||
+		scope?.kind !== "git_worktree" ||
+		scope.coverage !== "tracked_and_untracked_nonignored" ||
+		typeof scope.root !== "string" ||
+		scope.root.trim().length === 0
+	) {
+		throw new TypeError(
+			"WorkspaceDeltaReceipt has an invalid envelope or scope.",
+		);
+	}
+	if (
+		raw.outcome !== "changed" &&
+		raw.outcome !== "unchanged" &&
+		raw.outcome !== "indeterminate"
+	) {
+		throw new TypeError("WorkspaceDeltaReceipt has an invalid outcome.");
+	}
+	if (
+		typeof raw.observedAt !== "string" ||
+		!Number.isFinite(Date.parse(raw.observedAt))
+	) {
+		throw new TypeError(
+			"WorkspaceDeltaReceipt.observedAt must be an ISO timestamp.",
+		);
+	}
+
+	if (raw.outcome === "indeterminate") {
+		if (typeof raw.reasonCode !== "string" || raw.reasonCode.length === 0) {
+			throw new TypeError(
+				"Indeterminate WorkspaceDeltaReceipt values require reasonCode.",
+			);
+		}
+		return {
+			version: 1,
+			kind: "workspace_delta",
+			scope: {
+				kind: "git_worktree",
+				root: scope.root,
+				coverage: "tracked_and_untracked_nonignored",
+			},
+			outcome: "indeterminate",
+			...(raw.beforeFingerprint === undefined
+				? {}
+				: {
+						beforeFingerprint: fingerprint(
+							raw.beforeFingerprint,
+							"beforeFingerprint",
+						),
+					}),
+			observedAt: raw.observedAt,
+			reasonCode: raw.reasonCode,
+		};
+	}
+
+	return {
+		version: 1,
+		kind: "workspace_delta",
+		scope: {
+			kind: "git_worktree",
+			root: scope.root,
+			coverage: "tracked_and_untracked_nonignored",
+		},
+		outcome: raw.outcome,
+		beforeFingerprint: fingerprint(raw.beforeFingerprint, "beforeFingerprint"),
+		afterFingerprint: fingerprint(raw.afterFingerprint, "afterFingerprint"),
+		observedAt: raw.observedAt,
+	};
+}
+
+/** Reads and validates the canonical receipt from ActionResult-style data. */
+export function readWorkspaceDeltaReceipt(
+	data: Record<string, unknown> | undefined,
+): WorkspaceDeltaReceipt | undefined {
+	const value = data?.[WORKSPACE_DELTA_RECEIPT_DATA_KEY];
+	return value === undefined
+		? undefined
+		: normalizeWorkspaceDeltaReceipt(value);
+}

--- a/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
+++ b/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
@@ -226,6 +226,7 @@ describe("@elizaos/plugin-coding-tools — end-to-end smoke", () => {
     services = new Map();
     runtime = {
       agentId: "00000000-0000-0000-0000-000000000000" as UUID,
+      runtimeInstanceId: "coding-tools-integration-runtime",
       actions: codingToolsPlugin.actions ?? [],
       getSetting: (_key: string) => undefined,
       getService: (key: string) => services.get(key) ?? null,

--- a/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
@@ -20,6 +20,7 @@ async function makeHostRuntime(): Promise<IAgentRuntime> {
   const services = new Map<string, unknown>();
   const runtime = {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    runtimeInstanceId: "coding-tools-error-path-runtime",
     getSetting: vi.fn(() => undefined),
     getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
     redactSecrets: vi.fn((text: string) => text),

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -576,6 +576,7 @@ describeIfPosix("shellAction", () => {
     expect(result.text).not.toContain("--- stdout ---\nlocal shell output");
     expect(calls).toHaveLength(1);
     expect(calls[0]?.command).toBe("echo local shell output");
+    expect(result.data?.workspaceDeltaReceipt).toBeUndefined();
   });
 
   it("runs a simple foreground command (echo hello)", async () => {
@@ -2036,6 +2037,99 @@ describeIfPosix("shellAction", () => {
     const data = result.data as Record<string, unknown> | undefined;
     expect(data?.command).toBe("exit 7");
     expect(data?.exit_code).toBe(7);
+  });
+
+  it("retains an observed worktree mutation when the command later fails", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-shell-delta-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "user.name=Test",
+          "-c",
+          "user.email=test@example.com",
+          "commit",
+          "--allow-empty",
+          "-qm",
+          "initial",
+        ],
+        { cwd: root },
+      );
+      const { runtime, session } = await makeRuntime({
+        workspaceRoots: root,
+      });
+      const message = makeMessage();
+      session.setCwd(String(message.roomId), root);
+
+      const result = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          command: "printf 'generated\\n' > generated.txt; exit 7",
+        }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "changed",
+        scope: {
+          root: await fs.realpath(root),
+          coverage: "tracked_and_untracked_nonignored",
+        },
+      });
+      expect(JSON.stringify(result.data?.workspaceDeltaReceipt)).not.toContain(
+        "generated\\n",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retains an observed worktree mutation when the command times out", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-shell-timeout-delta-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      await execFileAsync(
+        "git",
+        [
+          "-c",
+          "user.name=Test",
+          "-c",
+          "user.email=test@example.com",
+          "commit",
+          "--allow-empty",
+          "-qm",
+          "initial",
+        ],
+        { cwd: root },
+      );
+      const { runtime, session } = await makeRuntime({ workspaceRoots: root });
+      const message = makeMessage();
+      session.setCwd(String(message.roomId), root);
+
+      const result = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          command: "printf 'generated\\n' > timed-out.txt; sleep 5",
+          timeout: 200,
+        }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("timeout");
+      expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "changed",
+        scope: {
+          root: await fs.realpath(root),
+          coverage: "tracked_and_untracked_nonignored",
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("returns command_failed when an earlier pipeline command fails", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -576,7 +576,70 @@ describeIfPosix("shellAction", () => {
     expect(result.text).not.toContain("--- stdout ---\nlocal shell output");
     expect(calls).toHaveLength(1);
     expect(calls[0]?.command).toBe("echo local shell output");
-    expect(result.data?.workspaceDeltaReceipt).toBeUndefined();
+    expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+    });
+  });
+
+  it.each([
+    {
+      name: "dispatch exception",
+      run: async () => {
+        throw new Error("remote dispatch failed");
+      },
+    },
+    {
+      name: "complete-capture overflow",
+      run: async () => ({
+        output: "x".repeat(1_000_001),
+        exitCode: 0,
+        timedOut: false,
+      }),
+    },
+  ])("fails conservatively with a routed receipt on $name", async ({ run }) => {
+    const { runtime } = await makeRuntime({
+      capabilityRouter: makeShellRouter(run),
+    });
+    const result = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: "node generate.js",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+    });
+  });
+
+  it("preserves the receipt when transcript callback delivery fails", async () => {
+    process.env.ELIZA_SHELL_ECHO_TRANSCRIPT = "1";
+    const router = makeShellRouter(async () => ({
+      output: "done\n",
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime } = await makeRuntime({ capabilityRouter: router });
+    const result = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        makeMessage(),
+        undefined,
+        { command: "node generate.js" },
+        async () => {
+          throw new Error("callback unavailable");
+        },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("callback failed");
+    expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+    });
   });
 
   it("runs a simple foreground command (echo hello)", async () => {
@@ -875,6 +938,41 @@ describeIfPosix("shellAction", () => {
     expect(killed?.success).toBe(true);
     expect(killed?.text).toContain("status=killed");
     expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it("carries a pending receipt until a background mutation is observed", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-background-delta-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      const { runtime, session } = await makeRuntime({ workspaceRoots: root });
+      const message = makeMessage();
+      session.setCwd(String(message.roomId), root);
+      const start = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          action: "start_background",
+          command: `printf 'generated\\n' > '${path.join(root, "generated.txt")}'; sleep 1`,
+        }),
+      );
+      expect(start.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "indeterminate",
+        reasonCode: "BACKGROUND_RECEIPT_PENDING",
+      });
+      const handle = (start.data as Record<string, unknown>).handle as string;
+      const settled = await pollUntil(
+        runtime,
+        message,
+        handle,
+        (data) => data.status === "exited",
+      );
+      expect(settled.data?.workspaceDeltaReceipt).toMatchObject({
+        outcome: "changed",
+        scope: { root: await fs.realpath(root) },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("returns incremental background output using stream offsets", async () => {
@@ -2067,7 +2165,7 @@ describeIfPosix("shellAction", () => {
 
       const result = requireActionResult(
         await shellAction.handler?.(runtime, message, undefined, {
-          command: "printf 'generated\\n' > generated.txt; exit 7",
+          command: `printf 'generated\\n' > '${path.join(root, "generated.txt")}'; exit 7`,
         }),
       );
 
@@ -2113,7 +2211,7 @@ describeIfPosix("shellAction", () => {
 
       const result = requireActionResult(
         await shellAction.handler?.(runtime, message, undefined, {
-          command: "printf 'generated\\n' > timed-out.txt; sleep 5",
+          command: `printf 'generated\\n' > '${path.join(root, "timed-out.txt")}'; sleep 5`,
           timeout: 200,
         }),
       );

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -23,6 +23,7 @@ import {
   UnavailableCapabilityRouter,
   type UUID,
 } from "@elizaos/core";
+import { __codingMutationRequiresVerificationForTests } from "@elizaos/core/runtime/planner-loop";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // These tests exercise the SHELL action through `pwd`, `cd`, `git -C`, and
@@ -258,7 +259,14 @@ async function waitForBackgroundToSettle(
     const session = service
       .list(conversationId)
       .find((candidate) => candidate.handle === handle);
-    if (session && session.status !== "running") return;
+    if (
+      session &&
+      (session.status === "exited" ||
+        session.status === "killed" ||
+        session.status === "error")
+    ) {
+      return;
+    }
     await delay(50);
   }
   throw new Error(`background shell ${handle} did not settle`);
@@ -606,6 +614,107 @@ describeIfPosix("shellAction", () => {
       reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
       scope: workspaceExecution,
     });
+  });
+
+  it("carries real routed receipts through SHELL and planner scope matching", async () => {
+    const workspaceExecution = {
+      root: "/remote/workspace",
+      rootId: "a".repeat(64),
+      executionDomainId: "b".repeat(64),
+    };
+    const receipt = (outcome: "changed" | "unchanged") => ({
+      version: 1 as const,
+      kind: "workspace_delta" as const,
+      scope: {
+        kind: "git_worktree" as const,
+        ...workspaceExecution,
+        coverage: "tracked_and_untracked_nonignored" as const,
+      },
+      outcome,
+      beforeFingerprint: "c".repeat(64),
+      afterFingerprint: (outcome === "changed" ? "d" : "c").repeat(64),
+      observedAt: "2026-08-23T12:00:00.000Z",
+    });
+    let routedCall = 0;
+    const router = makeShellRouter(async () => {
+      routedCall += 1;
+      if (routedCall === 2) {
+        throw new CapabilityError({
+          code: "CAPABILITY_UNAVAILABLE",
+          message: "use local host",
+          capability: "pty",
+          method: "pty.command.run",
+        });
+      }
+      const workspaceDeltaReceipt = receipt(
+        routedCall === 1 ? "changed" : "unchanged",
+      );
+      return {
+        output: "remote ok\n",
+        exitCode: 0,
+        timedOut: false,
+        workspaceExecution,
+        workspaceDeltaReceipt,
+      };
+    });
+    const localRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "routed-receipt-local-domain-"),
+    );
+    await execFileAsync("git", ["init", "-q"], { cwd: localRoot });
+    const { runtime, session } = await makeRuntime({
+      capabilityRouter: router,
+    });
+    const message = makeMessage(undefined, "Mutate and verify remotely.");
+    session.setCwd(String(message.roomId), localRoot);
+    const execute = (command: string) =>
+      executePlannedToolCall(
+        runtime,
+        { message, activeContexts: ["code"], userRoles: ["OWNER"] },
+        { name: "SHELL", params: { command } },
+      );
+    const steps = [
+      {
+        toolCall: { name: "SHELL", params: { command: "node mutate.js" } },
+        result: await execute("node mutate.js"),
+      },
+    ];
+    const trajectory = { steps, archivedSteps: [] } as unknown as Parameters<
+      typeof __codingMutationRequiresVerificationForTests
+    >[0];
+    expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(true);
+    steps.push({
+      toolCall: { name: "SHELL", params: { command: "bun test --help" } },
+      result: await execute("bun test --help"),
+    });
+    expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(true);
+    steps.push({
+      toolCall: { name: "SHELL", params: { command: "bun test" } },
+      result: await execute("bun test"),
+    });
+    expect(steps.map((step) => step.result.success)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect(
+      steps.map(
+        (step) =>
+          (step.result.data as Record<string, unknown> | undefined)
+            ?.workspaceDeltaReceipt,
+      ),
+    ).toMatchObject([
+      { outcome: "changed", scope: workspaceExecution },
+      {
+        outcome: "unchanged",
+        scope: { rootId: expect.not.stringMatching(/^a+$/) },
+      },
+      { outcome: "unchanged", scope: workspaceExecution },
+    ]);
+    expect(__codingMutationRequiresVerificationForTests(trajectory)).toBe(
+      false,
+    );
+    expect(routedCall).toBe(3);
+    await fs.rm(localRoot, { recursive: true, force: true });
   });
 
   it.each([
@@ -1020,7 +1129,7 @@ describeIfPosix("shellAction", () => {
           runtime,
           message,
           undefined,
-          { action: "start_background", command: "sleep 0.05" },
+          { action: "start_background", command: "true" },
           callbackFailure,
         ),
       );
@@ -1029,7 +1138,7 @@ describeIfPosix("shellAction", () => {
         action: "start_background",
         handle: expect.stringMatching(/^bgsh_/),
         workspaceDeltaReceipt: {
-          reasonCode: "BACKGROUND_RECEIPT_PENDING",
+          operation: { handle: expect.stringMatching(/^bgsh_/) },
         },
       });
       const handle = (started.data as Record<string, unknown>).handle as string;
@@ -1095,7 +1204,7 @@ describeIfPosix("shellAction", () => {
     }
   });
 
-  it("finalizes a mutation receipt before rejecting background output overflow", async () => {
+  it("waits for overflow termination before snapshotting descendant late mutation", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "coding-tools-background-overflow-"),
     );
@@ -1110,10 +1219,33 @@ describeIfPosix("shellAction", () => {
       const started = requireActionResult(
         await shellAction.handler?.(runtime, message, undefined, {
           action: "start_background",
-          command: "printf changed > generated.txt; printf 123456",
+          command:
+            "trap 'sleep 0.15; printf late > generated.txt; exit 0' TERM; printf 123456; while :; do sleep 1; done",
         }),
       );
       const handle = (started.data as Record<string, unknown>).handle as string;
+      let terminating:
+        | Awaited<ReturnType<BackgroundShellService["inspect"]>>
+        | undefined;
+      for (let attempt = 0; attempt < 30; attempt += 1) {
+        const candidate = await backgroundShell.inspect({
+          conversationId: String(message.roomId),
+          handle,
+        });
+        if (candidate.status === "terminating") {
+          terminating = candidate;
+          break;
+        }
+        await delay(10);
+      }
+      expect(terminating).toMatchObject({
+        status: "terminating",
+        endedAt: null,
+        workspaceDeltaReceipt: {
+          reasonCode: "BACKGROUND_RECEIPT_PENDING",
+          operation: { handle, status: "terminating" },
+        },
+      });
       await waitForBackgroundToSettle(
         backgroundShell,
         String(message.roomId),
@@ -1132,7 +1264,7 @@ describeIfPosix("shellAction", () => {
         handle,
         workspaceDeltaReceipt: {
           outcome: "changed",
-          operation: { handle },
+          operation: { handle, status: "error" },
         },
       });
     } finally {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -582,6 +582,32 @@ describeIfPosix("shellAction", () => {
     });
   });
 
+  it("binds a routed receipt to an attested execution domain and opaque root", async () => {
+    const workspaceExecution = {
+      root: "/remote/workspace",
+      rootId: "a".repeat(64),
+      executionDomainId: "b".repeat(64),
+    };
+    const router = makeShellRouter(async () => ({
+      output: "remote\n",
+      exitCode: 0,
+      timedOut: false,
+      workspaceExecution,
+    }));
+    const { runtime } = await makeRuntime({ capabilityRouter: router });
+    const result = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: "node generate.js",
+      }),
+    );
+
+    expect(result.data?.workspaceDeltaReceipt).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "REMOTE_EXECUTION_UNOBSERVED",
+      scope: workspaceExecution,
+    });
+  });
+
   it.each([
     {
       name: "dispatch exception",
@@ -969,6 +995,145 @@ describeIfPosix("shellAction", () => {
       expect(settled.data?.workspaceDeltaReceipt).toMatchObject({
         outcome: "changed",
         scope: { root: await fs.realpath(root) },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves background ownership and final receipts across callback failures", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-background-callback-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      const { runtime, session, backgroundShell } = await makeRuntime({
+        workspaceRoots: root,
+      });
+      const message = makeMessage();
+      session.setCwd(String(message.roomId), root);
+      const callbackFailure = async () => {
+        throw new Error("callback unavailable");
+      };
+      const started = requireActionResult(
+        await shellAction.handler?.(
+          runtime,
+          message,
+          undefined,
+          { action: "start_background", command: "sleep 0.05" },
+          callbackFailure,
+        ),
+      );
+      expect(started.success).toBe(false);
+      expect(started.data).toMatchObject({
+        action: "start_background",
+        handle: expect.stringMatching(/^bgsh_/),
+        workspaceDeltaReceipt: {
+          reasonCode: "BACKGROUND_RECEIPT_PENDING",
+        },
+      });
+      const handle = (started.data as Record<string, unknown>).handle as string;
+      await waitForBackgroundToSettle(
+        backgroundShell,
+        String(message.roomId),
+        handle,
+      );
+      const polled = requireActionResult(
+        await shellAction.handler?.(
+          runtime,
+          message,
+          undefined,
+          { action: "poll_background", handle },
+          callbackFailure,
+        ),
+      );
+      expect(polled.success).toBe(false);
+      expect(polled.data).toMatchObject({
+        action: "poll_background",
+        handle,
+        status: "exited",
+        workspaceDeltaReceipt: {
+          outcome: expect.stringMatching(/^(?:unchanged|indeterminate)$/),
+          operation: { handle },
+        },
+      });
+      expect(
+        (
+          (polled.data as Record<string, unknown>)
+            .workspaceDeltaReceipt as Record<string, unknown>
+        ).reasonCode,
+      ).not.toBe("BACKGROUND_RECEIPT_PENDING");
+
+      const second = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          action: "start_background",
+          command: "sleep 5",
+        }),
+      );
+      const secondHandle = (second.data as Record<string, unknown>)
+        .handle as string;
+      const killed = requireActionResult(
+        await shellAction.handler?.(
+          runtime,
+          message,
+          undefined,
+          { action: "kill_background", handle: secondHandle },
+          callbackFailure,
+        ),
+      );
+      expect(killed.success).toBe(false);
+      expect(killed.data).toMatchObject({
+        action: "kill_background",
+        handle: secondHandle,
+        status: "killed",
+        workspaceDeltaReceipt: {
+          operation: { handle: secondHandle },
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("finalizes a mutation receipt before rejecting background output overflow", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-background-overflow-"),
+    );
+    try {
+      await execFileAsync("git", ["init", "-q"], { cwd: root });
+      const { runtime, session, backgroundShell } = await makeRuntime({
+        workspaceRoots: root,
+        backgroundBufferChars: 5,
+      });
+      const message = makeMessage();
+      session.setCwd(String(message.roomId), root);
+      const started = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          action: "start_background",
+          command: "printf changed > generated.txt; printf 123456",
+        }),
+      );
+      const handle = (started.data as Record<string, unknown>).handle as string;
+      await waitForBackgroundToSettle(
+        backgroundShell,
+        String(message.roomId),
+        handle,
+      );
+      const poll = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          action: "poll_background",
+          handle,
+        }),
+      );
+
+      expect(poll.success).toBe(false);
+      expect(poll.data).toMatchObject({
+        action: "poll_background",
+        handle,
+        workspaceDeltaReceipt: {
+          outcome: "changed",
+          operation: { handle },
+        },
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -2634,7 +2799,13 @@ describeIfPosix("shellAction", () => {
     expect(poll.text).toContain("no partial output is available");
     expect(JSON.stringify(poll)).not.toContain("mari");
     expect(JSON.stringify(poll)).not.toContain("gold9");
-    expect(poll.data).toBeUndefined();
+    expect(poll.data).toMatchObject({
+      action: "poll_background",
+      handle,
+      workspaceDeltaReceipt: {
+        operation: { kind: "background_shell", handle },
+      },
+    });
   });
 
   it("preserves same-stream event boundaries around harmless bytes", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -41,6 +41,7 @@ import { runShell } from "../lib/run-shell.js";
 import { persistShellOutputArtifact } from "../lib/shell-output-artifact.js";
 import { availableToolsProvider } from "../providers/available-tools.js";
 import {
+  BackgroundShellReapTimeoutError,
   BackgroundShellService,
   SandboxService,
   SessionCwdService,
@@ -128,6 +129,8 @@ interface RuntimeOptions {
   withShellHistoryService?: boolean;
   capabilityRouter?: ElizaCapabilityRouter;
   backgroundBufferChars?: number;
+  backgroundKillGraceMs?: number;
+  backgroundReapWaitMs?: number;
   configuredSecret?: string;
 }
 
@@ -161,6 +164,12 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
     settings.CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS =
       opts.backgroundBufferChars;
   }
+  if (opts.backgroundKillGraceMs !== undefined)
+    settings.CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS =
+      opts.backgroundKillGraceMs;
+  if (opts.backgroundReapWaitMs !== undefined)
+    settings.CODING_TOOLS_BACKGROUND_SHELL_REAP_WAIT_MS =
+      opts.backgroundReapWaitMs;
 
   const services = new Map<string, unknown>();
   const character = {
@@ -172,6 +181,7 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
   const secretOwner = new AgentRuntime({ character });
   const runtime = {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    runtimeInstanceId: secretOwner.runtimeInstanceId,
     actions: [shellAction],
     character,
     getSetting: vi.fn((key: string) => settings[key]),
@@ -1270,6 +1280,140 @@ describeIfPosix("shellAction", () => {
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("escalates overflow from TERM to KILL and reaps a TERM-ignoring process", async () => {
+    const { runtime, backgroundShell } = await makeRuntime({
+      backgroundBufferChars: 5,
+      backgroundKillGraceMs: 50,
+      backgroundReapWaitMs: 500,
+    });
+    const message = makeMessage();
+    const startedAt = Date.now();
+    const started = requireActionResult(
+      await shellAction.handler?.(runtime, message, undefined, {
+        action: "start_background",
+        command: "trap '' TERM; printf 123456; while :; do sleep 1; done",
+      }),
+    );
+    const handle = (started.data as Record<string, unknown>).handle as string;
+    await waitForBackgroundToSettle(
+      backgroundShell,
+      String(message.roomId),
+      handle,
+    );
+    const settled = await backgroundShell.inspect({
+      conversationId: String(message.roomId),
+      handle,
+    });
+    expect(Date.now() - startedAt).toBeLessThan(1_500);
+    expect(settled).toMatchObject({
+      status: "error",
+      endedAt: expect.any(Number),
+      signal: "SIGKILL",
+      workspaceDeltaReceipt: {
+        operation: { handle, status: "error" },
+      },
+    });
+  });
+
+  it("bounds explicit kill while escalating a TERM-ignoring process", async () => {
+    const { runtime } = await makeRuntime({
+      backgroundKillGraceMs: 50,
+      backgroundReapWaitMs: 500,
+    });
+    const message = makeMessage();
+    const started = requireActionResult(
+      await shellAction.handler?.(runtime, message, undefined, {
+        action: "start_background",
+        command: "trap '' TERM; printf ready; while :; do sleep 1; done",
+      }),
+    );
+    const handle = (started.data as Record<string, unknown>).handle as string;
+    await pollUntil(runtime, message, handle, (_data, text) =>
+      text.includes("ready"),
+    );
+    const startedAt = Date.now();
+    const killed = requireActionResult(
+      await shellAction.handler?.(runtime, message, undefined, {
+        action: "kill_background",
+        handle,
+      }),
+    );
+    expect(Date.now() - startedAt).toBeLessThan(1_500);
+    expect(killed.data).toMatchObject({
+      handle,
+      status: "killed",
+      workspaceDeltaReceipt: {
+        operation: { handle, status: "killed" },
+      },
+    });
+  });
+
+  it("retains a pending receipt when close cannot prove reap before the deadline", async () => {
+    const { runtime, backgroundShell } = await makeRuntime({
+      backgroundKillGraceMs: 30,
+      backgroundReapWaitMs: 80,
+    });
+    const message = makeMessage();
+    const started = requireActionResult(
+      await shellAction.handler?.(runtime, message, undefined, {
+        action: "start_background",
+        command: "trap '' TERM; printf ready; while :; do sleep 1; done",
+      }),
+    );
+    const handle = (started.data as Record<string, unknown>).handle as string;
+    await pollUntil(runtime, message, handle, (_data, text) =>
+      text.includes("ready"),
+    );
+    type CloseListener = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ) => void;
+    type CloseControlledProcess = {
+      rawListeners(event: "close"): CloseListener[];
+      removeAllListeners(event: "close"): void;
+      once(event: "close", listener: CloseListener): CloseControlledProcess;
+    };
+    const internal = backgroundShell as unknown as {
+      sessions: Map<string, { process: CloseControlledProcess }>;
+    };
+    const process = internal.sessions.get(handle)?.process;
+    if (!process) throw new Error("background process unavailable");
+    const closeListeners = process.rawListeners("close");
+    const originalOnce = process.once.bind(process);
+    process.removeAllListeners("close");
+    process.once = () => process;
+
+    await expect(
+      backgroundShell.kill({
+        conversationId: String(message.roomId),
+        handle,
+      }),
+    ).rejects.toBeInstanceOf(BackgroundShellReapTimeoutError);
+    expect(
+      await backgroundShell.inspect({
+        conversationId: String(message.roomId),
+        handle,
+      }),
+    ).toMatchObject({
+      status: "terminating",
+      endedAt: null,
+      workspaceDeltaReceipt: {
+        outcome: "indeterminate",
+        reasonCode: "BACKGROUND_RECEIPT_PENDING",
+        operation: { handle, status: "terminating" },
+      },
+    });
+
+    process.once = originalOnce;
+    for (const listener of closeListeners) listener(null, "SIGKILL");
+    expect(
+      await backgroundShell.inspect({
+        conversationId: String(message.roomId),
+        handle,
+      }),
+    ).toMatchObject({ status: "killed", endedAt: expect.any(Number) });
   });
 
   it("returns incremental background output using stream offsets", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -47,6 +47,7 @@ import {
   beginLocalWorkspaceDeltaObservation,
   finishLocalWorkspaceDeltaObservation,
   indeterminateWorkspaceDeltaReceipt,
+  runtimeWorkspaceExecutionDomainId,
   unattestedRemoteWorkspaceScope,
   workspaceDeltaResultData,
 } from "../lib/workspace-delta.js";
@@ -1554,6 +1555,8 @@ export const shellAction: Action = {
           return successActionResult(text, {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "write_background",
+            handle: session.handle,
+            status: session.status,
             session: redactedBackgroundSession(runtime, session),
             ...redactedWorkspaceDeltaResultData(
               runtime,
@@ -1575,6 +1578,8 @@ export const shellAction: Action = {
           return successActionResult(text, {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "kill_background",
+            handle: session.handle,
+            status: session.status,
             session: redactedBackgroundSession(runtime, session),
             ...redactedWorkspaceDeltaResultData(
               runtime,
@@ -1954,8 +1959,10 @@ export const shellAction: Action = {
           message: "Background shell service unavailable.",
         });
       }
-      const backgroundObservation =
-        await beginLocalWorkspaceDeltaObservation(cwd);
+      const backgroundObservation = await beginLocalWorkspaceDeltaObservation(
+        cwd,
+        { executionDomainId: runtimeWorkspaceExecutionDomainId(runtime) },
+      );
       let startedSession:
         | ReturnType<BackgroundShellService["startSession"]>
         | undefined;
@@ -2058,7 +2065,12 @@ export const shellAction: Action = {
     // remotely receives an indeterminate receipt instead of pairing remote
     // execution with this local snapshot.
     const capabilityRouterPresent = getCapabilityRouter(runtime) !== null;
-    const workspaceObservation = await beginLocalWorkspaceDeltaObservation(cwd);
+    const workspaceObservation = await beginLocalWorkspaceDeltaObservation(
+      cwd,
+      {
+        executionDomainId: runtimeWorkspaceExecutionDomainId(runtime),
+      },
+    );
     const startedAt = Date.now();
     const mode = resolveRuntimeExecutionMode(runtime);
     coreLogger.info(
@@ -2094,10 +2106,11 @@ export const shellAction: Action = {
 
     const workspaceDelta =
       result.sandbox === "capability-router"
-        ? indeterminateWorkspaceDeltaReceipt(
+        ? (result.workspaceDeltaReceipt ??
+          indeterminateWorkspaceDeltaReceipt(
             result.workspaceExecution ?? unattestedRemoteWorkspaceScope(cwd),
             "REMOTE_EXECUTION_UNOBSERVED",
-          )
+          ))
         : await finishLocalWorkspaceDeltaObservation(workspaceObservation);
     const workspaceDeltaData = redactedWorkspaceDeltaResultData(
       runtime,

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -47,9 +47,14 @@ import {
   beginLocalWorkspaceDeltaObservation,
   finishLocalWorkspaceDeltaObservation,
   indeterminateWorkspaceDeltaReceipt,
+  unattestedRemoteWorkspaceScope,
   workspaceDeltaResultData,
 } from "../lib/workspace-delta.js";
-import type { BackgroundShellService } from "../services/background-shell-service.js";
+import {
+  type BackgroundShellService,
+  type BackgroundShellSessionSnapshot,
+  BackgroundShellStartError,
+} from "../services/background-shell-service.js";
 import type { SandboxService } from "../services/sandbox-service.js";
 import type { SessionCwdService } from "../services/session-cwd-service.js";
 import { redactShellText } from "../shell/redaction.js";
@@ -87,6 +92,22 @@ function redactedWorkspaceDeltaResultData(
         }
       : undefined,
   );
+}
+
+function redactedBackgroundSession(
+  runtime: IAgentRuntime,
+  session: BackgroundShellSessionSnapshot,
+): BackgroundShellSessionSnapshot {
+  const redactedReceipt = session.workspaceDeltaReceipt
+    ? (redactedWorkspaceDeltaResultData(runtime, session.workspaceDeltaReceipt)
+        .workspaceDeltaReceipt as WorkspaceDeltaReceipt)
+    : undefined;
+  return {
+    ...session,
+    command: redactShellText(runtime, session.command),
+    cwd: redactShellText(runtime, session.cwd),
+    ...(redactedReceipt ? { workspaceDeltaReceipt: redactedReceipt } : {}),
+  };
 }
 
 type ShellActionSubaction =
@@ -1477,7 +1498,9 @@ export const shellAction: Action = {
       }
       try {
         if (subaction === "list_background") {
-          const sessions = backgroundShell.list(conversationId);
+          const sessions = backgroundShell
+            .list(conversationId)
+            .map((session) => redactedBackgroundSession(runtime, session));
           const lines = sessions.length
             ? sessions
                 .map((session) =>
@@ -1531,7 +1554,7 @@ export const shellAction: Action = {
           return successActionResult(text, {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "write_background",
-            session,
+            session: redactedBackgroundSession(runtime, session),
             ...redactedWorkspaceDeltaResultData(
               runtime,
               session.workspaceDeltaReceipt,
@@ -1552,7 +1575,7 @@ export const shellAction: Action = {
           return successActionResult(text, {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "kill_background",
-            session,
+            session: redactedBackgroundSession(runtime, session),
             ...redactedWorkspaceDeltaResultData(
               runtime,
               session.workspaceDeltaReceipt,
@@ -1597,6 +1620,8 @@ export const shellAction: Action = {
           actionName: "SHELL",
           [CANONICAL_SUBACTION_KEY]: "poll_background",
           ...poll,
+          command: redactShellText(runtime, poll.command),
+          cwd: redactShellText(runtime, poll.cwd),
           ...redactedWorkspaceDeltaResultData(
             runtime,
             poll.workspaceDeltaReceipt,
@@ -1606,10 +1631,43 @@ export const shellAction: Action = {
         // error-policy:J1 SHELL action boundary; background session lookup and
         // process-control failures are returned to the planner as structured
         // tool failures.
-        return failureToActionResult({
-          reason: "internal",
-          message: redactShellText(runtime, (err as Error).message),
-        });
+        const failedHandle = readStringParam(options, "handle");
+        let latest: BackgroundShellSessionSnapshot | undefined;
+        if (failedHandle) {
+          try {
+            latest = await backgroundShell.inspect({
+              conversationId,
+              handle: failedHandle,
+            });
+          } catch (inspectionError) {
+            // error-policy:J1 Secondary inspection enriches the original
+            // boundary failure; inability to inspect cannot replace it.
+            coreLogger.warn(
+              `${CODING_TOOLS_LOG_PREFIX} failed to inspect background SHELL ${failedHandle}: ${redactShellText(runtime, inspectionError instanceof Error ? inspectionError.message : String(inspectionError))}`,
+            );
+          }
+        }
+        return failureToActionResult(
+          {
+            reason: "internal",
+            message: redactShellText(runtime, (err as Error).message),
+          },
+          {
+            actionName: "SHELL",
+            [CANONICAL_SUBACTION_KEY]: subaction,
+            ...(failedHandle ? { handle: failedHandle } : {}),
+            ...(latest
+              ? {
+                  status: latest.status,
+                  session: redactedBackgroundSession(runtime, latest),
+                }
+              : {}),
+            ...redactedWorkspaceDeltaResultData(
+              runtime,
+              latest?.workspaceDeltaReceipt,
+            ),
+          },
+        );
       }
     }
 
@@ -1928,7 +1986,7 @@ export const shellAction: Action = {
           command: redactedCommand,
           cwd: redactedCwd,
           handle: session.handle,
-          session,
+          session: redactedBackgroundSession(runtime, session),
           execution_route: session.sandbox === "host" ? "host" : "sandbox",
           sandbox_backend: session.sandbox,
           ...redactedWorkspaceDeltaResultData(
@@ -1940,8 +1998,26 @@ export const shellAction: Action = {
         // error-policy:J1 SHELL action boundary; unsupported execution backends
         // and spawn failures must be visible to the planner instead of falling
         // back to a host-spawned process.
+        const failedHandle =
+          startedSession?.handle ??
+          (err instanceof BackgroundShellStartError ? err.handle : undefined);
+        let latest = startedSession;
+        if (failedHandle) {
+          try {
+            latest = await backgroundShell.inspect({
+              conversationId,
+              handle: failedHandle,
+            });
+          } catch (inspectionError) {
+            // error-policy:J1 Secondary inspection enriches the original
+            // boundary failure; the retained start snapshot remains authority.
+            coreLogger.warn(
+              `${CODING_TOOLS_LOG_PREFIX} failed to inspect background SHELL ${failedHandle}: ${redactShellText(runtime, inspectionError instanceof Error ? inspectionError.message : String(inspectionError))}`,
+            );
+          }
+        }
         const workspaceDelta =
-          startedSession?.workspaceDeltaReceipt ??
+          latest?.workspaceDeltaReceipt ??
           (await finishLocalWorkspaceDeltaObservation(backgroundObservation));
         return failureToActionResult(
           {
@@ -1949,8 +2025,17 @@ export const shellAction: Action = {
             message: redactShellText(runtime, (err as Error).message),
           },
           {
+            actionName: "SHELL",
+            [CANONICAL_SUBACTION_KEY]: "start_background",
             command: redactShellText(runtime, command),
             cwd: redactedCwd,
+            ...(latest
+              ? {
+                  handle: latest.handle,
+                  status: latest.status,
+                  session: redactedBackgroundSession(runtime, latest),
+                }
+              : {}),
             ...redactedWorkspaceDeltaResultData(runtime, workspaceDelta),
           },
         );
@@ -1994,7 +2079,7 @@ export const shellAction: Action = {
       );
       const workspaceDelta = capabilityRouterPresent
         ? indeterminateWorkspaceDeltaReceipt(
-            workspaceObservation?.root ?? cwd,
+            unattestedRemoteWorkspaceScope(cwd),
             "REMOTE_EXECUTION_UNOBSERVED",
           )
         : await finishLocalWorkspaceDeltaObservation(workspaceObservation);
@@ -2010,7 +2095,7 @@ export const shellAction: Action = {
     const workspaceDelta =
       result.sandbox === "capability-router"
         ? indeterminateWorkspaceDeltaReceipt(
-            workspaceObservation?.root ?? cwd,
+            result.workspaceExecution ?? unattestedRemoteWorkspaceScope(cwd),
             "REMOTE_EXECUTION_UNOBSERVED",
           )
         : await finishLocalWorkspaceDeltaObservation(workspaceObservation);

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -14,10 +14,12 @@ import {
   type ActionResult,
   CANONICAL_SUBACTION_KEY,
   logger as coreLogger,
+  getCapabilityRouter,
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
   type State,
+  type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
 import {
@@ -41,6 +43,11 @@ import {
   type ShellOutputArtifactStream,
 } from "../lib/shell-output-artifact.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
+import {
+  beginLocalWorkspaceDeltaObservation,
+  finishLocalWorkspaceDeltaObservation,
+  workspaceDeltaResultData,
+} from "../lib/workspace-delta.js";
 import type { BackgroundShellService } from "../services/background-shell-service.js";
 import type { SandboxService } from "../services/sandbox-service.js";
 import type { SessionCwdService } from "../services/session-cwd-service.js";
@@ -63,6 +70,23 @@ const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
 const COINGECKO_SIMPLE_PRICE_BASE =
   "https://api.coingecko.com/api/v3/simple/price";
+
+function redactedWorkspaceDeltaResultData(
+  runtime: IAgentRuntime,
+  receipt: WorkspaceDeltaReceipt | undefined,
+): Record<string, unknown> {
+  return workspaceDeltaResultData(
+    receipt
+      ? {
+          ...receipt,
+          scope: {
+            ...receipt.scope,
+            root: redactShellText(runtime, receipt.scope.root),
+          },
+        }
+      : undefined,
+  );
+}
 
 type ShellActionSubaction =
   | "run"
@@ -1916,6 +1940,12 @@ export const shellAction: Action = {
       `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch configuration`,
     );
 
+    // A remote PTY may execute on a different machine from this process. Never
+    // pair that execution with a local Git snapshot and call it authoritative;
+    // remote receipts must eventually come from the executing capability.
+    const workspaceObservation = getCapabilityRouter(runtime)
+      ? undefined
+      : await beginLocalWorkspaceDeltaObservation(cwd);
     const startedAt = Date.now();
     const mode = resolveRuntimeExecutionMode(runtime);
     coreLogger.info(
@@ -1934,11 +1964,23 @@ export const shellAction: Action = {
       coreLogger.error(
         `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch failed: ${message}`,
       );
+      const workspaceDelta =
+        await finishLocalWorkspaceDeltaObservation(workspaceObservation);
       return failureToActionResult(
         { reason: "internal", message },
-        { cwd: redactedCwd },
+        {
+          cwd: redactedCwd,
+          ...redactedWorkspaceDeltaResultData(runtime, workspaceDelta),
+        },
       );
     }
+
+    const workspaceDelta =
+      await finishLocalWorkspaceDeltaObservation(workspaceObservation);
+    const workspaceDeltaData = redactedWorkspaceDeltaResultData(
+      runtime,
+      workspaceDelta,
+    );
 
     const took = Date.now() - startedAt;
     if (result.outputLimitExceeded) {
@@ -1948,7 +1990,11 @@ export const shellAction: Action = {
           message:
             "command output exceeded the 1,000,000-character complete-capture safety limit; no partial output is available",
         },
-        { command: redactShellText(runtime, command), cwd: redactedCwd },
+        {
+          command: redactShellText(runtime, command),
+          cwd: redactedCwd,
+          ...workspaceDeltaData,
+        },
       );
     }
     const timedOut = result.timedOut;
@@ -1984,6 +2030,7 @@ export const shellAction: Action = {
           cwd: redactedCwd,
           output: text,
           output_truncated: false,
+          ...workspaceDeltaData,
         },
       );
     }
@@ -1999,6 +2046,7 @@ export const shellAction: Action = {
           cwd: redactedCwd,
           output: text,
           output_truncated: false,
+          ...workspaceDeltaData,
         },
       );
     }
@@ -2010,6 +2058,7 @@ export const shellAction: Action = {
       sandbox_backend: result.sandbox,
       signal,
       output_truncated: false,
+      ...workspaceDeltaData,
     });
     // The crypto / disk / memory / status projections are CHAT conveniences
     // keyed on the *message text*, and the coding sub-agent's message text is

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -46,6 +46,7 @@ import { resolveHostShell } from "../lib/terminal-capabilities.js";
 import {
   beginLocalWorkspaceDeltaObservation,
   finishLocalWorkspaceDeltaObservation,
+  indeterminateWorkspaceDeltaReceipt,
   workspaceDeltaResultData,
 } from "../lib/workspace-delta.js";
 import type { BackgroundShellService } from "../services/background-shell-service.js";
@@ -1531,6 +1532,10 @@ export const shellAction: Action = {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "write_background",
             session,
+            ...redactedWorkspaceDeltaResultData(
+              runtime,
+              session.workspaceDeltaReceipt,
+            ),
           });
         }
 
@@ -1548,10 +1553,14 @@ export const shellAction: Action = {
             actionName: "SHELL",
             [CANONICAL_SUBACTION_KEY]: "kill_background",
             session,
+            ...redactedWorkspaceDeltaResultData(
+              runtime,
+              session.workspaceDeltaReceipt,
+            ),
           });
         }
 
-        const poll = backgroundShell.poll({
+        const poll = await backgroundShell.poll({
           conversationId,
           handle,
           stdoutOffset: readNonNegativeOffset(options, "stdout_offset"),
@@ -1588,6 +1597,10 @@ export const shellAction: Action = {
           actionName: "SHELL",
           [CANONICAL_SUBACTION_KEY]: "poll_background",
           ...poll,
+          ...redactedWorkspaceDeltaResultData(
+            runtime,
+            poll.workspaceDeltaReceipt,
+          ),
         });
       } catch (err) {
         // error-policy:J1 SHELL action boundary; background session lookup and
@@ -1883,12 +1896,19 @@ export const shellAction: Action = {
           message: "Background shell service unavailable.",
         });
       }
+      const backgroundObservation =
+        await beginLocalWorkspaceDeltaObservation(cwd);
+      let startedSession:
+        | ReturnType<BackgroundShellService["startSession"]>
+        | undefined;
       try {
         const session = backgroundShell.startSession({
           conversationId,
           command,
           cwd,
+          workspaceObservation: backgroundObservation,
         });
+        startedSession = session;
         const redactedCommand = redactShellText(runtime, command);
         const text = [
           `$ ${redactedCommand}`,
@@ -1911,11 +1931,18 @@ export const shellAction: Action = {
           session,
           execution_route: session.sandbox === "host" ? "host" : "sandbox",
           sandbox_backend: session.sandbox,
+          ...redactedWorkspaceDeltaResultData(
+            runtime,
+            session.workspaceDeltaReceipt,
+          ),
         });
       } catch (err) {
         // error-policy:J1 SHELL action boundary; unsupported execution backends
         // and spawn failures must be visible to the planner instead of falling
         // back to a host-spawned process.
+        const workspaceDelta =
+          startedSession?.workspaceDeltaReceipt ??
+          (await finishLocalWorkspaceDeltaObservation(backgroundObservation));
         return failureToActionResult(
           {
             reason: "internal",
@@ -1924,6 +1951,7 @@ export const shellAction: Action = {
           {
             command: redactShellText(runtime, command),
             cwd: redactedCwd,
+            ...redactedWorkspaceDeltaResultData(runtime, workspaceDelta),
           },
         );
       }
@@ -1940,12 +1968,12 @@ export const shellAction: Action = {
       `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch configuration`,
     );
 
-    // A remote PTY may execute on a different machine from this process. Never
-    // pair that execution with a local Git snapshot and call it authoritative;
-    // remote receipts must eventually come from the executing capability.
-    const workspaceObservation = getCapabilityRouter(runtime)
-      ? undefined
-      : await beginLocalWorkspaceDeltaObservation(cwd);
+    // Capture a local baseline even when a router is registered because the
+    // router may explicitly fall back to the host. A command that actually ran
+    // remotely receives an indeterminate receipt instead of pairing remote
+    // execution with this local snapshot.
+    const capabilityRouterPresent = getCapabilityRouter(runtime) !== null;
+    const workspaceObservation = await beginLocalWorkspaceDeltaObservation(cwd);
     const startedAt = Date.now();
     const mode = resolveRuntimeExecutionMode(runtime);
     coreLogger.info(
@@ -1964,8 +1992,12 @@ export const shellAction: Action = {
       coreLogger.error(
         `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch failed: ${message}`,
       );
-      const workspaceDelta =
-        await finishLocalWorkspaceDeltaObservation(workspaceObservation);
+      const workspaceDelta = capabilityRouterPresent
+        ? indeterminateWorkspaceDeltaReceipt(
+            workspaceObservation?.root ?? cwd,
+            "REMOTE_EXECUTION_UNOBSERVED",
+          )
+        : await finishLocalWorkspaceDeltaObservation(workspaceObservation);
       return failureToActionResult(
         { reason: "internal", message },
         {
@@ -1976,7 +2008,12 @@ export const shellAction: Action = {
     }
 
     const workspaceDelta =
-      await finishLocalWorkspaceDeltaObservation(workspaceObservation);
+      result.sandbox === "capability-router"
+        ? indeterminateWorkspaceDeltaReceipt(
+            workspaceObservation?.root ?? cwd,
+            "REMOTE_EXECUTION_UNOBSERVED",
+          )
+        : await finishLocalWorkspaceDeltaObservation(workspaceObservation);
     const workspaceDeltaData = redactedWorkspaceDeltaResultData(
       runtime,
       workspaceDelta,
@@ -2016,11 +2053,30 @@ export const shellAction: Action = {
 
     const echoTranscript =
       process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
-    if (callback && (echoTranscript === "1" || echoTranscript === "true"))
-      await callback({
-        text: fencePreformatted(capTranscriptForChat(text)),
-        source: "coding-tools",
-      });
+    if (callback && (echoTranscript === "1" || echoTranscript === "true")) {
+      try {
+        await callback({
+          text: fencePreformatted(capTranscriptForChat(text)),
+          source: "coding-tools",
+        });
+      } catch (error) {
+        // error-policy:J1 the command has already executed; preserve its delta
+        // receipt even when transcript delivery fails at the action boundary.
+        return failureToActionResult(
+          {
+            reason: "internal",
+            message: `shell transcript callback failed: ${redactShellText(runtime, (error as Error).message)}`,
+          },
+          {
+            command: redactedCommand,
+            cwd: redactedCwd,
+            output: text,
+            output_truncated: false,
+            ...workspaceDeltaData,
+          },
+        );
+      }
+    }
 
     if (timedOut) {
       return failureToActionResult(

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -24,7 +24,9 @@ import {
   CapabilityError,
   getCapabilityRouter,
   type IAgentRuntime,
+  normalizeWorkspaceDeltaReceipt,
   sanitizeSpawnEnv,
+  type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
 import {
@@ -62,6 +64,7 @@ export interface ShellResult {
     rootId: string;
     executionDomainId: string;
   };
+  workspaceDeltaReceipt?: WorkspaceDeltaReceipt;
 }
 
 const COMPLETE_SHELL_CAPTURE_LIMIT_CHARS = 1_000_000;
@@ -662,6 +665,22 @@ async function runThroughCapabilityRouter(
       cwd: opts.cwd,
       timeoutMs: opts.timeoutMs,
     });
+    const workspaceDeltaReceipt = result.workspaceDeltaReceipt
+      ? normalizeWorkspaceDeltaReceipt(result.workspaceDeltaReceipt)
+      : undefined;
+    if (
+      workspaceDeltaReceipt &&
+      (!result.workspaceExecution ||
+        workspaceDeltaReceipt.scope.root !== result.workspaceExecution.root ||
+        workspaceDeltaReceipt.scope.rootId !==
+          result.workspaceExecution.rootId ||
+        workspaceDeltaReceipt.scope.executionDomainId !==
+          result.workspaceExecution.executionDomainId)
+    ) {
+      throw new Error(
+        "routed workspace receipt does not match its attested execution scope",
+      );
+    }
     return {
       exitCode: result.exitCode ?? -1,
       signal: null,
@@ -673,6 +692,7 @@ async function runThroughCapabilityRouter(
       ...(result.workspaceExecution
         ? { workspaceExecution: result.workspaceExecution }
         : {}),
+      ...(workspaceDeltaReceipt ? { workspaceDeltaReceipt } : {}),
     };
   } catch (error) {
     // error-policy:J4 only the expected "no PTY capability" shape

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -57,6 +57,11 @@ export interface ShellResult {
   signal: NodeJS.Signals | null;
   /** True only when complete capture was refused; stdout/stderr are empty. */
   outputLimitExceeded?: boolean;
+  workspaceExecution?: {
+    root: string;
+    rootId: string;
+    executionDomainId: string;
+  };
 }
 
 const COMPLETE_SHELL_CAPTURE_LIMIT_CHARS = 1_000_000;
@@ -665,6 +670,9 @@ async function runThroughCapabilityRouter(
       durationMs: Date.now() - start,
       timedOut: result.timedOut,
       sandbox: "capability-router",
+      ...(result.workspaceExecution
+        ? { workspaceExecution: result.workspaceExecution }
+        : {}),
     };
   } catch (error) {
     // error-policy:J4 only the expected "no PTY capability" shape

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
@@ -7,12 +7,25 @@ import * as path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  beginLocalWorkspaceDeltaObservation,
+  beginLocalWorkspaceDeltaObservation as beginObservation,
   finishLocalWorkspaceDeltaObservation,
+  type LocalWorkspaceDeltaDependencies,
+  runtimeWorkspaceExecutionDomainId,
 } from "./workspace-delta";
 
 const execFileAsync = promisify(execFile);
 const cleanup: string[] = [];
+const TEST_EXECUTION_DOMAIN_ID = "d".repeat(64);
+
+function beginLocalWorkspaceDeltaObservation(
+  cwd: string,
+  dependencies: LocalWorkspaceDeltaDependencies = {},
+) {
+  return beginObservation(cwd, {
+    executionDomainId: TEST_EXECUTION_DOMAIN_ID,
+    ...dependencies,
+  });
+}
 
 async function repository(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-delta-"));
@@ -37,6 +50,19 @@ afterEach(async () => {
 });
 
 describe("local workspace delta observation", () => {
+  it("derives distinct opaque domains from distinct runtime-owned identities on one host", () => {
+    const runtime = (instanceId: string) => ({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      getSetting: (key: string) =>
+        key === "ELIZA_RUNTIME_INSTANCE_ID" ? instanceId : undefined,
+    });
+    expect(
+      runtimeWorkspaceExecutionDomainId(runtime("installation-a") as never),
+    ).not.toBe(
+      runtimeWorkspaceExecutionDomainId(runtime("installation-b") as never),
+    );
+  });
+
   it("detects a content change when the tracked path was already dirty", async () => {
     const root = await repository();
     await fs.writeFile(
@@ -242,7 +268,7 @@ describe("local workspace delta observation", () => {
     },
   );
 
-  it("enforces one deterministic aggregate Git-output budget across serialized probes", async () => {
+  it("enforces one deterministic aggregate Git-output budget across coordinated parallel probes", async () => {
     const root = await repository();
     const observedCaps: number[] = [];
     const rootOutput = `${root}\n`;
@@ -264,6 +290,36 @@ describe("local workspace delta observation", () => {
       reasonCode: "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
     });
     expect(observedCaps).toEqual([...observedCaps].sort((a, b) => b - a));
+  });
+
+  it("charges stdout and stderr together inside disjoint multi-probe reservations", async () => {
+    const root = await repository();
+    const rootOutput = `${root}\n`;
+    const observation = await beginLocalWorkspaceDeltaObservation(root, {
+      maxGitOutputBytes: Buffer.byteLength(rootOutput) + 8_200,
+      runGit: async (_cwd, args) => {
+        if (args.includes("--show-toplevel")) {
+          return { stdout: rootOutput, stderr: "" };
+        }
+        if (args.includes("--verify")) {
+          return { stdout: "a".repeat(40), stderr: "warning" };
+        }
+        if (args.includes("symbolic-ref")) {
+          return { stdout: "refs/heads/main\n", stderr: "" };
+        }
+        if (args.includes("--others")) {
+          return { stdout: "", stderr: "stderr exceeds reservation" };
+        }
+        return { stdout: "", stderr: "" };
+      },
+    });
+
+    expect(
+      await finishLocalWorkspaceDeltaObservation(observation),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
+    });
   });
 
   it("bounds stalled filesystem metadata and file-stream reads", async () => {
@@ -333,6 +389,27 @@ describe("local workspace delta observation", () => {
       maxFileBytes: 1,
     });
     expect(await finishLocalWorkspaceDeltaObservation(bounded)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_BYTE_BUDGET_EXCEEDED",
+    });
+  });
+
+  it("streams untracked directory entries and fails closed at the entry-memory bound", async () => {
+    const root = await repository();
+    const embedded = path.join(root, "many-entries");
+    await fs.mkdir(embedded);
+    await execFileAsync("git", ["init", "-q"], { cwd: embedded });
+    await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        fs.writeFile(path.join(embedded, `entry-${index}.txt`), "x", "utf8"),
+      ),
+    );
+    const observation = await beginLocalWorkspaceDeltaObservation(root, {
+      maxDirectoryEntries: 4,
+    });
+    expect(
+      await finishLocalWorkspaceDeltaObservation(observation),
+    ).toMatchObject({
       outcome: "indeterminate",
       reasonCode: "OBSERVATION_BYTE_BUDGET_EXCEEDED",
     });

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
@@ -30,12 +30,14 @@ async function repository(): Promise<string> {
 
 afterEach(async () => {
   await Promise.all(
-    cleanup.splice(0).map((root) => fs.rm(root, { recursive: true })),
+    cleanup
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
   );
 });
 
 describe("local workspace delta observation", () => {
-  it("detects a content change when the porcelain status code was already dirty", async () => {
+  it("detects a content change when the tracked path was already dirty", async () => {
     const root = await repository();
     await fs.writeFile(
       path.join(root, "tracked.txt"),
@@ -106,6 +108,97 @@ describe("local workspace delta observation", () => {
       (await execFileAsync("git", ["status", "--porcelain"], { cwd: root }))
         .stdout,
     ).toBe("");
+  });
+
+  it.each(["--assume-unchanged", "--skip-worktree"])(
+    "detects content changes hidden by %s",
+    async (flag) => {
+      const root = await repository();
+      await execFileAsync("git", ["update-index", flag, "tracked.txt"], {
+        cwd: root,
+      });
+      const before = await beginLocalWorkspaceDeltaObservation(root);
+      await fs.writeFile(path.join(root, "tracked.txt"), `${flag}\n`, "utf8");
+
+      expect(
+        (await finishLocalWorkspaceDeltaObservation(before))?.outcome,
+      ).toBe("changed");
+    },
+  );
+
+  it("detects further changes inside an already-dirty submodule", async () => {
+    const child = await repository();
+    const root = await repository();
+    await execFileAsync(
+      "git",
+      [
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        child,
+        "nested",
+      ],
+      { cwd: root },
+    );
+    await execFileAsync("git", ["commit", "-qam", "add nested"], { cwd: root });
+    const nestedFile = path.join(root, "nested", "tracked.txt");
+    await fs.writeFile(nestedFile, "dirty-before\n", "utf8");
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(nestedFile, "dirty-after\n", "utf8");
+
+    expect((await finishLocalWorkspaceDeltaObservation(before))?.outcome).toBe(
+      "changed",
+    );
+  });
+
+  it("supports an unborn repository before its first commit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-unborn-"));
+    cleanup.push(root);
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(root, "first.txt"), "first\n", "utf8");
+
+    expect((await finishLocalWorkspaceDeltaObservation(before))?.outcome).toBe(
+      "changed",
+    );
+  });
+
+  it("fails closed at file-byte, Git-output, and wall-clock budgets", async () => {
+    const root = await repository();
+    const byteBefore = await beginLocalWorkspaceDeltaObservation(root, {
+      maxFileBytes: 4,
+    });
+    await fs.writeFile(path.join(root, "large.txt"), "12345", "utf8");
+    expect(
+      await finishLocalWorkspaceDeltaObservation(byteBefore),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_BYTE_BUDGET_EXCEEDED",
+    });
+
+    const outputBefore = await beginLocalWorkspaceDeltaObservation(root, {
+      maxGitOutputBytes: 1,
+    });
+    expect(
+      await finishLocalWorkspaceDeltaObservation(outputBefore),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
+    });
+
+    let clock = 0;
+    const timedBefore = await beginLocalWorkspaceDeltaObservation(root, {
+      maxObservationMs: 1,
+      now: () => clock++,
+    });
+    expect(
+      await finishLocalWorkspaceDeltaObservation(timedBefore),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_TIME_BUDGET_EXCEEDED",
+    });
   });
 
   it("reports indeterminate when a known worktree's Git probe fails", async () => {

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
@@ -165,6 +165,179 @@ describe("local workspace delta observation", () => {
     );
   });
 
+  it("accepts only Git's expected detached-HEAD status as detached", async () => {
+    const root = await repository();
+    await execFileAsync("git", ["checkout", "--detach", "-q"], { cwd: root });
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    expect((await finishLocalWorkspaceDeltaObservation(before))?.outcome).toBe(
+      "unchanged",
+    );
+  });
+
+  it.each([
+    ["rev-parse HEAD", ["rev-parse", "--verify", "HEAD"]],
+    ["symbolic-ref HEAD", ["symbolic-ref", "--quiet", "HEAD"]],
+  ])(
+    "treats an unexpected %s failure as indeterminate",
+    async (_name, injectedArgs) => {
+      const root = await repository();
+      const observation = await beginLocalWorkspaceDeltaObservation(root, {
+        runGit: async (cwd, args, limits) => {
+          if (args.join("\0") === injectedArgs.join("\0")) {
+            throw new Error("injected unexpected Git failure");
+          }
+          const result = await execFileAsync("git", args, {
+            cwd,
+            encoding: "utf8",
+            timeout: limits?.timeoutMs,
+            maxBuffer: limits?.maxOutputBytes,
+          });
+          return result.stdout;
+        },
+      });
+
+      expect(
+        await finishLocalWorkspaceDeltaObservation(observation),
+      ).toMatchObject({
+        outcome: "indeterminate",
+        reasonCode: "BASELINE_SNAPSHOT_FAILED",
+      });
+    },
+  );
+
+  it.each([
+    [
+      "missing HEAD with appended diagnostics",
+      ["rev-parse", "--verify", "HEAD"],
+      { code: 128, stderr: "fatal: Needed a single revision\nunexpected" },
+    ],
+    [
+      "detached HEAD with unexpected stdout",
+      ["symbolic-ref", "--quiet", "HEAD"],
+      { code: 1, stderr: "", stdout: "unexpected" },
+    ],
+  ])(
+    "rejects the near-miss Git state %s",
+    async (_name, injectedArgs, failure) => {
+      const root = await repository();
+      const observation = await beginLocalWorkspaceDeltaObservation(root, {
+        runGit: async (cwd, args, limits) => {
+          if (args.join("\0") === injectedArgs.join("\0")) throw failure;
+          const result = await execFileAsync("git", args, {
+            cwd,
+            encoding: "utf8",
+            timeout: limits?.timeoutMs,
+            maxBuffer: limits?.maxOutputBytes,
+          });
+          return result.stdout;
+        },
+      });
+
+      expect(
+        await finishLocalWorkspaceDeltaObservation(observation),
+      ).toMatchObject({
+        outcome: "indeterminate",
+        reasonCode: "BASELINE_SNAPSHOT_FAILED",
+      });
+    },
+  );
+
+  it("enforces one deterministic aggregate Git-output budget across serialized probes", async () => {
+    const root = await repository();
+    const observedCaps: number[] = [];
+    const rootOutput = `${root}\n`;
+    const observation = await beginLocalWorkspaceDeltaObservation(root, {
+      maxGitOutputBytes: Buffer.byteLength(rootOutput) + 3,
+      runGit: async (_cwd, args, limits) => {
+        observedCaps.push(limits?.maxOutputBytes ?? -1);
+        if (args.includes("--show-toplevel")) return rootOutput;
+        if (args.includes("--verify")) return "aa";
+        if (args.includes("symbolic-ref")) return "bb";
+        return "cc";
+      },
+    });
+
+    expect(
+      await finishLocalWorkspaceDeltaObservation(observation),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
+    });
+    expect(observedCaps).toEqual([...observedCaps].sort((a, b) => b - a));
+  });
+
+  it("bounds stalled filesystem metadata and file-stream reads", async () => {
+    const root = await repository();
+    const metadata = await beginLocalWorkspaceDeltaObservation(root, {
+      maxObservationMs: 20,
+      fs: { realpath: async () => await new Promise<string>(() => {}) },
+    });
+    expect(await finishLocalWorkspaceDeltaObservation(metadata)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_TIME_BUDGET_EXCEEDED",
+    });
+
+    await fs.writeFile(path.join(root, "tracked.txt"), "dirty\n", "utf8");
+    const lstat = await beginLocalWorkspaceDeltaObservation(root, {
+      maxObservationMs: 20,
+      fs: { lstat: async () => await new Promise(() => {}) },
+    });
+    expect(await finishLocalWorkspaceDeltaObservation(lstat)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_TIME_BUDGET_EXCEEDED",
+    });
+
+    const stream = await beginLocalWorkspaceDeltaObservation(root, {
+      maxObservationMs: 20,
+      fs: {
+        createReadStream: () =>
+          ({
+            destroy() {},
+            [Symbol.asyncIterator]() {
+              return {
+                next: async () => await new Promise(() => {}),
+              };
+            },
+          }) as never,
+      },
+    });
+    expect(await finishLocalWorkspaceDeltaObservation(stream)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_TIME_BUDGET_EXCEEDED",
+    });
+
+    await fs.symlink("tracked.txt", path.join(root, "untracked-link"));
+    const readlink = await beginLocalWorkspaceDeltaObservation(root, {
+      maxObservationMs: 20,
+      fs: { readlink: async () => await new Promise(() => {}) },
+    });
+    expect(await finishLocalWorkspaceDeltaObservation(readlink)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_TIME_BUDGET_EXCEEDED",
+    });
+  });
+
+  it("recursively fingerprints an untracked embedded repository and fails closed at its byte bound", async () => {
+    const root = await repository();
+    const embedded = path.join(root, "embedded");
+    await fs.mkdir(embedded);
+    await execFileAsync("git", ["init", "-q"], { cwd: embedded });
+    await fs.writeFile(path.join(embedded, "payload.txt"), "one\n", "utf8");
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(embedded, "payload.txt"), "two\n", "utf8");
+    expect((await finishLocalWorkspaceDeltaObservation(before))?.outcome).toBe(
+      "changed",
+    );
+
+    const bounded = await beginLocalWorkspaceDeltaObservation(root, {
+      maxFileBytes: 1,
+    });
+    expect(await finishLocalWorkspaceDeltaObservation(bounded)).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "OBSERVATION_BYTE_BUDGET_EXCEEDED",
+    });
+  });
+
   it("fails closed at file-byte, Git-output, and wall-clock budgets", async () => {
     const root = await repository();
     const byteBefore = await beginLocalWorkspaceDeltaObservation(root, {

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
@@ -1,0 +1,148 @@
+/** Tests local Git worktree delta capture against real temporary repositories. */
+
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  beginLocalWorkspaceDeltaObservation,
+  finishLocalWorkspaceDeltaObservation,
+} from "./workspace-delta";
+
+const execFileAsync = promisify(execFile);
+const cleanup: string[] = [];
+
+async function repository(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-delta-"));
+  cleanup.push(root);
+  await execFileAsync("git", ["init", "-q"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], {
+    cwd: root,
+  });
+  await execFileAsync("git", ["config", "user.name", "Test"], { cwd: root });
+  await fs.writeFile(path.join(root, "tracked.txt"), "initial\n", "utf8");
+  await execFileAsync("git", ["add", "tracked.txt"], { cwd: root });
+  await execFileAsync("git", ["commit", "-qm", "initial"], { cwd: root });
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    cleanup.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+describe("local workspace delta observation", () => {
+  it("detects a content change when the porcelain status code was already dirty", async () => {
+    const root = await repository();
+    await fs.writeFile(
+      path.join(root, "tracked.txt"),
+      "dirty-before\n",
+      "utf8",
+    );
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(root, "tracked.txt"), "dirty-after\n", "utf8");
+
+    const receipt = await finishLocalWorkspaceDeltaObservation(before);
+
+    expect(receipt).toMatchObject({
+      outcome: "changed",
+      scope: {
+        root: await fs.realpath(root),
+        coverage: "tracked_and_untracked_nonignored",
+      },
+    });
+    expect(receipt?.beforeFingerprint).not.toBe(receipt?.afterFingerprint);
+    expect(JSON.stringify(receipt)).not.toContain("dirty-after");
+  });
+
+  it("detects creation and later modification of a non-ignored untracked file", async () => {
+    const root = await repository();
+    const beforeCreate = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(root, "generated.ts"), "one\n", "utf8");
+    expect(
+      (await finishLocalWorkspaceDeltaObservation(beforeCreate))?.outcome,
+    ).toBe("changed");
+
+    const beforeModify = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(root, "generated.ts"), "two\n", "utf8");
+    expect(
+      (await finishLocalWorkspaceDeltaObservation(beforeModify))?.outcome,
+    ).toBe("changed");
+  });
+
+  it("detects a modify-and-commit command whose final worktree is clean", async () => {
+    const root = await repository();
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await fs.writeFile(path.join(root, "tracked.txt"), "committed\n", "utf8");
+    await execFileAsync("git", ["add", "tracked.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "modify tracked file"], {
+      cwd: root,
+    });
+
+    const receipt = await finishLocalWorkspaceDeltaObservation(before);
+
+    expect(receipt?.outcome).toBe("changed");
+    expect(receipt?.beforeFingerprint).not.toBe(receipt?.afterFingerprint);
+    expect(
+      (await execFileAsync("git", ["status", "--porcelain"], { cwd: root }))
+        .stdout,
+    ).toBe("");
+  });
+
+  it("detects switching between clean branches with different HEADs", async () => {
+    const root = await repository();
+    await execFileAsync("git", ["branch", "alternate"], { cwd: root });
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    await execFileAsync("git", ["switch", "-q", "alternate"], { cwd: root });
+
+    const receipt = await finishLocalWorkspaceDeltaObservation(before);
+
+    expect(receipt?.outcome).toBe("changed");
+    expect(receipt?.beforeFingerprint).not.toBe(receipt?.afterFingerprint);
+    expect(
+      (await execFileAsync("git", ["status", "--porcelain"], { cwd: root }))
+        .stdout,
+    ).toBe("");
+  });
+
+  it("reports indeterminate when a known worktree's Git probe fails", async () => {
+    const root = await repository();
+    const observation = await beginLocalWorkspaceDeltaObservation(root, {
+      runGit: async () => {
+        throw new Error("injected Git failure");
+      },
+    });
+
+    expect(
+      await finishLocalWorkspaceDeltaObservation(observation),
+    ).toMatchObject({
+      outcome: "indeterminate",
+      reasonCode: "WORKTREE_PROBE_FAILED",
+      scope: { root: await fs.realpath(root) },
+    });
+  });
+
+  it("reports unchanged for a read-only interval and no receipt outside Git", async () => {
+    const root = await repository();
+    const before = await beginLocalWorkspaceDeltaObservation(root);
+    expect((await finishLocalWorkspaceDeltaObservation(before))?.outcome).toBe(
+      "unchanged",
+    );
+
+    const nonRepo = await fs.mkdtemp(
+      path.join(os.tmpdir(), "workspace-no-git-"),
+    );
+    cleanup.push(nonRepo);
+    expect(await beginLocalWorkspaceDeltaObservation(nonRepo)).toBeUndefined();
+    expect(
+      await beginLocalWorkspaceDeltaObservation(nonRepo, {
+        runGit: async () => {
+          throw new Error("injected Git failure");
+        },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.test.ts
@@ -5,8 +5,10 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
+import { AgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  __runWorkspaceDeltaGitForTests,
   beginLocalWorkspaceDeltaObservation as beginObservation,
   finishLocalWorkspaceDeltaObservation,
   type LocalWorkspaceDeltaDependencies,
@@ -50,16 +52,11 @@ afterEach(async () => {
 });
 
 describe("local workspace delta observation", () => {
-  it("derives distinct opaque domains from distinct runtime-owned identities on one host", () => {
-    const runtime = (instanceId: string) => ({
-      agentId: "11111111-1111-1111-1111-111111111111",
-      getSetting: (key: string) =>
-        key === "ELIZA_RUNTIME_INSTANCE_ID" ? instanceId : undefined,
-    });
-    expect(
-      runtimeWorkspaceExecutionDomainId(runtime("installation-a") as never),
-    ).not.toBe(
-      runtimeWorkspaceExecutionDomainId(runtime("installation-b") as never),
+  it("derives distinct opaque domains for distinct runtime instances without environment ids", () => {
+    const runtime = () =>
+      new AgentRuntime({ character: { name: "shared-character" } as never });
+    expect(runtimeWorkspaceExecutionDomainId(runtime())).not.toBe(
+      runtimeWorkspaceExecutionDomainId(runtime()),
     );
   });
 
@@ -320,6 +317,18 @@ describe("local workspace delta observation", () => {
       outcome: "indeterminate",
       reasonCode: "OBSERVATION_OUTPUT_BUDGET_EXCEEDED",
     });
+  });
+
+  it("enforces the aggregate reservation while a real child fills both streams", async () => {
+    const root = await repository();
+    const bothStreamsAlias =
+      'alias.both=!node -e \'process.stdout.write("o".repeat(520)); process.stderr.write("e".repeat(520))\'';
+    await expect(
+      __runWorkspaceDeltaGitForTests(root, ["-c", bothStreamsAlias, "both"], {
+        timeoutMs: 1_000,
+        maxOutputBytes: 1_000,
+      }),
+    ).rejects.toMatchObject({ code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" });
   });
 
   it("bounds stalled filesystem metadata and file-stream reads", async () => {

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -1,88 +1,259 @@
 /**
- * Captures content-free Git worktree fingerprints around local foreground
- * commands. Only tracked and non-ignored untracked paths participate; the
- * receipt explicitly names that coverage and never claims whole-host capture.
+ * Captures content-free Git worktree fingerprints around local commands.
+ * Snapshot work is bounded by explicit wall-clock, Git-output, and file-byte
+ * budgets; exhaustion produces an indeterminate receipt, never a partial hash.
  */
 
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import {
   WORKSPACE_DELTA_RECEIPT_DATA_KEY,
+  type WorkspaceDeltaIndeterminateReasonCode,
   type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
 
 const execFileAsync = promisify(execFile);
-const GIT_TIMEOUT_MS = 15_000;
-const GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+export const WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS = 30_000;
+export const WORKSPACE_DELTA_FILE_BYTE_BUDGET = 64 * 1024 * 1024;
+export const WORKSPACE_DELTA_GIT_OUTPUT_BUDGET = 8 * 1024 * 1024;
 
 interface GitWorkspaceSnapshot {
   root: string;
   fingerprint: string;
 }
 
-type GitRunner = (cwd: string, args: string[]) => Promise<string>;
+type GitRunner = (
+  cwd: string,
+  args: string[],
+  limits?: { timeoutMs: number; maxOutputBytes: number },
+) => Promise<string>;
 
 export interface LocalWorkspaceDeltaDependencies {
-  /** Test seam for forcing Git probe and snapshot failures. */
+  /** Test seam for Git failures and resource-budget boundaries. */
   runGit?: GitRunner;
+  maxObservationMs?: number;
+  maxFileBytes?: number;
+  maxGitOutputBytes?: number;
+  now?: () => number;
+}
+
+interface ObservationLimits {
+  maxObservationMs: number;
+  maxFileBytes: number;
+  maxGitOutputBytes: number;
+  now: () => number;
+}
+
+interface SnapshotBudget {
+  deadline: number;
+  remainingFileBytes: number;
+  remainingGitOutputBytes: number;
+  now: () => number;
 }
 
 export interface LocalWorkspaceDeltaObservation {
   root: string;
   before?: GitWorkspaceSnapshot;
-  baselineFailure?: true;
+  baselineFailure?: WorkspaceDeltaIndeterminateReasonCode;
   probeFailure?: true;
   runGit: GitRunner;
+  limits: ObservationLimits;
 }
 
-async function git(cwd: string, args: string[]): Promise<string> {
+class ObservationBudgetError extends Error {
+  constructor(
+    readonly reasonCode: Extract<
+      WorkspaceDeltaIndeterminateReasonCode,
+      | "OBSERVATION_TIME_BUDGET_EXCEEDED"
+      | "OBSERVATION_BYTE_BUDGET_EXCEEDED"
+      | "OBSERVATION_OUTPUT_BUDGET_EXCEEDED"
+    >,
+  ) {
+    super(reasonCode);
+  }
+}
+
+async function git(
+  cwd: string,
+  args: string[],
+  limits?: { timeoutMs: number; maxOutputBytes: number },
+): Promise<string> {
   const result = await execFileAsync("git", args, {
     cwd,
     encoding: "utf8",
-    timeout: GIT_TIMEOUT_MS,
-    maxBuffer: GIT_MAX_BUFFER_BYTES,
+    timeout: limits?.timeoutMs ?? WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS,
+    maxBuffer: limits?.maxOutputBytes ?? WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
   });
   return result.stdout;
 }
 
-function pathsFromPorcelain(raw: string): string[] {
-  const records = raw.split("\0");
-  const paths = new Set<string>();
-  for (let index = 0; index < records.length; index += 1) {
-    const record = records[index];
-    if (!record || record.length < 4) continue;
-    const status = record.slice(0, 2);
-    paths.add(record.slice(3));
-    if (/[RC]/.test(status)) {
-      const source = records[index + 1];
-      if (source) paths.add(source);
-      index += 1;
-    }
-  }
-  return [...paths].sort((a, b) => a.localeCompare(b));
+function positiveLimit(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value ?? 0) > 0
+    ? Math.floor(value as number)
+    : fallback;
 }
 
-async function pathFingerprint(
-  root: string,
-  relative: string,
+function resolveLimits(
+  dependencies: LocalWorkspaceDeltaDependencies,
+): ObservationLimits {
+  return {
+    maxObservationMs: positiveLimit(
+      dependencies.maxObservationMs,
+      WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS,
+    ),
+    maxFileBytes: positiveLimit(
+      dependencies.maxFileBytes,
+      WORKSPACE_DELTA_FILE_BYTE_BUDGET,
+    ),
+    maxGitOutputBytes: positiveLimit(
+      dependencies.maxGitOutputBytes,
+      WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
+    ),
+    now: dependencies.now ?? Date.now,
+  };
+}
+
+function newBudget(value: ObservationLimits): SnapshotBudget {
+  return {
+    deadline: value.now() + value.maxObservationMs,
+    remainingFileBytes: value.maxFileBytes,
+    remainingGitOutputBytes: value.maxGitOutputBytes,
+    now: value.now,
+  };
+}
+
+function remainingLimits(
+  value: ObservationLimits,
+  phaseStartedAt: number,
+): ObservationLimits {
+  return {
+    ...value,
+    maxObservationMs: Math.max(
+      1,
+      value.maxObservationMs - Math.max(0, value.now() - phaseStartedAt),
+    ),
+  };
+}
+
+function assertTime(budget: SnapshotBudget): void {
+  if (budget.now() > budget.deadline) {
+    throw new ObservationBudgetError("OBSERVATION_TIME_BUDGET_EXCEEDED");
+  }
+}
+
+async function budgetedGit(
+  runGit: GitRunner,
+  cwd: string,
+  args: string[],
+  budget: SnapshotBudget,
 ): Promise<string> {
+  assertTime(budget);
+  const remainingMs = Math.max(1, budget.deadline - budget.now());
+  let output: string;
+  try {
+    output = await runGit(cwd, args, {
+      timeoutMs: remainingMs,
+      maxOutputBytes: Math.max(1, budget.remainingGitOutputBytes),
+    });
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & {
+      killed?: boolean;
+      signal?: NodeJS.Signals;
+    };
+    if (
+      failure.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" ||
+      failure.message?.includes("maxBuffer")
+    ) {
+      throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
+    }
+    if (failure.killed || failure.signal === "SIGTERM") {
+      throw new ObservationBudgetError("OBSERVATION_TIME_BUDGET_EXCEEDED");
+    }
+    throw error;
+  }
+  assertTime(budget);
+  const bytes = Buffer.byteLength(output);
+  if (bytes > budget.remainingGitOutputBytes) {
+    throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
+  }
+  budget.remainingGitOutputBytes -= bytes;
+  return output;
+}
+
+function nullSeparatedPaths(raw: string): string[] {
+  return raw.split("\0").filter(Boolean);
+}
+
+function trackedSpecialPaths(raw: string): {
+  contentPaths: string[];
+  submodulePaths: string[];
+} {
+  const contentPaths: string[] = [];
+  const submodulePaths: string[] = [];
+  for (const record of raw.split("\0")) {
+    const tab = record.indexOf("\t");
+    if (tab < 0 || record.length < 3) continue;
+    const tag = record[0];
+    const metadata = record.slice(2, tab).trim().split(/\s+/);
+    const relative = record.slice(tab + 1);
+    if (!relative) continue;
+    if (tag === "S" || tag.toLowerCase() === tag) contentPaths.push(relative);
+    if (metadata[0] === "160000") submodulePaths.push(relative);
+  }
+  return { contentPaths, submodulePaths };
+}
+
+function absoluteInsideRoot(root: string, relative: string): string {
   const absolute = path.resolve(root, relative);
   const relativeCheck = path.relative(root, absolute);
   if (relativeCheck.startsWith("..") || path.isAbsolute(relativeCheck)) {
     throw new Error("Git reported a path outside its worktree root.");
   }
+  return absolute;
+}
+
+async function hashFileBounded(
+  absolute: string,
+  hash: ReturnType<typeof createHash>,
+  budget: SnapshotBudget,
+): Promise<void> {
+  const stream = createReadStream(absolute, { highWaterMark: 64 * 1024 });
+  try {
+    for await (const chunk of stream) {
+      assertTime(budget);
+      const bytes = (chunk as Buffer).byteLength;
+      if (bytes > budget.remainingFileBytes) {
+        throw new ObservationBudgetError("OBSERVATION_BYTE_BUDGET_EXCEEDED");
+      }
+      budget.remainingFileBytes -= bytes;
+      hash.update(chunk as Buffer);
+    }
+  } finally {
+    stream.destroy();
+  }
+}
+
+async function pathFingerprint(
+  root: string,
+  relative: string,
+  budget: SnapshotBudget,
+): Promise<string> {
+  const absolute = absoluteInsideRoot(root, relative);
+  assertTime(budget);
   try {
     const stat = await fs.lstat(absolute);
     const hash = createHash("sha256");
     hash.update(
       `${stat.mode}:${stat.isFile() ? "file" : stat.isSymbolicLink() ? "symlink" : stat.isDirectory() ? "directory" : "other"}\0`,
     );
-    if (stat.isFile()) hash.update(await fs.readFile(absolute));
+    if (stat.isFile()) await hashFileBounded(absolute, hash, budget);
     else if (stat.isSymbolicLink()) hash.update(await fs.readlink(absolute));
     else hash.update(`${stat.size}:${stat.mtimeMs}`);
+    assertTime(budget);
     return hash.digest("hex");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
@@ -90,43 +261,140 @@ async function pathFingerprint(
   }
 }
 
+async function headIdentity(
+  root: string,
+  runGit: GitRunner,
+  budget: SnapshotBudget,
+): Promise<string> {
+  try {
+    const head = await budgetedGit(
+      runGit,
+      root,
+      ["rev-parse", "--verify", "HEAD"],
+      budget,
+    );
+    let headRef = "detached";
+    try {
+      headRef = (
+        await budgetedGit(
+          runGit,
+          root,
+          ["symbolic-ref", "--quiet", "HEAD"],
+          budget,
+        )
+      ).trim();
+    } catch (error) {
+      if (error instanceof ObservationBudgetError) throw error;
+    }
+    return `commit:${head.trim()}:ref:${headRef}`;
+  } catch (error) {
+    if (error instanceof ObservationBudgetError) throw error;
+    const headRef = (
+      await budgetedGit(
+        runGit,
+        root,
+        ["symbolic-ref", "--quiet", "HEAD"],
+        budget,
+      )
+    ).trim();
+    if (!headRef) throw error;
+    return `unborn:${headRef}`;
+  }
+}
+
 async function captureAtRoot(
   root: string,
   runGit: GitRunner,
+  budget: SnapshotBudget,
+  seenRoots = new Set<string>(),
 ): Promise<GitWorkspaceSnapshot> {
-  const [head, headRef, index, raw] = await Promise.all([
-    runGit(root, ["rev-parse", "--verify", "HEAD"]),
-    runGit(root, ["rev-parse", "--symbolic-full-name", "HEAD"]),
-    runGit(root, ["ls-files", "--stage", "-z"]),
-    runGit(root, [
-      "status",
-      "--porcelain=v1",
-      "-z",
-      "--untracked-files=all",
-      "--ignore-submodules=none",
-    ]),
-  ]);
-  const hash = createHash("sha256");
-  hash.update("head\0");
-  hash.update(head.trim());
-  hash.update("\0head-ref\0");
-  hash.update(headRef.trim());
-  hash.update("\0index\0");
-  hash.update(index);
-  hash.update("\0status\0");
-  hash.update(raw);
-  for (const relative of pathsFromPorcelain(raw)) {
-    hash.update("\0");
-    hash.update(relative);
-    hash.update("\0");
-    hash.update(await pathFingerprint(root, relative));
+  const canonicalRoot = await fs.realpath(root);
+  if (seenRoots.has(canonicalRoot)) {
+    throw new Error("Recursive Git worktree topology detected.");
   }
-  return { root, fingerprint: hash.digest("hex") };
+  seenRoots.add(canonicalRoot);
+  try {
+    const [head, index, trackedChanges, untracked] = await Promise.all([
+      headIdentity(canonicalRoot, runGit, budget),
+      budgetedGit(
+        runGit,
+        canonicalRoot,
+        ["ls-files", "--stage", "-v", "-z"],
+        budget,
+      ),
+      budgetedGit(
+        runGit,
+        canonicalRoot,
+        ["diff-files", "--name-only", "-z", "--ignore-submodules=none", "--"],
+        budget,
+      ),
+      budgetedGit(
+        runGit,
+        canonicalRoot,
+        ["ls-files", "--others", "--exclude-standard", "-z", "--"],
+        budget,
+      ),
+    ]);
+    const hash = createHash("sha256");
+    hash.update("head\0");
+    hash.update(head);
+    hash.update("\0index\0");
+    hash.update(index);
+    hash.update("\0tracked-worktree-changes\0");
+    hash.update(trackedChanges);
+    hash.update("\0untracked\0");
+    hash.update(untracked);
+    const special = trackedSpecialPaths(index);
+    const contentPaths = new Set([
+      ...nullSeparatedPaths(trackedChanges),
+      ...nullSeparatedPaths(untracked),
+      ...special.contentPaths,
+    ]);
+    for (const relative of [...contentPaths].sort((a, b) =>
+      a.localeCompare(b),
+    )) {
+      hash.update("\0path\0");
+      hash.update(relative);
+      hash.update("\0");
+      hash.update(await pathFingerprint(canonicalRoot, relative, budget));
+    }
+    for (const relative of special.submodulePaths.sort((a, b) =>
+      a.localeCompare(b),
+    )) {
+      hash.update("\0submodule\0");
+      hash.update(relative);
+      hash.update("\0");
+      const absolute = absoluteInsideRoot(canonicalRoot, relative);
+      try {
+        const stat = await fs.lstat(absolute);
+        if (!stat.isDirectory()) {
+          hash.update(await pathFingerprint(canonicalRoot, relative, budget));
+          continue;
+        }
+        const nested = await captureAtRoot(absolute, runGit, budget, seenRoots);
+        hash.update(nested.fingerprint);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          hash.update("missing");
+          continue;
+        }
+        throw error;
+      }
+    }
+    assertTime(budget);
+    return { root: canonicalRoot, fingerprint: hash.digest("hex") };
+  } finally {
+    seenRoots.delete(canonicalRoot);
+  }
 }
 
-async function findGitMarkerRoot(cwd: string): Promise<string | undefined> {
+async function findGitMarkerRoot(
+  cwd: string,
+  budget: SnapshotBudget,
+): Promise<string | undefined> {
   let current = await fs.realpath(cwd);
   while (true) {
+    assertTime(budget);
     try {
       const marker = await fs.lstat(path.join(current, ".git"));
       if (marker.isDirectory() || marker.isFile()) return current;
@@ -139,38 +407,76 @@ async function findGitMarkerRoot(cwd: string): Promise<string | undefined> {
   }
 }
 
+function failureReason(
+  error: unknown,
+  fallback: WorkspaceDeltaIndeterminateReasonCode,
+): WorkspaceDeltaIndeterminateReasonCode {
+  return error instanceof ObservationBudgetError ? error.reasonCode : fallback;
+}
+
 /** Returns undefined when cwd is not inside a Git worktree. */
 export async function beginLocalWorkspaceDeltaObservation(
   cwd: string,
   dependencies: LocalWorkspaceDeltaDependencies = {},
 ): Promise<LocalWorkspaceDeltaObservation | undefined> {
   const runGit = dependencies.runGit ?? git;
+  const observationLimits = resolveLimits(dependencies);
+  const phaseStartedAt = observationLimits.now();
+  const budget = newBudget(observationLimits);
   let root: string;
   try {
-    root = (await runGit(cwd, ["rev-parse", "--show-toplevel"])).trim();
-  } catch {
-    // error-policy:J7 a filesystem-confirmed worktree whose Git probe failed is
-    // indeterminate. A true non-repository remains outside this receipt's scope.
+    root = (
+      await budgetedGit(runGit, cwd, ["rev-parse", "--show-toplevel"], budget)
+    ).trim();
+  } catch (error) {
     let markerRoot: string | undefined;
     try {
-      markerRoot = await findGitMarkerRoot(cwd);
-    } catch {
-      // error-policy:J7 the fallback probe is diagnostic only and must not block
-      // execution when the cwd itself cannot be inspected.
+      markerRoot = await findGitMarkerRoot(cwd, budget);
+    } catch (fallbackError) {
+      if (fallbackError instanceof ObservationBudgetError) {
+        const realRoot = await fs.realpath(cwd).catch(() => cwd);
+        return {
+          root: realRoot,
+          baselineFailure: fallbackError.reasonCode,
+          runGit,
+          limits: remainingLimits(observationLimits, phaseStartedAt),
+        };
+      }
       return undefined;
     }
+    if (error instanceof ObservationBudgetError) {
+      return {
+        root: markerRoot ?? (await fs.realpath(cwd).catch(() => cwd)),
+        baselineFailure: error.reasonCode,
+        runGit,
+        limits: remainingLimits(observationLimits, phaseStartedAt),
+      };
+    }
     if (markerRoot) {
-      return { root: markerRoot, probeFailure: true, runGit };
+      return {
+        root: markerRoot,
+        probeFailure: true,
+        runGit,
+        limits: remainingLimits(observationLimits, phaseStartedAt),
+      };
     }
     return undefined;
   }
   if (!root) return undefined;
   try {
-    return { root, before: await captureAtRoot(root, runGit), runGit };
-  } catch {
-    // error-policy:J7 observation failure must not kill command execution. The
-    // final receipt is indeterminate and cannot masquerade as unchanged.
-    return { root, baselineFailure: true, runGit };
+    return {
+      root: await fs.realpath(root),
+      before: await captureAtRoot(root, runGit, budget),
+      runGit,
+      limits: remainingLimits(observationLimits, phaseStartedAt),
+    };
+  } catch (error) {
+    return {
+      root: await fs.realpath(root).catch(() => root),
+      baselineFailure: failureReason(error, "BASELINE_SNAPSHOT_FAILED"),
+      runGit,
+      limits: remainingLimits(observationLimits, phaseStartedAt),
+    };
   }
 }
 
@@ -199,11 +505,15 @@ export async function finishLocalWorkspaceDeltaObservation(
     return {
       ...base,
       outcome: "indeterminate",
-      reasonCode: "BASELINE_SNAPSHOT_FAILED",
+      reasonCode: observation.baselineFailure ?? "BASELINE_SNAPSHOT_FAILED",
     };
   }
   try {
-    const after = await captureAtRoot(observation.root, observation.runGit);
+    const after = await captureAtRoot(
+      observation.root,
+      observation.runGit,
+      newBudget(observation.limits),
+    );
     return {
       ...base,
       outcome:
@@ -213,16 +523,32 @@ export async function finishLocalWorkspaceDeltaObservation(
       beforeFingerprint: observation.before.fingerprint,
       afterFingerprint: after.fingerprint,
     };
-  } catch {
-    // error-policy:J7 post-command observation failure is retained as an
-    // indeterminate receipt so completion gating fails conservatively.
+  } catch (error) {
     return {
       ...base,
       outcome: "indeterminate",
       beforeFingerprint: observation.before.fingerprint,
-      reasonCode: "POST_SNAPSHOT_FAILED",
+      reasonCode: failureReason(error, "POST_SNAPSHOT_FAILED"),
     };
   }
+}
+
+export function indeterminateWorkspaceDeltaReceipt(
+  root: string,
+  reasonCode: WorkspaceDeltaIndeterminateReasonCode,
+): WorkspaceDeltaReceipt {
+  return {
+    version: 1,
+    kind: "workspace_delta",
+    scope: {
+      kind: "git_worktree",
+      root,
+      coverage: "tracked_and_untracked_nonignored",
+    },
+    outcome: "indeterminate",
+    observedAt: new Date().toISOString(),
+    reasonCode,
+  };
 }
 
 export function workspaceDeltaResultData(

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -108,14 +108,23 @@ async function git(
   args: string[],
   limits?: { timeoutMs: number; maxOutputBytes: number },
 ): Promise<{ stdout: string; stderr: string }> {
+  const aggregateLimit =
+    limits?.maxOutputBytes ?? WORKSPACE_DELTA_GIT_OUTPUT_BUDGET;
+  // Node applies maxBuffer independently to stdout and stderr. Give each
+  // stream a disjoint half-reservation so their live aggregate cannot exceed
+  // the observation reservation before the post-return byte accounting runs.
+  const perStreamLimit = Math.floor(aggregateLimit / 2);
   const result = await execFileAsync("git", args, {
     cwd,
     encoding: "utf8",
     timeout: limits?.timeoutMs ?? WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS,
-    maxBuffer: limits?.maxOutputBytes ?? WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
+    maxBuffer: perStreamLimit,
   });
   return { stdout: result.stdout, stderr: result.stderr };
 }
+
+/** Production Git subprocess seam exposed only for aggregate-buffer tests. */
+export const __runWorkspaceDeltaGitForTests = git;
 
 function positiveLimit(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) && (value ?? 0) > 0
@@ -173,18 +182,15 @@ function canonicalExecutionDomainId(value: string | undefined): string {
 
 /** Derives an opaque domain from stable identity owned by the runtime host. */
 export function runtimeWorkspaceExecutionDomainId(
-  runtime: Pick<IAgentRuntime, "agentId" | "getSetting">,
+  runtime: Pick<IAgentRuntime, "runtimeInstanceId">,
 ): string {
-  const configured = ["ELIZA_RUNTIME_INSTANCE_ID", "ELIZA_INSTANCE_ID"]
-    .map((key) => runtime.getSetting(key))
-    .find((value) => typeof value === "string" && value.trim().length > 0);
-  const ownerIdentity =
-    typeof configured === "string"
-      ? configured.trim()
-      : String(runtime.agentId);
-  if (!ownerIdentity) {
+  if (
+    typeof runtime.runtimeInstanceId !== "string" ||
+    runtime.runtimeInstanceId.trim().length === 0
+  ) {
     throw new TypeError("Runtime execution identity is unavailable.");
   }
+  const ownerIdentity = runtime.runtimeInstanceId.trim();
   return createHash("sha256")
     .update("eliza-runtime-workspace-execution-domain-v1\0")
     .update(ownerIdentity)

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -50,7 +50,7 @@ export interface LocalWorkspaceDeltaDependencies {
   fs?: Partial<WorkspaceDeltaFs>;
 }
 
-interface WorkspaceDeltaFs {
+export interface WorkspaceDeltaFs {
   realpath(value: string): Promise<string>;
   lstat(value: string): Promise<Awaited<ReturnType<typeof fs.lstat>>>;
   readlink(value: string): Promise<string>;
@@ -690,7 +690,26 @@ function failureReason(
   error: unknown,
   fallback: WorkspaceDeltaIndeterminateReasonCode,
 ): WorkspaceDeltaIndeterminateReasonCode {
-  return error instanceof ObservationBudgetError ? error.reasonCode : fallback;
+  if (error instanceof ObservationBudgetError) return error.reasonCode;
+  const failure = error as NodeJS.ErrnoException & {
+    killed?: boolean;
+    signal?: string;
+  };
+  if (failure.code === "EOBSERVATIONBYTE") {
+    return "OBSERVATION_BYTE_BUDGET_EXCEEDED";
+  }
+  if (failure.code === "EOBSERVATIONOUTPUT") {
+    return "OBSERVATION_OUTPUT_BUDGET_EXCEEDED";
+  }
+  if (
+    failure.code === "EOBSERVATIONTIME" ||
+    failure.killed ||
+    failure.signal === "SIGTERM" ||
+    failure.signal === "SIGKILL"
+  ) {
+    return "OBSERVATION_TIME_BUDGET_EXCEEDED";
+  }
+  return fallback;
 }
 
 /** Returns undefined when cwd is not inside a Git worktree. */

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -1,0 +1,232 @@
+/**
+ * Captures content-free Git worktree fingerprints around local foreground
+ * commands. Only tracked and non-ignored untracked paths participate; the
+ * receipt explicitly names that coverage and never claims whole-host capture.
+ */
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import {
+  WORKSPACE_DELTA_RECEIPT_DATA_KEY,
+  type WorkspaceDeltaReceipt,
+} from "@elizaos/core";
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 15_000;
+const GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+interface GitWorkspaceSnapshot {
+  root: string;
+  fingerprint: string;
+}
+
+type GitRunner = (cwd: string, args: string[]) => Promise<string>;
+
+export interface LocalWorkspaceDeltaDependencies {
+  /** Test seam for forcing Git probe and snapshot failures. */
+  runGit?: GitRunner;
+}
+
+export interface LocalWorkspaceDeltaObservation {
+  root: string;
+  before?: GitWorkspaceSnapshot;
+  baselineFailure?: true;
+  probeFailure?: true;
+  runGit: GitRunner;
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
+  });
+  return result.stdout;
+}
+
+function pathsFromPorcelain(raw: string): string[] {
+  const records = raw.split("\0");
+  const paths = new Set<string>();
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record || record.length < 4) continue;
+    const status = record.slice(0, 2);
+    paths.add(record.slice(3));
+    if (/[RC]/.test(status)) {
+      const source = records[index + 1];
+      if (source) paths.add(source);
+      index += 1;
+    }
+  }
+  return [...paths].sort((a, b) => a.localeCompare(b));
+}
+
+async function pathFingerprint(
+  root: string,
+  relative: string,
+): Promise<string> {
+  const absolute = path.resolve(root, relative);
+  const relativeCheck = path.relative(root, absolute);
+  if (relativeCheck.startsWith("..") || path.isAbsolute(relativeCheck)) {
+    throw new Error("Git reported a path outside its worktree root.");
+  }
+  try {
+    const stat = await fs.lstat(absolute);
+    const hash = createHash("sha256");
+    hash.update(
+      `${stat.mode}:${stat.isFile() ? "file" : stat.isSymbolicLink() ? "symlink" : stat.isDirectory() ? "directory" : "other"}\0`,
+    );
+    if (stat.isFile()) hash.update(await fs.readFile(absolute));
+    else if (stat.isSymbolicLink()) hash.update(await fs.readlink(absolute));
+    else hash.update(`${stat.size}:${stat.mtimeMs}`);
+    return hash.digest("hex");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+}
+
+async function captureAtRoot(
+  root: string,
+  runGit: GitRunner,
+): Promise<GitWorkspaceSnapshot> {
+  const [head, headRef, index, raw] = await Promise.all([
+    runGit(root, ["rev-parse", "--verify", "HEAD"]),
+    runGit(root, ["rev-parse", "--symbolic-full-name", "HEAD"]),
+    runGit(root, ["ls-files", "--stage", "-z"]),
+    runGit(root, [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--ignore-submodules=none",
+    ]),
+  ]);
+  const hash = createHash("sha256");
+  hash.update("head\0");
+  hash.update(head.trim());
+  hash.update("\0head-ref\0");
+  hash.update(headRef.trim());
+  hash.update("\0index\0");
+  hash.update(index);
+  hash.update("\0status\0");
+  hash.update(raw);
+  for (const relative of pathsFromPorcelain(raw)) {
+    hash.update("\0");
+    hash.update(relative);
+    hash.update("\0");
+    hash.update(await pathFingerprint(root, relative));
+  }
+  return { root, fingerprint: hash.digest("hex") };
+}
+
+async function findGitMarkerRoot(cwd: string): Promise<string | undefined> {
+  let current = await fs.realpath(cwd);
+  while (true) {
+    try {
+      const marker = await fs.lstat(path.join(current, ".git"));
+      if (marker.isDirectory() || marker.isFile()) return current;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/** Returns undefined when cwd is not inside a Git worktree. */
+export async function beginLocalWorkspaceDeltaObservation(
+  cwd: string,
+  dependencies: LocalWorkspaceDeltaDependencies = {},
+): Promise<LocalWorkspaceDeltaObservation | undefined> {
+  const runGit = dependencies.runGit ?? git;
+  let root: string;
+  try {
+    root = (await runGit(cwd, ["rev-parse", "--show-toplevel"])).trim();
+  } catch {
+    // error-policy:J7 a filesystem-confirmed worktree whose Git probe failed is
+    // indeterminate. A true non-repository remains outside this receipt's scope.
+    let markerRoot: string | undefined;
+    try {
+      markerRoot = await findGitMarkerRoot(cwd);
+    } catch {
+      // error-policy:J7 the fallback probe is diagnostic only and must not block
+      // execution when the cwd itself cannot be inspected.
+      return undefined;
+    }
+    if (markerRoot) {
+      return { root: markerRoot, probeFailure: true, runGit };
+    }
+    return undefined;
+  }
+  if (!root) return undefined;
+  try {
+    return { root, before: await captureAtRoot(root, runGit), runGit };
+  } catch {
+    // error-policy:J7 observation failure must not kill command execution. The
+    // final receipt is indeterminate and cannot masquerade as unchanged.
+    return { root, baselineFailure: true, runGit };
+  }
+}
+
+export async function finishLocalWorkspaceDeltaObservation(
+  observation: LocalWorkspaceDeltaObservation | undefined,
+): Promise<WorkspaceDeltaReceipt | undefined> {
+  if (!observation) return undefined;
+  const base = {
+    version: 1 as const,
+    kind: "workspace_delta" as const,
+    scope: {
+      kind: "git_worktree" as const,
+      root: observation.root,
+      coverage: "tracked_and_untracked_nonignored" as const,
+    },
+    observedAt: new Date().toISOString(),
+  };
+  if (observation.probeFailure) {
+    return {
+      ...base,
+      outcome: "indeterminate",
+      reasonCode: "WORKTREE_PROBE_FAILED",
+    };
+  }
+  if (!observation.before || observation.baselineFailure) {
+    return {
+      ...base,
+      outcome: "indeterminate",
+      reasonCode: "BASELINE_SNAPSHOT_FAILED",
+    };
+  }
+  try {
+    const after = await captureAtRoot(observation.root, observation.runGit);
+    return {
+      ...base,
+      outcome:
+        after.fingerprint === observation.before.fingerprint
+          ? "unchanged"
+          : "changed",
+      beforeFingerprint: observation.before.fingerprint,
+      afterFingerprint: after.fingerprint,
+    };
+  } catch {
+    // error-policy:J7 post-command observation failure is retained as an
+    // indeterminate receipt so completion gating fails conservatively.
+    return {
+      ...base,
+      outcome: "indeterminate",
+      beforeFingerprint: observation.before.fingerprint,
+      reasonCode: "POST_SNAPSHOT_FAILED",
+    };
+  }
+}
+
+export function workspaceDeltaResultData(
+  receipt: WorkspaceDeltaReceipt | undefined,
+): Record<string, unknown> {
+  return receipt ? { [WORKSPACE_DELTA_RECEIPT_DATA_KEY]: receipt } : {};
+}

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -8,6 +8,7 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import * as fs from "node:fs/promises";
+import { arch, hostname, platform } from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -17,9 +18,19 @@ import {
 } from "@elizaos/core";
 
 const execFileAsync = promisify(execFile);
-export const WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS = 30_000;
+// Observation is diagnostic and fail-closed; it must not consume the command's
+// own timeout or turn a prompt shell timeout into multi-second tail latency.
+export const WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS = 900;
 export const WORKSPACE_DELTA_FILE_BYTE_BUDGET = 64 * 1024 * 1024;
 export const WORKSPACE_DELTA_GIT_OUTPUT_BUDGET = 8 * 1024 * 1024;
+const LOCAL_EXECUTION_DOMAIN_ID = createHash("sha256")
+  .update("eliza-workspace-execution-domain-v1\0")
+  .update(hostname())
+  .update("\0")
+  .update(platform())
+  .update("\0")
+  .update(arch())
+  .digest("hex");
 
 interface GitWorkspaceSnapshot {
   root: string;
@@ -39,6 +50,16 @@ export interface LocalWorkspaceDeltaDependencies {
   maxFileBytes?: number;
   maxGitOutputBytes?: number;
   now?: () => number;
+  executionDomainId?: string;
+  fs?: Partial<WorkspaceDeltaFs>;
+}
+
+interface WorkspaceDeltaFs {
+  realpath(value: string): Promise<string>;
+  lstat(value: string): Promise<Awaited<ReturnType<typeof fs.lstat>>>;
+  readlink(value: string): Promise<string>;
+  readdir(value: string): Promise<string[]>;
+  createReadStream(value: string): ReturnType<typeof createReadStream>;
 }
 
 interface ObservationLimits {
@@ -46,6 +67,8 @@ interface ObservationLimits {
   maxFileBytes: number;
   maxGitOutputBytes: number;
   now: () => number;
+  executionDomainId: string;
+  fs: WorkspaceDeltaFs;
 }
 
 interface SnapshotBudget {
@@ -53,10 +76,13 @@ interface SnapshotBudget {
   remainingFileBytes: number;
   remainingGitOutputBytes: number;
   now: () => number;
+  fs: WorkspaceDeltaFs;
 }
 
 export interface LocalWorkspaceDeltaObservation {
   root: string;
+  rootId: string;
+  executionDomainId: string;
   before?: GitWorkspaceSnapshot;
   baselineFailure?: WorkspaceDeltaIndeterminateReasonCode;
   probeFailure?: true;
@@ -100,6 +126,7 @@ function positiveLimit(value: number | undefined, fallback: number): number {
 function resolveLimits(
   dependencies: LocalWorkspaceDeltaDependencies,
 ): ObservationLimits {
+  const fsDependencies = dependencies.fs ?? {};
   return {
     maxObservationMs: positiveLimit(
       dependencies.maxObservationMs,
@@ -114,6 +141,15 @@ function resolveLimits(
       WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
     ),
     now: dependencies.now ?? Date.now,
+    executionDomainId:
+      dependencies.executionDomainId ?? LOCAL_EXECUTION_DOMAIN_ID,
+    fs: {
+      realpath: fsDependencies.realpath ?? fs.realpath,
+      lstat: fsDependencies.lstat ?? fs.lstat,
+      readlink: fsDependencies.readlink ?? fs.readlink,
+      readdir: fsDependencies.readdir ?? fs.readdir,
+      createReadStream: fsDependencies.createReadStream ?? createReadStream,
+    },
   };
 }
 
@@ -123,12 +159,14 @@ function newBudget(value: ObservationLimits): SnapshotBudget {
     remainingFileBytes: value.maxFileBytes,
     remainingGitOutputBytes: value.maxGitOutputBytes,
     now: value.now,
+    fs: value.fs,
   };
 }
 
 function remainingLimits(
   value: ObservationLimits,
   phaseStartedAt: number,
+  budget: SnapshotBudget,
 ): ObservationLimits {
   return {
     ...value,
@@ -136,6 +174,8 @@ function remainingLimits(
       1,
       value.maxObservationMs - Math.max(0, value.now() - phaseStartedAt),
     ),
+    maxFileBytes: budget.remainingFileBytes,
+    maxGitOutputBytes: budget.remainingGitOutputBytes,
   };
 }
 
@@ -145,6 +185,63 @@ function assertTime(budget: SnapshotBudget): void {
   }
 }
 
+async function withinDeadline<T>(
+  operation: Promise<T>,
+  budget: SnapshotBudget,
+  abort?: () => void,
+): Promise<T> {
+  // error-policy:J5 The promise may already be running when a synthetic/test
+  // clock exhausts the budget here; the race observes its authoritative
+  // rejection, while this handler suppresses only a later duplicate rejection.
+  void operation.catch(() => undefined);
+  assertTime(budget);
+  const remainingMs = budget.deadline - budget.now();
+  if (remainingMs <= 0) {
+    abort?.();
+    throw new ObservationBudgetError("OBSERVATION_TIME_BUDGET_EXCEEDED");
+  }
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          abort?.();
+          reject(
+            new ObservationBudgetError("OBSERVATION_TIME_BUDGET_EXCEEDED"),
+          );
+        }, remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function workspaceRootId(executionDomainId: string, root: string): string {
+  return createHash("sha256")
+    .update("eliza-workspace-root-v1\0")
+    .update(executionDomainId)
+    .update("\0")
+    .update(root)
+    .digest("hex");
+}
+
+export function unattestedRemoteWorkspaceScope(root: string): {
+  root: string;
+  rootId: string;
+  executionDomainId: string;
+} {
+  const executionDomainId = createHash("sha256")
+    .update("eliza-unattested-remote-execution-domain-v1")
+    .digest("hex");
+  return {
+    root,
+    rootId: workspaceRootId(executionDomainId, root),
+    executionDomainId,
+  };
+}
+
 async function budgetedGit(
   runGit: GitRunner,
   cwd: string,
@@ -152,13 +249,19 @@ async function budgetedGit(
   budget: SnapshotBudget,
 ): Promise<string> {
   assertTime(budget);
+  if (budget.remainingGitOutputBytes <= 0) {
+    throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
+  }
   const remainingMs = Math.max(1, budget.deadline - budget.now());
   let output: string;
   try {
-    output = await runGit(cwd, args, {
-      timeoutMs: remainingMs,
-      maxOutputBytes: Math.max(1, budget.remainingGitOutputBytes),
-    });
+    output = await withinDeadline(
+      runGit(cwd, args, {
+        timeoutMs: remainingMs,
+        maxOutputBytes: Math.max(1, budget.remainingGitOutputBytes),
+      }),
+      budget,
+    );
   } catch (error) {
     const failure = error as NodeJS.ErrnoException & {
       killed?: boolean;
@@ -221,16 +324,22 @@ async function hashFileBounded(
   hash: ReturnType<typeof createHash>,
   budget: SnapshotBudget,
 ): Promise<void> {
-  const stream = createReadStream(absolute, { highWaterMark: 64 * 1024 });
+  const stream = budget.fs.createReadStream(absolute);
+  const iterator = stream[Symbol.asyncIterator]();
   try {
-    for await (const chunk of stream) {
+    while (true) {
+      const next = await withinDeadline(iterator.next(), budget, () =>
+        stream.destroy(),
+      );
+      if (next.done) break;
+      const chunk = next.value as Buffer;
       assertTime(budget);
-      const bytes = (chunk as Buffer).byteLength;
+      const bytes = chunk.byteLength;
       if (bytes > budget.remainingFileBytes) {
         throw new ObservationBudgetError("OBSERVATION_BYTE_BUDGET_EXCEEDED");
       }
       budget.remainingFileBytes -= bytes;
-      hash.update(chunk as Buffer);
+      hash.update(chunk);
     }
   } finally {
     stream.destroy();
@@ -245,14 +354,29 @@ async function pathFingerprint(
   const absolute = absoluteInsideRoot(root, relative);
   assertTime(budget);
   try {
-    const stat = await fs.lstat(absolute);
+    const stat = await withinDeadline(budget.fs.lstat(absolute), budget);
     const hash = createHash("sha256");
     hash.update(
       `${stat.mode}:${stat.isFile() ? "file" : stat.isSymbolicLink() ? "symlink" : stat.isDirectory() ? "directory" : "other"}\0`,
     );
     if (stat.isFile()) await hashFileBounded(absolute, hash, budget);
-    else if (stat.isSymbolicLink()) hash.update(await fs.readlink(absolute));
-    else hash.update(`${stat.size}:${stat.mtimeMs}`);
+    else if (stat.isSymbolicLink()) {
+      hash.update(await withinDeadline(budget.fs.readlink(absolute), budget));
+    } else if (stat.isDirectory()) {
+      const entries = (
+        await withinDeadline(budget.fs.readdir(absolute), budget)
+      ).sort((a, b) => a.localeCompare(b));
+      for (const entry of entries) {
+        const child = path.posix.join(
+          relative.split(path.sep).join("/"),
+          entry,
+        );
+        hash.update("\0entry\0");
+        hash.update(entry);
+        hash.update("\0");
+        hash.update(await pathFingerprint(root, child, budget));
+      }
+    } else hash.update(`${stat.size}:${stat.mtimeMs}`);
     assertTime(budget);
     return hash.digest("hex");
   } catch (error) {
@@ -266,40 +390,66 @@ async function headIdentity(
   runGit: GitRunner,
   budget: SnapshotBudget,
 ): Promise<string> {
-  try {
-    const head = await budgetedGit(
-      runGit,
-      root,
-      ["rev-parse", "--verify", "HEAD"],
-      budget,
+  const gitExit = (error: unknown) => {
+    const value = error as NodeJS.ErrnoException & {
+      stderr?: string;
+      stdout?: string;
+    };
+    return {
+      code:
+        typeof value.code === "number"
+          ? value.code
+          : typeof value.code === "string" && /^\d+$/.test(value.code)
+            ? Number(value.code)
+            : undefined,
+      stderr: typeof value.stderr === "string" ? value.stderr.trim() : "",
+      stdout: typeof value.stdout === "string" ? value.stdout.trim() : "",
+    };
+  };
+  const expectedMissingHead = (error: unknown) => {
+    const failure = gitExit(error);
+    return (
+      failure.code === 128 &&
+      /^(?:fatal: )?Needed a single revision$/.test(failure.stderr) &&
+      failure.stdout.length === 0
     );
-    let headRef = "detached";
-    try {
-      headRef = (
-        await budgetedGit(
-          runGit,
-          root,
-          ["symbolic-ref", "--quiet", "HEAD"],
-          budget,
-        )
-      ).trim();
-    } catch (error) {
-      if (error instanceof ObservationBudgetError) throw error;
+  };
+  const expectedDetachedHead = (error: unknown) => {
+    const failure = gitExit(error);
+    return (
+      failure.code === 1 &&
+      failure.stderr.length === 0 &&
+      failure.stdout.length === 0
+    );
+  };
+  const headCap = Math.ceil(budget.remainingGitOutputBytes / 2);
+  const refCap = budget.remainingGitOutputBytes - headCap;
+  const headBudget = { ...budget, remainingGitOutputBytes: headCap };
+  const refBudget = { ...budget, remainingGitOutputBytes: refCap };
+  const [headResult, refResult] = await Promise.allSettled([
+    budgetedGit(runGit, root, ["rev-parse", "--verify", "HEAD"], headBudget),
+    budgetedGit(runGit, root, ["symbolic-ref", "--quiet", "HEAD"], refBudget),
+  ]);
+  budget.remainingGitOutputBytes -=
+    headCap -
+    headBudget.remainingGitOutputBytes +
+    (refCap - refBudget.remainingGitOutputBytes);
+  if (headResult.status === "fulfilled") {
+    if (refResult.status === "fulfilled") {
+      return `commit:${headResult.value.trim()}:ref:${refResult.value.trim()}`;
     }
-    return `commit:${head.trim()}:ref:${headRef}`;
-  } catch (error) {
-    if (error instanceof ObservationBudgetError) throw error;
-    const headRef = (
-      await budgetedGit(
-        runGit,
-        root,
-        ["symbolic-ref", "--quiet", "HEAD"],
-        budget,
-      )
-    ).trim();
-    if (!headRef) throw error;
-    return `unborn:${headRef}`;
+    if (refResult.reason instanceof ObservationBudgetError)
+      throw refResult.reason;
+    if (!expectedDetachedHead(refResult.reason)) throw refResult.reason;
+    return `commit:${headResult.value.trim()}:ref:detached`;
   }
+  if (headResult.reason instanceof ObservationBudgetError)
+    throw headResult.reason;
+  if (!expectedMissingHead(headResult.reason)) throw headResult.reason;
+  if (refResult.status === "rejected") throw refResult.reason;
+  const headRef = refResult.value.trim();
+  if (!headRef) throw headResult.reason;
+  return `unborn:${headRef}`;
 }
 
 async function captureAtRoot(
@@ -308,33 +458,63 @@ async function captureAtRoot(
   budget: SnapshotBudget,
   seenRoots = new Set<string>(),
 ): Promise<GitWorkspaceSnapshot> {
-  const canonicalRoot = await fs.realpath(root);
+  const canonicalRoot = await withinDeadline(budget.fs.realpath(root), budget);
   if (seenRoots.has(canonicalRoot)) {
     throw new Error("Recursive Git worktree topology detected.");
   }
   seenRoots.add(canonicalRoot);
   try {
-    const [head, index, trackedChanges, untracked] = await Promise.all([
-      headIdentity(canonicalRoot, runGit, budget),
+    // Reserve disjoint output allowances before parallel dispatch. Their sum
+    // never exceeds the aggregate budget, while independent Git reads avoid
+    // adding four process latencies to every foreground shell command.
+    const totalGitBudget = budget.remainingGitOutputBytes;
+    const headCap = Math.min(8 * 1024, totalGitBudget);
+    const afterHead = totalGitBudget - headCap;
+    const indexCap = Math.floor(afterHead / 2);
+    const trackedCap = Math.floor((afterHead - indexCap) / 2);
+    const untrackedCap = afterHead - indexCap - trackedCap;
+    const childBudget = (remainingGitOutputBytes: number): SnapshotBudget => ({
+      ...budget,
+      remainingGitOutputBytes,
+    });
+    const headBudget = childBudget(headCap);
+    const indexBudget = childBudget(indexCap);
+    const trackedBudget = childBudget(trackedCap);
+    const untrackedBudget = childBudget(untrackedCap);
+    const probeResults = await Promise.allSettled([
+      headIdentity(canonicalRoot, runGit, headBudget),
       budgetedGit(
         runGit,
         canonicalRoot,
         ["ls-files", "--stage", "-v", "-z"],
-        budget,
+        indexBudget,
       ),
       budgetedGit(
         runGit,
         canonicalRoot,
         ["diff-files", "--name-only", "-z", "--ignore-submodules=none", "--"],
-        budget,
+        trackedBudget,
       ),
       budgetedGit(
         runGit,
         canonicalRoot,
         ["ls-files", "--others", "--exclude-standard", "-z", "--"],
-        budget,
+        untrackedBudget,
       ),
     ]);
+    const rejectedProbe = probeResults.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (rejectedProbe) throw rejectedProbe.reason;
+    const [head, index, trackedChanges, untracked] = probeResults.map(
+      (result) => (result as PromiseFulfilledResult<string>).value,
+    );
+    budget.remainingGitOutputBytes -=
+      headCap -
+      headBudget.remainingGitOutputBytes +
+      (indexCap - indexBudget.remainingGitOutputBytes) +
+      (trackedCap - trackedBudget.remainingGitOutputBytes) +
+      (untrackedCap - untrackedBudget.remainingGitOutputBytes);
     const hash = createHash("sha256");
     hash.update("head\0");
     hash.update(head);
@@ -366,7 +546,7 @@ async function captureAtRoot(
       hash.update("\0");
       const absolute = absoluteInsideRoot(canonicalRoot, relative);
       try {
-        const stat = await fs.lstat(absolute);
+        const stat = await withinDeadline(budget.fs.lstat(absolute), budget);
         if (!stat.isDirectory()) {
           hash.update(await pathFingerprint(canonicalRoot, relative, budget));
           continue;
@@ -392,11 +572,14 @@ async function findGitMarkerRoot(
   cwd: string,
   budget: SnapshotBudget,
 ): Promise<string | undefined> {
-  let current = await fs.realpath(cwd);
+  let current = await withinDeadline(budget.fs.realpath(cwd), budget);
   while (true) {
     assertTime(budget);
     try {
-      const marker = await fs.lstat(path.join(current, ".git"));
+      const marker = await withinDeadline(
+        budget.fs.lstat(path.join(current, ".git")),
+        budget,
+      );
       if (marker.isDirectory() || marker.isFile()) return current;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -434,54 +617,83 @@ export async function beginLocalWorkspaceDeltaObservation(
       markerRoot = await findGitMarkerRoot(cwd, budget);
     } catch (fallbackError) {
       if (fallbackError instanceof ObservationBudgetError) {
-        const realRoot = await fs.realpath(cwd).catch(() => cwd);
+        const realRoot = cwd;
         return {
           root: realRoot,
+          rootId: workspaceRootId(
+            observationLimits.executionDomainId,
+            realRoot,
+          ),
+          executionDomainId: observationLimits.executionDomainId,
           baselineFailure: fallbackError.reasonCode,
           runGit,
-          limits: remainingLimits(observationLimits, phaseStartedAt),
+          limits: remainingLimits(observationLimits, phaseStartedAt, budget),
         };
       }
       return undefined;
     }
     if (error instanceof ObservationBudgetError) {
+      const failedRoot = markerRoot ?? cwd;
       return {
-        root: markerRoot ?? (await fs.realpath(cwd).catch(() => cwd)),
+        root: failedRoot,
+        rootId: workspaceRootId(
+          observationLimits.executionDomainId,
+          failedRoot,
+        ),
+        executionDomainId: observationLimits.executionDomainId,
         baselineFailure: error.reasonCode,
         runGit,
-        limits: remainingLimits(observationLimits, phaseStartedAt),
+        limits: remainingLimits(observationLimits, phaseStartedAt, budget),
       };
     }
     if (markerRoot) {
       return {
         root: markerRoot,
+        rootId: workspaceRootId(
+          observationLimits.executionDomainId,
+          markerRoot,
+        ),
+        executionDomainId: observationLimits.executionDomainId,
         probeFailure: true,
         runGit,
-        limits: remainingLimits(observationLimits, phaseStartedAt),
+        limits: remainingLimits(observationLimits, phaseStartedAt, budget),
       };
     }
     return undefined;
   }
   if (!root) return undefined;
   try {
+    const canonicalRoot = await withinDeadline(
+      observationLimits.fs.realpath(root),
+      budget,
+    );
     return {
-      root: await fs.realpath(root),
-      before: await captureAtRoot(root, runGit, budget),
+      root: canonicalRoot,
+      rootId: workspaceRootId(
+        observationLimits.executionDomainId,
+        canonicalRoot,
+      ),
+      executionDomainId: observationLimits.executionDomainId,
+      before: await captureAtRoot(canonicalRoot, runGit, budget),
       runGit,
-      limits: remainingLimits(observationLimits, phaseStartedAt),
+      limits: remainingLimits(observationLimits, phaseStartedAt, budget),
     };
   } catch (error) {
+    const failedRoot = root;
     return {
-      root: await fs.realpath(root).catch(() => root),
+      root: failedRoot,
+      rootId: workspaceRootId(observationLimits.executionDomainId, failedRoot),
+      executionDomainId: observationLimits.executionDomainId,
       baselineFailure: failureReason(error, "BASELINE_SNAPSHOT_FAILED"),
       runGit,
-      limits: remainingLimits(observationLimits, phaseStartedAt),
+      limits: remainingLimits(observationLimits, phaseStartedAt, budget),
     };
   }
 }
 
 export async function finishLocalWorkspaceDeltaObservation(
   observation: LocalWorkspaceDeltaObservation | undefined,
+  backgroundHandle?: string,
 ): Promise<WorkspaceDeltaReceipt | undefined> {
   if (!observation) return undefined;
   const base = {
@@ -490,8 +702,18 @@ export async function finishLocalWorkspaceDeltaObservation(
     scope: {
       kind: "git_worktree" as const,
       root: observation.root,
+      rootId: observation.rootId,
+      executionDomainId: observation.executionDomainId,
       coverage: "tracked_and_untracked_nonignored" as const,
     },
+    ...(backgroundHandle
+      ? {
+          operation: {
+            kind: "background_shell" as const,
+            handle: backgroundHandle,
+          },
+        }
+      : {}),
     observedAt: new Date().toISOString(),
   };
   if (observation.probeFailure) {
@@ -534,17 +756,30 @@ export async function finishLocalWorkspaceDeltaObservation(
 }
 
 export function indeterminateWorkspaceDeltaReceipt(
-  root: string,
+  scope: {
+    root: string;
+    rootId: string;
+    executionDomainId: string;
+  },
   reasonCode: WorkspaceDeltaIndeterminateReasonCode,
+  backgroundHandle?: string,
 ): WorkspaceDeltaReceipt {
   return {
     version: 1,
     kind: "workspace_delta",
     scope: {
       kind: "git_worktree",
-      root,
+      ...scope,
       coverage: "tracked_and_untracked_nonignored",
     },
+    ...(backgroundHandle
+      ? {
+          operation: {
+            kind: "background_shell" as const,
+            handle: backgroundHandle,
+          },
+        }
+      : {}),
     outcome: "indeterminate",
     observedAt: new Date().toISOString(),
     reasonCode,

--- a/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
+++ b/plugins/plugin-coding-tools/src/lib/workspace-delta.ts
@@ -8,10 +8,10 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import * as fs from "node:fs/promises";
-import { arch, hostname, platform } from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import {
+  type IAgentRuntime,
   WORKSPACE_DELTA_RECEIPT_DATA_KEY,
   type WorkspaceDeltaIndeterminateReasonCode,
   type WorkspaceDeltaReceipt,
@@ -23,14 +23,8 @@ const execFileAsync = promisify(execFile);
 export const WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS = 900;
 export const WORKSPACE_DELTA_FILE_BYTE_BUDGET = 64 * 1024 * 1024;
 export const WORKSPACE_DELTA_GIT_OUTPUT_BUDGET = 8 * 1024 * 1024;
-const LOCAL_EXECUTION_DOMAIN_ID = createHash("sha256")
-  .update("eliza-workspace-execution-domain-v1\0")
-  .update(hostname())
-  .update("\0")
-  .update(platform())
-  .update("\0")
-  .update(arch())
-  .digest("hex");
+export const WORKSPACE_DELTA_DIRECTORY_ENTRY_BUDGET = 100_000;
+export const WORKSPACE_DELTA_DIRECTORY_NAME_BYTE_BUDGET = 8 * 1024 * 1024;
 
 interface GitWorkspaceSnapshot {
   root: string;
@@ -41,7 +35,7 @@ type GitRunner = (
   cwd: string,
   args: string[],
   limits?: { timeoutMs: number; maxOutputBytes: number },
-) => Promise<string>;
+) => Promise<string | { stdout: string; stderr: string }>;
 
 export interface LocalWorkspaceDeltaDependencies {
   /** Test seam for Git failures and resource-budget boundaries. */
@@ -49,6 +43,8 @@ export interface LocalWorkspaceDeltaDependencies {
   maxObservationMs?: number;
   maxFileBytes?: number;
   maxGitOutputBytes?: number;
+  maxDirectoryEntries?: number;
+  maxDirectoryNameBytes?: number;
   now?: () => number;
   executionDomainId?: string;
   fs?: Partial<WorkspaceDeltaFs>;
@@ -58,7 +54,7 @@ interface WorkspaceDeltaFs {
   realpath(value: string): Promise<string>;
   lstat(value: string): Promise<Awaited<ReturnType<typeof fs.lstat>>>;
   readlink(value: string): Promise<string>;
-  readdir(value: string): Promise<string[]>;
+  opendir(value: string): ReturnType<typeof fs.opendir>;
   createReadStream(value: string): ReturnType<typeof createReadStream>;
 }
 
@@ -66,6 +62,8 @@ interface ObservationLimits {
   maxObservationMs: number;
   maxFileBytes: number;
   maxGitOutputBytes: number;
+  maxDirectoryEntries: number;
+  maxDirectoryNameBytes: number;
   now: () => number;
   executionDomainId: string;
   fs: WorkspaceDeltaFs;
@@ -75,6 +73,8 @@ interface SnapshotBudget {
   deadline: number;
   remainingFileBytes: number;
   remainingGitOutputBytes: number;
+  remainingDirectoryEntries: number;
+  remainingDirectoryNameBytes: number;
   now: () => number;
   fs: WorkspaceDeltaFs;
 }
@@ -107,14 +107,14 @@ async function git(
   cwd: string,
   args: string[],
   limits?: { timeoutMs: number; maxOutputBytes: number },
-): Promise<string> {
+): Promise<{ stdout: string; stderr: string }> {
   const result = await execFileAsync("git", args, {
     cwd,
     encoding: "utf8",
     timeout: limits?.timeoutMs ?? WORKSPACE_DELTA_OBSERVATION_TIMEOUT_MS,
     maxBuffer: limits?.maxOutputBytes ?? WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
   });
-  return result.stdout;
+  return { stdout: result.stdout, stderr: result.stderr };
 }
 
 function positiveLimit(value: number | undefined, fallback: number): number {
@@ -140,17 +140,55 @@ function resolveLimits(
       dependencies.maxGitOutputBytes,
       WORKSPACE_DELTA_GIT_OUTPUT_BUDGET,
     ),
+    maxDirectoryEntries: positiveLimit(
+      dependencies.maxDirectoryEntries,
+      WORKSPACE_DELTA_DIRECTORY_ENTRY_BUDGET,
+    ),
+    maxDirectoryNameBytes: positiveLimit(
+      dependencies.maxDirectoryNameBytes,
+      WORKSPACE_DELTA_DIRECTORY_NAME_BYTE_BUDGET,
+    ),
     now: dependencies.now ?? Date.now,
-    executionDomainId:
-      dependencies.executionDomainId ?? LOCAL_EXECUTION_DOMAIN_ID,
+    executionDomainId: canonicalExecutionDomainId(
+      dependencies.executionDomainId,
+    ),
     fs: {
       realpath: fsDependencies.realpath ?? fs.realpath,
       lstat: fsDependencies.lstat ?? fs.lstat,
       readlink: fsDependencies.readlink ?? fs.readlink,
-      readdir: fsDependencies.readdir ?? fs.readdir,
+      opendir: fsDependencies.opendir ?? fs.opendir,
       createReadStream: fsDependencies.createReadStream ?? createReadStream,
     },
   };
+}
+
+function canonicalExecutionDomainId(value: string | undefined): string {
+  if (!value || !/^[a-f0-9]{64}$/.test(value)) {
+    throw new TypeError(
+      "Local workspace observation requires a canonical runtime-owned executionDomainId.",
+    );
+  }
+  return value;
+}
+
+/** Derives an opaque domain from stable identity owned by the runtime host. */
+export function runtimeWorkspaceExecutionDomainId(
+  runtime: Pick<IAgentRuntime, "agentId" | "getSetting">,
+): string {
+  const configured = ["ELIZA_RUNTIME_INSTANCE_ID", "ELIZA_INSTANCE_ID"]
+    .map((key) => runtime.getSetting(key))
+    .find((value) => typeof value === "string" && value.trim().length > 0);
+  const ownerIdentity =
+    typeof configured === "string"
+      ? configured.trim()
+      : String(runtime.agentId);
+  if (!ownerIdentity) {
+    throw new TypeError("Runtime execution identity is unavailable.");
+  }
+  return createHash("sha256")
+    .update("eliza-runtime-workspace-execution-domain-v1\0")
+    .update(ownerIdentity)
+    .digest("hex");
 }
 
 function newBudget(value: ObservationLimits): SnapshotBudget {
@@ -158,6 +196,8 @@ function newBudget(value: ObservationLimits): SnapshotBudget {
     deadline: value.now() + value.maxObservationMs,
     remainingFileBytes: value.maxFileBytes,
     remainingGitOutputBytes: value.maxGitOutputBytes,
+    remainingDirectoryEntries: value.maxDirectoryEntries,
+    remainingDirectoryNameBytes: value.maxDirectoryNameBytes,
     now: value.now,
     fs: value.fs,
   };
@@ -176,6 +216,8 @@ function remainingLimits(
     ),
     maxFileBytes: budget.remainingFileBytes,
     maxGitOutputBytes: budget.remainingGitOutputBytes,
+    maxDirectoryEntries: budget.remainingDirectoryEntries,
+    maxDirectoryNameBytes: budget.remainingDirectoryNameBytes,
   };
 }
 
@@ -253,7 +295,7 @@ async function budgetedGit(
     throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
   }
   const remainingMs = Math.max(1, budget.deadline - budget.now());
-  let output: string;
+  let output: string | { stdout: string; stderr: string };
   try {
     output = await withinDeadline(
       runGit(cwd, args, {
@@ -266,6 +308,8 @@ async function budgetedGit(
     const failure = error as NodeJS.ErrnoException & {
       killed?: boolean;
       signal?: NodeJS.Signals;
+      stdout?: string;
+      stderr?: string;
     };
     if (
       failure.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" ||
@@ -276,15 +320,28 @@ async function budgetedGit(
     if (failure.killed || failure.signal === "SIGTERM") {
       throw new ObservationBudgetError("OBSERVATION_TIME_BUDGET_EXCEEDED");
     }
+    const capturedBytes =
+      Buffer.byteLength(
+        typeof failure.stdout === "string" ? failure.stdout : "",
+      ) +
+      Buffer.byteLength(
+        typeof failure.stderr === "string" ? failure.stderr : "",
+      );
+    if (capturedBytes > budget.remainingGitOutputBytes) {
+      throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
+    }
+    budget.remainingGitOutputBytes -= capturedBytes;
     throw error;
   }
   assertTime(budget);
-  const bytes = Buffer.byteLength(output);
+  const stdout = typeof output === "string" ? output : output.stdout;
+  const stderr = typeof output === "string" ? "" : output.stderr;
+  const bytes = Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
   if (bytes > budget.remainingGitOutputBytes) {
     throw new ObservationBudgetError("OBSERVATION_OUTPUT_BUDGET_EXCEEDED");
   }
   budget.remainingGitOutputBytes -= bytes;
-  return output;
+  return stdout;
 }
 
 function nullSeparatedPaths(raw: string): string[] {
@@ -346,6 +403,41 @@ async function hashFileBounded(
   }
 }
 
+async function directoryEntriesBounded(
+  absolute: string,
+  budget: SnapshotBudget,
+): Promise<string[]> {
+  const directory = await withinDeadline(budget.fs.opendir(absolute), budget);
+  const iterator = directory[Symbol.asyncIterator]();
+  const entries: string[] = [];
+  try {
+    while (true) {
+      const next = await withinDeadline(iterator.next(), budget, () => {
+        // error-policy:J6 Timeout abort owns the observation failure; a racing
+        // close rejection is teardown-only and is observed here.
+        void directory.close().catch(() => undefined);
+      });
+      if (next.done) break;
+      const name = next.value.name;
+      const nameBytes = Buffer.byteLength(name);
+      if (
+        budget.remainingDirectoryEntries <= 0 ||
+        nameBytes > budget.remainingDirectoryNameBytes
+      ) {
+        throw new ObservationBudgetError("OBSERVATION_BYTE_BUDGET_EXCEEDED");
+      }
+      budget.remainingDirectoryEntries -= 1;
+      budget.remainingDirectoryNameBytes -= nameBytes;
+      entries.push(name);
+    }
+  } finally {
+    // error-policy:J6 Directory close is teardown-only; traversal errors and
+    // budget failures remain authoritative, and Dir may already be auto-closed.
+    void directory.close().catch(() => undefined);
+  }
+  return entries.sort((a, b) => a.localeCompare(b));
+}
+
 async function pathFingerprint(
   root: string,
   relative: string,
@@ -363,9 +455,7 @@ async function pathFingerprint(
     else if (stat.isSymbolicLink()) {
       hash.update(await withinDeadline(budget.fs.readlink(absolute), budget));
     } else if (stat.isDirectory()) {
-      const entries = (
-        await withinDeadline(budget.fs.readdir(absolute), budget)
-      ).sort((a, b) => a.localeCompare(b));
+      const entries = await directoryEntriesBounded(absolute, budget);
       for (const entry of entries) {
         const child = path.posix.join(
           relative.split(path.sep).join("/"),
@@ -694,6 +784,7 @@ export async function beginLocalWorkspaceDeltaObservation(
 export async function finishLocalWorkspaceDeltaObservation(
   observation: LocalWorkspaceDeltaObservation | undefined,
   backgroundHandle?: string,
+  backgroundStatus?: "exited" | "killed" | "error",
 ): Promise<WorkspaceDeltaReceipt | undefined> {
   if (!observation) return undefined;
   const base = {
@@ -711,6 +802,7 @@ export async function finishLocalWorkspaceDeltaObservation(
           operation: {
             kind: "background_shell" as const,
             handle: backgroundHandle,
+            status: backgroundStatus ?? "error",
           },
         }
       : {}),
@@ -763,6 +855,12 @@ export function indeterminateWorkspaceDeltaReceipt(
   },
   reasonCode: WorkspaceDeltaIndeterminateReasonCode,
   backgroundHandle?: string,
+  backgroundStatus:
+    | "running"
+    | "terminating"
+    | "exited"
+    | "killed"
+    | "error" = "running",
 ): WorkspaceDeltaReceipt {
   return {
     version: 1,
@@ -777,6 +875,7 @@ export function indeterminateWorkspaceDeltaReceipt(
           operation: {
             kind: "background_shell" as const,
             handle: backgroundHandle,
+            status: backgroundStatus,
           },
         }
       : {}),

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -53,7 +53,7 @@ export interface BackgroundShellSessionSnapshot {
   command: string;
   cwd: string;
   pid?: number;
-  status: "running" | "exited" | "killed" | "error";
+  status: "running" | "terminating" | "exited" | "killed" | "error";
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   startedAt: number;
@@ -85,7 +85,8 @@ interface BackgroundShellSession {
   cwd: string;
   process: HostShellProcess;
   pid?: number;
-  status: "running" | "exited" | "killed" | "error";
+  status: "running" | "terminating" | "exited" | "killed" | "error";
+  terminalStatusAfterClose?: "killed" | "error";
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   startedAt: number;
@@ -193,6 +194,8 @@ export class BackgroundShellService extends Service {
       if (session.killTimer) clearTimeout(session.killTimer);
       if (session.status === "running") {
         session.status = "exited";
+      } else if (session.status === "terminating") {
+        session.status = session.terminalStatusAfterClose ?? "error";
       }
       session.exitCode = code;
       session.signal = signal;
@@ -200,11 +203,10 @@ export class BackgroundShellService extends Service {
       void this.finalizeWorkspaceDelta(session);
     });
     started.process.on("error", (error) => {
-      session.status = "error";
-      session.exitCode = -1;
-      session.signal = null;
-      session.endedAt = Date.now();
-      void this.finalizeWorkspaceDelta(session);
+      session.status = "terminating";
+      session.terminalStatusAfterClose = "error";
+      session.exitCode = null;
+      this.refreshPendingWorkspaceReceipt(session);
       appendSessionOutput(
         this.runtime,
         session,
@@ -215,8 +217,9 @@ export class BackgroundShellService extends Service {
     });
     if (!started.process.stdout || !started.process.stderr) {
       signalHostProcessGroup(started.process, "SIGKILL");
-      session.status = "error";
-      session.exitCode = -1;
+      session.status = "terminating";
+      session.terminalStatusAfterClose = "error";
+      this.refreshPendingWorkspaceReceipt(session);
       throw new BackgroundShellStartError(
         "background shell process did not expose output streams",
         handle,
@@ -349,7 +352,9 @@ export class BackgroundShellService extends Service {
       await this.finalizeWorkspaceDelta(session);
       return snapshot(this.runtime, session);
     }
-    session.status = "killed";
+    session.status = "terminating";
+    session.terminalStatusAfterClose = "killed";
+    this.refreshPendingWorkspaceReceipt(session);
     signalHostProcessGroup(session.process, "SIGTERM");
     try {
       session.process.stdin?.end();
@@ -376,7 +381,9 @@ export class BackgroundShellService extends Service {
       session.process.once("close", () => resolve());
     });
     if (session.endedAt === null) {
-      session.endedAt = Date.now();
+      throw new Error(
+        `background shell did not emit close after process reap: ${session.handle}`,
+      );
     }
     coreLogger.debug(
       `${CODING_TOOLS_LOG_PREFIX} background SHELL reaped handle=${session.handle} pid=${session.pid ?? "unknown"}`,
@@ -393,6 +400,11 @@ export class BackgroundShellService extends Service {
       session.workspaceDeltaPromise = finishLocalWorkspaceDeltaObservation(
         session.workspaceObservation,
         session.handle,
+        session.status === "exited" ||
+          session.status === "killed" ||
+          session.status === "error"
+          ? session.status
+          : "error",
       ).then((receipt) => {
         session.workspaceDeltaReceipt = receipt;
         session.workspaceObservation = undefined;
@@ -402,9 +414,26 @@ export class BackgroundShellService extends Service {
     return session.workspaceDeltaPromise;
   }
 
+  private refreshPendingWorkspaceReceipt(
+    session: BackgroundShellSession,
+  ): void {
+    if (
+      !session.workspaceObservation ||
+      session.workspaceDeltaReceipt?.reasonCode !== "BACKGROUND_RECEIPT_PENDING"
+    ) {
+      return;
+    }
+    session.workspaceDeltaReceipt = indeterminateWorkspaceDeltaReceipt(
+      session.workspaceObservation,
+      "BACKGROUND_RECEIPT_PENDING",
+      session.handle,
+      session.status === "terminating" ? "terminating" : "running",
+    );
+  }
+
   private ensureCapacity(conversationId: string): void {
     const completed = [...this.sessions.values()]
-      .filter((session) => session.status !== "running")
+      .filter((session) => session.endedAt !== null)
       .sort((a, b) => (a.endedAt ?? a.startedAt) - (b.endedAt ?? b.startedAt));
     const conversationCount = () =>
       [...this.sessions.values()].filter(
@@ -479,9 +508,18 @@ function appendSessionOutput(
     cap
   ) {
     session.outputLimitExceeded = true;
-    session.status = "error";
-    session.exitCode = -1;
-    session.endedAt = Date.now();
+    session.status = "terminating";
+    session.terminalStatusAfterClose = "error";
+    session.exitCode = null;
+    session.signal = null;
+    session.workspaceDeltaReceipt = session.workspaceObservation
+      ? indeterminateWorkspaceDeltaReceipt(
+          session.workspaceObservation,
+          "BACKGROUND_RECEIPT_PENDING",
+          session.handle,
+          "terminating",
+        )
+      : session.workspaceDeltaReceipt;
     session.stdout = emptyRing();
     session.stderr = emptyRing();
     session.redaction = emptyFragmentRedactionState();

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -10,6 +10,7 @@ import {
   logger as coreLogger,
   type IAgentRuntime,
   Service,
+  type WorkspaceDeltaReceipt,
 } from "@elizaos/core";
 import {
   type HostShellProcess,
@@ -17,6 +18,11 @@ import {
   signalHostProcessGroup,
   startBackgroundShellOnHost,
 } from "../lib/run-shell.js";
+import {
+  finishLocalWorkspaceDeltaObservation,
+  indeterminateWorkspaceDeltaReceipt,
+  type LocalWorkspaceDeltaObservation,
+} from "../lib/workspace-delta.js";
 import { redactShellText } from "../shell/redaction.js";
 import { BACKGROUND_SHELL_SERVICE, CODING_TOOLS_LOG_PREFIX } from "../types.js";
 
@@ -56,6 +62,7 @@ export interface BackgroundShellSessionSnapshot {
   sandbox: ShellSandboxBackend;
   stdoutOffset: number;
   stderrOffset: number;
+  workspaceDeltaReceipt?: WorkspaceDeltaReceipt;
 }
 
 export interface BackgroundShellPollResult
@@ -89,6 +96,9 @@ interface BackgroundShellSession {
   redaction: FragmentRedactionState;
   stdinError?: Error;
   outputLimitExceeded?: boolean;
+  workspaceObservation?: LocalWorkspaceDeltaObservation;
+  workspaceDeltaReceipt?: WorkspaceDeltaReceipt;
+  workspaceDeltaPromise?: Promise<WorkspaceDeltaReceipt | undefined>;
   killTimer?: NodeJS.Timeout;
 }
 
@@ -135,6 +145,7 @@ export class BackgroundShellService extends Service {
     conversationId: string;
     command: string;
     cwd: string;
+    workspaceObservation?: LocalWorkspaceDeltaObservation;
   }): BackgroundShellSessionSnapshot {
     this.ensureCapacity(args.conversationId);
     const handle = this.nextHandle(args.conversationId);
@@ -158,6 +169,13 @@ export class BackgroundShellService extends Service {
       stdout: emptyRing(),
       stderr: emptyRing(),
       redaction: emptyFragmentRedactionState(),
+      workspaceObservation: args.workspaceObservation,
+      workspaceDeltaReceipt: args.workspaceObservation
+        ? indeterminateWorkspaceDeltaReceipt(
+            args.workspaceObservation.root,
+            "BACKGROUND_RECEIPT_PENDING",
+          )
+        : undefined,
     };
     if (!started.process.stdout || !started.process.stderr) {
       signalHostProcessGroup(started.process, "SIGKILL");
@@ -203,12 +221,14 @@ export class BackgroundShellService extends Service {
       session.exitCode = code;
       session.signal = signal;
       session.endedAt = Date.now();
+      void this.finalizeWorkspaceDelta(session);
     });
     started.process.on("error", (error) => {
       session.status = "error";
       session.exitCode = -1;
       session.signal = null;
       session.endedAt = Date.now();
+      void this.finalizeWorkspaceDelta(session);
       appendSessionOutput(
         this.runtime,
         session,
@@ -221,18 +241,20 @@ export class BackgroundShellService extends Service {
     return snapshot(this.runtime, session);
   }
 
-  poll(args: {
+  async poll(args: {
     conversationId: string;
     handle: string;
     stdoutOffset?: number;
     stderrOffset?: number;
-  }): BackgroundShellPollResult {
+  }): Promise<BackgroundShellPollResult> {
     const session = this.requireSession(args.conversationId, args.handle);
     if (session.outputLimitExceeded) {
       throw new Error(
         `background shell output exceeded the ${this.bufferChars}-character complete-capture safety limit; no partial output is available`,
       );
     }
+    if (session.status !== "running")
+      await this.finalizeWorkspaceDelta(session);
     refreshSessionRedaction(this.runtime, session);
     return {
       ...snapshot(this.runtime, session),
@@ -299,7 +321,10 @@ export class BackgroundShellService extends Service {
   private async killSession(
     session: BackgroundShellSession,
   ): Promise<BackgroundShellSessionSnapshot> {
-    if (session.status !== "running") return snapshot(this.runtime, session);
+    if (session.status !== "running") {
+      await this.finalizeWorkspaceDelta(session);
+      return snapshot(this.runtime, session);
+    }
     session.status = "killed";
     signalHostProcessGroup(session.process, "SIGTERM");
     try {
@@ -332,7 +357,24 @@ export class BackgroundShellService extends Service {
     coreLogger.debug(
       `${CODING_TOOLS_LOG_PREFIX} background SHELL reaped handle=${session.handle} pid=${session.pid ?? "unknown"}`,
     );
+    await this.finalizeWorkspaceDelta(session);
     return snapshot(this.runtime, session);
+  }
+
+  private async finalizeWorkspaceDelta(
+    session: BackgroundShellSession,
+  ): Promise<WorkspaceDeltaReceipt | undefined> {
+    if (!session.workspaceObservation) return session.workspaceDeltaReceipt;
+    if (!session.workspaceDeltaPromise) {
+      session.workspaceDeltaPromise = finishLocalWorkspaceDeltaObservation(
+        session.workspaceObservation,
+      ).then((receipt) => {
+        session.workspaceDeltaReceipt = receipt;
+        session.workspaceObservation = undefined;
+        return receipt;
+      });
+    }
+    return session.workspaceDeltaPromise;
   }
 
   private ensureCapacity(conversationId: string): void {
@@ -703,6 +745,7 @@ function snapshot(
     sandbox: session.sandbox,
     stdoutOffset: session.stdout.endOffset,
     stderrOffset: session.stderr.endOffset,
+    workspaceDeltaReceipt: session.workspaceDeltaReceipt,
   };
 }
 

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -28,6 +28,7 @@ import { BACKGROUND_SHELL_SERVICE, CODING_TOOLS_LOG_PREFIX } from "../types.js";
 
 const DEFAULT_BUFFER_CHARS = 1_000_000;
 const DEFAULT_KILL_GRACE_MS = 1_500;
+const DEFAULT_REAP_WAIT_MS = 3_000;
 const MAX_WRITE_CHARS = 1_000_000;
 const MAX_SESSIONS_PER_CONVERSATION = 16;
 const MAX_SESSIONS_GLOBAL = 128;
@@ -113,6 +114,15 @@ export class BackgroundShellStartError extends Error {
   }
 }
 
+export class BackgroundShellReapTimeoutError extends Error {
+  constructor(readonly handle: string) {
+    super(
+      `background shell reap was not proven before its deadline: ${handle}`,
+    );
+    this.name = "BackgroundShellReapTimeoutError";
+  }
+}
+
 interface FragmentRedactionState {
   fragments: SecretFragment[];
   ranges: SecretTaintRange[];
@@ -130,6 +140,7 @@ export class BackgroundShellService extends Service {
   private handleCounter = 0;
   private bufferChars = DEFAULT_BUFFER_CHARS;
   private killGraceMs = DEFAULT_KILL_GRACE_MS;
+  private reapWaitMs = DEFAULT_REAP_WAIT_MS;
 
   static async start(runtime: IAgentRuntime): Promise<BackgroundShellService> {
     const svc = new BackgroundShellService(runtime);
@@ -142,6 +153,11 @@ export class BackgroundShellService extends Service {
       runtime,
       "CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS",
       DEFAULT_KILL_GRACE_MS,
+    );
+    svc.reapWaitMs = readPositiveIntSetting(
+      runtime,
+      "CODING_TOOLS_BACKGROUND_SHELL_REAP_WAIT_MS",
+      DEFAULT_REAP_WAIT_MS,
     );
     return svc;
   }
@@ -237,6 +253,7 @@ export class BackgroundShellService extends Service {
         chunk,
         this.bufferChars,
       );
+      if (session.outputLimitExceeded) this.scheduleTermination(session);
     });
     started.process.stderr.on("data", (chunk: string) => {
       appendSessionOutput(
@@ -246,6 +263,7 @@ export class BackgroundShellService extends Service {
         chunk,
         this.bufferChars,
       );
+      if (session.outputLimitExceeded) this.scheduleTermination(session);
     });
     started.process.stdin?.on?.("error", (error: Error) => {
       session.stdinError = error;
@@ -352,10 +370,12 @@ export class BackgroundShellService extends Service {
       await this.finalizeWorkspaceDelta(session);
       return snapshot(this.runtime, session);
     }
-    session.status = "terminating";
-    session.terminalStatusAfterClose = "killed";
+    if (session.status === "running") {
+      session.status = "terminating";
+      session.terminalStatusAfterClose = "killed";
+    }
     this.refreshPendingWorkspaceReceipt(session);
-    signalHostProcessGroup(session.process, "SIGTERM");
+    this.scheduleTermination(session);
     try {
       session.process.stdin?.end();
     } catch (error) {
@@ -365,21 +385,22 @@ export class BackgroundShellService extends Service {
         `${CODING_TOOLS_LOG_PREFIX} background SHELL stdin close failed handle=${session.handle}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    session.killTimer = setTimeout(() => {
-      if (session.endedAt === null) {
-        signalHostProcessGroup(session.process, "SIGKILL");
-      }
-    }, this.killGraceMs);
-    if (typeof session.killTimer.unref === "function") {
-      session.killTimer.unref();
-    }
-    await new Promise<void>((resolve) => {
-      if (session.endedAt !== null) {
-        resolve();
-        return;
-      }
-      session.process.once("close", () => resolve());
-    });
+    let reapTimer: NodeJS.Timeout | undefined;
+    const closed = await Promise.race([
+      new Promise<true>((resolve) => {
+        if (session.endedAt !== null) resolve(true);
+        else session.process.once("close", () => resolve(true));
+      }),
+      new Promise<false>((resolve) => {
+        reapTimer = setTimeout(
+          () => resolve(false),
+          this.killGraceMs + this.reapWaitMs,
+        );
+        reapTimer.unref?.();
+      }),
+    ]);
+    if (reapTimer) clearTimeout(reapTimer);
+    if (!closed) throw new BackgroundShellReapTimeoutError(session.handle);
     if (session.endedAt === null) {
       throw new Error(
         `background shell did not emit close after process reap: ${session.handle}`,
@@ -390,6 +411,17 @@ export class BackgroundShellService extends Service {
     );
     await this.finalizeWorkspaceDelta(session);
     return snapshot(this.runtime, session);
+  }
+
+  private scheduleTermination(session: BackgroundShellSession): void {
+    signalHostProcessGroup(session.process, "SIGTERM");
+    if (session.killTimer || session.endedAt !== null) return;
+    session.killTimer = setTimeout(() => {
+      if (session.endedAt === null) {
+        signalHostProcessGroup(session.process, "SIGKILL");
+      }
+    }, this.killGraceMs);
+    session.killTimer.unref?.();
   }
 
   private async finalizeWorkspaceDelta(

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -102,6 +102,16 @@ interface BackgroundShellSession {
   killTimer?: NodeJS.Timeout;
 }
 
+export class BackgroundShellStartError extends Error {
+  constructor(
+    message: string,
+    readonly handle: string,
+  ) {
+    super(message);
+    this.name = "BackgroundShellStartError";
+  }
+}
+
 interface FragmentRedactionState {
   fragments: SecretFragment[];
   ranges: SecretTaintRange[];
@@ -172,14 +182,45 @@ export class BackgroundShellService extends Service {
       workspaceObservation: args.workspaceObservation,
       workspaceDeltaReceipt: args.workspaceObservation
         ? indeterminateWorkspaceDeltaReceipt(
-            args.workspaceObservation.root,
+            args.workspaceObservation,
             "BACKGROUND_RECEIPT_PENDING",
+            handle,
           )
         : undefined,
     };
+    this.sessions.set(handle, session);
+    started.process.on("close", (code, signal) => {
+      if (session.killTimer) clearTimeout(session.killTimer);
+      if (session.status === "running") {
+        session.status = "exited";
+      }
+      session.exitCode = code;
+      session.signal = signal;
+      session.endedAt = Date.now();
+      void this.finalizeWorkspaceDelta(session);
+    });
+    started.process.on("error", (error) => {
+      session.status = "error";
+      session.exitCode = -1;
+      session.signal = null;
+      session.endedAt = Date.now();
+      void this.finalizeWorkspaceDelta(session);
+      appendSessionOutput(
+        this.runtime,
+        session,
+        "stderr",
+        error.message,
+        this.bufferChars,
+      );
+    });
     if (!started.process.stdout || !started.process.stderr) {
       signalHostProcessGroup(started.process, "SIGKILL");
-      throw new Error("background shell process did not expose output streams");
+      session.status = "error";
+      session.exitCode = -1;
+      throw new BackgroundShellStartError(
+        "background shell process did not expose output streams",
+        handle,
+      );
     }
     // Decode before ring/redaction processing so chunk boundaries cannot
     // replace valid partial code points with U+FFFD.
@@ -213,31 +254,6 @@ export class BackgroundShellService extends Service {
         this.bufferChars,
       );
     });
-    started.process.on("close", (code, signal) => {
-      if (session.killTimer) clearTimeout(session.killTimer);
-      if (session.status === "running") {
-        session.status = "exited";
-      }
-      session.exitCode = code;
-      session.signal = signal;
-      session.endedAt = Date.now();
-      void this.finalizeWorkspaceDelta(session);
-    });
-    started.process.on("error", (error) => {
-      session.status = "error";
-      session.exitCode = -1;
-      session.signal = null;
-      session.endedAt = Date.now();
-      void this.finalizeWorkspaceDelta(session);
-      appendSessionOutput(
-        this.runtime,
-        session,
-        "stderr",
-        error.message,
-        this.bufferChars,
-      );
-    });
-    this.sessions.set(handle, session);
     return snapshot(this.runtime, session);
   }
 
@@ -248,13 +264,12 @@ export class BackgroundShellService extends Service {
     stderrOffset?: number;
   }): Promise<BackgroundShellPollResult> {
     const session = this.requireSession(args.conversationId, args.handle);
+    if (session.endedAt !== null) await this.finalizeWorkspaceDelta(session);
     if (session.outputLimitExceeded) {
       throw new Error(
         `background shell output exceeded the ${this.bufferChars}-character complete-capture safety limit; no partial output is available`,
       );
     }
-    if (session.status !== "running")
-      await this.finalizeWorkspaceDelta(session);
     refreshSessionRedaction(this.runtime, session);
     return {
       ...snapshot(this.runtime, session),
@@ -279,6 +294,15 @@ export class BackgroundShellService extends Service {
     return [...this.sessions.values()]
       .filter((session) => session.conversationId === conversationId)
       .map((session) => snapshot(this.runtime, session));
+  }
+
+  async inspect(args: {
+    conversationId: string;
+    handle: string;
+  }): Promise<BackgroundShellSessionSnapshot> {
+    const session = this.requireSession(args.conversationId, args.handle);
+    if (session.endedAt !== null) await this.finalizeWorkspaceDelta(session);
+    return snapshot(this.runtime, session);
   }
 
   write(args: {
@@ -321,7 +345,7 @@ export class BackgroundShellService extends Service {
   private async killSession(
     session: BackgroundShellSession,
   ): Promise<BackgroundShellSessionSnapshot> {
-    if (session.status !== "running") {
+    if (session.endedAt !== null) {
       await this.finalizeWorkspaceDelta(session);
       return snapshot(this.runtime, session);
     }
@@ -368,6 +392,7 @@ export class BackgroundShellService extends Service {
     if (!session.workspaceDeltaPromise) {
       session.workspaceDeltaPromise = finishLocalWorkspaceDeltaObservation(
         session.workspaceObservation,
+        session.handle,
       ).then((receipt) => {
         session.workspaceDeltaReceipt = receipt;
         session.workspaceObservation = undefined;

--- a/plugins/plugin-coding-tools/src/services/index.ts
+++ b/plugins/plugin-coding-tools/src/services/index.ts
@@ -1,5 +1,8 @@
 /** Barrel for the coding-tools services and the coding-agent-context Zod schemas. */
-export { BackgroundShellService } from "./background-shell-service.js";
+export {
+  BackgroundShellReapTimeoutError,
+  BackgroundShellService,
+} from "./background-shell-service.js";
 export * from "./coding-agent-context.js";
 export { FileStateService } from "./file-state-service.js";
 export {


### PR DESCRIPTION
## Summary

- add a typed, content-free `WorkspaceDeltaReceipt` for local foreground SHELL calls
- fingerprint the complete scoped Git worktree state before and after execution, including dirty/nonignored-untracked contents, HEAD, and index identity
- attach changed, unchanged, or indeterminate receipts on success and failure paths
- require a clean successful verifier after changed or indeterminate receipts while preserving legacy WRITE/EDIT/FILE gating
- deliberately emit no local receipt for remotely routed execution; background and persisted host identity remain out of scope

Closes #25138

The previous remote/background/persisted-runtime-identity expansion was removed. This exact head no longer changes agent startup or Windows behavior.

## Exact-head evidence

Head: `4c1e7329cc6e6d79b354eb3854746c0611f94421`
Base: `ef10cfb172c73c5628db07bb1aa45f6a2bc70d6f`

- workspace-delta real-Git tests: 6/6 pass
- SHELL action suite: 154/154 pass
- core workspace-delta + planner suites: 200/201 pass
- the sole core failure (`passes complete oversized input to the authoritative runtime boundary`) reproduces unchanged on exact base `ef10cfb172c73` (189/190)
- Biome on all 9 changed files: pass
- `git diff --check`: pass
- local package typechecks could not complete because this shared light install is missing unrelated dependencies (`ai`, `@types/markdown-it`, `@vscode/ripgrep`, `@lydell/node-pty`); hosted installed-workspace CI is authoritative

## Acceptance coverage

- dirty tracked contents: covered
- nonignored untracked creation and modification: covered
- edit + commit clean-to-clean: covered
- clean HEAD switch: covered
- read-only unchanged and non-worktree: covered
- failure-after-write and timeout-after-write: covered
- changed/indeterminate planner gating: covered
- mutation-producing verifier cannot clear gate: covered
- remote receipt claim: N/A — deliberately absent per issue scope
- background receipt lifecycle: N/A — explicitly deferred by #25138
- UI/media evidence: N/A — no rendered UI or media surface
