### PR TITLE
test(agent): cover waifu chat role resolver and jwt token validation

### DIFF
--- a/packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts
+++ b/packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for WaifuChat boundary-role resolver.
+ * Validates HS256 JWT validation, claims extraction, role-to-world-role mapping,
+ * and extension point registration.
+ */
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  registerWaifuChatRoleResolver,
+  resolveWaifuChatAccessToken,
+  WAIFU_CHAT_RESOLVER_ID,
+  WAIFU_CHAT_ROLE_TO_WORLD_ROLE,
+  waifuChatRoleResolver,
+  waifuChatRoleToWorldRole,
+} from "../waifu-chat-role-resolver.ts";
+
+function createJwt(
+  payload: Record<string, unknown>,
+  secret = "test-secret-key-12345",
+  header: Record<string, unknown> = { alg: "HS256", typ: "JWT" },
+): string {
+  const h = Buffer.from(JSON.stringify(header)).toString("base64url");
+  const p = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = crypto
+    .createHmac("sha256", secret)
+    .update(`${h}.${p}`)
+    .digest("base64url");
+  return `${h}.${p}.${sig}`;
+}
+
+describe("waifu-chat-role-resolver", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.WAIFU_CHAT_ACCESS_JWT_SECRET = "test-secret-key-12345";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("role mapping", () => {
+    it("maps waifu roles to canonical world roles", () => {
+      expect(waifuChatRoleToWorldRole("admin")).toBe("OWNER");
+      expect(waifuChatRoleToWorldRole("user")).toBe("USER");
+      expect(waifuChatRoleToWorldRole("guest")).toBe("GUEST");
+    });
+
+    it("freezes WAIFU_CHAT_ROLE_TO_WORLD_ROLE constant mapping", () => {
+      expect(Object.isFrozen(WAIFU_CHAT_ROLE_TO_WORLD_ROLE)).toBe(true);
+      expect(WAIFU_CHAT_ROLE_TO_WORLD_ROLE.admin).toBe("OWNER");
+      expect(WAIFU_CHAT_ROLE_TO_WORLD_ROLE.user).toBe("USER");
+      expect(WAIFU_CHAT_ROLE_TO_WORLD_ROLE.guest).toBe("GUEST");
+    });
+  });
+
+  describe("resolveWaifuChatAccessToken", () => {
+    it("returns null when secret is unset or token is missing", () => {
+      delete process.env.WAIFU_CHAT_ACCESS_JWT_SECRET;
+      expect(resolveWaifuChatAccessToken("some.valid.token")).toBeNull();
+
+      process.env.WAIFU_CHAT_ACCESS_JWT_SECRET = "secret";
+      expect(resolveWaifuChatAccessToken(null)).toBeNull();
+      expect(resolveWaifuChatAccessToken("")).toBeNull();
+    });
+
+    it("returns null for malformed token structures", () => {
+      expect(resolveWaifuChatAccessToken("not-a-jwt")).toBeNull();
+      expect(resolveWaifuChatAccessToken("two.segments")).toBeNull();
+      expect(resolveWaifuChatAccessToken("a.b.c.d")).toBeNull();
+    });
+
+    it("returns null when HMAC signature does not match secret", () => {
+      const token = createJwt(
+        {
+          iss: "waifu.fun",
+          aud: "eliza-cloud-chat",
+          role: "user",
+          walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        },
+        "wrong-secret",
+      );
+      expect(resolveWaifuChatAccessToken(token)).toBeNull();
+    });
+
+    it("validates algorithm is HS256", () => {
+      const token = createJwt(
+        {
+          iss: "waifu.fun",
+          aud: "eliza-cloud-chat",
+          role: "user",
+          walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        },
+        "test-secret-key-12345",
+        { alg: "RS256", typ: "JWT" },
+      );
+      expect(resolveWaifuChatAccessToken(token)).toBeNull();
+    });
+
+    it("validates issuer is waifu.fun", () => {
+      const token = createJwt({
+        iss: "other.issuer",
+        aud: "eliza-cloud-chat",
+        role: "user",
+        walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      expect(resolveWaifuChatAccessToken(token)).toBeNull();
+    });
+
+    it("validates audience contains eliza-cloud-chat", () => {
+      const token = createJwt({
+        iss: "waifu.fun",
+        aud: "other-aud",
+        role: "user",
+        walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      expect(resolveWaifuChatAccessToken(token)).toBeNull();
+    });
+
+    it("validates token expiration and not-before claims", () => {
+      const now = Math.floor(Date.now() / 1000);
+      const expired = createJwt({
+        iss: "waifu.fun",
+        aud: "eliza-cloud-chat",
+        role: "user",
+        walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        exp: now - 100,
+      });
+      expect(resolveWaifuChatAccessToken(expired, now)).toBeNull();
+
+      const future = createJwt({
+        iss: "waifu.fun",
+        aud: "eliza-cloud-chat",
+        role: "user",
+        walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        exp: now + 3600,
+        nbf: now + 500,
+      });
+      expect(resolveWaifuChatAccessToken(future, now)).toBeNull();
+    });
+
+    it("validates walletAddress format", () => {
+      const invalidWallet = createJwt({
+        iss: "waifu.fun",
+        aud: "eliza-cloud-chat",
+        role: "user",
+        walletAddress: "not-a-valid-0x-address",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      expect(resolveWaifuChatAccessToken(invalidWallet)).toBeNull();
+    });
+
+    it("successfully parses valid token with claims", () => {
+      const token = createJwt({
+        iss: "waifu.fun",
+        aud: "eliza-cloud-chat",
+        role: "admin",
+        walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        tokenAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        chainId: 8453,
+        cloudAgentId: "agent-999",
+        balanceTokens: 500,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      const access = resolveWaifuChatAccessToken(token);
+      expect(access).not.toBeNull();
+      expect(access?.role).toBe("admin");
+      expect(access?.walletAddress).toBe(
+        "0x1234567890abcdef1234567890abcdef12345678",
+      );
+      expect(access?.tokenAddress).toBe(
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      );
+      expect(access?.chainId).toBe(8453);
+      expect(access?.cloudAgentId).toBe("agent-999");
+      expect(access?.balanceTokens).toBe(500);
+    });
+  });
+
+  describe("resolver registration", () => {
+    it("exposes stable resolver id", () => {
+      expect(WAIFU_CHAT_RESOLVER_ID).toBe("waifu-chat");
+      expect(waifuChatRoleResolver.id).toBe("waifu-chat");
+    });
+
+    it("supports idempotent registration and teardown", () => {
+      const unregister = registerWaifuChatRoleResolver();
+      expect(typeof unregister).toBe("function");
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds isolated unit test coverage for `resolveWaifuChatAccessToken`, `waifuChatRoleToWorldRole`, and registration lifecycle in `waifu-chat-role-resolver.ts` with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `packages/agent/src/api/waifu-chat-role-resolver.ts`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts`

## Detailed testing steps
Run:
```bash
node packages/scripts/run-vitest.mjs run packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:fbd86273a1ce9e74028d5f97cd743a8ae5ac2c32 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
node packages/scripts/run-vitest.mjs run packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/.worktrees/wt-ship

 ✓ packages/agent/src/api/__tests__/waifu-chat-role-resolver.test.ts (13 tests) 3ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  09:42:42
   Duration  3.21s (transform 2.49s, setup 0ms, import 3.14s, tests 3ms, environment 0ms)
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
