### PR TITLE
test(agent): cover roles plugin manifest and lifecycle initialization

### DIFF
--- a/packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts
+++ b/packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for internal runtime roles plugin manifest and lifecycle initialization.
+ */
+import type { IAgentRuntime, World } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import rolesPlugin, { roleAction, rolesProvider } from "../index.ts";
+
+describe("roles plugin", () => {
+  describe("manifest", () => {
+    it("defines the expected plugin metadata and components", () => {
+      expect(rolesPlugin.name).toBe("roles");
+      expect(rolesPlugin.description).toBeTruthy();
+      expect(rolesPlugin.providers).toContain(rolesProvider);
+      expect(rolesPlugin.actions).toContain(roleAction);
+    });
+  });
+
+  describe("init", () => {
+    it("registers world event listeners and syncs canonical owner role", async () => {
+      const registeredEvents: Record<string, () => Promise<void>> = {};
+      const mockWorld = {
+        id: "world-1",
+        name: "Default World",
+        agentId: "agent-1",
+        metadata: {
+          ownership: { ownerId: "owner-entity-1" },
+          roles: {},
+        },
+      } as unknown as World;
+
+      const mockRuntime = {
+        agentId: "agent-1",
+        getAllWorlds: vi.fn().mockResolvedValue([mockWorld]),
+        getWorld: vi.fn().mockResolvedValue(mockWorld),
+        updateWorld: vi.fn().mockResolvedValue(undefined),
+        getSetting: vi.fn().mockReturnValue(undefined),
+        registerEvent: vi.fn((event: string, handler: () => Promise<void>) => {
+          registeredEvents[event] = handler;
+        }),
+      } as unknown as IAgentRuntime;
+
+      await rolesPlugin.init?.({}, mockRuntime);
+
+      expect(mockRuntime.registerEvent).toHaveBeenCalledWith(
+        "WORLD_JOINED",
+        expect.any(Function),
+      );
+      expect(mockRuntime.registerEvent).toHaveBeenCalledWith(
+        "WORLD_CONNECTED",
+        expect.any(Function),
+      );
+
+      // Verify event handlers can be executed without error
+      if (registeredEvents.WORLD_JOINED) {
+        await registeredEvents.WORLD_JOINED();
+      }
+      if (registeredEvents.WORLD_CONNECTED) {
+        await registeredEvents.WORLD_CONNECTED();
+      }
+    });
+
+    it("handles empty worlds or database errors gracefully without throwing", async () => {
+      const mockRuntime = {
+        agentId: "agent-1",
+        getAllWorlds: vi
+          .fn()
+          .mockRejectedValue(new Error("Database connection lost")),
+        getSetting: vi.fn().mockReturnValue(undefined),
+        registerEvent: vi.fn(),
+      } as unknown as IAgentRuntime;
+
+      await expect(
+        rolesPlugin.init?.({}, mockRuntime),
+      ).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for `rolesPlugin` in `packages/agent/src/runtime/roles/src/index.ts` with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `packages/agent/src/runtime/roles/src/index.ts`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts`

## Detailed testing steps
Run:
```bash
node packages/scripts/run-vitest.mjs run packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:243d68408404c550bd7e8adaf2665031de766423 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
node packages/scripts/run-vitest.mjs run packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/.worktrees/wt-ship

 ✓ packages/agent/src/runtime/roles/src/__tests__/roles-plugin-standalone.test.ts (3 tests) 5ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  09:57:07
   Duration  2.42s (transform 1.87s, setup 0ms, import 2.36s, tests 5ms, environment 0ms)
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
