### PR TITLE
fix(cloud): resolve prompt presets by own key, not prototype chain

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/prompt-presets.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/prompt-presets.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Pins preset resolution. The registry is a plain object looked up with a name
+ * that reaches it from an environment variable, so lookup must resolve only
+ * registry-owned keys: inherited Object.prototype members must never be
+ * returned as a preset. Also covers the merge contract, where text fields
+ * concatenate but scalar fields override. Env is saved and restored per test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  getPresetFromEnv,
+  getPromptPreset,
+  mergePromptConfig,
+  type PromptPresetName,
+  promptPresets,
+} from "./prompt-presets";
+
+const ENV_KEY = "APP_PROMPT_PRESET";
+const NAMES = Object.keys(promptPresets) as PromptPresetName[];
+
+/** Keys every plain object inherits but the registry never declares. */
+const INHERITED = [
+  "toString",
+  "valueOf",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+] as const;
+
+let saved: string | undefined;
+
+beforeEach(() => {
+  saved = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+});
+
+afterEach(() => {
+  if (saved === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = saved;
+});
+
+function isPreset(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("promptPresets registry", () => {
+  test("declares at least one preset, each an object", () => {
+    expect(NAMES.length).toBeGreaterThan(0);
+    for (const name of NAMES) expect(isPreset(promptPresets[name])).toBe(true);
+  });
+
+  test("owns exactly the declared names", () => {
+    for (const name of NAMES) {
+      expect(Object.hasOwn(promptPresets, name)).toBe(true);
+    }
+    for (const key of INHERITED) {
+      expect(Object.hasOwn(promptPresets, key)).toBe(false);
+    }
+  });
+});
+
+describe("getPromptPreset", () => {
+  test("returns the declared preset for each name", () => {
+    for (const name of NAMES) {
+      expect(getPromptPreset(name)).toBe(promptPresets[name]);
+    }
+  });
+
+  test("throws for an unknown name", () => {
+    expect(() => getPromptPreset("nope" as PromptPresetName)).toThrow();
+  });
+
+  test.each(INHERITED)("throws for inherited key %s", (key) => {
+    expect(() => getPromptPreset(key as PromptPresetName)).toThrow();
+  });
+
+  test("never returns a non-object", () => {
+    for (const key of [...NAMES, ...INHERITED]) {
+      let result: unknown;
+      try {
+        result = getPromptPreset(key as PromptPresetName);
+      } catch {
+        continue;
+      }
+      expect(isPreset(result)).toBe(true);
+    }
+  });
+});
+
+describe("getPresetFromEnv", () => {
+  test("returns null when unset or blank", () => {
+    expect(getPresetFromEnv()).toBeNull();
+    process.env[ENV_KEY] = "";
+    expect(getPresetFromEnv()).toBeNull();
+  });
+
+  test("returns the named preset", () => {
+    for (const name of NAMES) {
+      process.env[ENV_KEY] = name;
+      expect(getPresetFromEnv()).toBe(promptPresets[name]);
+    }
+  });
+
+  test("returns null for an unknown name", () => {
+    process.env[ENV_KEY] = "not-a-preset";
+    expect(getPresetFromEnv()).toBeNull();
+  });
+
+  test.each(INHERITED)("returns null for inherited key %s", (key) => {
+    process.env[ENV_KEY] = key;
+    expect(getPresetFromEnv()).toBeNull();
+  });
+
+  test("never returns a non-object", () => {
+    for (const value of [...NAMES, ...INHERITED, "junk", ""]) {
+      process.env[ENV_KEY] = value;
+      const result = getPresetFromEnv();
+      if (result === null) continue;
+      expect(isPreset(result)).toBe(true);
+    }
+  });
+});
+
+describe("mergePromptConfig", () => {
+  test("returns the base defaults with no inputs", () => {
+    expect(mergePromptConfig()).toEqual({
+      systemPrefix: "",
+      systemSuffix: "",
+      responseStyle: "",
+      flirtiness: "low",
+      romanticMode: false,
+    });
+  });
+
+  test("concatenates text fields preset-first, newline separated", () => {
+    const merged = mergePromptConfig(
+      { systemPrefix: "cfg", systemSuffix: "cfgS", responseStyle: "cfgR" },
+      { systemPrefix: "pre", systemSuffix: "preS", responseStyle: "preR" } as never,
+    );
+    expect(merged.systemPrefix).toBe("pre\ncfg");
+    expect(merged.systemSuffix).toBe("preS\ncfgS");
+    expect(merged.responseStyle).toBe("preR\ncfgR");
+  });
+
+  test("omits a missing side rather than leaving a blank line", () => {
+    expect(mergePromptConfig({ systemPrefix: "only" }).systemPrefix).toBe("only");
+    expect(mergePromptConfig(undefined, { systemPrefix: "only" } as never).systemPrefix).toBe(
+      "only",
+    );
+    expect(mergePromptConfig().systemPrefix).toBe("");
+  });
+
+  test("config overrides preset for scalar fields", () => {
+    const merged = mergePromptConfig({ flirtiness: "high", romanticMode: true }, {
+      flirtiness: "low",
+      romanticMode: false,
+    } as never);
+    expect(merged.flirtiness).toBe("high");
+    expect(merged.romanticMode).toBe(true);
+  });
+
+  test("preset supplies scalars the config omits", () => {
+    expect(mergePromptConfig({}, { flirtiness: "medium" } as never).flirtiness).toBe("medium");
+  });
+
+  test("tolerates a null preset", () => {
+    expect(mergePromptConfig({ flirtiness: "high" }, null).flirtiness).toBe("high");
+  });
+
+  test("does not mutate its inputs", () => {
+    const config = { systemPrefix: "cfg" };
+    const preset = { systemPrefix: "pre" } as never;
+    const snapshots = [{ ...config }, { ...(preset as object) }];
+    mergePromptConfig(config, preset);
+    expect([{ ...config }, { ...(preset as object) }]).toEqual(snapshots);
+  });
+
+  test("merges every declared preset without throwing", () => {
+    for (const name of NAMES) {
+      expect(() => mergePromptConfig({}, promptPresets[name])).not.toThrow();
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/prompt-presets.ts
+++ b/packages/cloud/shared/src/lib/eliza/prompt-presets.ts
@@ -199,11 +199,14 @@ export const promptPresets: Record<PromptPresetName, PromptPreset> = {
  * Get prompt preset by name
  */
 export function getPromptPreset(name: PromptPresetName): PromptPreset {
-  const preset = promptPresets[name];
-  if (!preset) {
+  // Own-key check, not a bare index: the registry is a plain object, so
+  // `promptPresets["toString"]` resolves an inherited Object.prototype function
+  // — truthy, so the guard below would never fire and a Function would be
+  // returned as if it were a preset.
+  if (!Object.hasOwn(promptPresets, name)) {
     throw new Error(`Unknown prompt preset: ${name}`);
   }
-  return preset;
+  return promptPresets[name];
 }
 
 /**
@@ -213,7 +216,9 @@ export function getPresetFromEnv(): PromptPreset | null {
   const presetName = process.env.APP_PROMPT_PRESET as PromptPresetName | undefined;
   if (!presetName) return null;
 
-  if (!(presetName in promptPresets)) {
+  // `in` also resolves inherited Object.prototype members, so an env value of
+  // "toString" or "constructor" would pass this check and return a Function.
+  if (!Object.hasOwn(promptPresets, presetName)) {
     logger.warn(`Unknown APP_PROMPT_PRESET: ${presetName}, using defaults`);
     return null;
   }


### PR DESCRIPTION
# Relates to

No existing issue. Found while writing first-time regression coverage for
`packages/cloud/shared/src/lib/eliza/prompt-presets.ts`, which is reachable as
a public subpath export (`@elizaos/cloud-shared/lib/eliza/prompt-presets`) and
had no test file.

Same defect class as the affiliate-theme registry fix
(elizaOS/eliza#26691) — a second plain-object registry resolved through the
prototype chain. Independent module, independent fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low.** Two guard changes in one module, plus a new test file. The change
strictly narrows which keys resolve: every declared preset behaves exactly as
before (asserted per-name against the registry object identity). Only inherited
`Object.prototype` keys change behaviour, and they change from "returns a
Function" to "throws / returns null" — which is what both functions already
document as their contract for an unknown name.

# Background

## What does this PR do?

`promptPresets` is a plain object literal, so it inherits from
`Object.prototype`. Both lookups resolved through that chain:

```ts
export function getPromptPreset(name: PromptPresetName): PromptPreset {
  const preset = promptPresets[name];
  if (!preset) throw new Error(`Unknown prompt preset: ${name}`);
  return preset;
}

export function getPresetFromEnv(): PromptPreset | null {
  const presetName = process.env.APP_PROMPT_PRESET as PromptPresetName | undefined;
  if (!presetName) return null;
  if (!(presetName in promptPresets)) { /* warn */ return null; }
  return promptPresets[presetName];
}
```

Two separate failures with the same root cause:

- `promptPresets["toString"]` is an inherited **function** — truthy — so
  `getPromptPreset`'s `!preset` guard cannot fire. It returns
  `Object.prototype.toString` typed as `PromptPreset`.
- `"toString" in promptPresets` is `true`, so `getPresetFromEnv` skips its
  warn-and-return-null branch and hands back the same Function.

The env path is the reachable one: `APP_PROMPT_PRESET=toString` returns a
Function where a preset is expected. Downstream that is silent rather than
loud — `mergePromptConfig` spreads it (a function spreads to no own enumerable
properties), so the caller gets base defaults with **no warning logged**, which
is precisely the outcome the `logger.warn` line exists to prevent.

Fix: `Object.hasOwn` on both, and index only after the check.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`prompt-presets.test.ts` — the `INHERITED` table drives the regression cases
across both `getPromptPreset` and `getPresetFromEnv`. The
`never returns a non-object` cases are the ones that would have caught this
without knowing the mechanism in advance.

## Detailed testing steps

```bash
# RED — revert only the production file
git checkout origin/develop -- packages/cloud/shared/src/lib/eliza/prompt-presets.ts
bun test --cwd packages/cloud/shared src/lib/eliza/prompt-presets.test.ts
#  15 pass, 14 fail

# GREEN — restore the fix
git checkout HEAD -- packages/cloud/shared/src/lib/eliza/prompt-presets.ts
bun test --cwd packages/cloud/shared src/lib/eliza/prompt-presets.test.ts
#  29 pass, 0 fail
```

The suite also pins behaviour the fix must **not** change: every declared preset
still resolves to the same object identity, an unknown name still throws / still
returns null with the warn, and the `mergePromptConfig` contract (text fields
concatenate preset-first with `\n`; scalar fields let config override preset)
is unchanged.

# Evidence Gate

<!-- evidence-head:d0785e295f9fdaa7484100b202b0741749309004 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface; this is a server-side config module in packages/cloud/shared and the diff touches no .tsx/.css/.svg.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the change is a lookup contract on a pure function, covered by the RED/GREEN transcript below.`
<!-- evidence-row:backend-logs -->
- [x] Relevant log line captured below — the restored `logger.warn` for an unknown preset name is part of the fix's observable behaviour.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; the module performs no I/O beyond reading process.env.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no live model is invoked. This module supplies prompt *configuration* consumed elsewhere; it issues no model call, and the diff changes only which object a name resolves to.`
<!-- evidence-row:domain-artifacts -->
- [x] Test transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row; no model call in the module under test.`

## Backend + frontend logs

The warn branch that the bug bypassed now fires. From the GREEN run, with
`APP_PROMPT_PRESET` set to an unrecognised value:

```
Unknown APP_PROMPT_PRESET: junk, using defaults
```

Before the fix, an inherited key such as `toString` skipped this line entirely
and returned a Function instead.

<details>
<summary>RED — production file reverted to <code>develop</code>, test file kept</summary>

```
(fail) getPromptPreset > throws for inherited key toString
(fail) getPromptPreset > throws for inherited key valueOf
(fail) getPromptPreset > throws for inherited key constructor
(fail) getPromptPreset > throws for inherited key hasOwnProperty
(fail) getPromptPreset > throws for inherited key isPrototypeOf
(fail) getPromptPreset > throws for inherited key propertyIsEnumerable
(fail) getPromptPreset > never returns a non-object
(fail) getPresetFromEnv > returns null for inherited key toString
(fail) getPresetFromEnv > returns null for inherited key valueOf
(fail) getPresetFromEnv > returns null for inherited key constructor
(fail) getPresetFromEnv > returns null for inherited key hasOwnProperty
(fail) getPresetFromEnv > returns null for inherited key isPrototypeOf
(fail) getPresetFromEnv > returns null for inherited key propertyIsEnumerable
(fail) getPresetFromEnv > never returns a non-object

 15 pass
 14 fail
```

</details>

<details>
<summary>GREEN — with the fix applied</summary>

```
bun test v1.3.11 (af24e281)

Unknown APP_PROMPT_PRESET: junk, using defaults

 29 pass
 0 fail
 56 expect() calls
Ran 29 tests across 1 file. [229.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface; the diff is confined to a server-side lib module.`

# Known gaps / failures

**Reachability, stated plainly.** The trigger is an environment variable, not
user input — an operator would have to set `APP_PROMPT_PRESET` to a
`Object.prototype` member name for this to fire in production. So the realistic
severity is lower than the affiliate-theme case (#26691), where the same defect
was reachable from a URL query parameter. I am shipping it because the
mechanism is identical, the fix is two lines, and the current code makes the
"unknown preset" warning unreachable for exactly the inputs most likely to be a
typo-turned-footgun.

**Scope I did not widen.** `mergePromptConfig` spreads `...preset`, which
carries `PromptPreset`'s extra `name` and `description` fields into a value
typed as `PromptConfig`. That is a pre-existing type looseness, not a
prototype-chain issue, and changing it could affect callers that read those
fields — so I left it alone and pinned the current merge behaviour in the suite
instead.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to this change. `npx biome check` is clean on
both files.
