### PR TITLE
test(core): cover embedding schema

### DIFF
--- a/packages/core/src/schemas/embedding.test.ts
+++ b/packages/core/src/schemas/embedding.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for embedding schema — verifies the vector-store table descriptor.
+ */
+import { describe, expect, it } from "vitest";
+import { embeddingSchema } from "./embedding.ts";
+
+describe("embedding schema", () => {
+	it("exports embeddingSchema with correct table name", () => {
+		expect(embeddingSchema.name).toBe("embeddings");
+	});
+
+	it("has expected columns", () => {
+		expect(embeddingSchema.columns.id.name).toBe("id");
+		expect(embeddingSchema.columns.memory_id.name).toBe("memory_id");
+		expect(embeddingSchema.columns.created_at.name).toBe("created_at");
+		expect(embeddingSchema.columns.dim_384.name).toBe("dim_384");
+		expect(embeddingSchema.columns.dim_3072.name).toBe("dim_3072");
+	});
+
+	it("has primary key on id", () => {
+		expect(embeddingSchema.columns.id.primaryKey).toBe(true);
+	});
+
+	it("has foreign key to memories", () => {
+		expect(embeddingSchema.foreignKeys.fk_embedding_memory).toBeDefined();
+		expect(embeddingSchema.foreignKeys.fk_embedding_memory.tableTo).toBe(
+			"memories",
+		);
+		expect(embeddingSchema.foreignKeys.fk_embedding_memory.onDelete).toBe(
+			"cascade",
+		);
+	});
+
+	it("has unique constraint on memory_id", () => {
+		expect(
+			embeddingSchema.uniqueConstraints.unique_embedding_memory,
+		).toBeDefined();
+		expect(
+			embeddingSchema.uniqueConstraints.unique_embedding_memory.columns,
+		).toEqual(["memory_id"]);
+	});
+
+	it("has index on memory_id", () => {
+		expect(embeddingSchema.indexes.idx_embedding_memory).toBeDefined();
+	});
+
+	it("has check constraint on memory_id", () => {
+		expect(
+			embeddingSchema.checkConstraints.embedding_source_check,
+		).toBeDefined();
+	});
+});


### PR DESCRIPTION
# Relates to

No issue — test-only coverage for an existing pure helper with no prior test file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: a new `packages/core/src/schemas/embedding.test.ts` exercising `embeddingSchema`. No production code is modified.

# Background

## What does this PR do?

Adds `test(core): cover embedding schema` — a new Vitest suite for `packages/core/src/schemas/embedding.ts`, which defines the vector-store table descriptor for memory embeddings.

## What kind of change is this?

Improvements — test coverage.

## Why are we doing this? Any context or related work?

Module had no existing test file. Covers `core` scope.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/schemas/embedding.test.ts`

## Detailed testing steps

- `bunx vitest run packages/core/src/schemas/embedding.test.ts --config packages/core/vitest.config.ts` — green (7/7).
- Reverted production file (`"embeddings"` → `"WRONG"`), re-ran — red.
- `bunx @biomejs/biome check packages/core/src/schemas/embedding.test.ts` — clean.
- `bun run --cwd packages/core typecheck` — passes.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f6082a3ce09fa9cc4792e06615a59b7060b21f9b -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure-function unit test, no UI`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure-function unit test, no UI`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - pure-function unit test, no UI`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - pure-function unit test, no backend service path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - pure-function unit test, no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit test, no model call`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifacts`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit test, no model call.

## Backend + frontend logs

N/A - pure-function unit test.

## Screenshots (before / after) + video walkthrough

N/A - pure-function unit test, no UI.

### Before

N/A - pure-function unit test, no UI.

### After

N/A - pure-function unit test, no UI.

### Walkthrough video

N/A - pure-function unit test, no UI.

## Audio / voice walkthrough

N/A - no voice change.

## Red -> Green (production reverted -> restored)

**Red (production reverted):**
```
 FAIL  packages/core/src/schemas/embedding.test.ts > embedding schema > exports embeddingSchema with correct table name
AssertionError: expected 'WRONG' to be 'embeddings' // Object.is equality

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

**Green (restored):**
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  10:05:22
   Duration  74ms (transform 17ms, setup 0ms, import 21ms, tests 2ms, environment 0ms)
```

## Biome

```
Checked 1 file in 3ms. No fixes applied.
```

## Typecheck

```
$ node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
Done!
```

## Existing suites

Existing suites still pass: test-only change.

# Known gaps / failures

- Screenshots/video N/A - no UI surface.
- LLM trajectory N/A - no model change.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
