### PR TITLE
test(cloud): pin origin allowlist security boundary

### DIFF
--- a/packages/cloud/shared/src/lib/security/origin-validation.test.ts
+++ b/packages/cloud/shared/src/lib/security/origin-validation.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Pins origin allowlisting. This is a security boundary: it decides whether a
+ * browser Origin/Referer or a redirect URI is trusted, so the cases that matter
+ * are the ones that must be REFUSED — non-http schemes, lookalike domains that
+ * merely end in the allowed suffix, the bare apex against a subdomain wildcard,
+ * and protocol or port mismatches. Pure module, no harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isAllowedOrigin, normalizeOrigin } from "./origin-validation";
+
+describe("normalizeOrigin — accepted", () => {
+  test("reduces a full URL to its origin", () => {
+    expect(normalizeOrigin("https://a.example.com/path?q=1#frag")).toBe("https://a.example.com");
+  });
+
+  test("lowercases scheme and host", () => {
+    expect(normalizeOrigin("HTTPS://A.EXAMPLE.COM")).toBe("https://a.example.com");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(normalizeOrigin("  https://x.com  ")).toBe("https://x.com");
+  });
+
+  test("keeps a non-default port and drops a default one", () => {
+    expect(normalizeOrigin("https://x.com:8443")).toBe("https://x.com:8443");
+    expect(normalizeOrigin("https://x.com:443")).toBe("https://x.com");
+    expect(normalizeOrigin("http://x.com:80")).toBe("http://x.com");
+  });
+
+  test("drops userinfo rather than carrying it into the origin", () => {
+    expect(normalizeOrigin("https://user:pw@x.example.com/")).toBe("https://x.example.com");
+  });
+
+  test("accepts plain http", () => {
+    expect(normalizeOrigin("http://x.com")).toBe("http://x.com");
+  });
+});
+
+describe("normalizeOrigin — refused", () => {
+  test("refuses every non-http(s) scheme", () => {
+    for (const value of [
+      "javascript:alert(1)",
+      "data:text/html,<script>",
+      "file:///etc/passwd",
+      "ftp://x.com",
+      "ws://x.com",
+      "vbscript:msgbox",
+      "blob:https://x.com/abc",
+    ]) {
+      expect(normalizeOrigin(value)).toBeNull();
+    }
+  });
+
+  test("refuses values that are not absolute URLs", () => {
+    for (const value of ["", "   ", "not a url", "//x.com", "/path", "x.com"]) {
+      expect(normalizeOrigin(value)).toBeNull();
+    }
+  });
+
+  test("never returns a value carrying a path, query, or fragment", () => {
+    for (const value of ["https://x.com/a/b", "https://x.com/?q=1", "https://x.com/#f"]) {
+      const origin = normalizeOrigin(value);
+      expect(origin).not.toBeNull();
+      expect((origin as string).split("://")[1]).not.toContain("/");
+    }
+  });
+});
+
+describe("isAllowedOrigin — exact entries", () => {
+  test("admits a matching origin", () => {
+    expect(isAllowedOrigin(["https://app.example.com"], "https://app.example.com")).toBe(true);
+  });
+
+  test("admits a candidate URL carrying a path", () => {
+    expect(isAllowedOrigin(["https://app.example.com"], "https://app.example.com/dash?x=1")).toBe(
+      true,
+    );
+  });
+
+  test("normalises an allowlist entry that carries a path", () => {
+    expect(isAllowedOrigin(["https://app.example.com/callback"], "https://app.example.com")).toBe(
+      true,
+    );
+  });
+
+  test("refuses a protocol downgrade", () => {
+    expect(isAllowedOrigin(["https://app.example.com"], "http://app.example.com")).toBe(false);
+  });
+
+  test("refuses a port mismatch", () => {
+    expect(isAllowedOrigin(["https://app.example.com"], "https://app.example.com:8443")).toBe(
+      false,
+    );
+  });
+
+  test("refuses a different host", () => {
+    for (const candidate of [
+      "https://evil.com",
+      "https://app.example.com.evil.com",
+      "https://appexample.com",
+      "https://app.example.co",
+    ]) {
+      expect(isAllowedOrigin(["https://app.example.com"], candidate)).toBe(false);
+    }
+  });
+
+  test("skips blank entries without admitting anything", () => {
+    expect(isAllowedOrigin(["", "   ", "\t"], "https://app.example.com")).toBe(false);
+  });
+
+  test("refuses when the allowlist is empty", () => {
+    expect(isAllowedOrigin([], "https://app.example.com")).toBe(false);
+  });
+
+  test("admits if any entry matches, regardless of position", () => {
+    const list = ["https://a.com", "https://b.com", "https://c.com"];
+    for (const candidate of list) {
+      expect(isAllowedOrigin(list, candidate)).toBe(true);
+    }
+  });
+});
+
+describe("isAllowedOrigin — refused candidates", () => {
+  test("refuses a candidate that is not an http(s) URL", () => {
+    for (const candidate of [
+      "javascript:alert(1)",
+      "data:text/html,x",
+      "file:///etc/passwd",
+      "not a url",
+      "",
+      "null",
+    ]) {
+      expect(isAllowedOrigin(["https://app.example.com"], candidate)).toBe(false);
+    }
+  });
+
+  test("a non-URL candidate is refused even by the allow-all entry", () => {
+    expect(isAllowedOrigin(["*"], "javascript:alert(1)")).toBe(false);
+    expect(isAllowedOrigin(["*"], "")).toBe(false);
+  });
+});
+
+describe("isAllowedOrigin — wildcard entries", () => {
+  const LIST = ["https://*.example.com"];
+
+  test("admits a direct subdomain", () => {
+    expect(isAllowedOrigin(LIST, "https://app.example.com")).toBe(true);
+  });
+
+  test("refuses the bare apex", () => {
+    expect(isAllowedOrigin(LIST, "https://example.com")).toBe(false);
+  });
+
+  test("refuses a lookalike that only ends similarly", () => {
+    for (const candidate of [
+      "https://evil-example.com",
+      "https://notexample.com",
+      "https://example.com.evil.com",
+      "https://exampleXcom",
+    ]) {
+      expect(isAllowedOrigin(LIST, candidate)).toBe(false);
+    }
+  });
+
+  test("refuses a host that merely CONTAINS the allowed domain", () => {
+    // The attacker controls evil.com and registers a subdomain that embeds the
+    // allowed one. Only an end-anchored match refuses these.
+    for (const candidate of [
+      "https://a.example.com.evil.com",
+      "https://app.example.com.attacker.net",
+      "https://x.example.com.example.org",
+    ]) {
+      expect(isAllowedOrigin(LIST, candidate)).toBe(false);
+    }
+  });
+
+  test("refuses a protocol downgrade on a wildcard entry", () => {
+    expect(isAllowedOrigin(LIST, "http://app.example.com")).toBe(false);
+  });
+
+  test("refuses a non-default port on a wildcard entry", () => {
+    expect(isAllowedOrigin(LIST, "https://app.example.com:8443")).toBe(false);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(isAllowedOrigin(["https://*.EXAMPLE.com"], "https://app.example.com")).toBe(true);
+  });
+
+  test("strips a path from a wildcard entry before matching", () => {
+    expect(isAllowedOrigin(["https://*.example.com/callback"], "https://app.example.com")).toBe(
+      true,
+    );
+  });
+
+  test("a wildcard entry does not leak into another registrable domain", () => {
+    expect(isAllowedOrigin(LIST, "https://app.example.org")).toBe(false);
+    expect(isAllowedOrigin(LIST, "https://app.attacker.com")).toBe(false);
+  });
+});
+
+describe("isAllowedOrigin — allow-all", () => {
+  test("the bare * entry admits any valid http(s) origin", () => {
+    for (const candidate of [
+      "https://anything.com",
+      "http://localhost:3000",
+      "https://a.b.c.example.com:9999",
+    ]) {
+      expect(isAllowedOrigin(["*"], candidate)).toBe(true);
+    }
+  });
+
+  test("a * mixed into a list still admits", () => {
+    expect(isAllowedOrigin(["https://a.com", "*"], "https://evil.com")).toBe(true);
+  });
+
+  test("a padded * is still treated as allow-all", () => {
+    expect(isAllowedOrigin(["  *  "], "https://evil.com")).toBe(true);
+  });
+});
+
+describe("isAllowedOrigin — regex safety", () => {
+  test("regex metacharacters in an entry are matched literally", () => {
+    // Without escaping, "." would match any character and admit a lookalike.
+    expect(isAllowedOrigin(["https://a.example.com"], "https://aXexample.com")).toBe(false);
+    expect(isAllowedOrigin(["https://*.a.example.com"], "https://x.aXexample.com")).toBe(false);
+  });
+
+  test("a candidate cannot inject regex syntax through its own host", () => {
+    for (const candidate of ["https://.*.example.com", "https://a.example.com%2e"]) {
+      expect(isAllowedOrigin(["https://app.example.com"], candidate)).toBe(false);
+    }
+  });
+
+  test("an entry full of metacharacters cannot become a catch-all", () => {
+    expect(isAllowedOrigin(["https://^$+?()[]{}|.com"], "https://evil.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/security/origin-validation.ts`
had no test file; this adds first-time coverage for a security boundary.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 35 cases over `normalizeOrigin` / `isAllowedOrigin`. This module decides
whether a browser `Origin`/`Referer` header or a redirect URI is trusted, so
the suite is weighted toward what must be **refused**, not what must be allowed:

- **Scheme.** `javascript:`, `data:`, `file:`, `ftp:`, `ws:`, `vbscript:`, and
  `blob:` all normalise to `null`. A `javascript:` candidate is refused even
  when the allowlist is the wildcard `"*"` — allow-all must still mean
  "any valid **http(s)** origin".
- **Suffix bypass.** The case with real teeth:
  `https://a.example.com.evil.com` must **not** match `https://*.example.com`.
  The attacker owns `evil.com` and registers a subdomain that embeds the allowed
  domain; only an end-anchored regex refuses it.
- **Apex vs subdomain.** `https://*.example.com` must not admit the bare
  `https://example.com`.
- **Lookalikes.** `evil-example.com`, `notexample.com`,
  `example.com.evil.com`, `app.example.co`.
- **Protocol downgrade and port mismatch** on both exact and wildcard entries.
- **Regex safety.** Metacharacters in an allowlist entry are matched literally,
  so `https://a.example.com` cannot admit `https://aXexample.com` through an
  unescaped `.`; and an entry made of metacharacters cannot collapse into a
  catch-all.

Positive paths are pinned too — path-carrying candidates and entries normalise
correctly, userinfo is dropped, default ports collapse, and matching is
case-insensitive.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`origin-validation.test.ts` — `refuses a host that merely CONTAINS the allowed
domain` and the `regex safety` block.

## Detailed testing steps

```bash
bun test --cwd packages/cloud/shared src/lib/security/origin-validation.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR):

| Mutation | Result |
|---|---|
| `escapeRegex` returns its input unchanged | 30 pass, **5 fail** |
| the `http:`/`https:` protocol check removed from `normalizeOrigin` | 33 pass, **2 fail** |
| wildcard regex loses its `^`/`$` anchors | 33 pass, **2 fail** |

**The third mutation initially caught only one case, and that is worth
reporting.** My first pass at "lookalike" hosts used
`https://example.com.evil.com`, which has `//example.com`, not `.example.com`,
so it fails to match the pattern with or without anchors. I added
`https://a.example.com.evil.com` — a host that genuinely *contains*
`.example.com` — which is the shape an unanchored regex would wrongly admit.
Mutation testing found the gap in my test, not in the code.

# Evidence Gate

<!-- evidence-head:d2b2250c6e72b51999dcd769cc8aad431306d3ae -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a pure URL-parsing module; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the module returns a string or a boolean.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module performs no I/O and emits no log lines; its observable behaviour is its return value, asserted directly.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; this is the helper a request handler would call, not the handler.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no I/O in the module under test.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 35 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — regex escaping removed</summary>

```
(fail) isAllowedOrigin - wildcard entries > admits a direct subdomain
(fail) isAllowedOrigin - wildcard entries > refuses the bare apex
(fail) isAllowedOrigin - wildcard entries > refuses a lookalike that only ends similarly
(fail) isAllowedOrigin - wildcard entries > matches case-insensitively
(fail) isAllowedOrigin - wildcard entries > strips a path from a wildcard entry before matching
 30 pass
 5 fail
```

</details>

<details>
<summary>Mutation B — http(s) scheme allowlist removed</summary>

```
(fail) normalizeOrigin - refused > refuses every non-http(s) scheme
(fail) isAllowedOrigin - refused candidates > a non-URL candidate is refused even by the allow-all entry
 33 pass
 2 fail
```

</details>

<details>
<summary>Mutation C — wildcard regex loses its anchors (after adding the suffix-bypass case)</summary>

```
(fail) isAllowedOrigin - wildcard entries > refuses a host that merely CONTAINS the allowed domain
(fail) isAllowedOrigin - wildcard entries > refuses a non-default port on a wildcard entry
 33 pass
 2 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side security helper; no UI surface.`

# Known gaps / failures

**A behaviour I found, verified, and deliberately did not change.** An
allowlist entry written **without a scheme** silently permits both protocols.
`stripPath("*.example.com")` does not match the scheme regex, so it is returned
as-is and becomes `/^.*\.example\.com$/i` — which matches
`http://a.example.com` as well as `https://a.example.com`. I confirmed this
directly:

```
*.example.com  vs https://a.example.com  -> true
*.example.com  vs http://a.example.com   -> true
```

I did not "fix" it because the module's own doc lists supported entry forms as
full URLs, origins, and wildcard origins **like `https://*.example.com`** —
scheme-less entries are not a documented form, and tightening them could break
a deployment whose stored allowlist relies on the current leniency. That is a
config-compatibility call for the owner, not something a test PR should decide.
Flagging it explicitly so it is a known quantity rather than a latent surprise;
I did **not** encode it as expected behaviour in the suite either way.

**Scope.** This pins the helper, not its callers. Whether every route that
should consult `isAllowedOrigin` actually does is a separate question this PR
does not answer.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
