### PR TITLE
test(cloud): pin voice consent nonce single-use and fail-closed

### DIFF
--- a/packages/cloud/shared/src/lib/voice-session/consent-nonce.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/consent-nonce.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Voice-session consent nonce (SEC-21). Consent is a server-enforced mint
+ * precondition, so the properties that matter are refusals: a nonce is
+ * single-use, scoped to its issuing user, and an unconfigured store refuses
+ * rather than fabricating consent. Runs against the repository's own in-memory
+ * Redis (MOCK_REDIS=1) so the atomic getdel path is exercised for real, plus a
+ * no-store lane that asserts the fail-closed behaviour. Env is saved and
+ * restored per test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __resetConsentNonceClientForTests,
+  CONSENT_NONCE_TTL_SECONDS,
+  consumeConsentNonce,
+  isConsentStoreConfigured,
+  issueConsentNonce,
+} from "./consent-nonce";
+
+const REDIS_KEYS = [
+  "MOCK_REDIS",
+  "REDIS_URL",
+  "DIRECT_REDIS_BACKEND",
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(REDIS_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of REDIS_KEYS) delete process.env[key];
+  __resetConsentNonceClientForTests();
+});
+
+afterEach(() => {
+  for (const key of REDIS_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  __resetConsentNonceClientForTests();
+});
+
+/** Turn on the repository's in-memory Redis for this test. */
+function withStore(): void {
+  process.env.MOCK_REDIS = "1";
+  __resetConsentNonceClientForTests();
+}
+
+describe("configuration", () => {
+  test("TTL is short-lived and positive", () => {
+    expect(Number.isInteger(CONSENT_NONCE_TTL_SECONDS)).toBe(true);
+    expect(CONSENT_NONCE_TTL_SECONDS).toBeGreaterThan(0);
+    expect(CONSENT_NONCE_TTL_SECONDS).toBeLessThanOrEqual(15 * 60);
+  });
+
+  test("reports the store as unconfigured with no backend env", () => {
+    expect(isConsentStoreConfigured()).toBe(false);
+  });
+
+  test("reports the store as configured under the mock backend", () => {
+    withStore();
+    expect(isConsentStoreConfigured()).toBe(true);
+  });
+});
+
+describe("fail closed with no store", () => {
+  test("issuing yields null rather than a usable nonce", async () => {
+    expect(await issueConsentNonce("user-a")).toBeNull();
+  });
+
+  test("consuming refuses any nonce", async () => {
+    for (const nonce of ["any", crypto.randomUUID(), "00000000-0000-0000-0000-000000000000"]) {
+      expect(await consumeConsentNonce("user-a", nonce)).toBe(false);
+    }
+  });
+
+  test("a nonce issued while configured is refused once the store is gone", async () => {
+    withStore();
+    const issued = await issueConsentNonce("user-a");
+    expect(issued).not.toBeNull();
+
+    delete process.env.MOCK_REDIS;
+    __resetConsentNonceClientForTests();
+    expect(await consumeConsentNonce("user-a", (issued as { nonce: string }).nonce)).toBe(false);
+  });
+});
+
+describe("issueConsentNonce — input validation", () => {
+  test("rejects a missing or blank userId before touching the store", async () => {
+    withStore();
+    for (const userId of ["", "   ", "\t\n"]) {
+      expect(issueConsentNonce(userId)).rejects.toThrow();
+    }
+  });
+
+  test("rejects a non-string userId", async () => {
+    withStore();
+    for (const userId of [null, undefined, 42, {}, []]) {
+      expect(issueConsentNonce(userId as unknown as string)).rejects.toThrow();
+    }
+  });
+});
+
+describe("issueConsentNonce — issued shape", () => {
+  test("returns a UUID nonce and a future expiry", async () => {
+    withStore();
+    const issued = await issueConsentNonce("user-a");
+    expect(issued).not.toBeNull();
+    const { nonce, expiresAt } = issued as { nonce: string; expiresAt: string };
+    expect(nonce).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    const ms = Date.parse(expiresAt);
+    expect(Number.isNaN(ms)).toBe(false);
+    expect(ms).toBeGreaterThan(Date.now());
+    expect(ms).toBeLessThanOrEqual(Date.now() + CONSENT_NONCE_TTL_SECONDS * 1000 + 5000);
+  });
+
+  test("never reissues the same nonce", async () => {
+    withStore();
+    const nonces = new Set<string>();
+    for (let i = 0; i < 25; i += 1) {
+      const issued = await issueConsentNonce("user-a");
+      nonces.add((issued as { nonce: string }).nonce);
+    }
+    expect(nonces.size).toBe(25);
+  });
+});
+
+describe("consumeConsentNonce — input validation", () => {
+  test("refuses blank or non-string arguments without throwing", async () => {
+    withStore();
+    const bad = ["", "   ", null, undefined, 42, {}] as unknown as string[];
+    for (const value of bad) {
+      expect(await consumeConsentNonce(value, "n")).toBe(false);
+      expect(await consumeConsentNonce("user-a", value)).toBe(false);
+    }
+  });
+});
+
+describe("consumeConsentNonce — single use", () => {
+  test("consumes a freshly issued nonce exactly once", async () => {
+    withStore();
+    const issued = await issueConsentNonce("user-a");
+    const { nonce } = issued as { nonce: string };
+    expect(await consumeConsentNonce("user-a", nonce)).toBe(true);
+    expect(await consumeConsentNonce("user-a", nonce)).toBe(false);
+  });
+
+  test("refuses a replay however many times it is retried", async () => {
+    withStore();
+    const { nonce } = (await issueConsentNonce("user-a")) as { nonce: string };
+    expect(await consumeConsentNonce("user-a", nonce)).toBe(true);
+    for (let i = 0; i < 5; i += 1) {
+      expect(await consumeConsentNonce("user-a", nonce)).toBe(false);
+    }
+  });
+
+  test("only one of many concurrent consumers wins", async () => {
+    withStore();
+    const { nonce } = (await issueConsentNonce("user-a")) as { nonce: string };
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => consumeConsentNonce("user-a", nonce)),
+    );
+    expect(results.filter(Boolean).length).toBe(1);
+  });
+
+  test("refuses a nonce that was never issued", async () => {
+    withStore();
+    expect(await consumeConsentNonce("user-a", crypto.randomUUID())).toBe(false);
+  });
+
+  test("consuming one nonce does not invalidate another", async () => {
+    withStore();
+    const first = (await issueConsentNonce("user-a")) as { nonce: string };
+    const second = (await issueConsentNonce("user-a")) as { nonce: string };
+    expect(await consumeConsentNonce("user-a", first.nonce)).toBe(true);
+    expect(await consumeConsentNonce("user-a", second.nonce)).toBe(true);
+  });
+});
+
+describe("consumeConsentNonce — user scoping", () => {
+  test("a nonce issued to one user cannot mint for another", async () => {
+    withStore();
+    const { nonce } = (await issueConsentNonce("user-a")) as { nonce: string };
+    expect(await consumeConsentNonce("user-b", nonce)).toBe(false);
+    // Still valid for its rightful owner — the failed attempt consumed nothing.
+    expect(await consumeConsentNonce("user-a", nonce)).toBe(true);
+  });
+
+  test("scoping is exact, not prefix-based", async () => {
+    withStore();
+    const { nonce } = (await issueConsentNonce("user")) as { nonce: string };
+    for (const impostor of ["user-x", "use", "User", " user", "user "]) {
+      expect(await consumeConsentNonce(impostor, nonce)).toBe(false);
+    }
+    expect(await consumeConsentNonce("user", nonce)).toBe(true);
+  });
+
+  test("two users' nonces are independent", async () => {
+    withStore();
+    const a = (await issueConsentNonce("user-a")) as { nonce: string };
+    const b = (await issueConsentNonce("user-b")) as { nonce: string };
+    expect(await consumeConsentNonce("user-a", a.nonce)).toBe(true);
+    expect(await consumeConsentNonce("user-b", b.nonce)).toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue. `packages/cloud/shared/src/lib/voice-session/consent-nonce.ts`
(SEC-21) had no test file — despite already exporting a
`__resetConsentNonceClientForTests()` hook for one.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Package lint/tests run after sync; see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] New suite passes post-sync.

# Risks

**Low — test-only.** No production file is modified; the diff adds one new
file. It cannot change runtime behaviour.

# Background

## What does this PR do?

Adds 19 cases over the voice-session consent nonce. The module's header states
the threat directly: an ambient/voice session could be minted API-direct with
no consent UI, so the server would start paying for a live mic stream with no
proof the human agreed. Three properties carry that mitigation, and each is now
pinned:

- **Single-use.** `consumeConsentNonce` uses an atomic `getdel`. The suite
  asserts a nonce consumes exactly once, that repeated replays keep failing,
  and — the case that actually proves atomicity — that of **10 concurrent
  consumers exactly one wins**.
- **User scoping.** A nonce issued to `user-a` must not mint for `user-b`, and
  a failed cross-user attempt must **consume nothing** (the rightful owner can
  still use it afterwards). Scoping is asserted as exact, not prefix-based:
  `"use"`, `"user-x"`, `"User"`, `" user"` are all refused for a `"user"` nonce.
- **Fail closed.** With no store configured, issuing returns `null` and
  consuming returns `false` — the module's stated rule that it never fabricates
  consent. There is also a lane where a nonce is issued *while* configured and
  then the store disappears; it must still be refused.

**This runs against a real client, not a stub.** Setting `MOCK_REDIS=1` selects
the repository's own in-memory `MockSocketRedis` through the normal
`buildRedisClient` path, so the actual `getdel` semantics are exercised rather
than a hand-written fake with the behaviour I wanted to prove.

## What kind of change is this?

Improvements (test coverage for an existing module).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`consent-nonce.test.ts` — `only one of many concurrent consumers wins` and the
`user scoping` block.

## Detailed testing steps

```bash
# The suite reaches @elizaos/cloud-routing transitively; build it once:
bun run --cwd packages/cloud/routing build
bun test --cwd packages/cloud/shared src/lib/voice-session/consent-nonce.test.ts
```

To confirm the suite is not vacuous, I ran three mutations against the
production file (all reverted; the file is untouched in this PR). Each maps to
one of the three security properties:

| Mutation | Breaks | Result |
|---|---|---|
| `redis.getdel(...)` → `redis.get(...)` | single-use | 16 pass, **3 fail** |
| `consentKey` drops `${userId}` | user scoping | 17 pass, **2 fail** |
| `if (!redis) return false` → `return true` | fail-closed | 17 pass, **2 fail** |

The third is the one worth dwelling on: it makes a missing Redis **fabricate
consent for every mint**, which is precisely the outcome the module's header
says must never happen.

# Evidence Gate

<!-- evidence-head:b38820f4d581488e34b91f9c677961496a30dad9 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff over a server-side security helper; no rendered UI surface and no .tsx/.css/.svg touched.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow is added or changed. The consent UI that calls issueConsentNonce is not touched by this diff.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the module emits no log lines. Its observable behaviour is its return value plus the store state, both asserted directly against a real in-memory Redis client.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or state change; this is the helper the mint route calls, not the route.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model code path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Test + mutation transcripts attached below. The domain artifact here is the store state, asserted through consume outcomes.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - the module emits no log lines; see the backend-logs row.`

<details>
<summary>New suite — passing</summary>

```
bun test v1.3.11 (af24e281)

 19 pass
 0 fail
```

</details>

<details>
<summary>Mutation A — getdel replaced with get (no longer single-use)</summary>

```
(fail) consumeConsentNonce - single use > consumes a freshly issued nonce exactly once
(fail) consumeConsentNonce - single use > refuses a replay however many times it is retried
(fail) consumeConsentNonce - single use > only one of many concurrent consumers wins
 16 pass
 3 fail
```

</details>

<details>
<summary>Mutation B — nonce key drops the user scope</summary>

```
(fail) consumeConsentNonce - user scoping > a nonce issued to one user cannot mint for another
(fail) consumeConsentNonce - user scoping > scoping is exact, not prefix-based
 17 pass
 2 fail
```

</details>

<details>
<summary>Mutation C — missing store fails OPEN (fabricates consent)</summary>

```
(fail) fail closed with no store > consuming refuses any nonce
(fail) fail closed with no store > a nonce issued while configured is refused once the store is gone
 17 pass
 2 fail
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff over a server-side module; no UI surface.`

# Known gaps / failures

**Build prerequisite, worth flagging.** This suite reaches
`@elizaos/cloud-routing` transitively (via `runtime/cloud-bindings`), which is
consumed from `dist/`. Without `bun run --cwd packages/cloud/routing build` it
fails at import with `Cannot find module '@elizaos/cloud-routing'` — the same
pre-existing error that already affects other suites in this package. It passes
once that package is built. If CI does not build `cloud/routing` before the
cloud-shared lane, this suite will need that step added; I could not verify the
CI ordering from here.

**TTL expiry is not tested.** The nonce is short-lived
(`CONSENT_NONCE_TTL_SECONDS = 300`), and I assert the value is positive and
under 15 minutes, but I do **not** assert that an expired nonce is refused —
that would need either a 5-minute wait or a clock/TTL seam the in-memory client
does not expose. The expiry itself is delegated to Redis's `ex`, so what is
untested is Redis's behaviour rather than this module's logic.

**Scope.** This pins the helper. Whether `POST /session` actually calls
`consumeConsentNonce` before minting — the thing that makes any of this
load-bearing — is the route's contract and is not covered here.

`bun run verify` was not run to completion in this environment — it builds the
full workspace and is unrelated to a test-only diff. `npx biome check` is clean
on the new file.
