### PR TITLE
test(core): cover edge fail-closed parser stubs

### DIFF
--- a/packages/core/src/features/documents/__tests__/parsers-edge.test.ts
+++ b/packages/core/src/features/documents/__tests__/parsers-edge.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+	convertPdfToTextFromBuffer,
+	extractTextFromFileBuffer,
+} from "./parsers.edge.ts";
+
+describe("edge parsers (fail-closed)", () => {
+	it("extractTextFromFileBuffer throws with context", async () => {
+		await expect(
+			extractTextFromFileBuffer(Buffer.alloc(0), "application/pdf", "doc.pdf"),
+		).rejects.toThrow(/unavailable on the edge runtime/i);
+		await expect(
+			extractTextFromFileBuffer(Buffer.alloc(0), "text/plain", "note.txt"),
+		).rejects.toThrow(/text\/plain/);
+	});
+
+	it("convertPdfToTextFromBuffer throws with filename", async () => {
+		await expect(
+			convertPdfToTextFromBuffer(Buffer.alloc(0), "report.pdf"),
+		).rejects.toThrow(/unavailable on the edge runtime/i);
+		await expect(
+			convertPdfToTextFromBuffer(Buffer.alloc(0), "report.pdf"),
+		).rejects.toThrow(/report\.pdf/);
+	});
+
+	it("convertPdfToTextFromBuffer works without a filename", async () => {
+		await expect(convertPdfToTextFromBuffer(Buffer.alloc(0))).rejects.toThrow(
+			/unavailable on the edge runtime/i,
+		);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
