### PR TITLE
fix(shared): restore eliza-root lint closure

### DIFF
--- a/packages/shared/src/utils/eliza-root.test.ts
+++ b/packages/shared/src/utils/eliza-root.test.ts
@@ -1,11 +1,16 @@
 /**
  * Coverage for eliza-root.
  */
-import { describe, expect, it } from "vitest";
-import { resolveElizaPackageRoot, resolveElizaPackageRootSync } from "./eliza-root.js";
-import * as path from "node:path";
-import * as os from "node:os";
+
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  resolveElizaPackageRoot,
+  resolveElizaPackageRootSync,
+} from "./eliza-root.js";
+
 describe("eliza-root", () => {
   it("finds root from repo", async () => {
     const root = await resolveElizaPackageRoot({ cwd: process.cwd() });
@@ -15,7 +20,9 @@ describe("eliza-root", () => {
     expect(resolveElizaPackageRootSync({ cwd: process.cwd() })).toBeTruthy();
   });
   it("returns null for tmp", async () => {
-    const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "eliza-test-"));
+    const tmp = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-test-"),
+    );
     expect(await resolveElizaPackageRoot({ cwd: tmp })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- format the newly merged `eliza-root` regression test with the repository-pinned Biome rules
- restore `@elizaos/shared#lint:check`, which is currently failing unrelated author PRs in the affected-workspace closure

Refs #20523.

## Verification

- exact head: `1138e617bb75d`
- `biome check packages/shared/src/utils/eliza-root.test.ts`: passed
- focused Vitest: 3/3 passed
- `git diff --check`: passed

No runtime behavior changes; the test token stream is unchanged apart from import organization and formatting.