### PR TITLE
fix(ci): restore affected-workspace formatting

### DIFF
--- a/packages/cloud/api/src/middleware/auth.test.ts
+++ b/packages/cloud/api/src/middleware/auth.test.ts
@@ -41,16 +41,15 @@ vi.mock("../services/audit-dispatcher-singleton", () => {
   };
 });
 
-const auditModule = (await import("../services/audit-dispatcher-singleton")) as unknown as {
+const auditModule = (await import(
+  "../services/audit-dispatcher-singleton"
+)) as unknown as {
   __auditEmits: AuditEmit[];
 };
 const auditEmits = auditModule.__auditEmits;
 
-const {
-  authMiddleware,
-  isPublicPath,
-  isRouteAuthenticatedInferencePath,
-} = await import("./auth");
+const { authMiddleware, isPublicPath, isRouteAuthenticatedInferencePath } =
+  await import("./auth");
 
 const PUBLIC_PREFIXES = [
   "/api/health",

--- a/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { BROWSER_TAB_PRELOAD_SCRIPT } from "./browser-tabs-renderer-registry.js";
+
 describe("browser-tabs-renderer-registry", () => {
   it("exports preload script", () => {
     expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__elizaTabKit");

--- a/packages/shared/src/utils/eliza-root.test.ts
+++ b/packages/shared/src/utils/eliza-root.test.ts
@@ -1,11 +1,15 @@
 /**
  * Coverage for eliza-root.
  */
-import { describe, expect, it } from "vitest";
-import { resolveElizaPackageRoot, resolveElizaPackageRootSync } from "./eliza-root.js";
-import * as path from "node:path";
-import * as os from "node:os";
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  resolveElizaPackageRoot,
+  resolveElizaPackageRootSync,
+} from "./eliza-root.js";
+
 describe("eliza-root", () => {
   it("finds root from repo", async () => {
     const root = await resolveElizaPackageRoot({ cwd: process.cwd() });
@@ -15,7 +19,9 @@ describe("eliza-root", () => {
     expect(resolveElizaPackageRootSync({ cwd: process.cwd() })).toBeTruthy();
   });
   it("returns null for tmp", async () => {
-    const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "eliza-test-"));
+    const tmp = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-test-"),
+    );
     expect(await resolveElizaPackageRoot({ cwd: tmp })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- restore Biome import ordering in the shared eliza-root test
- separate imports from the browser-tab renderer test body
- format the cloud auth middleware test
- unblock the affected-workspace lint closure on current develop

## Verification
- biome check packages/shared/src (522 files)
- biome check packages/cloud/api (1,427 files)
- both affected shared tests (5/5)
- git diff --check

These are the three pre-existing formatting failures surfaced sequentially by protected affected-workspace validation while reviewing #26868.