### PR TITLE
test(ui): cover setup-resume

### DIFF
--- a/packages/ui/src/state/__tests__/setup-resume.test.ts
+++ b/packages/ui/src/state/__tests__/setup-resume.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for onboarding resume derivation from partial server config.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  deriveFirstRunResumeFieldsFromConfig,
+  hasPartialSetupConnectionConfig,
+} from "../setup-resume.ts";
+
+describe("setup-resume", () => {
+  describe("hasPartialSetupConnectionConfig", () => {
+    it("returns false for null, undefined, or empty config", () => {
+      expect(hasPartialSetupConnectionConfig(null)).toBe(false);
+      expect(hasPartialSetupConnectionConfig(undefined)).toBe(false);
+      expect(hasPartialSetupConnectionConfig({})).toBe(false);
+    });
+
+    it("returns true when serviceRouting is configured", () => {
+      const config = {
+        serviceRouting: {
+          llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+        },
+      };
+      expect(hasPartialSetupConnectionConfig(config)).toBe(true);
+    });
+
+    it("returns true when deploymentTarget is not local", () => {
+      const config = {
+        deploymentTarget: {
+          runtime: "remote",
+          remoteApiBase: "https://agent.example.com",
+        },
+      };
+      expect(hasPartialSetupConnectionConfig(config)).toBe(true);
+    });
+
+    it("returns true when linkedAccounts is present in config root", () => {
+      const config = {
+        linkedAccounts: {
+          discord: { enabled: true },
+        },
+      };
+      expect(hasPartialSetupConnectionConfig(config)).toBe(true);
+    });
+  });
+
+  describe("deriveFirstRunResumeFieldsFromConfig", () => {
+    it("derives default empty fields when config is empty", () => {
+      const result = deriveFirstRunResumeFieldsFromConfig({});
+      expect(result).toEqual({
+        firstRunRuntimeTarget: "local",
+        firstRunProvider: "",
+        firstRunRemoteConnected: false,
+        firstRunRemoteApiBase: "",
+        firstRunRemoteToken: "",
+      });
+    });
+
+    it("derives remote connection fields when remote deploymentTarget is set", () => {
+      const config = {
+        deploymentTarget: {
+          runtime: "remote",
+          remoteApiBase: "https://remote.agent.app",
+          remoteAccessToken: "secret-token-123",
+        },
+      };
+      const result = deriveFirstRunResumeFieldsFromConfig(config);
+      expect(result).toEqual({
+        firstRunRuntimeTarget: "remote",
+        firstRunProvider: "",
+        firstRunRemoteConnected: true,
+        firstRunRemoteApiBase: "https://remote.agent.app",
+        firstRunRemoteToken: "secret-token-123",
+      });
+    });
+
+    it("derives elizacloud provider when cloud-proxy transport is configured", () => {
+      const config = {
+        serviceRouting: {
+          llmText: {
+            backend: "elizacloud",
+            transport: "cloud-proxy",
+          },
+        },
+      };
+      const result = deriveFirstRunResumeFieldsFromConfig(config);
+      expect(result.firstRunProvider).toBe("elizacloud");
+    });
+
+    it("derives non-cloud provider directly from backend routing", () => {
+      const config = {
+        serviceRouting: {
+          llmText: {
+            backend: "anthropic",
+            transport: "direct",
+          },
+        },
+      };
+      const result = deriveFirstRunResumeFieldsFromConfig(config);
+      expect(result.firstRunProvider).toBe("anthropic");
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for `hasPartialSetupConnectionConfig` and `deriveFirstRunResumeFieldsFromConfig` in `packages/ui/src/state/setup-resume.ts` with no production code changes.

# Background

## What does this PR do?
Adds unit tests for `packages/ui/src/state/setup-resume.ts`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/ui/src/state/__tests__/setup-resume.test.ts`

## Detailed testing steps
Run:
```bash
node packages/scripts/run-vitest.mjs run packages/ui/src/state/__tests__/setup-resume.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0e72f1b559381835a566439e062d51c370d2b629 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI changes in unit tests`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - unit test execution only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic unit tests with no model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
node packages/scripts/run-vitest.mjs run packages/ui/src/state/__tests__/setup-resume.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/.worktrees/wt-ship

 ✓ packages/ui/src/state/__tests__/setup-resume.test.ts (8 tests) 3ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  10:51:04
   Duration  9.62s (transform 7.64s, setup 0ms, import 9.49s, tests 3ms, environment 0ms)
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Audio / voice walkthrough
N/A - no audio change.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
