### PR TITLE
test(shared): cover config path safety and prototype-pollution guard

### DIFF
--- a/packages/shared/src/config/__tests__/config-paths.test.ts
+++ b/packages/shared/src/config/__tests__/config-paths.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  getConfigValueAtPath,
+  parseConfigPath,
+  setConfigValueAtPath,
+  unsetConfigValueAtPath,
+} from "./config-paths.ts";
+
+describe("parseConfigPath", () => {
+  it("parses dot notation", () => {
+    expect(parseConfigPath("foo.bar.baz")).toEqual({
+      ok: true,
+      path: ["foo", "bar", "baz"],
+    });
+  });
+
+  it("rejects empty and malformed paths", () => {
+    expect(parseConfigPath("").ok).toBe(false);
+    expect(parseConfigPath("  ").ok).toBe(false);
+    expect(parseConfigPath("foo..bar").ok).toBe(false);
+  });
+
+  it("rejects prototype-pollution segments", () => {
+    for (const bad of [
+      "__proto__",
+      "a.__proto__.b",
+      "prototype",
+      "constructor",
+    ]) {
+      expect(parseConfigPath(bad).ok).toBe(false);
+    }
+  });
+});
+
+describe("set/get/unset config paths", () => {
+  it("sets and gets nested values", () => {
+    const root: Record<string, unknown> = {};
+    setConfigValueAtPath(root, ["a", "b"], 42);
+    expect(getConfigValueAtPath(root, ["a", "b"])).toBe(42);
+  });
+
+  it("creates intermediate objects", () => {
+    const root: Record<string, unknown> = {};
+    setConfigValueAtPath(root, ["x", "y", "z"], "v");
+    expect(getConfigValueAtPath(root, ["x", "y", "z"])).toBe("v");
+  });
+
+  it("unsets and prunes empty parents", () => {
+    const root: Record<string, unknown> = { a: { b: { c: 1 } } };
+    expect(unsetConfigValueAtPath(root, ["a", "b", "c"])).toBe(true);
+    expect(root).toEqual({});
+  });
+
+  it("unset returns false for missing keys", () => {
+    const root: Record<string, unknown> = { a: 1 };
+    expect(unsetConfigValueAtPath(root, ["a", "b"])).toBe(false);
+    expect(unsetConfigValueAtPath(root, ["missing"])).toBe(false);
+  });
+
+  it("get returns undefined for missing paths", () => {
+    expect(getConfigValueAtPath({}, ["nope"])).toBeUndefined();
+    expect(getConfigValueAtPath({ a: 1 }, ["a", "b"])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 8 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
