### PR TITLE
test(core): cover secrets broker config fail-closed semantics

### DIFF
--- a/packages/core/src/features/secrets/storage/__tests__/broker-config.test.ts
+++ b/packages/core/src/features/secrets/storage/__tests__/broker-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolveSecretsBrokerConfig,
+	SecretsBrokerUnavailableError,
+} from "./broker-config.ts";
+
+describe("resolveSecretsBrokerConfig", () => {
+	it("is undefined when either url or token is missing", () => {
+		expect(resolveSecretsBrokerConfig(() => undefined)).toBeUndefined();
+		expect(
+			resolveSecretsBrokerConfig((k) =>
+				k === "ELIZA_SECRETS_BROKER_URL" ? "https://broker" : undefined,
+			),
+		).toBeUndefined();
+		expect(
+			resolveSecretsBrokerConfig((k) =>
+				k === "ELIZA_SECRETS_BROKER_TOKEN" ? "tok" : undefined,
+			),
+		).toBeUndefined();
+	});
+
+	it("activates only when both url and token are present", () => {
+		const cfg = resolveSecretsBrokerConfig((k) => {
+			const values: Record<string, string> = {
+				ELIZA_SECRETS_BROKER_URL: "https://broker.example",
+				ELIZA_SECRETS_BROKER_TOKEN: "agent-handle",
+			};
+			return values[k];
+		});
+		expect(cfg).toBeDefined();
+		expect(cfg?.url).toBe("https://broker.example");
+		expect(cfg?.token).toBe("agent-handle");
+	});
+
+	it("trims whitespace and treats empty as absent", () => {
+		const cfg = resolveSecretsBrokerConfig((k) => {
+			const values: Record<string, string> = {
+				ELIZA_SECRETS_BROKER_URL: "  https://broker  ",
+				ELIZA_SECRETS_BROKER_TOKEN: "   ",
+			};
+			return values[k];
+		});
+		expect(cfg).toBeUndefined();
+	});
+
+	it("parses the strict flag", () => {
+		const cfg = resolveSecretsBrokerConfig((k) => {
+			const values: Record<string, string> = {
+				ELIZA_SECRETS_BROKER_URL: "https://broker",
+				ELIZA_SECRETS_BROKER_TOKEN: "tok",
+				ELIZA_SECRETS_BROKER_STRICT: "1",
+			};
+			return values[k];
+		});
+		expect(cfg?.strict).toBe(true);
+	});
+});
+
+describe("SecretsBrokerUnavailableError", () => {
+	it("carries the broker url and names the strict mode", () => {
+		const err = new SecretsBrokerUnavailableError("https://broker");
+		expect(err.name).toBe("SecretsBrokerUnavailableError");
+		expect(err.brokerUrl).toBe("https://broker");
+		expect(err.message).toContain("Refusing to fall back to local storage");
+		expect(err.message).toContain("ELIZA_SECRETS_BROKER_STRICT");
+		expect(err instanceof Error).toBe(true);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 5 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
