### PR TITLE
test(cloud): cover database-adapter-config

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getRuntimeDatabaseBackend,
+  resolveRuntimeDatabaseAdapterConfig,
+} from "./database-adapter-config";
+
+describe("getRuntimeDatabaseBackend", () => {
+  test("defaults to postgresql when no env", () => {
+    expect(getRuntimeDatabaseBackend({})).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: undefined })).toBe("postgresql");
+  });
+
+  test("recognizes postgresql aliases case-insensitive and trimmed", () => {
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "postgres" })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "PostgreSQL" })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: " PG " })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "neon" })).toBe("postgresql");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "NEON" })).toBe("postgresql");
+  });
+
+  test("recognizes pglite aliases case-insensitive and trimmed", () => {
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "pglite" })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: " PGLite " })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "local" })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "FILE" })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "sqlite" })).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "SQLITE" })).toBe("pglite");
+  });
+
+  test("respects priority DATABASE_ADAPTER > DATABASE_ENGINE > DATABASE_DIALECT", () => {
+    expect(
+      getRuntimeDatabaseBackend({
+        DATABASE_ADAPTER: "pglite",
+        DATABASE_ENGINE: "postgresql",
+        DATABASE_DIALECT: "postgresql",
+      }),
+    ).toBe("pglite");
+    expect(
+      getRuntimeDatabaseBackend({
+        DATABASE_ENGINE: "pglite",
+        DATABASE_DIALECT: "postgresql",
+      }),
+    ).toBe("pglite");
+    expect(getRuntimeDatabaseBackend({ DATABASE_DIALECT: "pglite" })).toBe("pglite");
+  });
+
+  test("throws for unsupported backend", () => {
+    expect(() => getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "mysql" })).toThrow(
+      "Unsupported DATABASE_ENGINE/DATABASE_DIALECT value: mysql",
+    );
+    expect(() => getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "  unknown  " })).toThrow(
+      "Unsupported DATABASE_ENGINE/DATABASE_DIALECT value: unknown",
+    );
+  });
+
+  test("handles empty string as unsupported after trim", () => {
+    expect(() => getRuntimeDatabaseBackend({ DATABASE_ADAPTER: "   " })).toThrow(
+      "Unsupported DATABASE_ENGINE/DATABASE_DIALECT value:",
+    );
+  });
+});
+
+describe("resolveRuntimeDatabaseAdapterConfig", () => {
+  test("pglite returns dataDir with default fallback", () => {
+    expect(resolveRuntimeDatabaseAdapterConfig({ DATABASE_ADAPTER: "pglite" })).toEqual({
+      dataDir: ".eliza/.elizadb",
+    });
+  });
+
+  test("pglite prefers PGLITE_DATA_DIR over others", () => {
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "pglite",
+        PGLITE_DATA_DIR: "/custom/pglite",
+        SQLITE_DATABASE_PATH: "/sqlite/path",
+        LOCAL_DATABASE_PATH: "/local/path",
+      }),
+    ).toEqual({ dataDir: "/custom/pglite" });
+  });
+
+  test("pglite falls back through SQLITE_DATABASE_PATH etc", () => {
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "pglite",
+        SQLITE_DATABASE_PATH: "/sqlite/path",
+      }),
+    ).toEqual({ dataDir: "/sqlite/path" });
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "pglite",
+        SQLITE_DATABASE_URL: "/sqlite/url",
+      }),
+    ).toEqual({ dataDir: "/sqlite/url" });
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "pglite",
+        LOCAL_DATABASE_PATH: "/local/path",
+      }),
+    ).toEqual({ dataDir: "/local/path" });
+  });
+
+  test("postgresql requires POSTGRES_URL or DATABASE_URL", () => {
+    expect(() => resolveRuntimeDatabaseAdapterConfig({ DATABASE_ADAPTER: "postgresql" })).toThrow(
+      "DATABASE_URL environment variable is required",
+    );
+    expect(() =>
+      resolveRuntimeDatabaseAdapterConfig({ DATABASE_ADAPTER: "pg", POSTGRES_URL: "" }),
+    ).toThrow("DATABASE_URL environment variable is required");
+  });
+
+  test("postgresql prefers POSTGRES_URL over DATABASE_URL", () => {
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "postgresql",
+        POSTGRES_URL: "postgres://pg1",
+        DATABASE_URL: "postgres://db1",
+      }),
+    ).toEqual({ postgresUrl: "postgres://pg1" });
+    expect(
+      resolveRuntimeDatabaseAdapterConfig({
+        DATABASE_ADAPTER: "postgresql",
+        DATABASE_URL: "postgres://db1",
+      }),
+    ).toEqual({ postgresUrl: "postgres://db1" });
+  });
+
+  test("pglite ignores postgres urls and returns only dataDir", () => {
+    const cfg = resolveRuntimeDatabaseAdapterConfig({
+      DATABASE_ADAPTER: "pglite",
+      POSTGRES_URL: "postgres://should-be-ignored",
+      DATABASE_URL: "postgres://also-ignored",
+      PGLITE_DATA_DIR: "/pglite/dir",
+    });
+    expect(cfg).toEqual({ dataDir: "/pglite/dir" });
+    expect(cfg).not.toHaveProperty("postgresUrl");
+  });
+
+  test("postgresql ignores pglite data dir vars", () => {
+    const cfg = resolveRuntimeDatabaseAdapterConfig({
+      DATABASE_ADAPTER: "postgresql",
+      POSTGRES_URL: "postgres://pg",
+      PGLITE_DATA_DIR: "/ignored",
+    });
+    expect(cfg).toEqual({ postgresUrl: "postgres://pg" });
+    expect(cfg).not.toHaveProperty("dataDir");
+  });
+});


### PR DESCRIPTION
<!-- evidence-head:368ebe5322e93250a970842f2db26bc656605a59 -->

# Relates to

N/A - behavioral coverage for uncovered module; no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change for `getRuntimeDatabaseBackend` and `resolveRuntimeDatabaseAdapterConfig` in `packages/cloud/shared/src/lib/eliza/database-adapter-config.ts`. No production code changed. Covers backend alias resolution, priority ordering, error cases, and pglite/postgres config branching.

# Background

## What does this PR do?

Adds canonical behavioral coverage for `packages/cloud/shared/src/lib/eliza/database-adapter-config.ts` which had zero direct test coverage. Tests exercise backend normalization (postgresql/pglite aliases, case-insensitive trimming, priority of DATABASE_ADAPTER over ENGINE/DIALECT, unsupported throws) and adapter config resolution (pglite dataDir fallback chain, postgresql url requirement and priority, isolation of backend-specific fields).

## What kind of change is this?

Improvements (non-breaking change which adds functionality - test coverage)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts`

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
bun run --cwd packages/cloud/shared typecheck
bunx @biomejs/biome check packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts
```

Red (intentional bug: pglite alias broken) -> 6 fail, 7 pass. Green (restored) -> 13 pass, 0 fail.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:368ebe5322e93250a970842f2db26bc656605a59 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface changed (pure lib test)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface changed (pure lib test)`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow (pure lib test)`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - no backend process change (pure lib test); vitest output pasted below`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no LLM/prompt/provider change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifacts`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM/prompt/provider/model change

## Backend + frontend logs

<details><summary>Green - 13 pass</summary>

```
bun test v1.3.11 (af24e281)

packages/cloud/shared/src/lib/eliza/database-adapter-config.test.ts:
(pass) getRuntimeDatabaseBackend > defaults to postgresql when no env
(pass) getRuntimeDatabaseBackend > recognizes postgresql aliases case-insensitive and trimmed
(pass) getRuntimeDatabaseBackend > recognizes pglite aliases case-insensitive and trimmed
(pass) getRuntimeDatabaseBackend > respects priority DATABASE_ADAPTER > DATABASE_ENGINE > DATABASE_DIALECT
(pass) getRuntimeDatabaseBackend > throws for unsupported backend
(pass) getRuntimeDatabaseBackend > handles empty string as unsupported after trim
(pass) resolveRuntimeDatabaseAdapterConfig > pglite returns dataDir with default fallback
(pass) resolveRuntimeDatabaseAdapterConfig > pglite prefers PGLITE_DATA_DIR over others
(pass) resolveRuntimeDatabaseAdapterConfig > pglite falls back through SQLITE_DATABASE_PATH etc
(pass) resolveRuntimeDatabaseAdapterConfig > postgresql requires POSTGRES_URL or DATABASE_URL
(pass) resolveRuntimeDatabaseAdapterConfig > postgresql prefers POSTGRES_URL over DATABASE_URL
(pass) resolveRuntimeDatabaseAdapterConfig > pglite ignores postgres urls and returns only dataDir
(pass) resolveRuntimeDatabaseAdapterConfig > postgresql ignores pglite data dir vars

 13 pass
 0 fail
 32 expect() calls
Ran 13 tests across 1 file. [93.00ms]
```

</details>

<details><summary>Red - broken pglite alias (6 fail)</summary>

```
 7 pass
 6 fail
 16 expect() calls
Ran 13 tests across 1 file. [98.00ms]
```

</details>

<details><summary>Biome</summary>

```
Checked 1 file in 6ms. No fixes applied.
```

</details>

<details><summary>Typecheck</summary>

```
tsc --noEmit clean
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed (pure lib test)

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - no voice change

## Known gaps / failures

None. Package verification passed.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
