### PR TITLE
test(ui): cover approvals

### DIFF
--- a/packages/ui/src/cloud/approvals/lib/approvals.test.tsx
+++ b/packages/ui/src/cloud/approvals/lib/approvals.test.tsx
@@ -1,0 +1,536 @@
+/**
+ * Behavioural coverage for the approvals cloud data layer, exercised through
+ * the real React Query hooks with only the network boundary (`api`) and the
+ * Steward session mocked. Pins request shaping (paths, encoding, JSON bodies),
+ * response unwrapping, vote-error mapping, auth gating, and timestamp
+ * formatting exactly as shipped.
+ */
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let apiMockImpl: (path: string, options?: unknown) => Promise<unknown> =
+  async () => {
+    throw new Error("api mock not configured for this test");
+  };
+
+let sessionState: {
+  ready: boolean;
+  authenticated: boolean;
+  user: { id: string; email: string } | null;
+} = {
+  ready: true,
+  authenticated: true,
+  user: { id: "user-approvals", email: "user-approvals@example.test" },
+};
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return {
+    ...actual,
+    api: (path: string, options?: unknown) => apiMockImpl(path, options),
+  };
+});
+vi.mock("../../lib/use-session-auth", () => ({
+  useSessionAuth: () => sessionState,
+}));
+
+import type { ApprovalRequest, Ballot, SensitiveRequest } from "./approvals";
+import {
+  formatApprovalTimestamp,
+  useApprovalRequests,
+  useApproveRequest,
+  useBallots,
+  useCancelBallot,
+  useCancelSensitiveRequest,
+  useDenyRequest,
+  useSensitiveRequest,
+  useTallyBallot,
+  useVoteBallot,
+} from "./approvals";
+
+function approvalRequestFixture(): ApprovalRequest {
+  return {
+    id: "req-1",
+    organizationId: "org-1",
+    agentId: null,
+    userId: "user-approvals",
+    challengeKind: "signature",
+    challengePayload: {
+      message: "sign me",
+      signerKind: "wallet",
+      walletAddress: "0xabc",
+    },
+    expectedSignerIdentityId: "ident-1",
+    status: "pending",
+    signatureText: null,
+    signedAt: null,
+    expiresAt: "2026-12-31T23:59:59Z",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    metadata: {},
+  };
+}
+
+function ballotFixture(): Ballot {
+  return {
+    id: "ballot-1",
+    organizationId: "org-1",
+    agentId: null,
+    purpose: "upgrade agent",
+    participants: [{ identityId: "ident-1", label: "Owner" }],
+    threshold: 2,
+    status: "open",
+    tallyResult: null,
+    expiresAt: "2026-12-31T23:59:59Z",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    metadata: {},
+  };
+}
+
+function sensitiveRequestFixture(): SensitiveRequest {
+  return {
+    id: "sr-1",
+    kind: "secret",
+    status: "pending",
+  };
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+}
+
+function queryWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  apiMockImpl = async () => {
+    throw new Error("api mock not configured for this test");
+  };
+  sessionState = {
+    ready: true,
+    authenticated: true,
+    user: { id: "user-approvals", email: "user-approvals@example.test" },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("formatApprovalTimestamp", () => {
+  it("returns null for a missing value", () => {
+    expect(formatApprovalTimestamp(null)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(formatApprovalTimestamp("")).toBeNull();
+  });
+
+  it("returns null for a value Date cannot parse", () => {
+    expect(formatApprovalTimestamp("definitely-not-a-date")).toBeNull();
+  });
+
+  it("formats a parseable UTC timestamp as a short en-US label", () => {
+    // TZ=UTC is pinned by vitest.setup.ts; observed output on that clock.
+    expect(formatApprovalTimestamp("2026-03-05T13:45:00Z")).toBe(
+      "Mar 5, 1:45 PM",
+    );
+  });
+});
+
+describe("useApprovalRequests", () => {
+  it("fetches the owner list without a query string when unfiltered and unwraps approvalRequests", async () => {
+    const fixture = approvalRequestFixture();
+    let calls = 0;
+    apiMockImpl = async () => {
+      calls += 1;
+      return { success: true, approvalRequests: [fixture] };
+    };
+    const client = createQueryClient();
+
+    const { result } = renderHook(() => useApprovalRequests(), {
+      wrapper: queryWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([fixture]);
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("appends the encoded status filter to the endpoint path", async () => {
+    let requestedPath = "";
+    apiMockImpl = async (path) => {
+      requestedPath = path;
+      return { success: true, approvalRequests: [] };
+    };
+
+    const { result } = renderHook(
+      () => useApprovalRequests({ status: "pending" }),
+      { wrapper: queryWrapper(createQueryClient()) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+    expect(requestedPath).toBe("/api/v1/approval-requests?status=pending");
+  });
+
+  it("stays idle and never hits the API while signed out", () => {
+    sessionState = {
+      ready: true,
+      authenticated: false,
+      user: null,
+    };
+    let calls = 0;
+    apiMockImpl = async () => {
+      calls += 1;
+      return { success: true, approvalRequests: [] };
+    };
+
+    const { result } = renderHook(() => useApprovalRequests(), {
+      wrapper: queryWrapper(createQueryClient()),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(calls).toBe(0);
+  });
+});
+
+describe("useApproveRequest", () => {
+  it("POSTs the signature to the encoded approve endpoint and resolves the updated request", async () => {
+    const fixture = approvalRequestFixture();
+    let calledPath = "";
+    let calledOptions: unknown;
+    apiMockImpl = async (path, options) => {
+      calledPath = path;
+      calledOptions = options;
+      return { success: true, approvalRequest: fixture };
+    };
+
+    const { result } = renderHook(() => useApproveRequest(), {
+      wrapper: queryWrapper(createQueryClient()),
+    });
+
+    const approved = await result.current.mutateAsync({
+      id: "req/7",
+      signature: "0xsig",
+    });
+
+    expect(approved).toEqual(fixture);
+    expect(calledPath).toBe("/api/v1/approval-requests/req%2F7/approve");
+    expect(calledOptions).toEqual({
+      method: "POST",
+      json: { signature: "0xsig" },
+    });
+  });
+});
+
+describe("useDenyRequest", () => {
+  it("submits the caller's reason verbatim", async () => {
+    const fixture = approvalRequestFixture();
+    let calledOptions: unknown;
+    apiMockImpl = async (_path, options) => {
+      calledOptions = options;
+      return { success: true, approvalRequest: fixture };
+    };
+
+    const { result } = renderHook(() => useDenyRequest(), {
+      wrapper: queryWrapper(createQueryClient()),
+    });
+
+    await result.current.mutateAsync({
+      id: "req-1",
+      signature: "0xsig",
+      reason: "wrong agent",
+    });
+
+    expect(calledOptions).toEqual({
+      method: "POST",
+      json: { reason: "wrong agent", signature: "0xsig" },
+    });
+  });
+
+  it("falls back to the default owner denial reason when none is given", async () => {
+    let calledOptions: unknown;
+    apiMockImpl = async (_path, options) => {
+      calledOptions = options;
+      return { success: true, approvalRequest: approvalRequestFixture() };
+    };
+
+    const { result } = renderHook(() => useDenyRequest(), {
+      wrapper: queryWrapper(createQueryClient()),
+    });
+
+    await result.current.mutateAsync({ id: "req-1", signature: "0xsig" });
+
+    expect(calledOptions).toEqual({
+      method: "POST",
+      json: { reason: "denied by owner", signature: "0xsig" },
+    });
+  });
+});
+
+describe("useBallots", () => {
+  it("fetches ballots with the encoded status filter and unwraps ballots", async () => {
+    const fixture = ballotFixture();
+    let requestedPath = "";
+    apiMockImpl = async (path) => {
+      requestedPath = path;
+      return { success: true, ballots: [fixture] };
+    };
+
+    const { result } = renderHook(() => useBallots({ status: "open" }), {
+      wrapper: queryWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([fixture]);
+    });
+    expect(requestedPath).toBe("/api/v1/ballots?status=open");
+  });
+});
+
+describe("useVoteBallot", () => {
+  it("resolves the recorded outcome on success", async () => {
+    let calledPath = "";
+    let calledOptions: unknown;
+    apiMockImpl = async (path, options) => {
+      calledPath = path;
+      calledOptions = options;
+      return { success: true, outcome: "recorded", ballotStatus: "open" };
+    };
+
+    const { result } = renderHook(() => useVoteBallot(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    const response = await result.current.mutateAsync({
+      id: "ballot-1",
+      scopedToken: "tok",
+      value: "yes",
+    });
+
+    expect(response).toEqual({
+      success: true,
+      outcome: "recorded",
+      ballotStatus: "open",
+    });
+    expect(calledPath).toBe("/api/v1/ballots/ballot-1/vote");
+    expect(calledOptions).toEqual({
+      method: "POST",
+      json: { scopedToken: "tok", value: "yes" },
+    });
+  });
+
+  it("rejects with the server-provided error message when the vote fails", async () => {
+    apiMockImpl = async () => ({
+      success: false,
+      error: "Quorum not met",
+    });
+
+    const { result } = renderHook(() => useVoteBallot(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        id: "ballot-1",
+        scopedToken: "tok",
+        value: "yes",
+      }),
+    ).rejects.toThrow("Quorum not met");
+  });
+
+  it("rejects with the fallback message when the failure carries no error text", async () => {
+    apiMockImpl = async () => ({ success: false });
+
+    const { result } = renderHook(() => useVoteBallot(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        id: "ballot-1",
+        scopedToken: "tok",
+        value: "yes",
+      }),
+    ).rejects.toThrow("Unable to record vote.");
+  });
+});
+
+describe("useTallyBallot", () => {
+  it("POSTs an empty body and returns the tally response unchanged", async () => {
+    const ballot = ballotFixture();
+    let calledPath = "";
+    let calledOptions: unknown;
+    apiMockImpl = async (path, options) => {
+      calledPath = path;
+      calledOptions = options;
+      return {
+        success: true,
+        tallied: false,
+        ballot,
+        tallyResult: null,
+      };
+    };
+
+    const { result } = renderHook(() => useTallyBallot(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    const response = await result.current.mutateAsync({ id: "ballot-1" });
+
+    expect(response).toEqual({
+      success: true,
+      tallied: false,
+      ballot,
+      tallyResult: null,
+    });
+    expect(calledPath).toBe("/api/v1/ballots/ballot-1/tally");
+    expect(calledOptions).toEqual({ method: "POST", json: {} });
+  });
+});
+
+describe("useCancelBallot", () => {
+  it("returns the cancelled ballot and always sends a reason field", async () => {
+    const fixture = { ...ballotFixture(), status: "canceled" as const };
+    let calledJson: unknown;
+    apiMockImpl = async (_path, options) => {
+      calledJson = (options as { json?: unknown })?.json;
+      return { success: true, ballot: fixture };
+    };
+
+    const { result } = renderHook(() => useCancelBallot(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    const cancelled = await result.current.mutateAsync({ id: "ballot-1" });
+
+    expect(cancelled).toEqual(fixture);
+    expect("reason" in (calledJson as Record<string, unknown>)).toBe(true);
+  });
+});
+
+describe("useSensitiveRequest", () => {
+  it("stays disabled for a null id and never calls the API", () => {
+    let calls = 0;
+    apiMockImpl = async () => {
+      calls += 1;
+      return sensitiveRequestFixture();
+    };
+
+    const { result } = renderHook(() => useSensitiveRequest(null), {
+      wrapper: queryClientWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.isEnabled).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it("treats a whitespace-only id as empty and stays disabled", () => {
+    let calls = 0;
+    apiMockImpl = async () => {
+      calls += 1;
+      return sensitiveRequestFixture();
+    };
+
+    const { result } = renderHook(() => useSensitiveRequest("   "), {
+      wrapper: queryClientWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(calls).toBe(0);
+  });
+
+  it("trims the id before requesting its detail endpoint", async () => {
+    const fixture = sensitiveRequestFixture();
+    let requestedPath = "";
+    apiMockImpl = async (path) => {
+      requestedPath = path;
+      return fixture;
+    };
+
+    const { result } = renderHook(() => useSensitiveRequest("  sr-42  "), {
+      wrapper: queryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(fixture);
+    });
+    expect(requestedPath).toBe("/api/v1/sensitive-requests/sr-42");
+  });
+
+  it("unwraps a { request } envelope payload", async () => {
+    const fixture = sensitiveRequestFixture();
+    apiMockImpl = async () => ({ request: fixture });
+
+    const { result } = renderHook(() => useSensitiveRequest("sr-1"), {
+      wrapper: queryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(fixture);
+    });
+  });
+
+  it("passes a plain sensitive-request payload through untouched", async () => {
+    const fixture = sensitiveRequestFixture();
+    apiMockImpl = async () => fixture;
+
+    const { result } = renderHook(() => useSensitiveRequest("sr-1"), {
+      wrapper: queryClientWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(fixture);
+    });
+  });
+});
+
+describe("useCancelSensitiveRequest", () => {
+  it("POSTs an empty cancel body and resolves the returned request", async () => {
+    const fixture = {
+      ...sensitiveRequestFixture(),
+      status: "canceled" as const,
+    };
+    let calledPath = "";
+    let calledOptions: unknown;
+    apiMockImpl = async (path, options) => {
+      calledPath = path;
+      calledOptions = options;
+      return { success: true, request: fixture };
+    };
+
+    const { result } = renderHook(() => useCancelSensitiveRequest(), {
+      wrapper: queryClientWrapper(),
+    });
+
+    const cancelled = await result.current.mutateAsync({ id: "sr/9" });
+
+    expect(cancelled).toEqual(fixture);
+    expect(calledPath).toBe("/api/v1/sensitive-requests/sr%2F9/cancel");
+    expect(calledOptions).toEqual({ method: "POST", json: {} });
+  });
+});
+
+function queryClientWrapper(): (props: { children: ReactNode }) => ReactNode {
+  return queryWrapper(createQueryClient());
+}


### PR DESCRIPTION

Adds a co-located unit suite for the approvals cloud data layer (`packages/ui/src/cloud/approvals/lib/approvals.ts`), which previously had no same-named test file anywhere on develop.

**What the suite pins (22 cases, real hooks + pure function, only the network boundary and Steward session are mocked):**

- `formatApprovalTimestamp`: null / empty / unparseable inputs return null; a parseable UTC timestamp formats to the observed `en-US` label under the package's pinned `TZ=UTC`.
- `useApprovalRequests`: unwraps `approvalRequests`; unfiltered calls hit the bare endpoint; `{ status }` appends the query string; signed-out sessions stay idle and never call the API.
- `useApproveRequest` / `useDenyRequest`: POST path percent-encodes ids (`req/7` -> `req%2F7`); deny sends the caller's reason verbatim and falls back to `"denied by owner"` when omitted.
- `useBallots`: status-filtered fetch and `ballots` unwrap.
- `useVoteBallot`: success resolves the recorded outcome; failure rejects with the server error text, falling back to `"Unable to record vote."` when absent.
- `useTallyBallot` / `useCancelBallot` / `useCancelSensitiveRequest`: empty-JSON POST bodies, response passthrough, and the always-present `reason` field.
- `useSensitiveRequest`: null and whitespace-only ids stay disabled with zero API calls; ids are trimmed before the detail request; both `{ request }` envelope and plain payloads normalize correctly.

Test-only change: no production file is modified; the diff is one new file, +536/-0.

**Evidence (this is a fork contribution — hosted CI does not run on this PR):**

- `bunx vitest run src/cloud/approvals/lib/approvals.test.tsx` (in `packages/ui`, re-run against current develop immediately before filing): **1 file passed, 22/22 tests passed**.
- `bunx biome check --write src/cloud/approvals/lib/approvals.test.tsx`: clean.
- `bunx tsc --noEmit` in `packages/ui`: zero mentions of `approvals.test.tsx` in output (pre-existing unrelated errors elsewhere unchanged).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ff7f15f9f53cd3d3191ae95d858ddcf0305fac3a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
