### PR TITLE
test(agent): cover api index barrel

### DIFF
--- a/packages/agent/src/api/index.test.ts
+++ b/packages/agent/src/api/index.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Guards the runtime export contract of the public agent API barrel and drives
+ * its compatibility handlers through their real plugin implementations.
+ */
+import { handleAppsRoutes as pluginHandleAppsRoutes } from "@elizaos/plugin-app-manager";
+import { describe, expect, it } from "vitest";
+import { dispatchRoute } from "./dispatch-route.ts";
+import * as api from "./index.ts";
+import {
+  matchPluginRoutePath,
+  tryHandleRuntimePluginRoute,
+} from "./runtime-plugin-routes.ts";
+import { hasPersistedFirstRunState } from "./server-helpers.ts";
+
+const STAR_EXPORT_MODULES = [
+  "./accounts-routes.ts",
+  "./agent-admin-routes.ts",
+  "./agent-lifecycle-routes.ts",
+  "./agent-model.ts",
+  "./agent-transfer-routes.ts",
+  "./approval-routes.ts",
+  "./auth-routes.ts",
+  "./backup-v2-stream-response.ts",
+  "./bug-report-routes.ts",
+  "./character-routes.ts",
+  "./compat-utils.ts",
+  "./connector-health.ts",
+  "./conversation-restore.ts",
+  "./credit-detection.ts",
+  "./database.ts",
+  "./diagnostics-routes.ts",
+  "./documents-service-loader.ts",
+  "./early-logs.ts",
+  "./memory-bounds.ts",
+  "./memory-routes.ts",
+  "./model-catalog.ts",
+  "./model-config-routes.ts",
+  "./models-routes.ts",
+  "./parse-action-block.ts",
+  "./permissions-routes.ts",
+  "./plugin-validation.ts",
+  "./project-routes.ts",
+  "./provider-switch-config.ts",
+  "./rate-limiter.ts",
+  "./registry-routes.ts",
+  "./registry-service.ts",
+  "./subscription-routes.ts",
+  "./terminal-run-limits.ts",
+  "./tx-service.ts",
+  "./wallet.ts",
+  "./wallet-evm-balance.ts",
+  "./wallet-rpc.ts",
+  "./wallet-trading-profile.ts",
+  "./workbench-vfs-routes.ts",
+  "./zip-utils.ts",
+] as const;
+
+function createWalletRouteContext(method: string, pathname: string) {
+  const response: { body?: unknown; statusCode?: number } = {};
+  const context = {
+    req: { headers: {} },
+    res: response,
+    method,
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    config: {},
+    saveConfig() {},
+    ensureWalletKeysInEnvAndConfig: () => true,
+    resolveWalletExportRejection: () => null,
+    deps: {},
+    readJsonBody: async () => null,
+    json(target: typeof response, body: unknown, statusCode = 200) {
+      target.statusCode = statusCode;
+      target.body = body;
+    },
+    error(target: typeof response, message: string, statusCode = 400) {
+      target.statusCode = statusCode;
+      target.body = { error: message };
+    },
+  } as unknown as Parameters<typeof api.handleWalletRoutes>[0];
+
+  return { context, response };
+}
+
+describe("agent API barrel", () => {
+  it("re-exports every runtime symbol from each star-exported API module", async () => {
+    const publicApi = api as Record<string, unknown>;
+
+    for (const specifier of STAR_EXPORT_MODULES) {
+      const source = await import(specifier);
+      for (const [name, value] of Object.entries(source)) {
+        if (name === "default") continue;
+        expect(publicApi, `${specifier} export ${name}`).toHaveProperty(name);
+        expect(publicApi[name], `${specifier} export ${name}`).toBe(value);
+      }
+    }
+  });
+
+  it("preserves the explicitly named compatibility and dispatcher exports", () => {
+    expect(api.handleAppsRoutes).toBe(pluginHandleAppsRoutes);
+    expect(api.dispatchRoute).toBe(dispatchRoute);
+    expect(api.matchPluginRoutePath).toBe(matchPluginRoutePath);
+    expect(api.tryHandleRuntimePluginRoute).toBe(tryHandleRuntimePluginRoute);
+    expect(api.hasPersistedFirstRunState).toBe(hasPersistedFirstRunState);
+  });
+
+  it("delegates wallet routes lazily to the real plugin handler", async () => {
+    const unhandled = createWalletRouteContext(
+      "GET",
+      "/api/not-a-wallet-route",
+    );
+    await expect(api.handleWalletRoutes(unhandled.context)).resolves.toBe(
+      false,
+    );
+    expect(unhandled.response).toEqual({});
+
+    const removedExport = createWalletRouteContext(
+      "POST",
+      "/api/wallet/export",
+    );
+    await expect(api.handleWalletRoutes(removedExport.context)).resolves.toBe(
+      true,
+    );
+    expect(removedExport.response).toEqual({
+      statusCode: 410,
+      body: {
+        error:
+          "Private key export has been removed. Use Steward or OS-backed custody flows.",
+      },
+    });
+  });
+});


### PR DESCRIPTION

## Summary

- add runtime coverage for the `packages/agent/src/api/index.ts` public API barrel (`@elizaos/agent/api`)
- verify the star-export surface matches every one of the 40 re-exported API modules by runtime value identity, so a silently dropped or shadowed export fails the suite
- verify the named compatibility re-exports (`handleAppsRoutes`, `dispatchRoute`, `matchPluginRoutePath`, `tryHandleRuntimePluginRoute`, `hasPersistedFirstRunState`) bind to their owning modules
- drive `handleWalletRoutes` through the **real** plugin implementation (no mocks): an unmatched route resolves `false` and leaves the response untouched, and `POST /api/wallet/export` produces the actual removed-endpoint response (HTTP 410, "Private key export has been removed. Use Steward or OS-backed custody flows."), exercising the documented lazy dynamic-import path of the barrel

## Validation

- `cd packages/agent && bunx vitest run src/api/index.test.ts` → **Test Files 1 passed (1), Tests 3 passed (3)** (re-run and reproduced immediately before filing against current `origin/develop` @ `ef10cfb17`; run twice total, both green)
- `bunx biome check --write packages/agent/src/api/index.test.ts` → "Checked 1 file. No fixes applied." (repo `biome.json` present; checkout is not sparse)
- `cd packages/agent && bunx tsc --noEmit -p tsconfig.json` → exits 1 with 6 pre-existing diagnostics, none referencing `index.test.ts` (`grep 'index.test.ts'` over the full output: no match)
- the diff adds only `packages/agent/src/api/index.test.ts` (+132/−0, new file)

Note on runner: this suite runs through `packages/agent/vitest.config.ts` (the owning package lane) because its resolve aliases pin the `@elizaos/plugin-openai/endpoint-config` and `@elizaos/plugin-elizacloud/endpoint-config` subpath imports to source; the repo-root vitest config does not carry those two aliases.

This is a fork contribution, so hosted CI does not run on this pull request.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4fde90fc95af6339b84327eded0822fe2d721370 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
