### PR TITLE
fix(cloud): flush cold voice stream readiness

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -258,7 +258,7 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
   },
 }));
 mock.module("@/lib/services/shared-runtime/shared-eliza-runtime", () => ({
-  prewarmSharedElizaRuntime: async () => {
+  prewarmSharedElizaStreamingContext: async () => {
     markRuntimePrewarmEntered();
     if (runtimePrewarmGate) await runtimePrewarmGate;
   },
@@ -918,6 +918,19 @@ test("slow prewarm returns headers and releases the room queue before completion
     }),
   );
   await runtimePrewarmEntered;
+  const prewarmReader = prewarmResponse.body?.getReader();
+  const firstPrewarmByte = await Promise.race([
+    prewarmReader?.read(),
+    new Promise<"body-blocked">((resolve) =>
+      setTimeout(() => resolve("body-blocked"), 100),
+    ),
+  ]);
+  expect(firstPrewarmByte).not.toBe("body-blocked");
+  expect(
+    new TextDecoder().decode(
+      firstPrewarmByte === "body-blocked" ? undefined : firstPrewarmByte?.value,
+    ),
+  ).toBe('{"success":');
 
   const historyResult = await Promise.race([
     object
@@ -950,7 +963,9 @@ test("slow prewarm returns headers and releases the room queue before completion
   );
 
   resolveRuntimePrewarmGate();
-  await expect(prewarmResponse.json()).resolves.toEqual({ success: true });
+  const completedPrewarm = await prewarmReader?.read();
+  expect(new TextDecoder().decode(completedPrewarm?.value)).toBe("true}");
+  await expect(prewarmReader?.read()).resolves.toMatchObject({ done: true });
   await Promise.all(background.splice(0));
   expect(repositoryReads).toBe(1);
   expect(repositoryWrites).toBe(0);

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -485,7 +485,8 @@ export class SharedRuntimeConversation {
       ];
       imports.push(
         import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
-          ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
+          ({ prewarmSharedElizaStreamingContext }) =>
+            prewarmSharedElizaStreamingContext(),
         ),
       );
       await Promise.all(imports);
@@ -536,12 +537,11 @@ export class SharedRuntimeConversation {
     let canceled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"success":'));
         void completion.then(
           () => {
             if (canceled) return;
-            controller.enqueue(
-              new TextEncoder().encode(JSON.stringify({ success: true })),
-            );
+            controller.enqueue(new TextEncoder().encode("true}"));
             controller.close();
           },
           (error) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -263,6 +263,17 @@ afterEach(() => {
 });
 
 describe("Shared Eliza Workerd runtime", () => {
+  test("streaming-context prewarm does not construct a disposable runtime", async () => {
+    const { prewarmSharedElizaStreamingContext } = await import("./shared-eliza-runtime");
+    const initializeSpy = spyOn(AgentRuntime.prototype, "initialize");
+    try {
+      await prewarmSharedElizaStreamingContext();
+      expect(initializeSpy).not.toHaveBeenCalled();
+    } finally {
+      initializeSpy.mockRestore();
+    }
+  });
+
   test("prewarms once, releases the runtime, and never dispatches inference", async () => {
     const { prewarmSharedElizaRuntime } = await import("./shared-eliza-runtime");
     const stopSpy = spyOn(AgentRuntime.prototype, "stop");

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -313,6 +313,11 @@ function createRuntime(options: {
   });
 }
 
+/** Loads only the streaming context without constructing an AgentRuntime. */
+export async function prewarmSharedElizaStreamingContext(): Promise<void> {
+  await ensureEdgeStreamingContext();
+}
+
 /** Pays one-time Workerd runtime initialization before the first live user turn. */
 export async function prewarmSharedElizaRuntime(): Promise<void> {
   await ensureEdgeStreamingContext();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1220,6 +1220,29 @@ describe("SharedRuntimeChatService", () => {
     await Promise.all(h.background);
   });
 
+  test("flushes transport readiness before the first provider text delta", async () => {
+    let releaseProvider = () => {};
+    const providerGate = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    streamTurn = {
+      degraded: false,
+      parts: (async function* () {
+        await providerGate;
+        yield { type: "text-delta", text: "hello " };
+        yield { type: "finish", text: "hello back" };
+      })(),
+    };
+
+    const response = await new SharedRuntimeChatService().stream(agent, rpc, harness());
+    const reader = response.body?.getReader();
+    const first = await reader?.read();
+    expect(new TextDecoder().decode(first?.value)).toBe(": ready\n\n");
+
+    releaseProvider();
+    await reader?.cancel();
+  });
+
   test("a failed long-term-memory mirror is reported without failing the landed turn (#25689)", async () => {
     process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     recordTurnPair.mockImplementationOnce(async () => {
@@ -1267,7 +1290,7 @@ describe("SharedRuntimeChatService", () => {
     const body = await (await new SharedRuntimeChatService().stream(agent, rpc, harness())).text();
     const frames = body
       .split("\n\n")
-      .filter(Boolean)
+      .filter((frame) => Boolean(frame) && !frame.startsWith(":"))
       .map((frame) => {
         const lines = frame.split("\n");
         return {
@@ -1291,7 +1314,7 @@ describe("SharedRuntimeChatService", () => {
     const response = await service.stream(agent, rpc, harness());
     const frames = (await response.text())
       .split("\n\n")
-      .filter((frame) => frame.trim().length > 0)
+      .filter((frame) => frame.trim().length > 0 && !frame.startsWith(":"))
       .map((frame) => {
         const lines = frame.split("\n");
         const event = lines.find((line) => line.startsWith("event: "))?.slice("event: ".length);
@@ -1395,6 +1418,8 @@ describe("SharedRuntimeChatService", () => {
 
     const response = await service.stream(agent, keyedCancellationRpc, { ...h, turnClaims });
     const reader = response.body!.getReader();
+    const ready = await reader.read();
+    expect(new TextDecoder().decode(ready.value)).toBe(": ready\n\n");
     const first = await reader.read();
     expect(new TextDecoder().decode(first.value)).toContain("partial");
     const cancellation = reader.cancel("barge-in");

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -109,6 +109,7 @@ import {
 
 export { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
 
+const SSE_TRANSPORT_READY_COMMENT = ": ready\n\n";
 const BRIDGE_INSUFFICIENT_CREDITS_CODE = -32002;
 const PROVIDER_CANCELLATION_OBSERVE_MS = 5_000;
 const PERSONAL_SHARED_RATE_LIMIT = { windowMs: 60_000, maxRequests: 60 } as const;
@@ -1772,6 +1773,10 @@ export class SharedRuntimeChatService {
       start: async (controller) => {
         let finished = false;
         try {
+          // Flush one valid SSE comment before provider text so Workerd exposes
+          // the Durable Object response headers independently of model latency.
+          // Consumers ignore comments; the complete reply remains unchanged.
+          controller.enqueue(encoder.encode(SSE_TRANSPORT_READY_COMMENT));
           for await (const part of turn.parts!) {
             if (part.type === "text-delta") {
               streamedReply += part.text;


### PR DESCRIPTION
Closes #26722

## What changed
- flush a valid SSE readiness comment before the first provider text delta so the Durable Object transport exposes response headers independently of model latency
- stream the prewarm JSON prefix immediately so coordinator admission is not held behind background readiness
- restrict per-room prewarm to the streaming context instead of constructing, initializing, and stopping a second disposable AgentRuntime

No model, prompt, history, or response content is truncated.

## Production diagnosis
Privacy-bounded dual-channel PSTN acceptance reproduced 42.887 seconds of initial silence, followed by four warm replies with approximately 1.48–1.88 second end-of-turn-to-audio latency. Twilio completed the call without an application/media error. Human-call tails showed coordinator header timeouts while the media WebSocket remained connected. This disproves response length as the trigger and localizes the failure to cold runtime/transport readiness.

## Verification
- shared-runtime-conversation: 36 pass
- shared-runtime-chat: 42 pass
- coordinator-fetch: 3 pass
- focused shared runtime prewarm: 2 pass
- packages/cloud/shared typecheck: pass
- Biome on all six changed files: pass
- git diff --check: pass

Live cold-call acceptance will be repeated after exact-source deployment.