### PR TITLE
fix(desktop): recover authenticated external runtime preflight

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -273,10 +273,11 @@ function buildApiRequestHeaders(contentType?: string): Record<string, string> {
   }
   let apiToken = resolveApiToken(process.env);
   if (!apiToken && preparedDesktopRuntime?.mode === "external") {
-    apiToken = resolveQualifiedExternalToken(
-      preparedDesktopRuntime,
-      preparedDesktopRuntime.externalApi.base,
-    );
+    apiToken =
+      resolveQualifiedExternalToken(
+        preparedDesktopRuntime,
+        preparedDesktopRuntime.externalApi.base,
+      ) ?? null;
   }
   if (!apiToken) {
     const rt = resolveDesktopRuntime();

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -132,7 +132,11 @@ import {
   resolveRendererAssetDir,
 } from "./runtime-layout";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
-import { resolveDesktopRuntimeForBoot } from "./runtime-preflight";
+import {
+  type DesktopRuntimeBootResolution,
+  resolveDesktopRuntimeForBoot,
+  resolveQualifiedExternalToken,
+} from "./runtime-preflight";
 import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { registerShellSyncEndpoint } from "./shell-sync-relay";
@@ -241,13 +245,9 @@ onAgentReadyChange(() => setupApplicationMenu());
  * base resolves to `external` so the embedded agent is skipped; topology 1
  * (local agent → cloud inference) and topology 2 (all-local) keep `local`.
  */
-let preparedDesktopRuntime: ReturnType<
-  typeof resolveDesktopRuntimeModeWithDeployment
-> | null = null;
+let preparedDesktopRuntime: DesktopRuntimeBootResolution | null = null;
 
-function resolveDesktopRuntime(): ReturnType<
-  typeof resolveDesktopRuntimeModeWithDeployment
-> {
+function resolveDesktopRuntime(): DesktopRuntimeBootResolution {
   return (
     preparedDesktopRuntime ??
     resolveDesktopRuntimeModeWithDeployment(
@@ -272,6 +272,12 @@ function buildApiRequestHeaders(contentType?: string): Record<string, string> {
     headers["Content-Type"] = contentType;
   }
   let apiToken = resolveApiToken(process.env);
+  if (!apiToken && preparedDesktopRuntime?.mode === "external") {
+    apiToken = resolveQualifiedExternalToken(
+      preparedDesktopRuntime,
+      preparedDesktopRuntime.externalApi.base,
+    );
+  }
   if (!apiToken) {
     const rt = resolveDesktopRuntime();
     if (rt.mode === "local") {
@@ -848,7 +854,9 @@ async function startRendererServer(): Promise<string> {
   const initialApiToken =
     initialRuntime.mode === "local"
       ? configureDesktopLocalApiAuth()
-      : (resolveApiToken(process.env) ?? "");
+      : (resolveApiToken(process.env) ??
+        resolveQualifiedExternalToken(initialRuntime, initialApiBase) ??
+        "");
   apiBaseOwner.setCurrent(initialApiBase, initialApiToken);
 
   const resolveRendererCacheControl = (
@@ -1846,7 +1854,12 @@ function injectApiBase(win: BrowserWindow): void {
     apiBaseOwner.notifyChange(
       win,
       runtimeResolution.externalApi.base,
-      resolveApiToken(process.env) ?? "",
+      resolveApiToken(process.env) ??
+        resolveQualifiedExternalToken(
+          runtimeResolution,
+          runtimeResolution.externalApi.base,
+        ) ??
+        "",
     );
     setAgentReady(true);
     return;

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   probeExternalAgent,
   resolveDesktopRuntimeForBoot,
+  resolveQualifiedExternalToken,
 } from "./runtime-preflight";
 
 const remoteDeployment = {
@@ -16,11 +17,13 @@ type EndpointResponse = {
   body: string;
   contentType?: string;
   requiredBearer?: string;
+  location?: string;
 };
 
 function sendResponse(res: ServerResponse, response: EndpointResponse): void {
   res.writeHead(response.status ?? 200, {
     "content-type": response.contentType ?? "application/json",
+    ...(response.location ? { location: response.location } : {}),
   });
   res.end(response.body);
 }
@@ -102,6 +105,31 @@ describe("probeExternalAgent", () => {
     );
   });
 
+  it("rejects redirects without forwarding the persisted bearer", async () => {
+    await withProbeServer(
+      { "/redirect-target": readyElizaEndpoints["/api/status"] },
+      async (redirectBase, redirectRequests) => {
+        await withProbeServer(
+          {
+            ...readyElizaEndpoints,
+            "/api/status": {
+              status: 302,
+              body: "",
+              location: `${redirectBase}/redirect-target`,
+            },
+          },
+          async (base, requests) => {
+            await expect(
+              probeExternalAgent(base, "remote-secret"),
+            ).resolves.toBe(false);
+            expect(requests).toEqual(["/api/health", "/api/status"]);
+            expect(redirectRequests).toEqual([]);
+          },
+        );
+      },
+    );
+  });
+
   it.each([
     [
       "authentication challenge",
@@ -179,6 +207,52 @@ describe("resolveDesktopRuntimeForBoot", () => {
     expect(probe).toHaveBeenCalledWith(
       "http://127.0.0.1:2250",
       "remote-secret",
+    );
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2250/api/chat"),
+    ).toBe("remote-secret");
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2251/api/chat"),
+    ).toBeUndefined();
+  });
+
+  it("carries the qualified bearer from real preflight into a protected application request", async () => {
+    await withProbeServer(
+      {
+        ...readyElizaEndpoints,
+        "/api/status": {
+          ...readyElizaEndpoints["/api/status"],
+          requiredBearer: "remote-secret",
+        },
+        "/api/application": {
+          body: '{"ok":true}',
+          requiredBearer: "remote-secret",
+        },
+      },
+      async (base, requests) => {
+        const result = await resolveDesktopRuntimeForBoot({
+          env: {},
+          deployment: {
+            runtime: "remote",
+            remoteApiBase: base,
+            remoteAccessToken: "remote-secret",
+          },
+        });
+        const token = resolveQualifiedExternalToken(
+          result,
+          `${base}/api/application`,
+        );
+        const response = await fetch(`${base}/api/application`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+
+        expect(response.status).toBe(200);
+        expect(requests).toEqual([
+          "/api/health",
+          "/api/status",
+          "/api/application",
+        ]);
+      },
     );
   });
 

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
@@ -6,6 +6,7 @@
  */
 import {
   type DesktopRuntimeModeResolution,
+  normalizeApiBase,
   type PersistedDeployment,
   resolveDesktopRuntimeMode,
   resolveDesktopRuntimeModeWithDeployment,
@@ -17,6 +18,26 @@ export type ExternalReachabilityProbe = (
   base: string,
   accessToken?: string,
 ) => Promise<boolean>;
+
+export interface QualifiedExternalAccess {
+  origin: string;
+  token: string;
+}
+
+export interface DesktopRuntimeBootResolution
+  extends DesktopRuntimeModeResolution {
+  qualifiedAccess?: QualifiedExternalAccess;
+}
+
+export function resolveQualifiedExternalToken(
+  resolution: DesktopRuntimeBootResolution,
+  targetBase: string | null | undefined,
+): string | undefined {
+  const targetOrigin = normalizeApiBase(targetBase ?? undefined);
+  return targetOrigin && resolution.qualifiedAccess?.origin === targetOrigin
+    ? resolution.qualifiedAccess.token
+    : undefined;
+}
 
 function hasExplicitExternalTarget(
   env: Record<string, string | undefined>,
@@ -57,6 +78,7 @@ async function fetchJson(
   const response = await fetch(url, {
     method: "GET",
     headers,
+    redirect: "error",
     signal,
   });
   if (response.status !== 200) return null;
@@ -73,7 +95,7 @@ export async function probeExternalAgent(
     const health = await fetchJson(
       `${normalizedBase}/api/health`,
       signal,
-      accessToken,
+      undefined,
     );
     if (!isReadyHealth(health)) return false;
 
@@ -97,7 +119,7 @@ export async function resolveDesktopRuntimeForBoot(options: {
   env: Record<string, string | undefined>;
   deployment: PersistedDeployment | null;
   probe?: ExternalReachabilityProbe;
-}): Promise<DesktopRuntimeModeResolution> {
+}): Promise<DesktopRuntimeBootResolution> {
   const { env, deployment, probe = probeExternalAgent } = options;
   const resolved = resolveDesktopRuntimeModeWithDeployment(env, deployment);
 
@@ -115,13 +137,14 @@ export async function resolveDesktopRuntimeForBoot(options: {
     return resolved;
   }
 
-  if (
-    await probe(
-      resolved.externalApi.base,
-      deployment?.remoteAccessToken?.trim() || undefined,
-    )
-  ) {
-    return resolved;
+  const token = deployment?.remoteAccessToken?.trim() || undefined;
+  if (await probe(resolved.externalApi.base, token)) {
+    return token
+      ? {
+          ...resolved,
+          qualifiedAccess: { origin: resolved.externalApi.base, token },
+        }
+      : resolved;
   }
 
   return envOnly;


### PR DESCRIPTION
## Recovery checkpoint

This draft preserves the two unmerged follow-ups after merged PR #21697. It is a recovery surface only, not merge authority.

## Exact pins

- Head: `571256d73d9ab290c0f6a7e34f310af506b0c9f1`
- Tree: `277badd596c18287e61fd3912230642dc788b5b7`
- Current base observed during checkpoint: `da1203a930100fbd5e51fa8100ca1819cb85d06d`
- Historical merge-base: `5bc247fc11c860d46b2967a6a482aa69b35714bf`
- Branch: `nubs-sync-mac-runtime-preflight`

## Done

- Preserves merged #21697 readiness validation as ancestry.
- Adds authenticated persisted-target preflight without writing or logging bearer credentials.
- Adds a real redirect-server regression proving preflight fails closed, does not follow redirects, and does not forward authorization to a redirect target.
- Recovery audit: exact six-path Biome check passed; `git diff --check` passed; tracked worktree is clean.

## Current

- Branch is already pushed at the exact head above.
- The #21697 foundation is merged; the authentication and redirect-hardening follow-ups remain unique to this branch.
- This draft is intentionally not rebased or restacked during the flight checkpoint.

## Remaining

1. Rebase or restack only the two unique follow-up commits onto current `develop`, dropping the already-merged #21697-equivalent ancestor.
2. Resolve current drift and rerun the focused real-HTTP runtime-preflight suite plus package typecheck.
3. Obtain independent security/content review at the replacement exact head.
4. Prove authenticated persisted-target retention and unreachable-target embedded fallback in a current signed normal macOS app before readiness.

## Blockers

- The recovery branch is 3838 commits behind the current observed `develop`; it is expected to require a focused restack rather than direct merge.
- Current exact-head signed native evidence is not attached.
- No maintainer or human acceptance has been recorded for these follow-up bytes.

## Evidence

- Unit/integration: exact six-file formatting and diff sanity passed during checkpoint.
- Native screenshots/video: N/A - recovery draft only; current signed-app evidence must be captured after restack.
- Live model trajectory: N/A - this change is runtime preflight transport/auth policy, not model behavior.
- Deployment evidence: N/A - no deployment was authorized or performed.

**Not manually accepted by Nubs.**

Do not merge or mark ready from this recovery checkpoint.