### PR TITLE
test(ui): cover auth-query

### DIFF
--- a/packages/ui/src/cloud/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/lib/auth-query.test.tsx
@@ -184,3 +184,85 @@ describe("shared cloud query gate — session from persisted JWT only (page-relo
     expect(result.current.userId).toMatch(/^native-api-key:/);
   });
 });
+
+describe("shared cloud query gate — additional branches", () => {
+  it("web: ignores a garbage steward token that is not a JWT", () => {
+    storage.setItem("steward_session_token", "not-a-jwt");
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.userId).toBeNull();
+  });
+
+  it("exposes the user id even when the caller disables the query", () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate(false));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.userId).toBe("u1");
+  });
+});
+
+// Appended coverage lives in its own chunk so the base import block above
+// stays byte-identical (additive-only PR contract).
+import { authenticatedQueryKey } from "./auth-query";
+
+describe("authenticatedQueryKey", () => {
+  it("namespaces parts with the auth segment and the user id", () => {
+    expect(
+      authenticatedQueryKey(["api-keys", "list"], {
+        enabled: true,
+        userId: "u1",
+      }),
+    ).toEqual(["api-keys", "list", "auth", "u1"]);
+  });
+
+  it("preserves every part in order, including non-string parts", () => {
+    const filters = { status: "active" };
+    expect(
+      authenticatedQueryKey(["instances", 42, filters, true], {
+        enabled: true,
+        userId: "u2",
+      }),
+    ).toEqual(["instances", 42, filters, true, "auth", "u2"]);
+  });
+
+  it("keeps a usable key for an unauthenticated gate with a null user id", () => {
+    expect(
+      authenticatedQueryKey(["agents"], { enabled: false, userId: null }),
+    ).toEqual(["agents", "auth", null]);
+  });
+
+  it("produces a bare key when there are no parts", () => {
+    expect(authenticatedQueryKey([], { enabled: true, userId: "u3" })).toEqual([
+      "auth",
+      "u3",
+    ]);
+  });
+
+  it("changes the key when the session switches users", () => {
+    expect(
+      authenticatedQueryKey(["agents"], { enabled: true, userId: "user-a" }),
+    ).not.toEqual(
+      authenticatedQueryKey(["agents"], { enabled: true, userId: "user-b" }),
+    );
+  });
+
+  it("returns structurally equal keys for identical inputs", () => {
+    const gate = { enabled: true, userId: "u1" };
+    expect(authenticatedQueryKey(["agents"], gate)).toEqual(
+      authenticatedQueryKey(["agents"], gate),
+    );
+  });
+
+  it("does not mutate the parts array it receives", () => {
+    const parts = ["api-keys"];
+    authenticatedQueryKey(parts, { enabled: true, userId: "u1" });
+    expect(parts).toEqual(["api-keys"]);
+  });
+});


### PR DESCRIPTION

Additive-only test coverage for `packages/ui/src/cloud/lib/auth-query.ts`.

## Why additive

Current `develop` already carries `packages/ui/src/cloud/lib/auth-query.test.tsx` (10 cases covering `useAuthenticatedQueryGate`). Per the repository's additive-only rule for existing suites, this diff **appends cases and deletes nothing**: `+82/-0`, every pre-existing line byte-identical.

## What was uncovered

- `authenticatedQueryKey(parts, gate)` had **zero** coverage anywhere in the repo. It now has 7 cases: auth-segment namespacing + user id, part ordering with non-string parts (number/object/boolean), null-userId gates, empty parts, session-switch key invalidation (different users → different keys), structural equality for identical inputs, and no mutation of the input array.
- Two `useAuthenticatedQueryGate` branches are newly pinned on the web path: a garbage (non-JWT) steward token stays disabled with a null user id, and the user id is still exposed when the caller disables the query (the gate only ANDs `enabled`, it does not hide identity).

All expectations record observed behavior of the module as it exists on `develop`; nothing aspirational.

## Evidence (fork contributor: hosted CI does not run on this PR)

Run against current `origin/develop` @ `da1203a930` immediately before filing:

1. `bunx vitest run src/cloud/lib/auth-query.test.tsx` (in `packages/ui`): **Test Files 1 passed (1), Tests 19 passed (19)** — 10 pre-existing + 9 added.
2. `bunx biome check --write src/cloud/lib/auth-query.test.tsx`: clean, exit 0, no fixes needed.
3. `bunx tsc --noEmit` in `packages/ui`: zero mentions of `auth-query` in output — the new code introduces no type errors.
4. Diff touches only `packages/ui/src/cloud/lib/auth-query.test.tsx` (`+82/-0`). No production behavior changes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a3375fb64e76028f7492a27d33f9db8b2c80191c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
