### PR TITLE
test(ui): cover join index

### DIFF
--- a/packages/ui/src/cloud/join/index.test.ts
+++ b/packages/ui/src/cloud/join/index.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Verifies the join domain barrel (`./index`): every runtime export resolves to
+ * the real underlying implementation, and the behaviours reachable through the
+ * barrel — cloud-route registration, Cloud connection resolution, the join flow
+ * controller's validation and persistence contract, and the Steward session
+ * hook's localStorage fallback — behave as their modules define.
+ */
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../../config/boot-config";
+import { getCloudRoute, listCloudRoutes } from "../shell/cloud-route-registry";
+import * as joinBarrel from "./index";
+import {
+  JOIN_ROUTE_PATH,
+  type JoinFlowClient,
+  type JoinFlowEffects,
+  type JoinFlowResult,
+  registerJoinFlow,
+  resolveJoinAuthToken,
+  resolveJoinCloudApiBase,
+  runJoinFlow,
+  useJoinSessionAuth,
+} from "./index";
+import JoinPageModule from "./JoinPage";
+import * as resolveModule from "./lib/resolve-cloud-connection";
+import * as runJoinFlowModule from "./lib/run-join-flow";
+import * as useJoinSessionModule from "./lib/use-join-session";
+import * as registerModule from "./register";
+
+const CLOUD_API_BASE = "https://api.eliza.app";
+const PERSONAL_ID = "personal:00000000-0000-5000-8000-000000000001";
+const PERSONAL_BASE = `${CLOUD_API_BASE}/api/v1/eliza/agents/personal%3A00000000-0000-5000-8000-000000000001`;
+// Obviously-fake, low-entropy stand-in for the opaque Steward session JWT
+// (a realistic random UUID here trips the gitleaks generic-api-key rule).
+const TOKEN = "aaaaaaaa-test-test-test-tokentoken01";
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const encode = (value: string) =>
+    btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `hdr.${encode(JSON.stringify(claims))}.sig`;
+}
+
+interface JoinFlowHarness {
+  client: JoinFlowClient;
+  effects: JoinFlowEffects;
+  requested: {
+    cloudApiBase: string;
+    authToken: string;
+    signal?: AbortSignal;
+  }[];
+  baseUrlCalls: (string | null)[];
+  tokenCalls: (string | null)[];
+  savedServers: Parameters<JoinFlowEffects["savePersistedActiveServer"]>[0][];
+  firstRunFlags: boolean[];
+  progress: [string, string?][];
+}
+
+function makeJoinFlowHarness(selected: JoinFlowResult): JoinFlowHarness {
+  const harness: JoinFlowHarness = {
+    client: {
+      async getPersonalSharedEliza(options) {
+        harness.requested.push({ ...options });
+        return selected;
+      },
+      setBaseUrl(baseUrl) {
+        harness.baseUrlCalls.push(baseUrl);
+      },
+      setToken(token) {
+        harness.tokenCalls.push(token);
+      },
+    },
+    effects: {
+      savePersistedActiveServer(server) {
+        harness.savedServers.push(server);
+      },
+      savePersistedFirstRunComplete(complete) {
+        harness.firstRunFlags.push(complete);
+      },
+    },
+    requested: [],
+    baseUrlCalls: [],
+    tokenCalls: [],
+    savedServers: [],
+    firstRunFlags: [],
+    progress: [],
+  };
+  return harness;
+}
+
+afterEach(() => {
+  cleanup();
+  setBootConfig(DEFAULT_BOOT_CONFIG);
+  window.localStorage.clear();
+});
+
+describe("join barrel wiring", () => {
+  it("re-exports the real implementations, not copies", () => {
+    expect(joinBarrel.JoinPage).toBe(JoinPageModule);
+    expect(joinBarrel.resolveJoinAuthToken).toBe(
+      resolveModule.resolveJoinAuthToken,
+    );
+    expect(joinBarrel.resolveJoinCloudApiBase).toBe(
+      resolveModule.resolveJoinCloudApiBase,
+    );
+    expect(joinBarrel.runJoinFlow).toBe(runJoinFlowModule.runJoinFlow);
+    expect(joinBarrel.registerJoinFlow).toBe(registerModule.registerJoinFlow);
+    expect(joinBarrel.JOIN_ROUTE_PATH).toBe(registerModule.JOIN_ROUTE_PATH);
+    expect(typeof joinBarrel.useJoinSessionAuth).toBe("function");
+    expect(joinBarrel.useJoinSessionAuth).toBe(
+      useJoinSessionModule.useJoinSessionAuth,
+    );
+  });
+
+  it("exports the canonical join route path", () => {
+    expect(JOIN_ROUTE_PATH).toBe("join");
+  });
+});
+
+describe("registerJoinFlow", () => {
+  it("registers authenticated join and get-started routes in the shared registry", () => {
+    expect(getCloudRoute(JOIN_ROUTE_PATH)).toBeUndefined();
+
+    registerJoinFlow();
+
+    const joinRoute = getCloudRoute(JOIN_ROUTE_PATH);
+    expect(joinRoute?.group).toBe("auth");
+    expect(joinRoute?.public).toBeFalsy();
+    expect(joinRoute?.element).toBeDefined();
+
+    const getStartedRoute = getCloudRoute("get-started");
+    expect(getStartedRoute?.group).toBe("auth");
+    expect(getStartedRoute?.public).toBeFalsy();
+    expect(getStartedRoute?.element).toBeDefined();
+  });
+
+  it("is idempotent — a second call leaves the registry untouched", () => {
+    const before = listCloudRoutes().map((route) => route.path);
+
+    registerJoinFlow();
+
+    expect(listCloudRoutes().map((route) => route.path)).toEqual(before);
+  });
+});
+
+describe("resolveJoinCloudApiBase through the barrel", () => {
+  it("prefers the boot-configured direct-cloud origin, trimmed", () => {
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "  https://cloud.join.example  ",
+    });
+    expect(resolveJoinCloudApiBase()).toBe("https://cloud.join.example");
+  });
+
+  it("falls back to the public Eliza Cloud origin when unconfigured", () => {
+    setBootConfig({ branding: {} });
+    expect(resolveJoinCloudApiBase()).toBe(CLOUD_API_BASE);
+  });
+});
+
+describe("resolveJoinAuthToken through the barrel", () => {
+  it("returns the trimmed stored Steward session token", () => {
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, `  ${TOKEN}  `);
+    expect(resolveJoinAuthToken()).toBe(TOKEN);
+  });
+
+  it("reads as signed out when no usable token is stored", () => {
+    expect(resolveJoinAuthToken()).toBeNull();
+
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "   ");
+    expect(resolveJoinAuthToken()).toBeNull();
+  });
+});
+
+describe("runJoinFlow through the barrel", () => {
+  it("connects, persists the Shared identity, and reports ordered progress", async () => {
+    const h = makeJoinFlowHarness({
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: PERSONAL_ID,
+      agentName: "",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+
+    const result = await runJoinFlow({
+      client: h.client,
+      effects: h.effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: TOKEN,
+      onProgress: (status, detail) => h.progress.push([status, detail]),
+    });
+
+    expect(h.requested).toEqual([
+      { cloudApiBase: CLOUD_API_BASE, authToken: TOKEN },
+    ]);
+    expect(h.progress).toEqual([
+      ["connecting", "Opening your personal Eliza…"],
+      ["connecting", "Connecting to Shared…"],
+      ["connecting", "Finishing setup…"],
+    ]);
+    expect(h.baseUrlCalls).toEqual([PERSONAL_BASE]);
+    expect(h.tokenCalls).toEqual([TOKEN]);
+    expect(h.savedServers).toEqual([
+      {
+        id: `cloud:${PERSONAL_ID}`,
+        kind: "cloud",
+        label: "Eliza",
+        apiBase: PERSONAL_BASE,
+        accessToken: TOKEN,
+        cloudRuntimeAgentId: PERSONAL_ID,
+        cloudRuntime: "shared",
+      },
+    ]);
+    expect(h.firstRunFlags).toEqual([true]);
+    expect(result).toEqual({
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: PERSONAL_ID,
+      agentName: "Eliza",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+  });
+
+  it("announces the Dedicated variant when the account runtime is dedicated", async () => {
+    const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const dedicatedBase = `https://${dedicatedAgentId}.cloud.eliza.app`;
+    const h = makeJoinFlowHarness({
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: dedicatedAgentId,
+      agentName: "Work Eliza",
+      apiBase: dedicatedBase,
+      runtime: "dedicated",
+    });
+
+    await runJoinFlow({
+      client: h.client,
+      effects: h.effects,
+      cloudApiBase: CLOUD_API_BASE,
+      authToken: TOKEN,
+      onProgress: (status, detail) => h.progress.push([status, detail]),
+    });
+
+    expect(h.progress[1]).toEqual([
+      "connecting",
+      "Connecting to your Dedicated agent…",
+    ]);
+    expect(h.savedServers[0]?.cloudRuntimeAgentId).toBe(dedicatedAgentId);
+    expect(h.savedServers[0]?.cloudRuntime).toBe("dedicated");
+    expect(h.savedServers[0]?.label).toBe("Work Eliza");
+  });
+
+  it("rejects a blank personal id without touching the client or persistence", async () => {
+    const h = makeJoinFlowHarness({
+      personalElizaId: "",
+      agentId: "",
+      activeAgentId: PERSONAL_ID,
+      agentName: "Eliza",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+
+    await expect(
+      runJoinFlow({
+        client: h.client,
+        effects: h.effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: TOKEN,
+      }),
+    ).rejects.toThrow("Cloud did not return a personal Eliza to connect to.");
+
+    expect(h.baseUrlCalls).toEqual([]);
+    expect(h.savedServers).toEqual([]);
+    expect(h.firstRunFlags).toEqual([]);
+  });
+
+  it("rejects an agent id that does not match the personal id", async () => {
+    const h = makeJoinFlowHarness({
+      personalElizaId: PERSONAL_ID,
+      agentId: "00000000-0000-4000-8000-000000000099",
+      activeAgentId: PERSONAL_ID,
+      agentName: "Eliza",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+
+    await expect(
+      runJoinFlow({
+        client: h.client,
+        effects: h.effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: TOKEN,
+      }),
+    ).rejects.toThrow("Cloud did not return a personal Eliza to connect to.");
+
+    expect(h.baseUrlCalls).toEqual([]);
+    expect(h.savedServers).toEqual([]);
+    expect(h.firstRunFlags).toEqual([]);
+  });
+
+  it("rejects a payload with no active agent id", async () => {
+    const h = makeJoinFlowHarness({
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: "",
+      agentName: "Eliza",
+      apiBase: PERSONAL_BASE,
+      runtime: "shared",
+    });
+
+    await expect(
+      runJoinFlow({
+        client: h.client,
+        effects: h.effects,
+        cloudApiBase: CLOUD_API_BASE,
+        authToken: TOKEN,
+      }),
+    ).rejects.toThrow("Cloud did not return a personal Eliza to connect to.");
+
+    expect(h.baseUrlCalls).toEqual([]);
+    expect(h.savedServers).toEqual([]);
+    expect(h.firstRunFlags).toEqual([]);
+  });
+});
+
+describe("useJoinSessionAuth through the barrel", () => {
+  it("reports settled and unauthenticated with no provider and no stored token", () => {
+    const { result } = renderHook(() => useJoinSessionAuth());
+    expect(result.current).toEqual({ ready: true, authenticated: false });
+  });
+
+  it("authenticates from a live locally stored Steward session", () => {
+    window.localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+    );
+    const { result } = renderHook(() => useJoinSessionAuth());
+    expect(result.current).toEqual({ ready: true, authenticated: true });
+  });
+
+  it("treats an expired stored session as signed out", () => {
+    window.localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ exp: Math.floor(Date.now() / 1000) - 3600 }),
+    );
+    const { result } = renderHook(() => useJoinSessionAuth());
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it("treats a malformed stored token as signed out", () => {
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "not-a-jwt");
+    const { result } = renderHook(() => useJoinSessionAuth());
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it("re-reads storage when the steward-token-sync event fires", async () => {
+    const { result } = renderHook(() => useJoinSessionAuth());
+    expect(result.current.authenticated).toBe(false);
+
+    window.localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+    );
+    act(() => {
+      window.dispatchEvent(new Event("steward-token-sync"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.authenticated).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION

Adds a first unit suite for `packages/ui/src/cloud/join/index.ts`, which had no same-named test file anywhere on develop. This is a test-only change: one new file (`packages/ui/src/cloud/join/index.test.ts`, +376/-0), no production code touched.

## What the suite covers

All assertions drive the real modules through the barrel import — no module mocks, and every expectation records behaviour actually observed on current develop:

- **Barrel wiring** — every runtime export (`JoinPage`, `resolveJoinAuthToken`, `resolveJoinCloudApiBase`, `runJoinFlow`, `registerJoinFlow`, `JOIN_ROUTE_PATH`, `useJoinSessionAuth`) is identical-by-reference to its underlying module export, so the barrel cannot silently drift into copies.
- **`registerJoinFlow`** — registers authenticated (`group: "auth"`, non-public) `join` and `get-started` routes into the shared cloud-route registry, and is idempotent: a second call leaves the ordered registry snapshot untouched.
- **`resolveJoinCloudApiBase`** — prefers the boot-configured origin (trimmed), falls back to `https://api.eliza.app` when unconfigured.
- **`resolveJoinAuthToken`** — trims the stored Steward token; blank or absent storage reads as signed out (`null`).
- **`runJoinFlow`** — connects, persists the rowless Shared identity (`id: cloud:<agentId>`, access token, runtime agent id), reports ordered progress, and falls back the label to `"Eliza"` when `agentName` is empty; announces the Dedicated variant when the account runtime is dedicated; fails closed without touching client base URL or persistence when Cloud returns a blank personal id, an `agentId` that does not match `personalElizaId`, or no `activeAgentId`.
- **`useJoinSessionAuth`** — localStorage fallback: settled-and-unauthenticated with no provider, live stored JWT authenticates, expired and malformed tokens read as signed out, and the hook re-reads storage when the `steward-token-sync` event fires.

## Verification

Run against current `origin/develop` (`da1203a93`) immediately before filing, in the owning package:

```
bunx vitest run --config ./vitest.config.ts src/cloud/join/index.test.ts
  Test Files  1 passed (1)
       Tests  18 passed (18)
```

- `bunx biome check packages/ui/src/cloud/join/index.test.ts` — clean (repo `biome.json` verified present; checkout is not sparse).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui` — the new test file appears nowhere in the output (the three reported errors are pre-existing in unrelated files and unchanged by this diff).

## Notes

- Test-only diff; no production behaviour changes.
- Fork contributor: hosted CI does not run on this PR — the vitest/biome/tsc results above are quoted from a local run of the owning package's own lane.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ce521107f98e34ba28915b6597e9e57a5a99f8fa -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
