### PR TITLE
test(core): cover json-output

### DIFF
--- a/packages/core/src/runtime/__tests__/json-output.test.ts
+++ b/packages/core/src/runtime/__tests__/json-output.test.ts
@@ -12,6 +12,8 @@ import {
 	parseJsonObject,
 	parsePseudoTagToolInvocations,
 	repairJsonStringEscapes,
+	stringifyForDiagnostics,
+	stringifyForModel,
 	stripJsonStructuralJunkReply,
 } from "../json-output";
 
@@ -210,6 +212,163 @@ describe("containsToolCallShapedMarkup", () => {
 		).toBe(false);
 		expect(containsToolCallShapedMarkup("plain answer, 35°C in paris")).toBe(
 			false,
+		);
+	});
+});
+
+describe("stringifyForModel", () => {
+	it("pretty-prints nested values with two-space indentation", () => {
+		expect(stringifyForModel({ plan: { contexts: ["tasks"] } })).toBe(
+			'{\n  "plan": {\n    "contexts": [\n      "tasks"\n    ]\n  }\n}',
+		);
+	});
+
+	it("serializes primitives without wrapping them", () => {
+		expect(stringifyForModel(42)).toBe("42");
+		expect(stringifyForModel(false)).toBe("false");
+		expect(stringifyForModel(null)).toBe("null");
+	});
+
+	it("throws a TypeError for values JSON cannot represent", () => {
+		expect(() => stringifyForModel(undefined)).toThrow(TypeError);
+		expect(() => stringifyForModel(() => "nope")).toThrow(
+			"Model prompt data is not JSON-serializable",
+		);
+	});
+});
+
+describe("stringifyForDiagnostics", () => {
+	it("returns string input unchanged instead of re-serializing it", () => {
+		expect(stringifyForDiagnostics('{"already":"raw"}')).toBe(
+			'{"already":"raw"}',
+		);
+	});
+
+	it("pretty-prints plain objects", () => {
+		expect(stringifyForDiagnostics({ ok: true, n: 1 })).toBe(
+			'{\n  "ok": true,\n  "n": 1\n}',
+		);
+	});
+
+	it("renders bigints as quoted n-suffixed strings instead of throwing", () => {
+		expect(stringifyForDiagnostics({ id: BigInt("9007199254740993") })).toBe(
+			'{\n  "id": "9007199254740993n"\n}',
+		);
+	});
+
+	it("marks cyclic references so diagnostics stay printable", () => {
+		const node: { name: string; next?: unknown } = { name: "head" };
+		node.next = node;
+		expect(stringifyForDiagnostics(node)).toBe(
+			'{\n  "name": "head",\n  "next": "[Circular]"\n}',
+		);
+	});
+
+	it("falls back to formatError when serialization itself throws", () => {
+		const hostile = {
+			get bad(): string {
+				throw new Error("boom");
+			},
+		};
+		expect(stringifyForDiagnostics(hostile)).toBe("[object Object]");
+	});
+
+	it("describes undefined through formatError because JSON.stringify yields undefined", () => {
+		expect(stringifyForDiagnostics(undefined)).toBe("undefined");
+	});
+});
+
+describe("parseJsonObject — rejected shapes, fences, and repaired extraction", () => {
+	it("returns null for empty or whitespace-only input", () => {
+		expect(parseJsonObject("")).toBeNull();
+		expect(parseJsonObject("   \n\t  ")).toBeNull();
+	});
+
+	it("rejects arrays and bare primitives even though they are valid JSON", () => {
+		expect(parseJsonObject("[1,2,3]")).toBeNull();
+		expect(parseJsonObject('"just words"')).toBeNull();
+		expect(parseJsonObject("42")).toBeNull();
+	});
+
+	it("unwraps a whole json code fence before parsing", () => {
+		expect(parseJsonObject('```json\n{"thought":"fenced"}\n```')).toEqual({
+			thought: "fenced",
+		});
+	});
+
+	it("extracts an object that only becomes balanced after escape repair", () => {
+		expect(parseJsonObject(String.raw`note {"msg":"abc\"}`)).toEqual({
+			msg: "abc\\",
+		});
+	});
+});
+
+describe("extractJsonObjects — boundary branches", () => {
+	it("returns an empty array when an object never closes", () => {
+		expect(extractJsonObjects('{"open":true')).toEqual([]);
+	});
+
+	it("ignores stray closing braces with no open object", () => {
+		expect(extractJsonObjects('noise} more } {"after":1}')).toEqual([
+			'{"after":1}',
+		]);
+	});
+
+	it("captures empty objects and objects inside arrays", () => {
+		expect(extractJsonObjects('[{},{"a":1}]')).toEqual(["{}", '{"a":1}']);
+	});
+
+	it("keeps the boundary when an escaped backslash precedes the closing quote", () => {
+		expect(extractJsonObjects(String.raw`{"s":"ends\\"}`)).toEqual([
+			String.raw`{"s":"ends\\"}`,
+		]);
+	});
+});
+
+describe("stripJsonStructuralJunkReply — punctuation-only replies and prose mentions", () => {
+	it("empties a reply that is only JSON punctuation", () => {
+		expect(stripJsonStructuralJunkReply('{,":]}')).toBe("");
+		expect(stripJsonStructuralJunkReply(' {} [] ":, ')).toBe("");
+	});
+
+	it("empties whitespace-only replies", () => {
+		expect(stripJsonStructuralJunkReply("   \n\t ")).toBe("");
+	});
+
+	it("preserves a lowercase prose mention of <tool_call> syntax", () => {
+		expect(
+			stripJsonStructuralJunkReply("the docs describe <tool_call> syntax"),
+		).toBe("the docs describe <tool_call> syntax");
+	});
+
+	it("strips multiple leaked pseudo-tag blocks and keeps interleaved prose", () => {
+		expect(
+			stripJsonStructuralJunkReply("<A_1>x</A_1> keep me <B_2>y</B_2>"),
+		).toBe("keep me");
+	});
+
+	it("strips a truncated <tool_call> tail when native arg markup follows", () => {
+		expect(
+			stripJsonStructuralJunkReply(
+				'answer ready <tool_call>{"u":1} <arg_value>v',
+			),
+		).toBe("answer ready");
+	});
+});
+
+describe("parsePseudoTagToolInvocations — input guards and parse failures", () => {
+	it("returns an empty array for undefined, empty, and tagless input", () => {
+		expect(parsePseudoTagToolInvocations(undefined)).toEqual([]);
+		expect(parsePseudoTagToolInvocations("")).toEqual([]);
+		expect(parsePseudoTagToolInvocations("no angle brackets at all")).toEqual(
+			[],
+		);
+		expect(parsePseudoTagToolInvocations("1 < 2 and 3 > 2")).toEqual([]);
+	});
+
+	it("declines a matched tag whose body fails JSON.parse", () => {
+		expect(parsePseudoTagToolInvocations("<NOTE_A>{oops}</NOTE_A>")).toEqual(
+			[],
 		);
 	});
 });


### PR DESCRIPTION

## What

Extends `packages/core/src/runtime/__tests__/json-output.test.ts` with unit coverage that was missing for two fully exported helpers of `packages/core/src/runtime/json-output.ts` and several of their branches:

- **`stringifyForModel`** (previously untested): pretty-printed nested serialization, primitive serialization, and the `TypeError` thrown when a value is not JSON-serializable (`undefined`, functions).
- **`stringifyForDiagnostics`** (previously untested): string passthrough without re-serialization, plain-object pretty-printing, bigint rendering as quoted `n`-suffixed strings, `[Circular]` marking for cyclic references, the `formatError` fallback when serialization throws (hostile getter), and the `?? formatError(value)` path for `JSON.stringify` returning `undefined`.
- **`parseJsonObject`**: empty / whitespace-only input returning `null`, rejection of arrays and bare primitives despite being valid JSON, whole-```` ```json ```` code-fence unwrapping, and recovery of an embedded object that only becomes balanced after escape repair.
- **`extractJsonObjects`**: unterminated object, stray closing braces with no open object, empty objects, objects inside arrays, and an escaped backslash immediately before a closing quote.
- **`stripJsonStructuralJunkReply`**: punctuation-only replies emptied by the junk-character guard, whitespace-only input, preservation of a lowercase prose mention of `<tool_call>` syntax, multiple leaked pseudo-tag blocks with interleaved prose kept, and a truncated `<tool_call>` tail stripped when native `<arg_value>` markup follows.
- **`parsePseudoTagToolInvocations`**: guards for `undefined` / empty / tagless input, and declining a matched tag whose body fails `JSON.parse`.

## Why

The module already had partial coverage, but every assertion in this PR was written from observed behavior of the real module — no mocks are involved anywhere; the helpers are pure functions driven directly. All expectations record what the code does today; nothing here proposes or smuggles a behavior change.

## Scope

**Test-only change.** The diff touches exactly one file, `packages/core/src/runtime/__tests__/json-output.test.ts`, and is purely additive: `159 insertions(+), 0 deletions(-)` against current `develop`. No production source, no configuration, and no existing test case was modified or removed.

## Verification

Fork contributor note: hosted CI does not run on pull requests from this fork, so local results are quoted directly.

- `bunx vitest run packages/core/src/runtime/__tests__/json-output.test.ts` → **Test Files 1 passed (1); Tests 46 passed (46)** (22 pre-existing cases untouched + 24 new), run against current `origin/develop` (`da1203a93010`) immediately before filing.
- `bunx biome check --write packages/core/src/runtime/__tests__/json-output.test.ts` → clean (`Checked 1 file ... Fixed 1 file`; formatting-only normalization).
- `bunx tsc --noEmit` in `packages/core` → zero diagnostics referencing the test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da1203a930100fbd5e51fa8100ca1819cb85d06d -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
