### PR TITLE
test(core): cover localized-examples-provider

### DIFF
--- a/packages/core/src/runtime/__tests__/localized-examples-provider.test.ts
+++ b/packages/core/src/runtime/__tests__/localized-examples-provider.test.ts
@@ -34,3 +34,92 @@ describe("localized-examples-provider registry", () => {
 		expect(getLocalizedExamplesProvider(runtime)).toBeNull();
 	});
 });
+
+describe("localized-examples-provider registration lifecycle", () => {
+	it("re-registration replaces the previous provider", () => {
+		const runtime = {} as never;
+		const first = async () => null;
+		const second = async () => null;
+		registerLocalizedExamplesProvider(runtime, first);
+		registerLocalizedExamplesProvider(runtime, second);
+		expect(getLocalizedExamplesProvider(runtime)).toBe(second);
+	});
+
+	it("reset is scoped to the given runtime", () => {
+		const a = {} as never;
+		const b = {} as never;
+		registerLocalizedExamplesProvider(a, provider);
+		registerLocalizedExamplesProvider(b, provider);
+		__resetLocalizedExamplesProviderForTests(a);
+		expect(getLocalizedExamplesProvider(a)).toBeNull();
+		expect(getLocalizedExamplesProvider(b)).toBe(provider);
+	});
+
+	it("reset on a never-registered runtime is a safe no-op", () => {
+		const runtime = {} as never;
+		expect(() =>
+			__resetLocalizedExamplesProviderForTests(runtime),
+		).not.toThrow();
+		expect(getLocalizedExamplesProvider(runtime)).toBeNull();
+	});
+
+	it("register after reset works again", () => {
+		const runtime = {} as never;
+		registerLocalizedExamplesProvider(runtime, provider);
+		__resetLocalizedExamplesProviderForTests(runtime);
+		const replacement = async () => null;
+		registerLocalizedExamplesProvider(runtime, replacement);
+		expect(getLocalizedExamplesProvider(runtime)).toBe(replacement);
+	});
+});
+
+describe("localized-examples-provider async contract", () => {
+	it("hands the exact registered function back and forwards the input to it", async () => {
+		const runtime = {} as never;
+		const observedInputs: Array<{ recentMessage?: string | null }> = [];
+		registerLocalizedExamplesProvider(runtime, async (input) => {
+			observedInputs.push(input);
+			return ({ actionName, exampleIndex }) =>
+				exampleIndex === 1 && actionName !== ""
+					? [
+							{
+								name: actionName,
+								content: { text: `localizado:${actionName}` },
+							},
+							{ name: actionName, content: { text: actionName } },
+						]
+					: null;
+		});
+		const retrieved = getLocalizedExamplesProvider(runtime);
+		if (!retrieved) {
+			throw new Error("expected the registered provider to be retrievable");
+		}
+		const resolver = await retrieved({ recentMessage: "bonjour" });
+		expect(observedInputs).toEqual([{ recentMessage: "bonjour" }]);
+		expect(typeof resolver).toBe("function");
+		expect(resolver?.({ actionName: "HELP", exampleIndex: 1 })).toEqual([
+			{ name: "HELP", content: { text: "localizado:HELP" } },
+			{ name: "HELP", content: { text: "HELP" } },
+		]);
+		expect(resolver?.({ actionName: "HELP", exampleIndex: 0 })).toBeNull();
+	});
+
+	it("invocation arguments pass through verbatim, including absent and null recentMessage", async () => {
+		const runtime = {} as never;
+		const seen: unknown[] = [];
+		registerLocalizedExamplesProvider(runtime, async (input) => {
+			seen.push(input);
+			return null;
+		});
+		const retrieved = getLocalizedExamplesProvider(runtime);
+		if (!retrieved) {
+			throw new Error("expected the registered provider to be retrievable");
+		}
+		const withNull = await retrieved({ recentMessage: null });
+		const withNoArgument = await (retrieved as () => Promise<null>)();
+		expect(withNull).toBeNull();
+		expect(withNoArgument).toBeNull();
+		expect(seen[0]).toEqual({ recentMessage: null });
+		expect(seen[1]).toBeUndefined();
+	});
+});


### PR DESCRIPTION

Additive coverage for the localized examples provider registry in `packages/core/src/runtime/localized-examples-provider.ts`.

A suite already existed for this module on `develop` at `packages/core/src/runtime/__tests__/localized-examples-provider.test.ts`, so this pull request only ADDS cases to that file (+89/-0, zero deletions, no reorganisation of existing cases).

New coverage:

- registration lifecycle: re-registration replaces the previous provider (`toBe` identity), reset is scoped to the given runtime, reset of a never-registered runtime is a safe no-op, and register-after-reset works again.
- async contract: the registry hands back the exact registered function, forwards the caller's input to it verbatim, and the awaited resolver is invoked with `{ actionName, exampleIndex }` returning the localized `[user, agent]` pair or `null` for the English-fallback path. Invocation arguments pass through untouched including absent and explicit-null `recentMessage`.

Evidence for this test-only change:

- `bunx vitest run packages/core/src/runtime/__tests__/localized-examples-provider.test.ts`: 1 test file passed, 10/10 tests passed (4 pre-existing + 6 new), re-run against current `origin/develop` immediately before filing.
- `bunx biome check --write` on the touched file: clean, no fixes applied.
- `bunx tsc --noEmit` in `packages/core`: the new test file appears nowhere in the output.
- The diff touches only this one test file and changes no production behaviour.

Note: hosted CI does not run on fork pull requests, so the quoted local runs are the verification for this diff.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b09ff7d85d7e38704d03aa7b723117573e479204 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
