### PR TITLE
test(agent): cover index

### DIFF
--- a/packages/agent/src/runtime/operations/index.test.ts
+++ b/packages/agent/src/runtime/operations/index.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit coverage for the RuntimeOperation public-surface barrel. Drives the
+ * real re-exports: exact runtime namespace keys, reference identity with
+ * each sibling implementation, and live calls through the barrel for the
+ * classifier, cold strategy, vault-ref helpers, and health checker.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { classifyOperation, defaultClassifier } from "./classifier.ts";
+import { createColdStrategy } from "./cold-strategy.ts";
+import { getDefaultHealthChecker, HealthChecker } from "./health.ts";
+import {
+  builtInHealthChecks,
+  dbConnectionCheck,
+  essentialServicesCheck,
+  providerSmokeCheck,
+  runtimeReadyCheck,
+} from "./health-checks.ts";
+import * as barrel from "./index.ts";
+import { DefaultRuntimeOperationManager } from "./manager.ts";
+import { createHotStrategy } from "./reload-hot.ts";
+import {
+  FilesystemRuntimeOperationRepository,
+  getDefaultRepository,
+} from "./repository.ts";
+import type { OperationPhase } from "./types.ts";
+import {
+  _resetDefaultSecretsManagerForTesting,
+  defaultSecretsManager,
+  formatVaultRef,
+  isVaultRef,
+  parseVaultRef,
+  persistProviderApiKey,
+  resolveConfigEnvForProcess,
+  resolveConnectorSecretSettings,
+  resolveProviderApiKey,
+  vaultKeyForProviderApiKey,
+} from "./vault-bridge.ts";
+
+const EXPECTED_RUNTIME_EXPORTS = [
+  "_resetDefaultSecretsManagerForTesting",
+  "builtInHealthChecks",
+  "classifyOperation",
+  "createColdStrategy",
+  "createHotStrategy",
+  "dbConnectionCheck",
+  "DefaultRuntimeOperationManager",
+  "defaultClassifier",
+  "defaultSecretsManager",
+  "essentialServicesCheck",
+  "FilesystemRuntimeOperationRepository",
+  "formatVaultRef",
+  "getDefaultHealthChecker",
+  "getDefaultRepository",
+  "HealthChecker",
+  "isVaultRef",
+  "parseVaultRef",
+  "persistProviderApiKey",
+  "providerSmokeCheck",
+  "resolveConfigEnvForProcess",
+  "resolveConnectorSecretSettings",
+  "resolveProviderApiKey",
+  "runtimeReadyCheck",
+  "vaultKeyForProviderApiKey",
+];
+
+describe("runtime operations barrel namespace", () => {
+  it("exposes exactly the documented runtime exports", () => {
+    expect(Object.keys(barrel).sort()).toEqual(
+      [...EXPECTED_RUNTIME_EXPORTS].sort(),
+    );
+  });
+
+  it("keeps sibling-internal helpers out of the public surface", () => {
+    const keys = Object.keys(barrel);
+    expect(keys).not.toContain("describeError");
+    expect(keys).not.toContain("VaultResolveError");
+    expect(keys).not.toContain("resolveOptimizedPromptIntegrityKey");
+  });
+});
+
+describe("barrel re-export identity", () => {
+  it("re-exports classifier bindings unchanged", () => {
+    expect(barrel.classifyOperation).toBe(classifyOperation);
+    expect(barrel.defaultClassifier).toBe(defaultClassifier);
+  });
+
+  it("re-exports strategy factories unchanged", () => {
+    expect(barrel.createColdStrategy).toBe(createColdStrategy);
+    expect(barrel.createHotStrategy).toBe(createHotStrategy);
+  });
+
+  it("re-exports health checker bindings unchanged", () => {
+    expect(barrel.HealthChecker).toBe(HealthChecker);
+    expect(barrel.getDefaultHealthChecker).toBe(getDefaultHealthChecker);
+  });
+
+  it("re-exports the built-in health checks unchanged", () => {
+    expect(barrel.builtInHealthChecks).toBe(builtInHealthChecks);
+    expect(barrel.runtimeReadyCheck).toBe(runtimeReadyCheck);
+    expect(barrel.essentialServicesCheck).toBe(essentialServicesCheck);
+    expect(barrel.dbConnectionCheck).toBe(dbConnectionCheck);
+    expect(barrel.providerSmokeCheck).toBe(providerSmokeCheck);
+  });
+
+  it("re-exports the manager class unchanged", () => {
+    expect(barrel.DefaultRuntimeOperationManager).toBe(
+      DefaultRuntimeOperationManager,
+    );
+  });
+
+  it("re-exports repository bindings unchanged", () => {
+    expect(barrel.FilesystemRuntimeOperationRepository).toBe(
+      FilesystemRuntimeOperationRepository,
+    );
+    expect(barrel.getDefaultRepository).toBe(getDefaultRepository);
+  });
+
+  it("re-exports vault bridge bindings unchanged", () => {
+    expect(barrel.formatVaultRef).toBe(formatVaultRef);
+    expect(barrel.isVaultRef).toBe(isVaultRef);
+    expect(barrel.parseVaultRef).toBe(parseVaultRef);
+    expect(barrel.vaultKeyForProviderApiKey).toBe(vaultKeyForProviderApiKey);
+    expect(barrel.resolveConfigEnvForProcess).toBe(resolveConfigEnvForProcess);
+    expect(barrel.resolveConnectorSecretSettings).toBe(
+      resolveConnectorSecretSettings,
+    );
+    expect(barrel.persistProviderApiKey).toBe(persistProviderApiKey);
+    expect(barrel.resolveProviderApiKey).toBe(resolveProviderApiKey);
+    expect(barrel.defaultSecretsManager).toBe(defaultSecretsManager);
+    expect(barrel._resetDefaultSecretsManagerForTesting).toBe(
+      _resetDefaultSecretsManagerForTesting,
+    );
+  });
+});
+
+describe("barrel bindings drive real behavior", () => {
+  it("classifies intents through the re-exported classifier", () => {
+    expect(barrel.classifyOperation({ kind: "restart", reason: "" }, {})).toBe(
+      "cold",
+    );
+    expect(
+      barrel.classifyOperation(
+        { kind: "provider-switch", provider: "openai" },
+        { currentProvider: "openai" },
+      ),
+    ).toBe("hot");
+    expect(
+      barrel.classifyOperation(
+        { kind: "config-reload", changedPaths: ["env.OPENAI_API_KEY"] },
+        {},
+      ),
+    ).toBe("hot");
+    expect(
+      barrel.classifyOperation(
+        { kind: "config-reload", changedPaths: ["plugins.enabled"] },
+        {},
+      ),
+    ).toBe("cold");
+  });
+
+  it("re-exported defaultClassifier matches classifyOperation", () => {
+    const cases = [
+      [{ kind: "restart", reason: "manual" }, {}],
+      [
+        { kind: "provider-switch", provider: "openai-subscription" },
+        { currentProvider: "openai" },
+      ],
+      [{ kind: "config-reload", changedPaths: ["vars.timezone"] }, {}],
+    ] as const;
+    for (const [intent, ctx] of cases) {
+      expect(barrel.defaultClassifier(intent, ctx)).toBe(
+        barrel.classifyOperation(intent, ctx),
+      );
+    }
+  });
+
+  it("runs a cold restart end-to-end through the re-exported factory", async () => {
+    const replacementRuntime = { agentId: "replacement-agent" } as AgentRuntime;
+    let receivedReason = "";
+    const phases: OperationPhase[] = [];
+
+    const strategy = barrel.createColdStrategy({
+      restartRuntime: async (reason) => {
+        receivedReason = reason;
+        return replacementRuntime;
+      },
+    });
+
+    expect(strategy.tier).toBe("cold");
+
+    const returned = await strategy.apply({
+      runtime: { agentId: "old-agent" } as AgentRuntime,
+      intent: { kind: "restart", reason: "manual restart" },
+      reportPhase: async (phase) => {
+        phases.push(phase);
+      },
+    });
+
+    expect(returned).toBe(replacementRuntime);
+    expect(receivedReason).toContain("restart");
+    expect(phases).toHaveLength(1);
+    expect(phases[0].name).toBe("cold-restart");
+    expect(phases[0].status).toBe("succeeded");
+    expect(typeof phases[0].startedAt).toBe("number");
+    expect(typeof phases[0].finishedAt).toBe("number");
+  });
+
+  it("round-trips vault refs through the re-exported helpers", () => {
+    const key = "providers.openai.api-key";
+    const ref = barrel.formatVaultRef(key);
+
+    expect(ref).toBe(`vault://${key}`);
+    expect(barrel.isVaultRef(ref)).toBe(true);
+    expect(barrel.isVaultRef(key)).toBe(false);
+    expect(barrel.isVaultRef("vault://")).toBe(false);
+    expect(barrel.parseVaultRef(ref)).toBe(key);
+    expect(barrel.parseVaultRef("not-a-ref")).toBe(null);
+
+    expect(() => barrel.formatVaultRef("")).toThrowError(TypeError);
+    expect(() => barrel.vaultKeyForProviderApiKey("")).toThrowError(TypeError);
+    expect(() => barrel.vaultKeyForProviderApiKey("has.dot")).toThrowError(
+      TypeError,
+    );
+    expect(barrel.vaultKeyForProviderApiKey("anthropic")).toBe(
+      "providers.anthropic.api-key",
+    );
+  });
+
+  it("exposes the four built-in health checks in order with their metadata", () => {
+    expect([...barrel.builtInHealthChecks]).toEqual([
+      barrel.runtimeReadyCheck,
+      barrel.essentialServicesCheck,
+      barrel.dbConnectionCheck,
+      barrel.providerSmokeCheck,
+    ]);
+    expect(barrel.runtimeReadyCheck).toMatchObject({
+      name: "runtime-ready",
+      required: true,
+      timeoutMs: 1000,
+    });
+    expect(barrel.essentialServicesCheck).toMatchObject({
+      name: "essential-services",
+      required: true,
+      timeoutMs: 2000,
+    });
+    expect(barrel.dbConnectionCheck).toMatchObject({
+      name: "db-connection",
+      required: true,
+      timeoutMs: 1500,
+    });
+    expect(barrel.providerSmokeCheck).toMatchObject({
+      name: "provider-smoke",
+      required: true,
+      timeoutMs: 5000,
+    });
+  });
+
+  it("constructs an empty HealthChecker whose report passes", async () => {
+    const checker = new barrel.HealthChecker();
+    await expect(
+      checker.runForRuntime({ agentId: "agent-id" } as AgentRuntime),
+    ).resolves.toEqual({ passed: [], failed: [], ok: true });
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/agent/src/runtime/operations/index.test.ts` — unit coverage for the RuntimeOperation public-surface barrel (`packages/agent/src/runtime/operations/index.ts`), which had no same-named test file on `develop`.

## Why

The barrel is the documented import surface every consumer of runtime operations goes through, but nothing pinned it. A broken or accidentally shadowed re-export would surface only at consumer call sites. The sibling implementation modules (`classifier`, `cold-strategy`, `health`, `health-checks`, `manager`, `reload-hot`, `repository`, `vault-bridge`) each have their own suites; this closes the remaining gap at the barrel itself.

## What the suite covers (15 cases)

- **Namespace surface:** `Object.keys` of the barrel namespace equals exactly the 24 documented runtime exports — sibling-internal helpers (`describeError`, `VaultResolveError`, `resolveOptimizedPromptIntegrityKey`) stay out of the public surface.
- **Re-export identity:** every binding is the same reference as its sibling module's direct export (`toBe`) across all eight source modules — proves no rewrap/shadowing.
- **Live behavior through the barrel (real modules, no mocks):**
  - classifier tiers via the barrel: restart → cold, same-provider switch → hot, `env.` config-reload → hot, non-hot path → cold;
  - `defaultClassifier` parity with `classifyOperation`;
  - end-to-end cold restart through `createColdStrategy`: replacement runtime returned, restart reason forwarded, single succeeded `cold-restart` phase with timestamps;
  - vault-ref round trip (`formatVaultRef` / `isVaultRef` / `parseVaultRef`, malformed inputs) and `vaultKeyForProviderApiKey` canonical output plus its two `TypeError` branches;
  - `builtInHealthChecks` contains exactly the four exported checks in order, each asserted with observed name/required/timeoutMs metadata;
  - `new HealthChecker()` with an empty registry reports `{ passed: [], failed: [], ok: true }`.

## Evidence (test-only diff; touches only the new test file)

- `bunx vitest run packages/agent/src/runtime/operations/index.test.ts` → **Test Files 1 passed (1), Tests 15 passed (15)** (re-fetched `develop` immediately before filing; base unchanged at `da1203a930100fbd5e51fa8100ca1819cb85d06d`, so these counts reproduce on current develop).
- `bunx biome check --write` applied once, then `bunx biome check <file>` → clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent` → the new file appears nowhere in the output (grep for `index.test.ts` exits 1).
- Diff is +266/-0, new file only. No production behavior changed.
- This is a fork PR: hosted CI does not run on it; the counts above are quoted from local runs of the real runner (`vitest`, which owns `packages/agent`'s unit lane).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da1203a930100fbd5e51fa8100ca1819cb85d06d -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
