### PR TITLE
test(core): cover message-handler

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 import { HANDLE_RESPONSE_SCHEMA } from "../../actions/to-tool";
 import {
+	getMessageHandlerReply,
 	parseMessageHandlerOutput,
 	routeMessageHandlerOutput,
 	SIMPLE_CONTEXT_ID,
@@ -581,5 +582,340 @@ describe("explicit media-ask promotion", () => {
 		expect(route.output.plan.candidateActions ?? []).not.toContain(
 			"GENERATE_MEDIA",
 		);
+	});
+});
+
+describe("plain-text keyed transcript recovery (#11712)", () => {
+	it("parses a raw keyed transcript echo instead of letting it ship verbatim", () => {
+		const parsed = parseMessageHandlerOutput(
+			[
+				"shouldRespond: RESPOND",
+				"",
+				"replyText: it's live https://example/",
+				"",
+				"contexts: simple",
+				"",
+				"candidateActionNames: BASH, TASKS",
+			].join("\n"),
+		);
+		expect(parsed?.processMessage).toBe("RESPOND");
+		expect(parsed?.thought).toBe("");
+		expect(parsed?.plan.contexts).toEqual(["simple"]);
+		expect(parsed?.plan.reply).toBe("it's live https://example/");
+		expect(parsed?.plan.candidateActions).toEqual(["BASH", "TASKS"]);
+	});
+
+	it("preserves a multi-line replyText value containing embedded blank lines", () => {
+		const parsed = parseMessageHandlerOutput(
+			[
+				"shouldRespond: RESPOND",
+				"",
+				"replyText: built it out at /workspace",
+				"",
+				"go click around and tell me what breaks.",
+				"",
+				"contexts: simple",
+			].join("\n"),
+		);
+		expect(parsed?.plan.reply).toBe(
+			"built it out at /workspace\n\ngo click around and tell me what breaks.",
+		);
+	});
+
+	it("recovers an IGNORE echo whose list fields read 'none' as empty selections", () => {
+		const parsed = parseMessageHandlerOutput(
+			"shouldRespond: IGNORE\n\ncontexts: none",
+		);
+		if (!parsed) throw new Error("expected parsed transcript output");
+		expect(parsed.processMessage).toBe("IGNORE");
+		expect(parsed.plan.contexts).toEqual([]);
+		expect(routeMessageHandlerOutput(parsed)).toEqual({
+			type: "ignored",
+			output: parsed,
+		});
+	});
+
+	it("returns null for prose that merely quotes field lines, keeping the tolerant plain-text path intact", () => {
+		const raw = [
+			"You pasted what looks like a leaked transcript.",
+			"",
+			"shouldRespond: RESPOND",
+			"",
+			"replyText: hello",
+		].join("\n");
+		expect(parseMessageHandlerOutput(raw)).toBeNull();
+	});
+
+	it("returns null when transcript-shaped text carries only non-hallmark fields", () => {
+		const raw = ["topics: website build, aurora", "", "emotion: none"].join(
+			"\n",
+		);
+		expect(parseMessageHandlerOutput(raw)).toBeNull();
+	});
+});
+
+describe("hint-array rejection contract", () => {
+	it("rejects the envelope when candidateActionNames is not an array", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "On it.",
+				contexts: ["general"],
+				candidateActionNames: "BASH",
+			}),
+		);
+		expect(parsed).toBeNull();
+	});
+
+	it("rejects the envelope when candidateActionNames contains a non-string item", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "On it.",
+				contexts: ["general"],
+				candidateActionNames: ["BASH", 7],
+			}),
+		);
+		expect(parsed).toBeNull();
+	});
+
+	it("rejects the envelope when intents contains a non-string item", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "On it.",
+				contexts: ["general"],
+				intents: ["delete reminder", 42],
+			}),
+		);
+		expect(parsed).toBeNull();
+	});
+
+	it("omits the candidateActions and intents keys when neither hint was sent", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Hello.",
+				contexts: ["simple"],
+			}),
+		);
+		expect(parsed?.plan.candidateActions).toBeUndefined();
+		expect(parsed?.plan.intents).toBeUndefined();
+	});
+});
+
+describe("intents propagation", () => {
+	it("carries declared intents through to the plan in order", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "On both.",
+				contexts: ["general"],
+				intents: ["delete reminder", "create reminder"],
+			}),
+		);
+		expect(parsed?.plan.intents).toEqual([
+			"delete reminder",
+			"create reminder",
+		]);
+	});
+
+	it("omits the intents key when Stage 1 declares none", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Done.",
+				contexts: ["simple"],
+				intents: [],
+			}),
+		);
+		expect(parsed?.plan.intents).toBeUndefined();
+	});
+});
+
+describe("reminder-ask denial promotion", () => {
+	it("promotes a capability denial for an explicit reminder ask to tasks planning and seeds both reminder siblings", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "I don't have a reminder tool in this setup.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		if (!parsed) throw new Error("expected parsed output");
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "remind me to stretch in 20 minutes",
+		});
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["tasks"]);
+			expect(route.output.plan.candidateActions).toContain("OWNER_REMINDERS");
+			expect(route.output.plan.candidateActions).toContain("TRIGGER");
+			expect(route.output.plan.candidateActions).not.toContain(
+				"GENERATE_MEDIA",
+			);
+		}
+	});
+
+	it("keeps the same denial a final reply when the user did not ask for a reminder", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "I don't have a reminder tool in this setup.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		if (!parsed) throw new Error("expected parsed output");
+		expect(routeMessageHandlerOutput(parsed).type).toBe("final_reply");
+	});
+});
+
+describe("task-status claim promotion", () => {
+	it("promotes a task-state claim for an explicit status ask to tasks planning and seeds TASKS", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "no such task exists right now.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		if (!parsed) throw new Error("expected parsed output");
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "did the website build finish?",
+		});
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["tasks"]);
+			expect(route.output.plan.candidateActions).toContain("TASKS");
+		}
+	});
+
+	it("keeps an unprompted task-state claim a final reply", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "no such task exists right now.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		if (!parsed) throw new Error("expected parsed output");
+		expect(routeMessageHandlerOutput(parsed).type).toBe("final_reply");
+	});
+});
+
+describe("shouldRespond normalization fallbacks", () => {
+	it("defaults an unrecognized routing verb to RESPOND", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "MAYBE",
+				replyText: "Hello.",
+				contexts: ["simple"],
+			}),
+		);
+		expect(parsed?.processMessage).toBe("RESPOND");
+	});
+
+	it("normalizes lowercase routing verbs before routing", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "ignore",
+				replyText: "",
+				contexts: [],
+			}),
+		);
+		if (!parsed) return;
+		expect(parsed.processMessage).toBe("IGNORE");
+		expect(routeMessageHandlerOutput(parsed).type).toBe("ignored");
+	});
+});
+
+describe("context normalization in the JSON envelope", () => {
+	it("trims context entries and drops blank ones", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Hello.",
+				contexts: [" simple ", "", "calendar "],
+			}),
+		);
+		expect(parsed?.plan.contexts).toEqual(["simple", "calendar"]);
+	});
+
+	it("collapses a non-array contexts value to an empty selection", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Hello.",
+				contexts: "general",
+			}),
+		);
+		expect(parsed?.plan.contexts).toEqual([]);
+	});
+});
+
+describe("getMessageHandlerReply", () => {
+	it("trims surrounding whitespace from the planned reply", () => {
+		expect(
+			getMessageHandlerReply({
+				processMessage: "RESPOND",
+				thought: "",
+				plan: { contexts: [], reply: "  padded reply  " },
+			}),
+		).toBe("padded reply");
+	});
+
+	it("yields an empty string when the plan carries no reply", () => {
+		expect(
+			getMessageHandlerReply({
+				processMessage: "RESPOND",
+				thought: "",
+				plan: { contexts: [] },
+			}),
+		).toBe("");
+	});
+});
+
+describe("progress-ack length cap", () => {
+	it("keeps a long progress-opener answer a final reply instead of promoting it", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText:
+					"checking the forecast, fetching your calendar, and gathering your notes now",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		if (!parsed) throw new Error("expected parsed output");
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("final_reply");
+		if (route.type === "final_reply") {
+			expect(route.reply).toBe(
+				"checking the forecast, fetching your calendar, and gathering your notes now",
+			);
+		}
+	});
+});
+
+describe("candidate-action promotion arm", () => {
+	it("promotes to general planning when candidates are named and requiresTool is unset rather than false", () => {
+		const output = {
+			processMessage: "RESPOND" as const,
+			thought: "Tool hinted, flag omitted.",
+			plan: {
+				contexts: [SIMPLE_CONTEXT_ID],
+				candidateActions: ["BASH"],
+				reply: "On it.",
+			},
+		};
+		const route = routeMessageHandlerOutput(output);
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["general"]);
+		}
 	});
 });


### PR DESCRIPTION

## What

Additive unit-test coverage for `packages/core/src/runtime/message-handler.ts`, appended to the existing suite at `packages/core/src/runtime/__tests__/message-handler.test.ts` (+336/−0, a single test file, no production code touched).

The new cases cover branches that had no coverage on develop:

- **Plain-text keyed transcript recovery (#11712):** full envelope echo parses through the transcript grammar; multi-line `replyText` with an embedded blank line is preserved intact; an IGNORE echo whose list fields read `none` routes as ignored; prose that merely quotes field lines falls through (`null`) so the tolerant plain-text path keeps it complete; transcript-shaped text carrying only non-hallmark fields returns `null`.
- **Hint-array rejection contract:** `candidateActionNames` or `intents` that are non-arrays or contain non-string items reject the envelope (`null`); omitted hints leave the corresponding plan keys unset.
- **Intents propagation:** declared intents carry through to `plan.intents` in order; empty intents omit the key.
- **Reminder-ask denial promotion:** a capability denial shipped on the simple path for an explicit "remind me" ask promotes to tasks planning and seeds both `OWNER_REMINDERS` and `TRIGGER` (and not `GENERATE_MEDIA`); the identical denial without an explicit ask stays a final reply.
- **Task-status claim promotion:** a "no such task exists" reply for an explicit status ask promotes to tasks planning and seeds `TASKS`; an unprompted task-state claim stays a final reply.
- **shouldRespond normalization:** an unrecognized routing verb defaults to RESPOND; lowercase verbs normalize before routing.
- **Context normalization:** entries are trimmed and blanks dropped; a non-array `contexts` value collapses to an empty selection.
- **getMessageHandlerReply:** trims surrounding whitespace; a missing reply yields "".
- **Progress-ack length cap:** a >64-character progress-opener answer stays a final reply.
- **Candidate-action promotion arm:** named candidates with `requiresTool` *unset* (not `false`) promote to planning against `general`.

## Verification (fork contributor — hosted CI does NOT run on this PR)

- `bunx vitest run packages/core/src/runtime/__tests__/message-handler.test.ts` → **Test Files 1 passed (1), Tests 52 passed (52)** (29 pre-existing cases untouched plus 23 new), re-run immediately before filing against current origin/develop.
- `bunx biome check --write` on the touched file → clean, no fixes applied.
- `bunx tsc --noEmit` in `packages/core` → zero output lines; the new test file appears nowhere in the output.
- The diff touches only this one test file: **336 insertions, 0 deletions** — no existing case was modified or removed.

All expectations record observed behavior of the real module; no mocks stand in for the system under test.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d09144f9a1fd83a4979a4a427af651ad8cc71ad9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
