### PR TITLE
chore(ios-deps): remove inert exclusion entries

### DIFF
--- a/packages/native/ios-deps/VERSIONS
+++ b/packages/native/ios-deps/VERSIONS
@@ -4,13 +4,6 @@
 # Update these when bumping a dep. Each entry should match the version Bun
 # upstream pins for desktop, unless we have a specific reason to diverge.
 
-boringssl=excluded-from-ios-build
-c-ares=excluded-from-ios-build
-lol-html=excluded-from-ios-build
-mimalloc=excluded-from-ios-build
-zstd=excluded-from-ios-build
-brotli=excluded-from-ios-build
-
 # llama.cpp pin for on-device inference. Tracks the elizaOS fork at
 # https://github.com/elizaOS/llama.cpp (branch `main`), not upstream
 # ggml-org. The fork carries the elizaOS kernels (Q4_POLAR / QJL1_256 /


### PR DESCRIPTION
Closes #27168

## Summary

Remove six performative `excluded-from-ios-build` records from `packages/native/ios-deps/VERSIONS`. The two actual build scripts select only the `llama.cpp` and `sqlite-vec` keys with exact-key `awk` expressions, so these declarations were never consumed and did not exclude anything.

Exact validated base: `38e5d5524e6a535832dd8578ea147d1df5dcd721`
Exact review head: `c55042758ff51fa67a600a97bc1befaacf07541e`

## Verification

- exact repository search: removed keys occur only in the deleted lines
- both retained pin parsers still resolve `llama.cpp=ce85787c8` and `sqlite-vec=v0.1.6`
- both build scripts pass `bash -n`
- package lint check passes
- package format check passes
- `git diff --check` passes
- native build/device evidence: N/A; no executable, ABI, pin, build flag, or generated artifact changed
- root verify: not run because the host remains under critical disk pressure; exact-head hosted checks are required before merge