### PR TITLE
test(core): cover tool-arg-aliases

### DIFF
--- a/packages/core/src/runtime/__tests__/tool-arg-aliases.test.ts
+++ b/packages/core/src/runtime/__tests__/tool-arg-aliases.test.ts
@@ -128,6 +128,58 @@ describe("resolveEntityAliasRefs", () => {
 			(resolved as Record<string, unknown> & { polluted?: unknown }).polluted,
 		).toBeUndefined();
 	});
+
+	it("leaves placeholders nested beyond the scan depth limit redacted", () => {
+		let deep: Record<string, unknown> = { leaf: ADMIN_PLACEHOLDER };
+		for (let index = 0; index < 9; index += 1) {
+			deep = { wrap: deep };
+		}
+		const args = {
+			...deep,
+			shallow: { entityId: ADMIN_PLACEHOLDER },
+		};
+		const resolved = resolveEntityAliasRefs(OWNER_ALIASES, args);
+		expect(resolved.shallow).toEqual({ entityId: OWNER_ID });
+		let cursor = resolved as Record<string, unknown>;
+		for (let index = 0; index < 9; index += 1) {
+			cursor = cursor.wrap as Record<string, unknown>;
+		}
+		expect(cursor.leaf).toBe(ADMIN_PLACEHOLDER);
+	});
+
+	it("keeps trailing placeholders redacted once the scan budget is exhausted", () => {
+		const filler = Array.from(
+			{ length: 2_100 },
+			(_, index) => `filler-${index}`,
+		);
+		const args = {
+			head: [ADMIN_PLACEHOLDER],
+			list: [...filler, ADMIN_PLACEHOLDER],
+		};
+		const resolved = resolveEntityAliasRefs(OWNER_ALIASES, args);
+		expect((resolved.head as string[])[0]).toBe(OWNER_ID);
+		const list = resolved.list as unknown[];
+		expect(list[list.length - 1]).toBe(ADMIN_PLACEHOLDER);
+		// The exhausted subtree is returned untouched by reference.
+		expect(resolved.list).toBe(args.list);
+		expect(args.head).toEqual([ADMIN_PLACEHOLDER]);
+	});
+
+	it("refuses granted values that are not strings", () => {
+		const args = { entityId: ADMIN_PLACEHOLDER };
+		const resolved = resolveEntityAliasRefs(
+			{ [CANONICAL_OWNER_ENTITY_ALIAS]: 12345 as unknown as string },
+			args,
+		);
+		expect(resolved.entityId).toBe(ADMIN_PLACEHOLDER);
+	});
+
+	it("traverses null-valued entries without resolving them", () => {
+		const args = { meta: null, entityId: ADMIN_PLACEHOLDER };
+		const resolved = resolveEntityAliasRefs(OWNER_ALIASES, args);
+		expect(resolved.meta).toBeNull();
+		expect(resolved.entityId).toBe(OWNER_ID);
+	});
 });
 
 describe("buildTurnEntityAliases", () => {
@@ -182,6 +234,37 @@ describe("buildTurnEntityAliases", () => {
 		);
 		expect(aliases).toEqual({});
 	});
+
+	it("returns no grants when roles are absent entirely", async () => {
+		const aliases = await buildTurnEntityAliases(
+			makeRuntime([], settings),
+			makeMessage(),
+			makeState(ADMIN_PLACEHOLDER),
+			undefined,
+		);
+		expect(aliases).toEqual({});
+	});
+
+	it("returns no grants when no canonical owner can be resolved at all", async () => {
+		const aliases = await buildTurnEntityAliases(
+			makeRuntime([]),
+			makeMessage(),
+			makeState(ADMIN_PLACEHOLDER),
+			["OWNER"],
+		);
+		expect(aliases).toEqual({});
+	});
+
+	it("returns a frozen capability map on success", async () => {
+		const aliases = await buildTurnEntityAliases(
+			makeRuntime([], settings),
+			makeMessage(),
+			makeState(ADMIN_PLACEHOLDER),
+			["OWNER"],
+		);
+		expect(Object.isFrozen(aliases)).toBe(true);
+		expect(aliases[CANONICAL_OWNER_ENTITY_ALIAS]).toBe(OWNER_ID);
+	});
 });
 
 describe("statePresentsEntityAlias", () => {
@@ -194,6 +277,39 @@ describe("statePresentsEntityAlias", () => {
 		).toBe(false);
 		expect(
 			statePresentsEntityAlias(undefined, CANONICAL_OWNER_ENTITY_ALIAS),
+		).toBe(false);
+	});
+
+	it("finds the exact token in state text", () => {
+		expect(
+			statePresentsEntityAlias(
+				makeState(`context: ${ADMIN_PLACEHOLDER}`),
+				CANONICAL_OWNER_ENTITY_ALIAS,
+			),
+		).toBe(true);
+	});
+
+	it("finds the exact token inside state data", () => {
+		const base = makeState("");
+		const state = {
+			...base,
+			data: { ownership: { ownerId: ADMIN_PLACEHOLDER } },
+		};
+		expect(statePresentsEntityAlias(state, CANONICAL_OWNER_ENTITY_ALIAS)).toBe(
+			true,
+		);
+	});
+
+	it("ignores tokens nested beyond the scan depth limit", () => {
+		let deep: Record<string, unknown> = { leaf: ADMIN_PLACEHOLDER };
+		for (let index = 0; index < 9; index += 1) {
+			deep = { wrap: deep };
+		}
+		expect(
+			statePresentsEntityAlias(
+				makeState("", deep as never),
+				CANONICAL_OWNER_ENTITY_ALIAS,
+			),
 		).toBe(false);
 	});
 });


### PR DESCRIPTION

## What this adds

Ten new cases appended to the existing `tool-arg-aliases` suite in
`packages/core/src/runtime/__tests__/tool-arg-aliases.test.ts`, covering
branches of `packages/core/src/runtime/tool-arg-aliases.ts` that had no direct
coverage on develop. **Additive only: +116/-0, one test file, no production
code touched.**

New coverage:

- `resolveEntityAliasRefs`
  - placeholders nested deeper than the 8-level scan limit stay redacted while a shallow sibling still resolves (`MAX_ALIAS_SCAN_DEPTH`)
  - once the 2048-node scan budget is exhausted, trailing placeholders stay redacted and the untouched subtree is returned by reference (`MAX_ALIAS_SCAN_NODES`)
  - a granted value that is not a string is refused (distinct from the covered invalid-UUID-string refusal)
  - null-valued entries are traversed without crashing and pass through unchanged
- `buildTurnEntityAliases`
  - `userRoles` absent entirely yields no grants (the optional-chain short-circuit)
  - when no canonical owner can be resolved at all (null owner id), grants are empty — distinct from the covered non-UUID-shaped string case
  - a successful grant map is frozen and carries the canonical owner alias
- `statePresentsEntityAlias`
  - positive detection of the exact token in `state.text`
  - positive detection of the token inside `state.data`
  - tokens nested beyond the scan depth limit are ignored

All cases drive the real module; runtime stubs only supply the boundary the
same way the existing suite does.

## Verification

Fork contributor: hosted CI does not run on this PR. Local verification:

- `bunx vitest run packages/core/src/runtime/__tests__/tool-arg-aliases.test.ts` → **Test Files 1 passed (1), Tests 27 passed (27)** (17 pre-existing + 10 new), re-run against current `origin/develop` immediately before filing
- `bunx biome check --write packages/core/src/runtime/__tests__/tool-arg-aliases.test.ts` → clean
- `bunx tsc --noEmit` in `packages/core` → zero occurrences of the test file in output
- `git diff origin/develop --stat` on the branch → exactly one file, +116/-0

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a9fd11d7c4ee9f5981eadf31b764016fe59b6b5c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
