### PR TITLE
test(core): cover agent

### DIFF
--- a/packages/core/src/schemas/agent.test.ts
+++ b/packages/core/src/schemas/agent.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the `agents` table descriptor (`agentSchema`) — the root of
+ * the data model that many core tables foreign-key back to via `agent_id`.
+ * Pure declarative-shape assertions over the real exported object — no mocks,
+ * no DB: the descriptor itself is the contract adapters materialize. Covers
+ * table identity, the full seventeen-column set with nullability and defaults
+ * (including the raw boolean default on `enabled`), the sole uuid primary
+ * key, the columns requiring explicit values, and the deliberately empty
+ * index/constraint maps.
+ */
+import { describe, expect, it } from "vitest";
+import { agentSchema } from "./agent";
+
+describe("agentSchema table identity", () => {
+	it("names the agents table in the default schema", () => {
+		expect(agentSchema.name).toBe("agents");
+		expect(agentSchema.schema).toBe("");
+	});
+});
+
+describe("agentSchema columns", () => {
+	it("declares exactly the seventeen agent columns", () => {
+		expect(Object.keys(agentSchema.columns).sort()).toEqual([
+			"adjectives",
+			"bio",
+			"created_at",
+			"documents",
+			"enabled",
+			"id",
+			"message_examples",
+			"name",
+			"plugins",
+			"post_examples",
+			"server_id",
+			"settings",
+			"style",
+			"system",
+			"topics",
+			"updated_at",
+			"username",
+		]);
+	});
+
+	it("keeps every column key consistent with its own name field", () => {
+		for (const [key, column] of Object.entries(agentSchema.columns)) {
+			expect(column.name).toBe(key);
+		}
+	});
+
+	it("types id as the sole non-null uuid primary key defaulting to defaultRandom()", () => {
+		expect(agentSchema.columns.id).toEqual({
+			name: "id",
+			type: "uuid",
+			primaryKey: true,
+			notNull: true,
+			default: "defaultRandom()",
+		});
+	});
+
+	it("flags no column other than id as a primary key", () => {
+		const primaryKeys = Object.entries(agentSchema.columns)
+			.filter(([, column]) => column.primaryKey === true)
+			.map(([key]) => key);
+		expect(primaryKeys).toEqual(["id"]);
+	});
+
+	it("marks no column as explicitly unique", () => {
+		for (const column of Object.values(agentSchema.columns)) {
+			expect(column.isUnique).toBeUndefined();
+			expect(column.uniqueName).toBeUndefined();
+			expect(column.uniqueType).toBeUndefined();
+		}
+	});
+
+	it("types enabled as a non-null boolean with a literal true default", () => {
+		expect(agentSchema.columns.enabled).toEqual({
+			name: "enabled",
+			type: "boolean",
+			notNull: true,
+			default: true,
+		});
+		expect(agentSchema.columns.enabled.default).toBe(true);
+	});
+
+	it("timestamps created_at and updated_at as non-null now()-defaulted columns", () => {
+		expect(agentSchema.columns.created_at).toEqual({
+			name: "created_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+		expect(agentSchema.columns.updated_at).toEqual({
+			name: "updated_at",
+			type: "timestamp",
+			notNull: true,
+			default: "now()",
+		});
+	});
+
+	it("leaves server_id as an optional uuid link without notNull or default", () => {
+		expect(agentSchema.columns.server_id.type).toBe("uuid");
+		expect(agentSchema.columns.server_id.notNull).toBeUndefined();
+		expect(agentSchema.columns.server_id.default).toBeUndefined();
+	});
+
+	it("requires name but leaves username optional, both plain text", () => {
+		expect(agentSchema.columns.name).toEqual({
+			name: "name",
+			type: "text",
+			notNull: true,
+		});
+		expect(agentSchema.columns.username.type).toBe("text");
+		expect(agentSchema.columns.username.notNull).toBeUndefined();
+		expect(agentSchema.columns.username.default).toBeUndefined();
+	});
+
+	it("defaults system to an empty string rather than leaving it unset", () => {
+		expect(agentSchema.columns.system.type).toBe("text");
+		expect(agentSchema.columns.system.default).toBe("");
+	});
+
+	it("stores the seven profile-array fields as non-null jsonb defaulting to []", () => {
+		const arrayColumns = [
+			"adjectives",
+			"bio",
+			"documents",
+			"message_examples",
+			"plugins",
+			"post_examples",
+			"topics",
+		] as const;
+		for (const key of arrayColumns) {
+			const column = agentSchema.columns[key];
+			expect(column.type).toBe("jsonb");
+			expect(column.notNull).toBe(true);
+			expect(column.default).toBe("[]");
+		}
+	});
+
+	it("stores settings and style as non-null jsonb object maps defaulting to {}", () => {
+		for (const key of ["settings", "style"] as const) {
+			const column = agentSchema.columns[key];
+			expect(column.type).toBe("jsonb");
+			expect(column.notNull).toBe(true);
+			expect(column.default).toBe("{}");
+		}
+	});
+
+	it("marks exactly fourteen columns non-null", () => {
+		const notNullColumns = Object.entries(agentSchema.columns)
+			.filter(([, column]) => column.notNull === true)
+			.map(([key]) => key)
+			.sort();
+		expect(notNullColumns).toEqual([
+			"adjectives",
+			"bio",
+			"created_at",
+			"documents",
+			"enabled",
+			"id",
+			"message_examples",
+			"name",
+			"plugins",
+			"post_examples",
+			"settings",
+			"style",
+			"topics",
+			"updated_at",
+		]);
+	});
+
+	it("requires explicit values for exactly name, server_id, and username", () => {
+		const withoutDefault = Object.entries(agentSchema.columns)
+			.filter(([, column]) => column.default === undefined)
+			.map(([key]) => key)
+			.sort();
+		expect(withoutDefault).toEqual(["name", "server_id", "username"]);
+	});
+});
+
+describe("agentSchema indexes and constraints", () => {
+	it("declares no indexes of its own", () => {
+		expect(agentSchema.indexes).toEqual({});
+	});
+
+	it("declares no foreign keys — dependant tables reference agents instead", () => {
+		expect(agentSchema.foreignKeys).toEqual({});
+	});
+
+	it("uses the uuid default as implicit primary key — no composite keys", () => {
+		expect(agentSchema.compositePrimaryKeys).toEqual({});
+	});
+
+	it("declares no unique or check constraints", () => {
+		expect(agentSchema.uniqueConstraints).toEqual({});
+		expect(agentSchema.checkConstraints).toEqual({});
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for `packages/core/src/schemas/agent.ts`, which exports the canonical `agentSchema` table descriptor for the `agents` table — the root of the core data model that many other tables foreign-key back to via `agent_id`. The module previously had no same-named test file anywhere in the repository.

The suite follows the existing declarative-shape convention used by its siblings (e.g. `packages/core/src/schemas/log.test.ts`): it imports the real exported object and asserts its contract directly — no mocks, no database.

## What is covered

- **Table identity:** table name `agents` in the default (`""`) schema.
- **Column inventory:** exactly seventeen columns; every column key consistent with its own `name` field.
- **Primary key:** `id` as the sole non-null uuid primary key defaulting to `defaultRandom()`; no other column flagged `primaryKey`.
- **Uniqueness:** no column declares `isUnique` / `uniqueName` / `uniqueType`.
- **Defaults edge cases:** `enabled` carries a literal boolean `true` default (the only non-string default); `system` defaults to an empty string rather than being unset; timestamps default to `now()`.
- **Nullability partitions:** exactly fourteen columns are `notNull`; `server_id` and `username` are optional uuid/text links without notNull or default.
- **Required values:** exactly `name`, `server_id`, and `username` lack defaults.
- **jsonb shapes:** the seven profile-array fields (`bio`, `message_examples`, `post_examples`, `topics`, `adjectives`, `documents`, `plugins`) are non-null jsonb defaulting to `[]`; `settings` and `style` default to `{}` instead.
- **Empty maps:** `indexes`, `foreignKeys`, `compositePrimaryKeys`, `uniqueConstraints`, and `checkConstraints` are all deliberately empty — dependant tables reference `agents`, not the reverse.

## Evidence

Test-only change: one new file, `+198/-0`, no production behavior touched.

Fork contributor note: hosted CI does not run on this pull request; local verification below was run against a working tree identical to current `origin/develop` (`e3e63588fd59ebb229d6ac6c8706659058f4fa35`), re-fetched immediately before filing:

- `bunx vitest run packages/core/src/schemas/agent.test.ts` — **1 test file passed, 19/19 tests passed** (130ms).
- `bunx biome check --write packages/core/src/schemas/agent.test.ts` — clean ("Checked 1 file... No fixes applied").
- `bunx tsc --noEmit` in `packages/core` — zero output; the new test file appears nowhere in the output (the package tsconfig excludes `src/**/*.test.ts`).

No `expectTypeOf` or type-only assertions; no mocks; no `vi.hoisted`. Assertions record observed behavior of the module as it exists on develop.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e3e63588fd59ebb229d6ac6c8706659058f4fa35 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
