### PR TITLE
test(agent): cover index

### DIFF
--- a/packages/agent/src/security/index.test.ts
+++ b/packages/agent/src/security/index.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Public-surface and behavior coverage for the agent security barrel
+ * (`security/index.ts`). The barrel must re-export every runtime symbol of
+ * access.ts and audit-log.ts with preserved identity — a dropped or ambiguous
+ * `export *` binding would silently break every plugin-facing import through
+ * `@elizaos/agent/security` — and the authorization wrappers reachable
+ * through it must keep their documented decisions: fail-closed denial for
+ * unresolvable senders, the lenient local path when no sender context exists,
+ * the #14707 fold of sourceless legacy OWNER grants, and J4 reporting on a
+ * broken world-resolution pipeline. Real modules are driven end to end;
+ * collaborators are minimal typed runtimes following access.test.ts.
+ */
+
+import type {
+  IAgentRuntime,
+  Memory,
+  Role,
+  Room,
+  UUID,
+  World,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as accessModule from "./access.ts";
+import * as auditLogModule from "./audit-log.ts";
+import * as securityIndex from "./index.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ENTITY_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const OTHER_ENTITY_ID = "00000000-0000-0000-0000-0000000000ee" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000ff" as UUID;
+
+function noReports(): void {}
+
+function runtimeWith(
+  reportError: () => void,
+  overrides: Partial<IAgentRuntime> = {},
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getSetting: () => undefined,
+    reportError,
+    ...overrides,
+  } as unknown as IAgentRuntime;
+}
+
+function message(entityId: UUID = ENTITY_ID): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000cc" as UUID,
+    entityId,
+    roomId: ROOM_ID,
+    content: { text: "x" },
+  } as Memory;
+}
+
+function dmRoom(): Room {
+  return {
+    id: ROOM_ID,
+    agentId: AGENT_ID,
+    source: "test",
+    type: "DM",
+    worldId: WORLD_ID,
+  };
+}
+
+function groupRoomWithoutWorld(): Room {
+  return {
+    id: ROOM_ID,
+    agentId: AGENT_ID,
+    source: "test",
+    type: "GROUP",
+  };
+}
+
+function worldWithRoles(
+  roles: Record<string, Role>,
+  roleSources?: Record<string, string>,
+): World {
+  return {
+    id: WORLD_ID,
+    agentId: AGENT_ID,
+    name: "world",
+    metadata: { roles, ...(roleSources ? { roleSources } : {}) },
+  };
+}
+
+describe("security barrel public surface", () => {
+  it("re-exports every runtime export of access.ts with preserved identity", () => {
+    expect(Object.keys(accessModule).length).toBeGreaterThan(0);
+    for (const [name, value] of Object.entries(accessModule)) {
+      expect(securityIndex).toHaveProperty(name);
+      expect(
+        (securityIndex as unknown as Record<string, unknown>)[name],
+        `barrel export ${name} must be the same binding`,
+      ).toBe(value);
+    }
+  });
+
+  it("re-exports every runtime export of audit-log.ts with preserved identity", () => {
+    expect(Object.keys(auditLogModule).length).toBeGreaterThan(0);
+    for (const [name, value] of Object.entries(auditLogModule)) {
+      expect(securityIndex).toHaveProperty(name);
+      expect(
+        (securityIndex as unknown as Record<string, unknown>)[name],
+        `barrel export ${name} must be the same binding`,
+      ).toBe(value);
+    }
+  });
+
+  it("keeps the SandboxAuditLog class identity across import paths", () => {
+    const log = new securityIndex.SandboxAuditLog({ console: false });
+    expect(log).toBeInstanceOf(auditLogModule.SandboxAuditLog);
+  });
+
+  it("exposes the audit taxonomy constants", () => {
+    expect(securityIndex.AUDIT_SEVERITIES).toEqual([
+      "info",
+      "warn",
+      "error",
+      "critical",
+    ]);
+    for (const eventType of [
+      "policy_decision",
+      "security_kill_switch",
+      "sandbox_lifecycle",
+    ] as const) {
+      expect(securityIndex.AUDIT_EVENT_TYPES).toContain(eventType);
+    }
+  });
+});
+
+describe("isAgentSelf through the barrel", () => {
+  it("detects the agent's own entity", () => {
+    expect(
+      securityIndex.isAgentSelf(runtimeWith(noReports), message(AGENT_ID)),
+    ).toBe(true);
+  });
+
+  it("rejects another entity", () => {
+    expect(securityIndex.isAgentSelf(runtimeWith(noReports), message())).toBe(
+      false,
+    );
+  });
+
+  it("fails closed without a runtime", () => {
+    expect(securityIndex.isAgentSelf(undefined, message())).toBe(false);
+  });
+
+  it("fails closed on an empty sender entityId", () => {
+    expect(
+      securityIndex.isAgentSelf(runtimeWith(noReports), message("" as UUID)),
+    ).toBe(false);
+  });
+});
+
+describe("role-gated access through the barrel", () => {
+  it("grants OWNER to an explicit manual owner grant", async () => {
+    const granted = await securityIndex.hasOwnerAccess(
+      runtimeWith(noReports, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () =>
+          worldWithRoles({ [ENTITY_ID]: "OWNER" }, { [ENTITY_ID]: "manual" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(true);
+  });
+
+  it("folds a sourceless legacy OWNER grant to GUEST (#14707)", async () => {
+    const granted = await securityIndex.hasOwnerAccess(
+      runtimeWith(noReports, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => worldWithRoles({ [ENTITY_ID]: "OWNER" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(false);
+  });
+
+  it("grants ADMIN to an explicitly granted admin", async () => {
+    const granted = await securityIndex.hasAdminAccess(
+      runtimeWith(noReports, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => worldWithRoles({ [ENTITY_ID]: "ADMIN" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(true);
+  });
+
+  it("denies ADMIN to an unranked sender inside a resolved world", async () => {
+    const reportError = vi.fn();
+    const granted = await securityIndex.hasAdminAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => worldWithRoles({ [OTHER_ENTITY_ID]: "ADMIN" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(false);
+    // A clean rank denial is not a broken pipeline: nothing is reported.
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});
+
+describe("private-channel access through the barrel", () => {
+  it("grants an explicitly granted member of a private world", async () => {
+    const reportError = vi.fn();
+    const granted = await securityIndex.hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => worldWithRoles({ [ENTITY_ID]: "MEMBER" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(true);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("denies when the message resolves to no world", async () => {
+    const reportError = vi.fn();
+    const granted = await securityIndex.hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => groupRoomWithoutWorld(),
+      }),
+      message(),
+    );
+    expect(granted).toBe(false);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("denies an unlisted sender inside a resolved world", async () => {
+    const reportError = vi.fn();
+    const granted = await securityIndex.hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => worldWithRoles({ [OTHER_ENTITY_ID]: "ADMIN" }),
+      }),
+      message(),
+    );
+    expect(granted).toBe(false);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("stays fail-closed and reports when world resolution throws", async () => {
+    const boom = new Error("world store unavailable");
+    const reportError = vi.fn();
+    const granted = await securityIndex.hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => dmRoom(),
+        getWorld: async () => {
+          throw boom;
+        },
+      }),
+      message(),
+    );
+    expect(granted).toBe(false);
+    // error-policy:J4 — deny AND surface via the wrapper's own scope.
+    expect(reportError).toHaveBeenCalledWith("Access.hasPrivateAccess", boom, {
+      entityId: ENTITY_ID,
+    });
+  });
+});
+
+describe("process-wide audit feed wiring through the barrel", () => {
+  beforeEach(() => {
+    securityIndex.__resetAuditFeedForTests();
+  });
+
+  it("publishes SandboxAuditLog records into the shared feed", () => {
+    const log = new securityIndex.SandboxAuditLog({ console: false });
+    log.record({ type: "policy_decision", summary: "s1", severity: "info" });
+    log.record({ type: "fetch_proxy_error", summary: "s2", severity: "error" });
+    expect(securityIndex.getAuditFeedSize()).toBe(2);
+    const policyEntries = securityIndex.queryAuditFeed({
+      type: "policy_decision",
+    });
+    expect(policyEntries).toHaveLength(1);
+    expect(policyEntries[0].summary).toBe("s1");
+  });
+
+  it("notifies subscribers until they unsubscribe", () => {
+    const handler = vi.fn();
+    const unsubscribe = securityIndex.subscribeAuditFeed(handler);
+    const log = new securityIndex.SandboxAuditLog({ console: false });
+    log.record({ type: "sandbox_lifecycle", summary: "a", severity: "info" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    log.record({ type: "sandbox_lifecycle", summary: "b", severity: "info" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset isolates process-wide feed state between specs", () => {
+    const log = new securityIndex.SandboxAuditLog({ console: false });
+    log.record({ type: "sandbox_lifecycle", summary: "a", severity: "info" });
+    expect(securityIndex.getAuditFeedSize()).toBe(1);
+    securityIndex.__resetAuditFeedForTests();
+    expect(securityIndex.getAuditFeedSize()).toBe(0);
+    expect(securityIndex.queryAuditFeed()).toEqual([]);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/agent/src/security/index.test.ts` — unit coverage for the agent
security barrel (`security/index.ts`), which previously had no same-named suite
anywhere on develop. Test-only change: one new file, +301/-0, no production
code touched.

## Why this surface

The barrel is the plugin-facing import point (`@elizaos/agent/security`). Two
real hazards live exactly there and had no coverage:

- **Star-export integrity.** `export *` from `access.ts` and `audit-log.ts`
  silently drops ambiguous bindings; a future symbol collision would break
  every consumer with no error. The suite asserts every runtime export of both
  submodules is reachable through the barrel *with preserved identity*
  (`toBe` on the module namespace bindings, plus `instanceof` across import
  paths), so a dropped or shadowed re-export fails loudly.
- **Documented authorization decisions behind the barrel.** The wrappers are
  thin, but their contracts are easy to regress silently:
  - `isAgentSelf` fails closed on missing runtime or empty `entityId`;
  - `hasOwnerAccess` honors an explicit manual OWNER grant and folds a
    sourceless legacy OWNER grant to GUEST (#14707 semantics);
  - `hasAdminAccess` grants an explicit ADMIN grant and denies an unranked
    sender without reporting a broken pipeline;
  - `hasPrivateAccess` grants an explicitly granted member, denies when no
    world resolves or the sender is unlisted, and stays fail-closed while
    surfacing (`reportError("Access.hasPrivateAccess", ...)`) when world
    resolution throws;
  - the process-wide audit feed wiring (publish, subscribe/unsubscribe,
    reset isolation) works through the same public exports.

All expectations record observed behavior driven through the real modules and
the real `@elizaos/core` role primitives; collaborators are minimal typed
runtimes following the existing `access.test.ts` pattern.

## Evidence (this fork does not run hosted CI; all checks were run locally)

- `bunx vitest run src/security/index.test.ts` (in `packages/agent`):
  **Test Files 1 passed (1), Tests 19 passed (19)**.
- `bunx biome check src/security/index.test.ts`: clean ("Checked 1 file … No
  fixes applied") after an initial `--write` format pass.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent`: the new file
  appears nowhere in output (grep exit 1). Pre-existing errors elsewhere in
  the package are untouched by this diff.
- Diff is additive only: `git diff --stat origin/develop..HEAD` shows exactly
  one file, +301/-0.

Note: the sibling branch name `test/agent-index-coverage` is occupied on our
fork by an unrelated stale push from an earlier session, so this PR uses the
`-2` suffix; content is unaffected.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:745958d137ffe00f65f80077ad2a95145467258f -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
