### PR TITLE
test(ui): cover follower-controller

### DIFF
--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts
@@ -114,4 +114,264 @@ describe("buildFollowerController commands", () => {
     await vi.waitFor(() => expect(errors).toHaveLength(1));
     expect((errors[0] as Error).message).toBe("owner gone");
   });
+
+  it("passes the failing command itself to onCommandError", async () => {
+    const dispatch = vi.fn(async () => {
+      throw new Error("timed out");
+    });
+    const errors: { command: ShellControllerCommand; error: unknown }[] = [];
+    const controller = buildFollowerController({
+      snapshot: baseSnapshot(),
+      dispatch,
+      onCommandError: (command, error) => errors.push({ command, error }),
+      setDictationSink: vi.fn(),
+      setTranscriptSessionSink: vi.fn(),
+    });
+    controller.open();
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect(errors[0].command).toEqual({ kind: "open" });
+    expect((errors[0].error as Error).message).toBe("timed out");
+  });
+});
+
+describe("buildFollowerController nav mirroring", () => {
+  it("mirrors conversationNav data and forwards goPrev", () => {
+    const { controller, dispatch } = build({
+      conversationNav: {
+        hasPrev: true,
+        hasNext: true,
+        activeId: "c7",
+        index: 3,
+      },
+    });
+    expect(controller.conversationNav.hasPrev).toBe(true);
+    expect(controller.conversationNav.hasNext).toBe(true);
+    expect(controller.conversationNav.activeId).toBe("c7");
+    expect(controller.conversationNav.index).toBe(3);
+    controller.conversationNav.goPrev();
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: "navConversation",
+      direction: "prev",
+    });
+  });
+});
+
+describe("buildFollowerController send option branches", () => {
+  function capture(): {
+    sent: ShellControllerCommand[];
+    dispatch: (command: ShellControllerCommand) => Promise<void>;
+  } {
+    const sent: ShellControllerCommand[] = [];
+    return {
+      sent,
+      dispatch: async (command) => {
+        sent.push(command);
+      },
+    };
+  }
+
+  it("omits every optional key when send carries no options", () => {
+    const { sent, dispatch } = capture();
+    const controller = buildFollowerController({
+      snapshot: baseSnapshot(),
+      dispatch,
+      onCommandError: () => {},
+      setDictationSink: vi.fn(),
+      setTranscriptSessionSink: vi.fn(),
+    });
+    controller.send("hi");
+    expect(sent).toEqual([{ kind: "send", text: "hi" }]);
+    expect(Object.keys(sent[0]).sort()).toEqual(["kind", "text"]);
+  });
+
+  it("forwards images while omitting channelType and metadata keys", () => {
+    const { sent, dispatch } = capture();
+    const controller = buildFollowerController({
+      snapshot: baseSnapshot(),
+      dispatch,
+      onCommandError: () => {},
+      setDictationSink: vi.fn(),
+      setTranscriptSessionSink: vi.fn(),
+    });
+    controller.send("look", {
+      images: [
+        {
+          data: "data:image/png;base64,AA",
+          mimeType: "image/png",
+          name: "shot.png",
+        },
+      ],
+    });
+    expect(sent[0]).toEqual({
+      kind: "send",
+      text: "look",
+      images: [
+        {
+          data: "data:image/png;base64,AA",
+          mimeType: "image/png",
+          name: "shot.png",
+        },
+      ],
+    });
+    expect(Object.keys(sent[0]).sort()).toEqual(["images", "kind", "text"]);
+  });
+
+  it("forwards channelType alone when it is the only option", () => {
+    const { sent, dispatch } = capture();
+    const controller = buildFollowerController({
+      snapshot: baseSnapshot(),
+      dispatch,
+      onCommandError: () => {},
+      setDictationSink: vi.fn(),
+      setTranscriptSessionSink: vi.fn(),
+    });
+    controller.send("hi", { channelType: "DM" });
+    expect(sent[0]).toEqual({ kind: "send", text: "hi", channelType: "DM" });
+    expect(Object.keys(sent[0]).sort()).toEqual([
+      "channelType",
+      "kind",
+      "text",
+    ]);
+  });
+});
+
+describe("buildFollowerController startRecording intent branch", () => {
+  it("omits the intent key for a bare startRecording", () => {
+    const { controller, dispatch } = build();
+    controller.startRecording();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ kind: "startRecording" });
+  });
+});
+
+describe("buildFollowerController remaining reads", () => {
+  it("mirrors the rest of the snapshot surface", () => {
+    const { controller } = build({
+      phase: "listening",
+      isOpen: true,
+      responding: true,
+      canSend: false,
+      waveformMode: "listening",
+      visionCapturing: true,
+      speaking: true,
+      agentVoiceMuted: true,
+      needsAudioUnlock: true,
+      transcriptionMode: true,
+      currentTab: "chat",
+      conversationLoading: true,
+      noProviderConfigured: true,
+      bootProgressSignal: "boot-1",
+    });
+    expect(controller.phase).toBe("listening");
+    expect(controller.isOpen).toBe(true);
+    expect(controller.responding).toBe(true);
+    expect(controller.canSend).toBe(false);
+    expect(controller.waveformMode).toBe("listening");
+    expect(controller.visionCapturing).toBe(true);
+    expect(controller.speaking).toBe(true);
+    expect(controller.agentVoiceMuted).toBe(true);
+    expect(controller.needsAudioUnlock).toBe(true);
+    expect(controller.transcriptionMode).toBe(true);
+    expect(controller.currentTab).toBe("chat");
+    expect(controller.conversationLoading).toBe(true);
+    expect(controller.noProviderConfigured).toBe(true);
+    expect(controller.bootProgressSignal).toBe("boot-1");
+    expect(controller.turnStatus).toBeNull();
+    expect(controller.modelStatus.kind).toBe("not-required");
+  });
+});
+
+describe("buildFollowerController forwards every owner command", () => {
+  type Ctl = ReturnType<typeof buildFollowerController>;
+  const rows: {
+    m: string;
+    run: (c: Ctl) => void;
+    cmd: ShellControllerCommand;
+  }[] = [
+    { m: "open", run: (c) => c.open(), cmd: { kind: "open" } },
+    { m: "close", run: (c) => c.close(), cmd: { kind: "close" } },
+    {
+      m: "captureVision",
+      run: (c) => c.captureVision(),
+      cmd: { kind: "captureVision" },
+    },
+    {
+      m: "toggleRecording",
+      run: (c) => c.toggleRecording(),
+      cmd: { kind: "toggleRecording" },
+    },
+    {
+      m: "stopRecording",
+      run: (c) => c.stopRecording(),
+      cmd: { kind: "stopRecording" },
+    },
+    {
+      m: "cancelRecording",
+      run: (c) => c.cancelRecording(),
+      cmd: { kind: "cancelRecording" },
+    },
+    {
+      m: "toggleHandsFree",
+      run: (c) => c.toggleHandsFree(),
+      cmd: { kind: "toggleHandsFree" },
+    },
+    {
+      m: "toggleTranscriptionMode",
+      run: (c) => c.toggleTranscriptionMode(),
+      cmd: { kind: "toggleTranscriptionMode" },
+    },
+    {
+      m: "stopTranscriptionAndMic",
+      run: (c) => c.stopTranscriptionAndMic(),
+      cmd: { kind: "stopTranscriptionAndMic" },
+    },
+    {
+      m: "stopSpeaking",
+      run: (c) => c.stopSpeaking(),
+      cmd: { kind: "stopSpeaking" },
+    },
+    {
+      m: "toggleAgentVoiceMute",
+      run: (c) => c.toggleAgentVoiceMute(),
+      cmd: { kind: "toggleAgentVoiceMute" },
+    },
+    {
+      m: "unlockAudio",
+      run: (c) => c.unlockAudio(),
+      cmd: { kind: "unlockAudio" },
+    },
+    {
+      m: "clearConversation",
+      run: (c) => c.clearConversation(),
+      cmd: { kind: "clearConversation" },
+    },
+    {
+      m: "openSettings",
+      run: (c) => c.openSettings(),
+      cmd: { kind: "openSettings" },
+    },
+    {
+      m: "navigateHome",
+      run: (c) => c.navigateHome?.(),
+      cmd: { kind: "navigateHome" },
+    },
+    { m: "stop", run: (c) => c.stop(), cmd: { kind: "stop" } },
+    {
+      m: "speak",
+      run: (c) => c.speak("hello"),
+      cmd: { kind: "speak", text: "hello" },
+    },
+    {
+      m: "setComposerHasDraft",
+      run: (c) => c.setComposerHasDraft(false),
+      cmd: { kind: "setComposerHasDraft", hasDraft: false },
+    },
+  ];
+
+  it.each(rows)("$m forwards its command exactly once", ({ run, cmd }) => {
+    const { controller, dispatch } = build();
+    run(controller);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(cmd);
+  });
 });


### PR DESCRIPTION

Adds unit coverage for `buildFollowerController` in
`packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts`.

The module already had a small suite on develop; this change is strictly
additive (+260/-0, one test file) and appends cases for branches it did not
exercise:

- `conversationNav` data mirroring (`hasPrev`/`hasNext`/`activeId`/`index`)
  and the `goPrev` command.
- `send` option branches: bare text omits every optional key; an images-only
  send carries no `channelType`/`metadata` keys; a channelType-only send
  carries no `images`/`metadata` keys (asserted on exact key sets, since the
  wire shape is spread-built).
- Bare `startRecording()` omits the `intent` key.
- The remaining snapshot reads mirrored onto the follower controller
  (`phase`, `isOpen`, `responding`, `canSend`, `waveformMode`,
  `visionCapturing`, `speaking`, `agentVoiceMuted`, `needsAudioUnlock`,
  `transcriptionMode`, `currentTab`, `conversationLoading`,
  `noProviderConfigured`, `bootProgressSignal`, plus default-null
  `turnStatus`).
- Every remaining owner command forwarding exactly once with its typed
  command payload (open, close, captureVision, toggleRecording,
  stopRecording, cancelRecording, toggleHandsFree, toggleTranscriptionMode,
  stopTranscriptionAndMic, stopSpeaking, toggleAgentVoiceMute, unlockAudio,
  clearConversation, openSettings, navigateHome, stop, speak,
  setComposerHasDraft). `navigateHome` is invoked through the optional-call
  idiom used by production callers because it is optional on
  `ShellController`; the suite still asserts the follower always supplies it.
- Dispatch failure routes the failing command object itself (not just the
  error) to `onCommandError`.

All assertions drive the real `buildFollowerController` against the shared
snapshot fixture; the dispatch boundary is recorded as plain data and every
expectation was observed from actual behaviour.

Evidence (test-only change; no production behaviour modified):

- `bunx vitest run src/components/shell/shell-controller-sync/__tests__/follower-controller.test.ts`
  (packages/ui): **1 file passed, 31 tests passed** (25 new cases added to
  the 6 pre-existing ones).
- `bunx biome check --write` on the touched file: clean ("Checked 1 file...
  No fixes applied").
- `bunx tsc --noEmit` in packages/ui: zero diagnostics mentioning the touched
  test file.

Note: this comes from a fork, so hosted CI does not run on this pull request;
the counts above were produced locally against the pushed head.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:03e491eec0f5656d72dff9af23f1a0ae5a6dcc93 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
