### PR TITLE
test(ui): cover useOsIntentRouting

### DIFF
--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/useOsIntentRouting.test.tsx
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/useOsIntentRouting.test.tsx
@@ -84,4 +84,115 @@ describe("useOsIntentRouting", () => {
     expect(dispatch).not.toHaveBeenCalled();
     expect(window.location.hash).toContain("source=attacker");
   });
+
+  it("consumes a later hashchange and routes non-send intents as execute", async () => {
+    const dispatch = vi.fn(async () => {});
+    renderHook(() => useOsIntentRouting(syncWith(dispatch)));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(dispatch).not.toHaveBeenCalled();
+
+    window.history.replaceState(
+      null,
+      "",
+      "/#voice?source=siri&voice=1&assistant.launchId=launch-voice",
+    );
+    window.dispatchEvent(new Event("hashchange"));
+    await waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: "routeOsIntent",
+      intent: {
+        type: "start-voice",
+        intentId: "launch-voice",
+        source: "siri",
+        mode: "converse",
+      },
+      deliveryPolicy: "execute",
+    });
+    await waitFor(() => expect(window.location.hash).toBe("#voice"));
+  });
+
+  it("skips an intent whose dispatch is already in flight", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/#voice?source=siri&voice=1&assistant.launchId=launch-inflight",
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const dispatch = vi.fn(() => gate);
+    renderHook(() => useOsIntentRouting(syncWith(dispatch)));
+
+    await waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+    window.dispatchEvent(new Event("hashchange"));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    release();
+    await waitFor(() => expect(window.location.hash).toBe("#voice"));
+  });
+
+  it("re-fires an intent after its first dispatch failed", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/#chat?source=siri&action=ask&text=retry&assistant.launchId=launch-retry",
+    );
+    let attempts = 0;
+    const sync = syncWith(
+      vi.fn(async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("transient dispatch failure");
+      }),
+    );
+    renderHook(() => useOsIntentRouting(sync));
+
+    await waitFor(() =>
+      expect(sync.reportError).toHaveBeenCalledWith(
+        "OS intent dispatch failed",
+        expect.any(Error),
+      ),
+    );
+    window.dispatchEvent(new Event("hashchange"));
+    await waitFor(() => expect(attempts).toBe(2));
+    await waitFor(() => expect(window.location.hash).toBe("#chat"));
+  });
+
+  it("leaves the launch payload when unmounted before dispatch settles", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/#chat?source=siri&action=ask&text=late&assistant.launchId=launch-late",
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { unmount } = renderHook(() =>
+      useOsIntentRouting(syncWith(vi.fn(() => gate))),
+    );
+    unmount();
+
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.location.hash).toContain("assistant.launchId=launch-late");
+    expect(window.location.hash).not.toBe("#");
+  });
+
+  it("stops consuming hash changes after unmount", async () => {
+    const dispatch = vi.fn(async () => {});
+    const { unmount } = renderHook(() =>
+      useOsIntentRouting(syncWith(dispatch)),
+    );
+    unmount();
+
+    window.history.replaceState(
+      null,
+      "",
+      "/#voice?source=siri&voice=1&assistant.launchId=launch-after-unmount",
+    );
+    window.dispatchEvent(new Event("hashchange"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION

## Summary

Additive unit-test coverage for `packages/ui/src/components/shell/shell-controller-sync/useOsIntentRouting.ts`, the app-shell hook that decodes OS-intent hashes, routes them through the shell controller owner, and clears the launch payload only after the owner has handled the outcome.

`develop` already carried a three-case suite for this hook; this pull request **only adds cases** (`+111/-0`, single file). No existing line is removed or rewritten, and there is no production change of any kind.

## What is newly covered

Five behaviors of the real module that no existing case exercised:

1. **Later `hashchange` consumption + execute policy** — a mount on a clean path routes nothing; changing the hash to `#voice?source=siri&voice=1&assistant.launchId=…` and firing `hashchange` dispatches `{ kind: "routeOsIntent", intent: start-voice, … }` with `deliveryPolicy: "execute"` (the non-send ternary branch), then strips the launch params from the hash.
2. **In-flight dedupe** — while the first dispatch promise is still pending, a second identical `hashchange` does NOT re-dispatch (the `processingRef` guard); after the promise settles, the launch payload is cleared.
3. **Retry after failure** — when the first dispatch rejects (`reportError("OS intent dispatch failed", …)`), the intent id is removed from the in-flight set by `.finally`, so a later identical hash event dispatches again and succeeds.
4. **Unmount-before-settle guard** — if the hook unmounts while dispatch is pending, resolution does NOT clear the launch payload (the `active` flag branch); the retryable hash survives.
5. **Listener teardown** — after unmount, `hashchange` events no longer trigger consumption.

All expectations assert observed behavior of the real decoder/host modules (`decodeOsIntentFromHash`, `clearAssistantLaunchPayloadFromHash`) driven through `@testing-library/react`; fakes exist only at the `ShellControllerSync` boundary, matching the existing suite's established helper.

## Evidence

Environment: fork contributor — hosted CI does not run on this pull request; all counts below are quoted from local runs on the pushed head `72278c4046` (base `e3e63588fd` = current `origin/develop` at run time).

1. `bunx vitest run src/components/shell/shell-controller-sync/__tests__/useOsIntentRouting.test.tsx` → **Test Files 1 passed (1), Tests 8 passed (8)** (3 pre-existing cases still green, 5 new).
2. `bunx biome check --write <file>` → *Checked 1 file. No fixes applied.* (non-sparse checkout; `biome.json` present at repo root).
3. `bunx tsc --noEmit` in `packages/ui` → grep for `useOsIntentRouting.test` matches nothing: zero type errors introduced by this diff.
4. The diff touches exactly one file — the test file above — `+111/-0`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:72278c4046b9dd3c593920c026fa144b57f9f434 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
