### PR TITLE
fix(plugin-openai): fail over keyless OpenAI to the pooled openai-codex RESPONSE_HANDLER

### DIFF
--- a/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { ElizaError } from "../../errors";
 import { AgentRuntime } from "../../runtime";
 import { type Character, ModelType } from "../../types";
 
@@ -197,5 +198,189 @@ describe("AgentRuntime.useModel provider fallback", () => {
 		expect(runtime.getLastResolvedModelProvider(ModelType.TEXT_LARGE)).toBe(
 			"eliza-cloud",
 		);
+	});
+});
+
+/**
+ * Regression for the production incident: Anthropic's RESPONSE_HANDLER
+ * exhausted its overload retries, the runtime failed over to the next
+ * registered RESPONSE_HANDLER provider, and that provider was a keyless
+ * plugin-openai (no OPENAI_API_KEY, not proxy mode). Its client construction
+ * threw "OPENAI_API_KEY is required" as a BARE Error, which is not a
+ * fallback-class error — so the failover chain rethrew and the whole turn died,
+ * even though a healthy pooled ChatGPT/Codex handler (plugin-codex-cli leasing
+ * an `openai-codex` subscription seat via the local codex-proxy Responses path)
+ * was ALSO registered.
+ *
+ * The fix types that missing-credential throw as
+ * `OPENAI_CREDENTIAL_UNAVAILABLE` so `isModelProviderFallbackError` classifies
+ * it as fallback-class and `useModel` advances to the pooled openai-codex
+ * handler. These tests are bidirectional: the typed error rotates to the pool
+ * (post-fix), while a bare "OPENAI_API_KEY is required" Error still strands the
+ * brain (reproduces the pre-fix failure), proving the classification — not the
+ * message text — is what unblocks the pooled fallback.
+ */
+describe("AgentRuntime.useModel RESPONSE_HANDLER openai->openai-codex pool fallback (incident #27268)", () => {
+	function anthropicOverload(): Error {
+		return statusError(
+			529,
+			"API Error: 529 Overloaded. This is a server-side issue.",
+		);
+	}
+
+	it("Anthropic overload -> keyless plugin-openai (typed) -> pooled openai-codex RESPONSE_HANDLER serves", async () => {
+		const runtime = makeRuntime();
+
+		// 1. Anthropic subscription RESPONSE_HANDLER, highest priority, overloaded.
+		const anthropicFails = vi.fn(async () => {
+			throw anthropicOverload();
+		});
+		// 2. plugin-openai RESPONSE_HANDLER with NO credential: it surfaces the
+		//    typed OPENAI_CREDENTIAL_UNAVAILABLE that createOpenAIClient throws.
+		const openaiKeyless = vi.fn(async () => {
+			throw new ElizaError(
+				"OPENAI_API_KEY is required. Set it in your environment variables or runtime settings.",
+				{ code: "OPENAI_CREDENTIAL_UNAVAILABLE", severity: "ephemeral" },
+			);
+		});
+		// 3. plugin-codex-cli RESPONSE_HANDLER: leases an openai-codex seat via the
+		//    local codex-proxy Responses path. This is the pooled fallback target.
+		const codexPooledOk = vi.fn(async () => "codex-pooled-response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			anthropicFails,
+			"anthropic",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			openaiKeyless,
+			"openai",
+			50,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			codexPooledOk,
+			"codex-cli",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).resolves.toBe("codex-pooled-response");
+		// All three were consulted in priority order; the pooled handler served.
+		expect(anthropicFails).toHaveBeenCalledTimes(1);
+		expect(openaiKeyless).toHaveBeenCalledTimes(1);
+		expect(codexPooledOk).toHaveBeenCalledTimes(1);
+		expect(
+			runtime.getLastResolvedModelProvider(ModelType.RESPONSE_HANDLER),
+		).toBe("codex-cli");
+	});
+
+	it("pre-fix repro: a BARE 'OPENAI_API_KEY is required' Error strands the brain (pool never reached)", async () => {
+		const runtime = makeRuntime();
+		const anthropicFails = vi.fn(async () => {
+			throw anthropicOverload();
+		});
+		// The pre-fix throw: a plain Error, NOT typed. No rate-limit / 5xx /
+		// timeout signal, so it is not fallback-class — the chain must rethrow.
+		const openaiKeylessBare = vi.fn(async () => {
+			throw new Error(
+				"OPENAI_API_KEY is required. Set it in your environment variables or runtime settings.",
+			);
+		});
+		const codexPooledOk = vi.fn(async () => "codex-pooled-response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			anthropicFails,
+			"anthropic",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			openaiKeylessBare,
+			"openai",
+			50,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			codexPooledOk,
+			"codex-cli",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).rejects.toThrow("OPENAI_API_KEY is required");
+		expect(anthropicFails).toHaveBeenCalledTimes(1);
+		expect(openaiKeylessBare).toHaveBeenCalledTimes(1);
+		// The pooled openai-codex handler is stranded behind the untyped throw.
+		expect(codexPooledOk).not.toHaveBeenCalled();
+	});
+
+	it("fails closed: keyless plugin-openai is the LAST handler -> typed error still surfaces (no pool, no silent success)", async () => {
+		const runtime = makeRuntime();
+		const anthropicFails = vi.fn(async () => {
+			throw anthropicOverload();
+		});
+		const openaiKeyless = vi.fn(async () => {
+			throw new ElizaError(
+				"OPENAI_API_KEY is required. Set it in your environment variables or runtime settings.",
+				{ code: "OPENAI_CREDENTIAL_UNAVAILABLE", severity: "ephemeral" },
+			);
+		});
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			anthropicFails,
+			"anthropic",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			openaiKeyless,
+			"openai",
+			50,
+		);
+
+		// No pooled handler registered: the classification never fabricates a
+		// success, it just permits advancing. With nothing after it, the terminal
+		// missing-credential error surfaces (fail-closed).
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).rejects.toThrow("OPENAI_API_KEY is required");
+		expect(anthropicFails).toHaveBeenCalledTimes(1);
+		expect(openaiKeyless).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT over-trigger: a real keyed OpenAI request error still classifies on its own signal", async () => {
+		const runtime = makeRuntime();
+		// A genuine OpenAI 400 (keyed, request-level) is NOT the missing-credential
+		// path and must NOT be treated as fallback-class by the new code branch.
+		const openaiBadRequest = vi.fn(async () => {
+			throw statusError(400, "bad request: invalid tool schema");
+		});
+		const codexPooledOk = vi.fn(async () => "unused");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			openaiBadRequest,
+			"openai",
+			50,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			codexPooledOk,
+			"codex-cli",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).rejects.toThrow("bad request");
+		expect(openaiBadRequest).toHaveBeenCalledTimes(1);
+		expect(codexPooledOk).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/services/message/fallback-reply.test.ts
+++ b/packages/core/src/services/message/fallback-reply.test.ts
@@ -292,6 +292,31 @@ describe("fallback-reply", () => {
 			).toBe(false);
 		});
 
+		it("fails over on the typed openai missing-credential error (incident #27268)", () => {
+			// A keyless plugin-openai surfaces OPENAI_CREDENTIAL_UNAVAILABLE so an
+			// Anthropic->OpenAI failover can advance to a pooled openai-codex
+			// RESPONSE_HANDLER instead of stranding the brain on the bare
+			// "OPENAI_API_KEY is required" throw.
+			expect(
+				isModelProviderFallbackError({
+					code: "OPENAI_CREDENTIAL_UNAVAILABLE",
+					message: "OPENAI_API_KEY is required.",
+				}),
+			).toBe(true);
+			// Text-only condition: TTS still fails closed (voice never rotates).
+			expect(
+				isModelProviderFallbackError(
+					{ code: "OPENAI_CREDENTIAL_UNAVAILABLE" },
+					ModelType.TEXT_TO_SPEECH,
+				),
+			).toBe(false);
+			// Pre-fix shape: the SAME message as a bare untyped Error is NOT
+			// fallback-class — proving the typed code, not the text, unblocks failover.
+			expect(
+				isModelProviderFallbackError(new Error("OPENAI_API_KEY is required.")),
+			).toBe(false);
+		});
+
 		it("fails over on structural 529 and inherited rate limits", () => {
 			expect(isModelProviderFallbackError({ statusCode: 529 })).toBe(true);
 			expect(isModelProviderFallbackError({ statusCode: 429 })).toBe(true);

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -276,6 +276,20 @@ export function isModelProviderFallbackError(
 	if (asErrorObject(unwrapped)?.code === "LOCAL_INFERENCE_UNAVAILABLE") {
 		return true;
 	}
+	// An OpenAI-compatible provider registered without a usable credential
+	// (no OPENAI_API_KEY, not in proxy mode) cannot serve the call, but a
+	// DIFFERENT registered text provider can — e.g. a pooled ChatGPT/Codex
+	// RESPONSE_HANDLER (plugin-codex-cli) leasing an `openai-codex`
+	// subscription seat via the local codex-proxy. Without this, an
+	// Anthropic->OpenAI failover that lands on a keyless plugin-openai throws
+	// a bare "OPENAI_API_KEY is required" (not otherwise fallback-class) and
+	// strands the brain instead of advancing to the pooled handler. Typed so
+	// only the deliberate missing-credential path fails over; a real OpenAI
+	// request failure still classifies on its own status/message. Fail-closed:
+	// with no next handler, the terminal error still surfaces.
+	if (asErrorObject(unwrapped)?.code === "OPENAI_CREDENTIAL_UNAVAILABLE") {
+		return true;
+	}
 	if (isRateLimitError(error)) {
 		return true;
 	}

--- a/plugins/plugin-openai/__tests__/missing-credential-fallback.test.ts
+++ b/plugins/plugin-openai/__tests__/missing-credential-fallback.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression for incident #27268. `createOpenAIClient` builds the OpenAI client
+ * from the resolved key; when no key resolves (no OPENAI_API_KEY / compatible
+ * alias and not proxy mode) the provider cannot serve the call.
+ *
+ * The throw is TYPED (`ElizaError` with code `OPENAI_CREDENTIAL_UNAVAILABLE`)
+ * so the runtime's `useModel` failover loop classifies it as fallback-class and
+ * advances to the next registered RESPONSE_HANDLER — e.g. a pooled
+ * ChatGPT/Codex handler (plugin-codex-cli) leasing an `openai-codex`
+ * subscription seat through the local codex-proxy — instead of stranding the
+ * brain on the pre-fix bare "OPENAI_API_KEY is required" Error.
+ *
+ * These are node/shape tests: no network, no live model calls.
+ */
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenAIClient, OPENAI_CREDENTIAL_UNAVAILABLE } from "../providers/openai";
+
+function buildRuntime(settings: Record<string, string | undefined>): IAgentRuntime {
+  return {
+    getSetting: vi.fn((key: string) => (key in settings ? (settings[key] ?? null) : null)),
+  } as unknown as IAgentRuntime;
+}
+
+const ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "CEREBRAS_API_KEY",
+  "EVOLINK_API_KEY",
+  "OPENAI_BASE_URL",
+  "ELIZA_PROVIDER",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const prev = originalEnv.get(key);
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("createOpenAIClient missing-credential classification (incident #27268)", () => {
+  it("throws a typed, fallback-classifiable ElizaError when no key resolves (fail-closed)", () => {
+    const runtime = buildRuntime({});
+    let thrown: unknown;
+    try {
+      createOpenAIClient(runtime);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    const err = thrown as ElizaError;
+    // The typed code is what unblocks failover to a pooled openai-codex handler.
+    expect(err.code).toBe(OPENAI_CREDENTIAL_UNAVAILABLE);
+    expect(OPENAI_CREDENTIAL_UNAVAILABLE).toBe("OPENAI_CREDENTIAL_UNAVAILABLE");
+    // Operator-facing hint preserved verbatim.
+    expect(err.message).toContain("OPENAI_API_KEY is required");
+    // Not a hard/fatal secret leak: ephemeral, no key material in the message.
+    expect(err.severity).toBe("ephemeral");
+    expect(err.message).not.toMatch(/sk-/);
+  });
+
+  it("short-circuits on an explicit OPENAI_API_KEY (no throw, env-first unchanged)", () => {
+    const runtime = buildRuntime({ OPENAI_API_KEY: "sk-test-key" });
+    // A concrete client is returned; construction does not throw.
+    const client = createOpenAIClient(runtime);
+    expect(typeof client).toBe("function");
+  });
+});

--- a/plugins/plugin-openai/providers/index.ts
+++ b/plugins/plugin-openai/providers/index.ts
@@ -1,2 +1,2 @@
 /** Barrel re-exporting the OpenAI client factory. */
-export { createOpenAIClient } from "./openai";
+export { createOpenAIClient, OPENAI_CREDENTIAL_UNAVAILABLE } from "./openai";

--- a/plugins/plugin-openai/providers/openai.ts
+++ b/plugins/plugin-openai/providers/openai.ts
@@ -1,13 +1,40 @@
 /**
  * `createOpenAIClient`: builds the `@ai-sdk/openai` provider bound to the
  * runtime's resolved base URL and key. In proxy mode with no key it uses a
- * placeholder key (auth is injected upstream); otherwise a missing key throws.
+ * placeholder key (auth is injected upstream); otherwise a missing key means
+ * this provider cannot serve the call.
+ *
+ * A missing credential is surfaced as a typed, *fallback-classifiable* error
+ * (`OPENAI_CREDENTIAL_UNAVAILABLE`) rather than a bare `Error`. This mirrors
+ * plugin-local-inference's `LOCAL_INFERENCE_UNAVAILABLE`: when a text provider
+ * is registered but cannot serve a request, the runtime's `useModel` failover
+ * loop must advance to the *next* registered handler (e.g. a pooled
+ * ChatGPT/Codex `RESPONSE_HANDLER` from plugin-codex-cli that leases an
+ * `openai-codex` subscription seat through the local codex-proxy) instead of
+ * stranding the brain.
+ *
+ * Before this change, an Anthropic `RESPONSE_HANDLER` overload failed over to
+ * plugin-openai, whose bare "OPENAI_API_KEY is required" throw is NOT a
+ * fallback-class error (no rate-limit / 5xx / timeout signal), so the failover
+ * chain rethrew and the whole turn died — even when a healthy pooled
+ * openai-codex handler was registered later in the chain. Typing the error
+ * lets that handler take over. It is still fail-closed: when no next handler
+ * exists, the same terminal failure surfaces (no silent placeholder, no static
+ * key invented).
  */
 import { createOpenAI, type OpenAIProvider } from "@ai-sdk/openai";
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { getApiKey, getBaseURL, isProxyMode } from "../utils/config";
 
 const PROXY_API_KEY = "sk-proxy";
+
+/**
+ * Typed error code for "this OpenAI-compatible provider has no usable
+ * credential for this runtime." Recognized by
+ * `isModelProviderFallbackError` in `@elizaos/core` so `useModel` fails over
+ * to the next registered text handler rather than stranding the brain.
+ */
+export const OPENAI_CREDENTIAL_UNAVAILABLE = "OPENAI_CREDENTIAL_UNAVAILABLE";
 
 export function createOpenAIClient(runtime: IAgentRuntime): OpenAIProvider {
   const baseURL = getBaseURL(runtime);
@@ -21,8 +48,15 @@ export function createOpenAIClient(runtime: IAgentRuntime): OpenAIProvider {
   }
 
   if (!apiKey) {
-    throw new Error(
-      "OPENAI_API_KEY is required. Set it in your environment variables or runtime settings."
+    // Fallback-classifiable: another registered text provider (e.g. a pooled
+    // openai-codex RESPONSE_HANDLER via plugin-codex-cli) may safely answer.
+    // The message preserves the operator-facing hint verbatim.
+    throw new ElizaError(
+      "OPENAI_API_KEY is required. Set it in your environment variables or runtime settings.",
+      {
+        code: OPENAI_CREDENTIAL_UNAVAILABLE,
+        severity: "ephemeral",
+      }
     );
   }
 


### PR DESCRIPTION
## Problem

Production incident on a hot runtime: Anthropic's `RESPONSE_HANDLER` exhausted its overload retries, the runtime failed over to the next registered `RESPONSE_HANDLER` provider, and that provider was a **keyless** `plugin-openai` (no `OPENAI_API_KEY`, not proxy mode). `createOpenAIClient` threw a **bare** `Error`:

```
OPENAI_API_KEY is required. Set it in your environment variables or runtime settings.
```

A bare `Error` carries no rate-limit / 5xx / timeout signal, so `isModelProviderFallbackError` classified it as **not** fallback-class. The `useModel` failover chain therefore **rethrew and stranded the brain** — even though a healthy pooled ChatGPT/Codex `RESPONSE_HANDLER` (`plugin-codex-cli`, which leases an `openai-codex` subscription seat through the local codex-proxy Responses path) was **also** registered later in the chain.

The live account pool holds `openai-codex` accounts and **no** `openai-api` direct-key accounts. The correct seam is the **existing** `openai-codex` RESPONSE_HANDLER path (plugin-codex-cli → codex-proxy → broker), not a new direct-API-key account system.

> Note: this supersedes the first revision of this PR, which added a parallel `openai-api` direct-key account-pool bridge. That approach targeted accounts that do not exist in the pool (it would have failed closed and never served the fallback), duplicated what codex-proxy/plugin-codex-cli already do, and did not fix the real strand. It has been dropped.

## Fix

Root-cause, smallest correct change; reuses the existing failover seam:

- **`@elizaos/plugin-openai`** — when no credential resolves (and not proxy mode), `createOpenAIClient` throws a **typed** `ElizaError` with code `OPENAI_CREDENTIAL_UNAVAILABLE` instead of a bare `Error`. The operator-facing "OPENAI_API_KEY is required" message is preserved verbatim; severity is `ephemeral`; no key material is emitted. The factory stays **synchronous** (no call-site churn).
- **`@elizaos/core`** — `isModelProviderFallbackError` treats `OPENAI_CREDENTIAL_UNAVAILABLE` as fallback-class, mirroring the existing `LOCAL_INFERENCE_UNAVAILABLE` precedent: a text provider that cannot serve the request lets another registered text provider answer. The `TEXT_TO_SPEECH` gate still fails closed (voice never rotates).

Now an Anthropic → keyless-OpenAI failover **falls through** to the pooled `openai-codex` `RESPONSE_HANDLER`.

## Behavior / invariants

- **Provider ordering preserved** — the pooled `openai-codex` handler is reached only *after* the keyless plugin-openai attempt, in registration/priority order.
- **Fail-closed** — with no next handler registered, the same terminal missing-credential error still surfaces (no silent placeholder, no static key invented).
- **No over-trigger** — a real keyed OpenAI request failure (e.g. HTTP 400) classifies on its own status/message, unchanged.
- No new persistence, no cloud calls, **no secrets, no direct static OpenAI key**. Does not touch Telegram, workflows, or CI checks.

## Tests (bidirectional — reproduce the actual incident)

- `packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts` — Anthropic 529 overload → keyless plugin-openai (typed) → **pooled openai-codex `RESPONSE_HANDLER` serves**; a **bare** "OPENAI_API_KEY is required" `Error` **strands the brain** (pool never reached — the pre-fix failure); keyless-openai-as-last-handler still throws (fail-closed); a keyed 400 does not fall over.
- `packages/core/src/services/message/fallback-reply.test.ts` — `OPENAI_CREDENTIAL_UNAVAILABLE` is fallback-class; the same message as a bare untyped `Error` is **not** (the code, not the text, unblocks failover); TTS gate holds.
- `plugins/plugin-openai/__tests__/missing-credential-fallback.test.ts` — keyless `createOpenAIClient` throws the typed ephemeral code with no key material; an explicit `OPENAI_API_KEY` short-circuits (env-first, unchanged).

Verified the pool-fallback test **fails** against the pre-fix core classifier (brain stranded, exactly as the incident) and **passes** with this change.

## Activating the pooled fallback (config, non-secret)

The upstream fix makes the failover *possible*; the pooled handler must also be *registered*. On the affected runtime, enable `plugin-codex-cli` (the `openai-codex` RESPONSE_HANDLER) and point it at the local codex-proxy so it leases from the broker — no static OpenAI key, no prod restart implied by this PR.
