### PR TITLE
test(ui): cover electrobun-transport

### DIFF
--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts
@@ -1,0 +1,273 @@
+/** Companion coverage for the electrobun shell-authority transport: the
+ * bootstrap fallback plus the request-plumbing and malformed-push branches the
+ * primary suite does not exercise. Deterministic unit harness — the real
+ * transport module runs against a stubbed renderer bridge only. */
+import { describe, expect, it, vi } from "vitest";
+import type { ElectrobunRendererRpc } from "../../../../bridge/electrobun-rpc";
+import {
+  buildElectrobunShellAuthorityTransport,
+  createElectrobunShellAuthorityTransport,
+  SHELL_AUTHORITY_COMMAND_MESSAGE,
+  SHELL_AUTHORITY_DELIVERY_MESSAGE,
+  SHELL_AUTHORITY_STATE_MESSAGE,
+} from "../electrobun-transport";
+import { baseSnapshot } from "./fixtures";
+
+const state = {
+  endpointId: "shell-2",
+  ownerEndpointId: "shell-1",
+  generation: 3,
+  role: "follower" as const,
+  status: "connected" as const,
+  snapshotSeq: 1,
+  snapshot: baseSnapshot(),
+};
+
+function fakeRpc(): {
+  rpc: ElectrobunRendererRpc;
+  requests: Record<string, ReturnType<typeof vi.fn>>;
+  listeners: Map<string, (payload: unknown) => void>;
+} {
+  const requests = {
+    shellControllerConnect: vi.fn(async () => state),
+    shellControllerHeartbeat: vi.fn(async () => state),
+    shellControllerPublishSnapshot: vi.fn(async () => ({ ok: true })),
+    shellControllerDispatchCommand: vi.fn(async () => ({ ok: true })),
+    shellControllerCompleteCommand: vi.fn(async () => ({ ok: true })),
+    shellControllerDeliver: vi.fn(async () => ({ ok: true })),
+  };
+  const listeners = new Map<string, (payload: unknown) => void>();
+  return {
+    requests,
+    listeners,
+    rpc: {
+      request: requests,
+      onMessage: (name, listener) => listeners.set(name, listener),
+      offMessage: (name) => listeners.delete(name),
+    },
+  };
+}
+
+describe("buildElectrobunShellAuthorityTransport request plumbing", () => {
+  it("rejects connect and heartbeat when the desktop RPC handler is missing", async () => {
+    const { rpc } = fakeRpc();
+    rpc.request = {};
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+    await expect(transport.connect("2")).rejects.toThrow(
+      "missing desktop RPC: shellControllerConnect",
+    );
+    await expect(transport.heartbeat("2")).rejects.toThrow(
+      "missing desktop RPC: shellControllerHeartbeat",
+    );
+  });
+
+  it("throws when connect or heartbeat receive an unparsable state", async () => {
+    const { rpc, requests } = fakeRpc();
+    requests.shellControllerConnect.mockResolvedValue({ broken: true });
+    requests.shellControllerHeartbeat.mockResolvedValue(null);
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+    await expect(transport.connect("2")).rejects.toThrow(
+      "shell authority returned invalid state",
+    );
+    await expect(transport.heartbeat("2")).rejects.toThrow(
+      "shell authority returned invalid state",
+    );
+  });
+
+  it("heartbeats with the protocol version and resolves the parsed state", async () => {
+    const { rpc, requests } = fakeRpc();
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+    await expect(transport.heartbeat("7")).resolves.toEqual(state);
+    expect(requests.shellControllerHeartbeat).toHaveBeenCalledWith({
+      protocolVersion: "7",
+    });
+  });
+
+  it("publishes snapshots, reports rejections, and rejects malformed responses", async () => {
+    const { rpc, requests } = fakeRpc();
+    const snapshot = baseSnapshot({ phase: "responding" });
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+
+    await expect(transport.publishSnapshot(4, snapshot)).resolves.toEqual({
+      ok: true,
+    });
+    expect(requests.shellControllerPublishSnapshot).toHaveBeenCalledWith({
+      generation: 4,
+      snapshot,
+    });
+
+    requests.shellControllerPublishSnapshot.mockResolvedValue({ ok: false });
+    await expect(transport.publishSnapshot(5, snapshot)).resolves.toEqual({
+      ok: false,
+    });
+
+    requests.shellControllerPublishSnapshot.mockResolvedValue({ ok: "yes" });
+    await expect(transport.publishSnapshot(6, snapshot)).rejects.toThrow(
+      "shell authority returned an invalid response",
+    );
+  });
+
+  it("surfaces failed dispatch outcomes and defaults their missing error", async () => {
+    const { rpc, requests } = fakeRpc();
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+
+    requests.shellControllerDispatchCommand.mockResolvedValue({
+      ok: false,
+      error: "mic-busy",
+    });
+    await expect(
+      transport.dispatchCommand("command-2", { kind: "startRecording" }),
+    ).resolves.toEqual({ ok: false, error: "mic-busy" });
+
+    requests.shellControllerDispatchCommand.mockResolvedValue({ ok: false });
+    await expect(
+      transport.dispatchCommand("command-3", { kind: "stop" }),
+    ).resolves.toEqual({ ok: false, error: "owner-command-failed" });
+
+    requests.shellControllerDispatchCommand.mockResolvedValue("nope");
+    await expect(
+      transport.dispatchCommand("command-4", { kind: "stop" }),
+    ).rejects.toThrow("shell authority returned an invalid command outcome");
+  });
+
+  it("completes commands by spreading the terminal outcome into the request", async () => {
+    const { rpc, requests } = fakeRpc();
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+    await expect(
+      transport.completeCommand(3, "command-1", "shell-2", {
+        ok: false,
+        error: "denied",
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(requests.shellControllerCompleteCommand).toHaveBeenCalledWith({
+      generation: 3,
+      commandId: "command-1",
+      fromEndpointId: "shell-2",
+      ok: false,
+      error: "denied",
+    });
+  });
+
+  it("delivers payloads to a target endpoint", async () => {
+    const { rpc, requests } = fakeRpc();
+    const transport = buildElectrobunShellAuthorityTransport(rpc, () => {});
+    await expect(
+      transport.deliver(3, "shell-2", {
+        kind: "composer-prefill",
+        text: "hi",
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(requests.shellControllerDeliver).toHaveBeenCalledWith({
+      generation: 3,
+      targetEndpointId: "shell-2",
+      delivery: { kind: "composer-prefill", text: "hi" },
+    });
+  });
+});
+
+describe("buildElectrobunShellAuthorityTransport malformed pushes", () => {
+  it("routes every invalid push shape to onError without invoking handlers", () => {
+    const { rpc, listeners } = fakeRpc();
+    const errors: unknown[] = [];
+    const onState = vi.fn();
+    const onCommand = vi.fn();
+    const onDelivery = vi.fn();
+    const onPing = vi.fn();
+    const transport = buildElectrobunShellAuthorityTransport(rpc, (error) =>
+      errors.push(error),
+    );
+    transport.subscribe({ onState, onCommand, onDelivery, onPing });
+
+    listeners.get(SHELL_AUTHORITY_STATE_MESSAGE)?.({ role: "owner" });
+    listeners.get(SHELL_AUTHORITY_DELIVERY_MESSAGE)?.({
+      generation: Number.NaN,
+      delivery: { kind: "dictation", text: "hello" },
+    });
+    listeners.get(SHELL_AUTHORITY_DELIVERY_MESSAGE)?.({
+      generation: 3,
+      delivery: { kind: "unknown-kind" },
+    });
+
+    expect(errors).toEqual([
+      new Error("shell authority pushed invalid state"),
+      new Error("shell authority pushed invalid delivery envelope"),
+      new Error("shell authority pushed invalid delivery"),
+    ]);
+    expect(onState).not.toHaveBeenCalled();
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(onDelivery).not.toHaveBeenCalled();
+    expect(onPing).not.toHaveBeenCalled();
+  });
+});
+
+describe("createElectrobunShellAuthorityTransport", () => {
+  type BridgeWindow = {
+    __ELIZA_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  };
+
+  function bridgeGlobal(): { window?: BridgeWindow } {
+    return globalThis as unknown as { window?: BridgeWindow };
+  }
+
+  function setBridgeWindow(value: BridgeWindow | undefined): void {
+    bridgeGlobal().window = value;
+  }
+
+  function currentBridgeWindow(): BridgeWindow | undefined {
+    return bridgeGlobal().window;
+  }
+
+  it("returns null when no renderer bridge is installed", () => {
+    const previous = currentBridgeWindow();
+    try {
+      setBridgeWindow(undefined);
+      expect(createElectrobunShellAuthorityTransport(() => {})).toBeNull();
+    } finally {
+      setBridgeWindow(previous);
+    }
+  });
+
+  it("returns null when the bridge lacks shell-authority endpoints", () => {
+    const { rpc } = fakeRpc();
+    rpc.request = {};
+    const previous = currentBridgeWindow();
+    try {
+      setBridgeWindow({ __ELIZA_ELECTROBUN_RPC__: rpc });
+      expect(createElectrobunShellAuthorityTransport(() => {})).toBeNull();
+    } finally {
+      setBridgeWindow(previous);
+    }
+  });
+
+  it("builds a working transport when the bridge exposes the authority", () => {
+    const { rpc, listeners } = fakeRpc();
+    const previous = currentBridgeWindow();
+    try {
+      setBridgeWindow({ __ELIZA_ELECTROBUN_RPC__: rpc });
+      const errors: unknown[] = [];
+      const transport = createElectrobunShellAuthorityTransport((error) =>
+        errors.push(error),
+      );
+      expect(transport).not.toBeNull();
+      const onState = vi.fn();
+      const onCommand = vi.fn();
+      const unsubscribe = transport?.subscribe({
+        onState,
+        onCommand,
+        onDelivery: vi.fn(),
+        onPing: vi.fn(),
+      });
+      listeners.get(SHELL_AUTHORITY_STATE_MESSAGE)?.(state);
+      listeners.get(SHELL_AUTHORITY_COMMAND_MESSAGE)?.({ forged: true });
+      expect(onState).toHaveBeenCalledWith(state);
+      expect(errors).toEqual([
+        new Error("shell authority pushed invalid command"),
+      ]);
+      expect(onCommand).not.toHaveBeenCalled();
+      unsubscribe?.();
+      expect(listeners).toHaveLength(0);
+    } finally {
+      setBridgeWindow(previous);
+    }
+  });
+});


### PR DESCRIPTION

## Summary

Adds a unit-test suite for `packages/ui/src/components/shell/shell-controller-sync/electrobun-transport.ts` as a **new companion spec**: `__tests__/electrobun-transport-bootstrap.test.ts`. The existing `__tests__/electrobun-transport.test.ts` already on `develop` is left byte-for-byte untouched — this diff is exactly one new file (+273/−0) and changes no production code.

## Previously untested branches now covered

Every case drives the real module; only the documented renderer-bridge seam (`ElectrobunRendererRpc`) is stubbed:

- `createElectrobunShellAuthorityTransport` (zero prior coverage): returns `null` when no bridge is installed; returns `null` when the bridge lacks shell-authority endpoints (older/test bridges); builds a live transport when the authority is exposed — proven by subscribing, pushing an authority-state message through the bridge listener map, and receiving the parsed state, while a forged command push routes to `onError`; unsubscribe clears every listener.
- Missing desktop RPC handlers reject `connect`/`heartbeat` with `missing desktop RPC: …`.
- Unparsable connect/heartbeat responses throw `shell authority returned invalid state`.
- `heartbeat` sends `{ protocolVersion }` and resolves the parsed state.
- `publishSnapshot`: request params (`generation`, `snapshot`); an authority `ok:false` surfaces as a resolved `{ ok: false }` rather than a throw; a malformed response rejects.
- `dispatchCommand`: failed outcome preserves the authority `error`; a failure without `error` defaults to `owner-command-failed`; a malformed outcome rejects.
- `completeCommand`: terminal outcome is spread into the request (`generation`, `commandId`, `fromEndpointId`, `ok`, `error`) and the response passes `parseOk`.
- `deliver`: forwards `generation`, `targetEndpointId`, and the delivery payload to `shellControllerDeliver`.
- Malformed pushes: invalid state push, delivery envelope with non-safe-integer `generation`, unknown delivery kind — each lands in `onError` with its exact error message and never invokes a handler.

## Verification (test-only pull request)

Fork contributor: hosted CI does not run on this pull request. Local verification record:

- `bunx vitest run src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts` from `packages/ui`: **1 test file passed, 11 tests passed, 0 failed** (vitest v4.1.10).
- Re-run together with the pre-existing suite: **2 test files passed, 13 tests passed, 0 failed** — no interference with existing coverage.
- Counts reproduced against current `origin/develop` immediately before filing (`e3e63588fd`, the base of this branch).
- `bunx biome check --write` on the touched file: clean — `Checked 1 file … No fixes applied` (config presence verified: `biome.json` + `tsconfig.json` exist, checkout is not sparse).
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mention the new file (grep for the filename over full package output returned nothing).
- No `vi.hoisted`, no `expectTypeOf`, no mocks asserting their own return values.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

Adds a unit-test companion suite for the electrobun shell-authority transport (`packages/ui/src/components/shell/shell-controller-sync/electrobun-transport.ts`): `__tests__/electrobun-transport-bootstrap.test.ts`. Test-only diff — one new file (+273/−0), zero production code touched, the pre-existing suite left byte-for-byte intact.

## What kind of change is this?

Improvements — test coverage only; no runtime behaviour changes.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Read `packages/ui/src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts` next to the module it covers. The existing `electrobun-transport.test.ts` already on `develop` is untouched; this file only adds the branches it does not exercise.

## Detailed testing steps

From `packages/ui`:

```bash
bunx vitest run src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts
# → Test Files  1 passed (1), Tests  11 passed (11)

bunx vitest run src/components/shell/shell-controller-sync/__tests__/electrobun-transport.test.ts src/components/shell/shell-controller-sync/__tests__/electrobun-transport-bootstrap.test.ts
# → Test Files  2 passed (2), Tests  13 passed (13)
```

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ad641f40485e4fbd9a3f15a6bf7c24c7d8ff3349 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      **N/A** - test-only diff; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      **N/A** - test-only diff; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      **N/A** - no user-facing flow exists to walk through.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      **N/A** - no runtime code path changed; vitest counts quoted above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      **N/A** - no frontend request/state behaviour changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      **N/A** - no agent/provider/prompt/model behaviour touched.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      **N/A** - suite exercises pure transport parsing/dispatch; no domain artifacts produced.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      **N/A** - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - test-only diff; no rendered UI surface.

### After

N/A - test-only diff; no rendered UI surface.

### Walkthrough video

Or write `N/A - <reason>`.

N/A - no user-facing flow changed.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

N/A - no voice/transcript path touched.

## Known gaps / failures

All evidence rows are marked N/A because this is a test-only pull request: it adds one vitest file and changes no production behaviour. Fork contributor — hosted CI does not run on this PR; the verification record is the local command output quoted above (vitest 11 passed / combined 13 passed against base `e3e63588fd` = current `origin/develop`, biome clean, `tsc --noEmit` in `packages/ui` with zero diagnostics mentioning the new file).

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
