### PR TITLE
test(core): cover trajectory-stage-kind

### DIFF
--- a/packages/core/src/runtime/trajectory-stage-kind.test.ts
+++ b/packages/core/src/runtime/trajectory-stage-kind.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Contract tests for the canonical recorded stage-kind vocabulary shared by
+ * trajectory producers and transports. Deterministic — pure module import,
+ * no runtime, no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { RECORDED_STAGE_KINDS } from "./trajectory-stage-kind.ts";
+
+describe("RECORDED_STAGE_KINDS", () => {
+	it("exposes the canonical vocabulary in producer order", () => {
+		expect(RECORDED_STAGE_KINDS).toEqual([
+			"messageHandler",
+			"planner",
+			"tool",
+			"toolSearch",
+			"evaluation",
+			"subPlanner",
+			"compaction",
+			"factsAndRelationships",
+		]);
+	});
+
+	it("is a plain array of exactly eight entries", () => {
+		expect(Array.isArray(RECORDED_STAGE_KINDS)).toBe(true);
+		expect(RECORDED_STAGE_KINDS).toHaveLength(8);
+	});
+
+	it("holds unique kinds so set-backed membership stays unambiguous", () => {
+		expect(new Set(RECORDED_STAGE_KINDS).size).toBe(
+			RECORDED_STAGE_KINDS.length,
+		);
+	});
+
+	it("holds only non-empty, unpadded string kinds", () => {
+		for (const kind of RECORDED_STAGE_KINDS) {
+			expect(typeof kind).toBe("string");
+			expect(kind.length).toBeGreaterThan(0);
+			expect(kind).toBe(kind.trim());
+		}
+	});
+
+	it("admits every declared kind under exact-match membership", () => {
+		const members = new Set<string>(RECORDED_STAGE_KINDS);
+		for (const kind of RECORDED_STAGE_KINDS) {
+			expect(members.has(kind)).toBe(true);
+		}
+	});
+
+	it("rejects unknown, mutated, and empty kinds under exact-match membership", () => {
+		const members = new Set<string>(RECORDED_STAGE_KINDS);
+		for (const kind of RECORDED_STAGE_KINDS) {
+			expect(members.has(`${kind}!`)).toBe(false);
+			expect(members.has(kind.toUpperCase())).toBe(false);
+		}
+		expect(members.has("unknown")).toBe(false);
+		expect(members.has("")).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/trajectory-stage-kind.test.ts
+++ b/packages/core/src/runtime/trajectory-stage-kind.test.ts
@@ -1,58 +1,129 @@
 /**
- * Contract tests for the canonical recorded stage-kind vocabulary shared by
- * trajectory producers and transports. Deterministic — pure module import,
- * no runtime, no mocks.
+ * Verifies the canonical recorded stage-kind vocabulary through its real
+ * consumers: the runtime recorder re-export must stay the single shared array
+ * instance, every declared kind must convert through the semantic-stage
+ * adapter and pass the persisted-envelope validator, and values outside the
+ * vocabulary must be rejected with the typed kind error instead of being
+ * normalized. Deterministic — plain fixtures, no mocks, no live runtime.
  */
+
 import { describe, expect, it } from "vitest";
-import { RECORDED_STAGE_KINDS } from "./trajectory-stage-kind.ts";
+import { ElizaError } from "../errors";
+import {
+	parseTrajectorySemanticStage,
+	parseTrajectorySemanticStages,
+	recordedStageToSemanticStage,
+} from "../services/trajectory-semantic-stage";
+import type { RecordedStage } from "./trajectory-recorder";
+import { RECORDED_STAGE_KINDS as RECORDED_STAGE_KINDS_VIA_RECORDER } from "./trajectory-recorder";
+import {
+	RECORDED_STAGE_KINDS,
+	type RecordedStageKind,
+} from "./trajectory-stage-kind";
 
-describe("RECORDED_STAGE_KINDS", () => {
-	it("exposes the canonical vocabulary in producer order", () => {
-		expect(RECORDED_STAGE_KINDS).toEqual([
-			"messageHandler",
-			"planner",
-			"tool",
-			"toolSearch",
-			"evaluation",
-			"subPlanner",
-			"compaction",
-			"factsAndRelationships",
+const envelopeForKind = (kind: RecordedStageKind) => ({
+	schemaVersion: 1,
+	stageId: `stage-${kind}`,
+	kind,
+	startedAt: 1_000,
+	endedAt: 1_012,
+	latencyMs: 12,
+	payload: {},
+});
+
+const recordedStageOfKind = (kind: RecordedStageKind): RecordedStage => ({
+	stageId: `stage-${kind}`,
+	kind,
+	iteration: 2,
+	startedAt: 1_000,
+	endedAt: 1_012,
+	latencyMs: 12,
+});
+
+const parseWithKind = (kindValue: unknown): ElizaError => {
+	try {
+		parseTrajectorySemanticStage({
+			...envelopeForKind("planner"),
+			kind: kindValue,
+		});
+	} catch (error) {
+		if (error instanceof ElizaError) return error;
+		throw error;
+	}
+	throw new Error(`expected kind ${JSON.stringify(kindValue)} to be rejected`);
+};
+
+describe("RECORDED_STAGE_KINDS vocabulary", () => {
+	it("is exported by the runtime recorder as the same single array instance", () => {
+		expect(RECORDED_STAGE_KINDS_VIA_RECORDER).toBe(RECORDED_STAGE_KINDS);
+	});
+
+	it("admits every declared kind through the persisted-envelope validator", () => {
+		for (const kind of RECORDED_STAGE_KINDS) {
+			const parsed = parseTrajectorySemanticStage(envelopeForKind(kind));
+			expect(parsed.kind).toBe(kind);
+			expect(parsed.schemaVersion).toBe(1);
+			expect(parsed.payload).toEqual({});
+		}
+	});
+
+	it("converts a recorded producer stage for every declared kind", () => {
+		for (const kind of RECORDED_STAGE_KINDS) {
+			const semantic = recordedStageToSemanticStage(recordedStageOfKind(kind));
+			expect(semantic.kind).toBe(kind);
+			expect(semantic.iteration).toBe(2);
+			expect(semantic.payload).toEqual({});
+			expect(
+				parseTrajectorySemanticStage(JSON.parse(JSON.stringify(semantic))),
+			).toEqual(semantic);
+		}
+	});
+
+	it("accepts the complete vocabulary as one ordered batch", () => {
+		const stages = RECORDED_STAGE_KINDS.map((kind, index) => ({
+			...envelopeForKind(kind),
+			stageId: `stage-${index}-${kind}`,
+		}));
+		const parsed = parseTrajectorySemanticStages(stages);
+		expect(parsed?.map((stage) => stage.kind)).toEqual([
+			...RECORDED_STAGE_KINDS,
 		]);
+		const stageIds = parsed?.map((stage) => stage.stageId) ?? [];
+		expect(new Set(stageIds).size).toBe(RECORDED_STAGE_KINDS.length);
 	});
 
-	it("is a plain array of exactly eight entries", () => {
-		expect(Array.isArray(RECORDED_STAGE_KINDS)).toBe(true);
-		expect(RECORDED_STAGE_KINDS).toHaveLength(8);
+	it.each([
+		["empty string", ""],
+		["case-flipped member", "MessageHandler"],
+		["uppercased member", "PLANNER"],
+		["leading whitespace", " planner"],
+		["trailing whitespace", "planner "],
+		["punctuated member", "tool!"],
+		["former or imagined kind", "retrieval"],
+		["newline-suffixed member", "messageHandler\n"],
+	])("rejects %s without normalizing it into a member", (_label, kindValue) => {
+		const error = parseWithKind(kindValue);
+		expect(error.code).toBe("TRAJECTORY_SEMANTIC_STAGE_INVALID");
+		expect(error.name).toBe("ElizaError");
+		expect(error.context?.field).toBe("kind");
+		expect(error.context?.value).toBe(kindValue);
 	});
 
-	it("holds unique kinds so set-backed membership stays unambiguous", () => {
-		expect(new Set(RECORDED_STAGE_KINDS).size).toBe(
-			RECORDED_STAGE_KINDS.length,
-		);
-	});
-
-	it("holds only non-empty, unpadded string kinds", () => {
-		for (const kind of RECORDED_STAGE_KINDS) {
-			expect(typeof kind).toBe("string");
-			expect(kind.length).toBeGreaterThan(0);
-			expect(kind).toBe(kind.trim());
+	it.each([
+		["a number", 42],
+		["null", null],
+		["undefined", undefined],
+		["boolean", true],
+		["array of members", ["messageHandler"]],
+		["plain object", { kind: "planner" }],
+	])("rejects a non-string kind (%s)", (_label, kindValue) => {
+		const error = parseWithKind(kindValue);
+		expect(error.code).toBe("TRAJECTORY_SEMANTIC_STAGE_INVALID");
+		expect(error.context?.field).toBe("kind");
+		if (typeof kindValue === "number") {
+			expect(error.context?.value).toBe(kindValue);
+		} else {
+			expect(error.context?.value).toBeUndefined();
 		}
-	});
-
-	it("admits every declared kind under exact-match membership", () => {
-		const members = new Set<string>(RECORDED_STAGE_KINDS);
-		for (const kind of RECORDED_STAGE_KINDS) {
-			expect(members.has(kind)).toBe(true);
-		}
-	});
-
-	it("rejects unknown, mutated, and empty kinds under exact-match membership", () => {
-		const members = new Set<string>(RECORDED_STAGE_KINDS);
-		for (const kind of RECORDED_STAGE_KINDS) {
-			expect(members.has(`${kind}!`)).toBe(false);
-			expect(members.has(kind.toUpperCase())).toBe(false);
-		}
-		expect(members.has("unknown")).toBe(false);
-		expect(members.has("")).toBe(false);
 	});
 });


### PR DESCRIPTION

## What

Adds a new deterministic vitest suite for the canonical recorded stage-kind vocabulary in `packages/core/src/runtime/trajectory-stage-kind.ts`, which had no test coverage. This is a **test-only change**: no production source file is modified, and the diff against the merge base is a single new file (`+129/-0`).

## Why this design

A previous attempt at covering this module (closed #27024) asserted the array's contents back to itself, which reviewers correctly identified as non-behavioral. This suite takes the maintainer guidance from that closure — "test that behavior at the owning boundary" — and instead drives the two real consumers of the vocabulary, so the assertions exercise observable runtime contracts rather than restating literals:

- **Single-vocabulary wiring** — `trajectory-recorder.ts` re-exports the same array instance (`toBe`), so producers and transports cannot drift into a second stage vocabulary.
- **Transport acceptance** — every declared kind passes the real persisted-envelope validator `parseTrajectorySemanticStage`, preserving kind, schema version, and payload.
- **Producer conversion** — every declared kind round-trips through the real adapter `recordedStageToSemanticStage` (including a JSON transport hop).
- **Batch ordering** — the complete vocabulary parses as one ordered, uniquely-id'd batch via `parseTrajectorySemanticStages`.
- **Typed rejection exactness** — values outside the vocabulary (empty/case-flipped/padded/punctuated strings, non-strings) are rejected with `ElizaError` code `TRAJECTORY_SEMANTIC_STAGE_INVALID`, context field `kind`, and no normalization into a member; string and number inputs carry their value in error context, other types do not (asserted as observed).

If a kind is added to or removed from the vocabulary without the validator and recorder agreeing, these tests fail.

## Evidence (test-only; no production behavior changed)

All runs executed on working-tree sources whose consumer files (`trajectory-stage-kind.ts`, `trajectory-recorder.ts`, `trajectory-semantic-stage.ts`, `errors.ts`) are byte-identical (git blob hashes verified) to current `origin/develop` at `e3e63588fd59`.

1. `bunx vitest run packages/core/src/runtime/trajectory-stage-kind.test.ts` → **1 test file passed, 18 tests passed / 0 failed**, re-run immediately before filing.
2. `bunx biome check --write packages/core/src/runtime/trajectory-stage-kind.test.ts` → clean (formatting applied once; config present at repo root, checkout not sparse).
3. `bunx tsc --noEmit` in `packages/core` → exit 0 with zero output; the new test file appears nowhere in diagnostics.
4. Diff touches only the new test file: `git diff --name-status <merge-base>..head` → `A packages/core/src/runtime/trajectory-stage-kind.test.ts`.

No `expectTypeOf` and no type-only assertions are used; all expectations are runtime behavior. No mocks stand in for the system under test.

## CI note

This pull request is filed from a fork, so hosted GitHub Actions do **not** run on it. The verification above was executed locally and its real counts are quoted here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ee1f8fe833f2a7f2fe68041dd335cf6b7332ba19 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
