### PR TITLE
test(ui): cover useShellControllerSync

### DIFF
--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx
@@ -114,4 +114,590 @@ describe("useShellControllerSync", () => {
     expect(view.result.current.role).toBe("owner");
     expect(view.result.current.status).toBe("connected");
   });
+
+  it("ignores authority states that regress generation or snapshot sequence", async () => {
+    const fake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 3,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 5,
+      snapshot: baseSnapshot({ transcript: "current" }),
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport }),
+    );
+    await act(async () => {});
+    expect(view.result.current.snapshot?.transcript).toBe("current");
+
+    act(() => {
+      fake.handlers().onState({
+        endpointId: "follower",
+        ownerEndpointId: "owner",
+        generation: 2,
+        role: "follower",
+        status: "connected",
+        snapshotSeq: 9,
+        snapshot: baseSnapshot({ transcript: "older-generation" }),
+      });
+      fake.handlers().onState({
+        endpointId: "follower",
+        ownerEndpointId: "owner",
+        generation: 3,
+        role: "follower",
+        status: "connected",
+        snapshotSeq: 4,
+        snapshot: baseSnapshot({ transcript: "older-sequence" }),
+      });
+    });
+    expect(view.result.current.snapshot?.transcript).toBe("current");
+
+    act(() => {
+      fake.handlers().onState({
+        endpointId: "follower",
+        ownerEndpointId: "owner",
+        generation: 3,
+        role: "follower",
+        status: "connected",
+        snapshotSeq: 6,
+        snapshot: baseSnapshot({ transcript: "newer-sequence" }),
+      });
+    });
+    expect(view.result.current.snapshot?.transcript).toBe("newer-sequence");
+  });
+
+  it("reports an error and keeps prior state when the authority endpoint identity changes", async () => {
+    const onError = vi.fn();
+    const fake = authorityTransport({
+      endpointId: "ep-a",
+      ownerEndpointId: "ep-a",
+      generation: 1,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport, onError }),
+    );
+    await act(async () => {});
+    expect(view.result.current.generation).toBe(1);
+
+    act(() => {
+      fake.handlers().onState({
+        endpointId: "ep-b",
+        ownerEndpointId: "ep-b",
+        generation: 2,
+        role: "owner",
+        status: "connected",
+        snapshotSeq: 0,
+        snapshot: null,
+      });
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBe(
+      "shell authority endpoint identity changed",
+    );
+    expect((onError.mock.calls[0][1] as Error).message).toBe(
+      "expected ep-a, received ep-b",
+    );
+    expect(view.result.current.generation).toBe(1);
+    expect(view.result.current.role).toBe("owner");
+  });
+
+  it("disconnects and reports when the authority supplies an invalid follower snapshot", async () => {
+    const onError = vi.fn();
+    const fake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 2,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 1,
+      snapshot: { phase: "not-a-real-phase" },
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport, onError }),
+    );
+    await act(async () => {});
+    expect(view.result.current.status).toBe("disconnected");
+    expect(view.result.current.snapshot).toBeNull();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBe(
+      "shell authority supplied an invalid snapshot",
+    );
+  });
+
+  it("disconnects and reports when the initial connection fails", async () => {
+    const onError = vi.fn();
+    const fake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 1,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    fake.transport.connect = vi.fn(async () => {
+      throw new Error("bridge down");
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport, onError }),
+    );
+    expect(view.result.current.status).toBe("connecting");
+    await act(async () => {});
+    expect(view.result.current.status).toBe("disconnected");
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBe("shell authority connection failed");
+    expect((onError.mock.calls[0][1] as Error).message).toBe("bridge down");
+  });
+
+  it("applies refreshed authority state delivered by a ping", async () => {
+    const initial = {
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 4,
+      role: "owner" as const,
+      status: "connected" as const,
+      snapshotSeq: 0,
+      snapshot: null,
+    };
+    const fake = authorityTransport(initial);
+    fake.transport.heartbeat = vi.fn(async () => ({
+      ...initial,
+      generation: 6,
+      snapshotSeq: 2,
+      status: "version-mismatch" as const,
+    }));
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport }),
+    );
+    await act(async () => {});
+    expect(view.result.current.status).toBe("connected");
+
+    await act(async () => {
+      fake.handlers().onPing();
+    });
+    expect(fake.transport.heartbeat).toHaveBeenCalledWith(expect.any(String));
+    expect(view.result.current.status).toBe("version-mismatch");
+  });
+
+  it("reports heartbeat failures raised by the authority transport", async () => {
+    const onError = vi.fn();
+    const fake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 1,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    fake.transport.heartbeat = vi.fn(async () => {
+      throw new Error("hb down");
+    });
+    renderHook(() =>
+      useShellControllerSync({ transport: fake.transport, onError }),
+    );
+    await act(async () => {});
+
+    await act(async () => {
+      fake.handlers().onPing();
+    });
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        "shell authority heartbeat failed",
+        expect.any(Error),
+      ),
+    );
+    expect((onError.mock.calls[0][1] as Error).message).toBe("hb down");
+  });
+
+  it("completes an owner command as failed when no controller handler is mounted", async () => {
+    const fake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 9,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    renderHook(() => useShellControllerSync({ transport: fake.transport }));
+    await act(async () => {});
+
+    act(() => {
+      fake.handlers().onCommand({
+        generation: 9,
+        commandId: "command-orphan",
+        fromEndpointId: "follower",
+        command: { kind: "stop" },
+      });
+    });
+    await vi.waitFor(() =>
+      expect(fake.completeCommand).toHaveBeenCalledWith(
+        9,
+        "command-orphan",
+        "follower",
+        { ok: false, error: "owner controller is not mounted" },
+      ),
+    );
+  });
+
+  it("completes an owner command with the thrown reason when its handler fails", async () => {
+    const fake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 11,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport }),
+    );
+    await act(async () => {});
+
+    act(() => {
+      view.result.current.setCommandHandler(async () => {
+        throw new Error("boom");
+      });
+      fake.handlers().onCommand({
+        generation: 11,
+        commandId: "c-err",
+        fromEndpointId: "follower",
+        command: { kind: "stop" },
+      });
+    });
+    await vi.waitFor(() =>
+      expect(fake.completeCommand).toHaveBeenLastCalledWith(
+        11,
+        "c-err",
+        "follower",
+        { ok: false, error: "boom" },
+      ),
+    );
+
+    act(() => {
+      view.result.current.setCommandHandler(async () => {
+        throw "raw";
+      });
+      fake.handlers().onCommand({
+        generation: 11,
+        commandId: "c-raw",
+        fromEndpointId: "follower",
+        command: { kind: "stop" },
+      });
+    });
+    await vi.waitFor(() =>
+      expect(fake.completeCommand).toHaveBeenLastCalledWith(
+        11,
+        "c-raw",
+        "follower",
+        { ok: false, error: "raw" },
+      ),
+    );
+  });
+
+  it("reports when the authority rejects a successful command completion", async () => {
+    const onError = vi.fn();
+    const fake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 12,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    fake.completeCommand.mockResolvedValue({ ok: false });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport, onError }),
+    );
+    await act(async () => {});
+
+    act(() => {
+      view.result.current.setCommandHandler(async () => {});
+      fake.handlers().onCommand({
+        generation: 12,
+        commandId: "c-rej",
+        fromEndpointId: "follower",
+        command: { kind: "stop" },
+      });
+    });
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        "shell command completion failed",
+        expect.any(Error),
+      ),
+    );
+    expect((onError.mock.calls[0][1] as Error).message).toBe(
+      "authority rejected command completion",
+    );
+  });
+
+  it("ignores command requests outside the applied generation or while not owner", async () => {
+    const handler = vi.fn(async () => {});
+    const fake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 13,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport }),
+    );
+    await act(async () => {});
+    act(() => {
+      view.result.current.setCommandHandler(handler);
+      fake.handlers().onCommand({
+        generation: 99,
+        commandId: "c-wrong-gen",
+        fromEndpointId: "follower",
+        command: { kind: "stop" },
+      });
+    });
+    await act(async () => {});
+    expect(handler).not.toHaveBeenCalled();
+    expect(fake.completeCommand).not.toHaveBeenCalled();
+
+    const followerFake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 2,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const followerView = renderHook(() =>
+      useShellControllerSync({ transport: followerFake.transport }),
+    );
+    await act(async () => {});
+    let reached = false;
+    act(() => {
+      followerView.result.current.setCommandHandler(async () => {
+        reached = true;
+      });
+      followerFake.handlers().onCommand({
+        generation: 2,
+        commandId: "c-follower",
+        fromEndpointId: "someone-else",
+        command: { kind: "stop" },
+      });
+    });
+    await act(async () => {});
+    expect(reached).toBe(false);
+    expect(followerFake.completeCommand).not.toHaveBeenCalled();
+  });
+
+  it("dispatches locally as a lone owner and refuses without a mounted handler", async () => {
+    const view = renderHook(() => useShellControllerSync({ transport: null }));
+    let seenKind = "";
+    let seenFrom = "";
+    act(() => {
+      view.result.current.setCommandHandler(async (command, fromEndpointId) => {
+        seenKind = command.kind;
+        seenFrom = fromEndpointId;
+      });
+    });
+    await act(async () => {
+      await view.result.current.dispatch({ kind: "stop" });
+    });
+    expect(seenKind).toBe("stop");
+    expect(seenFrom).toBe("local");
+
+    act(() => {
+      view.result.current.setCommandHandler(null);
+    });
+    let refusal = "";
+    await act(async () => {
+      try {
+        await view.result.current.dispatch({ kind: "stop" });
+      } catch (error) {
+        refusal = (error as Error).message;
+      }
+    });
+    expect(refusal).toBe("shell controller is not mounted");
+  });
+
+  it("forwards follower dispatch through the authority and surfaces its failures", async () => {
+    const fake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 3,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: fake.transport }),
+    );
+    await act(async () => {});
+
+    await act(async () => {
+      await view.result.current.dispatch({ kind: "toggleRecording" });
+    });
+    expect(fake.transport.dispatchCommand).toHaveBeenCalledWith(
+      expect.any(String),
+      { kind: "toggleRecording" },
+    );
+
+    const captureDispatchError = async (): Promise<string> => {
+      let message = "";
+      await act(async () => {
+        try {
+          await view.result.current.dispatch({ kind: "stop" });
+        } catch (error) {
+          message = (error as Error).message;
+        }
+      });
+      return message;
+    };
+
+    fake.transport.dispatchCommand = vi.fn(async () => ({
+      ok: false,
+      error: "owner declined",
+    }));
+    expect(await captureDispatchError()).toBe("owner declined");
+
+    fake.transport.dispatchCommand = vi.fn(async () => ({ ok: false }));
+    expect(await captureDispatchError()).toBe("owner command failed");
+  });
+
+  it("publishes snapshots only from the owner with an authority transport", async () => {
+    const lone = renderHook(() => useShellControllerSync({ transport: null }));
+    expect(() =>
+      lone.result.current.publishSnapshot(baseSnapshot()),
+    ).not.toThrow();
+
+    const followerFake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 7,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const followerView = renderHook(() =>
+      useShellControllerSync({ transport: followerFake.transport }),
+    );
+    await act(async () => {});
+    followerView.result.current.publishSnapshot(baseSnapshot());
+    await act(async () => {});
+    expect(followerFake.transport.publishSnapshot).not.toHaveBeenCalled();
+
+    const onError = vi.fn();
+    const ownerFake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 21,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const ownerView = renderHook(() =>
+      useShellControllerSync({ transport: ownerFake.transport, onError }),
+    );
+    await act(async () => {});
+    const published = baseSnapshot({ recording: true });
+    ownerView.result.current.publishSnapshot(published);
+    await vi.waitFor(() =>
+      expect(ownerFake.transport.publishSnapshot).toHaveBeenCalledWith(
+        21,
+        published,
+      ),
+    );
+
+    ownerFake.transport.publishSnapshot = vi.fn(async () => ({ ok: false }));
+    ownerView.result.current.publishSnapshot(published);
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        "shell snapshot publish failed",
+        expect.any(Error),
+      ),
+    );
+    expect((onError.mock.calls[0][1] as Error).message).toBe(
+      "authority rejected owner snapshot",
+    );
+  });
+
+  it("delivers targeted payloads only from the owner with an authority transport", async () => {
+    const delivery = { kind: "dictation", text: "hi" } as const;
+
+    const lone = renderHook(() => useShellControllerSync({ transport: null }));
+    await act(async () => {
+      await expect(
+        lone.result.current.deliver("ep-x", delivery),
+      ).rejects.toThrow("targeted delivery requires desktop authority");
+    });
+
+    const followerFake = authorityTransport({
+      endpointId: "follower",
+      ownerEndpointId: "owner",
+      generation: 5,
+      role: "follower",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const followerView = renderHook(() =>
+      useShellControllerSync({ transport: followerFake.transport }),
+    );
+    await act(async () => {});
+    await act(async () => {
+      await expect(
+        followerView.result.current.deliver("ep-y", delivery),
+      ).rejects.toThrow("only owner can deliver");
+    });
+    expect(followerFake.transport.deliver).not.toHaveBeenCalled();
+
+    const ownerFake = authorityTransport({
+      endpointId: "ep-owner",
+      ownerEndpointId: "ep-owner",
+      generation: 5,
+      role: "owner",
+      status: "connected",
+      snapshotSeq: 0,
+      snapshot: null,
+    });
+    const ownerView = renderHook(() =>
+      useShellControllerSync({ transport: ownerFake.transport }),
+    );
+    await act(async () => {});
+    await act(async () => {
+      await ownerView.result.current.deliver("ep-t", delivery);
+    });
+    expect(ownerFake.transport.deliver).toHaveBeenCalledWith(
+      5,
+      "ep-t",
+      delivery,
+    );
+
+    ownerFake.transport.deliver = vi.fn(async () => ({ ok: false }));
+    await act(async () => {
+      await expect(
+        ownerView.result.current.deliver("ep-z", delivery),
+      ).rejects.toThrow("authority rejected targeted delivery");
+    });
+  });
+
+  it("forwards reportError to the injected error handler", () => {
+    const onError = vi.fn();
+    const view = renderHook(() =>
+      useShellControllerSync({ transport: null, onError }),
+    );
+    const boom = new Error("manual");
+    view.result.current.reportError("operator note", boom);
+    expect(onError).toHaveBeenCalledWith("operator note", boom);
+  });
 });


### PR DESCRIPTION

Adds unit coverage for `useShellControllerSync` (`packages/ui/src/components/shell/shell-controller-sync/useShellControllerSync.ts`).

When this work started, current `origin/develop` already carried a three-case suite for the hook, so this change is strictly additive: it appends cases to the existing suite and removes nothing. The new cases drive the real hook through an injected in-memory authority transport and assert observable behavior for branches the suite did not yet reach:

- stale-authority filtering: states that regress generation or snapshot sequence are ignored; a newer sequence on the same generation is applied
- endpoint identity changes are reported as errors and the prior state is kept
- an invalid follower snapshot from the authority disconnects the follower and reports the rejection instead of adopting it
- connection failure moves the follower from `connecting` to `disconnected` and reports the transport error
- pings apply refreshed authority state delivered by `heartbeat`, and heartbeat failures are reported
- owner command completion: unmounted handler completes `{ ok: false }` with "owner controller is not mounted"; handler rejections complete with the thrown reason (both `Error` and non-`Error`); an authority that rejects a successful completion surfaces "authority rejected command completion"
- command requests from another generation or while not owner are ignored entirely
- dispatch routing: lone owners dispatch locally to their own handler (endpoint `local`) and refuse without one; followers forward through `dispatchCommand` and surface its failure strings, including the default "owner command failed"
- snapshot publishing is owner-only and reports publish failures; targeted delivery is owner-only with an authority transport and reports rejection

Evidence (all quoted from real runs against current `origin/develop`, base `e3e63588fd59`):

- `bunx vitest run src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx` in `packages/ui`: **1 file passed, 18 tests passed (18)** — 3 pre-existing plus 15 new; zero failures
- `bunx biome check --write <file>`: clean ("Checked 1 file... No fixes applied"), with `biome.json` present at the repo root and sparse-checkout disabled
- `tsc --noEmit -p tsconfig.json` in `packages/ui`: the new test file appears nowhere in the output
- The diff touches only `packages/ui/src/components/shell/shell-controller-sync/__tests__/useShellControllerSync.test.tsx`: +586/-0, no production behavior changed

Note: this is a fork contribution, so hosted CI does not run on this pull request; the counts above are the verification record.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ebb89805596235f6d7b8923ad4b4119eaf0f3781 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
