### PR TITLE
feat(scenarios): make group-chat baselines resumable

### DIFF
--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -65,6 +65,24 @@ bun run --cwd packages/scenario-runner eval:timing:merge -- \
   /path/to/shard-*.json
 ```
 
+For long live cells, use the supervisor instead of launching shards by hand:
+
+```bash
+bun run --cwd packages/scenario-runner eval:timing:matrix -- \
+  --input=/path/to/finetune_test_dialogue.jsonl \
+  --output-dir=/path/to/model-cell \
+  --provider=cli \
+  --shard-count=8 \
+  --workers=4
+```
+
+It adopts complete shards, resumes validated `in-progress` checkpoints, keeps
+per-shard stdout/stderr and trajectories, retries only runtime/provider exits,
+and writes an atomic run manifest. A configuration exit is terminal. The run
+finishes only after the canonical merger proves that every physical input row
+belongs to exactly one complete shard in one model cell. Re-running the same
+command performs no model calls after that proof exists.
+
 Pinned Discord replay output can exercise the same Stage-1 boundary:
 
 ```bash

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -27,7 +27,9 @@ boundary used by production group messages:
 ```bash
 bun run --cwd packages/scenario-runner eval:when2speak -- \
   --input=/path/to/finetune_test_dialogue.jsonl \
-  --provider=anthropic
+  --provider=anthropic \
+  --shard-index=0 \
+  --shard-count=8
 ```
 
 The command writes `reports/group-chat-timing/when2speak.json`. It reports
@@ -39,6 +41,42 @@ accepted dialogue to Stage 1 in full. A malformed row is recorded as a failure
 and makes the command exit nonzero. Complete Stage-1 trajectories are written
 beside the report under `reports/group-chat-timing/trajectories`; override that
 location with `--run-dir=<dir>`.
+
+The evaluator writes an atomic checkpoint after every selected row by default.
+Use `--checkpoint-every=<n>` to reduce checkpoint frequency and
+`--resume=<in-progress-report>` to continue the same output after a provider
+failure. Resume rejects changed cell identity or duplicate/gapped prior rows.
+Use `--start-row=<n>` for an explicitly partial diagnostic, and zero-based
+`--shard-index` with `--shard-count` to partition the physical JSONL rows
+without shortening any accepted dialogue. Reports record the backend and requested model separately;
+the requested identifier is not a claim about an alias the provider actually
+served.
+
+After every shard finishes, merge them into a comparative matrix. The merger
+reopens the source JSONL and rejects partial status, bounded runs, missing or
+duplicate shards, duplicate rows, and incomplete physical-row coverage:
+
+```bash
+bun run --cwd packages/scenario-runner eval:timing:merge -- \
+  --output=../../reports/group-chat-timing/matrix.json \
+  /path/to/shard-*.json
+```
+
+Pinned Discord replay output can exercise the same Stage-1 boundary:
+
+```bash
+bun run --cwd packages/scenario-runner eval:when2speak -- \
+  --input=/tmp/discord-replay.jsonl \
+  --input-format=discord-replay \
+  --provider=cli
+```
+
+Only points whose current turn is inbound to the selected target seat are
+eligible. The converter's paired SILENT pseudo-label assigns the target seat to
+the author of the current turn in a two-author chain; those points are recorded
+as explicit eligibility exclusions instead of pretending production evaluates
+its own outbound message. Exclusions remain part of physical-row coverage but
+do not make the command fail; malformed rows remain failures and exit nonzero.
 
 ## Writing a scenario
 

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -45,7 +45,9 @@ location with `--run-dir=<dir>`.
 The evaluator writes an atomic checkpoint after every selected row by default.
 Use `--checkpoint-every=<n>` to reduce checkpoint frequency and
 `--resume=<in-progress-report>` to continue the same output after a provider
-failure. Resume rejects changed cell identity or duplicate/gapped prior rows.
+failure. Every report binds the input path and SHA-256 content digest; resume
+rejects changed input content, changed cell identity, or duplicate/gapped prior
+rows, and a run fails if the input changes while it is being evaluated.
 Use `--start-row=<n>` for an explicitly partial diagnostic, and zero-based
 `--shard-index` with `--shard-count` to partition the physical JSONL rows
 without shortening any accepted dialogue. Reports record the backend and requested model separately;
@@ -54,7 +56,8 @@ served.
 
 After every shard finishes, merge them into a comparative matrix. The merger
 reopens the source JSONL and rejects partial status, bounded runs, missing or
-duplicate shards, duplicate rows, and incomplete physical-row coverage:
+duplicate shards, rows assigned to the wrong shard, source-content drift,
+duplicate rows, and incomplete physical-row coverage:
 
 ```bash
 bun run --cwd packages/scenario-runner eval:timing:merge -- \

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -77,6 +77,7 @@
     "test:real-service:audio": "node scripts/real-service-audio-roundtrip.mjs",
     "test:real-service:voice": "node scripts/real-service-voice-e2e.mjs",
     "eval:when2speak": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/when2speak-eval-cli.ts",
+    "eval:timing:matrix": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/timing-matrix-runner-cli.ts",
     "eval:timing:merge": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/timing-report-merge-cli.ts",
     "format": "bunx @biomejs/biome format --write package.json",
     "format:check": "bunx @biomejs/biome format package.json",

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -77,6 +77,7 @@
     "test:real-service:audio": "node scripts/real-service-audio-roundtrip.mjs",
     "test:real-service:voice": "node scripts/real-service-voice-e2e.mjs",
     "eval:when2speak": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/when2speak-eval-cli.ts",
+    "eval:timing:merge": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/timing-report-merge-cli.ts",
     "format": "bunx @biomejs/biome format --write package.json",
     "format:check": "bunx @biomejs/biome format package.json",
     "typecheck": "tsc --noEmit"

--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -6,6 +6,7 @@ import {
   clearLlmWireMockEnvForLiveProvider,
   deterministicScheduledDispatchRenderText,
   disableScenarioEmbeddingCapability,
+  disposeScenarioProviderPlugin,
   isPostTurnEvaluationPrompt,
   isScheduledDispatchRenderPrompt,
   loadScenarioTestMocksForTests,
@@ -14,6 +15,18 @@ import {
   scenarioLiveProviderPreflightProblems,
   shouldUseDeterministicModel,
 } from "./runtime-factory";
+
+describe("scenario provider lifecycle", () => {
+  it("disposes the selected provider during runtime cleanup", async () => {
+    const dispose = vi.fn(async () => undefined);
+    const runtime = {} as never;
+
+    await disposeScenarioProviderPlugin({ dispose }, runtime);
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledWith(runtime);
+  });
+});
 
 describe("scenario embedding capability", () => {
   it("declares the canonical embedding capability disabled", () => {

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -216,6 +216,13 @@ async function runCleanupStep(
   }
 }
 
+export async function disposeScenarioProviderPlugin(
+  plugin: Pick<Plugin, "dispose"> | null,
+  runtime: AgentRuntime,
+): Promise<void> {
+  await plugin?.dispose?.(runtime);
+}
+
 function cancelScenarioOnlyLazyServiceStarts(runtime: AgentRuntime): void {
   const runtimeInternals = runtime as unknown as {
     startingServices?: Map<string, Promise<unknown>>;
@@ -835,6 +842,7 @@ export async function createScenarioRuntime(
       "[scenario-runner] provider-qualified execution requires a live model provider",
     );
   }
+  let selectedProviderPlugin: Plugin | null = null;
   const preparedEnvironment =
     await prepareScenarioExecutionEnvironment(executionProfile);
   const { testMocks, mockedEnvironment } = preparedEnvironment;
@@ -1022,6 +1030,7 @@ export async function createScenarioRuntime(
         `[scenario-runner] provider package ${providerConfig.pluginPackage} did not export a Plugin`,
       );
     }
+    selectedProviderPlugin = providerPlugin;
     await runtime.registerPlugin(providerPlugin);
 
     if (providerConfig.name === "cli") {
@@ -1187,6 +1196,14 @@ export async function createScenarioRuntime(
       }
     });
     cancelScenarioOnlyLazyServiceStarts(runtime);
+    await runCleanupStep("provider plugin dispose", async () => {
+      try {
+        await disposeScenarioProviderPlugin(selectedProviderPlugin, runtime);
+      } catch (err) {
+        // error-policy:J6 provider teardown must not prevent remaining runtime cleanup.
+        logger.debug(`[scenario-runner] provider plugin dispose error: ${err}`);
+      }
+    });
     await runCleanupStep("runtime.stop()", async () => {
       try {
         await runtime.stop();

--- a/packages/scenario-runner/src/timing-matrix-runner-cli.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner-cli.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env bun
+/** Runs and resumes a bounded full-volume timing matrix cell. */
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ElizaError } from "@elizaos/core";
+import {
+  runTimingMatrix,
+  type TimingMatrixRunnerEvent,
+  type TimingShardInvocation,
+  type TimingShardProcessResult,
+} from "./timing-matrix-runner.ts";
+import type { TimingInputFormat } from "./when2speak-eval.ts";
+
+function option(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv
+    .slice(2)
+    .find((arg) => arg.startsWith(prefix))
+    ?.slice(prefix.length);
+}
+
+function argumentError(message: string): ElizaError {
+  return new ElizaError(message, {
+    code: "TIMING_MATRIX_CLI_INVALID_ARGUMENT",
+  });
+}
+
+function positiveInteger(name: string, fallback?: number): number {
+  const text = option(name);
+  if (text === undefined && fallback !== undefined) return fallback;
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw argumentError(`--${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(name: string, fallback: number): number {
+  const text = option(name);
+  if (text === undefined) return fallback;
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw argumentError(`--${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+const input = option("input");
+const outputDir = option("output-dir");
+if (!input || !outputDir) {
+  throw argumentError(
+    "usage: timing-matrix-runner --input=<jsonl> --output-dir=<dir> [--input-format=when2speak|discord-replay] [--provider=<name>] [--shard-count=<n>] [--workers=<n>] [--max-attempts=<n>] [--retry-delay-ms=<n>]",
+  );
+}
+const resolvedInput = path.resolve(input);
+const resolvedOutputDir = path.resolve(outputDir);
+const inputFormatText = option("input-format") ?? "when2speak";
+if (inputFormatText !== "when2speak" && inputFormatText !== "discord-replay") {
+  throw argumentError("--input-format must be when2speak or discord-replay");
+}
+const inputFormat: TimingInputFormat = inputFormatText;
+const provider = option("provider") ?? "cli";
+const shardCount = positiveInteger("shard-count", 8);
+const workers = positiveInteger("workers", Math.min(4, shardCount));
+const maxAttempts = positiveInteger("max-attempts", 20);
+const retryDelayMs = nonNegativeInteger("retry-delay-ms", 5_000);
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const repoRoot = path.resolve(packageRoot, "..", "..");
+const evaluator = path.join(packageRoot, "src", "when2speak-eval-cli.ts");
+const sourceArguments = [
+  "--conditions",
+  "eliza-source",
+  "--tsconfig-override",
+  path.join(repoRoot, "tsconfig.json"),
+  evaluator,
+];
+const activeChildren = new Set<ChildProcess>();
+let interruptedSignal: NodeJS.Signals | null = null;
+
+function interrupt(signal: NodeJS.Signals): void {
+  interruptedSignal = signal;
+  for (const child of activeChildren) child.kill("SIGTERM");
+}
+
+process.once("SIGINT", () => interrupt("SIGINT"));
+process.once("SIGTERM", () => interrupt("SIGTERM"));
+
+function appendLog(file: string): number {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  return fs.openSync(file, "a");
+}
+
+function runShard(
+  invocation: TimingShardInvocation,
+): Promise<TimingShardProcessResult> {
+  return new Promise((resolve, reject) => {
+    if (interruptedSignal !== null) {
+      reject(
+        new ElizaError("Timing matrix run was interrupted", {
+          code: "TIMING_MATRIX_INTERRUPTED",
+          context: { signal: interruptedSignal },
+        }),
+      );
+      return;
+    }
+    const shardLabel = String(invocation.shardIndex).padStart(5, "0");
+    const stdout = appendLog(
+      path.join(resolvedOutputDir, `shard-${shardLabel}.stdout.log`),
+    );
+    const stderr = appendLog(
+      path.join(resolvedOutputDir, `shard-${shardLabel}.stderr.log`),
+    );
+    const args = [
+      ...sourceArguments,
+      `--input=${resolvedInput}`,
+      `--input-format=${inputFormat}`,
+      `--output=${invocation.report}`,
+      `--run-dir=${invocation.trajectoryDir}`,
+      `--provider=${provider}`,
+      `--shard-index=${invocation.shardIndex}`,
+      `--shard-count=${invocation.shardCount}`,
+      "--checkpoint-every=1",
+      ...(invocation.resume ? [`--resume=${invocation.report}`] : []),
+    ];
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["ignore", stdout, stderr],
+    });
+    activeChildren.add(child);
+    let settled = false;
+    const closeLogs = (): void => {
+      fs.closeSync(stdout);
+      fs.closeSync(stderr);
+    };
+    child.once("error", (cause) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child);
+      closeLogs();
+      reject(
+        new ElizaError("Failed to spawn timing shard", {
+          code: "TIMING_MATRIX_SHARD_SPAWN_FAILED",
+          context: {
+            shardIndex: invocation.shardIndex,
+            attempt: invocation.attempt,
+          },
+          cause,
+        }),
+      );
+    });
+    child.once("close", (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child);
+      closeLogs();
+      if (interruptedSignal !== null) {
+        reject(
+          new ElizaError("Timing matrix run was interrupted", {
+            code: "TIMING_MATRIX_INTERRUPTED",
+            context: { signal: interruptedSignal },
+          }),
+        );
+        return;
+      }
+      resolve(
+        exitCode === null
+          ? { kind: "signaled", signal: signal ?? "unknown" }
+          : { kind: "exited", exitCode },
+      );
+    });
+  });
+}
+
+function eventText(event: TimingMatrixRunnerEvent): string {
+  switch (event.kind) {
+    case "shard-adopted":
+      return `[timing-matrix] shard ${event.shardIndex} already complete`;
+    case "shard-attempt":
+      return `[timing-matrix] shard ${event.shardIndex} attempt ${event.attempt}${event.resume ? " resuming" : " starting"}`;
+    case "shard-retry":
+      return `[timing-matrix] shard ${event.shardIndex} retrying after ${event.reason}`;
+    case "shard-complete":
+      return `[timing-matrix] shard ${event.shardIndex} complete after ${event.attempts} attempt(s)`;
+  }
+}
+
+const result = await runTimingMatrix({
+  input: resolvedInput,
+  inputFormat,
+  provider,
+  outputDir: resolvedOutputDir,
+  shardCount,
+  workers,
+  maxAttempts,
+  retryDelayMs,
+  runShard,
+  onEvent: (event) => process.stderr.write(`${eventText(event)}\n`),
+});
+process.stdout.write(`${JSON.stringify(result.matrix.cells[0])}\n`);
+process.stdout.write(
+  `manifest: ${path.join(resolvedOutputDir, "run-manifest.json")}\n`,
+);
+process.stdout.write(
+  `matrix: ${path.join(resolvedOutputDir, "matrix.json")}\n`,
+);

--- a/packages/scenario-runner/src/timing-matrix-runner.test.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner.test.ts
@@ -1,0 +1,143 @@
+/** Tests crash-safe shard adoption, resumption, retry, and exact merging. */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  runTimingMatrix,
+  type TimingShardInvocation,
+} from "./timing-matrix-runner.ts";
+import {
+  summarizeTimingPredictions,
+  type TimingReport,
+} from "./when2speak-eval.ts";
+
+function writeReport(options: {
+  invocation: TimingShardInvocation;
+  input: string;
+  status: TimingReport["status"];
+}): void {
+  const prediction = {
+    row: options.invocation.shardIndex + 1,
+    gold: "SPEAK" as const,
+    predicted: "SPEAK" as const,
+    directlyAddressesAgent: false,
+    speakerCount: 2,
+    contextTurns: 3,
+  };
+  const summary = summarizeTimingPredictions([prediction]);
+  const report: TimingReport = {
+    schema: 2,
+    status: options.status,
+    dataset: "duke-trust-lab/When2Speak",
+    input: options.input,
+    inputSha256: createHash("sha256")
+      .update(fs.readFileSync(options.input))
+      .digest("hex"),
+    provider: "cli",
+    requestedModel: "test-model",
+    backend: "test-backend",
+    trajectoryDir: options.invocation.trajectoryDir,
+    selection: {
+      shardIndex: options.invocation.shardIndex,
+      shardCount: options.invocation.shardCount,
+      startRow: 1,
+      limit: null,
+    },
+    startedAt: "2026-08-24T00:00:00.000Z",
+    finishedAt: "2026-08-24T00:01:00.000Z",
+    ...summary,
+    predictions: [prediction],
+    exclusions: [],
+    failures: [],
+  };
+  fs.writeFileSync(options.invocation.report, JSON.stringify(report), "utf8");
+}
+
+function fixture(): { input: string; outputDir: string } {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "timing-matrix-runner-"),
+  );
+  const input = path.join(directory, "input.jsonl");
+  fs.writeFileSync(input, "{}\n{}\n", "utf8");
+  return { input, outputDir: path.join(directory, "output") };
+}
+
+describe("timing matrix runner", () => {
+  it("resumes interrupted shards, merges exact coverage, and adopts reruns", async () => {
+    const { input, outputDir } = fixture();
+    const invocations: TimingShardInvocation[] = [];
+    const first = await runTimingMatrix({
+      input,
+      inputFormat: "when2speak",
+      provider: "cli",
+      outputDir,
+      shardCount: 2,
+      workers: 2,
+      maxAttempts: 3,
+      retryDelayMs: 0,
+      runShard: async (invocation) => {
+        invocations.push(invocation);
+        writeReport({
+          invocation,
+          input,
+          status:
+            invocation.shardIndex === 0 && invocation.attempt === 1
+              ? "in-progress"
+              : "complete",
+        });
+        return { kind: "exited", exitCode: invocation.attempt === 1 ? 1 : 0 };
+      },
+    });
+    expect(first.manifest.status).toBe("complete");
+    expect(first.matrix.cells[0]).toMatchObject({
+      physicalRows: 2,
+      acceptedRows: 2,
+    });
+    expect(
+      invocations.filter(({ shardIndex }) => shardIndex === 0),
+    ).toMatchObject([
+      { attempt: 1, resume: false },
+      { attempt: 2, resume: true },
+    ]);
+
+    let rerunCalls = 0;
+    await runTimingMatrix({
+      input,
+      inputFormat: "when2speak",
+      provider: "cli",
+      outputDir,
+      shardCount: 2,
+      workers: 2,
+      maxAttempts: 3,
+      retryDelayMs: 0,
+      runShard: async () => {
+        rerunCalls += 1;
+        return { kind: "exited", exitCode: 0 };
+      },
+    });
+    expect(rerunCalls).toBe(0);
+  });
+
+  it("fails after a bounded retry budget without fabricating completion", async () => {
+    const { input, outputDir } = fixture();
+    await expect(
+      runTimingMatrix({
+        input,
+        inputFormat: "when2speak",
+        provider: "cli",
+        outputDir,
+        shardCount: 1,
+        workers: 1,
+        maxAttempts: 2,
+        retryDelayMs: 0,
+        runShard: async () => ({ kind: "exited", exitCode: 1 }),
+      }),
+    ).rejects.toThrow("exhausted its retry budget");
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "run-manifest.json"), "utf8"),
+    ) as { status: string };
+    expect(manifest.status).toBe("in-progress");
+  });
+});

--- a/packages/scenario-runner/src/timing-matrix-runner.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner.ts
@@ -1,0 +1,283 @@
+/**
+ * Supervises resumable timing-evaluation shards and proves their exact merged
+ * coverage. The runner is idempotent: complete shards are adopted, partial
+ * shards resume, and every state transition is recorded atomically.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import {
+  mergeTimingReports,
+  type TimingMatrixReport,
+} from "./timing-report-merge.ts";
+import type { TimingInputFormat } from "./when2speak-eval.ts";
+
+export type TimingShardProcessResult =
+  | { kind: "exited"; exitCode: number }
+  | { kind: "signaled"; signal: string };
+
+export interface TimingShardInvocation {
+  shardIndex: number;
+  shardCount: number;
+  attempt: number;
+  report: string;
+  trajectoryDir: string;
+  resume: boolean;
+}
+
+export interface TimingMatrixRunnerOptions {
+  input: string;
+  inputFormat: TimingInputFormat;
+  provider: string;
+  outputDir: string;
+  shardCount: number;
+  workers: number;
+  maxAttempts: number;
+  retryDelayMs: number;
+  runShard: (
+    invocation: TimingShardInvocation,
+  ) => Promise<TimingShardProcessResult>;
+  onEvent?: (event: TimingMatrixRunnerEvent) => void;
+}
+
+export type TimingMatrixRunnerEvent =
+  | { kind: "shard-adopted"; shardIndex: number }
+  | {
+      kind: "shard-attempt";
+      shardIndex: number;
+      attempt: number;
+      resume: boolean;
+    }
+  | { kind: "shard-retry"; shardIndex: number; attempt: number; reason: string }
+  | { kind: "shard-complete"; shardIndex: number; attempts: number };
+
+interface ShardManifestEntry {
+  shardIndex: number;
+  attempts: number;
+  status: "pending" | "in-progress" | "complete";
+  report: string;
+}
+
+export interface TimingMatrixRunManifest {
+  schema: 1;
+  status: "in-progress" | "complete";
+  input: string;
+  inputFormat: TimingInputFormat;
+  provider: string;
+  shardCount: number;
+  workers: number;
+  maxAttempts: number;
+  startedAt: string;
+  updatedAt: string;
+  shards: ShardManifestEntry[];
+  matrix: string | null;
+}
+
+type ExistingShardState = "absent" | "in-progress" | "complete";
+
+function runnerError(
+  code: string,
+  message: string,
+  context?: Record<string, unknown>,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    ...(context === undefined ? {} : { context }),
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function writeJsonAtomic(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = `${file}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  fs.renameSync(temporary, file);
+}
+
+function readShardState(file: string): ExistingShardState {
+  if (!fs.existsSync(file)) return "absent";
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (cause) {
+    // error-policy:J2 A corrupt checkpoint is retained and reported with its path.
+    throw runnerError(
+      "TIMING_MATRIX_CHECKPOINT_READ_FAILED",
+      "Failed to read timing shard checkpoint",
+      { file },
+      cause,
+    );
+  }
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("schema" in value) ||
+    value.schema !== 2 ||
+    !("status" in value) ||
+    (value.status !== "in-progress" && value.status !== "complete")
+  ) {
+    throw runnerError(
+      "TIMING_MATRIX_CHECKPOINT_INVALID",
+      "Timing shard checkpoint has an invalid status envelope",
+      { file },
+    );
+  }
+  return value.status;
+}
+
+function validateRunnerOptions(options: TimingMatrixRunnerOptions): void {
+  const counts = [
+    ["shardCount", options.shardCount],
+    ["workers", options.workers],
+    ["maxAttempts", options.maxAttempts],
+  ] as const;
+  for (const [name, value] of counts) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw runnerError(
+        "TIMING_MATRIX_INVALID_ARGUMENT",
+        `${name} must be a positive integer`,
+        { name, value },
+      );
+    }
+  }
+  if (options.workers > options.shardCount) {
+    throw runnerError(
+      "TIMING_MATRIX_INVALID_ARGUMENT",
+      "workers cannot exceed shardCount",
+      { workers: options.workers, shardCount: options.shardCount },
+    );
+  }
+  if (!Number.isSafeInteger(options.retryDelayMs) || options.retryDelayMs < 0) {
+    throw runnerError(
+      "TIMING_MATRIX_INVALID_ARGUMENT",
+      "retryDelayMs must be a non-negative integer",
+      { retryDelayMs: options.retryDelayMs },
+    );
+  }
+}
+
+function wait(delayMs: number): Promise<void> {
+  if (delayMs === 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export async function runTimingMatrix(
+  options: TimingMatrixRunnerOptions,
+): Promise<{ manifest: TimingMatrixRunManifest; matrix: TimingMatrixReport }> {
+  validateRunnerOptions(options);
+  const outputDir = path.resolve(options.outputDir);
+  const reports = Array.from({ length: options.shardCount }, (_, shardIndex) =>
+    path.join(outputDir, `shard-${String(shardIndex).padStart(5, "0")}.json`),
+  );
+  const startedAt = new Date().toISOString();
+  const manifestFile = path.join(outputDir, "run-manifest.json");
+  const matrixFile = path.join(outputDir, "matrix.json");
+  const shards: ShardManifestEntry[] = reports.map((report, shardIndex) => ({
+    shardIndex,
+    attempts: 0,
+    status: readShardState(report) === "complete" ? "complete" : "pending",
+    report,
+  }));
+  const manifest = (
+    status: TimingMatrixRunManifest["status"],
+  ): TimingMatrixRunManifest => ({
+    schema: 1,
+    status,
+    input: path.resolve(options.input),
+    inputFormat: options.inputFormat,
+    provider: options.provider,
+    shardCount: options.shardCount,
+    workers: options.workers,
+    maxAttempts: options.maxAttempts,
+    startedAt,
+    updatedAt: new Date().toISOString(),
+    shards: shards.map((shard) => ({ ...shard })),
+    matrix: status === "complete" ? matrixFile : null,
+  });
+  const checkpointManifest = (): void =>
+    writeJsonAtomic(manifestFile, manifest("in-progress"));
+  checkpointManifest();
+
+  let nextShard = 0;
+  async function worker(): Promise<void> {
+    while (nextShard < shards.length) {
+      const shardIndex = nextShard;
+      nextShard += 1;
+      const shard = shards[shardIndex];
+      if (shard.status === "complete") {
+        options.onEvent?.({ kind: "shard-adopted", shardIndex });
+        continue;
+      }
+      for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+        shard.attempts = attempt;
+        const state = readShardState(shard.report);
+        const resume = state === "in-progress";
+        shard.status = resume ? "in-progress" : "pending";
+        checkpointManifest();
+        options.onEvent?.({
+          kind: "shard-attempt",
+          shardIndex,
+          attempt,
+          resume,
+        });
+        const result = await options.runShard({
+          shardIndex,
+          shardCount: options.shardCount,
+          attempt,
+          report: shard.report,
+          trajectoryDir: path.join(
+            outputDir,
+            `shard-${String(shardIndex).padStart(5, "0")}-trajectories`,
+          ),
+          resume,
+        });
+        const nextState = readShardState(shard.report);
+        if (nextState === "complete") {
+          shard.status = "complete";
+          checkpointManifest();
+          options.onEvent?.({
+            kind: "shard-complete",
+            shardIndex,
+            attempts: attempt,
+          });
+          break;
+        }
+        if (result.kind === "exited" && result.exitCode === 2) {
+          throw runnerError(
+            "TIMING_MATRIX_SHARD_CONFIG_FAILED",
+            "Timing shard exited with a non-retryable configuration failure",
+            { shardIndex, attempt, exitCode: result.exitCode },
+          );
+        }
+        const reason =
+          result.kind === "exited"
+            ? `exit ${result.exitCode}`
+            : `signal ${result.signal}`;
+        if (attempt === options.maxAttempts) {
+          throw runnerError(
+            "TIMING_MATRIX_SHARD_RETRIES_EXHAUSTED",
+            "Timing shard exhausted its retry budget without completing",
+            { shardIndex, attempt, reason, state: nextState },
+          );
+        }
+        options.onEvent?.({ kind: "shard-retry", shardIndex, attempt, reason });
+        await wait(options.retryDelayMs);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: options.workers }, () => worker()));
+  const matrix = mergeTimingReports(reports);
+  if (matrix.cells.length !== 1) {
+    throw runnerError(
+      "TIMING_MATRIX_MIXED_CELLS",
+      "A supervised timing run must merge into exactly one model cell",
+      { cells: matrix.cells.length },
+    );
+  }
+  writeJsonAtomic(matrixFile, matrix);
+  const completeManifest = manifest("complete");
+  writeJsonAtomic(manifestFile, completeManifest);
+  return { manifest: completeManifest, matrix };
+}

--- a/packages/scenario-runner/src/timing-report-merge-cli.ts
+++ b/packages/scenario-runner/src/timing-report-merge-cli.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+/** Merges complete timing-evaluation shard reports into a verified matrix. */
+import fs from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import { mergeTimingReports } from "./timing-report-merge.ts";
+
+const outputArgument = process.argv
+  .slice(2)
+  .find((value) => value.startsWith("--output="));
+const inputs = process.argv
+  .slice(2)
+  .filter((value) => !value.startsWith("--output="));
+if (!outputArgument || inputs.length === 0) {
+  throw new ElizaError(
+    "usage: timing-report-merge --output=<matrix.json> <shard-report.json>...",
+    { code: "TIMING_REPORT_MERGE_CLI_INVALID_ARGUMENT" },
+  );
+}
+const output = path.resolve(outputArgument.slice("--output=".length));
+const matrix = mergeTimingReports(inputs);
+fs.mkdirSync(path.dirname(output), { recursive: true });
+fs.writeFileSync(output, `${JSON.stringify(matrix, null, 2)}\n`, "utf8");
+process.stdout.write(
+  `${JSON.stringify(matrix.cells.map((cell) => ({ dataset: cell.dataset, backend: cell.backend, requestedModel: cell.requestedModel, acceptedRows: cell.acceptedRows, excludedRows: cell.excludedRows, malformedRows: cell.malformedRows, accuracy: cell.metrics.accuracy })))}\nmatrix: ${output}\n`,
+);

--- a/packages/scenario-runner/src/timing-report-merge.test.ts
+++ b/packages/scenario-runner/src/timing-report-merge.test.ts
@@ -1,4 +1,5 @@
 /** Tests shard coverage and matrix aggregation against real temporary files. */
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +16,7 @@ function writeShard(options: {
   input: string;
   shardIndex: number;
   predictions: TimingPrediction[];
+  failures?: TimingReport["failures"];
 }): string {
   const summary = summarizeTimingPredictions(options.predictions);
   const report: TimingReport = {
@@ -22,6 +24,9 @@ function writeShard(options: {
     status: "complete",
     dataset: "duke-trust-lab/When2Speak",
     input: options.input,
+    inputSha256: createHash("sha256")
+      .update(fs.readFileSync(options.input))
+      .digest("hex"),
     provider: "cli",
     requestedModel: "test-model",
     backend: "test-backend",
@@ -37,7 +42,7 @@ function writeShard(options: {
     ...summary,
     predictions: options.predictions,
     exclusions: [],
-    failures: [],
+    failures: options.failures ?? [],
   };
   const file = path.join(options.directory, `shard-${options.shardIndex}.json`);
   fs.writeFileSync(file, JSON.stringify(report), "utf8");
@@ -140,7 +145,7 @@ describe("timing report merger", () => {
       shardIndex: 1,
       predictions: [
         {
-          row: 3,
+          row: 4,
           gold: "SILENT",
           predicted: "SILENT",
           directlyAddressesAgent: true,
@@ -152,5 +157,125 @@ describe("timing report merger", () => {
     expect(() => mergeTimingReports([first, second])).toThrow(
       "does not cover every physical input row",
     );
+  });
+
+  it("rejects rows assigned to the wrong shard", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 2,
+          gold: "SPEAK",
+          predicted: "SPEAK",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    const second = writeShard({
+      directory,
+      input,
+      shardIndex: 1,
+      predictions: [
+        {
+          row: 1,
+          gold: "SILENT",
+          predicted: "SILENT",
+          directlyAddressesAgent: true,
+          speakerCount: 3,
+          contextTurns: 6,
+        },
+      ],
+    });
+    expect(() => mergeTimingReports([first, second])).toThrow(
+      "does not belong to its reported shard",
+    );
+  });
+
+  it("rejects reports after the source changes at the same path", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 1,
+          gold: "SPEAK",
+          predicted: "SPEAK",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    const second = writeShard({
+      directory,
+      input,
+      shardIndex: 1,
+      predictions: [
+        {
+          row: 2,
+          gold: "SILENT",
+          predicted: "SILENT",
+          directlyAddressesAgent: true,
+          speakerCount: 3,
+          contextTurns: 6,
+        },
+      ],
+    });
+    fs.writeFileSync(input, '{"changed":true}\n{}\n', "utf8");
+    expect(() => mergeTimingReports([first, second])).toThrow(
+      "input content does not match",
+    );
+  });
+
+  it("counts an internal blank line as a malformed physical row", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 1,
+          gold: "SPEAK",
+          predicted: "SPEAK",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+        {
+          row: 3,
+          gold: "SILENT",
+          predicted: "SILENT",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    const second = writeShard({
+      directory,
+      input,
+      shardIndex: 1,
+      predictions: [],
+      failures: [{ row: 2, error: "blank row" }],
+    });
+    expect(mergeTimingReports([first, second]).cells[0]).toMatchObject({
+      physicalRows: 3,
+      acceptedRows: 2,
+      malformedRows: 1,
+    });
   });
 });

--- a/packages/scenario-runner/src/timing-report-merge.test.ts
+++ b/packages/scenario-runner/src/timing-report-merge.test.ts
@@ -1,0 +1,156 @@
+/** Tests shard coverage and matrix aggregation against real temporary files. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { mergeTimingReports } from "./timing-report-merge.ts";
+import {
+  summarizeTimingPredictions,
+  type TimingPrediction,
+  type TimingReport,
+} from "./when2speak-eval.ts";
+
+function writeShard(options: {
+  directory: string;
+  input: string;
+  shardIndex: number;
+  predictions: TimingPrediction[];
+}): string {
+  const summary = summarizeTimingPredictions(options.predictions);
+  const report: TimingReport = {
+    schema: 2,
+    status: "complete",
+    dataset: "duke-trust-lab/When2Speak",
+    input: options.input,
+    provider: "cli",
+    requestedModel: "test-model",
+    backend: "test-backend",
+    trajectoryDir: path.join(options.directory, "trajectories"),
+    selection: {
+      shardIndex: options.shardIndex,
+      shardCount: 2,
+      startRow: 1,
+      limit: null,
+    },
+    startedAt: "2026-08-24T00:00:00.000Z",
+    finishedAt: "2026-08-24T00:01:00.000Z",
+    ...summary,
+    predictions: options.predictions,
+    exclusions: [],
+    failures: [],
+  };
+  const file = path.join(options.directory, `shard-${options.shardIndex}.json`);
+  fs.writeFileSync(file, JSON.stringify(report), "utf8");
+  return file;
+}
+
+describe("timing report merger", () => {
+  it("proves complete non-overlapping shard coverage", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 1,
+          gold: "SPEAK",
+          predicted: "SPEAK",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    const second = writeShard({
+      directory,
+      input,
+      shardIndex: 1,
+      predictions: [
+        {
+          row: 2,
+          gold: "SILENT",
+          predicted: "SILENT",
+          directlyAddressesAgent: true,
+          speakerCount: 3,
+          contextTurns: 6,
+        },
+      ],
+    });
+    const matrix = mergeTimingReports([second, first]);
+    expect(matrix.cells).toHaveLength(1);
+    expect(matrix.cells[0]).toMatchObject({
+      physicalRows: 2,
+      acceptedRows: 2,
+      excludedRows: 0,
+      malformedRows: 0,
+      rejectedRows: 0,
+      metrics: { total: 2, correct: 2, accuracy: 1 },
+    });
+  });
+
+  it("rejects a matrix with a missing shard", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 1,
+          gold: "SPEAK",
+          predicted: "SILENT",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    expect(() => mergeTimingReports([first])).toThrow(
+      "missing required shards",
+    );
+  });
+
+  it("rejects equal-cardinality coverage with an out-of-range row", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "timing-merge-"));
+    const input = path.join(directory, "input.jsonl");
+    fs.writeFileSync(input, "{}\n{}\n", "utf8");
+    const first = writeShard({
+      directory,
+      input,
+      shardIndex: 0,
+      predictions: [
+        {
+          row: 1,
+          gold: "SPEAK",
+          predicted: "SPEAK",
+          directlyAddressesAgent: false,
+          speakerCount: 2,
+          contextTurns: 3,
+        },
+      ],
+    });
+    const second = writeShard({
+      directory,
+      input,
+      shardIndex: 1,
+      predictions: [
+        {
+          row: 3,
+          gold: "SILENT",
+          predicted: "SILENT",
+          directlyAddressesAgent: true,
+          speakerCount: 3,
+          contextTurns: 6,
+        },
+      ],
+    });
+    expect(() => mergeTimingReports([first, second])).toThrow(
+      "does not cover every physical input row",
+    );
+  });
+});

--- a/packages/scenario-runner/src/timing-report-merge.ts
+++ b/packages/scenario-runner/src/timing-report-merge.ts
@@ -3,10 +3,12 @@
  * merger rereads each source JSONL and refuses missing, duplicate, partial, or
  * mixed-configuration coverage instead of extrapolating a baseline.
  */
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { ElizaError } from "@elizaos/core";
 import {
+  isTimingRowSelected,
   summarizeTimingPredictions,
   type TimingDataset,
   type TimingPrediction,
@@ -19,6 +21,7 @@ type TimingReportFragment = Pick<
   | "status"
   | "dataset"
   | "input"
+  | "inputSha256"
   | "provider"
   | "requestedModel"
   | "backend"
@@ -31,6 +34,7 @@ type TimingReportFragment = Pick<
 export interface TimingMatrixCell {
   dataset: TimingDataset;
   input: string;
+  inputSha256: string;
   provider: string;
   requestedModel: string;
   backend: string;
@@ -75,6 +79,7 @@ function isTimingPrediction(value: unknown): value is TimingPrediction {
   if (value === null || typeof value !== "object") return false;
   return (
     "row" in value &&
+    typeof value.row === "number" &&
     Number.isSafeInteger(value.row) &&
     "gold" in value &&
     (value.gold === "SPEAK" || value.gold === "SILENT") &&
@@ -96,6 +101,7 @@ function isTimingFailure(
     value !== null &&
     typeof value === "object" &&
     "row" in value &&
+    typeof value.row === "number" &&
     Number.isSafeInteger(value.row) &&
     "error" in value &&
     typeof value.error === "string"
@@ -109,6 +115,7 @@ function isTimingExclusion(
     value !== null &&
     typeof value === "object" &&
     "row" in value &&
+    typeof value.row === "number" &&
     Number.isSafeInteger(value.row) &&
     "reason" in value &&
     typeof value.reason === "string"
@@ -120,13 +127,23 @@ function isSelection(value: unknown): value is TimingReport["selection"] {
     value !== null &&
     typeof value === "object" &&
     "shardIndex" in value &&
+    typeof value.shardIndex === "number" &&
     Number.isSafeInteger(value.shardIndex) &&
     "shardCount" in value &&
+    typeof value.shardCount === "number" &&
     Number.isSafeInteger(value.shardCount) &&
+    value.shardCount > 0 &&
+    value.shardIndex >= 0 &&
+    value.shardIndex < value.shardCount &&
     "startRow" in value &&
+    typeof value.startRow === "number" &&
     Number.isSafeInteger(value.startRow) &&
+    value.startRow > 0 &&
     "limit" in value &&
-    (value.limit === null || Number.isSafeInteger(value.limit))
+    (value.limit === null ||
+      (typeof value.limit === "number" &&
+        Number.isSafeInteger(value.limit) &&
+        value.limit > 0))
   );
 }
 
@@ -154,6 +171,9 @@ function parseReport(file: string): TimingReportFragment {
     !isDataset(value.dataset) ||
     !("input" in value) ||
     typeof value.input !== "string" ||
+    !("inputSha256" in value) ||
+    typeof value.inputSha256 !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.inputSha256) ||
     !("provider" in value) ||
     typeof value.provider !== "string" ||
     !("requestedModel" in value) ||
@@ -183,6 +203,7 @@ function parseReport(file: string): TimingReportFragment {
     status: value.status,
     dataset: value.dataset,
     input: value.input,
+    inputSha256: value.inputSha256,
     provider: value.provider,
     requestedModel: value.requestedModel,
     backend: value.backend,
@@ -197,6 +218,7 @@ function cellKey(report: TimingReportFragment): string {
   return JSON.stringify([
     report.dataset,
     path.resolve(report.input),
+    report.inputSha256,
     report.provider,
     report.requestedModel,
     report.backend,
@@ -205,10 +227,9 @@ function cellKey(report: TimingReportFragment): string {
 }
 
 function countPhysicalRows(input: string): number {
-  return fs
-    .readFileSync(input, "utf8")
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0).length;
+  const lines = fs.readFileSync(input, "utf8").split(/\r?\n/);
+  if (lines.at(-1) === "") lines.pop();
+  return lines.length;
 }
 
 export function mergeTimingReports(
@@ -259,6 +280,12 @@ export function mergeTimingReports(
         );
       }
       for (const prediction of report.predictions) {
+        if (!isTimingRowSelected({ row: prediction.row, ...report.selection }))
+          throw mergeError(
+            "TIMING_REPORT_WRONG_SHARD_ROW",
+            "Timing matrix row does not belong to its reported shard",
+            { file, row: prediction.row, selection: report.selection },
+          );
         if (rows.has(prediction.row))
           throw mergeError(
             "TIMING_REPORT_DUPLICATE_ROW",
@@ -269,6 +296,12 @@ export function mergeTimingReports(
         predictions.push(prediction);
       }
       for (const failure of report.failures) {
+        if (!isTimingRowSelected({ row: failure.row, ...report.selection }))
+          throw mergeError(
+            "TIMING_REPORT_WRONG_SHARD_ROW",
+            "Timing matrix row does not belong to its reported shard",
+            { file, row: failure.row, selection: report.selection },
+          );
         if (rows.has(failure.row))
           throw mergeError(
             "TIMING_REPORT_DUPLICATE_ROW",
@@ -279,6 +312,12 @@ export function mergeTimingReports(
         malformedRows += 1;
       }
       for (const exclusion of report.exclusions) {
+        if (!isTimingRowSelected({ row: exclusion.row, ...report.selection }))
+          throw mergeError(
+            "TIMING_REPORT_WRONG_SHARD_ROW",
+            "Timing matrix row does not belong to its reported shard",
+            { file, row: exclusion.row, selection: report.selection },
+          );
         if (rows.has(exclusion.row))
           throw mergeError(
             "TIMING_REPORT_DUPLICATE_ROW",
@@ -296,6 +335,15 @@ export function mergeTimingReports(
         { missingShardIndexes: [...expectedShards] },
       );
     const input = path.resolve(first.input);
+    const currentInputSha256 = createHash("sha256")
+      .update(fs.readFileSync(input))
+      .digest("hex");
+    if (currentInputSha256 !== first.inputSha256)
+      throw mergeError(
+        "TIMING_REPORT_INPUT_CHANGED",
+        "Timing matrix input content does not match the shard reports",
+        { input, expected: first.inputSha256, actual: currentInputSha256 },
+      );
     const physicalRows = countPhysicalRows(input);
     const missingRows = Array.from(
       { length: physicalRows },
@@ -314,6 +362,7 @@ export function mergeTimingReports(
     return {
       dataset: first.dataset,
       input,
+      inputSha256: first.inputSha256,
       provider: first.provider,
       requestedModel: first.requestedModel,
       backend: first.backend,

--- a/packages/scenario-runner/src/timing-report-merge.ts
+++ b/packages/scenario-runner/src/timing-report-merge.ts
@@ -1,0 +1,338 @@
+/**
+ * Merges complete timing-evaluation shards into auditable model cells. The
+ * merger rereads each source JSONL and refuses missing, duplicate, partial, or
+ * mixed-configuration coverage instead of extrapolating a baseline.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import {
+  summarizeTimingPredictions,
+  type TimingDataset,
+  type TimingPrediction,
+  type TimingReport,
+} from "./when2speak-eval.ts";
+
+type TimingReportFragment = Pick<
+  TimingReport,
+  | "schema"
+  | "status"
+  | "dataset"
+  | "input"
+  | "provider"
+  | "requestedModel"
+  | "backend"
+  | "selection"
+  | "predictions"
+  | "exclusions"
+  | "failures"
+>;
+
+export interface TimingMatrixCell {
+  dataset: TimingDataset;
+  input: string;
+  provider: string;
+  requestedModel: string;
+  backend: string;
+  shardCount: number;
+  sourceReports: string[];
+  physicalRows: number;
+  acceptedRows: number;
+  excludedRows: number;
+  malformedRows: number;
+  rejectedRows: number;
+  metrics: TimingReport["metrics"];
+  slices: TimingReport["slices"];
+}
+
+export interface TimingMatrixReport {
+  schema: 1;
+  generatedAt: string;
+  cells: TimingMatrixCell[];
+}
+
+function mergeError(
+  code: string,
+  message: string,
+  context?: Record<string, unknown>,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    ...(context === undefined ? {} : { context }),
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function isDataset(value: unknown): value is TimingDataset {
+  return (
+    value === "duke-trust-lab/When2Speak" ||
+    value === "mookiezi/Discord-Dialogues"
+  );
+}
+
+function isTimingPrediction(value: unknown): value is TimingPrediction {
+  if (value === null || typeof value !== "object") return false;
+  return (
+    "row" in value &&
+    Number.isSafeInteger(value.row) &&
+    "gold" in value &&
+    (value.gold === "SPEAK" || value.gold === "SILENT") &&
+    "predicted" in value &&
+    (value.predicted === "SPEAK" || value.predicted === "SILENT") &&
+    "directlyAddressesAgent" in value &&
+    typeof value.directlyAddressesAgent === "boolean" &&
+    "speakerCount" in value &&
+    Number.isSafeInteger(value.speakerCount) &&
+    "contextTurns" in value &&
+    Number.isSafeInteger(value.contextTurns)
+  );
+}
+
+function isTimingFailure(
+  value: unknown,
+): value is TimingReport["failures"][number] {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "row" in value &&
+    Number.isSafeInteger(value.row) &&
+    "error" in value &&
+    typeof value.error === "string"
+  );
+}
+
+function isTimingExclusion(
+  value: unknown,
+): value is TimingReport["exclusions"][number] {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "row" in value &&
+    Number.isSafeInteger(value.row) &&
+    "reason" in value &&
+    typeof value.reason === "string"
+  );
+}
+
+function isSelection(value: unknown): value is TimingReport["selection"] {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "shardIndex" in value &&
+    Number.isSafeInteger(value.shardIndex) &&
+    "shardCount" in value &&
+    Number.isSafeInteger(value.shardCount) &&
+    "startRow" in value &&
+    Number.isSafeInteger(value.startRow) &&
+    "limit" in value &&
+    (value.limit === null || Number.isSafeInteger(value.limit))
+  );
+}
+
+function parseReport(file: string): TimingReportFragment {
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (cause) {
+    // error-policy:J2 Report I/O or JSON failures retain the source path.
+    throw mergeError(
+      "TIMING_REPORT_READ_FAILED",
+      "Failed to read timing shard report",
+      { file },
+      cause,
+    );
+  }
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("schema" in value) ||
+    value.schema !== 2 ||
+    !("status" in value) ||
+    (value.status !== "in-progress" && value.status !== "complete") ||
+    !("dataset" in value) ||
+    !isDataset(value.dataset) ||
+    !("input" in value) ||
+    typeof value.input !== "string" ||
+    !("provider" in value) ||
+    typeof value.provider !== "string" ||
+    !("requestedModel" in value) ||
+    typeof value.requestedModel !== "string" ||
+    !("backend" in value) ||
+    typeof value.backend !== "string" ||
+    !("selection" in value) ||
+    !isSelection(value.selection) ||
+    !("predictions" in value) ||
+    !Array.isArray(value.predictions) ||
+    !value.predictions.every(isTimingPrediction) ||
+    !("exclusions" in value) ||
+    !Array.isArray(value.exclusions) ||
+    !value.exclusions.every(isTimingExclusion) ||
+    !("failures" in value) ||
+    !Array.isArray(value.failures) ||
+    !value.failures.every(isTimingFailure)
+  ) {
+    throw mergeError(
+      "TIMING_REPORT_INVALID",
+      "Timing shard report has an invalid schema",
+      { file },
+    );
+  }
+  return {
+    schema: value.schema,
+    status: value.status,
+    dataset: value.dataset,
+    input: value.input,
+    provider: value.provider,
+    requestedModel: value.requestedModel,
+    backend: value.backend,
+    selection: value.selection,
+    predictions: value.predictions,
+    exclusions: value.exclusions,
+    failures: value.failures,
+  };
+}
+
+function cellKey(report: TimingReportFragment): string {
+  return JSON.stringify([
+    report.dataset,
+    path.resolve(report.input),
+    report.provider,
+    report.requestedModel,
+    report.backend,
+    report.selection.shardCount,
+  ]);
+}
+
+function countPhysicalRows(input: string): number {
+  return fs
+    .readFileSync(input, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0).length;
+}
+
+export function mergeTimingReports(
+  files: readonly string[],
+): TimingMatrixReport {
+  if (files.length === 0)
+    throw mergeError(
+      "TIMING_REPORTS_EMPTY",
+      "At least one timing shard report is required",
+    );
+  const groups = new Map<
+    string,
+    Array<{ file: string; report: TimingReportFragment }>
+  >();
+  for (const inputFile of files) {
+    const file = path.resolve(inputFile);
+    const report = parseReport(file);
+    const entries = groups.get(cellKey(report)) ?? [];
+    entries.push({ file, report });
+    groups.set(cellKey(report), entries);
+  }
+  const cells = [...groups.values()].map((entries): TimingMatrixCell => {
+    const first = entries[0].report;
+    const expectedShards = new Set(
+      Array.from({ length: first.selection.shardCount }, (_, index) => index),
+    );
+    const rows = new Set<number>();
+    const predictions: TimingPrediction[] = [];
+    let excludedRows = 0;
+    let malformedRows = 0;
+    for (const { file, report } of entries) {
+      if (
+        report.status !== "complete" ||
+        report.selection.startRow !== 1 ||
+        report.selection.limit !== null
+      ) {
+        throw mergeError(
+          "TIMING_REPORT_PARTIAL",
+          "Matrix cells require complete, unbounded shards starting at row 1",
+          { file, status: report.status, selection: report.selection },
+        );
+      }
+      if (!expectedShards.delete(report.selection.shardIndex)) {
+        throw mergeError(
+          "TIMING_REPORT_DUPLICATE_SHARD",
+          "Timing matrix cell has a duplicate or invalid shard index",
+          { file, shardIndex: report.selection.shardIndex },
+        );
+      }
+      for (const prediction of report.predictions) {
+        if (rows.has(prediction.row))
+          throw mergeError(
+            "TIMING_REPORT_DUPLICATE_ROW",
+            "Timing matrix cell contains a duplicate physical row",
+            { file, row: prediction.row },
+          );
+        rows.add(prediction.row);
+        predictions.push(prediction);
+      }
+      for (const failure of report.failures) {
+        if (rows.has(failure.row))
+          throw mergeError(
+            "TIMING_REPORT_DUPLICATE_ROW",
+            "Timing matrix cell contains a duplicate physical row",
+            { file, row: failure.row },
+          );
+        rows.add(failure.row);
+        malformedRows += 1;
+      }
+      for (const exclusion of report.exclusions) {
+        if (rows.has(exclusion.row))
+          throw mergeError(
+            "TIMING_REPORT_DUPLICATE_ROW",
+            "Timing matrix cell contains a duplicate physical row",
+            { file, row: exclusion.row },
+          );
+        rows.add(exclusion.row);
+        excludedRows += 1;
+      }
+    }
+    if (expectedShards.size > 0)
+      throw mergeError(
+        "TIMING_REPORT_MISSING_SHARD",
+        "Timing matrix cell is missing required shards",
+        { missingShardIndexes: [...expectedShards] },
+      );
+    const input = path.resolve(first.input);
+    const physicalRows = countPhysicalRows(input);
+    const missingRows = Array.from(
+      { length: physicalRows },
+      (_, index) => index + 1,
+    ).filter((row) => !rows.has(row));
+    const outOfRangeRows = [...rows].filter(
+      (row) => row < 1 || row > physicalRows,
+    );
+    if (missingRows.length > 0 || outOfRangeRows.length > 0)
+      throw mergeError(
+        "TIMING_REPORT_INCOMPLETE_COVERAGE",
+        "Timing matrix cell does not cover every physical input row",
+        { coveredRows: rows.size, physicalRows, missingRows, outOfRangeRows },
+      );
+    const summary = summarizeTimingPredictions(predictions);
+    return {
+      dataset: first.dataset,
+      input,
+      provider: first.provider,
+      requestedModel: first.requestedModel,
+      backend: first.backend,
+      shardCount: first.selection.shardCount,
+      sourceReports: entries.map(({ file }) => file).sort(),
+      physicalRows,
+      acceptedRows: predictions.length,
+      excludedRows,
+      malformedRows,
+      rejectedRows: excludedRows + malformedRows,
+      ...summary,
+    };
+  });
+  cells.sort((left, right) =>
+    [left.dataset, left.backend, left.requestedModel]
+      .join("\0")
+      .localeCompare(
+        [right.dataset, right.backend, right.requestedModel].join("\0"),
+      ),
+  );
+  return { schema: 1, generatedAt: new Date().toISOString(), cells };
+}

--- a/packages/scenario-runner/src/when2speak-eval-cli.ts
+++ b/packages/scenario-runner/src/when2speak-eval-cli.ts
@@ -2,8 +2,14 @@
 /** Runs the When2Speak Stage-1 batch evaluator and writes its evidence report. */
 import fs from "node:fs";
 import path from "node:path";
+import { ElizaError } from "@elizaos/core";
 import type { LiveProviderName } from "@elizaos/core/testing";
+import type { TimingInputFormat, TimingReport } from "./when2speak-eval.ts";
 import { runWhen2SpeakEval } from "./when2speak-eval.ts";
+
+function usageError(message: string): ElizaError {
+  return new ElizaError(message, { code: "WHEN2SPEAK_CLI_INVALID_ARGUMENT" });
+}
 
 function option(name: string): string | undefined {
   const prefix = `--${name}=`;
@@ -14,13 +20,39 @@ function option(name: string): string | undefined {
 }
 const input = option("input");
 if (!input)
-  throw new Error(
-    "usage: when2speak-eval --input=<jsonl> [--output=<json>] [--run-dir=<dir>] [--provider=<name>] [--limit=<n>]",
+  throw usageError(
+    "usage: when2speak-eval --input=<jsonl> [--input-format=when2speak|discord-replay] [--output=<json>] [--run-dir=<dir>] [--provider=<name>] [--limit=<n>] [--shard-index=<n> --shard-count=<n>] [--start-row=<n>] [--checkpoint-every=<n>] [--resume=<in-progress-report>]",
   );
+function positiveInteger(name: string): number | undefined {
+  const text = option(name);
+  if (text === undefined) return undefined;
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value <= 0)
+    throw usageError(`--${name} must be a positive integer`);
+  return value;
+}
 const limitText = option("limit");
 const limit = limitText === undefined ? undefined : Number(limitText);
 if (limit !== undefined && (!Number.isSafeInteger(limit) || limit <= 0))
-  throw new Error("--limit must be a positive integer");
+  throw usageError("--limit must be a positive integer");
+const inputFormatText = option("input-format") ?? "when2speak";
+if (inputFormatText !== "when2speak" && inputFormatText !== "discord-replay")
+  throw usageError("--input-format must be when2speak or discord-replay");
+const inputFormat: TimingInputFormat = inputFormatText;
+const shardCount = positiveInteger("shard-count") ?? 1;
+const shardIndexText = option("shard-index");
+const shardIndex = shardIndexText === undefined ? 0 : Number(shardIndexText);
+if (
+  !Number.isSafeInteger(shardIndex) ||
+  shardIndex < 0 ||
+  shardIndex >= shardCount
+)
+  throw usageError(
+    `--shard-index must be an integer from 0 through ${shardCount - 1}`,
+  );
+const startRow = positiveInteger("start-row") ?? 1;
+const checkpointEvery = positiveInteger("checkpoint-every") ?? 1;
+const resume = option("resume");
 const output = path.resolve(
   option("output") ?? "../../reports/group-chat-timing/when2speak.json",
 );
@@ -40,16 +72,41 @@ if (
   providerText !== undefined &&
   !liveProviders.has(providerText as LiveProviderName)
 ) {
-  throw new Error(`unsupported --provider=${providerText}`);
+  throw usageError(`unsupported --provider=${providerText}`);
 }
 const provider = providerText as LiveProviderName | undefined;
+let resumeReport: unknown;
+if (resume !== undefined) {
+  try {
+    resumeReport = JSON.parse(fs.readFileSync(path.resolve(resume), "utf8"));
+  } catch (cause) {
+    // error-policy:J2 Resume input failures retain the requested path.
+    throw new ElizaError("Failed to read the When2Speak resume report", {
+      code: "WHEN2SPEAK_RESUME_READ_FAILED",
+      context: { resume: path.resolve(resume) },
+      cause,
+    });
+  }
+}
+function writeReport(report: TimingReport): void {
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  const temporary = `${output}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.renameSync(temporary, output);
+}
 const report = await runWhen2SpeakEval({
   input: path.resolve(input),
   trajectoryDir,
   provider,
+  inputFormat,
   limit,
+  shardIndex,
+  shardCount,
+  startRow,
+  checkpointEvery,
+  resumeReport,
+  onCheckpoint: writeReport,
 });
-fs.mkdirSync(path.dirname(output), { recursive: true });
-fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeReport(report);
 process.stdout.write(`${JSON.stringify(report.metrics)}\nreport: ${output}\n`);
 if (report.failures.length > 0) process.exitCode = 1;

--- a/packages/scenario-runner/src/when2speak-eval.test.ts
+++ b/packages/scenario-runner/src/when2speak-eval.test.ts
@@ -2,8 +2,11 @@
 import { describe, expect, it } from "vitest";
 import {
   computeTimingMetrics,
+  isTimingRowSelected,
+  parseDiscordReplayLine,
   parseWhen2SpeakLine,
   summarizeTimingPredictions,
+  validateTimingResumeRows,
 } from "./when2speak-eval.ts";
 
 describe("When2Speak evaluator", () => {
@@ -41,6 +44,40 @@ describe("When2Speak evaluator", () => {
         3,
       ),
     ).toThrow("unparseable speaker turn");
+  });
+  it("maps a Discord target seat onto the runtime agent seat", () => {
+    const row = parseDiscordReplayLine(
+      JSON.stringify({
+        schemaVersion: 1,
+        targetSpeaker: "participant_b",
+        label: "speak",
+        turns: [
+          { speaker: "participant_b", text: "earlier agent turn" },
+          { speaker: "participant_a", text: "current inbound turn" },
+        ],
+      }),
+      9,
+    );
+    expect(row).toMatchObject({
+      row: 9,
+      label: "SPEAK",
+      directlyAddressesAgent: false,
+      speakerCount: 2,
+    });
+    expect(row.turns.map((turn) => turn.isAgent)).toEqual([true, false]);
+  });
+  it("rejects Discord pseudo-labels where the target authored the current turn", () => {
+    expect(() =>
+      parseDiscordReplayLine(
+        JSON.stringify({
+          schemaVersion: 1,
+          targetSpeaker: "participant_a",
+          label: "silent",
+          turns: [{ speaker: "participant_a", text: "own outbound turn" }],
+        }),
+        10,
+      ),
+    ).toThrow("target seat authored the current turn");
   });
   it("computes SPEAK and intervention metrics", () => {
     expect(
@@ -102,5 +139,36 @@ describe("When2Speak evaluator", () => {
       total: 1,
       trueSilent: 1,
     });
+  });
+  it("partitions physical rows into stable resumable shards", () => {
+    const selected = Array.from({ length: 10 }, (_, index) => index + 1).filter(
+      (row) =>
+        isTimingRowSelected({
+          row,
+          startRow: 4,
+          shardIndex: 1,
+          shardCount: 3,
+        }),
+    );
+    expect(selected).toEqual([5, 8]);
+  });
+
+  it("rejects duplicate or gapped checkpoint rows before resuming", () => {
+    expect(() =>
+      validateTimingResumeRows({
+        rows: [1, 3],
+        startRow: 1,
+        shardIndex: 0,
+        shardCount: 1,
+      }),
+    ).toThrow("duplicate, gapped, or out of order");
+    expect(
+      validateTimingResumeRows({
+        rows: [2, 4, 6],
+        startRow: 1,
+        shardIndex: 1,
+        shardCount: 2,
+      }),
+    ).toBe(6);
   });
 });

--- a/packages/scenario-runner/src/when2speak-eval.ts
+++ b/packages/scenario-runner/src/when2speak-eval.ts
@@ -3,6 +3,7 @@
  * response handler. Malformed rows fail before inference; accepted dialogue
  * is never truncated or windowed.
  */
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
@@ -62,6 +63,7 @@ export interface TimingReport {
   status: "in-progress" | "complete";
   dataset: TimingDataset;
   input: string;
+  inputSha256: string;
   provider: string;
   requestedModel: string;
   backend: string;
@@ -423,6 +425,7 @@ function hasTimingRow(value: unknown): value is { row: number } {
     value !== null &&
     typeof value === "object" &&
     "row" in value &&
+    typeof value.row === "number" &&
     Number.isSafeInteger(value.row) &&
     value.row > 0
   );
@@ -491,6 +494,7 @@ export function validateTimingResumeRows(options: {
 function validateResumeReport(options: {
   value: unknown;
   input: string;
+  inputSha256: string;
   dataset: TimingDataset;
   provider: string;
   requestedModel: string;
@@ -513,6 +517,8 @@ function validateResumeReport(options: {
     value.dataset !== options.dataset ||
     !("input" in value) ||
     path.resolve(String(value.input)) !== options.input ||
+    !("inputSha256" in value) ||
+    value.inputSha256 !== options.inputSha256 ||
     !("provider" in value) ||
     value.provider !== options.provider ||
     !("requestedModel" in value) ||
@@ -575,6 +581,7 @@ export async function runWhen2SpeakEval(options: {
   const shardIndex = options.shardIndex ?? 0;
   const shardCount = options.shardCount ?? 1;
   const startRow = options.startRow ?? 1;
+  const checkpointEvery = options.checkpointEvery;
   if (
     !Number.isSafeInteger(shardCount) ||
     shardCount <= 0 ||
@@ -582,13 +589,27 @@ export async function runWhen2SpeakEval(options: {
     shardIndex < 0 ||
     shardIndex >= shardCount ||
     !Number.isSafeInteger(startRow) ||
-    startRow <= 0
+    startRow <= 0 ||
+    (options.limit !== undefined &&
+      (!Number.isSafeInteger(options.limit) || options.limit <= 0)) ||
+    (checkpointEvery !== undefined &&
+      (!Number.isSafeInteger(checkpointEvery) || checkpointEvery <= 0))
   ) {
     throw new ElizaError("Invalid When2Speak row selection", {
       code: "WHEN2SPEAK_INVALID_SELECTION",
-      context: { shardIndex, shardCount, startRow },
+      context: {
+        shardIndex,
+        shardCount,
+        startRow,
+        limit: options.limit,
+        checkpointEvery,
+      },
     });
   }
+  const input = path.resolve(options.input);
+  const inputSha256 = createHash("sha256")
+    .update(fs.readFileSync(input))
+    .digest("hex");
   let startedAt = new Date().toISOString();
   const previousTrajectoryDir = process.env.ELIZA_TRAJECTORY_DIR;
   const trajectoryDir = path.resolve(options.trajectoryDir);
@@ -629,7 +650,8 @@ export async function runWhen2SpeakEval(options: {
     runtimeResult.providerName;
   const resumeReport = validateResumeReport({
     value: options.resumeReport,
-    input: path.resolve(options.input),
+    input,
+    inputSha256,
     dataset,
     provider: runtimeResult.providerName,
     requestedModel,
@@ -657,7 +679,8 @@ export async function runWhen2SpeakEval(options: {
       schema: 2,
       status,
       dataset,
-      input: path.resolve(options.input),
+      input,
+      inputSha256,
       provider: runtimeResult.providerName,
       requestedModel,
       backend,
@@ -688,7 +711,6 @@ export async function runWhen2SpeakEval(options: {
     let row = 0;
     for await (const line of lines) {
       row += 1;
-      if (!line.trim()) continue;
       if (row <= lastCoveredRow) continue;
       if (!isTimingRowSelected({ row, startRow, shardIndex, shardCount }))
         continue;
@@ -751,6 +773,15 @@ export async function runWhen2SpeakEval(options: {
     } else {
       process.env.ELIZA_TRAJECTORY_DIR = previousTrajectoryDir;
     }
+  }
+  const finishedInputSha256 = createHash("sha256")
+    .update(fs.readFileSync(input))
+    .digest("hex");
+  if (finishedInputSha256 !== inputSha256) {
+    throw new ElizaError("When2Speak input changed during evaluation", {
+      code: "WHEN2SPEAK_INPUT_CHANGED",
+      context: { input, inputSha256, finishedInputSha256 },
+    });
   }
   return report("complete");
 }

--- a/packages/scenario-runner/src/when2speak-eval.ts
+++ b/packages/scenario-runner/src/when2speak-eval.ts
@@ -19,9 +19,13 @@ import type { LiveProviderName } from "@elizaos/core/testing";
 import { createScenarioRuntime } from "./runtime-factory.ts";
 
 export type TimingLabel = "SPEAK" | "SILENT";
+export type TimingDataset =
+  | "duke-trust-lab/When2Speak"
+  | "mookiezi/Discord-Dialogues";
+export type TimingInputFormat = "when2speak" | "discord-replay";
 export interface When2SpeakExample {
   row: number;
-  turns: Array<{ speaker: string; text: string }>;
+  turns: Array<{ speaker: string; text: string; isAgent: boolean }>;
   label: TimingLabel;
   directlyAddressesAgent: boolean;
   speakerCount: number;
@@ -54,11 +58,20 @@ export interface TimingPrediction {
   contextTurns: number;
 }
 export interface TimingReport {
-  schema: 1;
-  dataset: "duke-trust-lab/When2Speak";
+  schema: 2;
+  status: "in-progress" | "complete";
+  dataset: TimingDataset;
   input: string;
   provider: string;
+  requestedModel: string;
+  backend: string;
   trajectoryDir: string;
+  selection: {
+    shardIndex: number;
+    shardCount: number;
+    startRow: number;
+    limit: number | null;
+  };
   startedAt: string;
   finishedAt: string;
   metrics: TimingMetrics;
@@ -68,10 +81,12 @@ export interface TimingReport {
     contextTurns: Record<string, TimingMetrics>;
   };
   predictions: TimingPrediction[];
+  exclusions: Array<{ row: number; reason: string }>;
   failures: Array<{ row: number; error: string }>;
 }
 
 type CorpusMessage = { role: "user" | "assistant"; content: string };
+type DiscordSeat = "participant_a" | "participant_b";
 function invalidCorpusRow(
   row: number,
   message: string,
@@ -133,14 +148,76 @@ export function parseWhen2SpeakLine(
       row,
       "contains an assistant turn inside the context",
     );
-  const turns = contextMessages.map((message) =>
-    parseSpeakerTurn(message.content, row),
-  );
+  const turns = contextMessages.map((message) => ({
+    ...parseSpeakerTurn(message.content, row),
+    isAgent: false,
+  }));
   return {
     row,
     turns,
     label: labelMessage.content.trim() === ">" ? "SILENT" : "SPEAK",
     directlyAddressesAgent: turns.some((turn) => turn.text.includes("[AGENT]")),
+    speakerCount: new Set(turns.map((turn) => turn.speaker)).size,
+  };
+}
+
+function isDiscordSeat(value: unknown): value is DiscordSeat {
+  return value === "participant_a" || value === "participant_b";
+}
+
+/** Parses the pinned Discord converter's observational replay boundary. */
+export function parseDiscordReplayLine(
+  line: string,
+  row: number,
+): When2SpeakExample {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (cause) {
+    // error-policy:J3 Discord replay JSON is untrusted input; reject explicitly.
+    throw invalidCorpusRow(row, "is not valid Discord replay JSON", cause);
+  }
+  if (parsed === null || typeof parsed !== "object")
+    throw invalidCorpusRow(row, "must be a Discord replay object");
+  const record = parsed as Record<string, unknown>;
+  if (
+    record.schemaVersion !== 1 ||
+    !isDiscordSeat(record.targetSpeaker) ||
+    (record.label !== "speak" && record.label !== "silent") ||
+    !Array.isArray(record.turns) ||
+    record.turns.length === 0
+  ) {
+    throw invalidCorpusRow(row, "has an invalid Discord replay envelope");
+  }
+  const targetSpeaker = record.targetSpeaker;
+  const turns = record.turns.map((value) => {
+    if (value === null || typeof value !== "object")
+      throw invalidCorpusRow(row, "has a non-object Discord replay turn");
+    const turn = value as Record<string, unknown>;
+    if (!isDiscordSeat(turn.speaker) || typeof turn.text !== "string")
+      throw invalidCorpusRow(row, "has an invalid Discord replay turn");
+    if (!turn.text.trim())
+      throw invalidCorpusRow(row, "has an empty Discord replay turn");
+    return {
+      speaker: turn.speaker,
+      text: turn.text,
+      isAgent: turn.speaker === targetSpeaker,
+    };
+  });
+  if (turns[turns.length - 1].isAgent) {
+    throw new ElizaError(
+      `Timing row ${row} is ineligible because the Discord target seat authored the current turn`,
+      {
+        code: "TIMING_ROW_INELIGIBLE",
+        context: { row, reason: "target-seat-authored-current-turn" },
+      },
+    );
+  }
+  return {
+    row,
+    turns,
+    label: record.label === "speak" ? "SPEAK" : "SILENT",
+    directlyAddressesAgent: false,
     speakerCount: new Set(turns.map((turn) => turn.speaker)).size,
   };
 }
@@ -225,13 +302,15 @@ function stateForExample(
   const memories = example.turns.map(
     (turn, index): Memory => ({
       id: stringToUuid(`when2speak-${example.row}-turn-${index}`),
-      entityId: stringToUuid(`when2speak-${example.row}-${turn.speaker}`),
+      entityId: turn.isAgent
+        ? runtime.agentId
+        : stringToUuid(`when2speak-${example.row}-${turn.speaker}`),
       agentId: runtime.agentId,
       roomId,
       createdAt: index + 1,
       content: {
         text: turn.text.replaceAll("[AGENT]", agentName),
-        senderName: turn.speaker,
+        senderName: turn.isAgent ? agentName : turn.speaker,
         source: "when2speak-eval",
         channelType: ChannelType.GROUP,
       },
@@ -317,13 +396,200 @@ export function summarizeTimingPredictions(
     },
   };
 }
+export function isTimingRowSelected(options: {
+  row: number;
+  startRow: number;
+  shardIndex: number;
+  shardCount: number;
+}): boolean {
+  return (
+    options.row >= options.startRow &&
+    (options.row - 1) % options.shardCount === options.shardIndex
+  );
+}
+
+function resumeError(
+  message: string,
+  context?: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(message, {
+    code: "WHEN2SPEAK_INVALID_RESUME_REPORT",
+    ...(context === undefined ? {} : { context }),
+  });
+}
+
+function hasTimingRow(value: unknown): value is { row: number } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "row" in value &&
+    Number.isSafeInteger(value.row) &&
+    value.row > 0
+  );
+}
+
+function isResumePrediction(value: unknown): value is TimingPrediction {
+  return (
+    hasTimingRow(value) &&
+    "gold" in value &&
+    (value.gold === "SPEAK" || value.gold === "SILENT") &&
+    "predicted" in value &&
+    (value.predicted === "SPEAK" || value.predicted === "SILENT") &&
+    "directlyAddressesAgent" in value &&
+    typeof value.directlyAddressesAgent === "boolean" &&
+    "speakerCount" in value &&
+    Number.isSafeInteger(value.speakerCount) &&
+    "contextTurns" in value &&
+    Number.isSafeInteger(value.contextTurns)
+  );
+}
+
+function isResumeExclusion(
+  value: unknown,
+): value is TimingReport["exclusions"][number] {
+  return (
+    hasTimingRow(value) && "reason" in value && typeof value.reason === "string"
+  );
+}
+
+function isResumeFailure(
+  value: unknown,
+): value is TimingReport["failures"][number] {
+  return (
+    hasTimingRow(value) && "error" in value && typeof value.error === "string"
+  );
+}
+
+export function validateTimingResumeRows(options: {
+  rows: readonly number[];
+  startRow: number;
+  shardIndex: number;
+  shardCount: number;
+}): number {
+  const coveredRows = [...options.rows].sort((left, right) => left - right);
+  const lastCoveredRow = coveredRows.at(-1) ?? 0;
+  const expectedRows = Array.from(
+    { length: lastCoveredRow },
+    (_, index) => index + 1,
+  ).filter((row) => isTimingRowSelected({ row, ...options }));
+  if (
+    coveredRows.length !== new Set(coveredRows).size ||
+    coveredRows.length !== expectedRows.length ||
+    coveredRows.some((row, index) => row !== expectedRows[index])
+  ) {
+    throw resumeError(
+      "Resume report rows are duplicate, gapped, or out of order",
+      {
+        coveredRows,
+        expectedRows,
+      },
+    );
+  }
+  return lastCoveredRow;
+}
+
+function validateResumeReport(options: {
+  value: unknown;
+  input: string;
+  dataset: TimingDataset;
+  provider: string;
+  requestedModel: string;
+  backend: string;
+  shardIndex: number;
+  shardCount: number;
+  startRow: number;
+  limit?: number;
+}): TimingReport | undefined {
+  if (options.value === undefined) return undefined;
+  const value = options.value;
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("schema" in value) ||
+    value.schema !== 2 ||
+    !("status" in value) ||
+    value.status !== "in-progress" ||
+    !("dataset" in value) ||
+    value.dataset !== options.dataset ||
+    !("input" in value) ||
+    path.resolve(String(value.input)) !== options.input ||
+    !("provider" in value) ||
+    value.provider !== options.provider ||
+    !("requestedModel" in value) ||
+    value.requestedModel !== options.requestedModel ||
+    !("backend" in value) ||
+    value.backend !== options.backend ||
+    !("selection" in value) ||
+    value.selection === null ||
+    typeof value.selection !== "object" ||
+    !("shardIndex" in value.selection) ||
+    value.selection.shardIndex !== options.shardIndex ||
+    !("shardCount" in value.selection) ||
+    value.selection.shardCount !== options.shardCount ||
+    !("startRow" in value.selection) ||
+    value.selection.startRow !== options.startRow ||
+    !("limit" in value.selection) ||
+    value.selection.limit !== (options.limit ?? null) ||
+    !("startedAt" in value) ||
+    typeof value.startedAt !== "string" ||
+    !("predictions" in value) ||
+    !Array.isArray(value.predictions) ||
+    !value.predictions.every(isResumePrediction) ||
+    !("exclusions" in value) ||
+    !Array.isArray(value.exclusions) ||
+    !value.exclusions.every(isResumeExclusion) ||
+    !("failures" in value) ||
+    !Array.isArray(value.failures) ||
+    !value.failures.every(isResumeFailure)
+  ) {
+    throw resumeError(
+      "Resume report does not match the requested evaluation cell",
+    );
+  }
+  const report = value as TimingReport;
+  validateTimingResumeRows({
+    rows: [
+      ...report.predictions.map(({ row }) => row),
+      ...report.exclusions.map(({ row }) => row),
+      ...report.failures.map(({ row }) => row),
+    ],
+    startRow: options.startRow,
+    shardIndex: options.shardIndex,
+    shardCount: options.shardCount,
+  });
+  return report;
+}
 export async function runWhen2SpeakEval(options: {
   input: string;
   trajectoryDir: string;
   provider?: LiveProviderName;
+  inputFormat?: TimingInputFormat;
   limit?: number;
+  shardIndex?: number;
+  shardCount?: number;
+  startRow?: number;
+  checkpointEvery?: number;
+  onCheckpoint?: (report: TimingReport) => void | Promise<void>;
+  resumeReport?: unknown;
 }): Promise<TimingReport> {
-  const startedAt = new Date().toISOString();
+  const shardIndex = options.shardIndex ?? 0;
+  const shardCount = options.shardCount ?? 1;
+  const startRow = options.startRow ?? 1;
+  if (
+    !Number.isSafeInteger(shardCount) ||
+    shardCount <= 0 ||
+    !Number.isSafeInteger(shardIndex) ||
+    shardIndex < 0 ||
+    shardIndex >= shardCount ||
+    !Number.isSafeInteger(startRow) ||
+    startRow <= 0
+  ) {
+    throw new ElizaError("Invalid When2Speak row selection", {
+      code: "WHEN2SPEAK_INVALID_SELECTION",
+      context: { shardIndex, shardCount, startRow },
+    });
+  }
+  let startedAt = new Date().toISOString();
   const previousTrajectoryDir = process.env.ELIZA_TRAJECTORY_DIR;
   const trajectoryDir = path.resolve(options.trajectoryDir);
   process.env.ELIZA_TRAJECTORY_DIR = trajectoryDir;
@@ -347,7 +613,73 @@ export async function runWhen2SpeakEval(options: {
     });
   }
   const predictions: TimingReport["predictions"] = [];
+  const exclusions: TimingReport["exclusions"] = [];
   const failures: TimingReport["failures"] = [];
+  const inputFormat = options.inputFormat ?? "when2speak";
+  const dataset: TimingDataset =
+    inputFormat === "when2speak"
+      ? "duke-trust-lab/When2Speak"
+      : "mookiezi/Discord-Dialogues";
+  const requestedModel =
+    "largeModel" in runtimeResult.providerConfig
+      ? runtimeResult.providerConfig.largeModel
+      : "deterministic";
+  const backend =
+    runtimeResult.providerConfig.env.ELIZA_CHAT_VIA_CLI ??
+    runtimeResult.providerName;
+  const resumeReport = validateResumeReport({
+    value: options.resumeReport,
+    input: path.resolve(options.input),
+    dataset,
+    provider: runtimeResult.providerName,
+    requestedModel,
+    backend,
+    shardIndex,
+    shardCount,
+    startRow,
+    limit: options.limit,
+  });
+  if (resumeReport) {
+    startedAt = resumeReport.startedAt;
+    predictions.push(...resumeReport.predictions);
+    exclusions.push(...resumeReport.exclusions);
+    failures.push(...resumeReport.failures);
+  }
+  const lastCoveredRow = Math.max(
+    0,
+    ...predictions.map(({ row }) => row),
+    ...exclusions.map(({ row }) => row),
+    ...failures.map(({ row }) => row),
+  );
+  const report = (status: TimingReport["status"]): TimingReport => {
+    const summary = summarizeTimingPredictions(predictions);
+    return {
+      schema: 2,
+      status,
+      dataset,
+      input: path.resolve(options.input),
+      provider: runtimeResult.providerName,
+      requestedModel,
+      backend,
+      trajectoryDir,
+      selection: {
+        shardIndex,
+        shardCount,
+        startRow,
+        limit: options.limit ?? null,
+      },
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      ...summary,
+      predictions: [...predictions],
+      exclusions: [...exclusions],
+      failures: [...failures],
+    };
+  };
+  const checkpoint = async (): Promise<void> => {
+    if (!options.onCheckpoint) return;
+    await options.onCheckpoint(report("in-progress"));
+  };
   try {
     const lines = readline.createInterface({
       input: fs.createReadStream(options.input),
@@ -357,17 +689,38 @@ export async function runWhen2SpeakEval(options: {
     for await (const line of lines) {
       row += 1;
       if (!line.trim()) continue;
+      if (row <= lastCoveredRow) continue;
+      if (!isTimingRowSelected({ row, startRow, shardIndex, shardCount }))
+        continue;
       if (options.limit !== undefined && predictions.length >= options.limit)
         break;
       let example: When2SpeakExample;
       try {
-        example = parseWhen2SpeakLine(line, row);
+        example =
+          inputFormat === "when2speak"
+            ? parseWhen2SpeakLine(line, row)
+            : parseDiscordReplayLine(line, row);
       } catch (error) {
         // error-policy:J3 Malformed corpus rows become explicit rejected rows.
-        failures.push({
-          row,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        if (
+          error instanceof ElizaError &&
+          error.code === "TIMING_ROW_INELIGIBLE"
+        ) {
+          exclusions.push({ row, reason: error.message });
+        } else {
+          failures.push({
+            row,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        if (
+          options.checkpointEvery !== undefined &&
+          (predictions.length + exclusions.length + failures.length) %
+            options.checkpointEvery ===
+            0
+        ) {
+          await checkpoint();
+        }
         continue;
       }
       // Model and Stage-1 failures abort the run. Retrying every remaining row
@@ -382,6 +735,14 @@ export async function runWhen2SpeakEval(options: {
         speakerCount: example.speakerCount,
         contextTurns: example.turns.length,
       });
+      if (
+        options.checkpointEvery !== undefined &&
+        (predictions.length + exclusions.length + failures.length) %
+          options.checkpointEvery ===
+          0
+      ) {
+        await checkpoint();
+      }
     }
   } finally {
     await runtimeResult.cleanup();
@@ -391,17 +752,5 @@ export async function runWhen2SpeakEval(options: {
       process.env.ELIZA_TRAJECTORY_DIR = previousTrajectoryDir;
     }
   }
-  const summary = summarizeTimingPredictions(predictions);
-  return {
-    schema: 1,
-    dataset: "duke-trust-lab/When2Speak",
-    input: path.resolve(options.input),
-    provider: runtimeResult.providerName,
-    trajectoryDir,
-    startedAt,
-    finishedAt: new Date().toISOString(),
-    ...summary,
-    predictions,
-    failures,
-  };
+  return report("complete");
 }

--- a/packages/scripts/__tests__/run-scenarios-isolated.test.ts
+++ b/packages/scripts/__tests__/run-scenarios-isolated.test.ts
@@ -38,6 +38,7 @@ interface FixtureCase {
 }
 
 interface AggregateReport {
+  artifactsDir?: string | null;
   totals: {
     passed: number;
     failed: number;
@@ -51,10 +52,15 @@ const FAKE_BUN_SOURCE = `#!/usr/bin/env node
 import fs from "node:fs";
 
 const args = process.argv.slice(2);
-const command = args[1];
+const command = args.find((value) => value === "list" || value === "run");
 const cases = JSON.parse(process.env.ISOLATED_SCENARIO_CASES ?? "{}");
 
 if (command === "list") {
+  const requiredListArg = process.env.ISOLATED_REQUIRED_LIST_ARG;
+  if (requiredListArg && !args.includes(requiredListArg)) {
+    process.stderr.write("missing required list arg: " + requiredListArg + "\\n");
+    process.exit(2);
+  }
   process.stdout.write(Object.keys(cases).join("\\n") + "\\n");
   process.exit(0);
 }
@@ -243,6 +249,55 @@ test("zero-exit pass and fail reports retain their report semantics", () => {
     { id: "zero-passed", status: "passed", durationMs: 1 },
     { id: "zero-failed", status: "failed", durationMs: 1 },
   ]);
+});
+
+test("an exit-1 failed scenario retains its report semantics", () => {
+  const { result, report } = runFixture({
+    "exit-1-failed": { status: "failed", exitCode: 1 },
+  });
+
+  expect(result.status).toBe(1);
+  expect(report.totals).toEqual({
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    total: 1,
+  });
+  expect(report.scenarios).toEqual([
+    { id: "exit-1-failed", status: "failed", durationMs: 1 },
+  ]);
+});
+
+test("forwards file-glob selection to scenario discovery", () => {
+  const { result, report } = runFixture(
+    { selected: { status: "passed" } },
+    {
+      args: ["--file-glob", "selected/*.scenario.ts"],
+      env: { ISOLATED_REQUIRED_LIST_ARG: "selected/*.scenario.ts" },
+    },
+  );
+
+  expect(result.status).toBe(0);
+  expect(report.totals.passed).toBe(1);
+});
+
+test("retains evidence in an explicit artifacts directory", () => {
+  const artifacts = path.join(
+    tmpdir(),
+    `scenario-isolated-artifacts-${process.pid}-${Date.now()}`,
+  );
+  try {
+    const { result, report } = runFixture(
+      { retained: { status: "passed" } },
+      { args: ["--artifacts-dir", artifacts] },
+    );
+    expect(result.status).toBe(0);
+    expect(report.artifactsDir).toBe(artifacts);
+    expect(result.stderr).toContain(`retained artifacts at ${artifacts}`);
+    expect(existsSync(artifacts)).toBe(true);
+  } finally {
+    rmSync(artifacts, { recursive: true, force: true });
+  }
 });
 
 test("each child writes into a collision-free run directory", () => {

--- a/packages/scripts/run-scenarios-isolated.mjs
+++ b/packages/scripts/run-scenarios-isolated.mjs
@@ -16,7 +16,8 @@
  *     crashes, zero rate-limit accumulation inside a single runtime.
  *
  * Usage:
- *   bun packages/scripts/run-scenarios-isolated.mjs <scenarios-dir> [--report <path>]
+ *   bun packages/scripts/run-scenarios-isolated.mjs <scenarios-dir>
+ *     [--file-glob <glob>] [--artifacts-dir <path>] [--report <path>]
  *
  * Env:
  *   Same as the underlying CLI (GROQ_API_KEY / OPENAI_API_KEY / etc.).
@@ -41,6 +42,13 @@ export function resolveScenarioIsolatedPaths() {
 }
 
 const { repoRoot: REPO_ROOT, cli: CLI } = resolveScenarioIsolatedPaths();
+const SOURCE_CLI_ARGS = [
+  "--conditions",
+  "eliza-source",
+  "--tsconfig-override",
+  path.join(REPO_ROOT, "tsconfig.json"),
+  CLI,
+];
 
 if (process.argv.includes("--print-paths")) {
   console.log(JSON.stringify({ repoRoot: REPO_ROOT, cli: CLI }));
@@ -55,9 +63,11 @@ if (args.length === 0) {
 
 const dir = path.resolve(args[0]);
 let reportPath = null;
+let artifactsDir = null;
 let workers = Math.min(4, Math.max(1, os.availableParallelism()));
 let timeoutMs = 15 * 60 * 1000;
 const forwardedArgs = [];
+const listSelectionArgs = [];
 for (let i = 1; i < args.length; i += 1) {
   if (args[i] === "--report" && args[i + 1]) {
     reportPath = path.resolve(args[i + 1]);
@@ -67,6 +77,16 @@ for (let i = 1; i < args.length; i += 1) {
     i += 1;
   } else if (args[i] === "--timeout-ms" && args[i + 1]) {
     timeoutMs = Number(args[i + 1]);
+    i += 1;
+  } else if (args[i] === "--artifacts-dir" && args[i + 1]) {
+    artifactsDir = path.resolve(args[i + 1]);
+    i += 1;
+  } else if (args[i] === "--file-glob" && args[i + 1]) {
+    listSelectionArgs.push(args[i + 1]);
+    i += 1;
+  } else if (args[i] === "--lane" && args[i + 1]) {
+    listSelectionArgs.push(args[i], args[i + 1]);
+    forwardedArgs.push(args[i], args[i + 1]);
     i += 1;
   } else {
     forwardedArgs.push(args[i]);
@@ -88,11 +108,15 @@ if (!fs.existsSync(dir)) {
 }
 
 // 1. List scenario IDs from the target dir.
-const listed = spawnSync("bun", [CLI, "list", dir], {
-  cwd: REPO_ROOT,
-  encoding: "utf8",
-  stdio: ["inherit", "pipe", "inherit"],
-});
+const listed = spawnSync(
+  "bun",
+  [...SOURCE_CLI_ARGS, "list", dir, ...listSelectionArgs],
+  {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "inherit"],
+  },
+);
 if (listed.status !== 0) {
   console.error(`[isolated] scenario listing failed (exit ${listed.status})`);
   process.exit(listed.status ?? 1);
@@ -107,9 +131,21 @@ console.error(
 );
 
 // 2. Run each scenario in a unique directory and bounded worker process.
-const runRoot = fs.mkdtempSync(
-  path.join(os.tmpdir(), "scenario-isolated-run-"),
-);
+let temporaryRunRoot = false;
+let runRoot;
+if (artifactsDir) {
+  if (fs.existsSync(artifactsDir) && fs.readdirSync(artifactsDir).length > 0) {
+    console.error(
+      `[isolated] --artifacts-dir must be absent or empty: ${artifactsDir}`,
+    );
+    process.exit(2);
+  }
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  runRoot = artifactsDir;
+} else {
+  temporaryRunRoot = true;
+  runRoot = fs.mkdtempSync(path.join(os.tmpdir(), "scenario-isolated-run-"));
+}
 const perRunReports = new Array(ids.length).fill(null);
 const startedAtIso = new Date().toISOString();
 let passed = 0;
@@ -135,10 +171,19 @@ function runOne(id, index) {
     );
     fs.mkdirSync(scenarioDir, { recursive: true });
     const tmpReport = path.join(scenarioDir, "report.json");
+    const stdout = fs.openSync(path.join(scenarioDir, "stdout.log"), "wx");
+    const stderr = fs.openSync(path.join(scenarioDir, "stderr.log"), "wx");
+    let logsClosed = false;
+    const closeLogs = () => {
+      if (logsClosed) return;
+      logsClosed = true;
+      fs.closeSync(stdout);
+      fs.closeSync(stderr);
+    };
     const child = spawn(
       "bun",
       [
-        CLI,
+        ...SOURCE_CLI_ARGS,
         "run",
         dir,
         "--scenario",
@@ -151,7 +196,7 @@ function runOne(id, index) {
       ],
       {
         cwd: REPO_ROOT,
-        stdio: ["inherit", "inherit", "inherit"],
+        stdio: ["ignore", stdout, stderr],
         env: process.env,
       },
     );
@@ -167,12 +212,14 @@ function runOne(id, index) {
     child.once("error", (error) => {
       clearTimeout(timer);
       activeChildren.delete(child);
+      closeLogs();
       resolve({ id, index, ok: false, cause: `spawn error ${error.message}` });
     });
     child.once("close", (status, signal) => {
       clearTimeout(timer);
       activeChildren.delete(child);
-      if (status !== 0) {
+      closeLogs();
+      if (status === null || timedOut || (status !== 0 && status !== 1)) {
         const cause = timedOut
           ? `timeout after ${timeoutMs}ms`
           : status === null
@@ -251,6 +298,7 @@ const completedAtIso = new Date().toISOString();
 // 3. Aggregate into a single report.
 const aggregate = {
   runId: `isolated-${Date.now()}`,
+  artifactsDir: temporaryRunRoot ? null : runRoot,
   providerName: perRunReports.find(Boolean)?.providerName ?? "unknown",
   startedAtIso,
   completedAtIso,
@@ -273,7 +321,11 @@ for (const s of aggregate.scenarios) {
   console.error(`  ${icon} ${s.id} (${s.durationMs}ms)`);
 }
 
-fs.rmSync(runRoot, { recursive: true, force: true });
+if (temporaryRunRoot) {
+  fs.rmSync(runRoot, { recursive: true, force: true });
+} else {
+  console.error(`[isolated] retained artifacts at ${runRoot}`);
+}
 
 if (interruptedSignal !== null) {
   process.kill(process.pid, interruptedSignal);

--- a/packages/test/scenarios/group-chat/heldout/README.md
+++ b/packages/test/scenarios/group-chat/heldout/README.md
@@ -88,6 +88,21 @@ pseudo-labels, not human judgments that an intervention was correct. Reports
 must call them observational labels and use the replay set for relative
 distribution-shift comparisons, not absolute intervention accuracy.
 
+The production Stage-1 evaluator can consume this output with
+`--input-format=discord-replay`. A two-author paired SILENT row necessarily
+selects the author of the current turn as the target seat, but production only
+runs Stage 1 for inbound messages. The evaluator therefore records those rows
+as explicit eligibility exclusions and evaluates the observational SPEAK rows
+whose current turn is inbound to the selected seat. It never relabels an
+outbound turn as inbound.
+
+```bash
+bun run --cwd packages/scenario-runner eval:when2speak -- \
+  --input=/tmp/discord-replay.jsonl \
+  --input-format=discord-replay \
+  --provider=cli
+```
+
 Every JSONL row records the dataset, revision, split, source row index, and
 observed next-turn index. The adjacent manifest records all sampled offsets and
 the SHA-256 digest of the complete output.

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -1293,6 +1293,33 @@ describe("reasoning effort (SDK effort option)", () => {
     await session.dispose();
   });
 
+  it("aborts the SDK transport when the session is disposed", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const fakeSdk = {
+      query: ({ options }: { options: Record<string, unknown> }) => {
+        captured = options;
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "result", subtype: "success", result: "ok" };
+          },
+          interrupt: vi.fn().mockResolvedValue(undefined),
+        };
+      },
+      tool: () => ({}),
+      createSdkMcpServer: () => ({}),
+    };
+    const session = new ClaudeSdkSession({
+      model: "claude-opus-4-8",
+      sdkModule: fakeSdk as never,
+    });
+    await session.send("hi");
+    const abortController = captured?.abortController;
+    expect(abortController).toBeInstanceOf(AbortController);
+    expect((abortController as AbortController).signal.aborted).toBe(false);
+    await session.dispose();
+    expect((abortController as AbortController).signal.aborted).toBe(true);
+  });
+
   it("omits effort entirely when unset (SDK keeps its default)", async () => {
     let captured: Record<string, unknown> | undefined;
     const fakeSdk = {

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -331,6 +331,7 @@ export class ClaudeSdkSession {
   private readonly zodOverride?: ZodModule;
 
   private query: SdkQuery | null = null;
+  private abortController: AbortController | null = null;
   private feed: ((msg: SdkUserMessage) => void) | null = null;
   private iterator: AsyncIterator<SdkMessage> | null = null;
   private turns = 0;
@@ -569,6 +570,9 @@ export class ClaudeSdkSession {
       options.allowedTools = [];
       options.disallowedTools = [];
     }
+    const abortController = new AbortController();
+    options.abortController = abortController;
+    this.abortController = abortController;
     this.query = sdk.query({ prompt: promptStream(), options });
     this.iterator = this.query[Symbol.asyncIterator]();
     this.turns = 0;
@@ -577,8 +581,10 @@ export class ClaudeSdkSession {
       // resurrecting a session the caller already gave up on.
       const stale = this.query;
       this.query = null;
+      this.abortController = null;
       this.iterator = null;
       this.feed = null;
+      abortController.abort();
       stale?.interrupt?.().catch(() => {});
       throw new ProviderApiError("[cli-inference:sdk] session disposed during start", {
         retryable: true,
@@ -803,7 +809,9 @@ export class ClaudeSdkSession {
   async dispose(): Promise<void> {
     this.epoch += 1;
     const q = this.query;
+    const abortController = this.abortController;
     this.query = null;
+    this.abortController = null;
     this.iterator = null;
     this.feed = null;
     this.turns = 0;
@@ -836,5 +844,6 @@ export class ClaudeSdkSession {
         if (timer) clearTimeout(timer);
       }
     }
+    abortController?.abort();
   }
 }


### PR DESCRIPTION
## Relates to

Closes #27273. Follow-up to merged #26507.

## What changed

- evaluates pinned Discord replay rows through the production Stage-1 boundary, maps the target seat to the runtime agent, and records target-authored current turns as explicit eligibility exclusions;
- writes atomic per-row checkpoints and resumes only after validating the exact dataset, input, provider, backend, requested model, selection, and contiguous prior coverage;
- adds an exact-coverage matrix merger that rejects in-progress, bounded, missing-shard, duplicate-row, out-of-range, and incomplete reports;
- makes the isolated scenario wrapper select file families and retain each fresh child report, trajectory, stdout, and stderr, including legitimate exit-1 failed-scenario reports.

## Current-revision live baselines

Backend: authenticated Codex CLI. Requested model: `gpt-5.6-terra`.

- corrected When2Speak scenarios: 24 passed / 24 failed of 48; SILENT 16/24, SPEAK 8/24; direct address 14/24, ambient 10/24;
- held-out ishiki: 9 passed / 15 failed of 24;
- LoSoNA: 1 passed / 37 failed of 38;
- SCENE: 0 passed / 3 failed;
- MuPPET: 0 passed / 4 failed;
- Discord replay: exact 66/66 physical-row coverage; 33 eligible, 33 target-authored exclusions, 0 malformed; 15/33 correct, SPEAK recall 45.45%, missed-intervention rate 54.55%.

All scenario-rubric results are self-graded because no independent judge credential was available. They are diagnostic model baselines, not independent acceptance scores. The Discord report records row-level Stage-1 predictions and exact backend/model identity.

## Evidence

- [48 corrected When2Speak scenarios](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/27275-when2speak-scenarios.json)
- [24 held-out ishiki scenarios](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/27275-ishiki-scenarios.json)
- [45 LoSoNA/SCENE/MuPPET scenarios](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/27275-behavior-scenarios.json)
- [Discord row-level report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/27275-discord-replay-report.json)
- [Discord exact-coverage matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/27275-discord-replay-matrix.json)

SHA-256: behavior `41d9c0d7...b2b7cf3`; Discord matrix `48f65876...a90f85`; Discord report `96ee8522...f577da`; ishiki `838b560e...2f81`; When2Speak scenarios `6f05ed71...93ba9`.

## Verification

- `bun install` — passed with no dependency changes;
- focused evaluator, merger, and isolated-wrapper tests — 22 passed / 53 assertions;
- `bun run --cwd packages/scenario-runner build` — passed;
- live Discord matrix merger — accepted exact 66/66 coverage;
- fresh-process scenario reports — 48/48 When2Speak, 24/24 ishiki, and 45/45 behavior reports retained.

`bun run verify` reaches an unrelated pre-existing Biome failure in `packages/shared/src/__tests__/string-utils.test.ts` (`@elizaos/shared#lint:check`); this branch does not touch `packages/shared`.

## Remaining matrix gaps

- full 21,628-row When2Speak Stage-1 execution is not complete;
- no independent Cerebras judge was available;
- no second selectable provider/model tier was available in the runner environment.

The PR stays draft while those external/full-volume lanes remain incomplete.