### PR TITLE
test(agent): cover chat-text-helpers

### DIFF
--- a/packages/agent/src/api/chat-text-helpers.test.ts
+++ b/packages/agent/src/api/chat-text-helpers.test.ts
@@ -1,14 +1,138 @@
 /**
  * Exercises the agent HTTP boundary's assistant-text cleanup without replacing
- * or clipping complete long responses.
+ * or clipping complete long responses. Covers stage direction stripping,
+ * spacing tidying, and no-response placeholder detection.
  */
 import { describe, expect, it } from "vitest";
-import { stripAssistantStageDirections } from "./chat-text-helpers.ts";
+import {
+  isClientVisibleNoResponse,
+  isNoResponsePlaceholder,
+  stripAssistantStageDirections,
+} from "./chat-text-helpers.ts";
+
+describe("isNoResponsePlaceholder", () => {
+  it("identifies empty and whitespace-only text as placeholder", () => {
+    expect(isNoResponsePlaceholder("")).toBe(true);
+    expect(isNoResponsePlaceholder("   ")).toBe(true);
+    expect(isNoResponsePlaceholder("\n\t  \r\n")).toBe(true);
+  });
+
+  it("identifies standard and parenthesized (no response) case-insensitively", () => {
+    expect(isNoResponsePlaceholder("no response")).toBe(true);
+    expect(isNoResponsePlaceholder("(no response)")).toBe(true);
+    expect(isNoResponsePlaceholder("NO RESPONSE")).toBe(true);
+    expect(isNoResponsePlaceholder("(NO RESPONSE)")).toBe(true);
+    expect(isNoResponsePlaceholder("  (No Response)  ")).toBe(true);
+    expect(isNoResponsePlaceholder("No response")).toBe(true);
+  });
+
+  it("rejects real messages and non-matching prefixes/suffixes", () => {
+    expect(isNoResponsePlaceholder("Hello world")).toBe(false);
+    expect(isNoResponsePlaceholder("no response received from server")).toBe(
+      false,
+    );
+    expect(isNoResponsePlaceholder("(no response needed)")).toBe(false);
+    expect(isNoResponsePlaceholder("there is no response")).toBe(false);
+  });
+});
 
 describe("stripAssistantStageDirections", () => {
   it("preserves complete text beyond the former 100k boundary", () => {
     const text = `${"complete line\n".repeat(9_000)}final line`;
     expect(text.length).toBeGreaterThan(100_000);
     expect(stripAssistantStageDirections(text)).toBe(text);
+  });
+
+  it("strips asterisk-wrapped stage directions", () => {
+    expect(stripAssistantStageDirections("*smiles* Hello there!")).toBe(
+      " Hello there!",
+    );
+    expect(
+      stripAssistantStageDirections("I can help you with that *beams warmly*."),
+    ).toBe("I can help you with that.");
+    expect(
+      stripAssistantStageDirections("Hello *chuckles softly* there."),
+    ).toBe("Hello there.");
+    expect(
+      stripAssistantStageDirections("Let me think... *pauses thoughtfully*"),
+    ).toBe("Let me think... ");
+  });
+
+  it("strips underscore-wrapped stage directions", () => {
+    expect(stripAssistantStageDirections("_nods_ Indeed.")).toBe(" Indeed.");
+    expect(stripAssistantStageDirections("I agree _glances at screen_.")).toBe(
+      "I agree.",
+    );
+    expect(stripAssistantStageDirections("Hello _yawns_ friend.")).toBe(
+      "Hello friend.",
+    );
+  });
+
+  it("preserves emphasis and words not in stage direction vocabulary", () => {
+    expect(
+      stripAssistantStageDirections("This is *important* information."),
+    ).toBe("This is *important* information.");
+    expect(
+      stripAssistantStageDirections("Please note the _critical_ detail."),
+    ).toBe("Please note the _critical_ detail.");
+    expect(stripAssistantStageDirections("See *custom note* here.")).toBe(
+      "See *custom note* here.",
+    );
+  });
+
+  it("preserves mid-word and non-boundary asterisks/underscores", () => {
+    expect(stripAssistantStageDirections("foo*smiles*bar")).toBe(
+      "foo*smiles*bar",
+    );
+    expect(stripAssistantStageDirections("snake_case_variable")).toBe(
+      "snake_case_variable",
+    );
+  });
+
+  it("tidies punctuation spacing after removing stage directions", () => {
+    expect(stripAssistantStageDirections("Hello *smiles* , world!")).toBe(
+      "Hello, world!",
+    );
+    expect(stripAssistantStageDirections("Is that true *winks* ?")).toBe(
+      "Is that true?",
+    );
+    expect(stripAssistantStageDirections("Great *cheers* !")).toBe("Great!");
+    expect(stripAssistantStageDirections("Status ( *nods* ) updated")).toBe(
+      "Status () updated",
+    );
+  });
+
+  it("collapses multiple spaces and tab runs around newlines", () => {
+    expect(stripAssistantStageDirections("Line 1   \n   Line 2")).toBe(
+      "Line 1\nLine 2",
+    );
+    expect(stripAssistantStageDirections("Word 1    Word 2")).toBe(
+      "Word 1 Word 2",
+    );
+  });
+});
+
+describe("isClientVisibleNoResponse", () => {
+  it("returns true for empty or raw placeholder text", () => {
+    expect(isClientVisibleNoResponse("")).toBe(true);
+    expect(isClientVisibleNoResponse("   ")).toBe(true);
+    expect(isClientVisibleNoResponse("(no response)")).toBe(true);
+  });
+
+  it("returns true when text contains only stage directions and placeholders", () => {
+    expect(isClientVisibleNoResponse("*smiles*")).toBe(true);
+    expect(isClientVisibleNoResponse("_sighs_ (no response)")).toBe(true);
+    expect(
+      isClientVisibleNoResponse("*waving* \n\n (NO RESPONSE) \n *nods*"),
+    ).toBe(true);
+    expect(isClientVisibleNoResponse("*beams* _chuckles_")).toBe(true);
+  });
+
+  it("returns false when meaningful text remains after stripping stage directions", () => {
+    expect(isClientVisibleNoResponse("*smiles* Hello world!")).toBe(false);
+    expect(isClientVisibleNoResponse("Sure, I can help *nods*")).toBe(false);
+    expect(
+      isClientVisibleNoResponse("*chuckles* That is a great question."),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/agent/src/api/chat-text-helpers.ts` inside the canonical test file (`packages/agent/src/api/chat-text-helpers.test.ts`). No production logic or public API contract modified.

# Background

## What does this PR do?

Expands unit test coverage for `packages/agent/src/api/chat-text-helpers.ts` across all exported helpers:
- `isNoResponsePlaceholder`: tests empty, whitespace-only, parenthesized, case-insensitive variants (`(no response)`, `NO RESPONSE`, `  (No Response)  `), and non-matching text.
- `stripAssistantStageDirections`: tests stripping asterisk-wrapped (`*smiles*`, `*beams warmly*`, `*chuckles softly*`, `*pauses thoughtfully*`) and underscore-wrapped (`_nods_`, `_glances at screen_`, `_yawns_`) stage directions, non-stage direction emphasis preservation (`*important*`, `_critical_`), mid-word punctuation preservation (`foo*smiles*bar`, `snake_case_variable`), punctuation spacing tidying, and newline whitespace collapsing.
- `isClientVisibleNoResponse`: tests detection of empty text, stage-direction-only residue (`*smiles*`, `_sighs_ (no response)`), and preservation of meaningful replies with inline stage directions.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/agent/src/api/chat-text-helpers.test.ts`.

## Detailed testing steps

Run:
```bash
cd packages/agent && bun test src/api/chat-text-helpers.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

src/api/chat-text-helpers.test.ts:
(pass) isNoResponsePlaceholder > identifies empty and whitespace-only text as placeholder
(pass) isNoResponsePlaceholder > identifies standard and parenthesized (no response) case-insensitively
(pass) isNoResponsePlaceholder > rejects real messages and non-matching prefixes/suffixes
(pass) stripAssistantStageDirections > preserves complete text beyond the former 100k boundary
(pass) stripAssistantStageDirections > strips asterisk-wrapped stage directions
(pass) stripAssistantStageDirections > strips underscore-wrapped stage directions
(pass) stripAssistantStageDirections > preserves emphasis and words not in stage direction vocabulary
(pass) stripAssistantStageDirections > preserves mid-word and non-boundary asterisks/underscores
(pass) stripAssistantStageDirections > tidies punctuation spacing after removing stage directions
(pass) stripAssistantStageDirections > collapses multiple spaces and tab runs around newlines
(pass) isClientVisibleNoResponse > returns true for empty or raw placeholder text
(pass) isClientVisibleNoResponse > returns true when text contains only stage directions and placeholders
(pass) isClientVisibleNoResponse > returns false when meaningful text remains after stripping stage directions

 13 pass
 0 fail
 43 expect() calls
Ran 13 tests across 1 file. [10.00ms]
```

# Evidence Gate

<!-- evidence-head:4b728876be1bad7dd3e9f800b0f8d83c8b809343 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; backend unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; backend unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; backend unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
