### PR TITLE
test(core): cover channel-utils

### DIFF
--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -6,15 +6,21 @@
  * @-mentioned it or spam every message in a group.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	createTypingCallbacks,
 	formatLocationText,
 	listSenderLabelCandidates,
+	logAckFailure,
+	logInboundDrop,
+	logTypingFailure,
 	normalizeChatType,
+	removeAckReactionAfterReply,
 	resolveMentionGating,
 	resolveMentionGatingWithBypass,
 	resolveSenderLabel,
 	shouldAckReaction,
+	shouldAckReactionForWhatsApp,
 	toLocationContext,
 } from "./channel-utils.ts";
 
@@ -291,16 +297,281 @@ describe("resolveSenderLabel and listSenderLabelCandidates", () => {
 		expect(resolveSenderLabel({})).toBeNull();
 	});
 
-	it("lists all distinct sender label candidates", () => {
+	it("lists all distinct sender label candidates including tags and phone numbers", () => {
 		const candidates = listSenderLabelCandidates({
 			name: "Alice",
 			username: "alice_w",
+			tag: "alice#0001",
+			e164: "+15551234567",
 			id: "u123",
 		});
 
 		expect(candidates).toContain("Alice");
 		expect(candidates).toContain("alice_w");
+		expect(candidates).toContain("alice#0001");
+		expect(candidates).toContain("+15551234567");
 		expect(candidates).toContain("u123");
-		expect(candidates).toContain("Alice (u123)");
+		expect(candidates).toContain("Alice (+15551234567)");
+	});
+});
+
+describe("createTypingCallbacks", () => {
+	it("executes start and handles start error with onStartError", async () => {
+		const start = vi.fn().mockRejectedValue(new Error("network failure"));
+		const onStartError = vi.fn();
+		const callbacks = createTypingCallbacks({
+			start,
+			onStartError,
+		});
+
+		await callbacks.onReplyStart();
+		expect(start).toHaveBeenCalledOnce();
+		expect(onStartError).toHaveBeenCalledWith(expect.any(Error));
+		expect(callbacks.onIdle).toBeUndefined();
+	});
+
+	it("executes stop on idle and forwards stop error to onStopError", async () => {
+		const start = vi.fn().mockResolvedValue(undefined);
+		const stop = vi.fn().mockRejectedValue(new Error("stop failure"));
+		const onStartError = vi.fn();
+		const onStopError = vi.fn();
+
+		const callbacks = createTypingCallbacks({
+			start,
+			stop,
+			onStartError,
+			onStopError,
+		});
+
+		await callbacks.onReplyStart();
+		expect(start).toHaveBeenCalledOnce();
+
+		expect(callbacks.onIdle).toBeDefined();
+		callbacks.onIdle?.();
+		expect(stop).toHaveBeenCalledOnce();
+
+		// Allow microtask to run for the rejected stop promise
+		await Promise.resolve();
+		expect(onStopError).toHaveBeenCalledWith(expect.any(Error));
+		expect(onStartError).not.toHaveBeenCalled();
+	});
+
+	it("falls back to onStartError when onStopError is omitted", async () => {
+		const start = vi.fn().mockResolvedValue(undefined);
+		const stop = vi.fn().mockRejectedValue(new Error("stop failure"));
+		const onStartError = vi.fn();
+
+		const callbacks = createTypingCallbacks({
+			start,
+			stop,
+			onStartError,
+		});
+
+		callbacks.onIdle?.();
+		await Promise.resolve();
+		expect(onStartError).toHaveBeenCalledWith(expect.any(Error));
+	});
+});
+
+describe("shouldAckReactionForWhatsApp", () => {
+	const base = {
+		emoji: "👀",
+		isDirect: false,
+		isGroup: true,
+		directEnabled: true,
+		groupMode: "mentions" as const,
+		wasMentioned: true,
+		groupActivated: false,
+	};
+
+	it("returns false if emoji is empty", () => {
+		expect(shouldAckReactionForWhatsApp({ ...base, emoji: "" })).toBe(false);
+	});
+
+	it("handles direct chats based on directEnabled", () => {
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				isDirect: true,
+				isGroup: false,
+				directEnabled: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				isDirect: true,
+				isGroup: false,
+				directEnabled: false,
+			}),
+		).toBe(false);
+	});
+
+	it("returns false for non-group non-direct chats", () => {
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				isDirect: false,
+				isGroup: false,
+			}),
+		).toBe(false);
+	});
+
+	it("handles groupMode never and always", () => {
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				groupMode: "never",
+			}),
+		).toBe(false);
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				groupMode: "always",
+			}),
+		).toBe(true);
+	});
+
+	it("handles groupMode mentions with explicit mention or group activation", () => {
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				groupMode: "mentions",
+				wasMentioned: true,
+				groupActivated: false,
+			}),
+		).toBe(true);
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				groupMode: "mentions",
+				wasMentioned: false,
+				groupActivated: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldAckReactionForWhatsApp({
+				...base,
+				groupMode: "mentions",
+				wasMentioned: false,
+				groupActivated: false,
+			}),
+		).toBe(false);
+	});
+});
+
+describe("removeAckReactionAfterReply", () => {
+	it("skips removal when removeAfterReply is false or ackReactionValue is null", () => {
+		const remove = vi.fn().mockResolvedValue(undefined);
+		removeAckReactionAfterReply({
+			removeAfterReply: false,
+			ackReactionPromise: Promise.resolve(true),
+			ackReactionValue: "👀",
+			remove,
+		});
+		expect(remove).not.toHaveBeenCalled();
+
+		removeAckReactionAfterReply({
+			removeAfterReply: true,
+			ackReactionPromise: Promise.resolve(true),
+			ackReactionValue: null,
+			remove,
+		});
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("skips removal when ackReactionPromise resolves false", async () => {
+		const remove = vi.fn().mockResolvedValue(undefined);
+		removeAckReactionAfterReply({
+			removeAfterReply: true,
+			ackReactionPromise: Promise.resolve(false),
+			ackReactionValue: "👀",
+			remove,
+		});
+		await Promise.resolve();
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("invokes remove and handles removal failure via onError", async () => {
+		const remove = vi.fn().mockRejectedValue(new Error("removal failed"));
+		const onError = vi.fn();
+
+		removeAckReactionAfterReply({
+			removeAfterReply: true,
+			ackReactionPromise: Promise.resolve(true),
+			ackReactionValue: "👀",
+			remove,
+			onError,
+		});
+
+		await Promise.resolve();
+		expect(remove).toHaveBeenCalledOnce();
+		await Promise.resolve();
+		expect(onError).toHaveBeenCalledWith(expect.any(Error));
+	});
+});
+
+describe("channel logging helpers", () => {
+	it("logs inbound message drop with and without target", () => {
+		const log = vi.fn();
+		logInboundDrop({
+			log,
+			channel: "telegram",
+			reason: "unmentioned",
+			target: "group-99",
+		});
+		expect(log).toHaveBeenCalledWith("telegram: drop unmentioned target=group-99");
+
+		logInboundDrop({
+			log,
+			channel: "discord",
+			reason: "muted",
+		});
+		expect(log).toHaveBeenCalledWith("discord: drop muted");
+	});
+
+	it("logs typing indicator failure with action and target", () => {
+		const log = vi.fn();
+		logTypingFailure({
+			log,
+			channel: "slack",
+			action: "start",
+			target: "C123",
+			error: new Error("Rate limited"),
+		});
+		expect(log).toHaveBeenCalledWith(
+			"slack typing action=start failed target=C123: Error: Rate limited",
+		);
+
+		logTypingFailure({
+			log,
+			channel: "whatsapp",
+			error: "Network timeout",
+		});
+		expect(log).toHaveBeenCalledWith(
+			"whatsapp typing failed: Network timeout",
+		);
+	});
+
+	it("logs ack cleanup failure with and without target", () => {
+		const log = vi.fn();
+		logAckFailure({
+			log,
+			channel: "discord",
+			target: "msg-456",
+			error: "Unknown Message",
+		});
+		expect(log).toHaveBeenCalledWith(
+			"discord ack cleanup failed target=msg-456: Unknown Message",
+		);
+
+		logAckFailure({
+			log,
+			channel: "telegram",
+			error: "Bad Request",
+		});
+		expect(log).toHaveBeenCalledWith(
+			"telegram ack cleanup failed: Bad Request",
+		);
 	});
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/core/src/utils/channel-utils.ts` in the canonical test file (`packages/core/src/utils/channel-utils.test.ts`). No production logic modified.

# Background

## What does this PR do?

Extends behavioral test coverage for `packages/core/src/utils/channel-utils.ts` across several previously uncovered functions:
- `createTypingCallbacks`: tests starting typing indicators, handling start errors with `onStartError`, stopping on idle, and error propagation to `onStopError` or fallback to `onStartError`.
- `shouldAckReactionForWhatsApp`: tests empty emoji handling, direct chat gating via `directEnabled`, non-group/non-direct exclusion, and group modes (`never`, `always`, `mentions` with mention/group-activated flags).
- `removeAckReactionAfterReply`: tests skipping when `removeAfterReply` is false or values are null, skipping when ack promise resolves false, invoking `remove()`, and capturing removal errors via `onError`.
- `listSenderLabelCandidates`: tests inclusion of `tag` and `e164` phone numbers in candidate arrays.
- Channel logging utilities (`logInboundDrop`, `logTypingFailure`, `logAckFailure`): tests message format generation with and without target/action parameters.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/channel-utils.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/channel-utils.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/core/src/utils/channel-utils.test.ts:
(pass) normalizeChatType > folds platform synonyms into direct/group/channel
(pass) resolveMentionGating > skips only when a mention is required, detectable, and absent
(pass) resolveMentionGating > treats an implicit mention (reply) or bypass as mentioned
(pass) resolveMentionGating > never skips when mention is not required or not detectable
(pass) resolveMentionGatingWithBypass > lets an authorized control command bypass the mention gate in a group
(pass) resolveMentionGatingWithBypass > does not bypass for an unauthorized command
(pass) shouldAckReaction > honors scope: off/all/direct/group-all
(pass) shouldAckReaction > group-mentions only acks a detectable mention in a mentionable group
(pass) formatLocationText > formats basic pin location with coordinates and positive accuracy
(pass) formatLocationText > sanitizes negative or non-finite accuracy values by omitting accuracy
(pass) formatLocationText > preserves zero accuracy as a valid non-negative measurement
(pass) formatLocationText > formats named place location with label and coordinates
(pass) formatLocationText > formats live location indicator and includes caption when present
(pass) toLocationContext > converts normalized location and sanitizes negative accuracy to undefined
(pass) toLocationContext > preserves valid positive accuracy in location context
(pass) toLocationContext > omits non-finite accuracy without fabricating a measurement
(pass) resolveSenderLabel and listSenderLabelCandidates > resolves display with id when both differ
(pass) resolveSenderLabel and listSenderLabelCandidates > falls back gracefully when only id or only name is provided
(pass) resolveSenderLabel and listSenderLabelCandidates > lists all distinct sender label candidates including tags and phone numbers
(pass) createTypingCallbacks > executes start and handles start error with onStartError
(pass) createTypingCallbacks > executes stop on idle and forwards stop error to onStopError
(pass) createTypingCallbacks > falls back to onStartError when onStopError is omitted
(pass) shouldAckReactionForWhatsApp > returns false if emoji is empty
(pass) shouldAckReactionForWhatsApp > handles direct chats based on directEnabled
(pass) shouldAckReactionForWhatsApp > returns false for non-group non-direct chats
(pass) shouldAckReactionForWhatsApp > handles groupMode never and always
(pass) shouldAckReactionForWhatsApp > handles groupMode mentions with explicit mention or group activation
(pass) removeAckReactionAfterReply > skips removal when removeAfterReply is false or ackReactionValue is null
(pass) removeAckReactionAfterReply > skips removal when ackReactionPromise resolves false
(pass) removeAckReactionAfterReply > invokes remove and handles removal failure via onError
(pass) channel logging helpers > logs inbound message drop with and without target
(pass) channel logging helpers > logs typing indicator failure with action and target
(pass) channel logging helpers > logs ack cleanup failure with and without target

 33 pass
 0 fail
 74 expect() calls
Ran 33 tests across 1 file. [97.00ms]
```

# Evidence Gate

<!-- evidence-head:13c6d083896e264aed66ffbcbc69cc2093355293 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; core unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
