### PR TITLE
test(shared): cover number-parsing

### DIFF
--- a/packages/shared/src/utils/number-parsing.test.ts
+++ b/packages/shared/src/utils/number-parsing.test.ts
@@ -19,6 +19,10 @@ describe("parseCanonicalInteger", () => {
   it("distinguishes omission from malformed and unsafe input", () => {
     expect(parseCanonicalInteger(null, { min: 1 })).toBeUndefined();
     expect(parseCanonicalInteger("", { min: 1 })).toBeUndefined();
+    expect(parseCanonicalInteger("   ", { min: 1 })).toBeUndefined();
+    expect(parseCanonicalInteger(" 1", { min: 1 })).toBe("invalid");
+    expect(parseCanonicalInteger("1 ", { min: 1 })).toBe("invalid");
+    expect(parseCanonicalInteger("-1", { min: 1 })).toBe("invalid");
     expect(parseCanonicalInteger("1e2", { min: 1 })).toBe("invalid");
     expect(parseCanonicalInteger("007", { min: 1 })).toBe("invalid");
     expect(parseCanonicalInteger("0x10", { min: 1 })).toBe("invalid");
@@ -35,6 +39,24 @@ describe("parseCanonicalInteger", () => {
     expect(
       parseCanonicalInteger("101", { min: 1, max: 100, clamp: true }),
     ).toBe(100);
+    expect(
+      parseCanonicalInteger("2", { min: 5, max: 100, clamp: true }),
+    ).toBe(5);
+  });
+
+  it("throws RangeError when bounds are unordered or not safe integers", () => {
+    expect(() => parseCanonicalInteger("10", { min: 100, max: 10 })).toThrow(
+      RangeError,
+    );
+    expect(() => parseCanonicalInteger("10", { min: 1.5, max: 10 })).toThrow(
+      RangeError,
+    );
+    expect(() => parseCanonicalInteger("10", { min: Number.NaN, max: 10 })).toThrow(
+      RangeError,
+    );
+    expect(() => parseCanonicalInteger("10", { min: 0, max: Number.POSITIVE_INFINITY })).toThrow(
+      RangeError,
+    );
   });
 });
 
@@ -44,6 +66,11 @@ describe("number parsing utilities", () => {
     expect(parsePositiveInteger("0", 7)).toBe(7);
     expect(parsePositiveInteger("-1", 7)).toBe(7);
     expect(parsePositiveInteger("12abc", 7)).toBe(7);
+    expect(parsePositiveInteger("1.5", 7)).toBe(7);
+    expect(parsePositiveInteger("9007199254740991")).toBe(9007199254740991);
+    expect(parsePositiveInteger("9007199254740992")).toBeUndefined();
+    expect(parsePositiveInteger("invalid", Number.NaN)).toBeUndefined();
+    expect(parsePositiveInteger("invalid", Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 
   it("parses non-negative integers without accepting alternate syntax", () => {
@@ -52,7 +79,9 @@ describe("number parsing utilities", () => {
     expect(parseNonNegativeInteger("1e3", 7)).toBe(7);
     expect(parseNonNegativeInteger("5junk", 7)).toBe(7);
     expect(parseNonNegativeInteger("-1", 7)).toBe(7);
+    expect(parseNonNegativeInteger("9007199254740991")).toBe(9007199254740991);
     expect(parseNonNegativeInteger("9007199254740993", 7)).toBe(7);
+    expect(parseNonNegativeInteger("invalid", Number.NaN)).toBeUndefined();
   });
 
   it("parses positive floats with optional flooring", () => {
@@ -62,18 +91,26 @@ describe("number parsing utilities", () => {
     expect(parsePositiveFloat("0.5", { floor: true })).toBeUndefined();
     expect(parsePositiveFloat("-1", { fallback: 3 })).toBe(3);
     expect(parsePositiveFloat("abc", { fallback: 3 })).toBe(3);
+    expect(parsePositiveFloat("Infinity", { fallback: 3 })).toBe(3);
+    expect(parsePositiveFloat("NaN", { fallback: 3 })).toBe(3);
+    expect(parsePositiveFloat("abc", { fallback: Number.NaN })).toBeUndefined();
   });
 
   it("clamps floats and rejects non-finite values", () => {
     expect(parseClampedFloat("12.5", { min: 1, max: 10 })).toBe(10);
     expect(parseClampedFloat("-5", { min: 1, max: 10 })).toBe(1);
     expect(parseClampedFloat("Infinity", { fallback: 4 })).toBe(4);
+    expect(parseClampedFloat("-50", { min: -100, max: -10 })).toBe(-50);
+    expect(parseClampedFloat("-5", { min: -100, max: -10 })).toBe(-10);
+    expect(parseClampedFloat("-200", { min: -100, max: -10 })).toBe(-100);
+    expect(parseClampedFloat("invalid", { fallback: Number.NaN })).toBeUndefined();
   });
 
   it("parses clamped integers without accepting partial strings", () => {
     expect(parseClampedInteger(" 12 ", { min: 1, max: 50 })).toBe(12);
     expect(parseClampedInteger("+12", { min: 1, max: 50 })).toBe(12);
     expect(parseClampedInteger("-12", { min: -10, max: 50 })).toBe(-10);
+    expect(parseClampedInteger("-25", { min: -50, max: 50 })).toBe(-25);
     expect(parseClampedInteger("99", { min: 1, max: 50 })).toBe(50);
   });
 
@@ -85,6 +122,7 @@ describe("number parsing utilities", () => {
     expect(parseClampedInteger("0x10", options)).toBe(15);
     expect(parseClampedInteger("1e2", options)).toBe(15);
     expect(parseClampedInteger("", options)).toBe(15);
+    expect(parseClampedInteger("abc")).toBeUndefined();
   });
 
   it("rejects unsafe clamped integers", () => {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/shared/src/utils/number-parsing.ts` in the canonical test file (`packages/shared/src/utils/number-parsing.test.ts`). No production logic modified.

# Background

## What does this PR do?

Expands unit test coverage for strict numeric parsers in `packages/shared/src/utils/number-parsing.ts`:
- `parseCanonicalInteger`: adds tests for whitespace padding rejection (`" 1"`, `"1 "`), negative string rejection (`"-1"`), lower-bound clamping, and `RangeError` validation when bounds are unordered (`min > max`) or non-safe-integer values (`min: 1.5`, `min: NaN`, `max: Infinity`).
- `parsePositiveInteger`: adds boundary tests for `Number.MAX_SAFE_INTEGER` and unsafe integer overflow, as well as non-finite fallback normalization (`NaN`, `Infinity`).
- `parseNonNegativeInteger`: adds boundary tests for `Number.MAX_SAFE_INTEGER` and non-finite fallback normalization.
- `parsePositiveFloat`: adds tests for non-finite string inputs (`"Infinity"`, `"NaN"`) and non-finite fallback normalization.
- `parseClampedFloat`: adds tests for negative `min`/`max` ranges (`min: -100, max: -10`) and non-finite fallback normalization.
- `parseClampedInteger`: adds tests for negative `min`/`max` ranges (`min: -50, max: 50`) and fallback normalization when no fallback option is provided.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/utils/number-parsing.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/shared/src/utils/number-parsing.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/shared/src/utils/number-parsing.test.ts:
(pass) parseCanonicalInteger > distinguishes omission from malformed and unsafe input
(pass) parseCanonicalInteger > supports explicit bounds and clamping
(pass) parseCanonicalInteger > throws RangeError when bounds are unordered or not safe integers
(pass) number parsing utilities > parses positive integers strictly
(pass) number parsing utilities > parses non-negative integers without accepting alternate syntax
(pass) number parsing utilities > parses positive floats with optional flooring
(pass) number parsing utilities > clamps floats and rejects non-finite values
(pass) number parsing utilities > parses clamped integers without accepting partial strings
(pass) number parsing utilities > rejects malformed clamped integers instead of coercing them
(pass) number parsing utilities > rejects unsafe clamped integers

 10 pass
 0 fail
 65 expect() calls
Ran 10 tests across 1 file. [94.00ms]
```

# Evidence Gate

<!-- evidence-head:2e51682f2181abaa198afc1e84b46f0c49420ad7 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; shared unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
