### PR TITLE
fix(dev): make source checkout startup reliable

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "clean": "node ../scripts/rm-path-recursive.mjs dist dist-mobile dist-mobile-ios dist-mobile-ios-jsc && node ../scripts/clean-stray-dts.mjs",
-    "start": "bun run src/bin.ts",
+    "start": "bun --no-install --conditions=eliza-source src/bin.ts",
     "dev": "bun --hot src/bin.ts",
     "prepublishOnly": "bun run build:dist",
     "build": "bun run build:dist",

--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -36,6 +36,8 @@ import {
   WS_AUTH_GRACE_TIMEOUT_MS,
 } from "./server-helpers-auth.ts";
 
+type WsClient = InstanceType<typeof WebSocket>;
+
 // The gate contract under test lives in server.ts. The cloud plugin's own
 // handler is NOT exercised here: under the source-alias test environment the
 // real `@elizaos/plugin-elizacloud` module graph fails to evaluate (ENOTDIR
@@ -378,7 +380,7 @@ describe("unauthenticated /ws bounds (W5-015)", () => {
     __resetPendingWebSocketsForTests();
   });
 
-  function openUnauthenticatedWs(port: number): Promise<WebSocket> {
+  function openUnauthenticatedWs(port: number): Promise<WsClient> {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
       ws.once("open", () => resolve(ws));
@@ -386,7 +388,7 @@ describe("unauthenticated /ws bounds (W5-015)", () => {
     });
   }
 
-  function waitForClose(ws: WebSocket, timeoutMs: number): Promise<number> {
+  function waitForClose(ws: WsClient, timeoutMs: number): Promise<number> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(
         () => reject(new Error("timed out waiting for the server close")),
@@ -400,7 +402,7 @@ describe("unauthenticated /ws bounds (W5-015)", () => {
   }
 
   /** Waits for a specific frame type, ignoring the interleaved status/replay. */
-  function waitForFrame(ws: WebSocket, type: string): Promise<void> {
+  function waitForFrame(ws: WsClient, type: string): Promise<void> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(
         () => reject(new Error(`timed out waiting for ${type}`)),

--- a/packages/agent/src/runtime/source-start-contract.test.ts
+++ b/packages/agent/src/runtime/source-start-contract.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guards standalone source-checkout startup against stale generated workspace
+ * artifacts. The integration-backed child imports the required SQL plugin with
+ * the same Bun condition as `bun run start`; manifest assertions keep its
+ * nearest tsconfig from redirecting runtime imports into declaration output.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const AGENT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const REPO_ROOT = path.resolve(AGENT_ROOT, "../..");
+const PLUGIN_SQL_SOURCE_ROOT = path.join(REPO_ROOT, "plugins/plugin-sql/src");
+
+describe("standalone source-checkout start contract", () => {
+  it("runs the agent and its required SQL plugin against workspace source", () => {
+    const agentPackage = JSON.parse(
+      readFileSync(path.join(AGENT_ROOT, "package.json"), "utf8"),
+    ) as { scripts?: Record<string, string> };
+    const pluginSqlTsconfig = JSON.parse(
+      readFileSync(path.join(PLUGIN_SQL_SOURCE_ROOT, "tsconfig.json"), "utf8"),
+    ) as { compilerOptions?: { paths?: Record<string, string[]> } };
+    const pluginSqlTypecheckConfig = JSON.parse(
+      readFileSync(
+        path.join(PLUGIN_SQL_SOURCE_ROOT, "tsconfig.typecheck.json"),
+        "utf8",
+      ),
+    ) as { compilerOptions?: { paths?: Record<string, string[]> } };
+
+    expect(agentPackage.scripts?.start).toBe(
+      "bun --no-install --conditions=eliza-source src/bin.ts",
+    );
+    expect(pluginSqlTsconfig.compilerOptions?.paths).toBeUndefined();
+    expect(
+      pluginSqlTypecheckConfig.compilerOptions?.paths?.["@elizaos/core"],
+    ).toEqual(["../../../packages/core/dist/index.d.ts"]);
+
+    const imported = spawnSync(
+      "bun",
+      [
+        "--no-install",
+        "--conditions=eliza-source",
+        "-e",
+        'await import("@elizaos/plugin-sql"); console.log("plugin-sql-source-ok")',
+      ],
+      {
+        cwd: AGENT_ROOT,
+        encoding: "utf8",
+        timeout: 30_000,
+      },
+    );
+
+    expect(imported.error).toBeUndefined();
+    expect(imported.status, imported.stderr).toBe(0);
+    expect(imported.stdout).toContain("plugin-sql-source-ok");
+  });
+});

--- a/packages/app-core/scripts/dev-platform-no-install.test.mjs
+++ b/packages/app-core/scripts/dev-platform-no-install.test.mjs
@@ -43,6 +43,13 @@ describe("dev-ui Vite runtime", () => {
     expect(apiEnv).toBeGreaterThan(viteEnv);
   });
 
+  it("keeps default dev startup non-interactive while preserving Keychain opt-in", () => {
+    const source = readFileSync(path.join(scriptsDir, "dev-ui.mjs"), "utf8");
+
+    expect(source).toContain("if (!nextEnv.ELIZA_WALLET_OS_STORE?.trim()) {");
+    expect(source).toContain('nextEnv.ELIZA_WALLET_OS_STORE = "0";');
+  });
+
   it("uses the validated package-manager Node instead of a PATH shim", () => {
     const source = readFileSync(path.join(scriptsDir, "dev-ui.mjs"), "utf8");
 

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -307,6 +307,12 @@ function createApiChildEnv(baseEnv) {
   for (const key of VITE_RENDERER_ONLY_MOBILE_ENV_KEYS) {
     delete nextEnv[key];
   }
+  // A native macOS Keychain read may wait for user interaction and blocks
+  // Bun's event loop while it does so. Dev startup must stay non-interactive;
+  // mirror dev-all's safe default while preserving an explicit operator opt-in.
+  if (!nextEnv.ELIZA_WALLET_OS_STORE?.trim()) {
+    nextEnv.ELIZA_WALLET_OS_STORE = "0";
+  }
   return nextEnv;
 }
 

--- a/packages/app-core/src/api/server-bind-first-wallet-hydration.guard.test.ts
+++ b/packages/app-core/src/api/server-bind-first-wallet-hydration.guard.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Guards the app-core API wrapper's bind-first contract. OS credential-store
+ * reads can prompt or block at the native boundary, so runtime boot owns them
+ * after the listener is live instead of `startApiServer` awaiting them.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(
+  new URL("./server.ts", import.meta.url),
+  "utf8",
+);
+
+function extractStartApiServerBody(source: string): string {
+  const signature = "export async function startApiServer(";
+  const start = source.indexOf(signature);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const bodyStart = source.indexOf("{", start);
+  expect(bodyStart).toBeGreaterThan(start);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(bodyStart + 1, index);
+    }
+  }
+  throw new Error("startApiServer body is not balanced");
+}
+
+describe("app-core API bind-first wallet hydration", () => {
+  it("does not read the OS credential store before binding", () => {
+    const body = extractStartApiServerBody(serverSource);
+
+    expect(body).toContain("await upstreamStartApiServer({");
+    expect(body).not.toContain("hydrateWalletKeysFromNodePlatformSecureStore");
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -200,7 +200,6 @@ import {
   getCloudSecret,
 } from "@elizaos/shared/elizacloud/cloud-secrets";
 import { getStartupEmbeddingAugmentation } from "../runtime/startup-overlay.js";
-import { hydrateWalletKeysFromNodePlatformSecureStore } from "../security/hydrate-wallet-keys-from-platform-store";
 import { isNodePlatformSecureStoreDefaultAvailable } from "../security/platform-secure-store-node";
 import { deleteWalletSecretsFromOsStore } from "../security/wallet-os-store-actions";
 
@@ -1071,7 +1070,6 @@ export async function startApiServer(
   // passes through to upstream which checks this env var).
   ensureCloudTtsApiKeyAlias();
   hydrateWalletOsStoreFlagFromConfig();
-  await hydrateWalletKeysFromNodePlatformSecureStore();
 
   const compatState: CompatRuntimeState = {
     current: (args[0]?.runtime as AgentRuntime | undefined) ?? null,

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
@@ -5,11 +5,11 @@
  * steward env vars stay on the OS-keystore path because that backend's
  * lifecycle is independent of the unified vault.
  *
- * Precedence contract: launch env > vault/OS-keystore > persisted config.
- * app-core's `startApiServer` still calls this before it merges `config.env`,
- * where the contract holds by ordering alone; the agent boot path instead
- * defers the hydrate to the post-ready wave and captures a pre-merge baseline
- * (`captureWalletEnvBootBaseline`) so the same precedence holds there too.
+ * Precedence contract: launch env > vault/OS-keystore > persisted config. The
+ * agent boot path defers the potentially interactive OS-store read until after
+ * the API listener is live and captures a pre-merge baseline
+ * (`captureWalletEnvBootBaseline`) so persisted config cannot outrank launch
+ * env while the deferred hydrate runs.
  */
 import { logger } from "@elizaos/core";
 
@@ -50,16 +50,15 @@ function stewardOsPairs(): ReadonlyArray<
   ];
 }
 
-// The hydrate used to run BEFORE config.env merged into process.env, so its
+// The hydrate used to run before config.env merged into process.env, so its
 // "skip keys that already have a value" check naturally meant "skip keys the
 // LAUNCH ENV set" — vault/keystore values beat persisted config, launch env
 // beat both. Now that the agent boot defers the hydrate (it runs after the
 // merge), the baseline preserves that exact precedence: the boot path records
 // which handled keys the launch env set pre-merge, and `hasLaunchEnvValue`
 // treats a post-merge value on a key absent from the baseline as
-// overwritable. With no baseline captured (callers that still hydrate
-// pre-merge, e.g. app-core's startApiServer), any present value is respected —
-// the original semantics.
+// overwritable. With no baseline captured, any present value is respected —
+// the original pre-merge semantics used by direct callers.
 let walletEnvBootBaseline: ReadonlySet<string> | null = null;
 
 /** Record which wallet/steward env keys currently hold values (pre-merge). */

--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -77,7 +77,7 @@
     "migrate:generate": "cd src && drizzle-kit generate",
     "dev": "cd src && bun --hot build.ts",
     "test": "cd src && vitest run",
-    "typecheck": "tsc --noEmit -p src/tsconfig.json",
+    "typecheck": "tsc --noEmit -p src/tsconfig.typecheck.json",
     "lint": "cd src && bun run lint",
     "lint:check": "cd src && bun run lint:check",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs src/dist .turbo",

--- a/plugins/plugin-sql/src/package.json
+++ b/plugins/plugin-sql/src/package.json
@@ -64,7 +64,7 @@
     "dev": "bun run build.ts --watch",
     "migrate:generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "clean": "node ../../../packages/scripts/rm-path-recursive.mjs dist .turbo .turbo-tsconfig.json *.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write --config-path ./biome.json .",
     "format:check": "bunx @biomejs/biome format --config-path ./biome.json .",

--- a/plugins/plugin-sql/src/tsconfig.json
+++ b/plugins/plugin-sql/src/tsconfig.json
@@ -23,10 +23,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "allowUnusedLabels": true,
-    "types": ["node", "bun"],
-    "paths": {
-      "@elizaos/core": ["../../../packages/core/dist/index.d.ts"]
-    }
+    "types": ["node", "bun"]
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "__tests__", "**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]

--- a/plugins/plugin-sql/src/tsconfig.typecheck.json
+++ b/plugins/plugin-sql/src/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@elizaos/core": ["../../../packages/core/dist/index.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #27200

## Summary
- run standalone startup against workspace source so stale generated declarations cannot break required plugin imports
- keep plugin-sql declaration-backed typechecking separate from Bun runtime resolution
- bind the dev API before any optional native credential-store hydration and default dev startup to non-interactive wallet storage unless explicitly opted in
- add regression coverage for the source-start and bind-first contracts
- correct the real-server WebSocket test annotations so the agent package typecheck resolves the optional ws client type

## Validation
- `bun install` on current head (clean working tree afterward)
- `bun run start`; `/api/health` returned `ready: true`, `agentState: running`
- `bun run dev`; `:31337/api/health` returned `ready: true`, `agentState: running`; `:2138/` returned HTTP 200
- agent startup contract: 1 test passed
- app-core focused suite: 9 tests passed
- package typechecks: agent, app-core, plugin-sql passed
- `bun run verify` passed completely on the same patch before the latest develop-only rebase; focused tests and typechecks were rerun after that rebase

## Runtime notes
The local configuration still reports invalid wallet credentials, an unavailable native activity collector, optional X authentication failure, and a warming cloud gateway. Those integrations degrade independently; both startup commands reach a running agent and responsive API/UI.