### PR TITLE
test(shared): cover labels

### DIFF
--- a/packages/shared/src/utils/labels.test.ts
+++ b/packages/shared/src/utils/labels.test.ts
@@ -34,4 +34,38 @@ describe("autoLabel", () => {
     expect(autoLabel("plugin_rpc_url", "plugin")).toBe("RPC URL");
     expect(autoLabel("custom_client_secret", "custom")).toBe("Client Secret");
   });
+
+  it("preserves all supported environment key acronyms", () => {
+    expect(autoLabel("FOO_SSH_PRIVATE_KEY", "foo")).toBe("SSH Private Key");
+    expect(autoLabel("FOO_SSL_CERT", "foo")).toBe("SSL Cert");
+    expect(autoLabel("FOO_HTTP_PROXY", "foo")).toBe("HTTP Proxy");
+    expect(autoLabel("FOO_HTTPS_PORT", "foo")).toBe("HTTPS Port");
+    expect(autoLabel("FOO_RPC_NODE", "foo")).toBe("RPC Node");
+    expect(autoLabel("FOO_NFT_METADATA", "foo")).toBe("NFT Metadata");
+    expect(autoLabel("FOO_EVM_CHAIN_ID", "foo")).toBe("EVM Chain ID");
+    expect(autoLabel("FOO_TLS_ENABLED", "foo")).toBe("TLS Enabled");
+    expect(autoLabel("FOO_DNS_RESOLVER", "foo")).toBe("DNS Resolver");
+    expect(autoLabel("FOO_IP_ADDRESS", "foo")).toBe("IP Address");
+    expect(autoLabel("FOO_JWT_SECRET", "foo")).toBe("JWT Secret");
+    expect(autoLabel("FOO_SDK_VERSION", "foo")).toBe("SDK Version");
+    expect(autoLabel("FOO_LLM_MODEL", "foo")).toBe("LLM Model");
+  });
+
+  it("handles consecutive acronyms and compound names", () => {
+    expect(autoLabel("FOO_JWT_SDK_TOKEN", "foo")).toBe("JWT SDK Token");
+    expect(autoLabel("PLUGIN_TLS_DNS_SERVER", "plugin")).toBe(
+      "TLS DNS Server",
+    );
+    expect(autoLabel("FOO_EVM_RPC_URL", "foo")).toBe("EVM RPC URL");
+  });
+
+  it("filters out empty segments from consecutive underscores", () => {
+    expect(autoLabel("PLUGIN__API___KEY", "plugin")).toBe("API Key");
+    expect(autoLabel("__FOO__BAR__", "other")).toBe("Foo Bar");
+  });
+
+  it("handles single-letter tokens and empty string inputs", () => {
+    expect(autoLabel("PLUGIN_A_B_C", "plugin")).toBe("A B C");
+    expect(autoLabel("", "plugin")).toBe("");
+  });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/shared/src/utils/labels.ts` in the canonical test file (`packages/shared/src/utils/labels.test.ts`). No production code modified.

# Background

## What does this PR do?

Expands unit test coverage for `autoLabel` in `packages/shared/src/utils/labels.ts`:
- Tests preservation of all acronyms registered in `ENV_KEY_ACRONYMS` (SSH, SSL, HTTP, HTTPS, RPC, NFT, EVM, TLS, DNS, IP, JWT, SDK, LLM).
- Tests consecutive acronyms and compound key names (e.g. `JWT SDK Token`, `TLS DNS Server`, `EVM RPC URL`).
- Tests filtering out empty segments from consecutive underscores (`PLUGIN__API___KEY`).
- Tests single-letter tokens and empty string keys.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/utils/labels.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/shared/src/utils/labels.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/shared/src/utils/labels.test.ts:
(pass) autoLabel > strips the underscored plugin prefix and preserves acronyms
(pass) autoLabel > strips the collapsed (hyphen-removed) plugin prefix
(pass) autoLabel > title-cases ordinary words
(pass) autoLabel > leaves a key without the plugin prefix as a single title-cased token
(pass) autoLabel > does not strip a prefix-only key (length must strictly exceed the prefix)
(pass) autoLabel > handles lowercase and mixed-case keys and plugin ids
(pass) autoLabel > preserves all supported environment key acronyms
(pass) autoLabel > handles consecutive acronyms and compound names
(pass) autoLabel > filters out empty segments from consecutive underscores
(pass) autoLabel > handles single-letter tokens and empty string inputs

 10 pass
 0 fail
 29 expect() calls
Ran 10 tests across 1 file. [99.00ms]
```

# Evidence Gate

<!-- evidence-head:e1b539309b3aaff5ddeec40b4678d4e18a9353a1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; shared unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
