### PR TITLE
test(shared): cover permission-deep-links

### DIFF
--- a/packages/shared/src/utils/permission-deep-links.test.ts
+++ b/packages/shared/src/utils/permission-deep-links.test.ts
@@ -52,6 +52,32 @@ describe("getMacPermissionDeepLink", () => {
     expect(getMacPermissionDeepLink("automation")).toBe(
       `${PRIVACY_PREFIX}_Automation`,
     );
+    expect(getMacPermissionDeepLink("speech-recognition")).toBe(
+      `${PRIVACY_PREFIX}_SpeechRecognition`,
+    );
+    expect(getMacPermissionDeepLink("photos")).toBe(`${PRIVACY_PREFIX}_Photos`);
+    expect(getMacPermissionDeepLink("phone")).toBe(PRIVACY_PREFIX);
+    expect(getMacPermissionDeepLink("messages")).toBe(
+      `${PRIVACY_PREFIX}_AllFiles`,
+    );
+    expect(getMacPermissionDeepLink("wifi")).toBe(
+      `${PRIVACY_PREFIX}_LocationServices`,
+    );
+    expect(getMacPermissionDeepLink("bluetooth")).toBe(
+      "x-apple.systempreferences:com.apple.BluetoothSettings",
+    );
+    expect(getMacPermissionDeepLink("app-blocking")).toBe(
+      "x-apple.systempreferences:com.apple.preference.screentime",
+    );
+    expect(getMacPermissionDeepLink("usage-access")).toBe(
+      "x-apple.systempreferences:com.apple.preference.screentime",
+    );
+    expect(getMacPermissionDeepLink("overlay")).toBe(PRIVACY_PREFIX);
+    expect(getMacPermissionDeepLink("write-settings")).toBe(PRIVACY_PREFIX);
+    expect(getMacPermissionDeepLink("local-network")).toBe(
+      `${PRIVACY_PREFIX}_LocalNetwork`,
+    );
+    expect(getMacPermissionDeepLink("battery-optimization")).toBe(PRIVACY_PREFIX);
     expect(getMacPermissionDeepLink("screentime")).toBe(
       "x-apple.systempreferences:com.apple.preference.screentime",
     );
@@ -60,6 +86,9 @@ describe("getMacPermissionDeepLink", () => {
   it("falls back to the root Privacy pane for unmapped ids", () => {
     expect(getMacPermissionDeepLink("shell")).toBe(PRIVACY_PREFIX);
     expect(getMacPermissionDeepLink("website-blocking")).toBe(PRIVACY_PREFIX);
+    expect(
+      getMacPermissionDeepLink("unknown-permission" as unknown as any),
+    ).toBe(PRIVACY_PREFIX);
   });
 });
 
@@ -71,6 +100,41 @@ describe("openPermissionSettings", () => {
     expect(open).toHaveBeenCalledWith(
       "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders",
     );
+  });
+
+  it("supports asynchronous opener handlers", async () => {
+    let completed = false;
+    const asyncOpener = vi.fn(async () => {
+      await Promise.resolve();
+      completed = true;
+    });
+
+    await openPermissionSettings("bluetooth", {
+      platform: "darwin",
+      open: asyncOpener,
+    });
+    expect(asyncOpener).toHaveBeenCalledWith(
+      "x-apple.systempreferences:com.apple.BluetoothSettings",
+    );
+    expect(completed).toBe(true);
+  });
+
+  it("invokes window.open by default when window global is available", async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    const mockWindowOpen = vi.fn();
+    (globalThis as { window?: { open: typeof mockWindowOpen } }).window = {
+      open: mockWindowOpen,
+    };
+
+    try {
+      await openPermissionSettings("photos", { platform: "darwin" });
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_Photos",
+        "_self",
+      );
+    } finally {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
   });
 
   it("logs a warning and skips opener on win32", async () => {
@@ -87,6 +151,25 @@ describe("openPermissionSettings", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await openPermissionSettings("microphone", { platform: "linux", open });
     expect(open).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("uses detected platform by default when platform option is omitted", async () => {
+    const open = vi.fn();
+    await openPermissionSettings("camera", { open });
+    // In macOS test environment, process.platform is "darwin"
+    expect(open).toHaveBeenCalledWith(
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
+    );
+  });
+
+  it("logs a warning and skips opener on unknown platform", async () => {
+    const open = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await openPermissionSettings("location", { platform: "unknown", open });
+    expect(open).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/shared/src/utils/permission-deep-links.ts` in the canonical test file (`packages/shared/src/utils/permission-deep-links.test.ts`). No production logic modified.

# Background

## What does this PR do?

Expands unit test coverage for macOS permission deep-link helpers in `packages/shared/src/utils/permission-deep-links.ts`:
- Tests mappings for all remaining permissions in `MAC_DEEP_LINKS`: `speech-recognition`, `photos`, `phone`, `messages`, `wifi`, `bluetooth`, `app-blocking`, `usage-access`, `overlay`, `write-settings`, `local-network`, `battery-optimization`, and unmapped fallback URLs.
- Tests `openPermissionSettings` asynchronous custom openers.
- Tests default `window.open` invocation when running in environments where `window` is present.
- Tests default platform detection when the `platform` option is omitted.
- Tests warning logging and skipping for unsupported or unknown platforms.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/utils/permission-deep-links.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/shared/src/utils/permission-deep-links.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/shared/src/utils/permission-deep-links.test.ts:
(pass) getMacPermissionDeepLink > maps each permission id to the documented pane
(pass) getMacPermissionDeepLink > falls back to the root Privacy pane for unmapped ids
(pass) openPermissionSettings > invokes the opener with the deep-link URL on darwin
(pass) openPermissionSettings > supports asynchronous opener handlers
(pass) openPermissionSettings > invokes window.open by default when window global is available
(pass) openPermissionSettings > logs a warning and skips opener on win32
(pass) openPermissionSettings > logs a warning and skips opener on linux
(pass) openPermissionSettings > uses detected platform by default when platform option is omitted
(pass) openPermissionSettings > logs a warning and skips opener on unknown platform

 9 pass
 0 fail
 41 expect() calls
Ran 9 tests across 1 file. [77.00ms]
```

# Evidence Gate

<!-- evidence-head:fc4426f5a770585947eb85f7bfc4f6d57a52b58d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; shared unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; shared unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
