### PR TITLE
test(ui): cover stream pop-out detector and window-size constants

### DIFF
--- a/packages/ui/src/components/stream/helpers.test.ts
+++ b/packages/ui/src/components/stream/helpers.test.ts
@@ -1,0 +1,93 @@
+/** Verifies the stream-view window-size constants and pop-out-mode detector through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Unit coverage for stream/helpers: PIP/FULL dimensions and the
+ * module-load-time IS_POPOUT probe across query-string, hash-query,
+ * missing-window, and precedence branches. Each IS_POPOUT case reloads the
+ * module fresh so its load-time URL probe runs against the staged location.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FULL_SIZE, PIP_SIZE } from "./helpers";
+
+async function loadIsPopout(): Promise<boolean> {
+  vi.resetModules();
+  const mod = await import("./helpers");
+  return mod.IS_POPOUT;
+}
+
+function stageUrl(url: string): void {
+  window.history.replaceState(null, "", url);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("PIP_SIZE and FULL_SIZE", () => {
+  it("exposes the documented PIP capture dimensions (640x360)", () => {
+    expect(PIP_SIZE).toEqual({ width: 640, height: 360 });
+  });
+
+  it("exposes the documented full-stream dimensions (1280x720)", () => {
+    expect(FULL_SIZE).toEqual({ width: 1280, height: 720 });
+  });
+});
+
+describe("IS_POPOUT", () => {
+  it("is false on a plain document without a popout flag", async () => {
+    stageUrl("http://localhost/");
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("detects a bare ?popout flag in the query string", async () => {
+    stageUrl("http://localhost/stream?popout");
+    expect(await loadIsPopout()).toBe(true);
+  });
+
+  it("detects a valued ?popout=1 flag in the query string", async () => {
+    stageUrl("http://localhost/stream?popout=1");
+    expect(await loadIsPopout()).toBe(true);
+  });
+
+  it("ignores unrelated query parameters", async () => {
+    stageUrl("http://localhost/stream?tab=chat&agent=nux");
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("routes file:/electrobun-style popouts through the hash query", async () => {
+    stageUrl("http://localhost/#/stream?popout=1");
+    expect(await loadIsPopout()).toBe(true);
+  });
+
+  it("ignores a hash without a query section", async () => {
+    stageUrl("http://localhost/#/stream");
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("ignores hash query parameters other than popout", async () => {
+    stageUrl("http://localhost/#/stream?tab=chat");
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("prefers the query string over the hash when both exist", async () => {
+    stageUrl("http://localhost/stream?tab=chat#/stream?popout=1");
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("reports false when window itself is absent (SSR)", async () => {
+    vi.stubGlobal("window", undefined);
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("reports false when window has no location object", async () => {
+    vi.stubGlobal("window", {});
+    expect(await loadIsPopout()).toBe(false);
+  });
+
+  it("tolerates a location without search or hash fields", async () => {
+    vi.stubGlobal("window", { location: {} });
+    expect(await loadIsPopout()).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds a unit suite for `packages/ui/src/components/stream/helpers.ts`, which had no same-named test file anywhere on develop. Test-only change: +93/−0 in a single new file, no production code touched.

## Coverage (13 cases)

- **PIP_SIZE / FULL_SIZE** — pinned to the documented 640x360 PIP and 1280x720 full-stream dimensions.
- **IS_POPOUT** — the detector runs at module load, so each case re-imports the module against a staged location:
  - bare `?popout` and valued `?popout=1` query flags → true
  - unrelated query params → false
  - hash-routed popouts (`#/stream?popout=1`, the file:/electrobun path) → true
  - hash without a query section, and hash query without `popout` → false
  - non-empty search wins over the hash when both exist (hash-only flag loses) → false
  - absent `window` (SSR), window without `location`, location missing search/hash fields → false via the guard branches

All expectations record observed behaviour of the current module; nothing aspirational.

## Verification

- `bunx vitest run src/components/stream/helpers.test.ts` (packages/ui): **13 passed (13)**, 1 test file passed.
- `bunx biome check --write packages/ui/src/components/stream/helpers.test.ts`: clean, "Checked 1 file ... No fixes applied".
- `bunx tsc --noEmit` in packages/ui: the new test file appears nowhere in the output.
- Diff touches only `packages/ui/src/components/stream/helpers.test.ts`.

## CI note

We are a fork contributor; hosted CI does not run on this PR. The counts above are quoted from local runs at head e93f5919a5 against origin/develop e3e63588fd.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e93f5919a5527b834f794676a555353700c33ba7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
