### PR TITLE
test(core): cover format-error

### DIFF
--- a/packages/core/src/utils/format-error.test.ts
+++ b/packages/core/src/utils/format-error.test.ts
@@ -89,4 +89,37 @@ describe("formatError", () => {
 		}).not.toThrow();
 		expect(out).toBe("[object Object]");
 	});
+
+	it("returns [unstringifiable error] when type-tag access is hostile", () => {
+		const hostile = new Proxy(
+			{},
+			{
+				get(_target, prop) {
+					if (
+						prop === Symbol.toPrimitive ||
+						prop === "toString" ||
+						prop === Symbol.toStringTag
+					) {
+						throw new Error("hostile property access");
+					}
+					return undefined;
+				},
+			},
+		);
+
+		let out = "";
+		expect(() => {
+			out = formatError(hostile);
+		}).not.toThrow();
+		expect(out).toBe("[unstringifiable error]");
+	});
+
+	it("formats standard built-in errors and empty message errors", () => {
+		expect(formatError(new TypeError("type mismatch"))).toBe("type mismatch");
+		expect(formatError(new RangeError("out of bounds"))).toBe("out of bounds");
+		expect(formatError(new SyntaxError("unexpected token"))).toBe(
+			"unexpected token",
+		);
+		expect(formatError(new Error(""))).toBe("");
+	});
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/core/src/utils/format-error.ts` in the canonical test file (`packages/core/src/utils/format-error.test.ts`). No production logic modified.

# Background

## What does this PR do?

Expands unit test coverage for `formatError` in `packages/core/src/utils/format-error.ts`:
- Tests hostile proxy objects throwing on `Symbol.toPrimitive`, `toString`, and `Symbol.toStringTag`, confirming fallback to `"[unstringifiable error]"` without uncaught exceptions.
- Tests standard JavaScript built-in error instances (`TypeError`, `RangeError`, `SyntaxError`) and empty-message `Error` instances.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/format-error.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/format-error.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/core/src/utils/format-error.test.ts:
(pass) formatError > returns an Error's message
(pass) formatError > returns the message of an Error subclass
(pass) formatError > stringifies primitives
(pass) formatError > stringifies a plain object via its toString
(pass) formatError > does not throw on a null-prototype object
(pass) formatError > does not throw when toString throws
(pass) formatError > does not throw when Symbol.toPrimitive throws
(pass) formatError > does not throw when an Error's message getter throws
(pass) formatError > does not throw on a circular object
(pass) formatError > returns [unstringifiable error] when type-tag access is hostile
(pass) formatError > formats standard built-in errors and empty message errors

 11 pass
 0 fail
 25 expect() calls
Ran 11 tests across 1 file. [83.00ms]
```

# Evidence Gate

<!-- evidence-head:63cbb67e39d7a90bf05628e5b5b85b32b9232f70 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; core unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
