### PR TITLE
test(core): cover atomic-json

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -117,6 +117,59 @@ describe("atomic-json", () => {
 			expect((await fsp.readdir(tempDir)).sort()).toEqual(["concurrent.json"]);
 		});
 
+		it("honors skipMkdir option in async and sync writers", async () => {
+			const existingParentTarget = path.join(tempDir, "skip-mkdir.json");
+			await writeJsonAtomic(
+				existingParentTarget,
+				{ ok: true },
+				{ skipMkdir: true },
+			);
+			expect(await readJsonFile(existingParentTarget)).toEqual({ ok: true });
+
+			const nonExistentDirTarget = path.join(
+				tempDir,
+				"non-existent-dir",
+				"data.json",
+			);
+			await expect(
+				writeJsonAtomic(
+					nonExistentDirTarget,
+					{ ok: true },
+					{ skipMkdir: true },
+				),
+			).rejects.toThrow();
+
+			expect(() =>
+				writeJsonAtomicSync(
+					nonExistentDirTarget,
+					{ ok: true },
+					{ skipMkdir: true },
+				),
+			).toThrow();
+		});
+
+		it("cleans up temporary file when value serialization fails", async () => {
+			const target = path.join(tempDir, "bigint-fail.json");
+			const circular: Record<string, unknown> = {};
+			circular.self = circular;
+
+			await expect(writeJsonAtomic(target, circular)).rejects.toThrow();
+			const files = await fsp.readdir(tempDir);
+			expect(files.filter((f) => f.includes("tmp-"))).toHaveLength(0);
+
+			expect(() => writeJsonAtomicSync(target, circular)).toThrow();
+			const filesSync = fs.readdirSync(tempDir);
+			expect(filesSync.filter((f) => f.includes("tmp-"))).toHaveLength(0);
+		});
+
+		it("propagates non-ENOENT read errors (e.g. EISDIR)", async () => {
+			const dirTarget = path.join(tempDir, "directory-target");
+			await fsp.mkdir(dirTarget);
+
+			await expect(readJsonFile(dirTarget)).rejects.toThrow();
+			expect(() => readJsonFileSync(dirTarget)).toThrow();
+		});
+
 		it("rejects non-string or empty file paths", async () => {
 			await expect(
 				writeJsonAtomic("" as unknown as string, {}),


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/core/src/utils/atomic-json.ts` in the canonical test file (`packages/core/src/utils/atomic-json.test.ts`). No production logic modified.

# Background

## What does this PR do?

Expands unit test coverage for atomic JSON helpers in `packages/core/src/utils/atomic-json.ts`:
- Tests `skipMkdir: true` option in both async (`writeJsonAtomic`) and sync (`writeJsonAtomicSync`) writers, ensuring writes succeed when parent directories exist and fail when directories are missing.
- Tests best-effort temporary file cleanup when serialization fails (e.g. circular structures).
- Tests error propagation when read operations encounter non-ENOENT filesystem errors (such as reading a directory path via `readJsonFile` or `readJsonFileSync`).

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/atomic-json.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/atomic-json.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/core/src/utils/atomic-json.test.ts:
(pass) atomic-json > writeJsonAtomic & readJsonFile (async) > writes and reads json data atomically
(pass) atomic-json > writeJsonAtomic & readJsonFile (async) > returns null for non-existent files (ENOENT)
(pass) atomic-json > writeJsonAtomic & readJsonFile (async) > throws for malformed JSON
(pass) atomic-json > writeJsonAtomic & readJsonFile (async) > supports custom formatting options like trailingNewline and indent
(pass) atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > writes and reads json data synchronously
(pass) atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > returns null for non-existent files (ENOENT)
(pass) atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > throws for malformed JSON
(pass) atomic-json > writeJsonAtomicSync & readJsonFileSync (sync) > supports custom formatting options synchronously
(pass) atomic-json > concurrency and validation > handles concurrent same-target writes in the same millisecond
(pass) atomic-json > concurrency and validation > honors skipMkdir option in async and sync writers
(pass) atomic-json > concurrency and validation > cleans up temporary file when value serialization fails
(pass) atomic-json > concurrency and validation > propagates non-ENOENT read errors (e.g. EISDIR)
(pass) atomic-json > concurrency and validation > rejects non-string or empty file paths

 13 pass
 0 fail
 25 expect() calls
Ran 13 tests across 1 file. [148.00ms]
```

# Evidence Gate

<!-- evidence-head:38dfe754719455d7217c4cf80a0431d55dab777f -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; core unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
