### PR TITLE
test(ui): cover view-icons.generated

### DIFF
--- a/packages/ui/src/components/views/view-icons.generated.test.ts
+++ b/packages/ui/src/components/views/view-icons.generated.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for view icons generated catalog: validates icon URL lookup.
  */
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { VIEW_ICONS, viewIconDataUri } from "./view-icons.generated.ts";
 
@@ -21,5 +23,50 @@ describe("view-icons.generated", () => {
   it("falls back to default icon URI for unknown view IDs", () => {
     const unknownIcon = viewIconDataUri("non-existent-view-id");
     expect(unknownIcon).toBe(VIEW_ICONS.default);
+  });
+
+  it("maps every catalog key to its own view-icons/<key>.png asset", () => {
+    const keys = Object.keys(VIEW_ICONS);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(VIEW_ICONS[key]).toBe(
+        new URL(`./view-icons/${key}.png`, import.meta.url).href,
+      );
+    }
+  });
+
+  it("references a packaged PNG on disk for every catalog entry", () => {
+    expect(Object.keys(VIEW_ICONS).length).toBe(52);
+    for (const url of Object.values(VIEW_ICONS)) {
+      expect(existsSync(fileURLToPath(url)), url).toBe(true);
+    }
+  });
+
+  it("returns the exact catalog entry for every known id", () => {
+    for (const [id, icon] of Object.entries(VIEW_ICONS)) {
+      expect(viewIconDataUri(id)).toBe(icon);
+    }
+  });
+
+  it("assigns a distinct asset to every id", () => {
+    const values = Object.values(VIEW_ICONS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("exposes parseable URLs whose paths end in .png under view-icons/", () => {
+    for (const url of Object.values(VIEW_ICONS)) {
+      const path = new URL(url).pathname;
+      expect(path.endsWith(".png"), url).toBe(true);
+      expect(path.includes("/view-icons/"), url).toBe(true);
+    }
+  });
+
+  it("falls back to the default icon for an empty id", () => {
+    expect(viewIconDataUri("")).toBe(VIEW_ICONS.default);
+  });
+
+  it("treats lookup as case-sensitive and falls back on mismatched case", () => {
+    expect(viewIconDataUri("Chat")).toBe(VIEW_ICONS.default);
+    expect(viewIconDataUri("SETTINGS")).toBe(VIEW_ICONS.default);
   });
 });


### PR DESCRIPTION

## Summary

Extends unit coverage for `packages/ui/src/components/views/view-icons.generated.ts` — the generated VIEW_ICONS catalog and its `viewIconDataUri` fallback resolver.

The existing suite (landed in #26989, 3 cases) is preserved byte-for-byte; this diff only **adds** 7 cases (+47/-0, no deletions):

- every catalog key maps to exactly `./view-icons/<key>.png` recomputed from the same `import.meta.url` base
- every referenced PNG actually exists on disk (`node:fs` check against the packaged assets — catches dangling baked URLs)
- catalog completeness pinned at the current 52 entries, each backed by a distinct asset
- resolver returns the exact catalog entry for every known id
- every value parses as a URL whose path ends in `.png` under `/view-icons/`
- empty-string id falls back to `VIEW_ICONS.default`
- lookup is case-sensitive ("Chat", "SETTINGS" fall back to default)

All assertions drive the real module — no mocks, no type-only subjects, no `expectTypeOf`.

## Test evidence

Fork contributor: hosted CI does not run on this PR. Local verification against current `origin/develop` (84f1f002a0):

```
bunx vitest run packages/ui/src/components/views/view-icons.generated.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)   # 3 pre-existing + 7 added

bunx biome check packages/ui/src/components/views/view-icons.generated.test.ts
Checked 1 file in 47ms. No fixes applied.

bunx tsc --noEmit (packages/ui) | grep view-icons.generated.test
# no matches — zero type errors introduced by this file
```

The diff touches only `packages/ui/src/components/views/view-icons.generated.test.ts`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e4a7fff43513e35abd89897540bb378786c4f0e4 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
