### PR TITLE
test(core): cover confirmation

### DIFF
--- a/packages/core/src/utils/confirmation.test.ts
+++ b/packages/core/src/utils/confirmation.test.ts
@@ -205,22 +205,147 @@ describe("confirmation utilities", () => {
 		expect(runtime.cacheStore.size).toBe(0);
 	});
 
-	it("delegates properly through gateDestructiveConfirmation", async () => {
+	it("delegates properly through gateDestructiveConfirmation across all statuses", async () => {
 		const runtime = createMockRuntime();
 		const message: Memory = {
 			entityId: "user-123",
 			content: { text: "remove" },
 		} as unknown as Memory;
 
-		const gate = await gateDestructiveConfirmation({
+		const pendingGate = await gateDestructiveConfirmation({
 			runtime,
 			message,
 			actionName: "REMOVE_ENTRY",
 			pendingKey: "entry:5",
 			prompt: "Remove entry 5?",
+			metadata: { entryId: 5 },
 		});
 
-		expect(gate.status).toBe("pending");
+		expect(pendingGate.status).toBe("pending");
+
+		// Confirmed branch
+		const confirmMessage: Memory = {
+			entityId: "user-123",
+			content: { text: "yes" },
+		} as unknown as Memory;
+
+		const confirmedGate = await gateDestructiveConfirmation({
+			runtime,
+			message: confirmMessage,
+			actionName: "REMOVE_ENTRY",
+			pendingKey: "entry:5",
+			prompt: "Remove entry 5?",
+		});
+
+		expect(confirmedGate.status).toBe("confirmed");
+		expect(confirmedGate.metadata).toEqual({ entryId: 5 });
+
+		// Cancelled branch
+		await gateDestructiveConfirmation({
+			runtime,
+			message,
+			actionName: "REMOVE_ENTRY",
+			pendingKey: "entry:6",
+			prompt: "Remove entry 6?",
+			metadata: { entryId: 6 },
+		});
+
+		const cancelMessage: Memory = {
+			entityId: "user-123",
+			content: { text: "no" },
+		} as unknown as Memory;
+
+		const cancelledGate = await gateDestructiveConfirmation({
+			runtime,
+			message: cancelMessage,
+			actionName: "REMOVE_ENTRY",
+			pendingKey: "entry:6",
+			prompt: "Remove entry 6?",
+		});
+
+		expect(cancelledGate.status).toBe("cancelled");
+		expect(cancelledGate.metadata).toEqual({ entryId: 6 });
+	});
+
+	it("supports custom confirmRegex pattern", async () => {
+		const runtime = createMockRuntime();
+		const message1: Memory = {
+			entityId: "user-123",
+			content: { text: "delete database" },
+		} as unknown as Memory;
+
+		const customRegex = /^PROCEED_WITH_PURGE$/;
+
+		await requireConfirmation({
+			runtime,
+			message: message1,
+			actionName: "PURGE_DB",
+			pendingKey: "db:production",
+			prompt: "Type PROCEED_WITH_PURGE to confirm",
+			confirmRegex: customRegex,
+		});
+
+		// Replying with standard "yes" is cancelled under customRegex
+		const regularYes: Memory = {
+			entityId: "user-123",
+			content: { text: "yes" },
+		} as unknown as Memory;
+
+		const decision1 = await requireConfirmation({
+			runtime,
+			message: regularYes,
+			actionName: "PURGE_DB",
+			pendingKey: "db:production",
+			prompt: "Type PROCEED_WITH_PURGE to confirm",
+			confirmRegex: customRegex,
+		});
+		expect(decision1.status).toBe("cancelled");
+
+		// Request again and reply with exact pattern
+		await requireConfirmation({
+			runtime,
+			message: message1,
+			actionName: "PURGE_DB",
+			pendingKey: "db:production",
+			prompt: "Type PROCEED_WITH_PURGE to confirm",
+			confirmRegex: customRegex,
+		});
+
+		const matchingReply: Memory = {
+			entityId: "user-123",
+			content: { text: "PROCEED_WITH_PURGE" },
+		} as unknown as Memory;
+
+		const decision2 = await requireConfirmation({
+			runtime,
+			message: matchingReply,
+			actionName: "PURGE_DB",
+			pendingKey: "db:production",
+			prompt: "Type PROCEED_WITH_PURGE to confirm",
+			confirmRegex: customRegex,
+		});
+		expect(decision2.status).toBe("confirmed");
+	});
+
+	it("falls back to DEFAULT_TTL_MS when non-positive ttlMs is supplied", async () => {
+		const runtime = createMockRuntime();
+		const message: Memory = {
+			entityId: "user-123",
+			content: { text: "delete item" },
+		} as unknown as Memory;
+
+		await requireConfirmation({
+			runtime,
+			message,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:1",
+			prompt: "Delete item?",
+			ttlMs: -100,
+		});
+
+		const cachedKey = "confirmation:user-123:DELETE_ITEM:item:1";
+		const record = runtime.cacheStore.get(cachedKey) as { ttlMs: number };
+		expect(record.ttlMs).toBe(300_000);
 	});
 
 	it("rejects LLM confirmed flag as authoritative", () => {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Purely additive unit test coverage for `packages/core/src/utils/confirmation.ts` in the canonical test file (`packages/core/src/utils/confirmation.test.ts`). No production logic modified.

# Background

## What does this PR do?

Expands unit test coverage for destructive action confirmation helpers in `packages/core/src/utils/confirmation.ts`:
- Tests `gateDestructiveConfirmation` resolution across all three status states: `pending` on initial invocation, `confirmed` with returned metadata on user yes reply, and `cancelled` with returned metadata on user negative reply.
- Tests `requireConfirmation` with custom `confirmRegex` options (ensuring non-matching affirmations cancel and exact matching replies confirm).
- Tests `DEFAULT_TTL_MS` fallback when non-positive `ttlMs` is supplied.

## What kind of change is this?

Improvements (misc. changes to existing features - test coverage expansion)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/confirmation.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/confirmation.test.ts
```

Output:
```text
bun test v1.3.11 (af24e281)

packages/core/src/utils/confirmation.test.ts:
(pass) confirmation utilities > stashes pending confirmation and invokes callback on first call
(pass) confirmation utilities > confirms on affirmative user reply across languages
(pass) confirmation utilities > cancels when user replies with non-affirmative text
(pass) confirmation utilities > treats expired pending confirmation as fresh call
(pass) confirmation utilities > clears pending confirmation via clearPendingConfirmation
(pass) confirmation utilities > delegates properly through gateDestructiveConfirmation across all statuses
(pass) confirmation utilities > supports custom confirmRegex pattern
(pass) confirmation utilities > falls back to DEFAULT_TTL_MS when non-positive ttlMs is supplied
(pass) confirmation utilities > rejects LLM confirmed flag as authoritative

 9 pass
 0 fail
 54 expect() calls
Ran 9 tests across 1 file. [89.00ms]
```

# Evidence Gate

<!-- evidence-head:5b1fcfcc7b8406b60354d63f688f04f0980347ec -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no rendered UI changes; core unit test only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow changes; core unit test only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test coverage with deterministic assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - unit test only; no LLM prompts or providers changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered UI changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - unit test only; no LLM prompts or providers changed.

## Backend + frontend logs

N/A - unit test coverage with deterministic assertions.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes.

### After
N/A - no rendered UI changes.

### Walkthrough video
N/A - no user flow changes.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
