### PR TITLE
test(ui): cover useShellController

### DIFF
--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -22,6 +22,7 @@ import {
   type Mock,
   vi,
 } from "vitest";
+import type { ImageAttachment } from "../../../api/client-types-chat";
 import type { RealtimeVoiceStartOutcome } from "../../../hooks/useRealtimeVoiceSession";
 import { RESYNC_EVENT } from "../../../state/AppContext.hooks";
 import {
@@ -2782,5 +2783,500 @@ describe("useShellController cloud-only auth gate", () => {
     expect(result.current.handsFree).toBe(false);
     expect(result.current.isOpen).toBe(false);
     expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── Additive coverage: input routing edges, pendant relay, vision, notices ──
+// These blocks extend (never rewrite) the suites above with branches they did
+// not reach: the omi pendant → chat relay effect, the VISION button pipeline,
+// send()'s empty/image-only guards, the remaining describeCaptureFailure copy
+// branches + the once-per-grant-epoch notice latch, the onSilentDrop hint,
+// unrecognized voice-settings continuous values, the bootProgressSignal token,
+// cancelRecording's dispose-without-drain contract, stopTurn's streaming-vs-TTS
+// split, the agent voice-mute toggle, and unlockAudio's realtime routing.
+
+describe("useShellController — send() edge guards", () => {
+  beforeEach(() => {
+    appMock.value.agentStatus = { ...READY_STATUS };
+    appMock.value.sendChatText.mockClear();
+  });
+
+  it("ignores a whitespace-only send that carries no attachments", () => {
+    const { result } = renderHook(() => useShellController());
+
+    act(() => result.current.send("   "));
+
+    // Neither text nor an image: nothing reaches sendChatText.
+    expect(appMock.value.sendChatText).not.toHaveBeenCalled();
+  });
+
+  it("accepts an image-only send with empty text", () => {
+    const { result } = renderHook(() => useShellController());
+    const image: ImageAttachment = {
+      data: "aGk=",
+      mimeType: "image/png",
+      name: "shot.png",
+    };
+
+    act(() => result.current.send("", { images: [image] }));
+
+    expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
+    expect(appMock.value.sendChatText.mock.calls[0]?.[0]).toBe("");
+    const options = appMock.value.sendChatText.mock.calls[0]?.[1] as {
+      images?: ImageAttachment[];
+      channelType?: string;
+    };
+    expect(options?.images).toHaveLength(1);
+    expect(options?.images?.[0]?.name).toBe("shot.png");
+    // A typed/image-only turn is NOT voice-originated — no spoken reply.
+    expect(voiceOutputMock.lastTurnVoiceSeen).toBe(false);
+  });
+
+  it("forwards channelType, metadata, and clientMessageId verbatim", () => {
+    const { result } = renderHook(() => useShellController());
+    const metadata = { source: "test" };
+
+    act(() =>
+      result.current.send("hello", {
+        channelType: "DM",
+        metadata,
+        clientMessageId: "client-1",
+      }),
+    );
+
+    expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
+    expect(appMock.value.sendChatText.mock.calls[0]?.[0]).toBe("hello");
+    expect(appMock.value.sendChatText.mock.calls[0]?.[1]).toEqual({
+      channelType: "DM",
+      metadata,
+      clientMessageId: "client-1",
+    });
+  });
+});
+
+describe("useShellController — pendant transcript relay", () => {
+  beforeEach(() => {
+    appMock.value.agentStatus = { ...READY_STATUS };
+    appMock.value.sendChatText.mockClear();
+  });
+
+  function firePendant(detail: Record<string, unknown>): void {
+    window.dispatchEvent(
+      new CustomEvent("eliza:pendant:voice-transcript", { detail }),
+    );
+  }
+
+  it("routes a finalized pendant transcript as a VOICE_DM turn", () => {
+    renderHook(() => useShellController());
+
+    act(() =>
+      firePendant({
+        text: "note from the pendant",
+        ownerId: "owner-1",
+        agentId: "agent-2",
+        sessionId: "sess-3",
+        segmentId: "seg-9",
+        segmentRevision: 4,
+      }),
+    );
+
+    expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
+    expect(appMock.value.sendChatText.mock.calls[0]?.[0]).toBe(
+      "note from the pendant",
+    );
+    expect(appMock.value.sendChatText.mock.calls[0]?.[1]).toMatchObject({
+      channelType: "VOICE_DM",
+      clientMessageId: "pendant:seg-9",
+      metadata: {
+        voiceSource: "pendant",
+        pendantOwnerId: "owner-1",
+        pendantAgentId: "agent-2",
+        pendantSessionId: "sess-3",
+        pendantSegmentId: "seg-9",
+        pendantSegmentRevision: 4,
+      },
+    });
+  });
+
+  it("omits the dedupe id when the pendant segment has none", () => {
+    renderHook(() => useShellController());
+
+    act(() => firePendant({ text: "quick note" }));
+
+    expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
+    const options = appMock.value.sendChatText.mock.calls[0]?.[1] as {
+      clientMessageId?: string;
+    };
+    expect(options.clientMessageId).toBeUndefined();
+  });
+
+  it("ignores a blank pendant transcript", () => {
+    renderHook(() => useShellController());
+
+    act(() => firePendant({ text: "   " }));
+
+    expect(appMock.value.sendChatText).not.toHaveBeenCalled();
+  });
+});
+
+describe("useShellController — vision capture", () => {
+  beforeEach(() => {
+    appMock.value.agentStatus = { ...READY_STATUS };
+    appMock.value.sendChatText.mockClear();
+  });
+
+  it("sends the screen-vision turn and pulses until the reply is in flight", () => {
+    const { result, rerender } = renderHook(() => useShellController());
+    expect(result.current.visionCapturing).toBe(false);
+
+    act(() => result.current.captureVision());
+
+    expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
+    expect(appMock.value.sendChatText.mock.calls[0]?.[0]).toBe(
+      "Take a look at my screen and tell me what you see.",
+    );
+    expect(appMock.value.sendChatText.mock.calls[0]?.[1]).toMatchObject({
+      metadata: { vision: { surface: "screen" } },
+    });
+    expect(result.current.visionCapturing).toBe(true);
+
+    // The pulse clears once the turn is actually in flight (responding rises).
+    composerMock.value.chatSending = true;
+    rerender();
+    expect(result.current.visionCapturing).toBe(false);
+    composerMock.value.chatSending = false;
+  });
+
+  it("does not capture vision when the agent is stopped", () => {
+    appMock.value.agentStatus = { state: "stopped", canRespond: false };
+    const { result } = renderHook(() => useShellController());
+    expect(result.current.canSend).toBe(false);
+
+    act(() => result.current.captureVision());
+
+    expect(appMock.value.sendChatText).not.toHaveBeenCalled();
+    expect(result.current.visionCapturing).toBe(false);
+  });
+});
+
+describe("useShellController — capture-failure copy + notice latch", () => {
+  /** Install a capture whose start() rejects with the given error. */
+  function installRejectingCapture(err: unknown): void {
+    createVoiceCaptureMock.mockImplementation(
+      () =>
+        ({
+          start: vi.fn(() => Promise.reject(err)),
+          stop: vi.fn(() => Promise.resolve()),
+          dispose: vi.fn(),
+          getAnalyser: vi.fn(() => null),
+        }) as never,
+    );
+  }
+
+  async function flushCaptureStart(): Promise<void> {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  beforeEach(() => {
+    createVoiceCaptureMock.mockReset();
+    appMock.value.setActionNotice.mockClear();
+    appMock.value.agentStatus = { ...READY_STATUS };
+    try {
+      window.localStorage.clear();
+    } catch {}
+  });
+
+  it("uses generic microphone wording for an unknown failure", async () => {
+    installRejectingCapture(new Error("kaboom"));
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    await flushCaptureStart();
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+    const [text, tone] = appMock.value.setActionNotice.mock.calls[0] as [
+      string,
+      string,
+    ];
+    expect(text).toContain("Could not start the microphone");
+    expect(tone).toBe("error");
+    expect(result.current.recording).toBe(false);
+  });
+
+  it("surfaces the transcription-failure wording for a post-capture STT error", async () => {
+    installFakeCapture();
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    expect(result.current.recording).toBe(true);
+
+    // The mic worked and the utterance was recorded, but cloud STT failed at
+    // stop() — the honest message blames transcription, not the microphone.
+    act(() =>
+      lastCaptureOpts?.onStateChange?.(
+        "error",
+        new Error("CloudSttError: upstream 502"),
+      ),
+    );
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+    const [text] = appMock.value.setActionNotice.mock.calls[0] as [string];
+    expect(text).toContain("Didn't catch that");
+    expect(text.toLowerCase()).not.toContain("permission");
+    expect(result.current.recording).toBe(false);
+  });
+
+  it("notifies once per grant epoch until a capture starts successfully", async () => {
+    installRejectingCapture(new Error("kaboom"));
+    const { result } = renderHook(() => useShellController());
+
+    // First failed open → one actionable notice.
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    await flushCaptureStart();
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+
+    // A retry (e.g. the hands-free re-listen loop) must NOT spam the toast
+    // while the grant epoch is unresolved.
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    await flushCaptureStart();
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+
+    // One successful open clears the latch…
+    installFakeCapture();
+    await act(async () => {
+      result.current.startRecording("dictate");
+    });
+    expect(result.current.recording).toBe(true);
+
+    // Release the healthy capture so the mic is free again…
+    await act(async () => {
+      result.current.stopRecording();
+    });
+    expect(result.current.recording).toBe(false);
+
+    // …then a later denial is surfaced again instead of vanishing forever.
+    installRejectingCapture(new Error("kaboom"));
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    await flushCaptureStart();
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the silent-drop hint as an info notice", async () => {
+    installFakeCapture();
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("ptt");
+    });
+    // The factory's pre-POST silence guard fired: a near-silent tap produced
+    // nothing worth sending — nudge the user to speak up (info, short).
+    act(() => lastCaptureOpts?.onSilentDrop?.());
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+      "Didn't catch that — try again.",
+      "info",
+      2500,
+    );
+  });
+});
+
+describe("useShellController — interim transcript + cancelRecording", () => {
+  beforeEach(() => {
+    lastCaptureOpts = null;
+    captureHandles = [];
+    createVoiceCaptureMock.mockReset();
+    installFakeCapture();
+    appMock.value.agentStatus = { ...READY_STATUS };
+    appMock.value.sendChatText.mockClear();
+    try {
+      window.localStorage.clear();
+    } catch {}
+  });
+
+  it("shows the live interim transcript and clears it on cancel without draining", async () => {
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.startRecording("dictate");
+    });
+    expect(result.current.recording).toBe(true);
+
+    // An interim (non-final) segment surfaces as the live transcription.
+    act(() =>
+      lastCaptureOpts?.onTranscript?.({
+        text: "partial words",
+        final: false,
+        backend: "browser",
+      }),
+    );
+    expect(result.current.transcript).toBe("partial words");
+
+    // Cancel (#20483 hold-release abort): dispose releases the mic WITHOUT the
+    // stop() STT drain — nothing transcribes, nothing sends.
+    act(() => result.current.cancelRecording());
+
+    expect(captureHandles[0]?.dispose).toHaveBeenCalledTimes(1);
+    expect(captureHandles[0]?.stop).not.toHaveBeenCalled();
+    expect(result.current.recording).toBe(false);
+    expect(result.current.transcript).toBe("");
+  });
+});
+
+describe("useShellController — stop() routing", () => {
+  beforeEach(() => {
+    appMock.value.handleChatStop.mockClear();
+    voiceOutputMock.stopSpeaking.mockClear();
+  });
+
+  it("halts a streaming turn via handleChatStop and stops speech", () => {
+    composerMock.value.chatSending = true;
+    const { result } = renderHook(() => useShellController());
+
+    act(() => result.current.stop());
+
+    expect(appMock.value.handleChatStop).toHaveBeenCalledTimes(1);
+    expect(voiceOutputMock.stopSpeaking).toHaveBeenCalledTimes(1);
+    composerMock.value.chatSending = false;
+  });
+
+  it("during pure TTS playback stops the speech but not the chat stream", () => {
+    composerMock.value.chatSending = false;
+    voiceOutputMock.speaking = true;
+    const { result } = renderHook(() => useShellController());
+
+    act(() => result.current.stop());
+
+    // handleChatStop also tears down unrelated PTY sessions — it must NOT run
+    // while only the spoken playback is active.
+    expect(appMock.value.handleChatStop).not.toHaveBeenCalled();
+    expect(voiceOutputMock.stopSpeaking).toHaveBeenCalledTimes(1);
+    voiceOutputMock.speaking = false;
+  });
+});
+
+describe("useShellController — agent voice mute toggle", () => {
+  it("projects the voice-output mute surface and delegates the toggle to it", () => {
+    const { result } = renderHook(() => useShellController());
+
+    // The controller exposes the voice-output hook's mute state + control.
+    expect(result.current.agentVoiceMuted).toBe(
+      voiceOutputMock.agentVoiceMuted,
+    );
+    expect(result.current.toggleAgentVoiceMute).toBe(
+      voiceOutputMock.toggleAgentVoiceMute,
+    );
+
+    act(() => result.current.toggleAgentVoiceMute());
+
+    expect(voiceOutputMock.toggleAgentVoiceMute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useShellController — audio unlock routing", () => {
+  beforeEach(() => {
+    // The file-wide afterEach does not clear these; earlier suites' engage
+    // paths would otherwise leak calls into the first assertion here.
+    voiceOutputMock.unlockAudio.mockClear();
+    realtimeVoiceMock.unlock.mockClear();
+  });
+
+  afterEach(() => {
+    voiceOutputMock.unlockAudio.mockClear();
+  });
+
+  it("routes to the realtime session while it owns the microphone", async () => {
+    realtimeVoiceMock.enabled = true;
+    realtimeVoiceMock.state.active = true;
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.unlockAudio();
+    });
+
+    expect(realtimeVoiceMock.unlock).toHaveBeenCalledTimes(1);
+    expect(voiceOutputMock.unlockAudio).not.toHaveBeenCalled();
+  });
+
+  it("falls back to voice output when realtime stays idle", async () => {
+    realtimeVoiceMock.enabled = true;
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      result.current.unlockAudio();
+    });
+
+    expect(realtimeVoiceMock.unlock).not.toHaveBeenCalled();
+    expect(voiceOutputMock.unlockAudio).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useShellController — voice-settings apply validation", () => {
+  beforeEach(() => {
+    lastCaptureOpts = null;
+    captureHandles = [];
+    createVoiceCaptureMock.mockReset();
+    appMock.value.agentStatus = { ...READY_STATUS };
+    try {
+      window.localStorage.clear();
+    } catch {}
+  });
+
+  it("ignores an apply whose continuous value is unrecognized", async () => {
+    const { result } = renderHook(() => useShellController());
+
+    await act(async () => {
+      emitViewEvent(
+        VOICE_SETTINGS_APPLY_EVENT,
+        { continuous: "sometimes" },
+        "agent",
+      );
+      await Promise.resolve();
+    });
+
+    expect(result.current.handsFree).toBe(false);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(
+      window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
+    ).toBe(null);
+  });
+});
+
+describe("useShellController — boot progress signal", () => {
+  it("advances on fresh warming observations and disappears once ready", () => {
+    // One live status record mutated across observations — exactly what the
+    // readiness poll produces (same shape, fresh fields).
+    const warming: {
+      state: string;
+      canRespond?: boolean;
+    } & Record<string, unknown> = { state: "starting", canRespond: false };
+    appMock.value.agentStatus = warming;
+    const { result, rerender } = renderHook(() => useShellController());
+
+    // While waking, the token is a truthy string the slow-boot banner keys on.
+    const firstToken = result.current.bootProgressSignal;
+    expect(typeof firstToken).toBe("string");
+
+    // A fresh observation of the still-warming agent (a new port report)
+    // advances the token so the banner restarts its escalation timer.
+    warming.port = 43110;
+    rerender();
+    expect(result.current.bootProgressSignal).not.toBe(firstToken);
+
+    // Once ready there is no boot-progress channel to report.
+    appMock.value.agentStatus = { ...READY_STATUS };
+    rerender();
+    expect(result.current.bootProgressSignal).toBeUndefined();
   });
 });


### PR DESCRIPTION

## Summary

Extends the existing `packages/ui/src/components/shell/__tests__/useShellController.test.tsx` suite with 20 new cases covering branches it did not previously reach. Strictly additive: **+496/-0 on one test file**; no production code, no existing cases rewritten or removed.

## What is covered

- **omi pendant relay** (`PENDANT_VOICE_TRANSCRIPT_EVENT`): a finalized pendant transcript routes as a `VOICE_DM` turn with the `pendant:<segmentId>` dedupe id and full provenance metadata; the id is omitted when the segment has none; a blank transcript is ignored.
- **VISION capture**: the tap sends the screen-vision intent turn (`metadata.vision.surface = "screen"`), `visionCapturing` pulses until the reply is in flight, and a stopped agent neither sends nor pulses (`canSend` false).
- **send() edge guards**: whitespace-only text without attachments is a no-op; an image-only send with empty text goes through and does not set the voice-originated latch; options (`channelType`, `metadata`, `clientMessageId`) are forwarded verbatim.
- **capture-failure copy + once-per-grant-epoch latch**: unknown failures use the generic "Could not start the microphone" wording; a post-capture cloud-STT error surfaces the "Didn't catch that" transcription wording (not a microphone accusation); a repeated failure while unresolved does not re-toast, one successful open re-arms the notice for a later denial.
- **Silent-drop hint**: the factory's `onSilentDrop` fires the short info notice ("Didn't catch that — try again.").
- **Interim transcript + cancelRecording (#20483)**: a non-final segment shows as live transcript; cancel disposes without the stop() drain, clearing recording/transcript.
- **stop() routing**: halts a streaming turn via `handleChatStop`; during pure TTS playback it stops speech but must not tear down the chat stream.
- **Agent voice mute projection**: the controller projects voice-output's mute state and delegates the toggle.
- **unlockAudio routing**: realtime-owned sessions unlock through the realtime client; idle realtime falls back to voice output.
- **voice-settings apply validation**: an unrecognized `continuous` value is ignored entirely (no persistence, no engagement).
- **bootProgressSignal (#14040)**: present and advancing on fresh warming observations, `undefined` once ready.

## Verification (fork contributor — hosted CI does not run on this PR)

- `bunx vitest run src/components/shell/__tests__/useShellController.test.tsx` → **115 passed / 115** (95 pre-existing + 20 new), re-run immediately before filing against current `origin/develop`.
- `bunx biome check --write <file>` clean (subsequent read-only check: "No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in output (zero type errors introduced).
- Diff touches only `packages/ui/src/components/shell/__tests__/useShellController.test.tsx` (+496/-0).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:beaa79790547500983f3778be7b70a17e0f4094c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
