### PR TITLE
test(coding-tools): cover terminalCapabilities

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit coverage for terminal-capability detection: platform checks,
+ * shell resolution, and missing-tool messaging for coding-tools. Deterministic
+ * — manipulates env and mocks host executable resolution, no shell spawned.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  isAndroidRuntime,
+  isAospTerminalRuntime,
+  missingToolMessage,
+  TERMINAL_TOOL_NAMES,
+} from "./terminalCapabilities";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("isAndroidRuntime", () => {
+  test("true for ELIZA_PLATFORM android case-insensitive and trimmed", () => {
+    process.env.ELIZA_PLATFORM = "android";
+    expect(isAndroidRuntime()).toBe(true);
+    process.env.ELIZA_PLATFORM = "  ANDROID  ";
+    expect(isAndroidRuntime()).toBe(true);
+    process.env.ELIZA_PLATFORM = "Android";
+    expect(isAndroidRuntime()).toBe(true);
+  });
+
+  test("true for ANDROID_ROOT or ANDROID_DATA", () => {
+    delete process.env.ELIZA_PLATFORM;
+    process.env.ANDROID_ROOT = "/system";
+    expect(isAndroidRuntime()).toBe(true);
+    delete process.env.ANDROID_ROOT;
+    process.env.ANDROID_DATA = "/data";
+    expect(isAndroidRuntime()).toBe(true);
+  });
+
+  test("false for other platforms and empty", () => {
+    process.env.ELIZA_PLATFORM = "ios";
+    delete process.env.ANDROID_ROOT;
+    delete process.env.ANDROID_DATA;
+    expect(isAndroidRuntime()).toBe(false);
+    process.env.ELIZA_PLATFORM = "";
+    expect(isAndroidRuntime()).toBe(false);
+    delete process.env.ELIZA_PLATFORM;
+    expect(isAndroidRuntime()).toBe(false);
+  });
+});
+
+describe("isAospTerminalRuntime", () => {
+  test("true only when android and ELIZA_AOSP_BUILD truthy", () => {
+    process.env.ELIZA_PLATFORM = "android";
+    process.env.ELIZA_AOSP_BUILD = "1";
+    expect(isAospTerminalRuntime()).toBe(true);
+    process.env.ELIZA_AOSP_BUILD = "true";
+    expect(isAospTerminalRuntime()).toBe(true);
+    process.env.ELIZA_AOSP_BUILD = "yes";
+    expect(isAospTerminalRuntime()).toBe(true);
+  });
+
+  test("false when not android or not truthy", () => {
+    process.env.ELIZA_PLATFORM = "android";
+    process.env.ELIZA_AOSP_BUILD = "0";
+    expect(isAospTerminalRuntime()).toBe(false);
+    process.env.ELIZA_AOSP_BUILD = "";
+    expect(isAospTerminalRuntime()).toBe(false);
+    process.env.ELIZA_PLATFORM = "ios";
+    process.env.ELIZA_AOSP_BUILD = "1";
+    expect(isAospTerminalRuntime()).toBe(false);
+  });
+});
+
+describe("missingTerminalToolForCommand", () => {
+  test("returns tool name when missing, undefined when present or sh", async () => {
+    vi.doMock("@elizaos/shared/host-execution-env", async () => {
+      const actual = await vi.importActual<
+        typeof import("@elizaos/shared/host-execution-env")
+      >("@elizaos/shared/host-execution-env");
+      return {
+        ...actual,
+        resolveHostExecutable: (name: string) =>
+          name === "git" ? "/usr/bin/git" : undefined,
+      };
+    });
+    const { missingTerminalToolForCommand: mocked } = await import(
+      "./terminalCapabilities"
+    );
+    expect(mocked("git status")).toBeUndefined();
+    expect(mocked("rg --help")).toBe("rg");
+    expect(mocked("acpx run")).toBe("acpx");
+    expect(mocked("sh -c 'echo hi'")).toBeUndefined();
+    expect(mocked("")).toBeUndefined();
+    vi.doUnmock("@elizaos/shared/host-execution-env");
+  });
+
+  test("skips leading env assignments and quotes", async () => {
+    vi.doMock("@elizaos/shared/host-execution-env", async () => {
+      const actual = await vi.importActual<
+        typeof import("@elizaos/shared/host-execution-env")
+      >("@elizaos/shared/host-execution-env");
+      return { ...actual, resolveHostExecutable: () => undefined };
+    });
+    const { missingTerminalToolForCommand: mocked } = await import(
+      "./terminalCapabilities"
+    );
+    expect(mocked("FOO=bar BAZ=1 rg --help")).toBe("rg");
+    expect(mocked('"rg" --help')).toBe("rg");
+    expect(mocked("  ")).toBeUndefined();
+    vi.doUnmock("@elizaos/shared/host-execution-env");
+  });
+});
+
+describe("missingToolMessage", () => {
+  test("mentions tool and android hint when android", () => {
+    process.env.ELIZA_PLATFORM = "android";
+    const msg = missingToolMessage("rg");
+    expect(msg).toContain("rg");
+    expect(msg).toContain("Android");
+  });
+
+  test("mentions PATH hint when not android", () => {
+    delete process.env.ELIZA_PLATFORM;
+    delete process.env.ANDROID_ROOT;
+    const msg = missingToolMessage("rg");
+    expect(msg).toContain("rg");
+    expect(msg).toContain("PATH");
+  });
+
+  test("TERMINAL_TOOL_NAMES contains expected tools", () => {
+    expect(TERMINAL_TOOL_NAMES).toContain("sh");
+    expect(TERMINAL_TOOL_NAMES).toContain("git");
+    expect(TERMINAL_TOOL_NAMES).toContain("bun");
+  });
+});


### PR DESCRIPTION
# Relates to

N/A - behavioral coverage for uncovered terminal capability detection

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only, no production. Covers pure env-based platform detection and missing-tool messaging with mocked host executable resolution.

# Background

## What does this PR do?

Adds missing coverage for `plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.ts`: `isAndroidRuntime`, `isAospTerminalRuntime`, `missingTerminalToolForCommand`, and `missingToolMessage`. No production changed.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.test.ts`

## Detailed testing steps

- `bun run --cwd plugins/plugin-coding-tools test -- --run src/shell/utils/terminalCapabilities.test.ts` — 10 tests, all green (red 4 fail when isAndroidRuntime forced false, green 10 pass after restore)
- `bunx biome check --write` — no fixes
- `git diff --check` — clean

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:54f4cb8cf3c743206a53e6d8f61508f59c7b82b8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, plugin unit test`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, plugin unit test`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow, unit test only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend path, pure env logic`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend, plugin unit test`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no LLM change, terminal capability detection`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact, env and string parsing`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change

## Backend + frontend logs

N/A - no backend/frontend

## Screenshots (before / after) + video walkthrough

N/A - no UI surface

## Known gaps / failures

- `bun run --cwd plugins/plugin-sql typecheck` shows pre-existing unrelated errors — not caused by this file. `bun run --cwd plugins/plugin-coding-tools test` passes 10/10, `biome` clean.

## Red

```
4 failed | 6 passed (10)
isAndroidRuntime forced false -> isAospTerminalRuntime and missingToolMessage Android hint failed
```

## Green

```
10 passed (10)
Ran 10 tests across 1 file.
```

# Checklist

- [x] Rebased onto latest origin/develop
- [x] Tests pass
- [x] Biome clean
- [x] No duplicate (gh pr list checked)
- [x] Non-vacuous behavioral tests
- [x] Red -> Green demonstrated
