### PR TITLE
chore(ui): inventory duplicate atomic and molecular components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 /packages/ui/src/**/__e2e__/output-*/
 /packages/ui/src/agent-surface/__e2e__/output/
 /packages/ui/scripts/duplicate-components-report.json
+/packages/ui/scripts/duplicate-molecular-components-report.json
 /packages/ui/scripts/stories-coverage-report.json
 /packages/ui/scripts/stories-coverage-report.md
 /packages/ui/stories/check-stories-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ node_modules
 /packages/ui/src/**/__e2e__/output-*/
 /packages/ui/src/agent-surface/__e2e__/output/
 /packages/ui/scripts/duplicate-components-report.json
-/packages/ui/scripts/duplicate-components-report.md
 /packages/ui/scripts/stories-coverage-report.json
 /packages/ui/scripts/stories-coverage-report.md
 /packages/ui/stories/check-stories-report.json

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -79,6 +79,8 @@
     "audit:story-coverage:report": "node scripts/stories-coverage.mjs --write-report",
     "audit:component-inventory": "node scripts/find-duplicate-components.mjs",
     "audit:component-inventory:test": "node --test scripts/find-duplicate-components.test.mjs",
+    "audit:molecular-inventory": "node scripts/find-duplicate-molecular-components.mjs",
+    "audit:molecular-inventory:test": "node --test scripts/find-duplicate-molecular-components.test.mjs",
     "audit:dead-code": "knip --config knip.json --include files,dependencies,unlisted,unresolved --max-issues 0",
     "audit:public-api:test": "node --test scripts/public-api-explicit-subpaths.test.mjs",
     "audit:public-api": "node --test scripts/public-api-explicit-subpaths.test.mjs",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,6 +77,8 @@
     "audit:stories:build": "bun run build-storybook --output-dir storybook-static --quiet && node test/story-gate/run-story-gate.mjs",
     "audit:story-coverage": "node scripts/stories-coverage.mjs",
     "audit:story-coverage:report": "node scripts/stories-coverage.mjs --write-report",
+    "audit:component-inventory": "node scripts/find-duplicate-components.mjs",
+    "audit:component-inventory:test": "node --test scripts/find-duplicate-components.test.mjs",
     "audit:dead-code": "knip --config knip.json --include files,dependencies,unlisted,unresolved --max-issues 0",
     "audit:public-api:test": "node --test scripts/public-api-explicit-subpaths.test.mjs",
     "audit:public-api": "node --test scripts/public-api-explicit-subpaths.test.mjs",

--- a/packages/ui/scripts/component-inventory-decisions.json
+++ b/packages/ui/scripts/component-inventory-decisions.json
@@ -1,0 +1,162 @@
+{
+  "packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx:CostAlerts": {
+    "disposition": "molecular",
+    "canonicalOwner": null,
+    "note": "Analytics alert collection, not an Alert primitive."
+  },
+  "packages/ui/src/cloud-ui/components/docs/llms-txt-badge.tsx:LlmsTxtBadge": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/badge.tsx",
+    "note": "Link-shaped badge duplicates badge chrome and should compose Badge with asChild support."
+  },
+  "packages/ui/src/components/apps/extensions/surface.tsx:SurfaceBadge": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/status-badge.tsx",
+    "note": "Tone-based text badge overlaps the canonical status badge contract."
+  },
+  "packages/ui/src/components/composites/chat/chat-source.tsx:ChatVoiceSpeakerBadge": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": "packages/ui/src/components/ui/badge.tsx",
+    "note": "Role and voice icon marker has domain behavior, but should continue to source base badge tokens from the canonical owner."
+  },
+  "packages/ui/src/components/composites/OwnerBadge.tsx:OwnerBadge": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": "packages/ui/src/components/ui/badge.tsx",
+    "note": "Placement-aware owner marker is shared domain UI rather than a second general badge."
+  },
+  "packages/ui/src/components/local-inference/HardwareBadge.tsx:HardwareBadge": {
+    "disposition": "molecular",
+    "canonicalOwner": null,
+    "note": "Multi-field hardware summary made of several status regions."
+  },
+  "packages/ui/src/components/RedactedBadge.tsx:RedactedBadge": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/badge.tsx",
+    "note": "Static labeled badge duplicates canonical badge structure and styling."
+  },
+  "packages/ui/src/components/shell/BuildBadge.tsx:BuildBadge": {
+    "disposition": "molecular",
+    "canonicalOwner": null,
+    "note": "Interactive build-details control and popover, not an atomic badge."
+  },
+  "packages/ui/src/components/transcripts/SpeakerNameAttributionBadge.tsx:SpeakerNameAttributionBadge": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/status-badge.tsx",
+    "note": "Status-toned attribution label should compose the canonical status badge."
+  },
+  "packages/ui/src/cloud-ui/components/brand/brand-button.tsx:BrandButton": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/button.tsx",
+    "note": "Reimplements Slot, button attributes, sizes, states, and variants already owned by Button."
+  },
+  "packages/ui/src/cloud-ui/components/brand/lock-on-button.tsx:LockOnButton": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/button.tsx",
+    "note": "Special hover treatment can be a canonical Button variant or wrapper without a second button base."
+  },
+  "packages/ui/src/components/shared/ViewHeader.tsx:ViewBackButton": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/button.tsx",
+    "note": "Agent instrumentation is specialized, but the raw button can compose the canonical Button."
+  },
+  "packages/ui/stories/src/lab/lab-ui.tsx:ActionButton": {
+    "disposition": "lab-only",
+    "canonicalOwner": "packages/ui/src/components/ui/button.tsx",
+    "note": "Design-lab fixture is not shipped product UI."
+  },
+  "packages/ui/src/cloud-ui/components/brand/brand-card.tsx:BrandCard": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/card.tsx",
+    "note": "Reimplements the base card surface, polymorphism, padding, border, and hover contract."
+  },
+  "packages/ui/src/cloud-ui/components/brand/mini-stat-card.tsx:MiniStatCard": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/card.tsx",
+    "note": "Metric composition, not a base card primitive."
+  },
+  "packages/ui/src/components/apps/extensions/surface.tsx:SurfaceCard": {
+    "disposition": "false-positive",
+    "canonicalOwner": null,
+    "note": "Compact label-value definition block; the Card suffix does not represent card chrome."
+  },
+  "packages/ui/src/cloud-ui/components/promotion/promote-app-dialog.tsx:PromoteAppDialog": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/dialog.tsx",
+    "note": "Multi-step workflow already composes the canonical Dialog family."
+  },
+  "packages/ui/src/components/conversations/ConversationRenameDialog.tsx:ConversationRenameDialog": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": "packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx",
+    "note": "Compatibility adapter around the shared conversation rename composition."
+  },
+  "packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:CloudInputRow": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/input.tsx",
+    "note": "Settings row composition; its internal raw input remains a separate migration target."
+  },
+  "packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:CloudTextInput": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/input.tsx",
+    "note": "Directly reimplements the canonical text input with a narrower value callback."
+  },
+  "plugins/plugin-notes/src/views/viewPrimitives.tsx:AgentInput": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/agent-surface/components.tsx",
+    "note": "Duplicates the shared agent-aware Input adapter inside one plugin."
+  },
+  "packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:MilestoneProgress": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/progress.tsx",
+    "note": "Milestone state composition, not a generic progress primitive."
+  },
+  "packages/ui/src/cloud-ui/components/navigation-progress.tsx:NavigationProgress": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": null,
+    "note": "Route lifecycle adapter around nprogress, not an inline progress control."
+  },
+  "packages/ui/src/components/local-inference/DownloadProgress.tsx:DownloadProgress": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/progress.tsx",
+    "note": "Inline determinate progress bar duplicates the canonical Progress base."
+  },
+  "packages/ui/src/cloud-ui/components/code/monaco-editor-skeleton.tsx:MonacoEditorSkeleton": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/skeleton.tsx",
+    "note": "Editor loading composition with label and spinner."
+  },
+  "packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:AppsSkeleton": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": "packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx",
+    "note": "Named preset around the shared dashboard table skeleton."
+  },
+  "packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:ContainersSkeleton": {
+    "disposition": "intentional-specialization",
+    "canonicalOwner": "packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx",
+    "note": "Named preset around the shared dashboard table skeleton."
+  },
+  "packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx:LoginOptionsSkeleton": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/components/ui/skeleton.tsx",
+    "note": "Full login-options loading composition."
+  },
+  "packages/ui/src/components/views/ViewStatusStates.tsx:ViewLoadingSkeleton": {
+    "disposition": "false-positive",
+    "canonicalOwner": null,
+    "note": "Loading status frame uses a spinner and contains no skeleton primitive."
+  },
+  "packages/ui/src/cloud/applications/components/apps-table.tsx:AppsTable": {
+    "disposition": "molecular",
+    "canonicalOwner": "packages/ui/src/cloud-ui/components/data-list/apps-list-view.tsx",
+    "note": "Application list composition, not a table primitive implementation."
+  },
+  "packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:BrandTabs": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/tabs.tsx",
+    "note": "Direct Radix Tabs root and subcomponent implementation duplicates canonical Tabs."
+  },
+  "plugins/plugin-notes/src/views/viewPrimitives.tsx:AgentTextarea": {
+    "disposition": "consolidation-candidate",
+    "canonicalOwner": "packages/ui/src/components/ui/textarea.tsx",
+    "note": "Duplicates agent instrumentation plus the canonical Textarea inside one plugin."
+  }
+}

--- a/packages/ui/scripts/duplicate-components-report.md
+++ b/packages/ui/scripts/duplicate-components-report.md
@@ -30,9 +30,10 @@ This is a candidate inventory, not an instruction to merge every entry. Canonica
 
 ### alert
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| parallel-primitive | `CostAlerts` in `packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx:16` | `AlertTriangle`, `Info`, `TrendingDown`, `div`, `p` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| parallel-primitive | molecular | `CostAlerts` in `packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx:16` | - | `AlertTriangle`, `Info`, `TrendingDown`, `div`, `p` |
+|  |  | Analytics alert collection, not an Alert primitive. |  |  |
 
 ### avatar
 
@@ -40,96 +41,111 @@ No named candidates.
 
 ### badge
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `ConnectionConnectedBadge` in `packages/ui/src/cloud-ui/components/connection-card.tsx:91` | `Badge`, `CheckCircle` |
-| canonical-wrapper | `VoiceStatusBadge` in `packages/ui/src/cloud-ui/components/voice/voice-status-badge.tsx:20` | `AlertCircle`, `CheckCircle2`, `Clock`, `Loader2`, `StatusBadge` |
-| canonical-wrapper | `ApprovalStatusBadge` in `packages/ui/src/cloud/approvals/components/status-badge.tsx:54` | `SharedStatusBadge` |
-| canonical-wrapper | `AgentCostBadge` in `packages/ui/src/cloud/instances/components/agent-cost-badge.tsx:30` | `Tooltip`, `TooltipContent`, `TooltipTrigger`, `p`, `span` |
-| canonical-wrapper | `McpStatusBadge` in `packages/ui/src/cloud/mcps/McpDetailDrawer.tsx:446` | `StatusBadge` |
-| canonical-wrapper | `CloudStatusBadge` in `packages/ui/src/components/cloud/CloudStatusBadge.tsx:143` | `Button`, `span` |
-| parallel-primitive | `LlmsTxtBadge` in `packages/ui/src/cloud-ui/components/docs/llms-txt-badge.tsx:8` | `a`, `div` |
-| parallel-primitive | `SurfaceBadge` in `packages/ui/src/components/apps/extensions/surface.tsx:33` | `span` |
-| parallel-primitive | `ChatVoiceSpeakerBadge` in `packages/ui/src/components/composites/chat/chat-source.tsx:56` | `Crown`, `Mic`, `span` |
-| parallel-primitive | `OwnerBadge` in `packages/ui/src/components/composites/OwnerBadge.tsx:53` | `Crown`, `span` |
-| parallel-primitive | `HardwareBadge` in `packages/ui/src/components/local-inference/HardwareBadge.tsx:16` | `AlertTriangle`, `Cpu`, `Gauge`, `HardDrive`, `div`, `span` |
-| parallel-primitive | `RedactedBadge` in `packages/ui/src/components/RedactedBadge.tsx:13` | `EyeOff`, `span` |
-| parallel-primitive | `BuildBadge` in `packages/ui/src/components/shell/BuildBadge.tsx:298` | `X`, `button`, `dd`, `div`, `dl`, `dt`, `span` |
-| parallel-primitive | `SpeakerNameAttributionBadge` in `packages/ui/src/components/transcripts/SpeakerNameAttributionBadge.tsx:40` | `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `ConnectionConnectedBadge` in `packages/ui/src/cloud-ui/components/connection-card.tsx:91` | - | `Badge`, `CheckCircle` |
+| canonical-wrapper | not-reviewed | `VoiceStatusBadge` in `packages/ui/src/cloud-ui/components/voice/voice-status-badge.tsx:20` | - | `AlertCircle`, `CheckCircle2`, `Clock`, `Loader2`, `StatusBadge` |
+| canonical-wrapper | not-reviewed | `ApprovalStatusBadge` in `packages/ui/src/cloud/approvals/components/status-badge.tsx:54` | - | `SharedStatusBadge` |
+| canonical-wrapper | not-reviewed | `AgentCostBadge` in `packages/ui/src/cloud/instances/components/agent-cost-badge.tsx:30` | - | `Tooltip`, `TooltipContent`, `TooltipTrigger`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `McpStatusBadge` in `packages/ui/src/cloud/mcps/McpDetailDrawer.tsx:446` | - | `StatusBadge` |
+| canonical-wrapper | not-reviewed | `CloudStatusBadge` in `packages/ui/src/components/cloud/CloudStatusBadge.tsx:143` | - | `Button`, `span` |
+| parallel-primitive | consolidation-candidate | `LlmsTxtBadge` in `packages/ui/src/cloud-ui/components/docs/llms-txt-badge.tsx:8` | `packages/ui/src/components/ui/badge.tsx` | `a`, `div` |
+|  |  | Link-shaped badge duplicates badge chrome and should compose Badge with asChild support. |  |  |
+| parallel-primitive | consolidation-candidate | `SurfaceBadge` in `packages/ui/src/components/apps/extensions/surface.tsx:33` | `packages/ui/src/components/ui/status-badge.tsx` | `span` |
+|  |  | Tone-based text badge overlaps the canonical status badge contract. |  |  |
+| parallel-primitive | intentional-specialization | `ChatVoiceSpeakerBadge` in `packages/ui/src/components/composites/chat/chat-source.tsx:56` | `packages/ui/src/components/ui/badge.tsx` | `Crown`, `Mic`, `span` |
+|  |  | Role and voice icon marker has domain behavior, but should continue to source base badge tokens from the canonical owner. |  |  |
+| parallel-primitive | intentional-specialization | `OwnerBadge` in `packages/ui/src/components/composites/OwnerBadge.tsx:53` | `packages/ui/src/components/ui/badge.tsx` | `Crown`, `span` |
+|  |  | Placement-aware owner marker is shared domain UI rather than a second general badge. |  |  |
+| parallel-primitive | molecular | `HardwareBadge` in `packages/ui/src/components/local-inference/HardwareBadge.tsx:16` | - | `AlertTriangle`, `Cpu`, `Gauge`, `HardDrive`, `div`, `span` |
+|  |  | Multi-field hardware summary made of several status regions. |  |  |
+| parallel-primitive | consolidation-candidate | `RedactedBadge` in `packages/ui/src/components/RedactedBadge.tsx:13` | `packages/ui/src/components/ui/badge.tsx` | `EyeOff`, `span` |
+|  |  | Static labeled badge duplicates canonical badge structure and styling. |  |  |
+| parallel-primitive | molecular | `BuildBadge` in `packages/ui/src/components/shell/BuildBadge.tsx:298` | - | `X`, `button`, `dd`, `div`, `dl`, `dt`, `span` |
+|  |  | Interactive build-details control and popover, not an atomic badge. |  |  |
+| parallel-primitive | consolidation-candidate | `SpeakerNameAttributionBadge` in `packages/ui/src/components/transcripts/SpeakerNameAttributionBadge.tsx:40` | `packages/ui/src/components/ui/status-badge.tsx` | `span` |
+|  |  | Status-toned attribution label should compose the canonical status badge. |  |  |
 
 ### button
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `AgentButton` in `packages/ui/src/agent-surface/components.tsx:32` | `Button` |
-| canonical-wrapper | `ExportButton` in `packages/ui/src/cloud-ui/components/analytics/export-button.tsx:36` | `Button`, `ChevronDown`, `Download`, `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuTrigger`, `Upload` |
-| canonical-wrapper | `ElizaConnectButton` in `packages/ui/src/cloud/instances/components/eliza-connect-button.tsx:16` | `BrandButton`, `ExternalLink` |
-| canonical-wrapper | `PstnCallButton` in `packages/ui/src/components/composites/chat/pstn-call-button.tsx:77` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Loader2`, `PhoneCall`, `div`, `p` |
-| canonical-wrapper | `SidebarCollapsedActionButton` in `packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.tsx:77` | `Button` |
-| canonical-wrapper | `SidebarItemButton` in `packages/ui/src/components/composites/sidebar/sidebar-content.tsx:253` | `Button` |
-| canonical-wrapper | `DestructiveSecondaryButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:74` | `Button` |
-| canonical-wrapper | `CloudActionButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:496` | `Button`, `SettingRowShell` |
-| canonical-wrapper | `SettingsActionButton` in `packages/ui/src/components/settings/settings-agent-rows.tsx:576` | `Button` |
-| canonical-wrapper | `GlassIconButton` in `packages/ui/src/components/shell/glass-composer.tsx:24` | `Button`, `Icon` |
-| canonical-wrapper | `RecoveryActionButton` in `plugins/plugin-task-coordinator/src/orchestrator-task-inspector.tsx:1101` | `Button` |
-| parallel-primitive | `BrandButton` in `packages/ui/src/cloud-ui/components/brand/brand-button.tsx:46` | `Comp` |
-| parallel-primitive | `LockOnButton` in `packages/ui/src/cloud-ui/components/brand/lock-on-button.tsx:14` | `Component` |
-| parallel-primitive | `ViewBackButton` in `packages/ui/src/components/shared/ViewHeader.tsx:44` | `ArrowLeft`, `button`, `span` |
-| parallel-primitive | `ActionButton` in `packages/ui/stories/src/lab/lab-ui.tsx:73` | `button` |
-| renderer-adapter | `Button` in `packages/ui/src/spatial/primitives.tsx:517` | `UiButton` |
-| template-adapter | `InferenceCloudAlertButton` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:14` |  |
-| test-double | `Button` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:46` | `button` |
-| test-double | `Button` in `plugins/plugin-contacts/test/stubs/ui.tsx:15` |  |
-| test-double | `Button` in `plugins/plugin-phone/test/stubs/ui.tsx:13` |  |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `AgentButton` in `packages/ui/src/agent-surface/components.tsx:32` | - | `Button` |
+| canonical-wrapper | not-reviewed | `ExportButton` in `packages/ui/src/cloud-ui/components/analytics/export-button.tsx:36` | - | `Button`, `ChevronDown`, `Download`, `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuTrigger`, `Upload` |
+| canonical-wrapper | not-reviewed | `ElizaConnectButton` in `packages/ui/src/cloud/instances/components/eliza-connect-button.tsx:16` | - | `BrandButton`, `ExternalLink` |
+| canonical-wrapper | not-reviewed | `PstnCallButton` in `packages/ui/src/components/composites/chat/pstn-call-button.tsx:77` | - | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Loader2`, `PhoneCall`, `div`, `p` |
+| canonical-wrapper | not-reviewed | `SidebarCollapsedActionButton` in `packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.tsx:77` | - | `Button` |
+| canonical-wrapper | not-reviewed | `SidebarItemButton` in `packages/ui/src/components/composites/sidebar/sidebar-content.tsx:253` | - | `Button` |
+| canonical-wrapper | not-reviewed | `DestructiveSecondaryButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:74` | - | `Button` |
+| canonical-wrapper | not-reviewed | `CloudActionButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:496` | - | `Button`, `SettingRowShell` |
+| canonical-wrapper | not-reviewed | `SettingsActionButton` in `packages/ui/src/components/settings/settings-agent-rows.tsx:576` | - | `Button` |
+| canonical-wrapper | not-reviewed | `GlassIconButton` in `packages/ui/src/components/shell/glass-composer.tsx:24` | - | `Button`, `Icon` |
+| canonical-wrapper | not-reviewed | `RecoveryActionButton` in `plugins/plugin-task-coordinator/src/orchestrator-task-inspector.tsx:1101` | - | `Button` |
+| parallel-primitive | consolidation-candidate | `BrandButton` in `packages/ui/src/cloud-ui/components/brand/brand-button.tsx:46` | `packages/ui/src/components/ui/button.tsx` | `Comp` |
+|  |  | Reimplements Slot, button attributes, sizes, states, and variants already owned by Button. |  |  |
+| parallel-primitive | consolidation-candidate | `LockOnButton` in `packages/ui/src/cloud-ui/components/brand/lock-on-button.tsx:14` | `packages/ui/src/components/ui/button.tsx` | `Component` |
+|  |  | Special hover treatment can be a canonical Button variant or wrapper without a second button base. |  |  |
+| parallel-primitive | consolidation-candidate | `ViewBackButton` in `packages/ui/src/components/shared/ViewHeader.tsx:44` | `packages/ui/src/components/ui/button.tsx` | `ArrowLeft`, `button`, `span` |
+|  |  | Agent instrumentation is specialized, but the raw button can compose the canonical Button. |  |  |
+| parallel-primitive | lab-only | `ActionButton` in `packages/ui/stories/src/lab/lab-ui.tsx:73` | `packages/ui/src/components/ui/button.tsx` | `button` |
+|  |  | Design-lab fixture is not shipped product UI. |  |  |
+| renderer-adapter | not-reviewed | `Button` in `packages/ui/src/spatial/primitives.tsx:517` | - | `UiButton` |
+| template-adapter | not-reviewed | `InferenceCloudAlertButton` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:14` | - |  |
+| test-double | not-reviewed | `Button` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:46` | - | `button` |
+| test-double | not-reviewed | `Button` in `plugins/plugin-contacts/test/stubs/ui.tsx:15` | - |  |
+| test-double | not-reviewed | `Button` in `plugins/plugin-phone/test/stubs/ui.tsx:13` | - |  |
 
 ### card
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `CostInsightsCard` in `packages/ui/src/cloud-ui/components/analytics/cost-insights-card.tsx:21` | `Badge`, `BrandCard`, `CostAlerts`, `Progress`, `div`, `h3`, `p`, `span` |
-| canonical-wrapper | `PromptCard` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:15` | `ArrowUp`, `Button`, `p` |
-| canonical-wrapper | `ConnectionCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:369` | `AlertTriangle`, `Button`, `ConnectionLoadingCard`, `div`, `h3`, `p`, `span` |
-| canonical-wrapper | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | `Skeleton`, `div` |
-| canonical-wrapper | `EndpointCard` in `packages/ui/src/cloud-ui/components/docs/endpoint-card.tsx:61` | `Button`, `ChevronRight`, `Coins`, `Sparkles`, `code`, `div`, `h3`, `p`, `span` |
-| canonical-wrapper | `BuyDomainCard` in `packages/ui/src/cloud/applications/components/BuyDomainCard.tsx:68` | `AlertDialog`, `AlertDialogAction`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `AlertDialogTrigger`, `AlertTriangle`, `Button`, `CheckCircle2`, `CreditCard`, `Input`, `Loader2`, `Search`, `ShoppingCart`, `XCircle`, `div`, `form`, `h3`, `p`, `span` |
-| canonical-wrapper | `ActiveComputeCardView` in `packages/ui/src/cloud/billing/components/active-compute-card.tsx:301` | `AlertCircle`, `BrandCard`, `Calculator`, `Clock3`, `LoadingCard`, `RefreshCw`, `ResourceCard`, `RetryButton`, `StatusBadge`, `div`, `h3`, `p`, `span`, `ul` |
-| canonical-wrapper | `AutoTopUpCard` in `packages/ui/src/cloud/billing/components/auto-top-up-card.tsx:144` | `AlertCircle`, `BrandCard`, `Button`, `CornerBrackets`, `CreditCard`, `Info`, `Loader2`, `RefreshCw`, `SettingsInputRow`, `SettingsSwitchRow`, `div`, `h3`, `p`, `span` |
-| canonical-wrapper | `DirectCryptoCreditCard` in `packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx:179` | `Button`, `Card`, `CardContent`, `CardHeader`, `CardTitle`, `Coins`, `ConnectButton.Custom`, `Link`, `Loader2`, `PaymentWaitingOverlay`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `Wallet`, `div`, `p`, `span` |
-| canonical-wrapper | `AccountCard` in `packages/ui/src/components/accounts/AccountCard.tsx:178` | `Badge`, `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `Spinner`, `StatusBadge`, `Trash2`, `UsageBar`, `div`, `span` |
-| canonical-wrapper | `AccountRequiredCard` in `packages/ui/src/components/chat/AccountRequiredCard.tsx:133` | `Button`, `ReconnectProgressLine`, `RefreshCw`, `ShieldAlert`, `Spinner`, `StatusBadge`, `UserRound`, `div`, `span` |
-| canonical-wrapper | `ConnectorCardWidget` in `packages/ui/src/components/chat/widgets/connector-card.tsx:83` | `Button`, `ConnectorBrandIcon`, `Input`, `ShieldCheck`, `div`, `form`, `label`, `span` |
-| canonical-wrapper | `HomeWidgetCard` in `packages/ui/src/components/chat/widgets/home-widget-card.tsx:89` | `Button`, `span` |
-| canonical-wrapper | `PermissionCard` in `packages/ui/src/components/composites/chat/permission-card.tsx:57` | `Button`, `div`, `h3`, `header`, `p`, `section`, `span` |
-| canonical-wrapper | `TrajectoryLlmCallCard` in `packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx:64` | `Button`, `CallMetric`, `ChevronDown`, `ChevronRight`, `PagePanel`, `TrajectoryCodeBlock`, `div`, `span` |
-| canonical-wrapper | `ConnectorAccountCard` in `packages/ui/src/components/connectors/ConnectorAccountCard.tsx:163` | `Badge`, `Button`, `Checkbox`, `ConnectedCapabilityChips`, `ConnectorAccountPrivacySelector`, `ConnectorAccountPurposeSelector`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `RefreshCw`, `Spinner`, `Star`, `StatusBadge`, `Trash2`, `div`, `img`, `span` |
-| canonical-wrapper | `ModelCard` in `packages/ui/src/components/local-inference/ModelCard.tsx:55` | `Button`, `DownloadProgress`, `div`, `p`, `span` |
-| canonical-wrapper | `PluginCard` in `packages/ui/src/components/pages/PluginCard.tsx:46` | `Button`, `PluginVisual`, `div`, `li`, `p`, `span` |
-| canonical-wrapper | `PendantSettingsCard` in `packages/ui/src/components/settings/PendantSettingsCard.tsx:46` | `BatteryBadge`, `Bluetooth`, `Button`, `Loader2`, `Radio`, `SettingsGroup`, `SettingsRow`, `span` |
-| canonical-wrapper | `ProviderCard` in `packages/ui/src/components/settings/ProviderCard.tsx:46` | `Button`, `CheckCircle2`, `Icon`, `span` |
-| canonical-wrapper | `AppBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx:110` | `AppBlockerStatusIcon`, `Button`, `CheckCircle2`, `Clock3`, `Input`, `ListChecks`, `Loader2`, `RefreshCw`, `Search`, `ShieldBan`, `Smartphone`, `Square`, `Timer`, `div`, `label`, `span` |
-| canonical-wrapper | `WebsiteBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/WebsiteBlockerSettingsCard.tsx:80` | `Button`, `CheckCircle2`, `Monitor`, `Settings`, `ShieldBan`, `div`, `span` |
-| canonical-wrapper | `GitHubConnectionCard` in `plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx:80` | `Button`, `CheckCircle2`, `ExternalLink`, `GitPullRequest`, `LogIn`, `SettingsControls.Input`, `Unplug`, `div`, `p`, `span` |
-| canonical-wrapper | `TaskCard` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:238` | `Button`, `GitBranch`, `TaskStatusChip`, `TaskStatusMedallion`, `span` |
-| molecular-candidate | `AgentCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:63` | `BrandCard`, `div`, `h3`, `p` |
-| molecular-candidate | `DashboardStatCard` in `packages/ui/src/cloud-ui/components/brand/dashboard-stat-card.tsx:37` | `BrandCard`, `div`, `p` |
-| molecular-candidate | `PromptCardGrid` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:40` | `PromptCard`, `div` |
-| molecular-candidate | `ConnectionLoadingCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:76` | `Loader2`, `div` |
-| molecular-candidate | `DashboardActionCards` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:72` | `ArrowRight`, `BookOpen`, `Bot`, `Code`, `CreditCard`, `KeyRound`, `Link`, `Rocket`, `Server`, `Store`, `Wallet`, `div`, `h3`, `span` |
-| molecular-candidate | `DashboardDataListCard` in `packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.tsx:79` | `div` |
-| molecular-candidate | `Cards` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:57` | `div` |
-| molecular-candidate | `MilestoneCard` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:88` | `MilestoneProgress`, `div`, `h4` |
-| molecular-candidate | `AgentCard` in `packages/ui/src/cloud/instances/components/agent-card.tsx:856` |  |
-| molecular-candidate | `MessagePermissionCard` in `packages/ui/src/components/chat/MessageContent.tsx:1259` |  |
-| molecular-candidate | `MapsCardWidget` in `packages/ui/src/components/chat/widgets/maps-card.tsx:347` | `AttributionLine`, `HandoffCard`, `LocateCard`, `PlaceRow`, `Route`, `a`, `div`, `li`, `span`, `ul` |
-| molecular-candidate | `OrchestratorGrillingCard` in `packages/ui/src/components/chat/widgets/orchestrator-grilling-card.tsx:85` | `div`, `li`, `p`, `span`, `ul` |
-| molecular-candidate | `SummaryCard` in `packages/ui/src/components/composites/page-panel/page-panel-header.tsx:102` | `div` |
-| molecular-candidate | `ProtectionCard` in `packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx:258` | `AlertCircle`, `CheckCircle2`, `div`, `p`, `section` |
-| parallel-primitive | `BrandCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:26` | `Component`, `CornerBrackets` |
-| parallel-primitive | `MiniStatCard` in `packages/ui/src/cloud-ui/components/brand/mini-stat-card.tsx:13` | `div`, `p` |
-| parallel-primitive | `SurfaceCard` in `packages/ui/src/components/apps/extensions/surface.tsx:49` | `div` |
-| renderer-adapter | `Card` in `packages/ui/src/spatial/primitives.tsx:801` | `Stack` |
-| template-adapter | `AppBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:15` |  |
-| template-adapter | `WebsiteBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:16` |  |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `CostInsightsCard` in `packages/ui/src/cloud-ui/components/analytics/cost-insights-card.tsx:21` | - | `Badge`, `BrandCard`, `CostAlerts`, `Progress`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `PromptCard` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:15` | - | `ArrowUp`, `Button`, `p` |
+| canonical-wrapper | not-reviewed | `ConnectionCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:369` | - | `AlertTriangle`, `Button`, `ConnectionLoadingCard`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | - | `Skeleton`, `div` |
+| canonical-wrapper | not-reviewed | `EndpointCard` in `packages/ui/src/cloud-ui/components/docs/endpoint-card.tsx:61` | - | `Button`, `ChevronRight`, `Coins`, `Sparkles`, `code`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `BuyDomainCard` in `packages/ui/src/cloud/applications/components/BuyDomainCard.tsx:68` | - | `AlertDialog`, `AlertDialogAction`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `AlertDialogTrigger`, `AlertTriangle`, `Button`, `CheckCircle2`, `CreditCard`, `Input`, `Loader2`, `Search`, `ShoppingCart`, `XCircle`, `div`, `form`, `h3`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `ActiveComputeCardView` in `packages/ui/src/cloud/billing/components/active-compute-card.tsx:301` | - | `AlertCircle`, `BrandCard`, `Calculator`, `Clock3`, `LoadingCard`, `RefreshCw`, `ResourceCard`, `RetryButton`, `StatusBadge`, `div`, `h3`, `p`, `span`, `ul` |
+| canonical-wrapper | not-reviewed | `AutoTopUpCard` in `packages/ui/src/cloud/billing/components/auto-top-up-card.tsx:144` | - | `AlertCircle`, `BrandCard`, `Button`, `CornerBrackets`, `CreditCard`, `Info`, `Loader2`, `RefreshCw`, `SettingsInputRow`, `SettingsSwitchRow`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `DirectCryptoCreditCard` in `packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx:179` | - | `Button`, `Card`, `CardContent`, `CardHeader`, `CardTitle`, `Coins`, `ConnectButton.Custom`, `Link`, `Loader2`, `PaymentWaitingOverlay`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `Wallet`, `div`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `AccountCard` in `packages/ui/src/components/accounts/AccountCard.tsx:178` | - | `Badge`, `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `Spinner`, `StatusBadge`, `Trash2`, `UsageBar`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `AccountRequiredCard` in `packages/ui/src/components/chat/AccountRequiredCard.tsx:133` | - | `Button`, `ReconnectProgressLine`, `RefreshCw`, `ShieldAlert`, `Spinner`, `StatusBadge`, `UserRound`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `ConnectorCardWidget` in `packages/ui/src/components/chat/widgets/connector-card.tsx:83` | - | `Button`, `ConnectorBrandIcon`, `Input`, `ShieldCheck`, `div`, `form`, `label`, `span` |
+| canonical-wrapper | not-reviewed | `HomeWidgetCard` in `packages/ui/src/components/chat/widgets/home-widget-card.tsx:89` | - | `Button`, `span` |
+| canonical-wrapper | not-reviewed | `PermissionCard` in `packages/ui/src/components/composites/chat/permission-card.tsx:57` | - | `Button`, `div`, `h3`, `header`, `p`, `section`, `span` |
+| canonical-wrapper | not-reviewed | `TrajectoryLlmCallCard` in `packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx:64` | - | `Button`, `CallMetric`, `ChevronDown`, `ChevronRight`, `PagePanel`, `TrajectoryCodeBlock`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `ConnectorAccountCard` in `packages/ui/src/components/connectors/ConnectorAccountCard.tsx:163` | - | `Badge`, `Button`, `Checkbox`, `ConnectedCapabilityChips`, `ConnectorAccountPrivacySelector`, `ConnectorAccountPurposeSelector`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `RefreshCw`, `Spinner`, `Star`, `StatusBadge`, `Trash2`, `div`, `img`, `span` |
+| canonical-wrapper | not-reviewed | `ModelCard` in `packages/ui/src/components/local-inference/ModelCard.tsx:55` | - | `Button`, `DownloadProgress`, `div`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `PluginCard` in `packages/ui/src/components/pages/PluginCard.tsx:46` | - | `Button`, `PluginVisual`, `div`, `li`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `PendantSettingsCard` in `packages/ui/src/components/settings/PendantSettingsCard.tsx:46` | - | `BatteryBadge`, `Bluetooth`, `Button`, `Loader2`, `Radio`, `SettingsGroup`, `SettingsRow`, `span` |
+| canonical-wrapper | not-reviewed | `ProviderCard` in `packages/ui/src/components/settings/ProviderCard.tsx:46` | - | `Button`, `CheckCircle2`, `Icon`, `span` |
+| canonical-wrapper | not-reviewed | `AppBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx:110` | - | `AppBlockerStatusIcon`, `Button`, `CheckCircle2`, `Clock3`, `Input`, `ListChecks`, `Loader2`, `RefreshCw`, `Search`, `ShieldBan`, `Smartphone`, `Square`, `Timer`, `div`, `label`, `span` |
+| canonical-wrapper | not-reviewed | `WebsiteBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/WebsiteBlockerSettingsCard.tsx:80` | - | `Button`, `CheckCircle2`, `Monitor`, `Settings`, `ShieldBan`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `GitHubConnectionCard` in `plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx:80` | - | `Button`, `CheckCircle2`, `ExternalLink`, `GitPullRequest`, `LogIn`, `SettingsControls.Input`, `Unplug`, `div`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `TaskCard` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:238` | - | `Button`, `GitBranch`, `TaskStatusChip`, `TaskStatusMedallion`, `span` |
+| molecular-candidate | not-reviewed | `AgentCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:63` | - | `BrandCard`, `div`, `h3`, `p` |
+| molecular-candidate | not-reviewed | `DashboardStatCard` in `packages/ui/src/cloud-ui/components/brand/dashboard-stat-card.tsx:37` | - | `BrandCard`, `div`, `p` |
+| molecular-candidate | not-reviewed | `PromptCardGrid` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:40` | - | `PromptCard`, `div` |
+| molecular-candidate | not-reviewed | `ConnectionLoadingCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:76` | - | `Loader2`, `div` |
+| molecular-candidate | not-reviewed | `DashboardActionCards` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:72` | - | `ArrowRight`, `BookOpen`, `Bot`, `Code`, `CreditCard`, `KeyRound`, `Link`, `Rocket`, `Server`, `Store`, `Wallet`, `div`, `h3`, `span` |
+| molecular-candidate | not-reviewed | `DashboardDataListCard` in `packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.tsx:79` | - | `div` |
+| molecular-candidate | not-reviewed | `Cards` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:57` | - | `div` |
+| molecular-candidate | not-reviewed | `MilestoneCard` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:88` | - | `MilestoneProgress`, `div`, `h4` |
+| molecular-candidate | not-reviewed | `AgentCard` in `packages/ui/src/cloud/instances/components/agent-card.tsx:856` | - |  |
+| molecular-candidate | not-reviewed | `MessagePermissionCard` in `packages/ui/src/components/chat/MessageContent.tsx:1259` | - |  |
+| molecular-candidate | not-reviewed | `MapsCardWidget` in `packages/ui/src/components/chat/widgets/maps-card.tsx:347` | - | `AttributionLine`, `HandoffCard`, `LocateCard`, `PlaceRow`, `Route`, `a`, `div`, `li`, `span`, `ul` |
+| molecular-candidate | not-reviewed | `OrchestratorGrillingCard` in `packages/ui/src/components/chat/widgets/orchestrator-grilling-card.tsx:85` | - | `div`, `li`, `p`, `span`, `ul` |
+| molecular-candidate | not-reviewed | `SummaryCard` in `packages/ui/src/components/composites/page-panel/page-panel-header.tsx:102` | - | `div` |
+| molecular-candidate | not-reviewed | `ProtectionCard` in `packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx:258` | - | `AlertCircle`, `CheckCircle2`, `div`, `p`, `section` |
+| parallel-primitive | consolidation-candidate | `BrandCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:26` | `packages/ui/src/components/ui/card.tsx` | `Component`, `CornerBrackets` |
+|  |  | Reimplements the base card surface, polymorphism, padding, border, and hover contract. |  |  |
+| parallel-primitive | molecular | `MiniStatCard` in `packages/ui/src/cloud-ui/components/brand/mini-stat-card.tsx:13` | `packages/ui/src/components/ui/card.tsx` | `div`, `p` |
+|  |  | Metric composition, not a base card primitive. |  |  |
+| parallel-primitive | false-positive | `SurfaceCard` in `packages/ui/src/components/apps/extensions/surface.tsx:49` | - | `div` |
+|  |  | Compact label-value definition block; the Card suffix does not represent card chrome. |  |  |
+| renderer-adapter | not-reviewed | `Card` in `packages/ui/src/spatial/primitives.tsx:801` | - | `Stack` |
+| template-adapter | not-reviewed | `AppBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:15` | - |  |
+| template-adapter | not-reviewed | `WebsiteBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:16` | - |  |
 
 ### checkbox
 
@@ -137,55 +153,63 @@ No named candidates.
 
 ### dialog
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `BulkDeleteDialog` in `packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx:75` | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button` |
-| canonical-wrapper | `AccountDeletionDialog` in `packages/ui/src/cloud/account-security/components/account-deletion-dialog.tsx:30` | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button`, `Input`, `a`, `div`, `label`, `p` |
-| canonical-wrapper | `WithdrawDialog` in `packages/ui/src/cloud/applications/components/withdraw-dialog.tsx:45` | `AlertCircle`, `ArrowRight`, `Button`, `CheckCircle2`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Loader2`, `Wallet`, `div`, `h3`, `label`, `p`, `span` |
-| canonical-wrapper | `McpEditorDialog` in `packages/ui/src/cloud/mcps/McpEditorDialog.tsx:185` | `BrandButton`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Switch`, `Textarea`, `div`, `p` |
-| canonical-wrapper | `ContributeCredentialDialog` in `packages/ui/src/cloud/organization/contribute-credential-dialog.tsx:54` | `AlertCircle`, `BrandButton`, `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `KeyRound`, `Label`, `Loader2`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `code`, `div`, `form`, `p`, `span` |
-| canonical-wrapper | `InviteMemberDialog` in `packages/ui/src/cloud/organization/invite-member-dialog.tsx:64` | `AlertCircle`, `BrandButton`, `Button`, `Copy`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Link2`, `Loader2`, `Mail`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `UserCog`, `code`, `div`, `form`, `p`, `span` |
-| canonical-wrapper | `AddAccountDialog` in `packages/ui/src/components/accounts/AddAccountDialog.tsx:180` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `ProviderPicker`, `Spinner`, `a`, `code`, `div`, `form`, `p`, `span` |
-| canonical-wrapper | `ChatConversationRenameDialog` in `packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx:41` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Sparkles`, `div` |
-| canonical-wrapper | `PluginSettingsDialog` in `packages/ui/src/components/pages/plugin-view-dialogs.tsx:68` | `AdminDialog.BodyScroll`, `AdminDialog.Content`, `AdminDialog.Footer`, `AdminDialog.Header`, `AdminDialog.MetaBadge`, `AdminDialog.MonoMeta`, `Button`, `CheckCircle2`, `ConnectorSetupPanel`, `Dialog`, `DialogDescription`, `DialogTitle`, `PluginConfigForm`, `SettingsDialogIcon`, `div`, `span` |
-| canonical-wrapper | `CloudConfirmDialog` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:685` | `Button`, `CloudModal`, `div`, `p` |
-| parallel-primitive | `PromoteAppDialog` in `packages/ui/src/cloud-ui/components/promotion/promote-app-dialog.tsx:152` | `AlertCircle`, `ArrowLeft`, `ArrowRight`, `Braces`, `Button`, `Check`, `CheckCircle`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `FileText`, `Input`, `Label`, `Loader2`, `Megaphone`, `Search`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Send`, `Share2`, `Textarea`, `div`, `h3`, `p`, `platform.Icon`, `span` |
-| parallel-primitive | `ConversationRenameDialog` in `packages/ui/src/components/conversations/ConversationRenameDialog.tsx:21` | `ChatConversationRenameDialog` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `BulkDeleteDialog` in `packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx:75` | - | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button` |
+| canonical-wrapper | not-reviewed | `AccountDeletionDialog` in `packages/ui/src/cloud/account-security/components/account-deletion-dialog.tsx:30` | - | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button`, `Input`, `a`, `div`, `label`, `p` |
+| canonical-wrapper | not-reviewed | `WithdrawDialog` in `packages/ui/src/cloud/applications/components/withdraw-dialog.tsx:45` | - | `AlertCircle`, `ArrowRight`, `Button`, `CheckCircle2`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Loader2`, `Wallet`, `div`, `h3`, `label`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `McpEditorDialog` in `packages/ui/src/cloud/mcps/McpEditorDialog.tsx:185` | - | `BrandButton`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Switch`, `Textarea`, `div`, `p` |
+| canonical-wrapper | not-reviewed | `ContributeCredentialDialog` in `packages/ui/src/cloud/organization/contribute-credential-dialog.tsx:54` | - | `AlertCircle`, `BrandButton`, `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `KeyRound`, `Label`, `Loader2`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `InviteMemberDialog` in `packages/ui/src/cloud/organization/invite-member-dialog.tsx:64` | - | `AlertCircle`, `BrandButton`, `Button`, `Copy`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Link2`, `Loader2`, `Mail`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `UserCog`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `AddAccountDialog` in `packages/ui/src/components/accounts/AddAccountDialog.tsx:180` | - | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `ProviderPicker`, `Spinner`, `a`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `ChatConversationRenameDialog` in `packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx:41` | - | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Sparkles`, `div` |
+| canonical-wrapper | not-reviewed | `PluginSettingsDialog` in `packages/ui/src/components/pages/plugin-view-dialogs.tsx:68` | - | `AdminDialog.BodyScroll`, `AdminDialog.Content`, `AdminDialog.Footer`, `AdminDialog.Header`, `AdminDialog.MetaBadge`, `AdminDialog.MonoMeta`, `Button`, `CheckCircle2`, `ConnectorSetupPanel`, `Dialog`, `DialogDescription`, `DialogTitle`, `PluginConfigForm`, `SettingsDialogIcon`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `CloudConfirmDialog` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:685` | - | `Button`, `CloudModal`, `div`, `p` |
+| parallel-primitive | molecular | `PromoteAppDialog` in `packages/ui/src/cloud-ui/components/promotion/promote-app-dialog.tsx:152` | `packages/ui/src/components/ui/dialog.tsx` | `AlertCircle`, `ArrowLeft`, `ArrowRight`, `Braces`, `Button`, `Check`, `CheckCircle`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `FileText`, `Input`, `Label`, `Loader2`, `Megaphone`, `Search`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Send`, `Share2`, `Textarea`, `div`, `h3`, `p`, `platform.Icon`, `span` |
+|  |  | Multi-step workflow already composes the canonical Dialog family. |  |  |
+| parallel-primitive | intentional-specialization | `ConversationRenameDialog` in `packages/ui/src/components/conversations/ConversationRenameDialog.tsx:21` | `packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx` | `ChatConversationRenameDialog` |
+|  |  | Compatibility adapter around the shared conversation rename composition. |  |  |
 
 ### input
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `PhoneNumberInput` in `packages/homepage/src/components/login/phone-number-input.tsx:109` | `ChevronDown`, `CountryFlag`, `Input`, `div`, `label`, `option`, `select` |
-| canonical-wrapper | `AgentInput` in `packages/ui/src/agent-surface/components.tsx:68` | `Input` |
-| canonical-wrapper | `TaskSearchInput` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:184` | `Input`, `Search`, `div` |
-| parallel-primitive | `CloudInputRow` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:416` | `SettingRowShell`, `input` |
-| parallel-primitive | `CloudTextInput` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:753` | `input` |
-| parallel-primitive | `AgentInput` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:187` | `input` |
-| test-double | `Input` in `plugins/plugin-contacts/test/stubs/ui.tsx:26` |  |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `PhoneNumberInput` in `packages/homepage/src/components/login/phone-number-input.tsx:109` | - | `ChevronDown`, `CountryFlag`, `Input`, `div`, `label`, `option`, `select` |
+| canonical-wrapper | not-reviewed | `AgentInput` in `packages/ui/src/agent-surface/components.tsx:68` | - | `Input` |
+| canonical-wrapper | not-reviewed | `TaskSearchInput` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:184` | - | `Input`, `Search`, `div` |
+| parallel-primitive | molecular | `CloudInputRow` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:416` | `packages/ui/src/components/ui/input.tsx` | `SettingRowShell`, `input` |
+|  |  | Settings row composition; its internal raw input remains a separate migration target. |  |  |
+| parallel-primitive | consolidation-candidate | `CloudTextInput` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:753` | `packages/ui/src/components/ui/input.tsx` | `input` |
+|  |  | Directly reimplements the canonical text input with a narrower value callback. |  |  |
+| parallel-primitive | consolidation-candidate | `AgentInput` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:187` | `packages/ui/src/agent-surface/components.tsx` | `input` |
+|  |  | Duplicates the shared agent-aware Input adapter inside one plugin. |  |  |
+| test-double | not-reviewed | `Input` in `plugins/plugin-contacts/test/stubs/ui.tsx:26` | - |  |
 
 ### popover
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `CellPopover` in `packages/ui/src/components/pages/database-utils.tsx:80` | `CodeBlock`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle` |
-| test-double | `Popover` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:61` | `div` |
-| test-double | `PopoverContent` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:74` | `div` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `CellPopover` in `packages/ui/src/components/pages/database-utils.tsx:80` | - | `CodeBlock`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle` |
+| test-double | not-reviewed | `Popover` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:61` | - | `div` |
+| test-double | not-reviewed | `PopoverContent` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:74` | - | `div` |
 
 ### progress
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| parallel-primitive | `MilestoneProgress` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:20` | `CheckCircle2`, `Target`, `div`, `span` |
-| parallel-primitive | `NavigationProgress` in `packages/ui/src/cloud-ui/components/navigation-progress.tsx:13` |  |
-| parallel-primitive | `DownloadProgress` in `packages/ui/src/components/local-inference/DownloadProgress.tsx:14` | `div`, `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| parallel-primitive | molecular | `MilestoneProgress` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:20` | `packages/ui/src/components/ui/progress.tsx` | `CheckCircle2`, `Target`, `div`, `span` |
+|  |  | Milestone state composition, not a generic progress primitive. |  |  |
+| parallel-primitive | intentional-specialization | `NavigationProgress` in `packages/ui/src/cloud-ui/components/navigation-progress.tsx:13` | - |  |
+|  |  | Route lifecycle adapter around nprogress, not an inline progress control. |  |  |
+| parallel-primitive | consolidation-candidate | `DownloadProgress` in `packages/ui/src/components/local-inference/DownloadProgress.tsx:14` | `packages/ui/src/components/ui/progress.tsx` | `div`, `span` |
+|  |  | Inline determinate progress bar duplicates the canonical Progress base. |  |  |
 
 ### select
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `ApiParameterSelect` in `packages/ui/src/cloud-ui/components/docs/api-parameter-select.tsx:29` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` |
-| canonical-wrapper | `FilterSelect` in `plugins/plugin-task-coordinator/src/orchestrator-workbench-list.tsx:29` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `TaskStatusChip`, `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `ApiParameterSelect` in `packages/ui/src/cloud-ui/components/docs/api-parameter-select.tsx:29` | - | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` |
+| canonical-wrapper | not-reviewed | `FilterSelect` in `plugins/plugin-task-coordinator/src/orchestrator-workbench-list.tsx:29` | - | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `TaskStatusChip`, `span` |
 
 ### separator
 
@@ -193,55 +217,63 @@ No named candidates.
 
 ### skeleton
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | `Skeleton`, `div` |
-| canonical-wrapper | `DashboardTableSkeleton` in `packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx:29` | `Skeleton`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div` |
-| parallel-primitive | `MonacoEditorSkeleton` in `packages/ui/src/cloud-ui/components/code/monaco-editor-skeleton.tsx:14` | `Loader2`, `div`, `span` |
-| parallel-primitive | `AppsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:218` | `DashboardTableSkeleton` |
-| parallel-primitive | `ContainersSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:237` | `DashboardTableSkeleton` |
-| parallel-primitive | `LoginOptionsSkeleton` in `packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx:39` | `GhostRow`, `div` |
-| parallel-primitive | `ViewLoadingSkeleton` in `packages/ui/src/components/views/ViewStatusStates.tsx:82` | `LoaderCircle`, `ViewStatusFrame` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | - | `Skeleton`, `div` |
+| canonical-wrapper | not-reviewed | `DashboardTableSkeleton` in `packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx:29` | - | `Skeleton`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div` |
+| parallel-primitive | molecular | `MonacoEditorSkeleton` in `packages/ui/src/cloud-ui/components/code/monaco-editor-skeleton.tsx:14` | `packages/ui/src/components/ui/skeleton.tsx` | `Loader2`, `div`, `span` |
+|  |  | Editor loading composition with label and spinner. |  |  |
+| parallel-primitive | intentional-specialization | `AppsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:218` | `packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx` | `DashboardTableSkeleton` |
+|  |  | Named preset around the shared dashboard table skeleton. |  |  |
+| parallel-primitive | intentional-specialization | `ContainersSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:237` | `packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx` | `DashboardTableSkeleton` |
+|  |  | Named preset around the shared dashboard table skeleton. |  |  |
+| parallel-primitive | molecular | `LoginOptionsSkeleton` in `packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx:39` | `packages/ui/src/components/ui/skeleton.tsx` | `GhostRow`, `div` |
+|  |  | Full login-options loading composition. |  |  |
+| parallel-primitive | false-positive | `ViewLoadingSkeleton` in `packages/ui/src/components/views/ViewStatusStates.tsx:82` | - | `LoaderCircle`, `ViewStatusFrame` |
+|  |  | Loading status frame uses a spinner and contains no skeleton primitive. |  |  |
 
 ### spinner
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| test-double | `Spinner` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:57` | `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| test-double | not-reviewed | `Spinner` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:57` | - | `span` |
 
 ### switch
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `ConnectorChannelModeSwitch` in `packages/ui/src/components/connectors/ConnectorChannelModeSwitch.tsx:40` | `SegmentedControl`, `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `ConnectorChannelModeSwitch` in `packages/ui/src/components/connectors/ConnectorChannelModeSwitch.tsx:40` | - | `SegmentedControl`, `span` |
 
 ### table
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `ApiKeysTable` in `packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx:83` | `DashboardDataListDesktop`, `DashboardDataListMobile`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div`, `p`, `span` |
-| canonical-wrapper | `ElizaAgentsTable` in `packages/ui/src/cloud/instances/components/eliza-agents-table.tsx:334` | `AgentCostBadge`, `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `ArrowUpDown`, `BulkDeleteDialog`, `BulkSelectionBar`, `Button`, `Checkbox`, `DashboardDataList`, `DashboardDataListDesktop`, `DashboardDataListFilteredCount`, `DashboardDataListMobile`, `DataListEmptyState`, `ExternalLink`, `Input`, `Moon`, `Pause`, `Play`, `Search`, `StatusCell`, `Sun`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `Tooltip`, `TooltipContent`, `TooltipProvider`, `TooltipTrigger`, `Trash2`, `a`, `div`, `p`, `span` |
-| canonical-wrapper | `AccountCommandTable` in `packages/ui/src/components/accounts/AccountCommandTable.tsx:224` | `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `HealthCell`, `KeyRound`, `RotateCw`, `SortHeader`, `Spinner`, `Trash2`, `UsageBar`, `button`, `div`, `input`, `span`, `table`, `tbody`, `td`, `th`, `thead`, `tr` |
-| parallel-primitive | `AppsTable` in `packages/ui/src/cloud/applications/components/apps-table.tsx:31` | `AppsListView`, `BulkDeleteDialog`, `BulkSelectionBar`, `Link`, `span` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `ApiKeysTable` in `packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx:83` | - | `DashboardDataListDesktop`, `DashboardDataListMobile`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `ElizaAgentsTable` in `packages/ui/src/cloud/instances/components/eliza-agents-table.tsx:334` | - | `AgentCostBadge`, `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `ArrowUpDown`, `BulkDeleteDialog`, `BulkSelectionBar`, `Button`, `Checkbox`, `DashboardDataList`, `DashboardDataListDesktop`, `DashboardDataListFilteredCount`, `DashboardDataListMobile`, `DataListEmptyState`, `ExternalLink`, `Input`, `Moon`, `Pause`, `Play`, `Search`, `StatusCell`, `Sun`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `Tooltip`, `TooltipContent`, `TooltipProvider`, `TooltipTrigger`, `Trash2`, `a`, `div`, `p`, `span` |
+| canonical-wrapper | not-reviewed | `AccountCommandTable` in `packages/ui/src/components/accounts/AccountCommandTable.tsx:224` | - | `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `HealthCell`, `KeyRound`, `RotateCw`, `SortHeader`, `Spinner`, `Trash2`, `UsageBar`, `button`, `div`, `input`, `span`, `table`, `tbody`, `td`, `th`, `thead`, `tr` |
+| parallel-primitive | molecular | `AppsTable` in `packages/ui/src/cloud/applications/components/apps-table.tsx:31` | `packages/ui/src/cloud-ui/components/data-list/apps-list-view.tsx` | `AppsListView`, `BulkDeleteDialog`, `BulkSelectionBar`, `Link`, `span` |
+|  |  | Application list composition, not a table primitive implementation. |  |  |
 
 ### tabs
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| canonical-wrapper | `BrandTabsResponsive` in `packages/ui/src/cloud-ui/components/brand/brand-tabs-responsive.tsx:53` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `TabsPrimitive.List`, `TabsPrimitive.Root`, `TabsPrimitive.Trigger`, `div`, `span` |
-| canonical-wrapper | `SimpleBrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:67` | `Button`, `div` |
-| canonical-wrapper | `Tabs` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:70` | `TabsContent`, `TabsList`, `TabsTrigger`, `UiTabs`, `div` |
-| canonical-wrapper | `AppDetailsTabs` in `packages/ui/src/cloud/applications/components/app-details-tabs.tsx:49` | `AppAnalytics`, `AppDomains`, `AppEarningsDashboard`, `AppFrontendHosting`, `AppMonetizationSettings`, `AppOverview`, `AppPromote`, `AppSettings`, `AppUsers`, `Button`, `Icon`, `div`, `span` |
-| canonical-wrapper | `BrowserTabSwitcher` in `packages/ui/src/components/pages/BrowserTabSwitcher.tsx:274` | `BrowserTabCard`, `Button`, `Dialog`, `DialogClose`, `DialogContent`, `DialogHeader`, `DialogTitle`, `Plus`, `X`, `div`, `h3`, `p`, `section`, `span` |
-| canonical-wrapper | `AgentTabsSection` in `plugins/plugin-task-coordinator/src/AgentTabsSection.tsx:38` | `Button`, `ExternalLink`, `InstallStateIcon`, `KeyRound`, `Loader2`, `RotateCw`, `SettingsControls.MutedText`, `SettingsControls.SegmentedGroup`, `a`, `div`, `span` |
-| parallel-primitive | `BrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:13` |  |
-| test-double | `Tabs` in `plugins/plugin-phone/test/stubs/ui-tabs.tsx:25` |  |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| canonical-wrapper | not-reviewed | `BrandTabsResponsive` in `packages/ui/src/cloud-ui/components/brand/brand-tabs-responsive.tsx:53` | - | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `TabsPrimitive.List`, `TabsPrimitive.Root`, `TabsPrimitive.Trigger`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `SimpleBrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:67` | - | `Button`, `div` |
+| canonical-wrapper | not-reviewed | `Tabs` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:70` | - | `TabsContent`, `TabsList`, `TabsTrigger`, `UiTabs`, `div` |
+| canonical-wrapper | not-reviewed | `AppDetailsTabs` in `packages/ui/src/cloud/applications/components/app-details-tabs.tsx:49` | - | `AppAnalytics`, `AppDomains`, `AppEarningsDashboard`, `AppFrontendHosting`, `AppMonetizationSettings`, `AppOverview`, `AppPromote`, `AppSettings`, `AppUsers`, `Button`, `Icon`, `div`, `span` |
+| canonical-wrapper | not-reviewed | `BrowserTabSwitcher` in `packages/ui/src/components/pages/BrowserTabSwitcher.tsx:274` | - | `BrowserTabCard`, `Button`, `Dialog`, `DialogClose`, `DialogContent`, `DialogHeader`, `DialogTitle`, `Plus`, `X`, `div`, `h3`, `p`, `section`, `span` |
+| canonical-wrapper | not-reviewed | `AgentTabsSection` in `plugins/plugin-task-coordinator/src/AgentTabsSection.tsx:38` | - | `Button`, `ExternalLink`, `InstallStateIcon`, `KeyRound`, `Loader2`, `RotateCw`, `SettingsControls.MutedText`, `SettingsControls.SegmentedGroup`, `a`, `div`, `span` |
+| parallel-primitive | consolidation-candidate | `BrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:13` | `packages/ui/src/components/ui/tabs.tsx` |  |
+|  |  | Direct Radix Tabs root and subcomponent implementation duplicates canonical Tabs. |  |  |
+| test-double | not-reviewed | `Tabs` in `plugins/plugin-phone/test/stubs/ui-tabs.tsx:25` | - |  |
 
 ### textarea
 
-| Classification | Definition | Rendered tags |
-| --- | --- | --- |
-| parallel-primitive | `AgentTextarea` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:225` | `textarea` |
+| Classification | Decision | Definition | Canonical owner | Rendered tags |
+| --- | --- | --- | --- | --- |
+| parallel-primitive | consolidation-candidate | `AgentTextarea` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:225` | `packages/ui/src/components/ui/textarea.tsx` | `textarea` |
+|  |  | Duplicates agent instrumentation plus the canonical Textarea inside one plugin. |  |  |
 
 ### tooltip
 

--- a/packages/ui/scripts/duplicate-components-report.md
+++ b/packages/ui/scripts/duplicate-components-report.md
@@ -1,0 +1,249 @@
+# Atomic component duplicate inventory
+
+Scanned 918 maintained React source files across packages and plugins.
+
+This is a candidate inventory, not an instruction to merge every entry. Canonical wrappers, renderer adapters, and test doubles remain separate because they often have legitimate ownership.
+
+| Atom | Canonical | Same-name | Wrappers | Parallel primitives | Raw host files |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| alert | 5 | 0 | 0 | 1 | 0 |
+| avatar | 2 | 0 | 0 | 0 | 0 |
+| badge | 3 | 0 | 6 | 8 | 0 |
+| button | 8 | 0 | 11 | 4 | 63 |
+| card | 6 | 0 | 24 | 3 | 0 |
+| checkbox | 1 | 0 | 0 | 0 | 14 |
+| dialog | 10 | 0 | 10 | 2 | 1 |
+| input | 4 | 0 | 3 | 3 | 14 |
+| popover | 1 | 0 | 1 | 0 | 0 |
+| progress | 1 | 0 | 0 | 3 | 0 |
+| select | 2 | 0 | 2 | 0 | 3 |
+| separator | 3 | 0 | 0 | 0 | 5 |
+| skeleton | 4 | 0 | 2 | 5 | 0 |
+| spinner | 1 | 0 | 0 | 0 | 0 |
+| switch | 2 | 0 | 1 | 0 | 14 |
+| table | 1 | 0 | 3 | 1 | 12 |
+| tabs | 1 | 0 | 6 | 1 | 0 |
+| textarea | 3 | 0 | 0 | 1 | 6 |
+| tooltip | 4 | 0 | 0 | 0 | 0 |
+
+## Named candidates by atom
+
+### alert
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| parallel-primitive | `CostAlerts` in `packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx:16` | `AlertTriangle`, `Info`, `TrendingDown`, `div`, `p` |
+
+### avatar
+
+No named candidates.
+
+### badge
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `ConnectionConnectedBadge` in `packages/ui/src/cloud-ui/components/connection-card.tsx:91` | `Badge`, `CheckCircle` |
+| canonical-wrapper | `VoiceStatusBadge` in `packages/ui/src/cloud-ui/components/voice/voice-status-badge.tsx:20` | `AlertCircle`, `CheckCircle2`, `Clock`, `Loader2`, `StatusBadge` |
+| canonical-wrapper | `ApprovalStatusBadge` in `packages/ui/src/cloud/approvals/components/status-badge.tsx:54` | `SharedStatusBadge` |
+| canonical-wrapper | `AgentCostBadge` in `packages/ui/src/cloud/instances/components/agent-cost-badge.tsx:30` | `Tooltip`, `TooltipContent`, `TooltipTrigger`, `p`, `span` |
+| canonical-wrapper | `McpStatusBadge` in `packages/ui/src/cloud/mcps/McpDetailDrawer.tsx:446` | `StatusBadge` |
+| canonical-wrapper | `CloudStatusBadge` in `packages/ui/src/components/cloud/CloudStatusBadge.tsx:143` | `Button`, `span` |
+| parallel-primitive | `LlmsTxtBadge` in `packages/ui/src/cloud-ui/components/docs/llms-txt-badge.tsx:8` | `a`, `div` |
+| parallel-primitive | `SurfaceBadge` in `packages/ui/src/components/apps/extensions/surface.tsx:33` | `span` |
+| parallel-primitive | `ChatVoiceSpeakerBadge` in `packages/ui/src/components/composites/chat/chat-source.tsx:56` | `Crown`, `Mic`, `span` |
+| parallel-primitive | `OwnerBadge` in `packages/ui/src/components/composites/OwnerBadge.tsx:53` | `Crown`, `span` |
+| parallel-primitive | `HardwareBadge` in `packages/ui/src/components/local-inference/HardwareBadge.tsx:16` | `AlertTriangle`, `Cpu`, `Gauge`, `HardDrive`, `div`, `span` |
+| parallel-primitive | `RedactedBadge` in `packages/ui/src/components/RedactedBadge.tsx:13` | `EyeOff`, `span` |
+| parallel-primitive | `BuildBadge` in `packages/ui/src/components/shell/BuildBadge.tsx:298` | `X`, `button`, `dd`, `div`, `dl`, `dt`, `span` |
+| parallel-primitive | `SpeakerNameAttributionBadge` in `packages/ui/src/components/transcripts/SpeakerNameAttributionBadge.tsx:40` | `span` |
+
+### button
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `AgentButton` in `packages/ui/src/agent-surface/components.tsx:32` | `Button` |
+| canonical-wrapper | `ExportButton` in `packages/ui/src/cloud-ui/components/analytics/export-button.tsx:36` | `Button`, `ChevronDown`, `Download`, `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuTrigger`, `Upload` |
+| canonical-wrapper | `ElizaConnectButton` in `packages/ui/src/cloud/instances/components/eliza-connect-button.tsx:16` | `BrandButton`, `ExternalLink` |
+| canonical-wrapper | `PstnCallButton` in `packages/ui/src/components/composites/chat/pstn-call-button.tsx:77` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Loader2`, `PhoneCall`, `div`, `p` |
+| canonical-wrapper | `SidebarCollapsedActionButton` in `packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.tsx:77` | `Button` |
+| canonical-wrapper | `SidebarItemButton` in `packages/ui/src/components/composites/sidebar/sidebar-content.tsx:253` | `Button` |
+| canonical-wrapper | `DestructiveSecondaryButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:74` | `Button` |
+| canonical-wrapper | `CloudActionButton` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:496` | `Button`, `SettingRowShell` |
+| canonical-wrapper | `SettingsActionButton` in `packages/ui/src/components/settings/settings-agent-rows.tsx:576` | `Button` |
+| canonical-wrapper | `GlassIconButton` in `packages/ui/src/components/shell/glass-composer.tsx:24` | `Button`, `Icon` |
+| canonical-wrapper | `RecoveryActionButton` in `plugins/plugin-task-coordinator/src/orchestrator-task-inspector.tsx:1101` | `Button` |
+| parallel-primitive | `BrandButton` in `packages/ui/src/cloud-ui/components/brand/brand-button.tsx:46` | `Comp` |
+| parallel-primitive | `LockOnButton` in `packages/ui/src/cloud-ui/components/brand/lock-on-button.tsx:14` | `Component` |
+| parallel-primitive | `ViewBackButton` in `packages/ui/src/components/shared/ViewHeader.tsx:44` | `ArrowLeft`, `button`, `span` |
+| parallel-primitive | `ActionButton` in `packages/ui/stories/src/lab/lab-ui.tsx:73` | `button` |
+| renderer-adapter | `Button` in `packages/ui/src/spatial/primitives.tsx:517` | `UiButton` |
+| template-adapter | `InferenceCloudAlertButton` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:14` |  |
+| test-double | `Button` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:46` | `button` |
+| test-double | `Button` in `plugins/plugin-contacts/test/stubs/ui.tsx:15` |  |
+| test-double | `Button` in `plugins/plugin-phone/test/stubs/ui.tsx:13` |  |
+
+### card
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `CostInsightsCard` in `packages/ui/src/cloud-ui/components/analytics/cost-insights-card.tsx:21` | `Badge`, `BrandCard`, `CostAlerts`, `Progress`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | `PromptCard` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:15` | `ArrowUp`, `Button`, `p` |
+| canonical-wrapper | `ConnectionCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:369` | `AlertTriangle`, `Button`, `ConnectionLoadingCard`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | `Skeleton`, `div` |
+| canonical-wrapper | `EndpointCard` in `packages/ui/src/cloud-ui/components/docs/endpoint-card.tsx:61` | `Button`, `ChevronRight`, `Coins`, `Sparkles`, `code`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | `BuyDomainCard` in `packages/ui/src/cloud/applications/components/BuyDomainCard.tsx:68` | `AlertDialog`, `AlertDialogAction`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `AlertDialogTrigger`, `AlertTriangle`, `Button`, `CheckCircle2`, `CreditCard`, `Input`, `Loader2`, `Search`, `ShoppingCart`, `XCircle`, `div`, `form`, `h3`, `p`, `span` |
+| canonical-wrapper | `ActiveComputeCardView` in `packages/ui/src/cloud/billing/components/active-compute-card.tsx:301` | `AlertCircle`, `BrandCard`, `Calculator`, `Clock3`, `LoadingCard`, `RefreshCw`, `ResourceCard`, `RetryButton`, `StatusBadge`, `div`, `h3`, `p`, `span`, `ul` |
+| canonical-wrapper | `AutoTopUpCard` in `packages/ui/src/cloud/billing/components/auto-top-up-card.tsx:144` | `AlertCircle`, `BrandCard`, `Button`, `CornerBrackets`, `CreditCard`, `Info`, `Loader2`, `RefreshCw`, `SettingsInputRow`, `SettingsSwitchRow`, `div`, `h3`, `p`, `span` |
+| canonical-wrapper | `DirectCryptoCreditCard` in `packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx:179` | `Button`, `Card`, `CardContent`, `CardHeader`, `CardTitle`, `Coins`, `ConnectButton.Custom`, `Link`, `Loader2`, `PaymentWaitingOverlay`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `Wallet`, `div`, `p`, `span` |
+| canonical-wrapper | `AccountCard` in `packages/ui/src/components/accounts/AccountCard.tsx:178` | `Badge`, `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `Spinner`, `StatusBadge`, `Trash2`, `UsageBar`, `div`, `span` |
+| canonical-wrapper | `AccountRequiredCard` in `packages/ui/src/components/chat/AccountRequiredCard.tsx:133` | `Button`, `ReconnectProgressLine`, `RefreshCw`, `ShieldAlert`, `Spinner`, `StatusBadge`, `UserRound`, `div`, `span` |
+| canonical-wrapper | `ConnectorCardWidget` in `packages/ui/src/components/chat/widgets/connector-card.tsx:83` | `Button`, `ConnectorBrandIcon`, `Input`, `ShieldCheck`, `div`, `form`, `label`, `span` |
+| canonical-wrapper | `HomeWidgetCard` in `packages/ui/src/components/chat/widgets/home-widget-card.tsx:89` | `Button`, `span` |
+| canonical-wrapper | `PermissionCard` in `packages/ui/src/components/composites/chat/permission-card.tsx:57` | `Button`, `div`, `h3`, `header`, `p`, `section`, `span` |
+| canonical-wrapper | `TrajectoryLlmCallCard` in `packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx:64` | `Button`, `CallMetric`, `ChevronDown`, `ChevronRight`, `PagePanel`, `TrajectoryCodeBlock`, `div`, `span` |
+| canonical-wrapper | `ConnectorAccountCard` in `packages/ui/src/components/connectors/ConnectorAccountCard.tsx:163` | `Badge`, `Button`, `Checkbox`, `ConnectedCapabilityChips`, `ConnectorAccountPrivacySelector`, `ConnectorAccountPurposeSelector`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `EditableAccountLabel`, `KeyRound`, `RefreshCw`, `Spinner`, `Star`, `StatusBadge`, `Trash2`, `div`, `img`, `span` |
+| canonical-wrapper | `ModelCard` in `packages/ui/src/components/local-inference/ModelCard.tsx:55` | `Button`, `DownloadProgress`, `div`, `p`, `span` |
+| canonical-wrapper | `PluginCard` in `packages/ui/src/components/pages/PluginCard.tsx:46` | `Button`, `PluginVisual`, `div`, `li`, `p`, `span` |
+| canonical-wrapper | `PendantSettingsCard` in `packages/ui/src/components/settings/PendantSettingsCard.tsx:46` | `BatteryBadge`, `Bluetooth`, `Button`, `Loader2`, `Radio`, `SettingsGroup`, `SettingsRow`, `span` |
+| canonical-wrapper | `ProviderCard` in `packages/ui/src/components/settings/ProviderCard.tsx:46` | `Button`, `CheckCircle2`, `Icon`, `span` |
+| canonical-wrapper | `AppBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx:110` | `AppBlockerStatusIcon`, `Button`, `CheckCircle2`, `Clock3`, `Input`, `ListChecks`, `Loader2`, `RefreshCw`, `Search`, `ShieldBan`, `Smartphone`, `Square`, `Timer`, `div`, `label`, `span` |
+| canonical-wrapper | `WebsiteBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/WebsiteBlockerSettingsCard.tsx:80` | `Button`, `CheckCircle2`, `Monitor`, `Settings`, `ShieldBan`, `div`, `span` |
+| canonical-wrapper | `GitHubConnectionCard` in `plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx:80` | `Button`, `CheckCircle2`, `ExternalLink`, `GitPullRequest`, `LogIn`, `SettingsControls.Input`, `Unplug`, `div`, `p`, `span` |
+| canonical-wrapper | `TaskCard` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:238` | `Button`, `GitBranch`, `TaskStatusChip`, `TaskStatusMedallion`, `span` |
+| molecular-candidate | `AgentCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:63` | `BrandCard`, `div`, `h3`, `p` |
+| molecular-candidate | `DashboardStatCard` in `packages/ui/src/cloud-ui/components/brand/dashboard-stat-card.tsx:37` | `BrandCard`, `div`, `p` |
+| molecular-candidate | `PromptCardGrid` in `packages/ui/src/cloud-ui/components/brand/prompt-card.tsx:40` | `PromptCard`, `div` |
+| molecular-candidate | `ConnectionLoadingCard` in `packages/ui/src/cloud-ui/components/connection-card.tsx:76` | `Loader2`, `div` |
+| molecular-candidate | `DashboardActionCards` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:72` | `ArrowRight`, `BookOpen`, `Bot`, `Code`, `CreditCard`, `KeyRound`, `Link`, `Rocket`, `Server`, `Store`, `Wallet`, `div`, `h3`, `span` |
+| molecular-candidate | `DashboardDataListCard` in `packages/ui/src/cloud-ui/components/data-list/dashboard-data-list.tsx:79` | `div` |
+| molecular-candidate | `Cards` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:57` | `div` |
+| molecular-candidate | `MilestoneCard` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:88` | `MilestoneProgress`, `div`, `h4` |
+| molecular-candidate | `AgentCard` in `packages/ui/src/cloud/instances/components/agent-card.tsx:856` |  |
+| molecular-candidate | `MessagePermissionCard` in `packages/ui/src/components/chat/MessageContent.tsx:1259` |  |
+| molecular-candidate | `MapsCardWidget` in `packages/ui/src/components/chat/widgets/maps-card.tsx:347` | `AttributionLine`, `HandoffCard`, `LocateCard`, `PlaceRow`, `Route`, `a`, `div`, `li`, `span`, `ul` |
+| molecular-candidate | `OrchestratorGrillingCard` in `packages/ui/src/components/chat/widgets/orchestrator-grilling-card.tsx:85` | `div`, `li`, `p`, `span`, `ul` |
+| molecular-candidate | `SummaryCard` in `packages/ui/src/components/composites/page-panel/page-panel-header.tsx:102` | `div` |
+| molecular-candidate | `ProtectionCard` in `packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx:258` | `AlertCircle`, `CheckCircle2`, `div`, `p`, `section` |
+| parallel-primitive | `BrandCard` in `packages/ui/src/cloud-ui/components/brand/brand-card.tsx:26` | `Component`, `CornerBrackets` |
+| parallel-primitive | `MiniStatCard` in `packages/ui/src/cloud-ui/components/brand/mini-stat-card.tsx:13` | `div`, `p` |
+| parallel-primitive | `SurfaceCard` in `packages/ui/src/components/apps/extensions/surface.tsx:49` | `div` |
+| renderer-adapter | `Card` in `packages/ui/src/spatial/primitives.tsx:801` | `Stack` |
+| template-adapter | `AppBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:15` |  |
+| template-adapter | `WebsiteBlockerSettingsCard` in `packages/elizaos/templates/project/apps/app/src/optional-eliza-app-stub.tsx:16` |  |
+
+### checkbox
+
+No named candidates.
+
+### dialog
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `BulkDeleteDialog` in `packages/ui/src/cloud-ui/components/bulk/bulk-select.tsx:75` | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button` |
+| canonical-wrapper | `AccountDeletionDialog` in `packages/ui/src/cloud/account-security/components/account-deletion-dialog.tsx:30` | `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `Button`, `Input`, `a`, `div`, `label`, `p` |
+| canonical-wrapper | `WithdrawDialog` in `packages/ui/src/cloud/applications/components/withdraw-dialog.tsx:45` | `AlertCircle`, `ArrowRight`, `Button`, `CheckCircle2`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Loader2`, `Wallet`, `div`, `h3`, `label`, `p`, `span` |
+| canonical-wrapper | `McpEditorDialog` in `packages/ui/src/cloud/mcps/McpEditorDialog.tsx:185` | `BrandButton`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Switch`, `Textarea`, `div`, `p` |
+| canonical-wrapper | `ContributeCredentialDialog` in `packages/ui/src/cloud/organization/contribute-credential-dialog.tsx:54` | `AlertCircle`, `BrandButton`, `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `KeyRound`, `Label`, `Loader2`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `ShieldCheck`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | `InviteMemberDialog` in `packages/ui/src/cloud/organization/invite-member-dialog.tsx:64` | `AlertCircle`, `BrandButton`, `Button`, `Copy`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Link2`, `Loader2`, `Mail`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `UserCog`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | `AddAccountDialog` in `packages/ui/src/components/accounts/AddAccountDialog.tsx:180` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `ProviderPicker`, `Spinner`, `a`, `code`, `div`, `form`, `p`, `span` |
+| canonical-wrapper | `ChatConversationRenameDialog` in `packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx:41` | `Button`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `Input`, `Label`, `Sparkles`, `div` |
+| canonical-wrapper | `PluginSettingsDialog` in `packages/ui/src/components/pages/plugin-view-dialogs.tsx:68` | `AdminDialog.BodyScroll`, `AdminDialog.Content`, `AdminDialog.Footer`, `AdminDialog.Header`, `AdminDialog.MetaBadge`, `AdminDialog.MonoMeta`, `Button`, `CheckCircle2`, `ConnectorSetupPanel`, `Dialog`, `DialogDescription`, `DialogTitle`, `PluginConfigForm`, `SettingsDialogIcon`, `div`, `span` |
+| canonical-wrapper | `CloudConfirmDialog` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:685` | `Button`, `CloudModal`, `div`, `p` |
+| parallel-primitive | `PromoteAppDialog` in `packages/ui/src/cloud-ui/components/promotion/promote-app-dialog.tsx:152` | `AlertCircle`, `ArrowLeft`, `ArrowRight`, `Braces`, `Button`, `Check`, `CheckCircle`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `FileText`, `Input`, `Label`, `Loader2`, `Megaphone`, `Search`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Send`, `Share2`, `Textarea`, `div`, `h3`, `p`, `platform.Icon`, `span` |
+| parallel-primitive | `ConversationRenameDialog` in `packages/ui/src/components/conversations/ConversationRenameDialog.tsx:21` | `ChatConversationRenameDialog` |
+
+### input
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `PhoneNumberInput` in `packages/homepage/src/components/login/phone-number-input.tsx:109` | `ChevronDown`, `CountryFlag`, `Input`, `div`, `label`, `option`, `select` |
+| canonical-wrapper | `AgentInput` in `packages/ui/src/agent-surface/components.tsx:68` | `Input` |
+| canonical-wrapper | `TaskSearchInput` in `plugins/plugin-task-coordinator/src/TaskCardList.tsx:184` | `Input`, `Search`, `div` |
+| parallel-primitive | `CloudInputRow` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:416` | `SettingRowShell`, `input` |
+| parallel-primitive | `CloudTextInput` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:753` | `input` |
+| parallel-primitive | `AgentInput` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:187` | `input` |
+| test-double | `Input` in `plugins/plugin-contacts/test/stubs/ui.tsx:26` |  |
+
+### popover
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `CellPopover` in `packages/ui/src/components/pages/database-utils.tsx:80` | `CodeBlock`, `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle` |
+| test-double | `Popover` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:61` | `div` |
+| test-double | `PopoverContent` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:74` | `div` |
+
+### progress
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| parallel-primitive | `MilestoneProgress` in `packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx:20` | `CheckCircle2`, `Target`, `div`, `span` |
+| parallel-primitive | `NavigationProgress` in `packages/ui/src/cloud-ui/components/navigation-progress.tsx:13` |  |
+| parallel-primitive | `DownloadProgress` in `packages/ui/src/components/local-inference/DownloadProgress.tsx:14` | `div`, `span` |
+
+### select
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `ApiParameterSelect` in `packages/ui/src/cloud-ui/components/docs/api-parameter-select.tsx:29` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` |
+| canonical-wrapper | `FilterSelect` in `plugins/plugin-task-coordinator/src/orchestrator-workbench-list.tsx:29` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `TaskStatusChip`, `span` |
+
+### separator
+
+No named candidates.
+
+### skeleton
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `DashboardActionCardsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:169` | `Skeleton`, `div` |
+| canonical-wrapper | `DashboardTableSkeleton` in `packages/ui/src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx:29` | `Skeleton`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div` |
+| parallel-primitive | `MonacoEditorSkeleton` in `packages/ui/src/cloud-ui/components/code/monaco-editor-skeleton.tsx:14` | `Loader2`, `div`, `span` |
+| parallel-primitive | `AppsSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:218` | `DashboardTableSkeleton` |
+| parallel-primitive | `ContainersSkeleton` in `packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx:237` | `DashboardTableSkeleton` |
+| parallel-primitive | `LoginOptionsSkeleton` in `packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx:39` | `GhostRow`, `div` |
+| parallel-primitive | `ViewLoadingSkeleton` in `packages/ui/src/components/views/ViewStatusStates.tsx:82` | `LoaderCircle`, `ViewStatusFrame` |
+
+### spinner
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| test-double | `Spinner` in `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx:57` | `span` |
+
+### switch
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `ConnectorChannelModeSwitch` in `packages/ui/src/components/connectors/ConnectorChannelModeSwitch.tsx:40` | `SegmentedControl`, `span` |
+
+### table
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `ApiKeysTable` in `packages/ui/src/cloud-ui/components/data-list/api-keys-table.tsx:83` | `DashboardDataListDesktop`, `DashboardDataListMobile`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `div`, `p`, `span` |
+| canonical-wrapper | `ElizaAgentsTable` in `packages/ui/src/cloud/instances/components/eliza-agents-table.tsx:334` | `AgentCostBadge`, `AlertDialog`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle`, `ArrowUpDown`, `BulkDeleteDialog`, `BulkSelectionBar`, `Button`, `Checkbox`, `DashboardDataList`, `DashboardDataListDesktop`, `DashboardDataListFilteredCount`, `DashboardDataListMobile`, `DataListEmptyState`, `ExternalLink`, `Input`, `Moon`, `Pause`, `Play`, `Search`, `StatusCell`, `Sun`, `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`, `Tooltip`, `TooltipContent`, `TooltipProvider`, `TooltipTrigger`, `Trash2`, `a`, `div`, `p`, `span` |
+| canonical-wrapper | `AccountCommandTable` in `packages/ui/src/components/accounts/AccountCommandTable.tsx:224` | `Button`, `Checkbox`, `ChevronDown`, `ChevronUp`, `Dialog`, `DialogContent`, `DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`, `HealthCell`, `KeyRound`, `RotateCw`, `SortHeader`, `Spinner`, `Trash2`, `UsageBar`, `button`, `div`, `input`, `span`, `table`, `tbody`, `td`, `th`, `thead`, `tr` |
+| parallel-primitive | `AppsTable` in `packages/ui/src/cloud/applications/components/apps-table.tsx:31` | `AppsListView`, `BulkDeleteDialog`, `BulkSelectionBar`, `Link`, `span` |
+
+### tabs
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| canonical-wrapper | `BrandTabsResponsive` in `packages/ui/src/cloud-ui/components/brand/brand-tabs-responsive.tsx:53` | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `TabsPrimitive.List`, `TabsPrimitive.Root`, `TabsPrimitive.Trigger`, `div`, `span` |
+| canonical-wrapper | `SimpleBrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:67` | `Button`, `div` |
+| canonical-wrapper | `Tabs` in `packages/ui/src/cloud-ui/components/docs/mdx-components.tsx:70` | `TabsContent`, `TabsList`, `TabsTrigger`, `UiTabs`, `div` |
+| canonical-wrapper | `AppDetailsTabs` in `packages/ui/src/cloud/applications/components/app-details-tabs.tsx:49` | `AppAnalytics`, `AppDomains`, `AppEarningsDashboard`, `AppFrontendHosting`, `AppMonetizationSettings`, `AppOverview`, `AppPromote`, `AppSettings`, `AppUsers`, `Button`, `Icon`, `div`, `span` |
+| canonical-wrapper | `BrowserTabSwitcher` in `packages/ui/src/components/pages/BrowserTabSwitcher.tsx:274` | `BrowserTabCard`, `Button`, `Dialog`, `DialogClose`, `DialogContent`, `DialogHeader`, `DialogTitle`, `Plus`, `X`, `div`, `h3`, `p`, `section`, `span` |
+| canonical-wrapper | `AgentTabsSection` in `plugins/plugin-task-coordinator/src/AgentTabsSection.tsx:38` | `Button`, `ExternalLink`, `InstallStateIcon`, `KeyRound`, `Loader2`, `RotateCw`, `SettingsControls.MutedText`, `SettingsControls.SegmentedGroup`, `a`, `div`, `span` |
+| parallel-primitive | `BrandTabs` in `packages/ui/src/cloud-ui/components/brand/brand-tabs.tsx:13` |  |
+| test-double | `Tabs` in `plugins/plugin-phone/test/stubs/ui-tabs.tsx:25` |  |
+
+### textarea
+
+| Classification | Definition | Rendered tags |
+| --- | --- | --- |
+| parallel-primitive | `AgentTextarea` in `plugins/plugin-notes/src/views/viewPrimitives.tsx:225` | `textarea` |
+
+### tooltip
+
+No named candidates.
+

--- a/packages/ui/scripts/duplicate-components-report.md
+++ b/packages/ui/scripts/duplicate-components-report.md
@@ -11,20 +11,176 @@ This is a candidate inventory, not an instruction to merge every entry. Canonica
 | badge | 3 | 0 | 6 | 8 | 0 |
 | button | 8 | 0 | 11 | 4 | 63 |
 | card | 6 | 0 | 24 | 3 | 0 |
-| checkbox | 1 | 0 | 0 | 0 | 14 |
+| checkbox | 1 | 0 | 0 | 0 | 2 |
 | dialog | 10 | 0 | 10 | 2 | 1 |
-| input | 4 | 0 | 3 | 3 | 14 |
+| input | 4 | 0 | 3 | 3 | 12 |
 | popover | 1 | 0 | 1 | 0 | 0 |
 | progress | 1 | 0 | 0 | 3 | 0 |
 | select | 2 | 0 | 2 | 0 | 3 |
 | separator | 3 | 0 | 0 | 0 | 5 |
 | skeleton | 4 | 0 | 2 | 5 | 0 |
 | spinner | 1 | 0 | 0 | 0 | 0 |
-| switch | 2 | 0 | 1 | 0 | 14 |
+| switch | 2 | 0 | 1 | 0 | 2 |
 | table | 1 | 0 | 3 | 1 | 12 |
 | tabs | 1 | 0 | 6 | 1 | 0 |
 | textarea | 3 | 0 | 0 | 1 | 6 |
 | tooltip | 4 | 0 | 0 | 0 | 0 |
+
+## Raw semantic host usage
+
+Raw host elements are reported only where HTML provides a meaningful atomic signal. Generic `div` and `span` usage is deliberately excluded.
+
+### Raw button hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| runtime-host-control | `packages/app-core/src/runtime/desktop/AppWindowRenderer.tsx` | 424 |
+| test-or-story-harness | `packages/app/test/view-screenshots/stubs/elizaos-ui.tsx` | 51, 93 |
+| template | `packages/elizaos/templates/plugin/src/frontend/index.tsx` | 65 |
+| mixed-canonical-and-raw | `packages/homepage/src/pages/connected.tsx` | 317, 428, 491, 532, 602, 645, 665 |
+| mixed-canonical-and-raw | `packages/homepage/src/pages/get-started.tsx` | 535, 627, 1417, 1471, 1490, 1521, 1559, 1577, 1596, 1615, 1633, 1887, 1936, 2025, 2084 |
+| product-package-raw-host | `packages/homepage/src/pages/landing.tsx` | 859, 865, 919, 1101, 1111, 1156, 1173 |
+| product-package-raw-host | `packages/homepage/src/pages/profile-edit.tsx` | 146, 165 |
+| ui-raw-host | `packages/ui/src/android-cloud/AndroidCloudApp.tsx` | 320, 328, 337, 358, 369, 395, 418, 440, 448 |
+| ui-raw-host | `packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx` | 351, 452 |
+| ui-raw-host | `packages/ui/src/cloud/shell/CloudRouterShell.tsx` | 218 |
+| mixed-canonical-and-raw | `packages/ui/src/components/accounts/AccountCommandTable.tsx` | 164, 530 |
+| mixed-canonical-and-raw | `packages/ui/src/components/accounts/AccountManagementPanel.tsx` | 338 |
+| mixed-canonical-and-raw | `packages/ui/src/components/accounts/ProviderAccountRow.tsx` | 229 |
+| ui-raw-host | `packages/ui/src/components/accounts/ProviderPicker.tsx` | 186 |
+| ui-raw-host | `packages/ui/src/components/auth/CloudPairRelay.tsx` | 425, 447, 543 |
+| ui-raw-host | `packages/ui/src/components/capabilities/ConnectedCapabilityChips.tsx` | 76 |
+| mixed-canonical-and-raw | `packages/ui/src/components/chat/MessageContent.tsx` | 571, 616, 899 |
+| mixed-canonical-and-raw | `packages/ui/src/components/chat/widgets/ChoiceWidget.tsx` | 162 |
+| ui-raw-host | `packages/ui/src/components/chat/widgets/chat-widget-shell.tsx` | 98 |
+| ui-raw-host | `packages/ui/src/components/chat/widgets/todo.tsx` | 188, 239 |
+| ui-raw-host | `packages/ui/src/components/chat/widgets/workflow-steps.tsx` | 178, 189 |
+| mixed-canonical-and-raw | `packages/ui/src/components/config-ui/config-field.tsx` | 244 |
+| ui-raw-host | `packages/ui/src/components/pages/Launcher.tsx` | 108 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/MemoryViewerView.tsx` | 857, 874 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/SettingsView.tsx` | 212 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/WorkflowCanvas.tsx` | 150 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/WorkflowEditor.tsx` | 515, 529, 659, 671, 798 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/WorkflowTriggerPanel.tsx` | 217, 260 |
+| test-or-story-harness | `packages/ui/src/components/pages/__e2e__/background-fixture.tsx` | 204, 228, 238 |
+| mixed-canonical-and-raw | `packages/ui/src/components/pages/documents-detail.tsx` | 356 |
+| mixed-canonical-and-raw | `packages/ui/src/components/permissions/PermissionPrimingModal.tsx` | 398 |
+| mixed-canonical-and-raw | `packages/ui/src/components/settings/BackgroundSettingsControls.tsx` | 152 |
+| mixed-canonical-and-raw | `packages/ui/src/components/settings/ConnectorsSection.tsx` | 432, 599 |
+| ui-raw-host | `packages/ui/src/components/settings/DesktopSettingsNavigation.tsx` | 99 |
+| ui-raw-host | `packages/ui/src/components/settings/SettingsHubList.tsx` | 47 |
+| ui-raw-host | `packages/ui/src/components/settings/cloud-panel/CloudSettingsPanel.tsx` | 82, 139, 279 |
+| ui-raw-host | `packages/ui/src/components/settings/cloud-panel/CloudSettingsSidebar.tsx` | 71, 118, 132, 164, 217 |
+| mixed-canonical-and-raw | `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx` | 652 |
+| ui-raw-host | `packages/ui/src/components/shared/ViewHeader.tsx` | 69 |
+| ui-raw-host | `packages/ui/src/components/shared/ViewHeaderSidebarTrigger.tsx` | 40 |
+| ui-raw-host | `packages/ui/src/components/shell/BuildBadge.tsx` | 371, 390, 404, 425 |
+| mixed-canonical-and-raw | `packages/ui/src/components/shell/ChatOverlay.tsx` | 5993 |
+| ui-raw-host | `packages/ui/src/components/shell/DefaultHomeWidgets.tsx` | 101 |
+| ui-raw-host | `packages/ui/src/components/shell/NotificationsHomeCenter.tsx` | 2602, 2998, 3012 |
+| ui-raw-host | `packages/ui/src/components/shell/VoiceCaptureHud.tsx` | 281 |
+| ui-raw-host | `packages/ui/src/components/shell/notification-shade-content.tsx` | 540, 598 |
+| mixed-canonical-and-raw | `packages/ui/src/components/transcripts/MeetingJoinBar.tsx` | 178 |
+| canonical-implementation | `packages/ui/src/components/ui/admin-dialog.tsx` | 162 |
+| canonical-implementation | `packages/ui/src/components/ui/confirm-delete.tsx` | 46, 68, 82 |
+| canonical-implementation | `packages/ui/src/components/ui/copy-button.tsx` | 73 |
+| canonical-implementation | `packages/ui/src/components/ui/field-switch.tsx` | 28 |
+| canonical-implementation | `packages/ui/src/components/ui/segmented-control.tsx` | 52, 128 |
+| canonical-implementation | `packages/ui/src/components/ui/switch.tsx` | 59 |
+| test-or-story-harness | `packages/ui/src/testing/__e2e__/widget-cert-fixture.tsx` | 67 |
+| test-or-story-harness | `packages/ui/stories/src/lab/DesignLab.tsx` | 105, 120 |
+| test-or-story-harness | `packages/ui/stories/src/lab/lab-ui.tsx` | 37, 83 |
+| test-or-story-harness | `packages/ui/stories/src/lab/surfaces/WidgetsLab.tsx` | 61 |
+| test-or-story-harness | `packages/ui/stories/src/voice-main.tsx` | 786, 809 |
+| plugin-raw-host | `plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx` | 274, 431, 444, 468, 488, 509, 535, 546 |
+| plugin-raw-host | `plugins/plugin-computeruse/src/views/ComputerUseSessionsView.tsx` | 384, 407, 427, 456, 480 |
+| plugin-raw-host | `plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx` | 386, 404 |
+| plugin-raw-host | `plugins/plugin-maps/src/components/MapsView.tsx` | 163, 210, 241, 306, 366 |
+| plugin-raw-host | `plugins/plugin-notes/src/views/viewPrimitives.tsx` | 166 |
+
+### Raw checkbox hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| ui-raw-host | `packages/ui/src/components/pages/WorkflowEditor.tsx` | 1054 |
+| test-or-story-harness | `packages/ui/stories/src/lab/lab-ui.tsx` | 62 |
+
+### Raw dialog hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| product-package-raw-host | `packages/homepage/src/pages/landing.tsx` | 835 |
+
+### Raw input hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| product-package-raw-host | `packages/homepage/src/pages/get-started.tsx` | 600 |
+| product-package-raw-host | `packages/homepage/src/pages/profile-edit.tsx` | 117, 131 |
+| test-or-story-harness | `packages/ui/src/agent-surface/__e2e__/teardown-fixture.tsx` | 46, 75 |
+| ui-raw-host | `packages/ui/src/components/accounts/AccountCommandTable.tsx` | 507 |
+| ui-raw-host | `packages/ui/src/components/accounts/ConsumerKeyPanel.tsx` | 311, 322, 504 |
+| ui-raw-host | `packages/ui/src/components/accounts/ProviderPicker.tsx` | 143 |
+| test-or-story-harness | `packages/ui/src/components/pages/__e2e__/background-fixture.tsx` | 220 |
+| ui-raw-host | `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx` | 446, 771 |
+| canonical-implementation | `packages/ui/src/components/ui/input-group.tsx` | 101 |
+| canonical-implementation | `packages/ui/src/components/ui/input.tsx` | 46 |
+| plugin-raw-host | `plugins/plugin-maps/src/components/MapsView.tsx` | 128 |
+| plugin-raw-host | `plugins/plugin-notes/src/views/viewPrimitives.tsx` | 212 |
+
+### Raw select hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| product-package-raw-host | `packages/homepage/src/components/login/phone-number-input.tsx` | 127 |
+| ui-raw-host | `packages/ui/src/components/pages/WorkflowTriggerPanel.tsx` | 289, 304, 321 |
+| plugin-raw-host | `plugins/plugin-calendar/src/components/calendar/SimpleCalendarView.tsx` | 476 |
+
+### Raw separator hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| ui-raw-host | `packages/ui/src/components/chat/TasksEventsPanel.tsx` | 267 |
+| ui-raw-host | `packages/ui/src/components/composites/sidebar/sidebar-root.tsx` | 829 |
+| ui-raw-host | `packages/ui/src/components/config-ui/ui-renderer.tsx` | 484 |
+| ui-raw-host | `packages/ui/src/genui/renderer.tsx` | 329 |
+| plugin-raw-host | `plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx` | 137 |
+
+### Raw switch hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| ui-raw-host | `packages/ui/src/components/pages/WorkflowEditor.tsx` | 1054 |
+| test-or-story-harness | `packages/ui/stories/src/lab/lab-ui.tsx` | 62 |
+
+### Raw table hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| ui-raw-host | `packages/ui/src/cloud/analytics/_components/model-breakdown.tsx` | 99 |
+| ui-raw-host | `packages/ui/src/cloud/applications/components/app-analytics.tsx` | 741, 889, 977 |
+| ui-raw-host | `packages/ui/src/cloud/applications/components/app-users.tsx` | 210 |
+| ui-raw-host | `packages/ui/src/components/accounts/AccountCommandTable.tsx` | 341 |
+| ui-raw-host | `packages/ui/src/components/config-ui/config-field.helpers.tsx` | 1844 |
+| ui-raw-host | `packages/ui/src/components/config-ui/ui-renderer.tsx` | 882 |
+| ui-raw-host | `packages/ui/src/components/pages/WorkflowEditor.tsx` | 212 |
+| ui-raw-host | `packages/ui/src/components/pages/database-utils.tsx` | 149 |
+| ui-raw-host | `packages/ui/src/components/settings/AppsManagementSection.tsx` | 743 |
+| ui-raw-host | `packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx` | 592 |
+| canonical-implementation | `packages/ui/src/components/ui/table.tsx` | 15 |
+| plugin-raw-host | `plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx` | 95 |
+
+### Raw textarea hosts
+
+| Classification | File | Lines |
+| --- | --- | --- |
+| product-package-raw-host | `packages/homepage/src/pages/profile-edit.tsx` | 159 |
+| ui-raw-host | `packages/ui/src/android-cloud/AndroidCloudApp.tsx` | 430 |
+| canonical-implementation | `packages/ui/src/components/ui/admin-dialog.tsx` | 131 |
+| canonical-implementation | `packages/ui/src/components/ui/input-group.tsx` | 118 |
+| canonical-implementation | `packages/ui/src/components/ui/textarea.tsx` | 44 |
+| plugin-raw-host | `plugins/plugin-notes/src/views/viewPrimitives.tsx` | 250 |
+
 
 ## Named candidates by atom
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,0 +1,91 @@
+# Molecular component duplicate inventory
+
+Scanned 918 maintained React files. 69 exported compositions have a recognized molecular role and at least two atomic dependencies.
+
+Clusters share both a role and an atomic dependency signature. They are review candidates. Product behavior, state ownership, and responsive layout still determine whether consolidation is correct.
+
+| Role | Atomic dependencies | Components | Decision |
+| --- | --- | ---: | --- |
+| dialog | button, dialog | 6 | distinct-domain-compositions |
+| card | button, input | 4 | distinct-domain-compositions |
+| dialog | button, dialog, input | 4 | shared-pattern-candidate |
+| panel | button, input | 4 | distinct-domain-compositions |
+| card | badge, button, checkbox, dialog, spinner | 2 | shared-shell-candidate |
+| dialog | button, input | 2 | distinct-domain-compositions |
+| form | button, input | 2 | distinct-domain-compositions |
+| header | button, input | 2 | distinct-domain-compositions |
+| list | button, spinner | 2 | shared-shell-candidate |
+| panel | badge, button, input | 2 | duplicate-implementation |
+
+## Candidate clusters
+
+### dialog: button + dialog
+
+- `PluginSettingsDialog` in `packages/ui/src/components/pages/plugin-view-dialogs.tsx:68`
+- `EditSkillModal` in `packages/ui/src/components/pages/skill-detail-panel.tsx:35`
+- `InstallModal` in `packages/ui/src/components/pages/skill-installer.tsx:16`
+- `CloudModal` in `packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx:599`
+- `ConfirmDialog` in `packages/ui/src/components/ui/confirm-dialog.tsx:35`
+- `EventEditorDrawer` in `plugins/plugin-calendar/src/components/EventEditorDrawer.tsx:470`
+- Decision: **distinct-domain-compositions** — The shared atoms describe ordinary modal chrome; the six components own unrelated workflows and state.
+
+### card: button + input
+
+- `BuyDomainCard` in `packages/ui/src/cloud/applications/components/BuyDomainCard.tsx:68`
+- `ChoiceWidget` in `packages/ui/src/components/chat/widgets/ChoiceWidget.tsx:60`
+- `ConnectorCardWidget` in `packages/ui/src/components/chat/widgets/connector-card.tsx:83`
+- `AppBlockerSettingsCard` in `plugins/plugin-personal-assistant/src/components/AppBlockerSettingsCard.tsx:110`
+- Decision: **distinct-domain-compositions** — Domain purchase, chat choice, connector, and app-blocking cards only coincide at a broad dependency signature.
+
+### dialog: button + dialog + input
+
+- `WithdrawDialog` in `packages/ui/src/cloud/applications/components/withdraw-dialog.tsx:45`
+- `SaveCommandModal` in `packages/ui/src/components/chat/SaveCommandModal.tsx:37`
+- `ChatConversationRenameDialog` in `packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx:41`
+- `PromptDialog` in `packages/ui/src/components/ui/confirm-dialog.tsx:95`
+- Decision: **shared-pattern-candidate** — These are submit-oriented form dialogs; compare their validation, pending, and error-state shell before extracting anything.
+
+### panel: button + input
+
+- `MessageSearchPanel` in `packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx:49`
+- `TelegramAccountConnectorPanel` in `packages/ui/src/components/connectors/TelegramAccountConnectorPanel.tsx:71`
+- `TelegramBotSetupPanel` in `packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx:34`
+- `ReleaseNotesSection` in `packages/ui/src/components/release-center/sections.tsx:241`
+- Decision: **distinct-domain-compositions** — Search, connector setup, and release-note panels have different interaction and state contracts.
+
+### card: badge + button + checkbox + dialog + spinner
+
+- `AccountCard` in `packages/ui/src/components/accounts/AccountCard.tsx:178`
+- `ConnectorAccountCard` in `packages/ui/src/components/connectors/ConnectorAccountCard.tsx:163`
+- Decision: **shared-shell-candidate** — AccountCard and ConnectorAccountCard repeat account status, editable identity, action, busy, and destructive-confirmation regions while retaining different domain behavior.
+
+### dialog: button + input
+
+- `AccountDeletionDialog` in `packages/ui/src/cloud/account-security/components/account-deletion-dialog.tsx:30`
+- `SigninSheet` in `packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx:930`
+- Decision: **distinct-domain-compositions** — Account deletion and sign-in are unrelated workflows despite using the same atoms.
+
+### form: button + input
+
+- `TriggerForm` in `packages/ui/src/components/pages/TriggerForm.tsx:229`
+- `TagEditor` in `packages/ui/src/components/ui/tag-editor.tsx:29`
+- Decision: **distinct-domain-compositions** — Trigger configuration and tag editing do not share a domain contract or meaningful layout beyond generic form controls.
+
+### header: button + input
+
+- `SidebarSearchBar` in `packages/ui/src/components/composites/search/searchbar.tsx:19`
+- `MeetingJoinBar` in `packages/ui/src/components/transcripts/MeetingJoinBar.tsx:43`
+- Decision: **distinct-domain-compositions** — Search navigation and meeting join controls have unrelated behavior; the role-name match is superficial.
+
+### list: button + spinner
+
+- `AccountList` in `packages/ui/src/components/accounts/AccountList.tsx:27`
+- `ConnectorAccountList` in `packages/ui/src/components/connectors/ConnectorAccountList.tsx:132`
+- Decision: **shared-shell-candidate** — Both account lists repeat loading, error, empty, add, and stacked-card regions, but their fetching and mutation controllers must remain domain-specific.
+
+### panel: badge + button + input
+
+- `AgentSection` in `packages/ui/src/components/settings/cloud-panel/sections/AgentSection.tsx:120`
+- `CloudAgentsSection` in `packages/ui/src/components/settings/CloudAgentsSection.tsx:91`
+- Decision: **duplicate-implementation** — AgentSection and CloudAgentsSection implement the same cloud-agent management lifecycle with near-identical state and operations; one owner should serve both surfaces.
+

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -1,296 +1,388 @@
 #!/usr/bin/env node
 /**
- * Finds candidate duplicate React components in @elizaos/ui.
- *
- * Walks packages/ui/src for .ts/.tsx files. Extracts:
- *   - filename basename (e.g. button)
- *   - exported React component identifiers (default + named PascalCase exports)
- *
- * Groups by:
- *   1. EXACT name (case-insensitive) — same component name in multiple files
- *   2. PARTIAL name — components whose normalized name is a token-subset of
- *      another, or differ only by a common suffix/prefix (Card / CardLite,
- *      ChatHeader / ChatHeaderCompact, etc.)
- *
- * Output is markdown to stdout + JSON report to scripts/duplicate-components-report.json
- *
- * Usage: bun run scripts/find-duplicate-components.mjs [--min N]
+ * Inventories atomic React component definitions across maintained packages and
+ * plugins. The TypeScript AST keeps definitions, wrappers, and adapters apart.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const pkgRoot = path.resolve(here, "..");
-const srcRoot = path.resolve(pkgRoot, "src");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../../..");
+const canonicalRoot = "packages/ui/src/components/ui";
+const reportJson = path.join(scriptDir, "duplicate-components-report.json");
+const reportMarkdown = path.join(scriptDir, "duplicate-components-report.md");
 
-const args = process.argv.slice(2);
-const arg = (n, d) => {
-  const i = args.indexOf(n);
-  return i >= 0 ? args[i + 1] : d;
+export const ATOMS = {
+  alert: { names: ["Alert"], hosts: ["div"], rawHosts: [] },
+  avatar: { names: ["Avatar"], hosts: ["div", "img"], rawHosts: [] },
+  badge: {
+    names: ["Badge", "StatusBadge"],
+    hosts: ["span", "div"],
+    rawHosts: [],
+  },
+  button: { names: ["Button"], hosts: ["button"], rawHosts: ["button"] },
+  card: { names: ["Card"], hosts: ["div", "section", "article"], rawHosts: [] },
+  checkbox: {
+    names: ["Checkbox"],
+    hosts: ["button", "input"],
+    rawHosts: ["input"],
+  },
+  dialog: { names: ["Dialog"], hosts: ["dialog", "div"], rawHosts: ["dialog"] },
+  input: { names: ["Input"], hosts: ["input"], rawHosts: ["input"] },
+  popover: { names: ["Popover"], hosts: ["div"], rawHosts: [] },
+  progress: {
+    names: ["Progress"],
+    hosts: ["div", "progress"],
+    rawHosts: ["progress"],
+  },
+  select: {
+    names: ["Select"],
+    hosts: ["select", "button"],
+    rawHosts: ["select"],
+  },
+  separator: { names: ["Separator"], hosts: ["div", "hr"], rawHosts: ["hr"] },
+  skeleton: { names: ["Skeleton"], hosts: ["div"], rawHosts: [] },
+  spinner: { names: ["Spinner"], hosts: ["svg", "div"], rawHosts: [] },
+  switch: {
+    names: ["Switch"],
+    hosts: ["button", "input"],
+    rawHosts: ["input"],
+  },
+  table: { names: ["Table"], hosts: ["table"], rawHosts: ["table"] },
+  tabs: { names: ["Tabs"], hosts: ["div"], rawHosts: [] },
+  textarea: {
+    names: ["Textarea"],
+    hosts: ["textarea"],
+    rawHosts: ["textarea"],
+  },
+  tooltip: { names: ["Tooltip"], hosts: ["div"], rawHosts: [] },
 };
-const minSize = Number(arg("--min", "2")) || 2;
-const verbose = args.includes("--verbose");
 
-/** Recursively walk dir, yielding .ts/.tsx files (skip .stories, .test, types/, dist) */
-function* walk(dir) {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === "node_modules" || entry.name === "dist") continue;
-    if (entry.name.startsWith(".")) continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walk(full);
-    } else if (entry.isFile()) {
-      if (
-        (entry.name.endsWith(".tsx") || entry.name.endsWith(".ts")) &&
-        !entry.name.endsWith(".stories.tsx") &&
-        !entry.name.endsWith(".stories.ts") &&
-        !entry.name.endsWith(".test.ts") &&
-        !entry.name.endsWith(".test.tsx") &&
-        !entry.name.endsWith(".spec.ts") &&
-        !entry.name.endsWith(".spec.tsx") &&
-        !entry.name.endsWith(".d.ts")
-      ) {
-        yield full;
+const ATOM_BY_NAME = new Map(
+  Object.entries(ATOMS).flatMap(([atom, definition]) =>
+    definition.names.map((name) => [name.toLowerCase(), atom]),
+  ),
+);
+
+const relative = (file) =>
+  path.relative(repoRoot, file).replaceAll(path.sep, "/");
+
+function isMaintainedSource(file) {
+  const rel = relative(file);
+  return (
+    /^(packages|plugins)\//.test(rel) &&
+    /\.[jt]sx$/.test(rel) &&
+    !/(^|\/)(node_modules|dist|build|coverage|generated)(\/|$)/.test(rel) &&
+    !/\.(stories|test|spec)\.[jt]sx$/.test(rel) &&
+    !/(^|\/)(__tests__|__fixtures__|fixtures)(\/|$)/.test(rel)
+  );
+}
+
+function* walk(directory) {
+  if (!fs.existsSync(directory)) return;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (["node_modules", "dist", "build", ".git"].includes(entry.name))
+      continue;
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (isMaintainedSource(full)) yield full;
+  }
+}
+
+function componentName(node) {
+  if (ts.isFunctionDeclaration(node) && node.name) return node.name.text;
+  if (ts.isClassDeclaration(node) && node.name) return node.name.text;
+  if (ts.isVariableStatement(node)) {
+    const declaration = node.declarationList.declarations[0];
+    if (declaration && ts.isIdentifier(declaration.name))
+      return declaration.name.text;
+  }
+  return null;
+}
+
+const isExported = (node, exportedNames) =>
+  Boolean(
+    node.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    ) || exportedNames.has(componentName(node)),
+  );
+
+function localExportNames(sourceFile) {
+  const names = new Set();
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isExportDeclaration(statement) &&
+      !statement.moduleSpecifier &&
+      statement.exportClause &&
+      ts.isNamedExports(statement.exportClause)
+    ) {
+      for (const element of statement.exportClause.elements) {
+        names.add(element.propertyName?.text ?? element.name.text);
       }
     }
+    if (
+      ts.isExportAssignment(statement) &&
+      ts.isIdentifier(statement.expression)
+    ) {
+      names.add(statement.expression.text);
+    }
   }
+  return names;
 }
 
-/** Extract component-ish *definitions* (not re-exports). */
-function extractExports(src) {
-  const names = new Set();
-  // export function PascalCase
-  for (const m of src.matchAll(
-    /\bexport\s+(?:default\s+)?(?:async\s+)?function\s+([A-Z]\w+)/g,
-  )) {
-    names.add(m[1]);
+function jsxTags(node) {
+  const tags = new Set();
+  function visit(current) {
+    if (
+      ts.isJsxOpeningElement(current) ||
+      ts.isJsxSelfClosingElement(current)
+    ) {
+      tags.add(current.tagName.getText());
+    }
+    ts.forEachChild(current, visit);
   }
-  // export const PascalCase =
-  for (const m of src.matchAll(
-    /\bexport\s+(?:default\s+)?(?:const|let|var)\s+([A-Z]\w+)\s*(?:[:=])/g,
-  )) {
-    names.add(m[1]);
-  }
-  // export class PascalCase
-  for (const m of src.matchAll(
-    /\bexport\s+(?:default\s+)?class\s+([A-Z]\w+)/g,
-  )) {
-    names.add(m[1]);
-  }
-  // export default IdentifierAlreadyDeclared (where Identifier is defined in this file)
-  for (const m of src.matchAll(/\bexport\s+default\s+([A-Z]\w+)\s*;?\s*$/gm)) {
-    const id = m[1];
-    // Require a local definition (function/const/class) for it to count as a
-    // definition rather than a re-export-via-import.
-    const localDef = new RegExp(
-      `\\b(?:function|const|let|var|class)\\s+${id}\\b`,
-    ).test(src);
-    if (localDef) names.add(id);
-  }
-  // NOTE: We deliberately ignore `export { X }` and `export { X } from "..."` —
-  // those are re-exports or alias exports, not definitions.
-  return [...names];
+  visit(node);
+  return [...tags].sort();
 }
 
-/** Detect whether the file likely contains a component (returns JSX or uses React types). */
-function looksLikeComponent(src, names) {
-  if (names.length === 0) return false;
-  // crude but cheap
-  return (
-    /\b(jsx|tsx|<\/?[A-Z]\w|React\.FC|React\.Component|React\.forwardRef|forwardRef\s*[<(]|React\.memo|memo\s*\()/i.test(
-      src,
-    ) ||
-    /return\s*\(\s*</.test(src) ||
-    /=>\s*</.test(src)
+function importsByLocalName(sourceFile) {
+  const imports = new Map();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause) continue;
+    const origin = statement.moduleSpecifier.text;
+    const bindings = statement.importClause.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        imports.set(element.name.text, {
+          imported: element.propertyName?.text ?? element.name.text,
+          origin,
+        });
+      }
+    }
+    if (statement.importClause.name) {
+      imports.set(statement.importClause.name.text, {
+        imported: "default",
+        origin,
+      });
+    }
+  }
+  return imports;
+}
+
+function isCanonicalImport(record, file) {
+  if (!record) return false;
+  const resolvedRelative = record.origin.startsWith(".")
+    ? relative(path.resolve(path.dirname(file), record.origin))
+    : "";
+  return Boolean(
+    record.origin === "@elizaos/ui" ||
+      record.origin.startsWith("@elizaos/ui/") ||
+      resolvedRelative.startsWith(`${canonicalRoot}/`) ||
+      /components\/(ui|primitives)\//.test(record.origin),
   );
 }
 
-/** Normalize component name for partial-match comparison. */
-function normalize(name) {
-  return name
-    .replace(/[A-Z]/g, (c) => ` ${c.toLowerCase()}`)
-    .trim()
-    .replace(/[-_]/g, " ")
-    .split(/\s+/)
-    .filter(Boolean);
+function classify({ atom, file, name, tags, imports }) {
+  const rel = relative(file);
+  if (rel.startsWith(`${canonicalRoot}/`)) return "canonical";
+  if (rel.includes("/templates/")) return "template-adapter";
+  if (/(^|\/)(test|tests|stubs|__mocks__)(\/|$)/.test(rel)) {
+    return "test-double";
+  }
+  if (rel.startsWith("packages/ui/src/spatial/")) return "renderer-adapter";
+  if (tags.some((tag) => isCanonicalImport(imports.get(tag), file))) {
+    return "canonical-wrapper";
+  }
+  if (ATOM_BY_NAME.get(name.toLowerCase()) === atom) {
+    return "same-name-definition";
+  }
+  if (atom === "card" && !/^(Brand|Mini|Surface)/.test(name)) {
+    return "molecular-candidate";
+  }
+  return "parallel-primitive";
 }
 
-const files = [...walk(srcRoot)];
-console.error(`Scanned ${files.length} files`);
-
-const byName = new Map(); // lowername -> [{file, name}]
-const allComponents = []; // {file, name, tokens}
-
-for (const file of files) {
-  let src;
-  try {
-    src = fs.readFileSync(file, "utf8");
-  } catch {
-    continue;
+function matchingAtoms(name, tags) {
+  const matches = new Set();
+  const normalized = name.toLowerCase();
+  const direct = ATOM_BY_NAME.get(normalized);
+  if (direct) matches.add(direct);
+  for (const [atom, definition] of Object.entries(ATOMS)) {
+    if (
+      definition.names.some((candidate) =>
+        normalized.endsWith(candidate.toLowerCase()),
+      ) ||
+      (normalized.includes(atom) &&
+        tags.some((tag) => definition.hosts.includes(tag)))
+    ) {
+      matches.add(atom);
+    }
   }
-  const exports = extractExports(src);
-  if (!looksLikeComponent(src, exports)) continue;
-  for (const name of exports) {
-    // Filter out non-component-ish: ALL_CAPS constants, very short names.
-    if (name === name.toUpperCase() && name.length > 1) continue;
-    if (name.length < 3) continue;
-    const tokens = normalize(name);
-    const lower = name.toLowerCase();
-    if (!byName.has(lower)) byName.set(lower, []);
-    byName.get(lower).push({ file: path.relative(pkgRoot, file), name });
-    allComponents.push({ file: path.relative(pkgRoot, file), name, tokens });
-  }
+  return [...matches];
 }
 
-console.error(`Found ${allComponents.length} component-like exports`);
-
-// 1. Exact-name collisions
-const exactDupes = [];
-for (const [key, entries] of byName) {
-  // Dedupe by (file, name) — same export listed twice via `export { X }` and named
-  const uniq = Array.from(
-    new Map(entries.map((e) => [`${e.file}::${e.name}`, e])).values(),
+export function buildInventory() {
+  const files = [
+    ...walk(path.join(repoRoot, "packages")),
+    ...walk(path.join(repoRoot, "plugins")),
+  ].sort();
+  const candidates = [];
+  const rawHostUsage = Object.fromEntries(
+    Object.keys(ATOMS).map((atom) => [atom, []]),
   );
-  if (uniq.length >= minSize) {
-    exactDupes.push({ name: key, count: uniq.length, entries: uniq });
-  }
-}
-exactDupes.sort((a, b) => b.count - a.count);
 
-// 2. Partial-name clusters: group components whose token-sets overlap heavily.
-// For each unique base name (first token), cluster all components sharing it.
-const byFirstToken = new Map();
-for (const c of allComponents) {
-  if (!c.tokens.length) continue;
-  const k = c.tokens[0];
-  if (!byFirstToken.has(k)) byFirstToken.set(k, []);
-  byFirstToken.get(k).push(c);
-}
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    const sourceFile = ts.createSourceFile(
+      file,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+    const imports = importsByLocalName(sourceFile);
+    const exportedNames = localExportNames(sourceFile);
+    const fileHostLines = new Map();
 
-const partialClusters = [];
-for (const [token, comps] of byFirstToken) {
-  // Dedupe by file::name
-  const uniq = Array.from(
-    new Map(comps.map((c) => [`${c.file}::${c.name}`, c])).values(),
-  );
-  // Require at least 2 *distinct file basenames* — otherwise it's just a barrel re-export.
-  const distinctBasenames = new Set(
-    uniq.map((c) => path.basename(c.file).replace(/\.[jt]sx?$/, "")),
-  );
-  if (uniq.length >= minSize && distinctBasenames.size >= 2) {
-    partialClusters.push({ token, count: uniq.length, entries: uniq });
-  }
-}
-partialClusters.sort((a, b) => b.count - a.count);
+    function visit(node) {
+      if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+        const tag = node.tagName.getText();
+        if (/^[a-z]/.test(tag)) {
+          const line =
+            sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+          if (!fileHostLines.has(tag)) fileHostLines.set(tag, []);
+          fileHostLines.get(tag).push(line);
+        }
+      }
 
-// 3. Suffix-variant detection: For each cluster, flag pairs that are "X" vs "XSomething"
-//    where Something looks like a variant marker (Lite, Compact, Mobile, Mini, Small, ...).
-const VARIANT_SUFFIXES = [
-  "lite",
-  "compact",
-  "mobile",
-  "mini",
-  "small",
-  "large",
-  "v2",
-  "v3",
-  "new",
-  "old",
-  "legacy",
-  "experimental",
-  "alt",
-  "simple",
-  "basic",
-  "extended",
-  "redesign",
-  "refresh",
-  "rewrite",
-  "next",
-  "card",
-  "row",
-  "list",
-  "grid",
-  "tile",
-  "page",
-  "panel",
-  "popover",
-  "dialog",
-  "header",
-  "footer",
-  "body",
-];
-const suffixSiblings = [];
-const allNames = new Set(allComponents.map((c) => c.name));
-for (const c of allComponents) {
-  for (const suf of VARIANT_SUFFIXES) {
-    const sufCap = suf.charAt(0).toUpperCase() + suf.slice(1);
-    if (c.name.endsWith(sufCap) && c.name.length > sufCap.length) {
-      const base = c.name.slice(0, -sufCap.length);
-      if (allNames.has(base)) {
-        suffixSiblings.push({
-          base,
-          variant: c.name,
-          file: c.file,
-          suffix: suf,
+      const name = componentName(node);
+      if (name && /^[A-Z]/.test(name) && isExported(node, exportedNames)) {
+        const tags = jsxTags(node);
+        for (const atom of matchingAtoms(name, tags)) {
+          candidates.push({
+            atom,
+            classification: classify({ atom, file, name, tags, imports }),
+            file: relative(file),
+            line:
+              sourceFile.getLineAndCharacterOfPosition(node.getStart()).line +
+              1,
+            name,
+            renderedTags: tags,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(sourceFile);
+
+    for (const [atom, definition] of Object.entries(ATOMS)) {
+      const lines = definition.rawHosts.flatMap(
+        (host) => fileHostLines.get(host) ?? [],
+      );
+      if (lines.length > 0) {
+        rawHostUsage[atom].push({
+          file: relative(file),
+          lines: [...new Set(lines)].sort((a, b) => a - b),
         });
       }
     }
   }
-}
 
-// --- Output -----------------------------------------------------------------
-const report = {
-  scanned: files.length,
-  components: allComponents.length,
-  exactDuplicates: exactDupes,
-  partialClusters,
-  suffixSiblings,
-};
-const outJson = path.join(here, "duplicate-components-report.json");
-fs.writeFileSync(outJson, JSON.stringify(report, null, 2));
-
-const lines = [];
-lines.push(`# Duplicate component candidates in @elizaos/ui\n`);
-lines.push(
-  `Scanned **${files.length}** files, **${allComponents.length}** component-like exports.\n`,
-);
-lines.push(`Report JSON: \`scripts/duplicate-components-report.json\`\n`);
-
-lines.push(`\n## 1. Exact-name duplicates (${exactDupes.length})\n`);
-lines.push(`Components exported with the *same name* from multiple files.\n`);
-for (const d of exactDupes) {
-  lines.push(`\n### \`${d.entries[0].name}\` × ${d.count}`);
-  for (const e of d.entries) lines.push(`- ${e.file}`);
-}
-
-lines.push(`\n\n## 2. Partial-name clusters (${partialClusters.length})\n`);
-lines.push(
-  `Components whose first token (lowercased) matches another. Useful for spotting families that share a name root (e.g. \`Chat*\`, \`Setup*\`).\n`,
-);
-if (!verbose) {
-  lines.push(`\n_(Showing top 40 by size; pass --verbose for all.)_\n`);
-}
-const partialToShow = verbose ? partialClusters : partialClusters.slice(0, 40);
-for (const c of partialToShow) {
-  lines.push(`\n### \`${c.token}*\` × ${c.count}`);
-  for (const e of c.entries) lines.push(`- \`${e.name}\` — ${e.file}`);
-}
-
-lines.push(`\n\n## 3. Variant suffix siblings (${suffixSiblings.length})\n`);
-lines.push(
-  `Components named like \`Foo\` AND \`FooLite/FooCompact/FooMobile/...\` — likely targets for a single component + variant prop.\n`,
-);
-for (const s of suffixSiblings) {
-  lines.push(
-    `- **${s.base}** ↔ **${s.variant}** (suffix: \`${s.suffix}\`) — ${s.file}`,
+  candidates.sort(
+    (a, b) =>
+      a.atom.localeCompare(b.atom) ||
+      a.classification.localeCompare(b.classification) ||
+      a.file.localeCompare(b.file) ||
+      a.line - b.line,
   );
+  const atoms = {};
+  for (const atom of Object.keys(ATOMS)) {
+    const entries = candidates.filter((candidate) => candidate.atom === atom);
+    atoms[atom] = {
+      canonical: entries.filter(
+        (entry) => entry.classification === "canonical",
+      ),
+      candidates: entries.filter(
+        (entry) => entry.classification !== "canonical",
+      ),
+      rawHostUsage: rawHostUsage[atom],
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    scope: ["packages/**/*.tsx", "plugins/**/*.tsx"],
+    scannedFiles: files.length,
+    atoms,
+    summary: {
+      atomicKinds: Object.keys(ATOMS).length,
+      componentCandidates: candidates.length,
+      sameNameDefinitions: candidates.filter(
+        (candidate) => candidate.classification === "same-name-definition",
+      ).length,
+      canonicalWrappers: candidates.filter(
+        (candidate) => candidate.classification === "canonical-wrapper",
+      ).length,
+      parallelPrimitives: candidates.filter(
+        (candidate) => candidate.classification === "parallel-primitive",
+      ).length,
+      molecularCandidates: candidates.filter(
+        (candidate) => candidate.classification === "molecular-candidate",
+      ).length,
+    },
+  };
 }
 
-const outMd = path.join(here, "duplicate-components-report.md");
-fs.writeFileSync(outMd, lines.join("\n"));
+export function renderMarkdown(report) {
+  const lines = [
+    "# Atomic component duplicate inventory",
+    "",
+    `Scanned ${report.scannedFiles} maintained React source files across packages and plugins.`,
+    "",
+    "This is a candidate inventory, not an instruction to merge every entry. Canonical wrappers, renderer adapters, and test doubles remain separate because they often have legitimate ownership.",
+    "",
+    "| Atom | Canonical | Same-name | Wrappers | Parallel primitives | Raw host files |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |",
+  ];
+  for (const [atom, group] of Object.entries(report.atoms)) {
+    const count = (classification) =>
+      group.candidates.filter(
+        (entry) => entry.classification === classification,
+      ).length;
+    lines.push(
+      `| ${atom} | ${group.canonical.length} | ${count("same-name-definition")} | ${count("canonical-wrapper")} | ${count("parallel-primitive")} | ${group.rawHostUsage.length} |`,
+    );
+  }
 
-console.log(lines.join("\n"));
-console.error(`\nWrote: ${path.relative(pkgRoot, outJson)}`);
-console.error(`Wrote: ${path.relative(pkgRoot, outMd)}`);
+  lines.push("", "## Named candidates by atom", "");
+  for (const [atom, group] of Object.entries(report.atoms)) {
+    lines.push(`### ${atom}`, "");
+    if (group.candidates.length === 0) {
+      lines.push("No named candidates.", "");
+      continue;
+    }
+    lines.push(
+      "| Classification | Definition | Rendered tags |",
+      "| --- | --- | --- |",
+    );
+    for (const entry of group.candidates) {
+      const tags = entry.renderedTags.map((tag) => `\`${tag}\``).join(", ");
+      lines.push(
+        `| ${entry.classification} | \`${entry.name}\` in \`${entry.file}:${entry.line}\` | ${tags} |`,
+      );
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const report = buildInventory();
+  const markdown = renderMarkdown(report);
+  fs.writeFileSync(reportJson, `${JSON.stringify(report, null, 2)}\n`);
+  fs.writeFileSync(reportMarkdown, markdown);
+  process.stdout.write(markdown);
+}

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -34,7 +34,7 @@ export const ATOMS = {
   checkbox: {
     names: ["Checkbox"],
     hosts: ["button", "input"],
-    rawHosts: ["input"],
+    rawHosts: ["input:checkbox"],
   },
   dialog: { names: ["Dialog"], hosts: ["dialog", "div"], rawHosts: ["dialog"] },
   input: { names: ["Input"], hosts: ["input"], rawHosts: ["input"] },
@@ -55,7 +55,7 @@ export const ATOMS = {
   switch: {
     names: ["Switch"],
     hosts: ["button", "input"],
-    rawHosts: ["input"],
+    rawHosts: ["input:checkbox"],
   },
   table: { names: ["Table"], hosts: ["table"], rawHosts: ["table"] },
   tabs: { names: ["Tabs"], hosts: ["div"], rawHosts: [] },
@@ -211,6 +211,37 @@ function classify({ atom, file, name, tags, imports }) {
   return "parallel-primitive";
 }
 
+function classifyRawHostFile({ atom, file, imports }) {
+  const rel = relative(file);
+  if (rel.startsWith(`${canonicalRoot}/`)) return "canonical-implementation";
+  if (rel.includes("/templates/")) return "template";
+  if (
+    /(^|\/)(test|tests|stories|__e2e__|__mocks__)(\/|$)/.test(rel) ||
+    /-(fixture|stub)\.[jt]sx$/.test(rel)
+  ) {
+    return "test-or-story-harness";
+  }
+  if (
+    rel.startsWith("packages/ui/src/spatial/") ||
+    rel.startsWith("packages/ui/src/native-")
+  ) {
+    return "renderer-adapter";
+  }
+  const canonicalNames = new Set(ATOMS[atom].names);
+  if (
+    [...imports.values()].some(
+      (record) =>
+        canonicalNames.has(record.imported) && isCanonicalImport(record, file),
+    )
+  ) {
+    return "mixed-canonical-and-raw";
+  }
+  if (rel.startsWith("plugins/")) return "plugin-raw-host";
+  if (rel.startsWith("packages/homepage/")) return "product-package-raw-host";
+  if (rel.startsWith("packages/app-core/")) return "runtime-host-control";
+  return "ui-raw-host";
+}
+
 function matchingAtoms(name, tags) {
   const matches = new Set();
   const normalized = name.toLowerCase();
@@ -230,12 +261,28 @@ function matchingAtoms(name, tags) {
   return [...matches];
 }
 
+function atomicDependencies(tags, imports, file) {
+  const dependencies = new Set();
+  for (const tag of tags) {
+    const imported = imports.get(tag);
+    if (imported && isCanonicalImport(imported, file)) {
+      const atom = ATOM_BY_NAME.get(imported.imported.toLowerCase());
+      if (atom) dependencies.add(atom);
+    }
+    for (const [atom, definition] of Object.entries(ATOMS)) {
+      if (definition.rawHosts.includes(tag)) dependencies.add(atom);
+    }
+  }
+  return [...dependencies].sort();
+}
+
 export function buildInventory() {
   const files = [
     ...walk(path.join(repoRoot, "packages")),
     ...walk(path.join(repoRoot, "plugins")),
   ].sort();
   const candidates = [];
+  const exportedComponents = [];
   const rawHostUsage = Object.fromEntries(
     Object.keys(ATOMS).map((atom) => [atom, []]),
   );
@@ -261,12 +308,40 @@ export function buildInventory() {
             sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
           if (!fileHostLines.has(tag)) fileHostLines.set(tag, []);
           fileHostLines.get(tag).push(line);
+          if (tag === "input") {
+            const typeAttribute = node.attributes.properties.find(
+              (property) =>
+                ts.isJsxAttribute(property) &&
+                property.name.getText() === "type",
+            );
+            if (
+              typeAttribute &&
+              ts.isJsxAttribute(typeAttribute) &&
+              typeAttribute.initializer &&
+              ts.isStringLiteral(typeAttribute.initializer)
+            ) {
+              const typedKey = `input:${typeAttribute.initializer.text}`;
+              if (!fileHostLines.has(typedKey)) fileHostLines.set(typedKey, []);
+              fileHostLines.get(typedKey).push(line);
+              if (typeAttribute.initializer.text === "checkbox") {
+                fileHostLines.get("input").pop();
+              }
+            }
+          }
         }
       }
 
       const name = componentName(node);
       if (name && /^[A-Z]/.test(name) && isExported(node, exportedNames)) {
         const tags = jsxTags(node);
+        exportedComponents.push({
+          atomicDependencies: atomicDependencies(tags, imports, file),
+          file: relative(file),
+          line:
+            sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+          name,
+          renderedTags: tags,
+        });
         for (const atom of matchingAtoms(name, tags)) {
           candidates.push({
             atom,
@@ -290,6 +365,7 @@ export function buildInventory() {
       );
       if (lines.length > 0) {
         rawHostUsage[atom].push({
+          classification: classifyRawHostFile({ atom, file, imports }),
           file: relative(file),
           lines: [...new Set(lines)].sort((a, b) => a - b),
         });
@@ -326,6 +402,12 @@ export function buildInventory() {
     schemaVersion: 1,
     scope: ["packages/**/*.tsx", "plugins/**/*.tsx"],
     scannedFiles: files.length,
+    components: exportedComponents.sort(
+      (a, b) =>
+        a.file.localeCompare(b.file) ||
+        a.line - b.line ||
+        a.name.localeCompare(b.name),
+    ),
     atoms,
     summary: {
       atomicKinds: Object.keys(ATOMS).length,
@@ -347,6 +429,17 @@ export function buildInventory() {
           candidate.classification === "parallel-primitive" &&
           candidate.decision,
       ).length,
+      rawHostCandidates: Object.values(rawHostUsage)
+        .flat()
+        .filter(
+          (entry) =>
+            ![
+              "canonical-implementation",
+              "renderer-adapter",
+              "template",
+              "test-or-story-harness",
+            ].includes(entry.classification),
+        ).length,
     },
   };
 }
@@ -370,6 +463,23 @@ export function renderMarkdown(report) {
     lines.push(
       `| ${atom} | ${group.canonical.length} | ${count("same-name-definition")} | ${count("canonical-wrapper")} | ${count("parallel-primitive")} | ${group.rawHostUsage.length} |`,
     );
+  }
+
+  lines.push("", "## Raw semantic host usage", "");
+  lines.push(
+    "Raw host elements are reported only where HTML provides a meaningful atomic signal. Generic `div` and `span` usage is deliberately excluded.",
+    "",
+  );
+  for (const [atom, group] of Object.entries(report.atoms)) {
+    if (group.rawHostUsage.length === 0) continue;
+    lines.push(`### Raw ${atom} hosts`, "");
+    lines.push("| Classification | File | Lines |", "| --- | --- | --- |");
+    for (const entry of group.rawHostUsage) {
+      lines.push(
+        `| ${entry.classification} | \`${entry.file}\` | ${entry.lines.join(", ")} |`,
+      );
+    }
+    lines.push("");
   }
 
   lines.push("", "## Named candidates by atom", "");

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -14,6 +14,12 @@ const repoRoot = path.resolve(scriptDir, "../../..");
 const canonicalRoot = "packages/ui/src/components/ui";
 const reportJson = path.join(scriptDir, "duplicate-components-report.json");
 const reportMarkdown = path.join(scriptDir, "duplicate-components-report.md");
+const decisions = JSON.parse(
+  fs.readFileSync(
+    path.join(scriptDir, "component-inventory-decisions.json"),
+    "utf8",
+  ),
+);
 
 export const ATOMS = {
   alert: { names: ["Alert"], hosts: ["div"], rawHosts: [] },
@@ -298,6 +304,10 @@ export function buildInventory() {
       a.file.localeCompare(b.file) ||
       a.line - b.line,
   );
+  for (const candidate of candidates) {
+    const decision = decisions[`${candidate.file}:${candidate.name}`];
+    if (decision) candidate.decision = decision;
+  }
   const atoms = {};
   for (const atom of Object.keys(ATOMS)) {
     const entries = candidates.filter((candidate) => candidate.atom === atom);
@@ -332,6 +342,11 @@ export function buildInventory() {
       molecularCandidates: candidates.filter(
         (candidate) => candidate.classification === "molecular-candidate",
       ).length,
+      reviewedParallelPrimitives: candidates.filter(
+        (candidate) =>
+          candidate.classification === "parallel-primitive" &&
+          candidate.decision,
+      ).length,
     },
   };
 }
@@ -365,14 +380,20 @@ export function renderMarkdown(report) {
       continue;
     }
     lines.push(
-      "| Classification | Definition | Rendered tags |",
-      "| --- | --- | --- |",
+      "| Classification | Decision | Definition | Canonical owner | Rendered tags |",
+      "| --- | --- | --- | --- | --- |",
     );
     for (const entry of group.candidates) {
       const tags = entry.renderedTags.map((tag) => `\`${tag}\``).join(", ");
+      const decision = entry.decision?.disposition ?? "not-reviewed";
+      const owner = entry.decision?.canonicalOwner
+        ? `\`${entry.decision.canonicalOwner}\``
+        : "-";
       lines.push(
-        `| ${entry.classification} | \`${entry.name}\` in \`${entry.file}:${entry.line}\` | ${tags} |`,
+        `| ${entry.classification} | ${decision} | \`${entry.name}\` in \`${entry.file}:${entry.line}\` | ${owner} | ${tags} |`,
       );
+      if (entry.decision?.note)
+        lines.push(`|  |  | ${entry.decision.note} |  |  |`);
     }
     lines.push("");
   }

--- a/packages/ui/scripts/find-duplicate-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-components.test.mjs
@@ -37,6 +37,27 @@ test("the inventory identifies canonical ownership and parallel controls", () =>
   assert.ok(parallelButtons.includes("ViewBackButton"));
   assert.equal(report.atoms.card.rawHostUsage.length, 0);
   assert.ok(report.atoms.button.rawHostUsage.length > 0);
+  assert.ok(
+    report.atoms.button.rawHostUsage.some(
+      (entry) => entry.classification === "mixed-canonical-and-raw",
+    ),
+  );
+  assert.ok(
+    report.atoms.button.rawHostUsage.some(
+      (entry) => entry.classification === "plugin-raw-host",
+    ),
+  );
+  assert.ok(
+    report.atoms.checkbox.rawHostUsage.every((entry) =>
+      entry.lines.every(
+        (line) =>
+          !report.atoms.input.rawHostUsage.some(
+            (inputEntry) =>
+              inputEntry.file === entry.file && inputEntry.lines.includes(line),
+          ),
+      ),
+    ),
+  );
   assert.equal(
     report.summary.reviewedParallelPrimitives,
     report.summary.parallelPrimitives,

--- a/packages/ui/scripts/find-duplicate-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-components.test.mjs
@@ -37,6 +37,10 @@ test("the inventory identifies canonical ownership and parallel controls", () =>
   assert.ok(parallelButtons.includes("ViewBackButton"));
   assert.equal(report.atoms.card.rawHostUsage.length, 0);
   assert.ok(report.atoms.button.rawHostUsage.length > 0);
+  assert.equal(
+    report.summary.reviewedParallelPrimitives,
+    report.summary.parallelPrimitives,
+  );
 });
 
 test("the markdown report exposes classifications and the molecular queue", () => {

--- a/packages/ui/scripts/find-duplicate-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-components.test.mjs
@@ -1,0 +1,51 @@
+/**
+ * Tests the repository-wide atomic component inventory against real source so
+ * scope, ownership, and classification cannot silently narrow.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATOMS,
+  buildInventory,
+  renderMarkdown,
+} from "./find-duplicate-components.mjs";
+
+test("the atomic inventory is deterministic and repository-wide", () => {
+  const first = buildInventory();
+  const second = buildInventory();
+
+  assert.deepEqual(second, first);
+  assert.equal(first.summary.atomicKinds, Object.keys(ATOMS).length);
+  assert.ok(first.scannedFiles > 800);
+  assert.deepEqual(first.scope, ["packages/**/*.tsx", "plugins/**/*.tsx"]);
+});
+
+test("the inventory identifies canonical ownership and parallel controls", () => {
+  const report = buildInventory();
+  const canonicalButtons = report.atoms.button.canonical.map(
+    (entry) => entry.file,
+  );
+  const parallelButtons = report.atoms.button.candidates
+    .filter((entry) => entry.classification === "parallel-primitive")
+    .map((entry) => entry.name);
+
+  assert.ok(
+    canonicalButtons.includes("packages/ui/src/components/ui/button.tsx"),
+  );
+  assert.ok(parallelButtons.includes("BrandButton"));
+  assert.ok(parallelButtons.includes("ViewBackButton"));
+  assert.equal(report.atoms.card.rawHostUsage.length, 0);
+  assert.ok(report.atoms.button.rawHostUsage.length > 0);
+});
+
+test("the markdown report exposes classifications and the molecular queue", () => {
+  const markdown = renderMarkdown(buildInventory());
+
+  assert.match(markdown, /Parallel primitives/);
+  assert.match(markdown, /molecular-candidate/);
+  assert.match(
+    markdown,
+    /packages\/ui\/src\/cloud-ui\/components\/brand\/brand-button\.tsx/,
+  );
+});

--- a/packages/ui/scripts/find-duplicate-molecular-components.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Groups exported React compositions by product role and canonical atomic
+ * dependencies. The output is a review queue for repeated molecular UI, not a
+ * claim that identical dependency sets imply identical behavior.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildInventory } from "./find-duplicate-components.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const reportJson = path.join(
+  scriptDir,
+  "duplicate-molecular-components-report.json",
+);
+const reportMarkdown = path.join(
+  scriptDir,
+  "duplicate-molecular-components-report.md",
+);
+const decisionsPath = path.join(
+  scriptDir,
+  "molecular-inventory-decisions.json",
+);
+
+const ARCHETYPES = [
+  ["empty-state", /(EmptyState|Empty|Unavailable|NoResults)$/],
+  ["dialog", /(Dialog|Modal|Sheet|Drawer)$/],
+  ["form", /(Form|Editor|Composer)$/],
+  ["picker", /(Picker|Selector|Chooser|Switcher)$/],
+  ["table", /(Table|Grid)$/],
+  ["list", /(List|Feed)$/],
+  ["card", /(Card|Tile|Widget)$/],
+  ["row", /(Row|Item|Cell)$/],
+  ["panel", /(Panel|Section|Pane)$/],
+  ["header", /(Header|Toolbar|Bar)$/],
+  ["navigation", /(Sidebar|Navigation|Nav|Tabs)$/],
+];
+
+function archetypeFor(name) {
+  return ARCHETYPES.find(([, pattern]) => pattern.test(name))?.[0] ?? null;
+}
+
+export function buildMolecularInventory() {
+  const atomicReport = buildInventory();
+  const decisions = JSON.parse(fs.readFileSync(decisionsPath, "utf8"));
+  const components = atomicReport.components
+    .map((component) => ({
+      ...component,
+      archetype: archetypeFor(component.name),
+    }))
+    .filter(
+      (component) =>
+        component.archetype && component.atomicDependencies.length >= 2,
+    );
+  const bySignature = new Map();
+  for (const component of components) {
+    const signature = `${component.archetype}:${component.atomicDependencies.join("+")}`;
+    if (!bySignature.has(signature)) bySignature.set(signature, []);
+    bySignature.get(signature).push(component);
+  }
+
+  const clusters = [...bySignature]
+    .map(([signature, entries]) => ({
+      archetype: entries[0].archetype,
+      atomicDependencies: entries[0].atomicDependencies,
+      entries: entries.sort(
+        (a, b) =>
+          a.file.localeCompare(b.file) ||
+          a.line - b.line ||
+          a.name.localeCompare(b.name),
+      ),
+      signature,
+      ...decisions[signature],
+    }))
+    .filter((cluster) => cluster.entries.length >= 2)
+    .sort(
+      (a, b) =>
+        b.entries.length - a.entries.length ||
+        a.signature.localeCompare(b.signature),
+    );
+
+  const missingDecisions = clusters
+    .filter((cluster) => !cluster.disposition || !cluster.rationale)
+    .map((cluster) => cluster.signature);
+  const staleDecisions = Object.keys(decisions).filter(
+    (signature) => !clusters.some((cluster) => cluster.signature === signature),
+  );
+  if (missingDecisions.length > 0 || staleDecisions.length > 0) {
+    throw new Error(
+      `Molecular decisions are incomplete. Missing: ${missingDecisions.join(", ") || "none"}; stale: ${staleDecisions.join(", ") || "none"}`,
+    );
+  }
+
+  return {
+    schemaVersion: 1,
+    sourceAtomicSchemaVersion: atomicReport.schemaVersion,
+    scannedFiles: atomicReport.scannedFiles,
+    eligibleComponents: components.length,
+    clusters,
+    summary: {
+      clusterCount: clusters.length,
+      clusteredComponents: clusters.reduce(
+        (total, cluster) => total + cluster.entries.length,
+        0,
+      ),
+      largestCluster: clusters[0]?.entries.length ?? 0,
+    },
+  };
+}
+
+export function renderMolecularMarkdown(report) {
+  const lines = [
+    "# Molecular component duplicate inventory",
+    "",
+    `Scanned ${report.scannedFiles} maintained React files. ${report.eligibleComponents} exported compositions have a recognized molecular role and at least two atomic dependencies.`,
+    "",
+    "Clusters share both a role and an atomic dependency signature. They are review candidates. Product behavior, state ownership, and responsive layout still determine whether consolidation is correct.",
+    "",
+    "| Role | Atomic dependencies | Components | Decision |",
+    "| --- | --- | ---: | --- |",
+  ];
+
+  for (const cluster of report.clusters) {
+    lines.push(
+      `| ${cluster.archetype} | ${cluster.atomicDependencies.join(", ")} | ${cluster.entries.length} | ${cluster.disposition} |`,
+    );
+  }
+
+  lines.push("", "## Candidate clusters", "");
+  for (const cluster of report.clusters) {
+    lines.push(
+      `### ${cluster.archetype}: ${cluster.atomicDependencies.join(" + ")}`,
+      "",
+    );
+    for (const entry of cluster.entries) {
+      lines.push(`- \`${entry.name}\` in \`${entry.file}:${entry.line}\``);
+    }
+    lines.push(`- Decision: **${cluster.disposition}** — ${cluster.rationale}`);
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const report = buildMolecularInventory();
+  const markdown = renderMolecularMarkdown(report);
+  fs.writeFileSync(reportJson, `${JSON.stringify(report, null, 2)}\n`);
+  fs.writeFileSync(reportMarkdown, markdown);
+  process.stdout.write(markdown);
+}

--- a/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
@@ -1,0 +1,31 @@
+/** Tests deterministic molecular grouping against the maintained repository. */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildMolecularInventory,
+  renderMolecularMarkdown,
+} from "./find-duplicate-molecular-components.mjs";
+
+test("molecular inventory is deterministic and requires meaningful signatures", () => {
+  const first = buildMolecularInventory();
+  const second = buildMolecularInventory();
+
+  assert.deepEqual(second, first);
+  assert.ok(first.summary.clusterCount > 0);
+  assert.ok(first.clusters.every((cluster) => cluster.entries.length >= 2));
+  assert.ok(
+    first.clusters.every((cluster) => cluster.atomicDependencies.length >= 2),
+  );
+  assert.ok(first.clusters.every((cluster) => cluster.disposition));
+  assert.ok(first.clusters.every((cluster) => cluster.rationale));
+});
+
+test("molecular report includes roles, dependencies, and source evidence", () => {
+  const markdown = renderMolecularMarkdown(buildMolecularInventory());
+
+  assert.match(markdown, /# Molecular component duplicate inventory/);
+  assert.match(markdown, /Candidate clusters/);
+  assert.match(markdown, /duplicate-implementation/);
+  assert.match(markdown, /packages\//);
+});

--- a/packages/ui/scripts/molecular-inventory-decisions.json
+++ b/packages/ui/scripts/molecular-inventory-decisions.json
@@ -1,0 +1,42 @@
+{
+  "dialog:button+dialog": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "The shared atoms describe ordinary modal chrome; the six components own unrelated workflows and state."
+  },
+  "card:button+input": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "Domain purchase, chat choice, connector, and app-blocking cards only coincide at a broad dependency signature."
+  },
+  "dialog:button+dialog+input": {
+    "disposition": "shared-pattern-candidate",
+    "rationale": "These are submit-oriented form dialogs; compare their validation, pending, and error-state shell before extracting anything."
+  },
+  "panel:button+input": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "Search, connector setup, and release-note panels have different interaction and state contracts."
+  },
+  "card:badge+button+checkbox+dialog+spinner": {
+    "disposition": "shared-shell-candidate",
+    "rationale": "AccountCard and ConnectorAccountCard repeat account status, editable identity, action, busy, and destructive-confirmation regions while retaining different domain behavior."
+  },
+  "dialog:button+input": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "Account deletion and sign-in are unrelated workflows despite using the same atoms."
+  },
+  "form:button+input": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "Trigger configuration and tag editing do not share a domain contract or meaningful layout beyond generic form controls."
+  },
+  "header:button+input": {
+    "disposition": "distinct-domain-compositions",
+    "rationale": "Search navigation and meeting join controls have unrelated behavior; the role-name match is superficial."
+  },
+  "list:button+spinner": {
+    "disposition": "shared-shell-candidate",
+    "rationale": "Both account lists repeat loading, error, empty, add, and stacked-card regions, but their fetching and mutation controllers must remain domain-specific."
+  },
+  "panel:badge+button+input": {
+    "disposition": "duplicate-implementation",
+    "rationale": "AgentSection and CloudAgentsSection implement the same cloud-agent management lifecycle with near-identical state and operations; one owner should serve both surfaces."
+  }
+}


### PR DESCRIPTION
## Summary

- add a deterministic AST inventory for atomic component ownership, wrappers, parallel primitives, and raw semantic hosts
- adjudicate every parallel atomic candidate so the report distinguishes consolidation targets from intentional specialization, molecular UI, test doubles, and false positives
- add a second molecular inventory keyed by product role plus atomic dependencies, with fail-closed review decisions for every cluster

Closes #26553

## Inventory results

### Atomic

- 918 maintained React source files scanned
- 19 atomic kinds inventoried
- 32 parallel primitives reviewed
- 13 consolidation candidates
- raw semantic-host usage classified by ownership instead of treating every raw HTML element as a duplicate

Full report: [`packages/ui/scripts/duplicate-components-report.md`](https://github.com/elizaOS/eliza/blob/chore/component-duplicate-inventory/packages/ui/scripts/duplicate-components-report.md)

### Molecular

- 69 eligible exported compositions
- 10 repeated role/dependency clusters
- 1 duplicate implementation: `AgentSection` / `CloudAgentsSection`
- 2 shared-shell candidates: account cards and account lists
- 1 shared form-dialog pattern candidate
- 6 distinct-domain matches retained separately

Full report: [`packages/ui/scripts/duplicate-molecular-components-report.md`](https://github.com/elizaOS/eliza/blob/chore/component-duplicate-inventory/packages/ui/scripts/duplicate-molecular-components-report.md)

## Verification

- `bun install`
- `bun run --cwd packages/ui audit:component-inventory`
- `bun run --cwd packages/ui audit:component-inventory:test` (3/3)
- `bun run --cwd packages/ui audit:molecular-inventory`
- `bun run --cwd packages/ui audit:molecular-inventory:test` (2/2)
- `bunx biome check ...`
- `git diff --check`

`bun run verify` currently stops in the rebased `develop` baseline during `ensure-plugin-test-conventions:check`: `packages/scripts/vitest/source-aliases.ts:69` dereferences a `null` export target. The inventory checks above complete before and independently of that unrelated gate failure.

## Evidence

This is repository tooling/report work and does not change rendered UI. Screenshots, video, browser logs, and live-model trajectories are N/A.