### PR TITLE
test(ui): cover event-source

### DIFF
--- a/packages/ui/src/utils/event-source.test.ts
+++ b/packages/ui/src/utils/event-source.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for safe EventSource opening: rejects non-http(s) schemes and
+ * unparseable URLs, degrades to null when EventSource is unavailable or throws,
+ * and only constructs for valid http(s) URLs. Deterministic — no network.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { openEventSource } from "./event-source";
+
+const originalEventSource = (globalThis as unknown as { EventSource?: unknown })
+  .EventSource;
+const originalWindow = (globalThis as unknown as { window?: unknown }).window;
+
+afterEach(() => {
+  (globalThis as unknown as { EventSource?: unknown }).EventSource =
+    originalEventSource;
+  (globalThis as unknown as { window?: unknown }).window = originalWindow;
+  vi.restoreAllMocks();
+});
+
+describe("openEventSource", () => {
+  test("returns null when EventSource is undefined", () => {
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      undefined;
+    expect(openEventSource("https://example.com/sse")).toBeNull();
+  });
+
+  test("returns null for unparseable URL", () => {
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      vi.fn() as unknown as typeof EventSource;
+    expect(openEventSource("http://[invalid")).toBeNull();
+  });
+
+  test("returns null for non-http(s) protocols", () => {
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      vi.fn() as unknown as typeof EventSource;
+    expect(openEventSource("eliza-local-agent://ipc/events")).toBeNull();
+    expect(openEventSource("ftp://example.com/file")).toBeNull();
+    expect(openEventSource("ws://example.com/socket")).toBeNull();
+    expect(openEventSource("file:///etc/passwd")).toBeNull();
+  });
+
+  test("returns null for relative URL that resolves to non-http base", () => {
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      vi.fn() as unknown as typeof EventSource;
+    (globalThis as unknown as { window?: unknown }).window = {
+      location: { href: "eliza-local-agent://ipc/" },
+    } as unknown as Window;
+    expect(openEventSource("/sse")).toBeNull();
+  });
+
+  test("constructs EventSource for valid http(s) URLs", () => {
+    const MockEventSource = vi.fn(function (this: unknown, url: string) {
+      (this as Record<string, unknown>).url = url;
+    }) as unknown as typeof EventSource;
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      MockEventSource;
+    const es = openEventSource("https://example.com/sse");
+    expect(MockEventSource).toHaveBeenCalledWith(
+      "https://example.com/sse",
+      undefined,
+    );
+    expect(es).toBeInstanceOf(MockEventSource);
+  });
+
+  test("passes init through", () => {
+    const MockEventSource = vi.fn() as unknown as typeof EventSource;
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      MockEventSource;
+    openEventSource("https://example.com/sse", {
+      withCredentials: true,
+    } as EventSourceInit);
+    expect(MockEventSource).toHaveBeenCalledWith("https://example.com/sse", {
+      withCredentials: true,
+    });
+  });
+
+  test("returns null when constructor throws", () => {
+    const ThrowingEventSource = vi.fn(() => {
+      throw new Error("The operation is insecure.");
+    }) as unknown as typeof EventSource;
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      ThrowingEventSource;
+    expect(openEventSource("https://example.com/sse")).toBeNull();
+    expect(openEventSource("https://example.com/sse")).toBeNull();
+  });
+
+  test("handles http and https explicitly", () => {
+    const MockEventSource = vi.fn() as unknown as typeof EventSource;
+    (globalThis as unknown as { EventSource?: unknown }).EventSource =
+      MockEventSource;
+    expect(openEventSource("http://example.com/sse")).not.toBeNull();
+    expect(openEventSource("https://example.com/sse")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

N/A - behavioral coverage for uncovered EventSource guard

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only, no production. Covers pure EventSource URL validation and graceful degradation.

# Background

## What does this PR do?

Adds missing coverage for `packages/ui/src/utils/event-source.ts`: `openEventSource` rejects non-http(s), unparseable URLs, missing EventSource, and constructor throws. No production changed.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/event-source.test.ts`

## Detailed testing steps

- `bun run --cwd packages/ui test -- --run src/utils/event-source.test.ts` — 8 tests, all green (red 2 fail when protocol check disabled, green 8 pass after restore)
- `bunx biome check --write` — fixed 1 file
- `git diff --check` — clean

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5bdb7f7d0a7451f458eb35aa2e8cf16070836bb4 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure EventSource guard`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure EventSource guard`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow, unit test only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend path, unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend, pure function test`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no LLM change, EventSource guard`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact, URL validation`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change

## Backend + frontend logs

N/A - no backend/frontend

## Screenshots (before / after) + video walkthrough

N/A - no UI surface

## Known gaps / failures

- `bun run --cwd plugins/plugin-sql typecheck` pre-existing errors — not caused by this file. `bun run --cwd packages/ui test` for this file passes 8/8, `biome` clean.

## Red

```
2 failed | 6 passed (8)
protocol check disabled -> non-http(s) incorrectly constructed EventSource
```

## Green

```
8 passed (8)
Ran 8 tests across 1 file.
```

# Checklist

- [x] Rebased onto latest origin/develop
- [x] Tests pass
- [x] Biome clean
- [x] No duplicate (gh pr list checked)
- [x] Non-vacuous behavioral tests
- [x] Red -> Green demonstrated
