### PR TITLE
test(ui): cover useAudioElement

### DIFF
--- a/packages/ui/src/components/transcripts/useAudioElement.test.tsx
+++ b/packages/ui/src/components/transcripts/useAudioElement.test.tsx
@@ -1,0 +1,298 @@
+/** Drives useAudioElement through a real mounted <audio> element to pin player state, seeking, and teardown contracts. */
+// @vitest-environment jsdom
+
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAudioElement } from "./useAudioElement";
+
+afterEach(cleanup);
+
+type AudioApi = ReturnType<typeof useAudioElement>;
+
+interface MountResult {
+  /**
+   * LIVE view of the hook API: every property read resolves against the most
+   * recent render. (A plain reference would be a frozen snapshot — the hook
+   * returns a new object literal each render.)
+   */
+  readonly api: AudioApi;
+  el: HTMLAudioElement;
+  unmount: () => void;
+}
+
+function liveApiView(holder: { current?: AudioApi }): AudioApi {
+  const seeded = holder.current;
+  if (!seeded) throw new Error("useAudioElement did not initialise");
+  const view = {} as AudioApi;
+  for (const key of Object.keys(seeded) as (keyof AudioApi)[]) {
+    Object.defineProperty(view, key, {
+      get: () => (holder.current as AudioApi)[key],
+      enumerable: true,
+    });
+  }
+  return view;
+}
+
+/**
+ * Mounts a harness that calls the hook and renders the <audio> tag exactly
+ * like TranscriptPlayer does: React assigns the real DOM node into the hook's
+ * own ref during commit, so the effect sees the element and every listener is
+ * registered against it. `prepare` runs on that node before the effect fires.
+ */
+function mountAudioHook(prepare?: (el: HTMLAudioElement) => void): MountResult {
+  const holder: { current?: AudioApi } = {};
+  function Harness() {
+    holder.current = useAudioElement();
+    const attach = React.useCallback((node: HTMLAudioElement | null) => {
+      const api = holder.current;
+      if (!api) return;
+      api.audioRef.current = node;
+      if (node) {
+        // jsdom's media properties are unreliable; pin currentTime to a plain
+        // writable value so seeks can be asserted without jsdom internals.
+        Object.defineProperty(node, "currentTime", {
+          value: 0,
+          writable: true,
+          configurable: true,
+        });
+        prepare?.(node);
+      }
+    }, []);
+    // biome-ignore lint/a11y/useMediaCaption: detached harness fixture driving the hook's ref contract — no user-facing media
+    return <audio ref={attach} />;
+  }
+  const utils = render(<Harness />);
+  return {
+    api: liveApiView(holder),
+    el: (holder.current as AudioApi).audioRef.current as HTMLAudioElement,
+    unmount: utils.unmount,
+  };
+}
+
+function emit(el: HTMLAudioElement, type: string) {
+  act(() => {
+    el.dispatchEvent(new Event(type));
+  });
+}
+
+describe("useAudioElement", () => {
+  it("starts idle at zero position/duration and no-ops every control before an element is attached", () => {
+    const { result } = renderHook(() => useAudioElement());
+
+    expect(result.current.audioRef.current).toBeNull();
+    expect(result.current.playing).toBe(false);
+    expect(result.current.currentMs).toBe(0);
+    expect(result.current.durationMs).toBe(0);
+
+    act(() => {
+      result.current.play();
+      result.current.pause();
+      result.current.toggle();
+      result.current.seekMs(90_000);
+    });
+
+    expect(result.current.playing).toBe(false);
+    expect(result.current.currentMs).toBe(0);
+  });
+
+  it("reports metadata already present at mount without waiting for an event", () => {
+    const { api } = mountAudioHook((el) => {
+      Object.defineProperty(el, "duration", {
+        value: 12.5,
+        configurable: true,
+      });
+    });
+    expect(api.durationMs).toBe(12_500);
+  });
+
+  it("tracks playback position in whole milliseconds across timeupdate events", () => {
+    const { api, el } = mountAudioHook();
+
+    el.currentTime = 1.5;
+    emit(el, "timeupdate");
+    expect(api.currentMs).toBe(1_500);
+
+    el.currentTime = 3.75;
+    emit(el, "timeupdate");
+    expect(api.currentMs).toBe(3_750);
+  });
+
+  it("rounds finite durations to milliseconds and reports non-finite durations as unknown", () => {
+    const { api, el } = mountAudioHook();
+    const setDuration = (value: number) =>
+      Object.defineProperty(el, "duration", { value, configurable: true });
+
+    setDuration(7.89);
+    emit(el, "loadedmetadata");
+    expect(api.durationMs).toBe(7_890);
+
+    setDuration(Number.NaN);
+    emit(el, "durationchange");
+    expect(api.durationMs).toBe(0);
+
+    setDuration(Number.POSITIVE_INFINITY);
+    emit(el, "durationchange");
+    expect(api.durationMs).toBe(0);
+  });
+
+  it("flips playing only from the element's own play, pause, and ended events", () => {
+    const { api, el } = mountAudioHook();
+
+    emit(el, "play");
+    expect(api.playing).toBe(true);
+
+    emit(el, "pause");
+    expect(api.playing).toBe(false);
+
+    emit(el, "play");
+    expect(api.playing).toBe(true);
+
+    emit(el, "ended");
+    expect(api.playing).toBe(false);
+  });
+
+  it("forwards play() to the element and lets the play event — not the call — set playing", () => {
+    const { api, el } = mountAudioHook((node) => {
+      node.play = vi.fn(() => Promise.resolve());
+    });
+
+    act(() => {
+      api.play();
+    });
+    expect(el.play).toHaveBeenCalledTimes(1);
+    expect(api.playing).toBe(false);
+
+    emit(el, "play");
+    expect(api.playing).toBe(true);
+  });
+
+  it("reflects an autoplay-rejected play() back to idle instead of leaving playing stuck", async () => {
+    const { api, el } = mountAudioHook((node) => {
+      node.play = vi.fn(() =>
+        Promise.reject(new DOMException("autoplay blocked", "NotAllowedError")),
+      );
+    });
+
+    emit(el, "play");
+    expect(api.playing).toBe(true);
+
+    await act(async () => {
+      void api.play();
+    });
+    expect(api.playing).toBe(false);
+  });
+
+  it("forwards pause() to the element while state still follows the pause event", () => {
+    const { api, el } = mountAudioHook((node) => {
+      node.pause = vi.fn();
+    });
+
+    emit(el, "play");
+    expect(api.playing).toBe(true);
+
+    act(() => {
+      api.pause();
+    });
+    expect(el.pause).toHaveBeenCalledTimes(1);
+    expect(api.playing).toBe(true);
+
+    emit(el, "pause");
+    expect(api.playing).toBe(false);
+  });
+
+  it("toggles by pausing state: play() when paused, pause() when playing", () => {
+    let paused = true;
+    const { api, el } = mountAudioHook((node) => {
+      node.play = vi.fn(() => Promise.resolve());
+      node.pause = vi.fn();
+      Object.defineProperty(node, "paused", {
+        get: () => paused,
+        configurable: true,
+      });
+    });
+
+    act(() => {
+      api.toggle();
+    });
+    expect(el.play).toHaveBeenCalledTimes(1);
+    expect(el.pause).not.toHaveBeenCalled();
+
+    paused = false;
+    emit(el, "play");
+
+    act(() => {
+      api.toggle();
+    });
+    expect(el.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it("seeks in seconds, clamps negatives to zero, and rounds fractional milliseconds", () => {
+    const { api, el } = mountAudioHook();
+
+    act(() => {
+      api.seekMs(1500.6);
+    });
+    expect(el.currentTime).toBeCloseTo(1.5006, 6);
+    expect(api.currentMs).toBe(1_501);
+
+    act(() => {
+      api.seekMs(-250);
+    });
+    expect(el.currentTime).toBe(0);
+    expect(api.currentMs).toBe(0);
+  });
+
+  it("removes all six media listeners from the element on unmount", () => {
+    const added: string[] = [];
+    const removed: string[] = [];
+    const { unmount } = mountAudioHook((node) => {
+      const realAdd = node.addEventListener.bind(node) as (
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+      ) => void;
+      const realRemove = node.removeEventListener.bind(node) as (
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | EventListenerOptions,
+      ) => void;
+      node.addEventListener = ((
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+      ) => {
+        added.push(type);
+        realAdd(type, listener, options);
+      }) as typeof node.addEventListener;
+      node.removeEventListener = ((
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | EventListenerOptions,
+      ) => {
+        removed.push(type);
+        realRemove(type, listener, options);
+      }) as typeof node.removeEventListener;
+    });
+
+    expect(added).toEqual([
+      "timeupdate",
+      "loadedmetadata",
+      "durationchange",
+      "play",
+      "pause",
+      "ended",
+    ]);
+
+    unmount();
+
+    expect(removed).toEqual([
+      "timeupdate",
+      "loadedmetadata",
+      "durationchange",
+      "play",
+      "pause",
+      "ended",
+    ]);
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located vitest suite for `packages/ui/src/components/transcripts/useAudioElement.ts` (the Transcripts player hook, #8789 lineage). No same-named test file existed anywhere on `develop` when this was filed, and no open PR touched the file.

## Coverage

Eleven cases driving the real hook through a mounted `<audio>` element whose DOM node React assigns into the hook's own ref (mirroring how TranscriptPlayer wires it):

- idle defaults (`playing=false`, `currentMs=0`, `durationMs=0`) and every control safely no-oping before an element is attached
- metadata already present at mount being reported without any event
- `timeupdate` position tracking in whole milliseconds
- finite durations rounded to ms via `loadedmetadata`; NaN and Infinity reported as unknown (0) via `durationchange`
- `playing` flipping only from the element's own `play` / `pause` / `ended` events
- `play()` forwarding to the element while state follows the `play` event, not the call
- an autoplay-rejected `play()` reflecting back to idle instead of leaving a stuck "playing" state
- `pause()` forwarding while state still follows the `pause` event
- `toggle()` playing when paused and pausing when playing
- `seekMs()` clamping negatives to zero and rounding fractional milliseconds
- unmount removing all six registered media listeners

jsdom media properties are pinned per-test where needed; every assertion records observed behaviour of the module as shipped.

## Evidence (test-only change)

Diff is exactly one new test file, +298/-0. No production behaviour changed.

- `bunx vitest run src/components/transcripts/useAudioElement.test.tsx` (in `packages/ui`): **1 file passed, 11 tests passed, 0 failed**
- `bunx biome check --write` on the file: **clean** (`biome.json` present; worktree is not sparse)
- `bunx tsc --noEmit` in `packages/ui`: **zero diagnostics referencing the new file**
- Branch rebased onto current `origin/develop` before push; the module under test is byte-identical between the base the counts were produced on and current `develop`

## CI note

We are a fork contributor: hosted CI does not run on this pull request. The counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3f076bb2ed8b294db72800ed9dea075fd8fb4801 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
