### PR TITLE
test(ui): narrow optional model hints assertion

### DIFF
--- a/packages/ui/src/components/settings/cloud-model-schema.test.ts
+++ b/packages/ui/src/components/settings/cloud-model-schema.test.ts
@@ -40,7 +40,7 @@ describe("cloud-model-schema", () => {
     const { schema, hints } = buildCloudModelSchema(options);
     expect(schema.type).toBe("object");
     expect(schema.properties.nano).toBeDefined();
-    expect(hints.nano.options.length).toBe(1);
+    expect(hints.nano?.options).toHaveLength(1);
     expect(hints.responseHandler).toBeDefined();
     expect(hints.actionPlanner).toBeDefined();
   });


### PR DESCRIPTION
## Summary

Repairs the current `@elizaos/ui` typecheck baseline by asserting the optional nested model-hint collection through optional chaining. The assertion remains strict: Vitest `toHaveLength(1)` fails for `undefined`, while TypeScript no longer rejects the test before execution.

This exact untouched failure blocked PR Static Smoke for frontend PRs #26604 (run 32696650937) and #27242 (run 32694106286):

```text
src/components/settings/cloud-model-schema.test.ts(43,12): error TS18048: hints.nano.options is possibly undefined
```

## Exact-base evidence

- base: `b87b7f7ad0af34451ead986d3b8aef9fbfdbfc90`
- head: `34e6c5eb78eac6582d711c3af9cad40ac24e54a4`
- focused schema suite: 2/2 PASS
- `bun run --cwd packages/ui typecheck`: PASS
- changed-file Biome: PASS
- `git diff --check`: PASS
- worktree clean after commit

## Evidence

N/A for screenshots/video/console/network: this is a test-only TypeScript narrowing repair and changes no runtime or rendered UI behavior.