### PR TITLE
fix(prompts): publish native Node package contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1006,6 +1006,9 @@
     "packages/prompts": {
       "name": "@elizaos/prompts",
       "version": "2.0.3-beta.7",
+      "devDependencies": {
+        "@typescript/native": "npm:typescript@^7.0.2",
+      },
     },
     "packages/registry": {
       "name": "@elizaos/registry",

--- a/packages/prompts/AGENTS.md
+++ b/packages/prompts/AGENTS.md
@@ -17,7 +17,13 @@ root [`CLAUDE.md`](../../CLAUDE.md).
   backward compatibility. Runtime and codegen paths use complete authored
   descriptions directly; the alias must never rewrite text.
 - Also owns the action/provider **specs** under `specs/` and the generators in `scripts/` that build a merged plugin action spec and emit `packages/core/src/generated/action-docs.ts`.
-- This package ships no compiled JS for `src/` — `main`/`exports['.']` point at `src/index.ts` directly (consumed by TS tooling / bundlers in the monorepo). The `dist/` subpath mappings in `exports` (`./*.css` and `./*`) exist for potential subpath consumers; no codegen script in this package writes to `dist/`.
+- Bun and `eliza-source` workspace consumers load the maintained TypeScript
+  source directly, and workspace TypeScript consumers resolve source types
+  before `dist/` exists. The generated publish manifest rewrites those type
+  paths so native Node and published-package consumers load compiled `dist/`
+  JavaScript and declarations. Both manifests expose only the package root.
+  Internal source imports use explicit `.js` specifiers so NodeNext typechecking
+  and emitted native ESM resolve the same sibling modules.
 
 ## Layout
 
@@ -50,17 +56,25 @@ packages/prompts/
 
 ```bash
 bun run --cwd packages/prompts build                    # gen plugin spec, format it, gen action-docs
+bun run --cwd packages/prompts build:package            # compile the native-Node publish artifact
 bun run --cwd packages/prompts build:plugin-action-spec # only regen specs/actions/plugins.generated.json
 bun run --cwd packages/prompts build:action-docs        # only regen packages/core/src/generated/action-docs.ts
 bun run --cwd packages/prompts check:secrets            # scan prompt files for secrets/PII
 bun run --cwd packages/prompts test                     # bun test ./test
+bun run --cwd packages/prompts typecheck                # typecheck both maintained TypeScript modules
 bun run --cwd packages/prompts lint                     # biome check --write
 bun run --cwd packages/prompts lint:check               # biome check (no write)
 bun run --cwd packages/prompts format:check             # biome format check
 bun run --cwd packages/prompts clean                    # rm -rf dist
 ```
 
-`typecheck` only prints its status because this package has no standalone TypeScript program beyond the prompt string module.
+`typecheck` uses the package-owned NodeNext `tsconfig.json` over the two
+maintained source modules. The package test lane builds and packs `dist/`
+exactly as the release path does, verifies that the tarball contains the
+compiled `dist/` contract rather than TypeScript runtime source, installs it
+into an isolated native Node consumer, separately exercises Bun's workspace
+package resolution, and emits the core prompt declarations after removing
+`dist/`; either path failing is a package-contract error.
 
 ## Config / env vars
 

--- a/packages/prompts/CLAUDE.md
+++ b/packages/prompts/CLAUDE.md
@@ -17,7 +17,13 @@ root [`CLAUDE.md`](../../CLAUDE.md).
   backward compatibility. Runtime and codegen paths use complete authored
   descriptions directly; the alias must never rewrite text.
 - Also owns the action/provider **specs** under `specs/` and the generators in `scripts/` that build a merged plugin action spec and emit `packages/core/src/generated/action-docs.ts`.
-- This package ships no compiled JS for `src/` — `main`/`exports['.']` point at `src/index.ts` directly (consumed by TS tooling / bundlers in the monorepo). The `dist/` subpath mappings in `exports` (`./*.css` and `./*`) exist for potential subpath consumers; no codegen script in this package writes to `dist/`.
+- Bun and `eliza-source` workspace consumers load the maintained TypeScript
+  source directly, and workspace TypeScript consumers resolve source types
+  before `dist/` exists. The generated publish manifest rewrites those type
+  paths so native Node and published-package consumers load compiled `dist/`
+  JavaScript and declarations. Both manifests expose only the package root.
+  Internal source imports use explicit `.js` specifiers so NodeNext typechecking
+  and emitted native ESM resolve the same sibling modules.
 
 ## Layout
 
@@ -50,17 +56,25 @@ packages/prompts/
 
 ```bash
 bun run --cwd packages/prompts build                    # gen plugin spec, format it, gen action-docs
+bun run --cwd packages/prompts build:package            # compile the native-Node publish artifact
 bun run --cwd packages/prompts build:plugin-action-spec # only regen specs/actions/plugins.generated.json
 bun run --cwd packages/prompts build:action-docs        # only regen packages/core/src/generated/action-docs.ts
 bun run --cwd packages/prompts check:secrets            # scan prompt files for secrets/PII
 bun run --cwd packages/prompts test                     # bun test ./test
+bun run --cwd packages/prompts typecheck                # typecheck both maintained TypeScript modules
 bun run --cwd packages/prompts lint                     # biome check --write
 bun run --cwd packages/prompts lint:check               # biome check (no write)
 bun run --cwd packages/prompts format:check             # biome format check
 bun run --cwd packages/prompts clean                    # rm -rf dist
 ```
 
-`typecheck` only prints its status because this package has no standalone TypeScript program beyond the prompt string module.
+`typecheck` uses the package-owned NodeNext `tsconfig.json` over the two
+maintained source modules. The package test lane builds and packs `dist/`
+exactly as the release path does, verifies that the tarball contains the
+compiled `dist/` contract rather than TypeScript runtime source, installs it
+into an isolated native Node consumer, separately exercises Bun's workspace
+package resolution, and emits the core prompt declarations after removing
+`dist/`; either path failing is a package-contract error.
 
 ## Config / env vars
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -11,7 +11,10 @@ This package is the single source of truth for prompt templates used by the runt
 ```
 packages/prompts/
 ├── src/
-│   └── index.ts      # TypeScript prompt template exports
+│   ├── index.ts      # TypeScript prompt template exports
+│   └── prompt-compression.ts # lossless compatibility helper
+├── dist/             # generated JavaScript, declarations, and publish manifest
+├── tsconfig.json     # package-owned source typecheck
 ├── specs/            # Merged action/provider specs (JSON) + generated plugins.generated.json
 └── scripts/          # Spec + docs generators
     ├── generate-action-docs.js
@@ -36,9 +39,19 @@ Some plugins keep **hand-edited** `actions.json` / `evaluators.json` / `provider
 ## Building
 
 ```bash
-# Generate plugin action spec + action docs
+# Compile the publishable package, generate the plugin action spec, and action docs
 bun run build
+
+# Compile only the native-Node package artifact
+bun run build:package
 ```
+
+Bun workspace tooling resolves the maintained TypeScript source through the
+`bun` export condition, and workspace TypeScript consumers resolve source types
+before `dist/` exists. The generated publish manifest rewrites those type paths
+to declarations in `dist/`; native Node and the release path resolve compiled
+JavaScript from the tarball packed out of that publish directory. TypeScript
+source is not published as runtime code.
 
 ## Usage
 

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -4,36 +4,44 @@
   "version": "2.0.3-beta.7",
   "description": "Shared prompt templates for elizaOS across TypeScript, Python, and Rust",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "./src/index.ts",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "bun": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
-    "./*.css": "./dist/*.css",
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
-    }
+    "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "node scripts/generate-plugin-action-spec.js && bunx @biomejs/biome format --write specs/actions/plugins.generated.json && node scripts/generate-action-docs.js",
+    "build": "bun run build:package && node scripts/generate-plugin-action-spec.js && bunx @biomejs/biome format --write specs/actions/plugins.generated.json && node scripts/generate-action-docs.js",
     "build:action-docs": "node scripts/generate-action-docs.js",
+    "build:package": "node ../scripts/rm-path-recursive.mjs dist && tsc6 --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --rootDir src --outDir dist --declaration src/index.ts src/prompt-compression.ts && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/prompts && node ../scripts/prepare-package-dist.mjs packages/prompts",
     "build:plugin-action-spec": "node scripts/generate-plugin-action-spec.js && bunx @biomejs/biome format --write specs/actions/plugins.generated.json",
     "check:secrets": "node scripts/check-secrets.js",
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "lint": "bunx @biomejs/biome check --write .",
     "lint:check": "bunx @biomejs/biome check .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "echo 'No TypeScript source files to check'",
-    "test": "bun test ./test"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun run build:package && bun test ./test"
   },
   "files": [
-    "src/",
-    "dist/",
-    "scripts/"
+    "dist"
   ],
   "keywords": [
     "elizaos",
@@ -45,6 +53,9 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2"
   },
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2",
   "elizaos": {

--- a/packages/prompts/test/package-contract.test.js
+++ b/packages/prompts/test/package-contract.test.js
@@ -1,0 +1,152 @@
+/**
+ * Exercises workspace and published package consumption with real runtimes.
+ * The integration harness packs and installs the compiled tarball outside the
+ * workspace so aliases cannot hide missing files or invalid specifiers.
+ */
+import assert from "node:assert";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = join(packageRoot, "../..");
+const publishRoot = join(packageRoot, "dist");
+describe("package consumer contract", () => {
+  it("executes through Bun workspace package resolution", async () => {
+    const { compressPromptDescription } = await import("@elizaos/prompts");
+    const payload = "  Bun keeps this complete.\nAnd this line too.  ";
+    assert.strictEqual(compressPromptDescription(payload), payload);
+  });
+
+  it("loads the packed build in an isolated native Node consumer", {
+    timeout: 60_000,
+  }, async () => {
+    const workspacePrompts = await import("@elizaos/prompts");
+    const sandbox = mkdtempSync(join(tmpdir(), "eliza-prompts-consumer-"));
+    const packDir = join(sandbox, "pack");
+    const consumerDir = join(sandbox, "consumer");
+    try {
+      mkdirSync(packDir);
+      mkdirSync(consumerDir);
+      const packOutput = execFileSync(
+        "npm",
+        ["pack", "--ignore-scripts", "--json", "--pack-destination", packDir],
+        { cwd: publishRoot, encoding: "utf8" },
+      );
+      const [packRecord] = JSON.parse(packOutput);
+      assert.ok(packRecord?.filename, "npm pack should report its tarball");
+      const packedPaths = new Set(packRecord.files.map(({ path }) => path));
+      assert.ok(packedPaths.has("index.js"));
+      assert.ok(packedPaths.has("index.d.ts"));
+      assert.ok(packedPaths.has("prompt-compression.js"));
+      assert.ok(packedPaths.has("prompt-compression.d.ts"));
+      assert.strictEqual(
+        [...packedPaths].some((path) => path.startsWith("src/")),
+        false,
+        "the release tarball must not publish TypeScript source as runtime code",
+      );
+
+      writeFileSync(
+        join(sandbox, "package.json"),
+        JSON.stringify({ private: true, type: "module" }),
+      );
+      execFileSync(
+        "npm",
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          join(packDir, basename(packRecord.filename)),
+        ],
+        { cwd: sandbox, stdio: "pipe" },
+      );
+      const installedManifest = JSON.parse(
+        readFileSync(
+          join(sandbox, "node_modules/@elizaos/prompts/package.json"),
+          "utf8",
+        ),
+      );
+      assert.strictEqual(installedManifest.types, "./index.d.ts");
+      assert.strictEqual(installedManifest.exports["."].types, "./index.d.ts");
+
+      const probe = join(consumerDir, "probe.mjs");
+      const payload =
+        "  Preserve every line.\n\n" +
+        "A URL: https://example.com/items?cursor=next\n" +
+        "A code fence: ```ts\nconst complete = true;\n```  ";
+      writeFileSync(
+        probe,
+        [
+          'import { compressPromptDescription } from "@elizaos/prompts";',
+          'import { replyTemplate } from "@elizaos/prompts";',
+          'if (process.release.name !== "node") process.exit(70);',
+          "const value = process.env.ELIZA_PROMPTS_PROBE;",
+          "if (compressPromptDescription(value) !== value) process.exit(71);",
+          "process.stdout.write(JSON.stringify({ replyTemplate, value }));",
+        ].join("\n"),
+      );
+
+      const probeOutput = execFileSync("node", [probe], {
+        cwd: consumerDir,
+        encoding: "utf8",
+        env: { ...process.env, ELIZA_PROMPTS_PROBE: payload },
+      });
+      const result = JSON.parse(probeOutput);
+      assert.strictEqual(result.value, payload);
+      assert.strictEqual(result.replyTemplate, workspacePrompts.replyTemplate);
+    } finally {
+      rmSync(sandbox, { force: true, recursive: true });
+    }
+  });
+
+  it("resolves core prompt declarations without a prebuilt prompts dist", {
+    timeout: 60_000,
+  }, () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "eliza-prompts-declarations-"));
+    try {
+      rmSync(join(packageRoot, "dist"), { force: true, recursive: true });
+      execFileSync(
+        join(repositoryRoot, "node_modules/.bin/tsc6"),
+        [
+          "--ignoreConfig",
+          "--target",
+          "ES2022",
+          "--module",
+          "ESNext",
+          "--moduleResolution",
+          "Bundler",
+          "--declaration",
+          "--emitDeclarationOnly",
+          "--skipLibCheck",
+          "--rootDir",
+          join(repositoryRoot, "packages/core/src"),
+          "--outDir",
+          sandbox,
+          join(repositoryRoot, "packages/core/src/prompts.ts"),
+          join(repositoryRoot, "packages/core/src/utils/prompt-compression.ts"),
+        ],
+        { cwd: repositoryRoot, stdio: "pipe" },
+      );
+      assert.ok(
+        readFileSync(join(sandbox, "prompts.d.ts")).length > 0,
+        "the production core prompt declaration should emit from a clean prompts package",
+      );
+    } finally {
+      execFileSync("bun", ["run", "build:package"], {
+        cwd: packageRoot,
+        stdio: "pipe",
+      });
+      rmSync(sandbox, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/prompts/tsconfig.json
+++ b/packages/prompts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -100,6 +100,7 @@
     "@elizaos/prompts#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "outputs": [
+        "dist/**",
         "specs/actions/plugins.generated.json",
         "$TURBO_ROOT$/packages/core/src/generated/action-docs.ts"
       ],


### PR DESCRIPTION
Closes #27174

## Summary

- publish `@elizaos/prompts` as compiled NodeNext ESM with declarations under `dist/`
- keep workspace type resolution on maintained source before `dist/` exists, while Bun runtime consumers use the `eliza-source` and `bun` conditions
- expose only the supported package root plus `./package.json`; no wildcard or nonexistent CSS subpaths
- generate a publish manifest that rewrites source type paths to compiled declarations before the existing prompt-spec/docs work
- test the real publish boundary by packing `dist/`, installing it into an isolated consumer, and importing it with native Node 24

The maintained source keeps the NodeNext-compatible `./prompt-compression.js` relative specifier. No prompt template text or prompt-compression behavior changed.

## Exact-head evidence

Base: `094f80ad2ded8fdd78da8664ccf3423590f1c25a`

Head: `39f8a00e0dfd163eeb2b4ad6059e9e76f2a29a5d`

| Check | Result |
| --- | --- |
| `bun install --frozen-lockfile` (Bun 1.3.14) | PASS — no lockfile changes |
| `bun run --cwd packages/prompts test` | PASS — 26 tests, including clean-dist core declaration regression, packed native Node consumer, and complete template-byte equality |
| `bun run --cwd packages/prompts typecheck` | PASS — NodeNext TypeScript check |
| `bun run --cwd packages/prompts lint:check` | PASS — 17 files |
| `bun run --cwd packages/prompts format:check` | PASS — 17 files |
| `bun run --cwd packages/prompts check:secrets` | PASS — one existing review-only generic-assignment warning in plugin-wallet |
| `bun run --cwd packages/prompts build` | PASS |
| `bun run audit:tsconfig-workspace-resolution` | PASS — 146 projects |
| `bun run audit:publish-graph` | PASS — 127 publishable packages |
| `bun run check:agents-claude` | PASS — 160 guide pairs |
| `bun run verify` | PASS — exact current base/head; all repository audits completed with `rc=0` |

## Artifact review

The publish-directory dry-run contains exactly the generated manifest plus compiled `index.js`, `index.d.ts`, `prompt-compression.js`, and `prompt-compression.d.ts`; no TypeScript source is published. The external consumer test imports the actual tarball under native Node 24 and compares complete `replyTemplate` and `compressPromptDescription` values with the workspace package.

## Evidence rows

| Evidence | Result |
| --- | --- |
| Published artifact | PASS — inspected the `dist/` tarball inventory and generated manifest, then imported the installed tarball under native Node 24 |
| Consumer behavior | PASS — workspace types resolve source with no `dist`; Bun source runtime, native Node compiled ESM, and NodeNext downstream declaration check pass |
| Prompt integrity | PASS — complete template/compression bytes compared across workspace and installed tarball; no model-facing text changed |
| Screenshots / video | N/A — package build and module-resolution contract only; no rendered surface changed |
| Live-model trajectory | N/A — no prompt text, assembly, or agent behavior changed |
