### PR TITLE
fix(core): harden Content-Length parsing in media fetch

### DIFF
--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -231,8 +231,15 @@ function enforceContentLengthLimit(
 		return;
 	}
 
-	const length = Number(contentLength);
-	if (Number.isFinite(length) && length > maxBytes) {
+	// Headers.get() concatenates duplicate headers with ", " per Fetch spec,
+	// so "10, 9999" would make Number() return NaN and bypass the check.
+	// Take only the first value and require canonical decimal form.
+	const firstValue = contentLength.split(",")[0]?.trim();
+	if (!firstValue || !/^(0|[1-9]\d*)$/.test(firstValue)) {
+		return;
+	}
+	const length = Number(firstValue);
+	if (Number.isSafeInteger(length) && length > maxBytes) {
 		throw new MediaFetchError(
 			"max_bytes",
 			`Failed to fetch media from ${url}: content length ${length} exceeds maxBytes ${maxBytes}`,


### PR DESCRIPTION
# Relates to

N/A - harden Content-Length early check bypass

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Early Content-Length check only; streaming cap in `readResponseWithLimit` remains authoritative. Fix narrows acceptance to canonical decimal.

# Background

## What does this PR do?

Fixes `enforceContentLengthLimit` in `packages/core/src/media/fetch.ts`. `Headers.get()` concatenates duplicate headers with `, ` per Fetch spec, so `Number("10, 9999")` yields `NaN` and the early limit check was bypassed. Fix splits on comma, validates canonical decimal form, and uses `isSafeInteger`.

`1e6` and similar non-canonical forms are now ignored for the early check (safe, streaming still caps).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/media/fetch.ts:224`

## Detailed testing steps

```bash
bun --cwd packages/core test src/media/fetch.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3d8824e757094d2bad4b9f15c15be321ab901d3f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface (media fetch)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface (media fetch)`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual surface (media fetch)`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - verified via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - verified via unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model change

## Backend + frontend logs

N/A - verified via unit test

Red (reverted):

```
Number("10000000, 10") => NaN => bypassed, expected to throw
```

Green (fixed):

```
firstValue "10000000" => 10000000 > 100 => throws max_bytes correctly
comma header handled via split
12 tests passed
```

Existing suite: `packages/core/src/media/fetch.test.ts` - 12 passed

## Screenshots (before / after) + video walkthrough

N/A - no visual surface

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
