### PR TITLE
test(core): cover sensitive-requests dispatch registry barrel

### DIFF
--- a/packages/core/src/sensitive-requests/index.test.ts
+++ b/packages/core/src/sensitive-requests/index.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Exercises the sensitive-requests public barrel (`./index`) — the
+ * dispatch-registry re-export wiring plus the registry and service behavior
+ * reachable only through it: empty-registry results, omitted-`supportsChannel`
+ * resolution, argument forwarding, unknown-target unregister, exact listing
+ * order, and the service start / delegate / stop lifecycle — over
+ * deterministic fake adapters with no real connector delivery.
+ */
+import { describe, expect, test } from "vitest";
+import {
+	createSensitiveRequestDispatchRegistry,
+	type DeliveryResult,
+	type DeliveryTarget,
+	SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE,
+	type SensitiveRequestDeliveryAdapter,
+	SensitiveRequestDispatchRegistryService,
+} from "./index";
+
+function makeAdapter(
+	target: DeliveryTarget,
+	overrides: Partial<SensitiveRequestDeliveryAdapter> = {},
+): SensitiveRequestDeliveryAdapter {
+	return {
+		target,
+		async deliver(): Promise<DeliveryResult> {
+			return {
+				delivered: true,
+				target,
+			};
+		},
+		...overrides,
+	};
+}
+
+describe("createSensitiveRequestDispatchRegistry (barrel export)", () => {
+	test("the barrel exposes a callable factory returning a full registry", () => {
+		expect(typeof createSensitiveRequestDispatchRegistry).toBe("function");
+
+		const registry = createSensitiveRequestDispatchRegistry();
+		expect(typeof registry.register).toBe("function");
+		expect(typeof registry.unregister).toBe("function");
+		expect(typeof registry.get).toBe("function");
+		expect(typeof registry.resolve).toBe("function");
+		expect(typeof registry.list).toBe("function");
+	});
+
+	test("get, list, and resolve are empty before anything registers", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+
+		expect(registry.get("dm")).toBeUndefined();
+		expect(registry.list()).toEqual([]);
+		expect(registry.resolve?.("dm", "chan-1", {})).toBeUndefined();
+	});
+
+	test("resolve treats an omitted supportsChannel as accepting any channel", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+		const declines = makeAdapter("dm", { supportsChannel: () => false });
+		const silent = makeAdapter("dm");
+		registry.register(declines);
+		registry.register(silent);
+
+		// An adapter without supportsChannel never vetoes: `!== false` passes it.
+		expect(registry.resolve?.("dm", "chan-1", {})).toBe(silent);
+	});
+
+	test("resolve forwards the requested channel and runtime to supportsChannel", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+		let seenChannelId: string | undefined;
+		let seenRuntime: unknown;
+		const observer = makeAdapter("dm", {
+			supportsChannel(channelId, runtime) {
+				seenChannelId = channelId;
+				seenRuntime = runtime;
+				return true;
+			},
+		});
+		registry.register(observer);
+
+		const runtimeMarker = { agentId: "agent-1" };
+		const resolved = registry.resolve?.("dm", "chan-42", runtimeMarker);
+
+		expect(resolved).toBe(observer);
+		expect(seenChannelId).toBe("chan-42");
+		expect(seenRuntime).toBe(runtimeMarker);
+	});
+
+	test("unregistering an unknown target is a no-op that keeps later registration intact", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+
+		expect(() => registry.unregister("public_link")).not.toThrow();
+
+		const adapter = makeAdapter("dm");
+		registry.register(adapter);
+		expect(registry.get("dm")).toBe(adapter);
+		expect(registry.list()).toEqual([adapter]);
+	});
+
+	test("list keeps each target at its first-insertion position and appends within it", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+		const dmFirst = makeAdapter("dm");
+		const ownerApp = makeAdapter("owner_app_inline");
+		const dmSecond = makeAdapter("dm");
+
+		registry.register(dmFirst);
+		registry.register(ownerApp);
+		registry.register(dmSecond);
+
+		// Re-registering "dm" does not move the group: the backing Map keeps
+		// the target's original insertion slot, so dmSecond lands inside the
+		// existing "dm" group rather than after owner_app_inline.
+		expect(registry.list()).toEqual([dmFirst, dmSecond, ownerApp]);
+	});
+});
+
+describe("SensitiveRequestDispatchRegistryService (barrel export)", () => {
+	test("exposes the service class wired to the shared service-name constant", () => {
+		expect(typeof SensitiveRequestDispatchRegistryService).toBe("function");
+		expect(SensitiveRequestDispatchRegistryService.serviceType).toBe(
+			SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE,
+		);
+		expect(SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE).toBe(
+			"SensitiveRequestDispatchRegistry",
+		);
+	});
+
+	test("start yields a usable registry instance", async () => {
+		const service = await SensitiveRequestDispatchRegistryService.start(
+			{} as never,
+		);
+
+		expect(service instanceof SensitiveRequestDispatchRegistryService).toBe(
+			true,
+		);
+
+		const adapter = makeAdapter("dm");
+		service.register(adapter);
+		expect(service.get("dm")).toBe(adapter);
+		expect(service.list()).toEqual([adapter]);
+	});
+
+	test("register, get, resolve, and list delegate to the internal registry", async () => {
+		const service = await SensitiveRequestDispatchRegistryService.start(
+			{} as never,
+		);
+		const declines = makeAdapter("dm", { supportsChannel: () => false });
+		const silent = makeAdapter("dm");
+		service.register(declines);
+		service.register(silent);
+
+		expect(service.get("dm")).toBe(silent);
+		expect(service.resolve("dm", "chan-7", null)).toBe(silent);
+		expect(service.list()).toHaveLength(2);
+	});
+
+	test("stop unregisters every target yet leaves the service reusable", async () => {
+		const service = await SensitiveRequestDispatchRegistryService.start(
+			{} as never,
+		);
+		service.register(makeAdapter("dm"));
+		service.register(makeAdapter("owner_app_inline"));
+
+		await service.stop();
+
+		expect(service.get("dm")).toBeUndefined();
+		expect(service.get("owner_app_inline")).toBeUndefined();
+		expect(service.list()).toHaveLength(0);
+
+		const replacement = makeAdapter("tunnel_authenticated_link");
+		service.register(replacement);
+		expect(service.get("tunnel_authenticated_link")).toBe(replacement);
+	});
+});


### PR DESCRIPTION

## What this adds

`packages/core/src/sensitive-requests/index.ts` had no test file anywhere in the repository. This PR adds a new suite at `packages/core/src/sensitive-requests/index.test.ts` covering the module's public barrel surface and the behavior reachable only through it. The diff touches only that one new test file (+172/-0) — no production code changes.

Coverage, all driving the real module (no mocked subjects):

- **Barrel wiring** — the factory, the service class, and the `SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE` constant are live through `./index`, and the class's `serviceType` matches the shared constant.
- **Empty registry** — `get`, `list`, and `resolve` are empty before anything registers.
- **Resolution semantics** — an adapter with no `supportsChannel` never vetoes (`!== false` contract); `resolve` forwards the requested channel id and runtime to `supportsChannel` by exact identity.
- **Unknown-target unregister** — unregistering a target that was never registered is a no-op that leaves later registration intact.
- **Listing order** — each target keeps its first-insertion position in `list()`; later adapters append within their existing target group rather than reordering it.
- **Service lifecycle** — `start()` yields a usable instance regardless of the runtime argument; register/get/resolve/list delegate to the internal registry; `stop()` unregisters every target yet leaves the service reusable.

The suite records behavior as observed on current develop. One case was corrected during development: re-registering a target does not move its group in `list()`, because the backing Map keeps the key's original insertion slot — the test asserts that actual behavior.

## Verification (fork contributor: hosted CI does not run on this PR)

All counts below were produced locally against develop at `84f1f002a004` immediately before filing:

- `bunx vitest run src/sensitive-requests/index.test.ts` (in packages/core): **Test Files 1 passed (1), Tests 10 passed (10)**.
- `bunx biome check --write src/sensitive-requests/index.test.ts`: clean ("Checked 1 file... No fixes applied"), against the repository's real root config.
- `bunx tsc --noEmit` in `packages/core`: the output contains zero references to `sensitive-requests/index.test`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d0e94dd8ec80aea078dd7d9bb05ad059500c8132 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
