### PR TITLE
test(core): cover activity plaintext duration formatting

### DIFF
--- a/packages/core/src/__tests__/activity-plaintext.test.ts
+++ b/packages/core/src/__tests__/activity-plaintext.test.ts
@@ -291,6 +291,66 @@ describe("activityEventToPlaintext", () => {
 			activityEventToPlaintext({ eventType: "plan", data: { entries: [] } }),
 		).toBeNull();
 	});
+
+	it("formats sub-second and multi-minute durations with precise units", () => {
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "action",
+				payload: { type: "complete", actionName: "BRIEF", duration: 42 },
+			})?.plaintext,
+		).toContain("(42ms)");
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "action",
+				payload: { type: "complete", actionName: "BRIEF", duration: 1500 },
+			})?.plaintext,
+		).toContain("(1.5s)");
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "lifecycle",
+				payload: { type: "run_end", success: true, duration: 90000 },
+			})?.plaintext,
+		).toBe("Run completed (1m 30s)");
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "lifecycle",
+				payload: { type: "run_end", success: true, duration: 60000 },
+			})?.plaintext,
+		).toBe("Run completed (1m 0s)");
+	});
+
+	it("omits duration suffix when payload duration is missing or non-finite", () => {
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "lifecycle",
+				payload: { type: "run_end", success: true },
+			})?.plaintext,
+		).toBe("Run completed");
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "action",
+				payload: {
+					type: "complete",
+					actionName: "BRIEF",
+					duration: Number.NaN,
+					output: {},
+				},
+			})?.plaintext,
+		).not.toContain("(");
+		expect(
+			activityEventToPlaintext({
+				type: "agent_event",
+				stream: "lifecycle",
+				payload: { type: "run_end", success: true, duration: "fast" },
+			})?.plaintext,
+		).toBe("Run completed");
+	});
 });
 
 describe("trajectory plaintext serializers", () => {


### PR DESCRIPTION
# Relates to

N/A - cover duration formatting

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only.

# Background

## What does this PR do?

Adds behavioral coverage for `activityEventToPlaintext` duration formatting in `packages/core/src/__tests__/activity-plaintext.test.ts`: sub-second ms, fractional seconds, multi-minute durations, and missing/non-finite duration handling.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/__tests__/activity-plaintext.test.ts`

## Detailed testing steps

```bash
node packages/scripts/run-vitest.mjs run packages/core/src/__tests__/activity-plaintext.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:50ed4018690b0870e1f0882be5507a68883dfcc2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - verified via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A

## Backend + frontend logs

N/A - verified via unit test: 12 passed (was 10)

## Screenshots (before / after) + video walkthrough

N/A

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
