### PR TITLE
fix(health): use setUTCFullYear in time helpers to preserve years 0-99

### DIFF
--- a/plugins/plugin-health/src/util/time.localdate.test.ts
+++ b/plugins/plugin-health/src/util/time.localdate.test.ts
@@ -177,6 +177,36 @@ describe("local-date arithmetic + keys", () => {
     );
   });
 
+  it("preserves years 0-99 in addDaysToLocalDate without 1900s remapping", () => {
+    expect(addDaysToLocalDate({ year: 24, month: 1, day: 15 }, 1)).toEqual({
+      year: 24,
+      month: 1,
+      day: 16,
+    });
+    expect(addDaysToLocalDate({ year: 0, month: 12, day: 31 }, 1)).toEqual({
+      year: 1,
+      month: 1,
+      day: 1,
+    });
+  });
+
+  it("calculates getWeekdayForLocalDate correctly for years 0-99", () => {
+    // 0024-01-15 is a Monday (1)
+    expect(getWeekdayForLocalDate({ year: 24, month: 1, day: 15 })).toBe(1);
+  });
+
+  it("builds UTC date from local parts preserving years 0-99", () => {
+    const utc = buildUtcDateFromLocalParts("UTC", {
+      year: 24,
+      month: 1,
+      day: 15,
+      hour: 12,
+      minute: 0,
+      second: 0,
+    });
+    expect(utc.getUTCFullYear()).toBe(24);
+  });
+
   it("addMinutes shifts an instant by whole minutes", () => {
     expect(addMinutes(new Date("2026-01-01T00:00:00Z"), 90).toISOString()).toBe(
       "2026-01-01T01:30:00.000Z",

--- a/plugins/plugin-health/src/util/time.ts
+++ b/plugins/plugin-health/src/util/time.ts
@@ -103,14 +103,19 @@ function formatOffsetToken(offsetMinutes: number): string {
 }
 
 function localPartsToEpochMs(parts: ZonedDateParts): number {
-  return Date.UTC(
+  const date = new Date(0);
+  date.setUTCFullYear(
     parts.year,
     parts.month - 1,
     parts.day,
+  );
+  date.setUTCHours(
     parts.hour,
     parts.minute,
     parts.second,
+    0,
   );
+  return date.getTime();
 }
 
 function sameZonedParts(left: ZonedDateParts, right: ZonedDateParts): boolean {
@@ -218,16 +223,13 @@ export function addDaysToLocalDate(
   dateOnly: Pick<ZonedDateParts, "year" | "month" | "day">,
   dayDelta: number,
 ): Pick<ZonedDateParts, "year" | "month" | "day"> {
-  const utcDate = new Date(
-    Date.UTC(
-      dateOnly.year,
-      dateOnly.month - 1,
-      dateOnly.day + dayDelta,
-      12,
-      0,
-      0,
-    ),
+  const utcDate = new Date(0);
+  utcDate.setUTCFullYear(
+    dateOnly.year,
+    dateOnly.month - 1,
+    dateOnly.day + dayDelta,
   );
+  utcDate.setUTCHours(12, 0, 0, 0);
   return {
     year: utcDate.getUTCFullYear(),
     month: utcDate.getUTCMonth() + 1,
@@ -238,9 +240,10 @@ export function addDaysToLocalDate(
 export function getWeekdayForLocalDate(
   dateOnly: Pick<ZonedDateParts, "year" | "month" | "day">,
 ): number {
-  return new Date(
-    Date.UTC(dateOnly.year, dateOnly.month - 1, dateOnly.day, 12, 0, 0),
-  ).getUTCDay();
+  const utcDate = new Date(0);
+  utcDate.setUTCFullYear(dateOnly.year, dateOnly.month - 1, dateOnly.day);
+  utcDate.setUTCHours(12, 0, 0, 0);
+  return utcDate.getUTCDay();
 }
 
 export function getLocalDateKey(


### PR DESCRIPTION
<!-- evidence-head:44dedfff32d2bfe9d49d291dd26a6b7f190968ca -->
## Summary
Fixes `localPartsToEpochMs`, `addDaysToLocalDate`, and `getWeekdayForLocalDate` in `plugins/plugin-health/src/util/time.ts` to construct dates using `new Date(0)` and `setUTCFullYear` rather than passing years directly to `Date.UTC(...)`. JavaScript's `Date.UTC(year, ...)` constructor maps two-digit years `0..99` to `1900..1999`, which silently corrupted date arithmetic and timezone resolution when handling dates with low year values.

## Proposed Changes
- **plugins/plugin-health/src/util/time.ts**: Replace `Date.UTC` invocations in `localPartsToEpochMs`, `addDaysToLocalDate`, and `getWeekdayForLocalDate` with `new Date(0)` and `setUTCFullYear`/`setUTCHours`.
- **plugins/plugin-health/src/util/time.localdate.test.ts**: Add unit tests verifying `addDaysToLocalDate`, `getWeekdayForLocalDate`, and `buildUtcDateFromLocalParts` preserve years `0..99` without remapping to the 1900s.

## Verification
- Run tests: `bun test plugins/plugin-health/src/util/time.localdate.test.ts`
- Biome check: `bunx biome check plugins/plugin-health/src/util/time.ts plugins/plugin-health/src/util/time.localdate.test.ts`

<details>
<summary>Red Test Output (prior to production fix)</summary>

```
error: expect(received).toEqual(expected)

  {
    "day": 16,
    "month": 1,
-   "year": 24,
+   "year": 1924,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/private/tmp/wt-ag-session/plugins/plugin-health/src/util/time.localdate.test.ts:181:68)
(fail) local-date arithmetic + keys > preserves years 0-99 in addDaysToLocalDate without 1900s remapping [0.16ms]
(fail) local-date arithmetic + keys > calculates getWeekdayForLocalDate correctly for years 0-99 [0.04ms]
RangeError: Local date-time cannot be resolved in timezone UTC
(fail) local-date arithmetic + keys > builds UTC date from local parts preserving years 0-99 [0.13ms]
```
</details>

<details>
<summary>Green Test Output (with fix applied)</summary>

```
bun test v1.3.11 (af24e281)

plugins/plugin-health/src/util/time.localdate.test.ts:
(pass) getZonedDateParts > projects a UTC instant into wall-clock parts for the zone
(pass) getTimeZoneOffsetMinutes > returns 0 for UTC and signed minutes elsewhere, DST-aware
(pass) getTimeZoneOffsetMinutes > parses half-hour offsets (Asia/Kolkata = +05:30)
(pass) buildUtcDateFromLocalParts (inverse of getZonedDateParts) > round-trips wall-clock parts back to the correct UTC instant
(pass) buildUtcDateFromLocalParts (inverse of getZonedDateParts) > moves Santiago's skipped midnight forward by the one-hour gap
(pass) buildUtcDateFromLocalParts (inverse of getZonedDateParts) > moves Apia's skipped date forward by the 24-hour gap
(pass) buildUtcDateFromLocalParts (inverse of getZonedDateParts) > chooses the earlier repeat and shifts a skipped clock time forward
(pass) formatInstantAsRfc3339InTimeZone > emits a zoned RFC-3339 string with the correct offset token
(pass) formatInstantAsRfc3339InTimeZone > throws on an invalid datetime rather than emitting NaN
(pass) local-date arithmetic + keys > addDaysToLocalDate rolls across month and year boundaries
(pass) local-date arithmetic + keys > getWeekdayForLocalDate matches UTC day-of-week (epoch = Thursday = 4)
(pass) local-date arithmetic + keys > getLocalDateKey zero-pads to YYYY-MM-DD
(pass) local-date arithmetic + keys > preserves years 0-99 in addDaysToLocalDate without 1900s remapping
(pass) local-date arithmetic + keys > calculates getWeekdayForLocalDate correctly for years 0-99
(pass) local-date arithmetic + keys > builds UTC date from local parts preserving years 0-99
(pass) local-date arithmetic + keys > addMinutes shifts an instant by whole minutes

 16 pass
 0 fail
 27 expect() calls
Ran 16 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.