### PR TITLE
test(discord): cover message-coalesce meta and formatting

### DIFF
--- a/plugins/plugin-discord/__tests__/message-coalesce.test.ts
+++ b/plugins/plugin-discord/__tests__/message-coalesce.test.ts
@@ -5,7 +5,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createChannelDebouncer } from "../debouncer";
 import {
+	formatCoalescedDiscordMessages,
 	getDiscordMessageCoalesceConfig,
+	getDiscordMessageMeta,
 	makeCoalescedDiscordMessage,
 } from "../message-coalesce";
 
@@ -107,6 +109,152 @@ describe("Discord message coalescing", () => {
 		debouncer.enqueue(mockMessage("1", "<@123> compare this with <@456>"));
 		expect(flushed).toHaveLength(1);
 		expect(flushed[0]).toHaveLength(1);
+	});
+});
+
+describe("getDiscordMessageMeta", () => {
+	it("extracts ids and prefers member displayName", () => {
+		const msg = mockMessage("42", "hello world", "author-9");
+		const meta = getDiscordMessageMeta(msg as never);
+		expect(meta.id).toBe("42");
+		expect(meta.channelId).toBe("channel-1");
+		expect(meta.authorId).toBe("author-9");
+		expect(meta.displayName).toBe("Member author-9");
+		expect(meta.username).toBe("user-author-9");
+		expect(meta.contentPreview).toBe("hello world");
+	});
+
+	it("falls back to globalName when member displayName missing", () => {
+		const msg = {
+			id: "1",
+			content: "hi",
+			createdTimestamp: 123,
+			channel: { id: "ch-1" },
+			author: {
+				id: "a-1",
+				username: "uname",
+				globalName: "Global Name",
+				displayName: "Display Name",
+			},
+			member: null,
+		} as never;
+		const meta = getDiscordMessageMeta(msg);
+		expect(meta.displayName).toBe("Global Name");
+	});
+
+	it("falls back to author displayName when globalName missing", () => {
+		const msg = {
+			id: "1",
+			content: "hi",
+			createdTimestamp: 123,
+			channel: { id: "ch-1" },
+			author: { id: "a-1", username: "uname", displayName: "Display Name" },
+			member: undefined,
+		} as never;
+		const meta = getDiscordMessageMeta(msg);
+		expect(meta.displayName).toBe("Display Name");
+	});
+
+	it("falls back to username when all display names missing", () => {
+		const msg = {
+			id: "1",
+			content: "hi",
+			createdTimestamp: 123,
+			channel: { id: "ch-1" },
+			author: { id: "a-1", username: "uname" },
+			member: { displayName: undefined },
+		} as never;
+		const meta = getDiscordMessageMeta(msg);
+		expect(meta.displayName).toBe("uname");
+	});
+
+	it("truncates long contentPreview to 300 without breaking surrogate pairs", () => {
+		const long = "a".repeat(290) + "\uD83D\uDE00".repeat(10);
+		const msg = mockMessage("1", long);
+		const meta = getDiscordMessageMeta(msg as never);
+		expect(meta.contentPreview.length).toBeLessThanOrEqual(300);
+		expect(meta.contentPreview).not.toContain("\uFFFD");
+		const last = meta.contentPreview.codePointAt(
+			meta.contentPreview.length - 1,
+		);
+		expect(last).not.toBe(0xd83d);
+	});
+
+	it("handles missing content as empty string", () => {
+		const msg = {
+			id: "1",
+			content: undefined,
+			createdTimestamp: 123,
+			channel: { id: "ch-1" },
+			author: { id: "a-1", username: "u" },
+			member: null,
+		} as never;
+		const meta = getDiscordMessageMeta(msg);
+		expect(meta.contentPreview).toBe("");
+	});
+
+	it("preserves createdTimestamp and handles missing channel", () => {
+		const msg = {
+			id: "99",
+			content: "x",
+			createdTimestamp: 999999,
+			channel: undefined,
+			author: { id: "a-1", username: "u" },
+			member: null,
+		} as never;
+		const meta = getDiscordMessageMeta(msg);
+		expect(meta.createdTimestamp).toBe(999999);
+		expect(meta.channelId).toBeUndefined();
+	});
+});
+
+describe("formatCoalescedDiscordMessages", () => {
+	it("formats single message with ordinal and content", () => {
+		const msg = mockMessage("7", "single content");
+		const text = formatCoalescedDiscordMessages([msg as never]);
+		expect(text).toContain("[Discord message 1/1 id=7");
+		expect(text).toContain("single content");
+		expect(text).toContain("[/Discord message 1/1 id=7]");
+	});
+
+	it("formats multiple messages with correct ordinals and author labels", () => {
+		const a = mockMessage("10", "first", "alice");
+		const b = mockMessage("20", "second", "bob");
+		const c = mockMessage("30", "third", "carol");
+		const text = formatCoalescedDiscordMessages([
+			a as never,
+			b as never,
+			c as never,
+		]);
+		expect(text).toContain("[Discord message 1/3 id=10 author=Member alice");
+		expect(text).toContain("[Discord message 2/3 id=20 author=Member bob");
+		expect(text).toContain("[Discord message 3/3 id=30 author=Member carol");
+		expect(text).toContain("first");
+		expect(text).toContain("second");
+		expect(text).toContain("third");
+	});
+
+	it("uses unknown for missing ids and handles empty content", () => {
+		const msg = {
+			id: undefined,
+			content: "",
+			createdTimestamp: undefined,
+			channel: undefined,
+			author: { id: undefined, username: undefined },
+			member: null,
+		} as never;
+		const text = formatCoalescedDiscordMessages([msg]);
+		expect(text).toContain("id=unknown");
+		expect(text).toContain("author=unknown");
+		expect(text).toContain("at=unknown");
+	});
+
+	it("preserves surrogate pairs across formatting", () => {
+		const emoji = "\uD83D\uDE00";
+		const msg = mockMessage("1", emoji.repeat(5));
+		const text = formatCoalescedDiscordMessages([msg as never]);
+		expect(text).toContain(emoji);
+		expect(text).not.toContain("\uFFFD");
 	});
 });
 


### PR DESCRIPTION
# Relates to

N/A - behavioral coverage for uncovered Discord coalescing helpers

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change, no production code. Extends canonical suite for pure Discord coalescing helpers with deterministic unit tests.

# Background

## What does this PR do?

Extends `plugins/plugin-discord/__tests__/message-coalesce.test.ts` with missing coverage for `getDiscordMessageMeta` and `formatCoalescedDiscordMessages`: displayName fallback chain, contentPreview truncation with surrogate safety, and formatted output ordinals/metadata. No production code changed.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-discord/__tests__/message-coalesce.test.ts`

## Detailed testing steps

- `bunx vitest run plugins/plugin-discord/__tests__/message-coalesce.test.ts --run` — 18 tests, all green (red 11 pass 7 fail when displayName mutated to broken, green 18 pass after restore)
- `bunx biome check --write` — fixed 1 file (imports)
- `git diff --check` — clean

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3f2783d387703f40993edd3a9de0e786a9fd386a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, plugin unit test`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, plugin unit test`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no user flow, unit test only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend path, pure function test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend, discord util test`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no LLM change, discord coalescing`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact, pure message formatting`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change, discord coalescing

## Backend + frontend logs

N/A - no backend/frontend, pure function test

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, plugin unit test

## Audio / voice walkthrough

N/A - no voice change

## Known gaps / failures

- No pre-existing failures for this suite; `bunx vitest run` passes 18/18, `biome check` clean, `diff --check` clean. Full `bun run verify` shows pre-existing unrelated typecheck failure in `packages/ui/src/components/settings/cloud-model-schema.test.ts` TS18048 — not caused by this file (fixed separately in #27312).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

## Red

```
 11 pass
 7 fail
Ran 18 tests across 1 file.
```

Break: mutated `getDiscordMessageMeta` displayName to "broken", 7 tests failed (displayName fallback chain and format author labels).

## Green

```
 18 pass
 0 fail
Ran 18 tests across 1 file.
```

Restore: 18 pass, 0 fail.

# Checklist

- [x] Rebased onto latest `origin/develop`
- [x] `bun install` verified
- [x] Tests pass (`bunx vitest` 18/18)
- [x] Biome clean
- [x] `git diff --check` clean
- [x] No duplicate test file (extended canonical suite, `git grep` and `gh pr list` checked for `getDiscordMessageMeta`/`formatCoalescedDiscordMessages` — 0 hits before this PR, existing suite extended per hard rule)
- [x] Non-vacuous behavioral tests with fixed vectors and surrogate edge inputs
- [x] Red -> Green demonstrated
