### PR TITLE
fix(agent): handle years 0-99 in describeOnceAt dayDiff calculation

### DIFF
--- a/packages/agent/src/triggers/humanize.test.ts
+++ b/packages/agent/src/triggers/humanize.test.ts
@@ -116,6 +116,21 @@ describe("describeOnceAt", () => {
     );
   });
 
+  it("handles dates with years 0-99 without 1900s dayDiff corruption", () => {
+    // 0099-12-31 to 0100-01-01 (year 99 to 100 transition)
+    const year99Now = new Date(0);
+    year99Now.setUTCFullYear(99, 11, 31);
+    year99Now.setUTCHours(12, 0, 0, 0);
+
+    const year100Tomorrow = new Date(0);
+    year100Tomorrow.setUTCFullYear(100, 0, 1);
+    year100Tomorrow.setUTCHours(12, 0, 0, 0);
+
+    expect(
+      describeOnceAt(year100Tomorrow.toISOString(), year99Now.getTime(), "UTC"),
+    ).toBe("tomorrow at 12pm");
+  });
+
   it("returns null for an unparseable timestamp", () => {
     expect(describeOnceAt("not a timestamp", NOW_MS, TIME_ZONE)).toBeNull();
   });

--- a/packages/agent/src/triggers/humanize.ts
+++ b/packages/agent/src/triggers/humanize.ts
@@ -185,11 +185,11 @@ export function describeOnceAt(
   const at = zonedDateParts(new Date(atMs), timeZone);
   const now = zonedDateParts(new Date(nowMs), timeZone);
   const time = formatClockTime(at.hour, at.minute);
-  const dayDiff = Math.round(
-    (Date.UTC(at.year, at.month - 1, at.day) -
-      Date.UTC(now.year, now.month - 1, now.day)) /
-      DAY_MS,
-  );
+  const atDate = new Date(0);
+  atDate.setUTCFullYear(at.year, at.month - 1, at.day);
+  const nowDate = new Date(0);
+  nowDate.setUTCFullYear(now.year, now.month - 1, now.day);
+  const dayDiff = Math.round((atDate.getTime() - nowDate.getTime()) / DAY_MS);
   if (dayDiff === 0) return `today at ${time}`;
   if (dayDiff === 1) return `tomorrow at ${time}`;
   if (dayDiff > 1 && dayDiff < 7) {


### PR DESCRIPTION
<!-- evidence-head:c82148666fb1de0e69977f3451273c723a24749d -->
## Summary
Fixes the calendar day difference calculation in `describeOnceAt` (`packages/agent/src/triggers/humanize.ts`) to construct date comparison boundaries using `setUTCFullYear` instead of passing `year` directly into `Date.UTC(...)`. Passing years `0..99` to `Date.UTC` remaps them to `1900..1999`, corrupting `dayDiff` (for example, across a century boundary from year 99 to 100).

## Proposed Changes
- **packages/agent/src/triggers/humanize.ts**: In `describeOnceAt`, compute `dayDiff` by setting `setUTCFullYear` on UTC dates initialized with epoch 0.
- **packages/agent/src/triggers/humanize.test.ts**: Add unit test covering century transition / years 0-99 for `describeOnceAt`.

## Verification
- Run tests: `bun test packages/agent/src/triggers/humanize.test.ts`
- Biome check: `bunx biome check packages/agent/src/triggers/humanize.ts packages/agent/src/triggers/humanize.test.ts`

<details>
<summary>Red Test Output (prior to production fix)</summary>

```
130 |       describeOnceAt(
131 |         year100Tomorrow.toISOString(),
132 |         year99Now.getTime(),
133 |         "UTC",
134 |       ),
135 |     ).toBe("tomorrow at 12pm");
            ^
error: expect(received).toBe(expected)

Expected: "tomorrow at 12pm"
Received: "on Jan 1, 100 at 12pm"

      at <anonymous> (/private/tmp/wt-ag-session/packages/agent/src/triggers/humanize.test.ts:135:7)
(fail) describeOnceAt > handles dates with years 0-99 without 1900s dayDiff corruption [0.42ms]
```
</details>

<details>
<summary>Green Test Output (with fix applied)</summary>

```
bun test v1.3.11 (af24e281)

packages/agent/src/triggers/humanize.test.ts:
(pass) describeCronSchedule > maps daily crons onto time-of-day nouns
(pass) describeCronSchedule > describes weekday, weekend, and single-day recurrences
(pass) describeCronSchedule > describes minute/hour and day-of-month shapes
(pass) describeCronSchedule > returns null for shapes outside the reminder vocabulary
(pass) describeOnceAt > renders near-term fires as a countdown
(pass) describeOnceAt > renders same-day, next-day, and same-week fires in the supplied timezone
(pass) describeOnceAt > uses the supplied timezone for calendar-day boundaries
(pass) describeOnceAt > renders far-out fires as dates, with the year only when it differs
(pass) describeOnceAt > handles dates with years 0-99 without 1900s dayDiff corruption
(pass) describeOnceAt > returns null for an unparseable timestamp
(pass) describeIntervalMs > picks the largest evenly-dividing unit
(pass) describeIntervalMs > never emits raw milliseconds
(pass) describeIntervalMs > fails closed on non-finite and non-positive intervals

 13 pass
 0 fail
 45 expect() calls
Ran 13 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.