### PR TITLE
test(ui): cover boot-config-react.hooks

### DIFF
--- a/packages/ui/src/config/boot-config-react.hooks.test.tsx
+++ b/packages/ui/src/config/boot-config-react.hooks.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Unit coverage for the boot-config React surface: AppBootContext's
+ * module-init default, useBootConfig's provider-driven reads and nesting
+ * precedence, live updates when a provider's value changes, and the
+ * context/store split — the hook reads the React context, never the
+ * process-global boot-config store.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppBootContext, useBootConfig } from "./boot-config-react.hooks";
+import {
+  type AppBootConfig,
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "./boot-config-store";
+
+afterEach(cleanup);
+
+const HOST_CONFIG: AppBootConfig = {
+  ...DEFAULT_BOOT_CONFIG,
+  apiBase: "https://host.example/api",
+};
+
+const NESTED_CONFIG: AppBootConfig = {
+  ...DEFAULT_BOOT_CONFIG,
+  apiBase: "https://nested.example/api",
+};
+
+const hostWrapper = ({ children }: { children: ReactNode }) => (
+  <AppBootContext.Provider value={HOST_CONFIG}>
+    {children}
+  </AppBootContext.Provider>
+);
+
+/** Renders the apiBase the hook actually returned so DOM asserts are possible. */
+function Probe() {
+  const config = useBootConfig();
+  return <span data-testid="probe-api-base">{config.apiBase ?? "none"}</span>;
+}
+
+describe("AppBootContext default", () => {
+  it("serves DEFAULT_BOOT_CONFIG to a consumer rendered without a provider", () => {
+    const { result } = renderHook(() => useBootConfig());
+    expect(result.current).toBe(DEFAULT_BOOT_CONFIG);
+  });
+});
+
+describe("useBootConfig", () => {
+  it("returns exactly the value supplied by the nearest enclosing provider", () => {
+    const { result } = renderHook(() => useBootConfig(), {
+      wrapper: hostWrapper,
+    });
+    expect(result.current).toBe(HOST_CONFIG);
+    expect(result.current.apiBase).toBe("https://host.example/api");
+  });
+
+  it("prefers the innermost provider when providers nest", () => {
+    function NestedWrapper({ children }: { children: ReactNode }) {
+      return (
+        <AppBootContext.Provider value={HOST_CONFIG}>
+          <AppBootContext.Provider value={NESTED_CONFIG}>
+            {children}
+          </AppBootContext.Provider>
+        </AppBootContext.Provider>
+      );
+    }
+
+    const { result } = renderHook(() => useBootConfig(), {
+      wrapper: NestedWrapper,
+    });
+    expect(result.current).toBe(NESTED_CONFIG);
+  });
+
+  it("propagates a changed provider value to consumers on rerender", () => {
+    const view = (config: AppBootConfig) => (
+      <AppBootContext.Provider value={config}>
+        <Probe />
+      </AppBootContext.Provider>
+    );
+
+    const { container, rerender } = render(view(HOST_CONFIG));
+    expect(container.textContent).toBe("https://host.example/api");
+
+    rerender(view(NESTED_CONFIG));
+    expect(container.textContent).toBe("https://nested.example/api");
+  });
+
+  it("reads the context, not the process-global boot-config store", () => {
+    const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+    const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+    const slot = globalThis as Record<PropertyKey, unknown>;
+    const resetGlobalStore = () => {
+      delete slot[STORE_KEY];
+      delete slot[WINDOW_KEY];
+    };
+
+    resetGlobalStore();
+    try {
+      // The store is live and points somewhere else entirely.
+      const globalOnly: AppBootConfig = {
+        ...DEFAULT_BOOT_CONFIG,
+        apiBase: "https://global-store.example/api",
+      };
+      setBootConfig(globalOnly);
+      expect(getBootConfig()).toBe(globalOnly);
+
+      // The hook still resolves through the context default: hosts must
+      // publish via <AppBootContext.Provider>, not setBootConfig alone.
+      const { result } = renderHook(() => useBootConfig());
+      expect(result.current).toBe(DEFAULT_BOOT_CONFIG);
+    } finally {
+      resetGlobalStore();
+    }
+  });
+});


### PR DESCRIPTION

## What

Adds a new co-located unit suite `packages/ui/src/config/boot-config-react.hooks.test.tsx` covering the module's full runtime surface. **Test-only change** — no production file is touched (`+119/-0`, single new file).

The module exports two symbols and the suite drives both through their real React behaviour (no mocks):

- **`AppBootContext` default** — a consumer rendered without a provider receives exactly `DEFAULT_BOOT_CONFIG` (identity assert on the module's context default).
- **`useBootConfig` inside a provider** — returns exactly the value supplied by the nearest enclosing `<AppBootContext.Provider>` (identity + field asserts).
- **Nesting precedence** — with providers nested, the innermost value wins.
- **Live propagation** — re-rendering a provider with a new config updates consumers through the hook (asserted on rendered DOM).
- **Context/store split** — even after `setBootConfig()` points the process-global store elsewhere (verified live via `getBootConfig()`), a provider-less `useBootConfig()` still resolves the context default. This pins the design boundary documented in the module header: hosts must publish via the React context, not the global store.

Conventions match the package: jsdom environment opt-in comment, `@testing-library/react` `renderHook`/`render` with `afterEach(cleanup)`, explicit vitest imports (`globals: false`), imports from the sibling modules. No `vi.hoisted` (packages/ui runs under vitest per its `vitest.config.ts`, but avoided regardless), no `expectTypeOf`.

## Verification

Run at head `a6407fa448` (base = current `origin/develop` `f11cedd35e`) immediately before filing:

1. **Tests** — `bunx vitest run src/config/boot-config-react.hooks.test.tsx` from `packages/ui`: **Test Files 1 passed (1), Tests 5 passed (5)** (~0.8s).
2. **Lint** — `bunx biome check --write src/config/boot-config-react.hooks.test.tsx` from `packages/ui`: clean after its initial formatting fix; the committed file is the formatted result.
3. **Types** — `bunx tsc --noEmit` from `packages/ui`: the package reports 10 pre-existing errors in unrelated files (`../core/src/cloud-routing.ts`, other lanes'/contributors' test files such as `src/cloud/mcps/lib/use-mcps.test.tsx`). `grep 'boot-config-react.hooks.test'` over the full tsc output finds **zero matches** — this PR introduces no type errors.
4. **Diff scope** — `git show --stat` at head: exactly one file changed, `packages/ui/src/config/boot-config-react.hooks.test.tsx | 119 +++++++++++++++++++++`, purely additive.

This is a fork contribution, so hosted CI does not run on this PR; the counts above are quoted from real local runs of the exact head commit. No production behaviour changes, so no behavioural-fix evidence procedure applies.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a6407fa448c42b5c423ab116b822adb67387bada -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
