### PR TITLE
fix(cloud): safe non-finite handling and sort stability in analytics-derived

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts
@@ -71,6 +71,17 @@ describe("toDistribution", () => {
   test("returns zero percent for empty input", () => {
     expect(toDistribution({})).toEqual([]);
   });
+
+  test("sorts ties deterministically by key name", () => {
+    const out = toDistribution({ beta: 5, alpha: 5 });
+    expect(out.map((e) => e.key)).toEqual(["alpha", "beta"]);
+  });
+
+  test("handles NaN and non-finite counts safely without corrupting total", () => {
+    const out = toDistribution({ valid: 10, invalid: Number.NaN, negative: -5 });
+    expect(out[0]?.key).toBe("valid");
+    expect(out[0]?.percent).toBe(100);
+  });
 });
 
 describe("toRetentionRates", () => {

--- a/packages/cloud/shared/src/lib/services/analytics-derived.ts
+++ b/packages/cloud/shared/src/lib/services/analytics-derived.ts
@@ -36,12 +36,15 @@ export function deriveCostTrendingFields(
   creditBalance: number,
 ): CostTrendingDerivedFields {
   const balance = Number(creditBalance);
-  const monthlyBurnPercent = balance > 0 ? (costTrending.projectedMonthlyBurn / balance) * 100 : 0;
+  const burn = Number(costTrending?.projectedMonthlyBurn);
+  const safeBurn = Number.isFinite(burn) && burn > 0 ? burn : 0;
+  const safeBalance = Number.isFinite(balance) && balance > 0 ? balance : 0;
+  const monthlyBurnPercent = safeBalance > 0 ? (safeBurn / safeBalance) * 100 : 0;
   return {
     monthlyBurnPercent: round1dp(monthlyBurnPercent),
-    monthlyBurnPercentClamped: round1dp(Math.min(100, monthlyBurnPercent)),
+    monthlyBurnPercentClamped: round1dp(Math.min(100, Math.max(0, monthlyBurnPercent))),
     burnAlertThresholdExceeded:
-      costTrending.projectedMonthlyBurn > balance * PROJECTED_BURN_ALERT_RATIO,
+      safeBalance > 0 ? safeBurn > safeBalance * PROJECTED_BURN_ALERT_RATIO : safeBurn > 0,
   };
 }
 
@@ -49,15 +52,23 @@ export function deriveCostTrendingFields(
  * Convert a 0..1 success rate to a 0..100 percent value rounded to one decimal.
  */
 export function toSuccessRatePercent(rate: number): number {
+  if (!Number.isFinite(rate) || rate <= 0) return 0;
   return round1dp(rate * 100);
 }
 
 /**
  * Compute `(numerator / denominator) * 100` rounded to one decimal.
- * Returns 0 when `denominator <= 0` so callers never divide by zero.
+ * Returns 0 when `denominator <= 0` or inputs are non-finite so callers never divide by zero.
  */
 export function toRatePercent(numerator: number, denominator: number): number {
-  if (denominator <= 0) return 0;
+  if (
+    !Number.isFinite(numerator) ||
+    !Number.isFinite(denominator) ||
+    denominator <= 0 ||
+    numerator <= 0
+  ) {
+    return 0;
+  }
   return round1dp((numerator / denominator) * 100);
 }
 
@@ -73,9 +84,16 @@ export interface DistributionEntry {
  * percentages of the total.
  */
 export function toDistribution(counts: Record<string, number>): DistributionEntry[] {
-  const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
-  return Object.entries(counts)
-    .sort(([, a], [, b]) => b - a)
+  const validEntries: [string, number][] = Object.entries(counts).map(([k, v]) => [
+    k,
+    Number.isFinite(v) && v > 0 ? v : 0,
+  ]);
+  const total = validEntries.reduce((sum, [, n]) => sum + n, 0);
+  return validEntries
+    .sort(([keyA, a], [keyB, b]) => {
+      const diff = b - a;
+      return diff !== 0 ? diff : keyA.localeCompare(keyB);
+    })
     .map(([key, count]) => ({
       key,
       count,
@@ -93,8 +111,15 @@ export interface RetentionRatePoint {
 }
 
 function toRetentionPercent(retained: number | null, cohortSize: number): number | null {
-  if (retained === null || cohortSize <= 0) return null;
-  return round1dp((retained / cohortSize) * 100);
+  if (
+    retained === null ||
+    !Number.isFinite(retained) ||
+    !Number.isFinite(cohortSize) ||
+    cohortSize <= 0
+  ) {
+    return null;
+  }
+  return round1dp((Math.max(0, retained) / cohortSize) * 100);
 }
 
 export interface RetentionCohortInput {


### PR DESCRIPTION
<!-- evidence-head:9193efc1e48dfcb5dc57a165bff3084b66233eb5 -->
## Summary
Hardens analytics presentation derivation helpers in `packages/cloud/shared/src/lib/services/analytics-derived.ts` against NaN and non-finite numeric inputs, and adds deterministic key-based tiebreaking to `toDistribution`.

## Proposed Changes
- **packages/cloud/shared/src/lib/services/analytics-derived.ts**:
  - `deriveCostTrendingFields`: Validate `projectedMonthlyBurn` and `creditBalance` with `Number.isFinite` and clamp to non-negative numbers.
  - `toSuccessRatePercent` and `toRatePercent`: Guard against `NaN`/non-finite values to prevent `NaN` leakage.
  - `toDistribution`: Sanitize non-finite/negative counts before summing total, and add deterministic secondary sorting by `key.localeCompare` on count ties.
  - `toRetentionPercent`: Guard against non-finite inputs.
- **packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts**: Add unit tests for non-finite inputs and deterministic tiebreak ordering.

## Verification
- Run tests: `bun test packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts`
- Biome check: `bunx biome check packages/cloud/shared/src/lib/services/analytics-derived.ts packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts`

<details>
<summary>Red Test Output (prior to production fix)</summary>

```
error: expect(received).toEqual(expected)

  [
-   "alpha",
    "beta",
+   "alpha",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/private/tmp/wt-ag-session/packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts:77:35)
(fail) toDistribution > sorts ties deterministically by key name [0.15ms]
(fail) toDistribution > handles NaN and non-finite counts safely without corrupting total [0.14ms]
```
</details>

<details>
<summary>Green Test Output (with fix applied)</summary>

```
bun test v1.3.11 (af24e281)

packages/cloud/shared/src/lib/services/__tests__/analytics-derived.test.ts:
(pass) deriveCostTrendingFields > returns zero when balance is zero
(pass) deriveCostTrendingFields > rounds percent to one decimal place
(pass) deriveCostTrendingFields > clamps progress percent to 100
(pass) deriveCostTrendingFields > burnAlertThresholdExceeded triggers at >80% of balance
(pass) toSuccessRatePercent > converts rate to percent rounded to 1dp
(pass) toRatePercent > computes percent of denominator
(pass) toRatePercent > returns zero when denominator is zero
(pass) toRatePercent > rounds to one decimal place
(pass) toDistribution > sorts by count desc and computes percents
(pass) toDistribution > returns zero percent for empty input
(pass) toDistribution > sorts ties deterministically by key name
(pass) toDistribution > handles NaN and non-finite counts safely without corrupting total
(pass) toRetentionRates > computes per-day retention percents and skips null retained
(pass) toRetentionRates > returns null retention when cohort size is zero

 14 pass
 0 fail
 28 expect() calls
Ran 14 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.