### PR TITLE
test(ui): cover branding-react.hooks

### DIFF
--- a/packages/ui/src/config/branding-react.hooks.test.tsx
+++ b/packages/ui/src/config/branding-react.hooks.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Unit coverage for the React branding surface: `BrandingContext` defaults and
+ * the `useBranding()` fallback contract. Real React rendering via
+ * @testing-library/react under jsdom — no mocks.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { type PropsWithChildren, useContext } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { type BrandingConfig, DEFAULT_BRANDING } from "./branding-base";
+import { BrandingContext, useBranding } from "./branding-react.hooks";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeBranding(overrides: Partial<BrandingConfig>): BrandingConfig {
+  return {
+    ...DEFAULT_BRANDING,
+    ...overrides,
+    appName: overrides.appName ?? "TestApp",
+  };
+}
+
+describe("useBranding", () => {
+  it("falls back to the module-level DEFAULT_BRANDING object when no provider is mounted", () => {
+    const { result } = renderHook(() => useBranding());
+
+    // Reference identity: the `??` branch hands back the imported constant
+    // itself, so consumers share one frozen default rather than copies.
+    expect(result.current).toBe(DEFAULT_BRANDING);
+    expect(result.current.appName).toBe("Eliza");
+  });
+
+  it("returns the provider value by reference when a provider is mounted", () => {
+    const provided = makeBranding({ hashtag: "#TestAgent" });
+
+    const { result } = renderHook(() => useBranding(), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <BrandingContext.Provider value={provided}>
+          {children}
+        </BrandingContext.Provider>
+      ),
+    });
+
+    expect(result.current).toBe(provided);
+    expect(result.current.hashtag).toBe("#TestAgent");
+  });
+
+  it("prefers a non-default provider value over DEFAULT_BRANDING", () => {
+    const provided = makeBranding({
+      orgName: "acme",
+      repoName: "fork",
+      docsUrl: "https://docs.acme.example",
+      cloudOnly: true,
+    });
+
+    const { result } = renderHook(() => useBranding(), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <BrandingContext.Provider value={provided}>
+          {children}
+        </BrandingContext.Provider>
+      ),
+    });
+
+    expect(result.current.orgName).toBe("acme");
+    expect(result.current.repoName).toBe("fork");
+    expect(result.current.docsUrl).toBe("https://docs.acme.example");
+    expect(result.current.cloudOnly).toBe(true);
+  });
+
+  it("tracks provider value changes across rerenders", () => {
+    const first = makeBranding({ fileExtension: ".first-agent" });
+    const second = makeBranding({ fileExtension: ".second-agent" });
+    let provided = first;
+    const { result, rerender } = renderHook(() => useBranding(), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <BrandingContext.Provider value={provided}>
+          {children}
+        </BrandingContext.Provider>
+      ),
+    });
+
+    expect(result.current).toBe(first);
+    expect(result.current.fileExtension).toBe(".first-agent");
+
+    provided = second;
+    rerender();
+
+    expect(result.current).toBe(second);
+    expect(result.current.fileExtension).toBe(".second-agent");
+  });
+
+  it("resolves through the innermost of nested providers", () => {
+    const outer = makeBranding({ packageScope: "outer" });
+    const inner = makeBranding({ packageScope: "inner" });
+
+    const { result } = renderHook(() => useBranding(), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <BrandingContext.Provider value={outer}>
+          <BrandingContext.Provider value={inner}>
+            {children}
+          </BrandingContext.Provider>
+        </BrandingContext.Provider>
+      ),
+    });
+
+    expect(result.current.packageScope).toBe("inner");
+  });
+});
+
+describe("BrandingContext", () => {
+  it("defaults to undefined so useBranding's fallback branch is what serves DEFAULT_BRANDING", () => {
+    const { result } = renderHook(() => useContext(BrandingContext));
+
+    expect(result.current).toBeUndefined();
+  });
+});


### PR DESCRIPTION

Adds a new co-located unit suite for `packages/ui/src/config/branding-react.hooks.ts`, which previously had no same-named test anywhere in the repo.

## What is covered

The suite drives the real module through real React rendering (`@testing-library/react` `renderHook` under jsdom) — no mocks:

- **`useBranding()` with no provider** returns the module-level `DEFAULT_BRANDING` constant by reference (the `??` fallback branch hands back the imported object itself, not a copy).
- **`useBranding()` inside a provider** returns the provided `BrandingConfig` by reference and reads its fields.
- **A non-default provider value wins over `DEFAULT_BRANDING`** for every overridden field, including optional ones (`cloudOnly`).
- **Provider value changes propagate across rerenders**: the hook result tracks first → second provider objects by reference.
- **Nested providers resolve to the innermost value**, matching React context semantics through this hook.
- **`BrandingContext` defaults to `undefined`** — pinning that it is specifically the hook's fallback branch (not a context default) that serves `DEFAULT_BRANDING`.

## Evidence

- `bunx vitest run src/config/branding-react.hooks.test.tsx` in `packages/ui`: **1 test file passed, 6/6 tests passed** (re-run immediately before filing against current `origin/develop`; the target module is byte-identical between the branch base and current develop).
- `bunx biome check --write src/config/branding-react.hooks.test.tsx`: clean ("No fixes applied") against the repo's pinned Biome config.
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output (no type errors introduced by this diff).
- The diff is one new file, +119/−0. No existing suite existed for this module on current `origin/develop`, so nothing was rewritten or deleted.

This PR changes no production behavior; it only adds tests. As a fork contribution, hosted CI does not run on this PR; the counts above are from local runs of the real commands.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:914d54c779c20c535d513aa010e2016c34c54983 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
