### PR TITLE
fix(plugin-finances): preserve years 0-99 in normalizeDate via setUTCFullYear

### DIFF
--- a/plugins/plugin-finances/src/payment-csv-import.test.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.test.ts
@@ -542,4 +542,11 @@ describe("parseTransactionsCsv", () => {
     expect(r.transactions).toEqual([]);
     expect(r.errors).toContain("CSV has no data rows.");
   });
+
+  it("preserves years 0-99 in date-only text without 1900s remapping", () => {
+    const csv = "Date,Amount,Merchant\n0024-01-15,-10,Coffee\n";
+    const r = parseTransactionsCsv(csv);
+    expect(r.transactions).toHaveLength(1);
+    expect(r.transactions[0]?.postedAt.startsWith("0024-01-15")).toBe(true);
+  });
 });

--- a/plugins/plugin-finances/src/payment-csv-import.ts
+++ b/plugins/plugin-finances/src/payment-csv-import.ts
@@ -288,9 +288,10 @@ function normalizeDate(raw: string): string | null {
     return new Date(native).toISOString();
   }
   const local = new Date(native);
-  return new Date(
-    Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()),
-  ).toISOString();
+  const utc = new Date(0);
+  utc.setUTCHours(0, 0, 0, 0);
+  utc.setUTCFullYear(local.getFullYear(), local.getMonth(), local.getDate());
+  return utc.toISOString();
 }
 
 export interface ParsedCsvTransaction


### PR DESCRIPTION
<!-- evidence-head:fcd56c4221c9e234a04c0ef479a00c469d4a6a07 -->
## Summary
Fixes `normalizeDate` in `plugins/plugin-finances/src/payment-csv-import.ts` to construct UTC dates using `setUTCFullYear` instead of passing `local.getFullYear()` directly to `Date.UTC(...)`, ensuring consistency with `utcMidnightIsoOrNull` and preventing years `0..99` from remapping to `1900..1999`.

## Proposed Changes
- **plugins/plugin-finances/src/payment-csv-import.ts**: Use `new Date(0)` and `setUTCFullYear` in the date-only fallback branch of `normalizeDate`.
- **plugins/plugin-finances/src/payment-csv-import.test.ts**: Add unit test verifying that four-digit low years (`0024`) are preserved without 1900s remapping.

## Verification
- Run tests: `bun test plugins/plugin-finances/src/payment-csv-import.test.ts`
- Biome check: `bunx biome check plugins/plugin-finances/src/payment-csv-import.ts plugins/plugin-finances/src/payment-csv-import.test.ts`

<details>
<summary>Green Test Output (with fix applied)</summary>

```
bun test v1.3.11 (af24e281)

plugins/plugin-finances/src/payment-csv-import.test.ts:
(pass) parseCsv (RFC 4180) > splits simple rows and trims empties
(pass) parseCsv (RFC 4180) > handles quoted fields with embedded commas and escaped quotes
(pass) parseCsv (RFC 4180) > handles CRLF and a quoted embedded newline
(pass) parseTransactionsCsv > parses a canonical single-amount statement
(pass) parseTransactionsCsv > supports separate debit/credit columns and accounting negatives
(pass) parseTransactionsCsv > routes 'Amount Debit'/'Amount Credit' headers through the separate debit/credit path
(pass) parseTransactionsCsv > keeps a credit-only 'Amount Credit' row instead of dropping it
(pass) parseTransactionsCsv > still classifies a single 'Amount' column by sign after the fix
(pass) parseTransactionsCsv > honors an explicit amountColumn even when it matches a debit hint
(pass) parseTransactionsCsv > treats a single 'Debit/Credit Amount' column as a signed amount
(pass) parseTransactionsCsv > treats a single 'Credit Card Amount' column as a signed amount
(pass) parseTransactionsCsv > treats a single 'Debit/Credit' column (no 'amount' hint) as a signed amount
(pass) parseTransactionsCsv > treats a lone 'Amount Debit' column as one-sided debit, not signed
(pass) parseTransactionsCsv > treats a lone 'Debit Amount' column as one-sided debit
(pass) parseTransactionsCsv > treats a lone 'Withdrawal Amount' column as one-sided debit
(pass) parseTransactionsCsv > treats a lone 'Amount Credit' column as one-sided credit
(pass) parseTransactionsCsv > treats a lone 'Deposit Amount' column as one-sided credit
(pass) parseTransactionsCsv > treats one-sided directional columns with descriptive amount tokens as one-sided, not signed
(pass) parseTransactionsCsv > keeps 'Credit Card Amount'/'Debit Card Amount' compound descriptors as signed
(pass) parseTransactionsCsv > classifies a card descriptor with adversarial separator whitespace
(pass) parseTransactionsCsv > preserves an explicit direction outside a card descriptor
(pass) parseTransactionsCsv > normalizes US-format and 2-digit-year dates to a 2026 calendar date
(pass) parseTransactionsCsv > timezone-deterministic date normalization > parses MM/DD/YYYY and ISO date-only values to the same UTC midnight
(pass) parseTransactionsCsv > timezone-deterministic date normalization > keeps mixed-format rows for the same day on one UTC base
(pass) parseTransactionsCsv > timezone-deterministic date normalization > preserves native semantics for datetimes carrying Z or an offset
(pass) parseTransactionsCsv > timezone-deterministic date normalization > preserves explicit zones on date-only RFC spellings
(pass) parseTransactionsCsv > timezone-deterministic date normalization > still rejects unparseable dates
(pass) parseTransactionsCsv > timezone-deterministic date normalization > rejects an out-of-range month/day instead of letting Date.UTC roll it into a different date
(pass) parseTransactionsCsv > timezone-deterministic date normalization > still accepts real calendar-edge dates
(pass) parseTransactionsCsv > timezone-deterministic date normalization > yields a stable transaction-id key for a re-imported row
(pass) parseTransactionsCsv > strips currency symbols and thousands separators
(pass) parseTransactionsCsv > honors explicit column option overrides
(pass) parseTransactionsCsv > reports per-row errors and skips bad rows without aborting
(pass) parseTransactionsCsv > reports missing required columns in the header
(pass) parseTransactionsCsv > early-returns when amount column is missing without generating redundant row errors
(pass) parseTransactionsCsv > flags a CSV with no data rows
(pass) parseTransactionsCsv > preserves years 0-99 in date-only text without 1900s remapping

 37 pass
 0 fail
 217 expect() calls
Ran 37 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.