### PR TITLE
fix(core): aggregate context routing signal scores per context to prevent duplicate secondary contexts

### DIFF
--- a/packages/core/src/utils/context-routing.test.ts
+++ b/packages/core/src/utils/context-routing.test.ts
@@ -94,6 +94,18 @@ describe("inferContextRoutingFromText", () => {
 		).toBe("general");
 		expect(inferContextRoutingFromText("").primaryContext).toBe("general");
 	});
+
+	it("aggregates signal scores per context without duplicating secondary contexts", () => {
+		// "catalog app" and "install plugin" match two distinct patterns under "connectors".
+		const result = inferContextRoutingFromText(
+			"launch catalog app and install plugin",
+		);
+		expect(result.primaryContext).toBe("connectors");
+		expect(result.secondaryContexts).not.toContain("connectors");
+		expect(new Set(result.secondaryContexts).size).toBe(
+			result.secondaryContexts?.length ?? 0,
+		);
+	});
 });
 
 describe("mergeContextRouting", () => {

--- a/packages/core/src/utils/context-routing.test.ts
+++ b/packages/core/src/utils/context-routing.test.ts
@@ -106,6 +106,21 @@ describe("inferContextRoutingFromText", () => {
 			result.secondaryContexts?.length ?? 0,
 		);
 	});
+
+	it("preserves declared context priority when aggregate scores tie", () => {
+		expect(inferContextRoutingFromText("install plugin")).toMatchObject({
+			primaryContext: "connectors",
+			secondaryContexts: ["admin"],
+		});
+		expect(inferContextRoutingFromText("discord settings")).toMatchObject({
+			primaryContext: "connectors",
+			secondaryContexts: ["admin", "settings"],
+		});
+		expect(inferContextRoutingFromText("voice")).toMatchObject({
+			primaryContext: "settings",
+			secondaryContexts: ["media"],
+		});
+	});
 });
 
 describe("mergeContextRouting", () => {

--- a/packages/core/src/utils/context-routing.ts
+++ b/packages/core/src/utils/context-routing.ts
@@ -449,12 +449,10 @@ export function inferContextRoutingFromText(
 
 	const scored = Array.from(contextScores.entries())
 		.map(([context, score]) => ({ context, score }))
-		.sort((left, right) => {
-			const diff = right.score - left.score;
-			return diff !== 0
-				? diff
-				: `${left.context}`.localeCompare(`${right.context}`);
-		});
+		// Map insertion follows CONTEXT_SIGNALS declaration order, and modern
+		// Array.sort is stable. Score-only sorting therefore preserves the
+		// established routing priority when multiple contexts tie.
+		.sort((left, right) => right.score - left.score);
 
 	const primaryContext = scored[0].context;
 	const secondaryContexts = scored

--- a/packages/core/src/utils/context-routing.ts
+++ b/packages/core/src/utils/context-routing.ts
@@ -429,19 +429,32 @@ export function inferContextRoutingFromText(
 		return { primaryContext: "general", secondaryContexts: [] };
 	}
 
-	const scored = CONTEXT_SIGNALS.map((signal) => ({
-		context: signal.context,
-		score: signal.patterns.reduce(
+	const contextScores = new Map<AgentContext, number>();
+	for (const signal of CONTEXT_SIGNALS) {
+		const matchCount = signal.patterns.reduce(
 			(score, pattern) => score + (pattern.test(normalized) ? 1 : 0),
 			0,
-		),
-	}))
-		.filter((entry) => entry.score > 0)
-		.sort((left, right) => right.score - left.score);
+		);
+		if (matchCount > 0) {
+			contextScores.set(
+				signal.context,
+				(contextScores.get(signal.context) ?? 0) + matchCount,
+			);
+		}
+	}
 
-	if (scored.length === 0) {
+	if (contextScores.size === 0) {
 		return { primaryContext: "general", secondaryContexts: [] };
 	}
+
+	const scored = Array.from(contextScores.entries())
+		.map(([context, score]) => ({ context, score }))
+		.sort((left, right) => {
+			const diff = right.score - left.score;
+			return diff !== 0
+				? diff
+				: `${left.context}`.localeCompare(`${right.context}`);
+		});
 
 	const primaryContext = scored[0].context;
 	const secondaryContexts = scored


### PR DESCRIPTION
<!-- evidence-head:8f282199a533f9fe65557b8396d3152617e3afee -->
## Summary
Fixes `inferContextRoutingFromText` in `packages/core/src/utils/context-routing.ts` to aggregate pattern match scores across all signal definitions for a given context before ranking. Previously, because `CONTEXT_SIGNALS` defines multiple entry objects for certain contexts (e.g. `connectors`, `messaging`, `settings`), matching patterns across multiple entries produced duplicate scored entries for the same context. This caused `secondaryContexts` to contain the `primaryContext` or redundant entries.

## Proposed Changes
- **packages/core/src/utils/context-routing.ts**: Accumulate signal match scores into a `Map<AgentContext, number>` before sorting and selecting `primaryContext` and `secondaryContexts`, with deterministic tie-breaking.
- **packages/core/src/utils/context-routing.test.ts**: Add unit test verifying that multi-signal matches under the same context produce unique contexts without self-containment in `secondaryContexts`.

## Verification
- Run tests: `bun test packages/core/src/utils/context-routing.test.ts`
- Biome check: `bunx biome check packages/core/src/utils/context-routing.ts packages/core/src/utils/context-routing.test.ts`

<details>
<summary>Red Test Output (prior to production fix)</summary>

```
error: expect(received).not.toContain(expected)

Expected to not contain: "connectors"
Received: [ "connectors", "admin" ]

      at <anonymous> (/private/tmp/wt-ag-session/packages/core/src/utils/context-routing.test.ts:104:40)
(fail) inferContextRoutingFromText > aggregates signal scores per context without duplicating secondary contexts [0.26ms]
```
</details>

<details>
<summary>Green Test Output (with fix applied)</summary>

```
bun test v1.3.11 (af24e281)

packages/core/src/utils/context-routing.test.ts:
(pass) routingContextsOverlap > is true only when the two sets share a context (case-insensitive)
(pass) shouldIncludeByContext > includes when declared or active is empty (permissive default)
(pass) shouldIncludeByContext > otherwise requires an overlap
(pass) getActiveRoutingContexts > adds general alongside primary + secondary, empty for an empty decision
(pass) deriveAvailableContexts > collects declared action contexts, always includes general, sorted
(pass) inferContextRoutingFromText > infers code intent from repo/fix language
(pass) inferContextRoutingFromText > infers browser intent from navigation language
(pass) inferContextRoutingFromText > falls back to general for chit-chat / empty
(pass) inferContextRoutingFromText > aggregates signal scores per context without duplicating secondary contexts
(pass) mergeContextRouting > demotes losing primary into secondaries instead of dropping (app-path: state knowledge, message general)
(pass) mergeContextRouting > keeps message primary precedence (knowledge vs documents)
(pass) mergeContextRouting > mixed documents + knowledge routing stays permissive (both visible, pins documents clause)
(pass) mergeContextRouting > knowledge-only routing blocks mutations but allows read-only
(pass) mergeContextRouting > no behavior change when only state has routing
(pass) mergeContextRouting > no behavior change when only message has routing
(pass) mergeContextRouting > existing message-routed shape still works (no state routing)
(pass) mergeContextRouting > deduplicates losing primary if already in secondaries

 17 pass
 0 fail
 40 expect() calls
Ran 17 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.