### PR TITLE
test(core): cover http-helpers JSON response and error methods

### DIFF
--- a/packages/core/src/api/http-helpers.test.ts
+++ b/packages/core/src/api/http-helpers.test.ts
@@ -5,7 +5,16 @@
 import http from "node:http";
 import { describe, expect, it } from "vitest";
 import { ElizaError } from "../errors.js";
-import { readJsonBody, readRequestBodyBuffer } from "./http-helpers.js";
+import {
+	isJsonObjectBody,
+	readJsonBody,
+	readRequestBody,
+	readRequestBodyBuffer,
+	sendJson,
+	sendJsonError,
+	writeJsonError,
+	writeJsonResponse,
+} from "./http-helpers.js";
 
 interface IncomingRequestResult<T> {
 	inspection: T;
@@ -142,5 +151,95 @@ describe("readRequestBodyBuffer", () => {
 		expect(outcome.responseBody).toBe(
 			JSON.stringify({ error: "Request body exceeds this route's limit" }),
 		);
+	});
+});
+
+describe("isJsonObjectBody", () => {
+	it("returns true for plain objects and false for arrays, null, or primitives", () => {
+		expect(isJsonObjectBody({ key: "val" })).toBe(true);
+		expect(isJsonObjectBody({})).toBe(true);
+		expect(isJsonObjectBody([])).toBe(false);
+		expect(isJsonObjectBody([1, 2, 3])).toBe(false);
+		expect(isJsonObjectBody(null)).toBe(false);
+		expect(isJsonObjectBody(undefined)).toBe(false);
+		expect(isJsonObjectBody("string")).toBe(false);
+		expect(isJsonObjectBody(123)).toBe(false);
+	});
+});
+
+describe("writeJsonResponse and writeJsonError", () => {
+	it("writes JSON payload and headers correctly", async () => {
+		const outcome = await withIncomingRequest("", async (_req, res) => {
+			await writeJsonResponse(res, { status: "ok" }, 201);
+		});
+
+		expect(outcome.status).toBe(201);
+		expect(outcome.responseBody).toBe(JSON.stringify({ status: "ok" }));
+	});
+
+	it("writes structured error payload and default status 400", async () => {
+		const outcome = await withIncomingRequest("", async (_req, res) => {
+			await writeJsonError(res, "Bad request", 400);
+		});
+
+		expect(outcome.status).toBe(400);
+		expect(outcome.responseBody).toBe(JSON.stringify({ error: "Bad request" }));
+	});
+
+	it("sendJson and sendJsonError fire-and-forget responders write responses safely", async () => {
+		const outcomeSuccess = await withIncomingRequest("", async (_req, res) => {
+			sendJson(res, { ack: true }, 200);
+		});
+		expect(outcomeSuccess.status).toBe(200);
+		expect(outcomeSuccess.responseBody).toBe(JSON.stringify({ ack: true }));
+
+		const outcomeError = await withIncomingRequest("", async (_req, res) => {
+			sendJsonError(res, "Forbidden", 403);
+		});
+		expect(outcomeError.status).toBe(403);
+		expect(outcomeError.responseBody).toBe(
+			JSON.stringify({ error: "Forbidden" }),
+		);
+	});
+});
+
+describe("readRequestBody and readJsonBody error handling", () => {
+	it("readRequestBody returns string body text", async () => {
+		const outcome = await withIncomingRequest("hello world", async (req) =>
+			readRequestBody(req),
+		);
+		expect(outcome.inspection).toBe("hello world");
+	});
+
+	it("readJsonBody handles malformed JSON and writes 400 parse error response", async () => {
+		const outcome = await withIncomingRequest(
+			"not-json-at-all",
+			async (req, res) => readJsonBody(req, res),
+		);
+		expect(outcome.inspection).toBeNull();
+		expect(outcome.status).toBe(400);
+		expect(outcome.responseBody).toBe(
+			JSON.stringify({ error: "Invalid JSON in request body" }),
+		);
+	});
+
+	it("readJsonBody rejects non-object JSON when requireObject is true", async () => {
+		const outcome = await withIncomingRequest(
+			'["array","item"]',
+			async (req, res) => readJsonBody(req, res, { requireObject: true }),
+		);
+		expect(outcome.inspection).toBeNull();
+		expect(outcome.status).toBe(400);
+		expect(outcome.responseBody).toBe(
+			JSON.stringify({ error: "Request body must be a JSON object" }),
+		);
+	});
+
+	it("readJsonBody permits array JSON when requireObject is false", async () => {
+		const outcome = await withIncomingRequest(
+			'["item1","item2"]',
+			async (req, res) => readJsonBody(req, res, { requireObject: false }),
+		);
+		expect(outcome.inspection).toEqual(["item1", "item2"]);
 	});
 });


### PR DESCRIPTION
<!-- evidence-head:3ae232f2d80719b35f84529166c9ba21ee9a4ff5 -->
## Summary
Adds unit test coverage in `packages/core/src/api/http-helpers.test.ts` for HTTP response methods (`writeJsonResponse`, `writeJsonError`, `sendJson`, `sendJsonError`), predicate `isJsonObjectBody`, text body reader `readRequestBody`, and `readJsonBody` error/array parsing branches.

## Proposed Changes
- **packages/core/src/api/http-helpers.test.ts**:
  - Test `isJsonObjectBody` against plain objects, arrays, null, undefined, and primitive values.
  - Test `writeJsonResponse` and `writeJsonError` with real Node server/response streams.
  - Test `sendJson` and `sendJsonError` safe fire-and-forget responders.
  - Test `readRequestBody` string body extraction.
  - Test `readJsonBody` handling of malformed JSON syntax (400 parse error response), non-object body rejection when `requireObject: true`, and array acceptance when `requireObject: false`.

## Verification
- Run tests: `bun test packages/core/src/api/http-helpers.test.ts`
- Biome check: `bunx biome check packages/core/src/api/http-helpers.test.ts`

<details>
<summary>Test Output</summary>

```
bun test v1.3.11 (af24e281)

packages/core/src/api/http-helpers.test.ts:
(pass) readRequestBodyBuffer > rejects a cached body that exceeds a later reader's byte budget without rewriting it
(pass) readRequestBodyBuffer > returns null for an oversized cached body only when explicitly requested
(pass) readRequestBodyBuffer > uses the same typed rejection for a first read over budget
(pass) readRequestBodyBuffer > rechecks a cached JSON body's byte budget before returning parsed data
(pass) isJsonObjectBody > returns true for plain objects and false for arrays, null, or primitives
(pass) writeJsonResponse and writeJsonError > writes JSON payload and headers correctly
(pass) writeJsonResponse and writeJsonError > writes structured error payload and default status 400
(pass) writeJsonResponse and writeJsonError > sendJson and sendJsonError fire-and-forget responders write responses safely
(pass) readRequestBody and readJsonBody error handling > readRequestBody returns string body text
(pass) readRequestBody and readJsonBody error handling > readJsonBody handles malformed JSON and writes 400 parse error response
(pass) readRequestBody and readJsonBody error handling > readJsonBody rejects non-object JSON when requireObject is true
(pass) readRequestBody and readJsonBody error handling > readJsonBody permits array JSON when requireObject is false

 12 pass
 0 fail
 36 expect() calls
Ran 12 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.