### PR TITLE
test(ui): cover branding

### DIFF
--- a/packages/ui/src/config/branding.test.ts
+++ b/packages/ui/src/config/branding.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit coverage for the branding barrel: every runtime symbol a consumer
+ * reaches through `config/branding` must be the same binding as its owning
+ * module, and the branding-base values it exposes keep their pinned defaults
+ * and interpolation fallbacks. Deterministic pure data; no mocks.
+ */
+
+import { EXTERNAL_URLS } from "@elizaos/shared/brand";
+import { describe, expect, it } from "vitest";
+import * as barrel from "./branding";
+import type { BrandingConfig } from "./branding-base";
+import {
+  appNameInterpolationVars,
+  DEFAULT_APP_DISPLAY_NAME,
+  DEFAULT_BRANDING,
+} from "./branding-base";
+import { BrandingContext, useBranding } from "./branding-react.hooks";
+
+describe("config/branding barrel", () => {
+  it("re-exports each branding-base runtime binding by identity, not copy", () => {
+    expect(barrel.DEFAULT_APP_DISPLAY_NAME).toBe(DEFAULT_APP_DISPLAY_NAME);
+    expect(barrel.DEFAULT_BRANDING).toBe(DEFAULT_BRANDING);
+    expect(barrel.appNameInterpolationVars).toBe(appNameInterpolationVars);
+  });
+
+  it("re-exports the React context and hook by identity so provider trees and consumers share one context object", () => {
+    expect(barrel.BrandingContext).toBe(BrandingContext);
+    expect(barrel.useBranding).toBe(useBranding);
+  });
+});
+
+describe("appNameInterpolationVars", () => {
+  it("returns the configured appName verbatim for a normal name", () => {
+    const branding = { ...DEFAULT_BRANDING, appName: "Aurora" };
+    expect(appNameInterpolationVars(branding)).toEqual({ appName: "Aurora" });
+  });
+
+  it("trims surrounding whitespace instead of interpolating padded copy", () => {
+    const branding = { ...DEFAULT_BRANDING, appName: "  Padded App  " };
+    expect(appNameInterpolationVars(branding)).toEqual({
+      appName: "Padded App",
+    });
+  });
+
+  it("falls back to DEFAULT_APP_DISPLAY_NAME when appName is an empty string", () => {
+    const branding = { ...DEFAULT_BRANDING, appName: "" };
+    expect(appNameInterpolationVars(branding)).toEqual({
+      appName: DEFAULT_APP_DISPLAY_NAME,
+    });
+  });
+
+  it("falls back when appName is whitespace-only (trim leaves nothing)", () => {
+    const branding = { ...DEFAULT_BRANDING, appName: " \t\n " };
+    expect(appNameInterpolationVars(branding)).toEqual({
+      appName: DEFAULT_APP_DISPLAY_NAME,
+    });
+  });
+
+  it("falls back when appName is undefined, as unvalidated legacy payloads reach the optional chain", () => {
+    const legacy = {
+      ...DEFAULT_BRANDING,
+      appName: undefined,
+    } as unknown as BrandingConfig;
+    expect(appNameInterpolationVars(legacy)).toEqual({
+      appName: DEFAULT_APP_DISPLAY_NAME,
+    });
+  });
+});
+
+describe("DEFAULT_BRANDING", () => {
+  it("derives appName from the single DEFAULT_APP_DISPLAY_NAME constant", () => {
+    expect(DEFAULT_APP_DISPLAY_NAME).toBe("Eliza");
+    expect(DEFAULT_BRANDING.appName).toBe(DEFAULT_APP_DISPLAY_NAME);
+  });
+
+  it("pins the repository identity fields", () => {
+    expect(DEFAULT_BRANDING.orgName).toBe("elizaos");
+    expect(DEFAULT_BRANDING.repoName).toBe("eliza");
+    expect(DEFAULT_BRANDING.packageScope).toBe("elizaos");
+    expect(DEFAULT_BRANDING.fileExtension).toBe(".eliza-agent");
+    expect(DEFAULT_BRANDING.hashtag).toBe("#ElizaAgent");
+  });
+
+  it("wires docs and app URLs to the shared brand EXTERNAL_URLS rather than local literals", () => {
+    expect(DEFAULT_BRANDING.docsUrl).toBe(EXTERNAL_URLS.docs);
+    expect(DEFAULT_BRANDING.appUrl).toBe(EXTERNAL_URLS.app);
+  });
+
+  it("points bug reports at the repository's bug_report issue template", () => {
+    expect(DEFAULT_BRANDING.bugReportUrl).toBe(
+      "https://github.com/elizaos/eliza/issues/new?template=bug_report.yml",
+    );
+  });
+
+  it("ships with no injected custom providers, theme overrides, or cloud-only lock-in", () => {
+    expect(DEFAULT_BRANDING.customProviders).toBeUndefined();
+    expect(DEFAULT_BRANDING.firstRunTheme).toBeUndefined();
+    expect(DEFAULT_BRANDING.theme).toBeUndefined();
+    expect(DEFAULT_BRANDING.cloudOnly).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds unit coverage for `packages/ui/src/config/branding.ts`, the branding barrel in `@elizaos/ui`, which had no same-named suite anywhere in the repo. The diff is one new test file, `packages/ui/src/config/branding.test.ts` (+101/-0); no production code changes.

## What is covered

- **Barrel wiring:** every runtime symbol reachable through `config/branding` (`DEFAULT_APP_DISPLAY_NAME`, `DEFAULT_BRANDING`, `appNameInterpolationVars`, `BrandingContext`, `useBranding`) is asserted to be the *same binding* as its owning module (`./branding-base`, `./branding-react.hooks`), so consumers importing through the barrel and modules importing directly share identity.
- **`appNameInterpolationVars` branches:** configured name returned verbatim; surrounding whitespace trimmed; empty string falls back to `DEFAULT_APP_DISPLAY_NAME`; whitespace-only string falls back (trim leaves nothing); `undefined` appName (unvalidated legacy payload reaching the optional chain) falls back.
- **`DEFAULT_BRANDING` pins:** derives `appName` from the single `DEFAULT_APP_DISPLAY_NAME` constant (`"Eliza"`); repository identity fields (`orgName`, `repoName`, `packageScope`, `fileExtension`, `hashtag`); `docsUrl`/`appUrl` wired to `EXTERNAL_URLS` from `@elizaos/shared/brand` rather than local literals; `bugReportUrl` pinned to the repository's `bug_report.yml` issue template; optional fields (`customProviders`, `firstRunTheme`, `theme`, `cloudOnly`) all unset by default.

Assertions record observed behaviour only — the suite drives the real module through the barrel import path with no mocks.

## Evidence

- `bunx vitest run src/config/branding.test.ts` (in `packages/ui`, jsdom-free node lane): **Test Files 1 passed (1), Tests 12 passed (12)** — re-fetched `origin/develop` immediately before filing; base `f11cedd35e` unchanged and still carries no branding suite.
- `bunx biome check src/config/branding.test.ts`: **clean** ("Checked 1 file … No fixes applied"), run with the repo-root `biome.json` present (checkout verified non-sparse).
- `bunx tsc --noEmit` in `packages/ui`: output grepped for `branding.test` — **zero matches**; the file introduces no type errors. (Pre-existing errors elsewhere in the package are untouched by this diff.)
- Diff is exactly **one new test file, +101/-0**, verified with `git diff --stat origin/develop HEAD`.

This comes from a fork, so hosted CI does not run on this PR; the counts above are quoted from local runs of the real toolchain at head `6bd872b4aff2b35491f5acc0c1b30a57e00c343e`.

## Notes

- Test-only change; no behavioural or public-surface change intended.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6bd872b4aff2b35491f5acc0c1b30a57e00c343e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
