### PR TITLE
test(ui): cover cloud-only

### DIFF
--- a/packages/ui/src/config/cloud-only.test.ts
+++ b/packages/ui/src/config/cloud-only.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit coverage for the @elizaos/ui/config cloud-only seam: the barrel must
+ * hand out the canonical shared predicate (not a forked copy), and the
+ * predicate's branch table must hold when driven through this package's
+ * import path.
+ */
+
+import { shouldUseCloudOnlyBranding as sharedShouldUseCloudOnlyBranding } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+
+import { shouldUseCloudOnlyBranding } from "./cloud-only";
+
+describe("shouldUseCloudOnlyBranding re-export", () => {
+  it("exposes a callable predicate", () => {
+    expect(typeof shouldUseCloudOnlyBranding).toBe("function");
+  });
+
+  it("re-exports the canonical shared implementation rather than a local copy", () => {
+    expect(shouldUseCloudOnlyBranding).toBe(sharedShouldUseCloudOnlyBranding);
+  });
+});
+
+describe("shouldUseCloudOnlyBranding", () => {
+  it("returns true for plain production web with no overrides", () => {
+    expect(shouldUseCloudOnlyBranding({ isDev: false })).toBe(true);
+  });
+
+  it("treats every optional field as absent when undefined or null", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: null,
+        nativeRuntimeMode: null,
+        desktopRuntimeMode: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false in dev so the loopback agent keeps its own branding", () => {
+    expect(shouldUseCloudOnlyBranding({ isDev: true })).toBe(false);
+  });
+
+  it("lets an explicit desktop cloud runtime mode win over dev mode and an injected backend", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "http://127.0.0.1:3000",
+        desktopRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes the desktop runtime mode across casing and surrounding whitespace", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        desktopRuntimeMode: "  ELIZACloud ",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not let a non-cloud desktop runtime mode force the override on its own", () => {
+    // "local" matches neither cloud keyword, so the decision falls through
+    // the remaining gates; on a plain production web build that means the
+    // default cloud-only answer.
+    expect(
+      shouldUseCloudOnlyBranding({ isDev: false, desktopRuntimeMode: "local" }),
+    ).toBe(true);
+  });
+
+  it("ignores a desktop runtime mode made only of whitespace", () => {
+    // A blank mode trims to "" and matches neither cloud keyword, so the
+    // decision falls through to the normal gates instead of forcing cloud.
+    expect(
+      shouldUseCloudOnlyBranding({ isDev: false, desktopRuntimeMode: "   " }),
+    ).toBe(true);
+  });
+
+  it("returns false when a host injects a backend base URL outside dev", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: "http://127.0.0.1:3000",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a whitespace-only injected API base as no injected backend", () => {
+    expect(
+      shouldUseCloudOnlyBranding({ isDev: false, injectedApiBase: "   " }),
+    ).toBe(true);
+  });
+
+  it("checks dev before the injected backend so a dev build stays on its loopback agent", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "https://api.example.com",
+      }),
+    ).toBe(false);
+  });
+
+  it("follows a native platform whose runtime mode selects cloud", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts elizacloud as the native cloud runtime mode in any casing", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: " ElizaCloud ",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a native platform running a local runtime mode", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: "local",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for a native platform with no runtime mode selected", () => {
+    expect(
+      shouldUseCloudOnlyBranding({ isDev: false, isNativePlatform: true }),
+    ).toBe(false);
+  });
+
+  it("ignores the native runtime mode when the build is not a native platform", () => {
+    // The native branch only runs once isNativePlatform holds, so a stray
+    // mode value on a web build cannot flip the production default.
+    expect(
+      shouldUseCloudOnlyBranding({ isDev: false, nativeRuntimeMode: "local" }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION

Test-only coverage for `packages/ui/src/config/cloud-only.ts` (`@elizaos/ui/config` cloud-only seam). No production behavior changes: the diff is one new test file, +146/-0.

## What the suite pins

The module re-exports `shouldUseCloudOnlyBranding` from `@elizaos/shared`. The suite drives the real module through this package's import path (no mocks) and asserts:

- the barrel hands out the canonical shared implementation by identity, not a local copy;
- an explicit desktop `cloud`/`elizacloud` runtime mode (case/whitespace normalized) wins over dev mode and an injected backend;
- dev mode returns false before the injected-backend gate;
- a trimmed-truthy `injectedApiBase` returns false; whitespace-only counts as absent;
- native platforms follow their normalized `nativeRuntimeMode` (`cloud`/`elizacloud`), else false;
- plain production web defaults to true, and all optionals may be undefined/null.

One expectation was corrected against observed behavior during development: a non-cloud `desktopRuntimeMode` does not force anything on its own; on a production web build the fall-through reaches the default `true`.

## Evidence (test-only change)

- `bunx vitest run src/config/cloud-only.test.ts` (packages/ui): **1 file passed, 17 tests passed** against current `origin/develop` (`f11cedd35e`), re-fetched immediately before filing.
- `bunx biome check --write src/config/cloud-only.test.ts`: clean ("No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mentioning the new file.
- Diff touches only `packages/ui/src/config/cloud-only.test.ts`.

Fork-contributor note: hosted CI does not run on this pull request; the counts above are from a local run of the owning package's pinned vitest config.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6dc9aaaef3810ac2e84424db7d29d1d1db59de4e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
