### PR TITLE
test(shared): cover speaker-name-inference resolution ambiguity and duplicate entities

### DIFF
--- a/packages/shared/src/speaker-name-inference.test.ts
+++ b/packages/shared/src/speaker-name-inference.test.ts
@@ -3,7 +3,10 @@
  * evidence, including the explicit user-correction escape hatch.
  */
 import { describe, expect, it } from "vitest";
-import { inferSpeakerName } from "./speaker-name-inference.ts";
+import {
+  inferSpeakerName,
+  toSpeakerNameAttribution,
+} from "./speaker-name-inference.ts";
 
 describe("inferSpeakerName borrowed-device precedence", () => {
   it("withholds automatic identity evidence that conflicts with the device roster", () => {
@@ -67,5 +70,124 @@ describe("inferSpeakerName borrowed-device precedence", () => {
       "A Speaker",
       "B Speaker",
     ]);
+  });
+});
+
+describe("inferSpeakerName guardrails and ambiguity handling", () => {
+  it("withholds resolution when sensitiveAttributeGuardrail is enabled", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      sensitiveAttributeGuardrail: true,
+      evidence: [
+        {
+          source: "voice_profile",
+          confidence: 0.99,
+          name: "Confident Speaker",
+        },
+      ],
+    });
+
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("sensitive_attribute_guardrail");
+    expect(result.bindingPlan.action).toBe("none");
+  });
+
+  it("withholds when two candidates share the same first name with high confidence", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "calendar_attendee",
+          confidence: 0.8,
+          name: "Alex Smith",
+        },
+        {
+          source: "platform_roster",
+          confidence: 0.75,
+          name: "Alex Jones",
+        },
+      ],
+    });
+
+    expect(result.resolution).toBe("withheld");
+    expect(result.reasonCodes).toContain("same_first_name_ambiguity");
+  });
+
+  it("marks as needs_confirmation when conflicting names have close confidence", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "calendar_attendee",
+          confidence: 0.85,
+          name: "Alice Baker",
+        },
+        {
+          source: "platform_roster",
+          confidence: 0.82,
+          name: "Charlie Davis",
+        },
+      ],
+    });
+
+    expect(result.resolution).toBe("needs_confirmation");
+    expect(result.reasonCodes).toContain("conflicting_name_evidence");
+  });
+
+  it("returns unknown when no name evidence is supplied", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [],
+    });
+
+    expect(result.resolution).toBe("unknown");
+    expect(result.reasonCodes).toContain("no_name_evidence");
+    expect(result.requiresReview).toBe(true);
+  });
+});
+
+describe("inferSpeakerName entity binding and attribution conversion", () => {
+  it("generates merge_duplicate_entities plan when multiple existing entities match", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "voice_profile",
+          confidence: 0.95,
+          name: "Alice Cooper",
+        },
+      ],
+      existingEntities: [
+        { entityId: "ent-1", displayName: "Alice Cooper" },
+        { entityId: "ent-2", displayName: "alice cooper" },
+      ],
+    });
+
+    expect(result.resolution).toBe("confirmed");
+    expect(result.bindingPlan.action).toBe("merge_duplicate_entities");
+    expect(result.bindingPlan.mergeEntityIds).toEqual(["ent-1", "ent-2"]);
+    expect(result.bindingPlan.reasonCodes).toContain(
+      "duplicate_entity_merge_required",
+    );
+    expect(result.requiresReview).toBe(true);
+  });
+
+  it("converts inference to transport-safe speaker attribution", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        {
+          source: "voice_profile",
+          confidence: 0.95,
+          name: "Alice Cooper",
+        },
+      ],
+    });
+
+    const attribution = toSpeakerNameAttribution(result);
+    expect(attribution.resolution).toBe("confirmed");
+    expect(attribution.displayName).toBe("Alice Cooper");
+    expect(attribution.confidence).toBe(0.95);
+    expect("bindingPlan" in attribution).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- evidence-head:57fe808c6ac8e947391a19c583bd9d4062f27640 -->
## Summary
Adds unit test coverage in `packages/shared/src/speaker-name-inference.test.ts` for identity inference resolution paths: sensitive attribute guardrails, same-first-name ambiguity, conflicting evidence resolution, duplicate entity merge plan creation, and conversion to transport-safe speaker attribution.

## Proposed Changes
- **packages/shared/src/speaker-name-inference.test.ts**:
  - Test `sensitiveAttributeGuardrail` withholds resolution with `sensitive_attribute_guardrail` reason code.
  - Test `same_first_name_ambiguity` detection when multiple candidates share first names with high confidence.
  - Test `conflicting_name_evidence` triggers `needs_confirmation`.
  - Test empty evidence yields `unknown` resolution and `no_name_evidence`.
  - Test `duplicate_entity_merge_required` produces `merge_duplicate_entities` action and aggregates matching entity IDs.
  - Test `toSpeakerNameAttribution` strips identity graph binding instructions for transport.

## Verification
- Run tests: `bun test packages/shared/src/speaker-name-inference.test.ts`
- Biome check: `bunx biome check packages/shared/src/speaker-name-inference.test.ts`

<details>
<summary>Test Output</summary>

```
bun test v1.3.11 (af24e281)

packages/shared/src/speaker-name-inference.test.ts:
(pass) inferSpeakerName borrowed-device precedence > withholds automatic identity evidence that conflicts with the device roster
(pass) inferSpeakerName borrowed-device precedence > lets an explicit user correction resolve a borrowed-device conflict
(pass) inferSpeakerName borrowed-device precedence > sorts equal-score candidates deterministically by normalized name
(pass) inferSpeakerName guardrails and ambiguity handling > withholds resolution when sensitiveAttributeGuardrail is enabled
(pass) inferSpeakerName guardrails and ambiguity handling > withholds when two candidates share the same first name with high confidence
(pass) inferSpeakerName guardrails and ambiguity handling > marks as needs_confirmation when conflicting names have close confidence
(pass) inferSpeakerName guardrails and ambiguity handling > returns unknown when no name evidence is supplied
(pass) inferSpeakerName entity binding and attribution conversion > generates merge_duplicate_entities plan when multiple existing entities match
(pass) inferSpeakerName entity binding and attribution conversion > converts inference to transport-safe speaker attribution

 9 pass
 0 fail
 27 expect() calls
Ran 9 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.