### PR TITLE
test(ui): cover config barrel

### DIFF
--- a/packages/ui/src/config/index.test.ts
+++ b/packages/ui/src/config/index.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Unit coverage for the `@elizaos/ui/config` barrel (src/config/index.ts).
+ * Deterministic real-module suite: drives every runtime helper the barrel
+ * re-exports through its public path and pins the export surface so a
+ * refactor cannot silently drop a name consumers depend on.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { AppConfig } from "./index";
+import {
+  BrandingContext,
+  buildPluginConfigUiSpec,
+  buildPluginListUiSpec,
+  builtInValidators,
+  DEFAULT_APP_DISPLAY_NAME,
+  DEFAULT_BOOT_CONFIG,
+  DEFAULT_BRANDING,
+  getBootConfig,
+  getByPath,
+  interpolateString,
+  isConfigValuePresent,
+  parseAllowedHostEnv,
+  resolveAppBranding,
+  resolveCharacterCatalog,
+  setBootConfig,
+  shouldUseCloudOnlyBranding,
+  toCapacitorAllowNavigation,
+  toViteAllowedHosts,
+  useBranding,
+} from "./index";
+
+type UiElement = Record<string, unknown>;
+
+/** Read a UI-spec element's props bag with a usable static shape. */
+function propsOf(element: UiElement): Record<string, unknown> {
+  return (element.props ?? {}) as Record<string, unknown>;
+}
+
+describe("barrel export surface", () => {
+  it("resolves and exposes every runtime helper consumers import", () => {
+    const runtimeExports = {
+      resolveAppBranding,
+      parseAllowedHostEnv,
+      toViteAllowedHosts,
+      toCapacitorAllowNavigation,
+      shouldUseCloudOnlyBranding,
+      buildPluginConfigUiSpec,
+      buildPluginListUiSpec,
+      DEFAULT_BRANDING,
+      DEFAULT_APP_DISPLAY_NAME,
+      BrandingContext,
+      useBranding,
+      DEFAULT_BOOT_CONFIG,
+      setBootConfig,
+      getBootConfig,
+      resolveCharacterCatalog,
+      getByPath,
+      interpolateString,
+      isConfigValuePresent,
+      builtInValidators,
+    };
+
+    for (const [name, value] of Object.entries(runtimeExports)) {
+      expect(value, `barrel dropped ${name}`).toBeDefined();
+    }
+    const nonFunctionExports = new Set([
+      "BrandingContext",
+      "builtInValidators",
+    ]);
+    for (const [name, value] of Object.entries(runtimeExports)) {
+      if (nonFunctionExports.has(name) || name.startsWith("DEFAULT_")) continue;
+      expect(typeof value, `${name} stopped being callable`).toBe("function");
+    }
+    expect(builtInValidators).toBeTypeOf("object");
+  });
+});
+
+describe("parseAllowedHostEnv (via barrel)", () => {
+  it("returns no patterns for null and undefined env values", () => {
+    expect(parseAllowedHostEnv(null)).toEqual([]);
+    expect(parseAllowedHostEnv(undefined)).toEqual([]);
+  });
+
+  it("parses bare hosts, origins, and subdomain wildcards from a comma list", () => {
+    expect(
+      parseAllowedHostEnv("example.com, https://app.example.com, *.foo.dev"),
+    ).toEqual([
+      { host: "example.com", includeSubdomains: false },
+      { host: "app.example.com", includeSubdomains: false },
+      { host: "foo.dev", includeSubdomains: true },
+    ]);
+  });
+
+  it("lowercases hosts and de-duplicates repeated entries", () => {
+    expect(parseAllowedHostEnv("Bar.IO, bar.io")).toEqual([
+      { host: "bar.io", includeSubdomains: false },
+    ]);
+  });
+
+  it("skips whitespace-only entries between commas", () => {
+    expect(parseAllowedHostEnv("a.com, , b.com")).toEqual([
+      { host: "a.com", includeSubdomains: false },
+      { host: "b.com", includeSubdomains: false },
+    ]);
+  });
+
+  it("rejects an entry containing control characters or spaces", () => {
+    expect(() => parseAllowedHostEnv("bad host.com")).toThrow(
+      /not a supported host pattern/,
+    );
+  });
+});
+
+describe("host conversion helpers (via barrel)", () => {
+  it("maps wildcard entries to Vite leading-dot hosts", () => {
+    expect(
+      toViteAllowedHosts([
+        { host: "foo.dev", includeSubdomains: true },
+        { host: "bar.io", includeSubdomains: false },
+      ]),
+    ).toEqual([".foo.dev", "bar.io"]);
+  });
+
+  it("maps wildcard entries to Capacitor star prefixes", () => {
+    expect(
+      toCapacitorAllowNavigation([
+        { host: "foo.dev", includeSubdomains: true },
+        { host: "bar.io", includeSubdomains: false },
+      ]),
+    ).toEqual(["*.foo.dev", "bar.io"]);
+  });
+});
+
+describe("shouldUseCloudOnlyBranding (via barrel)", () => {
+  it("lets an explicit desktop cloud mode win over dev + injected backend", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "http://127.0.0.1:3000",
+        desktopRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the elizacloud desktop mode case-insensitively despite padding", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        desktopRuntimeMode: "  ELIZACLOUD ",
+      }),
+    ).toBe(true);
+  });
+
+  it("stays out of cloud-only branding while running dev without opt-in", () => {
+    expect(shouldUseCloudOnlyBranding({ isDev: true })).toBe(false);
+  });
+
+  it("follows an injected production backend instead of the web preset", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: "http://10.0.0.5:3000",
+      }),
+    ).toBe(false);
+  });
+
+  it("uses the cloud-only preset for plain production web", () => {
+    expect(shouldUseCloudOnlyBranding({ isDev: false })).toBe(true);
+  });
+
+  it("on native platforms follows the native runtime mode alone", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        isNativePlatform: true,
+        nativeRuntimeMode: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveAppBranding (via barrel)", () => {
+  const appConfig: AppConfig = {
+    appName: "Nexa",
+    appId: "app.nexa",
+    orgName: "nexa-org",
+    repoName: "nexa-repo",
+    cliName: "nexa",
+    description: "Nexa agents",
+    branding: {},
+  };
+
+  it("layers app identity over the framework defaults", () => {
+    const branding = resolveAppBranding(appConfig);
+    expect(branding.appName).toBe("Nexa");
+    expect(branding.orgName).toBe("nexa-org");
+    expect(branding.repoName).toBe("nexa-repo");
+    expect(branding.fileExtension).toBe(".eliza-agent");
+  });
+
+  it("lets appConfig.branding win over both defaults and app identity", () => {
+    const branding = resolveAppBranding({
+      ...appConfig,
+      branding: { appName: "Nexa Pro", hashtag: "#Nexa" },
+    });
+    expect(branding.appName).toBe("Nexa Pro");
+    expect(branding.orgName).toBe("nexa-org");
+    expect(branding.hashtag).toBe("#Nexa");
+  });
+});
+
+describe("boot-config store (via barrel)", () => {
+  it("seeds the process-global store with the documented defaults", () => {
+    expect(getBootConfig()).toEqual(DEFAULT_BOOT_CONFIG);
+    expect(DEFAULT_BOOT_CONFIG.cloudApiBase).toBe("https://eliza.app");
+    expect(DEFAULT_BOOT_CONFIG.preferSharedCloudTier).toBe(true);
+    expect(DEFAULT_BOOT_CONFIG.autoUpgradeSharedToDedicated).toBe(false);
+  });
+
+  it("stores a host-provided config and mirrors it on globalThis", () => {
+    const custom = {
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://boot.example",
+    };
+    try {
+      setBootConfig(custom);
+      expect(getBootConfig()).toBe(custom);
+      expect(
+        (globalThis as { __ELIZAOS_APP_BOOT_CONFIG__?: unknown })
+          .__ELIZAOS_APP_BOOT_CONFIG__,
+      ).toBe(custom);
+    } finally {
+      setBootConfig(DEFAULT_BOOT_CONFIG);
+    }
+  });
+});
+
+describe("buildPluginConfigUiSpec (via barrel)", () => {
+  const basePlugin = { id: "plugin-a", name: "Plugin A" };
+
+  it("marks an enabled plugin whose required params are set as Ready", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: true,
+      parameters: [{ key: "endpoint", required: true, isSet: true }],
+    });
+    expect(spec.version).toBe(1);
+    expect(spec.root).toBe("root");
+    expect(spec.state.pluginId).toBe("plugin-a");
+    expect(propsOf(spec.elements.title).text).toBe("Configure Plugin A");
+    expect(propsOf(spec.elements.status)).toMatchObject({
+      text: "Ready",
+      variant: "default",
+    });
+  });
+
+  it("flags an enabled plugin with an unset required param", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: true,
+      parameters: [{ key: "apiKey", required: true, isSet: false }],
+    });
+    expect(propsOf(spec.elements.status)).toMatchObject({
+      text: "Needs Configuration",
+      variant: "secondary",
+    });
+  });
+
+  it("renders a disabled plugin with an Enable Plugin button", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: false,
+      parameters: [],
+    });
+    expect(propsOf(spec.elements.status)).toMatchObject({
+      text: "Disabled",
+      variant: "outline",
+    });
+    expect(spec.elements.enableBtn).toBeDefined();
+  });
+
+  it("adds a Test Connection button for connectors", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: true,
+      category: "connector",
+      parameters: [],
+    });
+    const testButton = propsOf(spec.elements.testBtn);
+    expect(testButton.text).toBe("Test Connection");
+    const onPress = testButton.on as {
+      press: { action: string; params: { pluginId: string } };
+    };
+    expect(onPress.press.action).toBe("plugin:test");
+    expect(onPress.press.params.pluginId).toBe("plugin-a");
+  });
+
+  it("masks secret params and reports already-set placeholders", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: true,
+      parameters: [
+        { key: "API_KEY", required: true, isSet: true, label: "API Key" },
+      ],
+    });
+    const field = propsOf(spec.elements.field_API_KEY);
+    expect(field.type).toBe("password");
+    expect(field.label).toBe("API Key");
+    expect(field.placeholder).toContain("(already set)");
+  });
+
+  it("routes the save action back to the owning plugin id", () => {
+    const spec = buildPluginConfigUiSpec({
+      ...basePlugin,
+      enabled: true,
+      parameters: [],
+    });
+    const onPress = propsOf(spec.elements.saveBtn).on as {
+      press: { action: string; params: { pluginId: string } };
+    };
+    expect(onPress.press.action).toBe("plugin:save");
+    expect(onPress.press.params.pluginId).toBe("plugin-a");
+  });
+});
+
+describe("buildPluginListUiSpec (via barrel)", () => {
+  it("titles the list and renders one name element per plugin", () => {
+    const spec = buildPluginListUiSpec(
+      [
+        { id: "p1", name: "First", parameters: [] },
+        { id: "p2", name: "Second", parameters: [] },
+      ],
+      "Available plugins",
+    );
+    expect(propsOf(spec.elements.heading)).toMatchObject({
+      level: 3,
+      text: "Available plugins",
+    });
+    expect(propsOf(spec.elements.name_0).text).toBe("First");
+    expect(propsOf(spec.elements.name_1).text).toBe("Second");
+    expect(spec.elements.name_2).toBeUndefined();
+  });
+
+  it("keeps the heading for an empty plugin list", () => {
+    const spec = buildPluginListUiSpec([], "No plugins");
+    expect(propsOf(spec.elements.heading).text).toBe("No plugins");
+    expect(spec.elements.name_0).toBeUndefined();
+  });
+});
+
+describe("config-catalog plumbing (via barrel)", () => {
+  it("reads nested values by slash-delimited path", () => {
+    expect(getByPath({ a: { b: "value" } }, "a/b")).toBe("value");
+    expect(getByPath({ a: { b: "value" } }, "a.b")).toBeUndefined();
+    expect(getByPath({ a: 1 }, "a/b/c")).toBeUndefined();
+  });
+});


### PR DESCRIPTION

Adds a new unit suite for the `@elizaos/ui/config` barrel (`packages/ui/src/config/index.ts`), which had no same-named test file on develop.

**What the suite covers (27 cases, one new file, +365/-0):**

- **Export surface pin:** every runtime helper the barrel re-exports resolves through the public path — allowed-hosts helpers, cloud-only branding predicate, branding values/context, boot-config store, plugin UI-spec builders, and the config-catalog plumbing.
- **`parseAllowedHostEnv`:** null/undefined envs, bare hosts + origins + subdomain wildcards, lowercasing with de-duplication, whitespace-entry skipping, and rejection of control-character entries.
- **`toViteAllowedHosts` / `toCapacitorAllowNavigation`:** leading-dot vs star-prefix wildcard mapping.
- **`shouldUseCloudOnlyBranding`:** desktop cloud/elizacloud override winning over dev + injected backend, case-insensitive mode matching, dev fall-through, injected-backend fall-through, plain-production-web preset, and native runtime-mode branches.
- **`resolveAppBranding`:** app identity layered over framework defaults and `appConfig.branding` winning last.
- **Boot-config store:** documented defaults seeding the process-global store, plus host-provided round-trip mirrored on `globalThis`.
- **`buildPluginConfigUiSpec`:** Ready / Needs Configuration / Disabled status branches, Enable Plugin button for disabled plugins, Test Connection button for connectors, secret masking with already-set placeholders, and save-action plugin-id routing.
- **`buildPluginListUiSpec`:** per-plugin name elements under a titled heading, including the empty-list shape.
- **config-catalog:** slash-delimited path reads through the barrel.

All expectations were written against observed behavior of the real modules — no mocks stand in for the system under test. Two initial drafts asserted dot-path lookups and case-insensitive secret detection; both were corrected to what the code actually does (slash-delimited paths; case-sensitive `KEY`/`TOKEN` substring match).

**Evidence (test-only change):**

1. `bunx vitest run src/config/index.test.ts` (in `packages/ui`, against current origin/develop at f11cedd35e): **Test Files 1 passed (1), Tests 27 passed (27)**.
2. `bunx biome check src/config/index.test.ts`: clean ("Checked 1 file in 15ms. No fixes applied.").
3. `bunx tsc --noEmit` in `packages/ui`: zero occurrences of `src/config/index.test.ts` in the output (remaining diagnostics are pre-existing errors in unrelated uncommitted working-tree files from concurrent lanes, none touching this diff's content).
4. The diff touches exactly one NEW test file; no production code changed.

Note: this pull request comes from a fork, so hosted CI does not run on it; the counts above are quoted from local runs.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:864839f7b0737e766f5ae70260808d47a7014f54 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
