### PR TITLE
test(agent): cover rate-limiter multi-key isolation, reset, and dynamic windows

### DIFF
--- a/packages/agent/src/api/rate-limiter.test.ts
+++ b/packages/agent/src/api/rate-limiter.test.ts
@@ -59,4 +59,37 @@ describe("checkRateLimit", () => {
     // Still only 6 minutes into hourly-op's 1-hour window: must stay blocked.
     expect(checkRateLimit("hourly-op", hourly).allowed).toBe(false);
   });
+
+  it("tracks independent limits across multiple distinct keys", () => {
+    const config = { maxRequests: 1, windowMs: MINUTE };
+    expect(checkRateLimit("user-a", config).allowed).toBe(true);
+    expect(checkRateLimit("user-a", config).allowed).toBe(false);
+
+    // user-b is completely independent
+    expect(checkRateLimit("user-b", config).allowed).toBe(true);
+    expect(checkRateLimit("user-b", config).allowed).toBe(false);
+  });
+
+  it("resetRateLimits clears active buckets immediately", () => {
+    const config = { maxRequests: 1, windowMs: MINUTE };
+    expect(checkRateLimit("key-x", config).allowed).toBe(true);
+    expect(checkRateLimit("key-x", config).allowed).toBe(false);
+
+    resetRateLimits();
+
+    expect(checkRateLimit("key-x", config).allowed).toBe(true);
+  });
+
+  it("adapts when a key's windowMs is dynamically updated", () => {
+    const configShort = { maxRequests: 2, windowMs: MINUTE };
+    expect(checkRateLimit("dyn-key", configShort).allowed).toBe(true);
+    expect(checkRateLimit("dyn-key", configShort).allowed).toBe(true);
+    expect(checkRateLimit("dyn-key", configShort).allowed).toBe(false);
+
+    // Switch key to a 5-second window
+    const configFiveSec = { maxRequests: 2, windowMs: 5_000 };
+    vi.advanceTimersByTime(6_000);
+
+    expect(checkRateLimit("dyn-key", configFiveSec).allowed).toBe(true);
+  });
 });


### PR DESCRIPTION
<!-- evidence-head:29bfa3851d61610e3220ee76cc104e6245689b4e -->
## Summary
Adds unit tests in `packages/agent/src/api/rate-limiter.test.ts` for sliding-window rate limiting behaviors: multi-key tracking isolation, immediate state reset via `resetRateLimits`, and dynamic window size adaptation when a key changes configurations across invocations.

## Proposed Changes
- **packages/agent/src/api/rate-limiter.test.ts**:
  - Test independent rate limits across distinct keys.
  - Test `resetRateLimits()` clears all tracked buckets and resets timestamps.
  - Test dynamic reconfiguration of `windowMs` for an existing key.

## Verification
- Run tests: `bun test packages/agent/src/api/rate-limiter.test.ts`
- Biome check: `bunx biome check packages/agent/src/api/rate-limiter.test.ts`

<details>
<summary>Test Output</summary>

```
bun test v1.3.11 (af24e281)

packages/agent/src/api/rate-limiter.test.ts:
(pass) checkRateLimit > allows up to maxRequests then rejects with a retry hint
(pass) checkRateLimit > allows again once the window slides past the oldest request
(pass) checkRateLimit > does not let a short-window key's cleanup sweep wipe a longer-window bucket
(pass) checkRateLimit > tracks independent limits across multiple distinct keys
(pass) checkRateLimit > resetRateLimits clears active buckets immediately
(pass) checkRateLimit > adapts when a key's windowMs is dynamically updated

 6 pass
 0 fail
 23 expect() calls
Ran 6 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.