### PR TITLE
test(core): cover fs-extra-lite edge cases and bound functions

### DIFF
--- a/packages/core/src/utils/fs-extra-lite.test.ts
+++ b/packages/core/src/utils/fs-extra-lite.test.ts
@@ -11,9 +11,13 @@ import {
 	copy,
 	ensureDir,
 	ensureSymlink,
+	readFile as fsReadFile,
 	pathExists,
+	readdir,
 	readJson,
 	remove,
+	stat,
+	unlink,
 	writeJson,
 } from "./fs-extra-lite.ts";
 
@@ -50,12 +54,28 @@ describe("fs-extra-lite JSON helpers", () => {
 		);
 	});
 
+	it("writes un-indented JSON followed by newline when options are omitted", async () => {
+		const directory = await createTemporaryDirectory();
+		const output = path.join(directory, "compact.json");
+
+		await writeJson(output, { a: 1 });
+		await expect(readFile(output, "utf8")).resolves.toBe('{"a":1}\n');
+	});
+
 	it("rejects values JSON.stringify cannot serialize", async () => {
 		const directory = await createTemporaryDirectory();
 		const output = path.join(directory, "output.json");
 
 		await expect(writeJson(output, undefined)).rejects.toThrow(TypeError);
 		await expect(pathExists(output)).resolves.toBe(false);
+	});
+
+	it("rejects when reading invalid JSON syntax", async () => {
+		const directory = await createTemporaryDirectory();
+		const file = path.join(directory, "invalid.json");
+		await writeFile(file, "{not-json", "utf8");
+
+		await expect(readJson(file)).rejects.toThrow(SyntaxError);
 	});
 });
 
@@ -78,5 +98,38 @@ describe("fs-extra-lite filesystem helpers", () => {
 
 		await remove(sourceDirectory);
 		await expect(pathExists(sourceDirectory)).resolves.toBe(false);
+	});
+
+	it("remove does not throw when path does not exist", async () => {
+		const directory = await createTemporaryDirectory();
+		const nonExistent = path.join(directory, "missing-dir", "missing-file.txt");
+
+		await expect(remove(nonExistent)).resolves.toBeUndefined();
+	});
+
+	it("ensureDir creates deeply nested directories", async () => {
+		const directory = await createTemporaryDirectory();
+		const deepPath = path.join(directory, "a", "b", "c", "d");
+
+		await ensureDir(deepPath);
+		await expect(pathExists(deepPath)).resolves.toBe(true);
+	});
+
+	it("readdir, stat, unlink, and readFile helpers work consistently", async () => {
+		const directory = await createTemporaryDirectory();
+		const testFile = path.join(directory, "sample.txt");
+		await writeFile(testFile, "content", "utf8");
+
+		const entries = await readdir(directory);
+		expect(entries).toContain("sample.txt");
+
+		const fileStat = await stat(testFile);
+		expect(fileStat.isFile()).toBe(true);
+
+		const readContent = await fsReadFile(testFile, "utf8");
+		expect(readContent).toBe("content");
+
+		await unlink(testFile);
+		await expect(pathExists(testFile)).resolves.toBe(false);
 	});
 });


### PR DESCRIPTION
<!-- evidence-head:fd7ce2c6d62c8c5a229cad41e1f2e69ca95e8f94 -->
## Summary
Extends unit test coverage in `packages/core/src/utils/fs-extra-lite.test.ts` for edge cases and bound helpers: `remove` on non-existent paths, `readJson` rejection on malformed JSON syntax, `writeJson` without formatting options, multi-level directory creation via `ensureDir`, and bound file system functions (`readdir`, `stat`, `unlink`, `readFile`).

## Proposed Changes
- **packages/core/src/utils/fs-extra-lite.test.ts**:
  - Test `remove` does not throw when target does not exist (`force: true`).
  - Test `readJson` rejects with `SyntaxError` on malformed JSON text.
  - Test `writeJson` without space options writes compact JSON followed by newline.
  - Test `ensureDir` creates deeply nested directory paths recursively.
  - Test re-exported file system methods (`readdir`, `stat`, `unlink`, `readFile`).

## Verification
- Run tests: `bun test packages/core/src/utils/fs-extra-lite.test.ts`
- Biome check: `bunx biome check packages/core/src/utils/fs-extra-lite.test.ts`

<details>
<summary>Test Output</summary>

```
bun test v1.3.11 (af24e281)

packages/core/src/utils/fs-extra-lite.test.ts:
(pass) fs-extra-lite JSON helpers > reads BOM-prefixed JSON and writes indented JSON with a final newline
(pass) fs-extra-lite JSON helpers > writes un-indented JSON followed by newline when options are omitted
(pass) fs-extra-lite JSON helpers > rejects values JSON.stringify cannot serialize
(pass) fs-extra-lite JSON helpers > rejects when reading invalid JSON syntax
(pass) fs-extra-lite filesystem helpers > creates, copies, links, and recursively removes paths
(pass) fs-extra-lite filesystem helpers > remove does not throw when path does not exist
(pass) fs-extra-lite filesystem helpers > ensureDir creates deeply nested directories
(pass) fs-extra-lite filesystem helpers > readdir, stat, unlink, and readFile helpers work consistently

 8 pass
 0 fail
 16 expect() calls
Ran 8 tests across 1 file.
```
</details>

## Quality Checklist
- [x] Changes meet the project's quality standards.
- [x] Code is clean, well-structured, and easy to understand.
- [x] All tests pass locally.
- [x] No regressions introduced.

## Maintainer CI Exception
N/A - no exception requested.