### PR TITLE
test(core): cover stage1-prompt-tier

### DIFF
--- a/packages/core/src/services/message/stage1-prompt-tier.test.ts
+++ b/packages/core/src/services/message/stage1-prompt-tier.test.ts
@@ -187,3 +187,99 @@ describe("isUnaddressedTextGroupTurn", () => {
 		expect(isUnaddressedTextGroupTurn(msg, false)).toBe(false);
 	});
 });
+
+describe("isUnaddressedTextGroupTurn edge branches", () => {
+	it("ignores non-object content metadata such as arrays", () => {
+		const msg = message({
+			content: {
+				text: "hi",
+				channelType: String(ChannelType.GROUP),
+				metadata: ["not-a-record"] as unknown as Record<string, unknown>,
+			},
+		});
+		expect(isUnaddressedTextGroupTurn(msg, false)).toBe(true);
+	});
+
+	it("ignores non-object top-level metadata such as strings or null", () => {
+		const asString = message({
+			metadata: "not-a-record" as unknown as Record<string, unknown>,
+			content: { text: "hi", channelType: String(ChannelType.GROUP) },
+		});
+		expect(isUnaddressedTextGroupTurn(asString, false)).toBe(true);
+		const asNull = message({
+			metadata: null as unknown as Record<string, unknown>,
+			content: { text: "hi", channelType: String(ChannelType.GROUP) },
+		});
+		expect(isUnaddressedTextGroupTurn(asNull, false)).toBe(true);
+	});
+
+	it("treats only strict-boolean true isAutonomous flags as autonomous", () => {
+		for (const flag of ["true", 1, false]) {
+			const msg = message({
+				content: {
+					text: "hi",
+					channelType: String(ChannelType.GROUP),
+					metadata: { isAutonomous: flag },
+				},
+			});
+			expect(isUnaddressedTextGroupTurn(msg, false)).toBe(true);
+		}
+	});
+
+	it("requires strict-boolean subAgent metadata relays", () => {
+		const msg = message({
+			content: {
+				text: "hi",
+				channelType: String(ChannelType.GROUP),
+				metadata: { subAgent: "yes" },
+			},
+		});
+		expect(isUnaddressedTextGroupTurn(msg, false)).toBe(true);
+	});
+
+	it("treats a non-string source as an ordinary turn", () => {
+		const msg = message({
+			content: {
+				text: "hi",
+				channelType: String(ChannelType.GROUP),
+				source: 42 as unknown as string,
+			},
+		});
+		expect(isUnaddressedTextGroupTurn(msg, false)).toBe(true);
+	});
+
+	it("rejects always-respond sources by substring containment", () => {
+		for (const source of ["client_chat_v2", "trigger-prompt-relay"]) {
+			const msg = message({
+				content: {
+					text: "hi",
+					channelType: String(ChannelType.GROUP),
+					source,
+				},
+			});
+			expect(isUnaddressedTextGroupTurn(msg, false)).toBe(false);
+		}
+	});
+
+	it("normalizes always-respond source case and whitespace", () => {
+		const msg = message({
+			content: {
+				text: "hi",
+				channelType: String(ChannelType.GROUP),
+				source: "  Client_Chat ",
+			},
+		});
+		expect(isUnaddressedTextGroupTurn(msg, false)).toBe(false);
+	});
+
+	it("fails open when channel type is a non-string or empty value", () => {
+		const numeric = message({
+			content: { text: "hi", channelType: 42 as unknown as string },
+		});
+		expect(isUnaddressedTextGroupTurn(numeric, false)).toBe(false);
+		const empty = message({
+			content: { text: "hi", channelType: "" },
+		});
+		expect(isUnaddressedTextGroupTurn(empty, false)).toBe(false);
+	});
+});


### PR DESCRIPTION

## What

Test-only, strictly additive coverage for `packages/core/src/services/message/stage1-prompt-tier.ts`.

The same-named suite already exists on `develop`; this PR **appends** a new `describe("isUnaddressedTextGroupTurn edge branches")` block with 8 new cases and removes nothing. The first 189 lines are byte-identical to the file on `origin/develop` (verified by prefix diff before staging); the diff is +96/-0.

## Why

The existing suite pins the main classification paths but leaves several real branches in `isUnaddressedTextGroupTurn` unobserved:

- non-object `metadata` (array / string / null) must be ignored by `metadataRecord`, not crash or disqualify;
- only strict-boolean `true` for `isAutonomous` / `subAgent` metadata flags rejects a turn (`"true"`, `1`, `false` still qualify);
- a non-string `content.source` is treated as an ordinary turn;
- always-respond sources match by **substring containment** (`client_chat_v2`, `trigger-prompt-relay` are rejected), with case/whitespace normalization applied;
- non-string and empty-string `channelType` fail open.

All expectations record behaviour observed from the module as it stands on `develop`; no production code is touched.

## Evidence (test-only change; no behavioural diff)

Fork contributor: hosted CI does not run on this PR. Local verification at head `f11cedd35e5a3a7aa28bd7e3aee6937381094376` (= current `origin/develop` tip at time of filing):

1. `bunx vitest run src/services/message/stage1-prompt-tier.test.ts` (in `packages/core`) — **1 test file passed, 23/23 tests passed** (15 inherited cases + 8 new).
2. `bunx biome check --write src/services/message/stage1-prompt-tier.test.ts` — clean ("Checked 1 file", no fixes applied).
3. `bunx tsc --noEmit` (in `packages/core`) — the new test file appears nowhere in the output.
4. The diff touches exactly one file, `packages/core/src/services/message/stage1-prompt-tier.test.ts`, additive only (+96/-0); no deletions, no rewritten cases, no type-level assertions (`expectTypeOf` unused), no mocks — every case drives the real exported function.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b94e288a22fd032214a1c3d14a13d8f7ff220031 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
