### PR TITLE
test(ui): cover boot-recovery-channel

### DIFF
--- a/packages/ui/src/first-run/boot-recovery-channel.test.ts
+++ b/packages/ui/src/first-run/boot-recovery-channel.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit coverage for the boot-recovery action channel: reserved-prefix
+ * classification and handler dispatch against the real module singleton.
+ * Deterministic: the module-level handler is reset between tests.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BOOT_RECOVERY_ACTION_PREFIX,
+  setBootRecoveryActionHandler,
+  tryHandleBootRecoveryAction,
+} from "./boot-recovery-channel";
+
+/**
+ * The boot-recovery channel routes the chat send funnel's `__boot_recovery__:`
+ * control values to the headless boot-recovery conductor. Invariants under
+ * test: a prefixed value is ALWAYS consumed (reported handled, never forwarded
+ * to the server) whether or not a conductor is active, the handler receives the
+ * full raw value, the handler's own verdict does not change consumption, and a
+ * non-prefixed value is never intercepted.
+ */
+
+afterEach(() => {
+  setBootRecoveryActionHandler(null);
+});
+
+describe("boot recovery action channel", () => {
+  it("exposes the reserved sentinel prefix", () => {
+    expect(BOOT_RECOVERY_ACTION_PREFIX).toBe("__boot_recovery__:");
+  });
+
+  it("routes a prefixed value to the active conductor's handler, passing the full raw value", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    const value = `${BOOT_RECOVERY_ACTION_PREFIX}relogin`;
+    expect(tryHandleBootRecoveryAction(value)).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith("__boot_recovery__:relogin");
+  });
+
+  it("consumes a prefixed value even with NO handler (never reaches the server)", () => {
+    // A tap on a stale recovery-card control after recovery must not become a
+    // literal `__boot_recovery__:` chat message.
+    expect(
+      tryHandleBootRecoveryAction(`${BOOT_RECOVERY_ACTION_PREFIX}retry`),
+    ).toBe(true);
+  });
+
+  it("still consumes a prefixed value after the conductor clears its handler", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    setBootRecoveryActionHandler(null);
+    const value = `${BOOT_RECOVERY_ACTION_PREFIX}retry-dedicated-agent`;
+    expect(tryHandleBootRecoveryAction(value)).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("never intercepts a non-prefixed value, even with an active handler", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(tryHandleBootRecoveryAction("a real message")).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept a value that merely contains the prefix mid-string", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(
+      tryHandleBootRecoveryAction(`see ${BOOT_RECOVERY_ACTION_PREFIX}docs`),
+    ).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("treats the bare prefix itself as a consumable value", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(tryHandleBootRecoveryAction(BOOT_RECOVERY_ACTION_PREFIX)).toBe(true);
+    expect(handler).toHaveBeenCalledWith(BOOT_RECOVERY_ACTION_PREFIX);
+  });
+
+  it("is case-sensitive about the sentinel prefix", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(tryHandleBootRecoveryAction("__BOOT_RECOVERY__:relogin")).toBe(
+      false,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects the empty string without touching the handler", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(tryHandleBootRecoveryAction("")).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("consumes based on the prefix alone, regardless of the handler's own verdict", () => {
+    // The channel reports handled as soon as the value is reserved; whether the
+    // conductor acted on it is the conductor's business.
+    const decliningHandler = vi.fn(() => false);
+    setBootRecoveryActionHandler(decliningHandler);
+    expect(
+      tryHandleBootRecoveryAction(`${BOOT_RECOVERY_ACTION_PREFIX}retry`),
+    ).toBe(true);
+    expect(decliningHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches only to the most recently registered handler", () => {
+    const first = vi.fn(() => true);
+    setBootRecoveryActionHandler(first);
+    const second = vi.fn(() => true);
+    setBootRecoveryActionHandler(second);
+    const value = `${BOOT_RECOVERY_ACTION_PREFIX}relogin`;
+    expect(tryHandleBootRecoveryAction(value)).toBe(true);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith(value);
+  });
+
+  it("delivers each reserved value to the live handler across sequential sends", () => {
+    const handler = vi.fn(() => true);
+    setBootRecoveryActionHandler(handler);
+    expect(
+      tryHandleBootRecoveryAction(`${BOOT_RECOVERY_ACTION_PREFIX}relogin`),
+    ).toBe(true);
+    expect(
+      tryHandleBootRecoveryAction(`${BOOT_RECOVERY_ACTION_PREFIX}retry`),
+    ).toBe(true);
+    expect(handler).toHaveBeenNthCalledWith(1, "__boot_recovery__:relogin");
+    expect(handler).toHaveBeenNthCalledWith(2, "__boot_recovery__:retry");
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/ui/src/first-run/boot-recovery-channel.ts`, which previously had no test coverage anywhere in the repository. **Test-only change: one new file, +130/-0. No production code is touched.**

The module is the seam that lets the chat's send funnel short-circuit reserved `__boot_recovery__:` control values to the headless boot-recovery conductor. The suite drives the real module (no mocks standing in for the subject; `vi.fn()` only records calls to the injected handler callback) and pins every exported symbol and branch:

- `BOOT_RECOVERY_ACTION_PREFIX` is exactly `"__boot_recovery__:"`.
- A prefixed value dispatches to the active handler with the **full raw value** (prefix included, not stripped) and reports handled (`true`).
- A prefixed value is consumed even when **no** handler is registered, and still consumed after the conductor clears its handler on teardown — a stale recovery-card tap never becomes a literal `__boot_recovery__:` chat message.
- Consumption depends on the prefix alone: the handler's own `false` verdict does not change the reported outcome.
- Non-prefixed values are never intercepted (handler untouched), including values that merely *contain* the prefix mid-string, a case-differentiated prefix, and the empty string.
- The bare prefix itself is a consumable value.
- Only the most recently registered handler receives dispatches; sequential sends each deliver their value in order.

Layout, imports, naming, and the `afterEach(() => setBootRecoveryActionHandler(null))` state-reset convention mirror the adjacent sibling suite `model-action-channel.test.ts`, which covers the channel this module mirrors.

## Evidence (test-only PR)

Fork contributor: hosted CI does not run on this pull request; local verification below was executed against the exact head commit of this branch.

1. **vitest** — `bunx vitest run src/first-run/boot-recovery-channel.test.ts` in `packages/ui`: **Test Files 1 passed (1), Tests 12 passed (12)**. Re-fetched `origin/develop` immediately before filing and re-ran: the target module is byte-identical between this branch's base (`f11cedd35e`) and current `origin/develop`, and the suite reproduces at **12 passed (12)**. No competing suite for this module exists on current `origin/develop` (verified via `git ls-tree`).
2. **biome** — `bunx biome check src/first-run/boot-recovery-channel.test.ts` (repo-rooted config verified present): **Checked 1 file … No fixes applied** (clean after an initial `--write` format pass).
3. **tsc** — `bunx tsc --noEmit` in `packages/ui`: the output contains **zero references to `boot-recovery-channel.test.ts`**. The package's 9 diagnostics are pre-existing and confined to unrelated files (`src/cloud/**`, `src/components/settings/cloud-model-schema.test.ts`).
4. **Diff scope** — `git show --stat HEAD`: exactly one file added, `packages/ui/src/first-run/boot-recovery-channel.test.ts`, **130 insertions(+), 0 deletions**. No `expectTypeOf`, no type-level assertions, no type-only imports; the suite exercises runtime behaviour only.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:394516b19afb36845bf33f4f67fa0719bb2b4f60 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
