### PR TITLE
test(ui): cover steward-session-event

### DIFF
--- a/packages/ui/src/events/steward-session-event.test.ts
+++ b/packages/ui/src/events/steward-session-event.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Verifies the Steward session-change event surface the UI package re-exports
+ * from @elizaos/shared/steward-session-client: the re-export wiring, the
+ * window CustomEvent contract, and the epoch / SSR behaviour behind
+ * dispatchStewardSessionChange. Listens on the jsdom window.
+ */
+// @vitest-environment jsdom
+
+import {
+  STEWARD_SESSION_CHANGE_EVENT as CANONICAL_STEWARD_SESSION_CHANGE_EVENT,
+  dispatchStewardSessionChange as canonicalDispatchStewardSessionChange,
+} from "@elizaos/shared/steward-session-client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchStewardSessionChange,
+  STEWARD_SESSION_CHANGE_EVENT,
+  type StewardSessionChangeDetail,
+} from "./steward-session-event";
+
+function captureTransitions(): {
+  seen: StewardSessionChangeDetail[];
+  events: Event[];
+  stop: () => void;
+} {
+  const seen: StewardSessionChangeDetail[] = [];
+  const events: Event[] = [];
+  const listener = (event: Event) => {
+    events.push(event);
+    seen.push((event as CustomEvent<StewardSessionChangeDetail>).detail);
+  };
+  window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, listener);
+  return {
+    seen,
+    events,
+    stop: () =>
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, listener),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("steward-session-event re-export surface", () => {
+  it("re-exports the canonical shared implementation, not a copy", () => {
+    expect(dispatchStewardSessionChange).toBe(
+      canonicalDispatchStewardSessionChange,
+    );
+    expect(STEWARD_SESSION_CHANGE_EVENT).toBe(
+      CANONICAL_STEWARD_SESSION_CHANGE_EVENT,
+    );
+  });
+
+  it("exposes the stable steward-session-change event name", () => {
+    expect(STEWARD_SESSION_CHANGE_EVENT).toBe("steward-session-change");
+  });
+});
+
+describe("dispatchStewardSessionChange", () => {
+  it("publishes typed transitions to window listeners in dispatch order", () => {
+    const capture = captureTransitions();
+    try {
+      dispatchStewardSessionChange("present");
+      dispatchStewardSessionChange("cleared");
+      dispatchStewardSessionChange("present");
+    } finally {
+      capture.stop();
+    }
+
+    expect(capture.seen.map(({ state }) => state)).toEqual([
+      "present",
+      "cleared",
+      "present",
+    ]);
+    expect(capture.events[0]?.type).toBe(STEWARD_SESSION_CHANGE_EVENT);
+
+    const [first, second, third] = capture.seen;
+    expect(second?.sessionEpoch).toBeGreaterThan(first?.sessionEpoch ?? 0);
+    expect(third?.sessionEpoch).toBeGreaterThan(second?.sessionEpoch ?? 0);
+  });
+
+  it("advances the session epoch by exactly one per browser dispatch", () => {
+    const capture = captureTransitions();
+    try {
+      dispatchStewardSessionChange("present");
+    } finally {
+      capture.stop();
+    }
+    const baseEpoch = capture.seen[0]?.sessionEpoch;
+
+    const next = captureTransitions();
+    try {
+      dispatchStewardSessionChange("cleared");
+    } finally {
+      next.stop();
+    }
+
+    expect(next.seen).toEqual([
+      { state: "cleared", sessionEpoch: (baseEpoch ?? 0) + 1 },
+    ]);
+  });
+
+  it("is a no-op outside the browser: no throw and no consumed epoch", () => {
+    const capture = captureTransitions();
+    try {
+      dispatchStewardSessionChange("present");
+    } finally {
+      capture.stop();
+    }
+    const baseEpoch = capture.seen[0]?.sessionEpoch;
+
+    vi.stubGlobal("window", undefined);
+    expect(() => dispatchStewardSessionChange("present")).not.toThrow();
+    vi.unstubAllGlobals();
+
+    const after = captureTransitions();
+    try {
+      dispatchStewardSessionChange("cleared");
+    } finally {
+      after.stop();
+    }
+
+    expect(after.seen).toEqual([
+      { state: "cleared", sessionEpoch: (baseEpoch ?? 0) + 1 },
+    ]);
+  });
+});


### PR DESCRIPTION

Adds the missing co-located unit suite for `packages/ui/src/events/steward-session-event.ts`, which re-exports the canonical Steward session-change contract from `@elizaos/shared/steward-session-client`. The suite drives the real module through jsdom (no mocks standing in for the subject) and covers:

- **Re-export wiring**: the UI module's `dispatchStewardSessionChange` and `STEWARD_SESSION_CHANGE_EVENT` are the same live bindings as the shared package's canonical exports (`toBe` identity against a direct import), not copies.
- **Stable event name**: `STEWARD_SESSION_CHANGE_EVENT === "steward-session-change"`.
- **Typed transition fan-out**: `"present"` / `"cleared"` dispatches reach window listeners in order as CustomEvents whose detail carries `{ state, sessionEpoch }`.
- **Epoch authority**: each browser dispatch advances the session epoch by exactly one, monotonic across transitions.
- **SSR guard**: with no `window`, dispatch is a silent no-op that neither throws nor consumes an epoch.

## Evidence (test-only diff; +127/-0, one new file)

- `bunx vitest run src/events/steward-session-event.test.ts` (packages/ui): **1 file passed, 5/5 tests passed** (695ms), re-run green after biome formatting.
- `bunx biome check --write` on the new file: clean ("Checked 1 file", then "No fixes applied" on re-check).
- `bunx tsc --noEmit` in `packages/ui`: the new test filename appears nowhere in the output.
- Suite verified at base `f11cedd35e`; re-fetched before filing and confirmed `origin/develop` moved to `16c9edf962` with **zero diff** in both the target module and `packages/shared/src/steward-session-client/`, so the counts reproduce on current develop. No same-named suite existed on `origin/develop` at file time.

This is a fork contribution from an unattended session: hosted CI does not run on this pull request, and the quoted commands above are the complete verification set for this behaviour-preserving, test-only change.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c4d9b1dc818f468660388ff58e142fc4e24add20 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
