### PR TITLE
ci(scenarios): add group-chat live evaluation lane

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -13,9 +13,9 @@ on:
         required: true
         default: all
         type: choice
-        options: [all, app, scenarios, live-information, cloud, voice, dedicated]
+        options: [all, app, scenarios, group-chat, live-information, cloud, voice, dedicated]
       planner_provider:
-        description: Planner backend for the focused live-information suite
+        description: Acting model provider for focused live-information or group-chat suites
         required: true
         default: openai
         type: choice
@@ -63,8 +63,8 @@ jobs:
         with:
           submodules: false
 
-      - name: Require exact live information credentials
-        if: inputs.suite == 'live-information'
+      - name: Require exact independently judged scenario credentials
+        if: inputs.suite == 'live-information' || inputs.suite == 'group-chat'
         shell: bash
         env:
           PLANNER_PROVIDER: ${{ inputs.planner_provider }}
@@ -74,13 +74,13 @@ jobs:
             openai) planner_key="${OPENAI_API_KEY:-}" ;;
             anthropic) planner_key="${ANTHROPIC_API_KEY:-}" ;;
             openrouter) planner_key="${OPENROUTER_API_KEY:-}" ;;
-            *) echo "::error::Unsupported live-information planner provider."; exit 1 ;;
+            *) echo "::error::Unsupported acting model provider."; exit 1 ;;
           esac
           planner_key_without_whitespace="${planner_key//[[:space:]]/}"
           judge_key="${EVAL_CEREBRAS_API_KEY:-${CEREBRAS_API_KEY:-}}"
           judge_key_without_whitespace="${judge_key//[[:space:]]/}"
           if [[ -z "$planner_key_without_whitespace" ]]; then
-            echo "::error::The selected live-information planner credential is missing or blank; compatible provider keys cannot substitute for it."
+            echo "::error::The selected acting model credential is missing or blank; compatible provider keys cannot substitute for it."
             exit 1
           fi
           if [[ -z "$judge_key_without_whitespace" ]]; then
@@ -109,12 +109,47 @@ jobs:
       # @elizaos/core/edge export. The lean install above skips lifecycle
       # scripts, so build that contract before either consumer starts.
       - name: Build core runtime contract
-        if: inputs.suite == 'all' || inputs.suite == 'scenarios' || inputs.suite == 'live-information' || inputs.suite == 'cloud'
+        if: inputs.suite == 'all' || inputs.suite == 'scenarios' || inputs.suite == 'group-chat' || inputs.suite == 'live-information' || inputs.suite == 'cloud'
         run: bun run build:core
 
       - name: Live scenarios
         if: inputs.suite == 'all' || inputs.suite == 'scenarios'
         run: bun run --cwd packages/scenario-runner test:live:e2e
+
+      - name: Group-chat evaluation
+        if: inputs.suite == 'group-chat'
+        id: group-chat-evaluation
+        continue-on-error: true
+        env:
+          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
+          SCENARIO_TURN_TIMEOUT_MS: "300000"
+        run: >-
+          bun packages/scripts/run-scenarios-isolated.mjs
+          packages/test/scenarios/group-chat
+          --lane live-only
+          --provider ${{ inputs.planner_provider }}
+          --workers 4
+          --timeout-ms 900000
+          --report reports/group-chat-evaluation/aggregate.json
+          --artifacts-dir reports/group-chat-evaluation/scenarios
+
+      - name: Validate complete independently judged group-chat evidence
+        if: inputs.suite == 'group-chat'
+        run: >-
+          bun packages/scripts/validate-group-chat-eval-report.ts
+          --report reports/group-chat-evaluation/aggregate.json
+          --artifacts-dir reports/group-chat-evaluation/scenarios
+          --scenario-dir packages/test/scenarios/group-chat
+          --provider ${{ inputs.planner_provider }}
+
+      - name: Upload group-chat evaluation evidence
+        if: always() && inputs.suite == 'group-chat'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: group-chat-${{ inputs.planner_provider }}-${{ github.run_id }}
+          path: reports/group-chat-evaluation
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Live information routing
         if: inputs.suite == 'live-information'

--- a/packages/scripts/__tests__/validate-group-chat-eval-report.test.ts
+++ b/packages/scripts/__tests__/validate-group-chat-eval-report.test.ts
@@ -1,0 +1,65 @@
+/** Tests fail-closed validation of retained group-chat benchmark evidence. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateGroupChatEvalReport } from "../validate-group-chat-eval-report.ts";
+
+function fixture(options?: { selfGraded?: boolean; omitArtifact?: boolean }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "group-chat-evidence-"));
+  const scenarioDir = path.join(root, "scenarios");
+  const artifactsDir = path.join(root, "artifacts");
+  fs.mkdirSync(scenarioDir);
+  fs.mkdirSync(artifactsDir);
+  for (const [index, id] of ["group.one", "group.two"].entries()) {
+    fs.writeFileSync(
+      path.join(scenarioDir, `${id}.scenario.ts`),
+      "export default {};\n",
+    );
+    if (!options?.omitArtifact || index === 0) {
+      const directory = path.join(artifactsDir, String(index));
+      fs.mkdirSync(directory);
+      fs.writeFileSync(path.join(directory, "report.json"), "{}\n");
+    }
+  }
+  const report = path.join(root, "aggregate.json");
+  fs.writeFileSync(
+    report,
+    JSON.stringify({
+      providerName: "anthropic",
+      totals: { passed: 1, failed: 1, skipped: 0, total: 2 },
+      scenarios: [
+        { id: "group.one", status: "passed" },
+        {
+          id: "group.two",
+          status: "failed",
+          judgeSelfGraded: options?.selfGraded === true,
+        },
+      ],
+    }),
+  );
+  return { report, artifactsDir, scenarioDir };
+}
+
+describe("group-chat evaluation report validation", () => {
+  it("accepts complete independent evidence even when benchmark assertions fail", () => {
+    expect(
+      validateGroupChatEvalReport({ ...fixture(), provider: "anthropic" }),
+    ).toEqual({ provider: "anthropic", total: 2, passed: 1, failed: 1 });
+  });
+
+  it("rejects self-graded or missing per-scenario evidence", () => {
+    expect(() =>
+      validateGroupChatEvalReport({
+        ...fixture({ selfGraded: true }),
+        provider: "anthropic",
+      }),
+    ).toThrow("self-graded");
+    expect(() =>
+      validateGroupChatEvalReport({
+        ...fixture({ omitArtifact: true }),
+        provider: "anthropic",
+      }),
+    ).toThrow("incomplete");
+  });
+});

--- a/packages/scripts/validate-group-chat-eval-report.ts
+++ b/packages/scripts/validate-group-chat-eval-report.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/** Validates complete, independently judged group-chat scenario evidence. */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface ValidationOptions {
+  report: string;
+  artifactsDir: string;
+  scenarioDir: string;
+  provider: string;
+}
+
+interface ScenarioRecord {
+  id: string;
+  status: "passed" | "failed";
+  judgeSelfGraded: boolean;
+}
+
+interface AggregateReport {
+  providerName: string;
+  totals: { passed: number; failed: number; skipped: number; total: number };
+  scenarios: ScenarioRecord[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readInteger(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (!Number.isSafeInteger(value) || typeof value !== "number" || value < 0) {
+    throw new Error(
+      `group-chat report totals.${key} must be a non-negative integer`,
+    );
+  }
+  return value;
+}
+
+function parseScenario(value: unknown): ScenarioRecord {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    value.id.length === 0
+  ) {
+    throw new Error("group-chat report contains a scenario without an id");
+  }
+  if (value.status !== "passed" && value.status !== "failed") {
+    throw new Error(
+      `group-chat scenario ${value.id} has status ${String(value.status)}`,
+    );
+  }
+  return {
+    id: value.id,
+    status: value.status,
+    judgeSelfGraded: value.judgeSelfGraded === true,
+  };
+}
+
+function parseAggregate(value: unknown): AggregateReport {
+  if (
+    !isRecord(value) ||
+    typeof value.providerName !== "string" ||
+    !isRecord(value.totals) ||
+    !Array.isArray(value.scenarios)
+  ) {
+    throw new Error("group-chat aggregate report has an invalid envelope");
+  }
+  return {
+    providerName: value.providerName,
+    totals: {
+      passed: readInteger(value.totals, "passed"),
+      failed: readInteger(value.totals, "failed"),
+      skipped: readInteger(value.totals, "skipped"),
+      total: readInteger(value.totals, "total"),
+    },
+    scenarios: value.scenarios.map(parseScenario),
+  };
+}
+
+function scenarioFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) return scenarioFiles(target);
+    return entry.isFile() && entry.name.endsWith(".scenario.ts")
+      ? [target]
+      : [];
+  });
+}
+
+function artifactReports(directory: string): string[] {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) return [];
+    const report = path.join(directory, entry.name, "report.json");
+    return fs.existsSync(report) ? [report] : [];
+  });
+}
+
+export function validateGroupChatEvalReport(options: ValidationOptions): {
+  provider: string;
+  total: number;
+  passed: number;
+  failed: number;
+} {
+  const aggregate = parseAggregate(
+    JSON.parse(fs.readFileSync(options.report, "utf8")),
+  );
+  const expectedTotal = scenarioFiles(options.scenarioDir).length;
+  const retainedReports = artifactReports(options.artifactsDir);
+  const ids = new Set(aggregate.scenarios.map(({ id }) => id));
+  const summedTotal = aggregate.totals.passed + aggregate.totals.failed;
+
+  if (expectedTotal === 0)
+    throw new Error("group-chat scenario directory is empty");
+  if (aggregate.providerName !== options.provider) {
+    throw new Error(
+      `group-chat acting provider mismatch: expected ${options.provider}, got ${aggregate.providerName}`,
+    );
+  }
+  if (
+    aggregate.totals.total !== expectedTotal ||
+    aggregate.scenarios.length !== expectedTotal ||
+    retainedReports.length !== expectedTotal ||
+    ids.size !== expectedTotal ||
+    aggregate.totals.skipped !== 0 ||
+    summedTotal !== expectedTotal
+  ) {
+    throw new Error(
+      `group-chat evidence is incomplete: expected=${expectedTotal} total=${aggregate.totals.total} scenarios=${aggregate.scenarios.length} retained=${retainedReports.length} unique=${ids.size} skipped=${aggregate.totals.skipped}`,
+    );
+  }
+  const selfGraded = aggregate.scenarios.filter(
+    ({ judgeSelfGraded }) => judgeSelfGraded,
+  );
+  if (selfGraded.length > 0) {
+    throw new Error(
+      `group-chat evidence contains ${selfGraded.length} self-graded scenario(s)`,
+    );
+  }
+  return {
+    provider: aggregate.providerName,
+    total: expectedTotal,
+    passed: aggregate.totals.passed,
+    failed: aggregate.totals.failed,
+  };
+}
+
+function option(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const report = option("report");
+  const artifactsDir = option("artifacts-dir");
+  const scenarioDir = option("scenario-dir");
+  const provider = option("provider");
+  if (!report || !artifactsDir || !scenarioDir || !provider) {
+    throw new Error(
+      "usage: validate-group-chat-eval-report --report <json> --artifacts-dir <dir> --scenario-dir <dir> --provider <name>",
+    );
+  }
+  process.stdout.write(
+    `${JSON.stringify(validateGroupChatEvalReport({ report, artifactsDir, scenarioDir, provider }))}\n`,
+  );
+}


### PR DESCRIPTION
Closes #27356. Follow-up to merged #27275.

## What changed

- adds `group-chat` to the credential-backed Live Smoke dispatcher;
- runs every committed group-chat scenario in its own process with an explicitly selected acting provider and strict independent Cerebras judging;
- retains per-scenario reports, trajectories, stdout, and stderr;
- adds a fail-closed validator that requires exact scenario/report cardinality, unique results, no skips, no self-grading, and the requested acting-provider identity;
- lets benchmark assertion failures remain benchmark data while missing or untrustworthy evidence fails the workflow.

## Verification

- `bun test packages/scripts/__tests__/validate-group-chat-eval-report.test.ts` — 2 passed;
- validator CLI accepted a complete retained fixture and rejected self-graded and missing-artifact fixtures;
- `bun run audit:workflow-triggers` — passed;
- `bun run audit:scripts` — passed;
- `bun run audit:scripts:inventory` — passed;
- workflow YAML parse — passed.

The workflow is manual and credential-backed. Normal pull requests do not consume live-model credentials.