### PR TITLE
test(ui): cover deep-link-handler

### DIFF
--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -216,6 +216,34 @@ describe("routeFirstRunDeepLink", () => {
 
     replaceStateSpy.mockRestore();
   });
+
+  it("tolerates repeated slashes between path segments", () => {
+    // The segment splitter trims and drops empty segments, so a host emitting
+    // doubled separators still routes instead of falling through as unmatched.
+    const handled = routeFirstRunDeepLink(
+      "eliza://first-run//runtime//cloud",
+      URL_SCHEME,
+    );
+
+    expect(handled).toBe(true);
+    expect(reloadIntoFirstRunRuntimeMock).toHaveBeenCalledWith("cloud");
+  });
+
+  it("returns false without dispatching a reload when no window exists (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+
+    try {
+      const handled = routeFirstRunDeepLink(
+        "eliza://first-run/runtime/local",
+        URL_SCHEME,
+      );
+
+      expect(handled).toBe(false);
+      expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe("installFirstRunDeepLinkListener", () => {
@@ -324,6 +352,36 @@ describe("installFirstRunDeepLinkListener", () => {
 
     await cleanup();
     expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed listener removal through onError during cleanup", async () => {
+    removeMock.mockRejectedValueOnce(new Error("remove failed"));
+    const onError = vi.fn();
+    const cleanup = await installFirstRunDeepLinkListener({
+      urlScheme: URL_SCHEME,
+      onError,
+    });
+
+    await cleanup();
+    // `remove()` rejection surfaces asynchronously from the cleanup closure.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe("remove failed");
+  });
+
+  it("routes an unmatched cold-launch URL to onUnmatched", async () => {
+    getLaunchUrlMock.mockResolvedValueOnce({ url: "eliza://chat" });
+    const onUnmatched = vi.fn();
+
+    await installFirstRunDeepLinkListener({
+      urlScheme: URL_SCHEME,
+      onUnmatched,
+    });
+
+    expect(onUnmatched).toHaveBeenCalledWith("eliza://chat");
+    expect(reloadIntoFirstRunRuntimeMock).not.toHaveBeenCalled();
   });
 });
 
@@ -441,5 +499,58 @@ describe("parseFirstRunRemoteConnectDeepLink", () => {
         URL_SCHEME,
       ),
     ).toBeNull();
+  });
+
+  it("falls through a blank value to the next alias key", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?api=%20&url=https://agent.example.com",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+  });
+
+  it("trims surrounding whitespace from the captured address", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?api=%20https%3A%2F%2Fagent.example.com%09",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+  });
+
+  it("prefers the documented api key over later aliases when several are present", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?url=https://fallback.example&api=https://agent.example.com",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?host=host.example&apiBase=base.example",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "base.example" });
+  });
+
+  it("matches extra path depth beneath the remote target", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote/session?api=https://agent.example.com",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+  });
+
+  it("accepts an uppercase scheme spelling through URL normalization", () => {
+    // The WHATWG parser lowercases scheme and host, so a host app that hands
+    // over `ELIZA://...` still matches the configured lowercase urlScheme.
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "ELIZA://first-run/runtime/remote?api=https://agent.example.com",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
   });
 });


### PR DESCRIPTION

## What this changes

Adds unit-test coverage for `packages/ui/src/first-run/deep-link-handler.ts` — the iOS/Android deep-link entry that translates `eliza://first-run/runtime/<id>` URLs into the first-run query contract.

**This is an additive-only change: +111/−0, one existing test file, no production code touched.**

### Why additive to `deep-link-entry.test.ts` instead of a new co-located file

The module's suite already exists on current `develop` as
`packages/ui/src/first-run/__tests__/deep-link-entry.test.ts` (its header declares it as coverage for `../deep-link-handler.ts`). Per this repository's additive-only policy for test files present on the base, this PR **extends that suite with 9 new cases** covering branches it did not reach. No line is removed or reorganised; nothing is duplicated; net coverage strictly grows.

### New cases (all asserting observed behaviour of the real module)

`routeFirstRunDeepLink`
- tolerates repeated slashes between path segments (`eliza://first-run//runtime//cloud` routes `cloud`)
- returns `false` and dispatches no reload when no `window` exists (SSR guard, exercised via `vi.stubGlobal`)

`installFirstRunDeepLinkListener`
- reports a failed listener removal through `onError` during cleanup (the J6 teardown branch)
- routes an unmatched cold-launch URL from `getLaunchUrl()` to `onUnmatched`

`parseFirstRunRemoteConnectDeepLink`
- falls through a blank (`%20`) value to the next alias key
- trims surrounding whitespace from the captured address
- prefers the documented `api` key over later aliases when several are present (`api` > `apiBase` > `url` > `host`)
- matches extra path depth beneath the remote target (`/runtime/remote/session`)
- accepts an uppercase scheme spelling through WHATWG URL normalization

Mocks stand only at the real external boundary (the optional native `@capacitor/app` bridge), matching the established pattern of the surrounding suite; all assertions drive the real parser/router.

## Evidence

Fork-contributor note: hosted CI does not run on this PR; the following checks were run locally against head `9170f0d27f8fd7d48687d281ddadadf010b5af05`:

- `bunx vitest run src/first-run/__tests__/deep-link-entry.test.ts` (in `packages/ui`): **Test Files 1 passed (1), Tests 37 passed (37)** — 28 pre-existing + 9 new. Re-run on the exact published tree (fresh worktree off current `develop`, `16c9edf962`): same result.
- `bunx biome check --write src/first-run/__tests__/deep-link-entry.test.ts`: clean ("Checked 1 file … No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero occurrences of the touched file in output.
- `git diff --stat`: 111 insertions(+), 0 deletions — test file only.
- No open PR touches `packages/ui/src/first-run/deep-link-handler*` (verified via API immediately before filing).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9170f0d27f8fd7d48687d281ddadadf010b5af05 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
