### PR TITLE
test(ui): cover events barrel

### DIFF
--- a/packages/ui/src/events/index.test.ts
+++ b/packages/ui/src/events/index.test.ts
@@ -1,0 +1,592 @@
+/**
+ * Unit coverage for the `@elizaos/ui/events` barrel (src/events/index.ts):
+ * the UI-only event-name constants, their typed dispatch helpers, the cloud-
+ * handoff phase cache, focus-connector session persistence, and the
+ * connect-request / native navigate-view replay queues owned here. Real-module
+ * suite over jsdom — the subject is driven through its public path only.
+ */
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  acknowledgeNotificationCenterOpenRequest,
+  peekNotificationCenterOpenRequest,
+  subscribeNotificationCenterOpenRequests,
+} from "../state/notifications/notification-center-open-request";
+import {
+  __resetLastCloudHandoffPhaseDetailForTests,
+  APP_EMOTE_EVENT,
+  CHAT_CLOSE_EVENT,
+  CHAT_MESSAGE_SEARCH_EVENT,
+  CHAT_OPEN_EVENT,
+  CHAT_PREFILL_EVENT,
+  CLOUD_HANDOFF_PHASE_EVENT,
+  CLOUD_HANDOFF_RETRY_EVENT,
+  CONNECT_EVENT,
+  clearPendingFocusConnector,
+  createNavigateViewEvent,
+  dispatchAppEvent,
+  dispatchBackIntent,
+  dispatchChatClose,
+  dispatchChatOpen,
+  dispatchChatPrefill,
+  dispatchCloudHandoffPhase,
+  dispatchCloudHandoffRetry,
+  dispatchConnectRequest,
+  dispatchFocusConnector,
+  dispatchNavigateViewRequest,
+  dispatchOpenNotificationCenter,
+  dispatchVoiceControl,
+  dispatchWindowEvent,
+  ELIZA_BACK_INTENT_EVENT,
+  FOCUS_CONNECTOR_EVENT,
+  getLastCloudHandoffPhaseDetail,
+  listenForConnectRequests,
+  listenForNavigateViewRequests,
+  OPEN_NOTIFICATION_CENTER_EVENT,
+  readPendingFocusConnector,
+  VOICE_CONTROL_EVENT,
+} from "./index";
+
+const tick = (): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+/** Records every event of `type` observed on `target` until `stop()`. */
+function record(
+  target: EventTarget,
+  type: string,
+): { events: CustomEvent[]; stop: () => void } {
+  const events: CustomEvent[] = [];
+  const handler = (event: Event): void => {
+    events.push(event as CustomEvent);
+  };
+  target.addEventListener(type, handler);
+  return {
+    events,
+    stop: () => target.removeEventListener(type, handler),
+  };
+}
+
+/** Applies every pending native navigate-view intent so tests stay isolated. */
+function drainNavigateViewQueue(): void {
+  listenForNavigateViewRequests(() => true)();
+}
+
+/** Consumes any pending connect request left behind by a test. */
+async function drainPendingConnectRequest(): Promise<void> {
+  const off = listenForConnectRequests(() => {});
+  await tick();
+  off();
+}
+
+afterEach(async () => {
+  __resetLastCloudHandoffPhaseDetailForTests();
+  drainNavigateViewQueue();
+  await drainPendingConnectRequest();
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("UI-only event-name constants", () => {
+  it("pins the literal wire values consumers and natives share", () => {
+    expect(FOCUS_CONNECTOR_EVENT).toBe("eliza:focus-connector");
+    expect(VOICE_CONTROL_EVENT).toBe("eliza:voice-control");
+    expect(CLOUD_HANDOFF_PHASE_EVENT).toBe("eliza:cloud-handoff-phase");
+    expect(CLOUD_HANDOFF_RETRY_EVENT).toBe("eliza:cloud-handoff-retry");
+    expect(CHAT_PREFILL_EVENT).toBe("eliza:chat:prefill");
+    expect(CHAT_OPEN_EVENT).toBe("eliza:chat:open");
+    expect(CHAT_CLOSE_EVENT).toBe("eliza:chat:close");
+    expect(CHAT_MESSAGE_SEARCH_EVENT).toBe("eliza:chat:message-search");
+    expect(OPEN_NOTIFICATION_CENTER_EVENT).toBe("eliza:notifications:open");
+    expect(ELIZA_BACK_INTENT_EVENT).toBe("eliza:back-intent");
+  });
+
+  it("re-exports the shared event vocabulary through the barrel", () => {
+    expect(typeof APP_EMOTE_EVENT).toBe("string");
+    expect(typeof CONNECT_EVENT).toBe("string");
+    expect(typeof createNavigateViewEvent).toBe("function");
+  });
+});
+
+describe("dispatchVoiceControl", () => {
+  it("delivers start and stop commands as window custom events", () => {
+    const sent = record(window, VOICE_CONTROL_EVENT);
+
+    dispatchVoiceControl({ command: "start" });
+    dispatchVoiceControl({ command: "stop" });
+
+    expect(sent.events).toHaveLength(2);
+    expect(sent.events[0].detail).toEqual({ command: "start" });
+    expect(sent.events[1].detail).toEqual({ command: "stop" });
+    sent.stop();
+  });
+});
+
+describe("floating-chat dispatchers", () => {
+  it("prefills the composer with optional draft selection", () => {
+    const sent = record(window, CHAT_PREFILL_EVENT);
+
+    dispatchChatPrefill({ text: "hello" });
+    dispatchChatPrefill({ text: "pick me", select: true });
+
+    expect(sent.events).toHaveLength(2);
+    expect(sent.events[0].detail).toEqual({ text: "hello" });
+    expect(sent.events[1].detail).toEqual({ text: "pick me", select: true });
+    sent.stop();
+  });
+
+  it("opens and collapses the floating chat with distinct events", () => {
+    const opened = record(window, CHAT_OPEN_EVENT);
+    const closed = record(window, CHAT_CLOSE_EVENT);
+
+    dispatchChatOpen();
+    dispatchChatClose();
+
+    expect(opened.events).toHaveLength(1);
+    expect(closed.events).toHaveLength(1);
+    opened.stop();
+    closed.stop();
+  });
+});
+
+describe("dispatchOpenNotificationCenter", () => {
+  it("fires the window event and records a real open request", async () => {
+    const sent = record(window, OPEN_NOTIFICATION_CENTER_EVENT);
+    const received: number[] = [];
+    const unsubscribe = subscribeNotificationCenterOpenRequests((id) => {
+      received.push(id);
+    });
+
+    dispatchOpenNotificationCenter();
+
+    expect(sent.events).toHaveLength(1);
+    expect(received.length).toBeGreaterThan(0);
+    expect(peekNotificationCenterOpenRequest()).toBe(received.at(-1));
+    // The retained request stays pending until the visible center acks it.
+    expect(
+      acknowledgeNotificationCenterOpenRequest(received.at(-1) as number),
+    ).toBe(true);
+    expect(peekNotificationCenterOpenRequest()).toBeNull();
+
+    unsubscribe();
+    sent.stop();
+  });
+});
+
+describe("cloud handoff phase surface", () => {
+  it("starts with no cached phase this session", () => {
+    expect(getLastCloudHandoffPhaseDetail()).toBeNull();
+  });
+
+  it("caches the latest dispatched phase for late-mounting surfaces", () => {
+    const sent = record(window, CLOUD_HANDOFF_PHASE_EVENT);
+    const migrating = {
+      agentId: "agent-1",
+      phase: "migrating",
+    } as const;
+    const switched = {
+      agentId: "agent-1",
+      phase: "switched",
+      imported: 7,
+    } as const;
+
+    dispatchCloudHandoffPhase(migrating);
+    expect(sent.events[0].detail).toBe(migrating);
+    expect(getLastCloudHandoffPhaseDetail()).toBe(migrating);
+
+    dispatchCloudHandoffPhase(switched);
+    expect(sent.events[1].detail).toBe(switched);
+    expect(getLastCloudHandoffPhaseDetail()).toBe(switched);
+
+    sent.stop();
+  });
+
+  it("resets the cached phase between sessions", () => {
+    dispatchCloudHandoffPhase({ agentId: "agent-1", phase: "failed" });
+    expect(getLastCloudHandoffPhaseDetail()).not.toBeNull();
+
+    __resetLastCloudHandoffPhaseDetailForTests();
+    expect(getLastCloudHandoffPhaseDetail()).toBeNull();
+  });
+
+  it("dispatches handoff retry requests on window", () => {
+    const sent = record(window, CLOUD_HANDOFF_RETRY_EVENT);
+
+    dispatchCloudHandoffRetry({ agentId: "agent-9" });
+
+    expect(sent.events).toHaveLength(1);
+    expect(sent.events[0].detail).toEqual({ agentId: "agent-9" });
+    sent.stop();
+  });
+});
+
+describe("dispatchBackIntent", () => {
+  it("reports false when no consumer handles the press", () => {
+    expect(dispatchBackIntent()).toBe(false);
+  });
+
+  it("reports false when attached consumers ignore the press", () => {
+    const seenDetails: Array<{ handled: boolean }> = [];
+    window.addEventListener(ELIZA_BACK_INTENT_EVENT, (event) => {
+      seenDetails.push((event as CustomEvent<{ handled: boolean }>).detail);
+    });
+
+    expect(dispatchBackIntent()).toBe(false);
+    expect(seenDetails).toEqual([{ handled: false }]);
+  });
+
+  it("reports true once a consumer flips handled synchronously", () => {
+    window.addEventListener(ELIZA_BACK_INTENT_EVENT, (event) => {
+      const detail = (event as CustomEvent<{ handled: boolean }>).detail;
+      if (!detail.handled) detail.handled = true;
+    });
+
+    expect(dispatchBackIntent()).toBe(true);
+  });
+});
+
+describe("focus connector helpers", () => {
+  const STORAGE_KEY = "elizaos:focus-connector";
+
+  it("persists the trimmed connector id and dispatches it on document", () => {
+    const sent = record(document, FOCUS_CONNECTOR_EVENT);
+
+    dispatchFocusConnector("  gmail  ");
+
+    expect(sent.events).toHaveLength(1);
+    expect(sent.events[0].detail).toEqual({ connectorId: "gmail" });
+    expect(readPendingFocusConnector()).toBe("gmail");
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe("gmail");
+    sent.stop();
+  });
+
+  it("treats a blank connector id as a no-op", () => {
+    const sent = record(document, FOCUS_CONNECTOR_EVENT);
+
+    dispatchFocusConnector("   ");
+
+    expect(sent.events).toHaveLength(0);
+    expect(readPendingFocusConnector()).toBeNull();
+    sent.stop();
+  });
+
+  it("reads null when nothing is pending", () => {
+    expect(readPendingFocusConnector()).toBeNull();
+  });
+
+  it("clears only a matching connector id", () => {
+    dispatchFocusConnector("gmail");
+
+    clearPendingFocusConnector("not-gmail");
+    expect(readPendingFocusConnector()).toBe("gmail");
+
+    clearPendingFocusConnector("gmail");
+    expect(readPendingFocusConnector()).toBeNull();
+  });
+
+  it("clears any stored id when called without one", () => {
+    dispatchFocusConnector("slack");
+    clearPendingFocusConnector();
+    expect(readPendingFocusConnector()).toBeNull();
+  });
+
+  it("degrades gracefully when sessionStorage throws", () => {
+    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    expect(readPendingFocusConnector()).toBeNull();
+
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const sent = record(document, FOCUS_CONNECTOR_EVENT);
+    dispatchFocusConnector("gmail");
+    expect(sent.events).toHaveLength(1);
+    expect(sent.events[0].detail).toEqual({ connectorId: "gmail" });
+    sent.stop();
+  });
+});
+
+describe("generic typed dispatch helpers", () => {
+  it("dispatchAppEvent targets document with the given detail", () => {
+    const sent = record(document, "eliza:test-doc-target");
+
+    dispatchAppEvent("eliza:test-doc-target" as never, { n: 1 });
+
+    expect(sent.events).toHaveLength(1);
+    expect(sent.events[0].detail).toEqual({ n: 1 });
+    sent.stop();
+  });
+
+  it("dispatchWindowEvent targets window with the given detail", () => {
+    const sent = record(window, "eliza:test-window-target");
+
+    dispatchWindowEvent("eliza:test-window-target" as never, { n: 2 });
+
+    expect(sent.events).toHaveLength(1);
+    expect(sent.events[0].detail).toEqual({ n: 2 });
+    sent.stop();
+  });
+});
+
+describe("connect-request replay queue", () => {
+  it("replays only the newest pre-mount request, with full detail", async () => {
+    dispatchConnectRequest({
+      gatewayUrl: "wss://old.example.com",
+      token: "stale",
+    });
+    const newest = {
+      gatewayUrl: "wss://new.example.com",
+      token: "fresh",
+      completeFirstRun: true,
+    };
+    dispatchConnectRequest(newest);
+
+    const received: Array<Record<string, unknown>> = [];
+    const off = listenForConnectRequests((request) => {
+      received.push({ ...request });
+    });
+    await tick();
+    off();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(newest);
+  });
+
+  it("delivers live requests synchronously to mounted listeners", () => {
+    const received: string[] = [];
+    const off = listenForConnectRequests((request) => {
+      received.push(request.gatewayUrl);
+    });
+
+    dispatchConnectRequest({ gatewayUrl: "wss://live.example.com" });
+
+    expect(received).toEqual(["wss://live.example.com"]);
+    off();
+  });
+
+  it("lets exactly one subscriber adopt a dispatched request", () => {
+    const firstGot: string[] = [];
+    const secondGot: string[] = [];
+    const offFirst = listenForConnectRequests((r) => {
+      firstGot.push(r.gatewayUrl);
+    });
+    const offSecond = listenForConnectRequests((r) => {
+      secondGot.push(r.gatewayUrl);
+    });
+
+    dispatchConnectRequest({ gatewayUrl: "wss://once.example.com" });
+
+    expect(firstGot).toEqual(["wss://once.example.com"]);
+    expect(secondGot).toEqual([]);
+
+    offFirst();
+    offSecond();
+  });
+
+  it("passes legacy raw CONNECT_EVENT customs to every subscriber", () => {
+    const firstGot: string[] = [];
+    const secondGot: string[] = [];
+    const offFirst = listenForConnectRequests((r) => {
+      firstGot.push(r.gatewayUrl);
+    });
+    const offSecond = listenForConnectRequests((r) => {
+      secondGot.push(r.gatewayUrl);
+    });
+
+    document.dispatchEvent(
+      new CustomEvent(CONNECT_EVENT, {
+        detail: { gatewayUrl: "wss://legacy.example.com" },
+      }),
+    );
+
+    expect(firstGot).toEqual(["wss://legacy.example.com"]);
+    expect(secondGot).toEqual(["wss://legacy.example.com"]);
+
+    offFirst();
+    offSecond();
+  });
+
+  it("ignores raw events whose detail is not a connect request", () => {
+    const received: unknown[] = [];
+    const off = listenForConnectRequests((request) => {
+      received.push(request);
+    });
+
+    const invalid: unknown[] = [
+      "not-an-object",
+      42,
+      ["array"],
+      {},
+      { gatewayUrl: 7 },
+    ];
+    for (const detail of invalid) {
+      document.dispatchEvent(new CustomEvent(CONNECT_EVENT, { detail }));
+    }
+
+    expect(received).toEqual([]);
+    off();
+  });
+
+  it("stops delivering after unsubscribe", async () => {
+    const received: string[] = [];
+    const off = listenForConnectRequests((request) => {
+      received.push(request.gatewayUrl);
+    });
+    off();
+
+    dispatchConnectRequest({ gatewayUrl: "wss://gone.example.com" });
+    await tick();
+
+    expect(received).toEqual([]);
+  });
+});
+
+describe("navigate-view request queue", () => {
+  it("resolves true once a listener applies and never redelivers", async () => {
+    const applied = dispatchNavigateViewRequest({
+      viewId: "wallet",
+      viewPath: "/wallet",
+    });
+
+    const latecomer: string[] = [];
+    const off = listenForNavigateViewRequests((event) => {
+      latecomer.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+
+    expect(latecomer).toEqual(["wallet"]);
+    expect(await applied).toBe(true);
+
+    // The committed request is durably consumed: a later mount sees nothing.
+    const secondMount: string[] = [];
+    const offSecond = listenForNavigateViewRequests((event) => {
+      secondMount.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+    expect(secondMount).toEqual([]);
+
+    off();
+    offSecond();
+  });
+
+  it("preserves FIFO order across several pending intents", async () => {
+    const pending = [
+      dispatchNavigateViewRequest({ viewId: "a", viewPath: "/a" }),
+      dispatchNavigateViewRequest({ viewId: "b", viewPath: "/b" }),
+      dispatchNavigateViewRequest({ viewId: "c", viewPath: "/c" }),
+    ];
+
+    const order: string[] = [];
+    const off = listenForNavigateViewRequests((event) => {
+      order.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+
+    expect(order).toEqual(["a", "b", "c"]);
+    expect(await Promise.all(pending)).toEqual([true, true, true]);
+    off();
+  });
+
+  it("retries an intent declined with an explicit false", async () => {
+    const appliedPromise = dispatchNavigateViewRequest({
+      viewId: "chat",
+      viewPath: "/chat",
+    });
+
+    let declinerCalls = 0;
+    const offDecliner = listenForNavigateViewRequests(() => {
+      declinerCalls += 1;
+      return false;
+    });
+
+    let applierCalls = 0;
+    const offApplier = listenForNavigateViewRequests(() => {
+      applierCalls += 1;
+      return true;
+    });
+
+    // The decliner saw the initial delivery AND the replay triggered by the
+    // applier's mount; the applier's acceptance consumed the intent.
+    expect(declinerCalls).toBe(2);
+    expect(applierCalls).toBe(1);
+    expect(await appliedPromise).toBe(true);
+
+    offDecliner();
+    offApplier();
+  });
+
+  it("does not let a throwing listener steal the intent", async () => {
+    const appliedPromise = dispatchNavigateViewRequest({
+      viewId: "settings",
+      viewPath: "/settings",
+    });
+
+    const offThrower = listenForNavigateViewRequests(() => {
+      throw new Error("listener exploded mid-apply");
+    });
+    const appliedBy: string[] = [];
+    const offApplier = listenForNavigateViewRequests((event) => {
+      appliedBy.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+
+    expect(appliedBy).toEqual(["settings"]);
+    expect(await appliedPromise).toBe(true);
+
+    offThrower();
+    offApplier();
+  });
+
+  it("drops the oldest past the 16-item bound and resolves it false", async () => {
+    const promises: Array<Promise<boolean>> = [];
+    for (let i = 1; i <= 17; i += 1) {
+      promises.push(
+        dispatchNavigateViewRequest({ viewId: `v${i}`, viewPath: `/${i}` }),
+      );
+    }
+
+    // The overflowed oldest intent is surfaced as unapplied, never acked.
+    expect(await promises[0]).toBe(false);
+
+    // The surviving 16 stay queued in arrival order and apply normally.
+    const order: string[] = [];
+    const off = listenForNavigateViewRequests((event) => {
+      order.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+
+    expect(order).toHaveLength(16);
+    expect(order[0]).toBe("v2");
+    expect(order.at(-1)).toBe("v17");
+    const survivors = await Promise.all(promises.slice(1));
+    expect(survivors.every((applied) => applied === true)).toBe(true);
+    off();
+  }, 10_000);
+
+  it("passes legacy raw navigation events without queuing them", () => {
+    const firstMount: string[] = [];
+    const offFirst = listenForNavigateViewRequests((event) => {
+      firstMount.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+
+    window.dispatchEvent(
+      createNavigateViewEvent({ viewId: "legacy", viewPath: "/legacy" }),
+    );
+    expect(firstMount).toEqual(["legacy"]);
+
+    // A legacy event never enters the replay queue: a later mount misses it.
+    const secondMount: string[] = [];
+    const offSecond = listenForNavigateViewRequests((event) => {
+      secondMount.push((event as CustomEvent).detail.viewId);
+      return true;
+    });
+    expect(secondMount).toEqual([]);
+
+    offFirst();
+    offSecond();
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/events/index.test.ts` — a real-module unit suite for the `@elizaos/ui/events` barrel (`packages/ui/src/events/index.ts`), which had no same-named test anywhere on develop. Test-only change: **one new file, +592/−0**, no production behavior touched.

Coverage driven through the public path:

- UI-only event-name constants pinned to their literal wire values (`eliza:focus-connector`, `eliza:voice-control`, handoff/chat/back-intent families).
- Typed dispatchers: voice control start/stop, chat prefill/open/close, generic `dispatchAppEvent`/`dispatchWindowEvent` targeting document vs window.
- Notification-center open: window event plus the real retained request observable through the notification-center-open-request store, including ack semantics.
- Cloud handoff phase cache: null before any dispatch, latest-wins caching for late-mounting surfaces, session reset helper, retry dispatch.
- Android back intent: fall-through returns `false`, synchronous `handled` flip returns `true`.
- Focus connector: trim + sessionStorage persistence + normalized event detail, blank-id no-op, match-gated clear, and documented storage-failure tolerance (J3/J6 catches).
- Connect-request replay queue: newest pre-mount request replayed once mounted, exactly-one-consumer claim semantics, legacy raw-event passthrough, invalid-detail rejection, unsubscribe.
- Native navigate-view queue: apply→resolve(`true`), durable consumption (no redelivery), strict FIFO across pending intents, explicit-`false` retry semantics (decliner sees initial delivery + replay), throwing-listener isolation, the 16-item overflow bound resolving the dropped intent `false`, and legacy non-queued passthrough.

No mocks stand in for the subject; only the `sessionStorage` boundary is stubbed where the module documents failure tolerance.

## Evidence

- `bunx vitest run src/events/index.test.ts` (packages/ui, vitest 4.1.10, jsdom): **Test Files 1 passed (1); Tests 33 passed (33)** against `origin/develop` @ `16c9edf962` (re-fetched immediately before filing; the target module is byte-identical between that tip and this PR's head, which only adds the test file).
- `bunx biome check --write src/events/index.test.ts`: fixed formatting once, then clean ("Checked 1 file... No fixes applied") against the repo-root `biome.json`.
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mentioning `src/events/index.test.ts`.
- Diff is additive only: one new test file, +592/−0.

Note: this PR is filed from a fork, so hosted CI does not run on it — the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a50f214ba6ebb8dc11be2bf08a552ce8760cfe98 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
