### PR TITLE
test(ui): cover runtime-target

### DIFF
--- a/packages/ui/src/first-run/runtime-target.test.ts
+++ b/packages/ui/src/first-run/runtime-target.test.ts
@@ -1,0 +1,114 @@
+/** Verifies first-run runtime-target resolution against the real boot-config store. */
+// @vitest-environment node
+
+/**
+ * Covers `resolveFirstRunLocalAgentApiBase` platform precedence (iOS > Android >
+ * configured Eliza API base > loopback default), the cloud-target predicate, and
+ * the active-server-kind → first-run-target mapping (the non-obvious
+ * `cloud → elizacloud` rename). The platform constants are the only seam
+ * substituted — detection is an import-time Capacitor probe that cannot fire in
+ * a test process — while the API-base path runs through the REAL
+ * `setElizaApiBase`/`clearElizaApiBase` boot-config store.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestPlatform = { isIOS: boolean; isAndroid: boolean };
+type GlobalWithTestPlatform = typeof globalThis & {
+  __runtimeTargetTestPlatform?: TestPlatform;
+};
+
+vi.mock("../platform/init", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../platform/init")>();
+  return {
+    ...actual,
+    get isIOS() {
+      return (
+        (globalThis as GlobalWithTestPlatform).__runtimeTargetTestPlatform
+          ?.isIOS ?? false
+      );
+    },
+    get isAndroid() {
+      return (
+        (globalThis as GlobalWithTestPlatform).__runtimeTargetTestPlatform
+          ?.isAndroid ?? false
+      );
+    },
+  };
+});
+
+import { clearElizaApiBase, setElizaApiBase } from "../utils";
+import {
+  activeServerKindToFirstRunRuntimeTarget,
+  isElizaCloudFirstRunTarget,
+  resolveFirstRunLocalAgentApiBase,
+} from "./runtime-target";
+
+function setTestPlatform(platform: TestPlatform): void {
+  (globalThis as GlobalWithTestPlatform).__runtimeTargetTestPlatform = platform;
+}
+
+beforeEach(() => {
+  clearElizaApiBase();
+  setTestPlatform({ isIOS: false, isAndroid: false });
+});
+
+afterEach(() => {
+  clearElizaApiBase();
+  delete (globalThis as GlobalWithTestPlatform).__runtimeTargetTestPlatform;
+});
+
+describe("resolveFirstRunLocalAgentApiBase", () => {
+  it("returns the iOS IPC base when iOS wins over Android", () => {
+    setTestPlatform({ isIOS: true, isAndroid: true });
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("eliza-local-agent://ipc");
+  });
+
+  it("returns the iOS IPC base on iOS alone", () => {
+    setTestPlatform({ isIOS: true, isAndroid: false });
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("eliza-local-agent://ipc");
+  });
+
+  it("returns the Android IPC base when only Android is detected", () => {
+    setTestPlatform({ isIOS: false, isAndroid: true });
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("eliza-local-agent://ipc");
+  });
+
+  it("returns the configured Eliza API base on desktop/web", () => {
+    setElizaApiBase("http://192.168.1.10:4545");
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("http://192.168.1.10:4545");
+  });
+
+  it("falls back to the loopback default when no API base is configured", () => {
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("http://127.0.0.1:31337");
+  });
+
+  it("treats a whitespace-only API base as unconfigured", () => {
+    setElizaApiBase("   ");
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("http://127.0.0.1:31337");
+  });
+
+  it("ignores a stale configured API base on native mobile", () => {
+    setElizaApiBase("http://192.168.1.10:4545");
+    setTestPlatform({ isIOS: false, isAndroid: true });
+    expect(resolveFirstRunLocalAgentApiBase()).toBe("eliza-local-agent://ipc");
+  });
+});
+
+describe("isElizaCloudFirstRunTarget", () => {
+  it("is true only for the elizacloud targets", () => {
+    expect(isElizaCloudFirstRunTarget("elizacloud")).toBe(true);
+    expect(isElizaCloudFirstRunTarget("elizacloud-hybrid")).toBe(true);
+    expect(isElizaCloudFirstRunTarget("local")).toBe(false);
+    expect(isElizaCloudFirstRunTarget("remote")).toBe(false);
+    expect(isElizaCloudFirstRunTarget("")).toBe(false);
+  });
+});
+
+describe("activeServerKindToFirstRunRuntimeTarget", () => {
+  it("maps each server kind to its first-run target", () => {
+    expect(activeServerKindToFirstRunRuntimeTarget("local")).toBe("local");
+    expect(activeServerKindToFirstRunRuntimeTarget("remote")).toBe("remote");
+    expect(activeServerKindToFirstRunRuntimeTarget("cloud")).toBe("elizacloud");
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new co-located unit suite for `packages/ui/src/first-run/runtime-target.ts`, which previously had no same-named test file anywhere in the repository. The diff is one new test file, +114/−0 — no production code is touched.

## What is covered

`resolveFirstRunLocalAgentApiBase()`:
- iOS wins over Android when both platform flags are set (precedence order pinned)
- iOS alone → the iOS IPC base (`eliza-local-agent://ipc`)
- Android alone → the same IPC base
- desktop/web returns the configured Eliza API base, driven through the REAL `setElizaApiBase()` boot-config store (no mock on this path)
- unconfigured API base falls back to the hardcoded loopback default `http://127.0.0.1:31337`
- a whitespace-only configured base behaves as unconfigured (trim contract observed through the real shared accessor)
- a stale configured API base does not leak onto native mobile

`isElizaCloudFirstRunTarget()`: true only for `elizacloud` and `elizacloud-hybrid`; false for `""`, `local`, `remote`.

`activeServerKindToFirstRunRuntimeTarget()`: `local→local`, `remote→remote`, and the non-obvious `cloud→elizacloud` rename.

Only the import-time Capacitor platform probe (`../platform/init`) is substituted, using the same `importOriginal` + getter pattern as the sibling `device-ram-gate.test.ts`; everything else runs the real module.

## Evidence (all commands run locally; counts are the actual observed output)

- `bunx vitest run src/first-run/runtime-target.test.ts` (in `packages/ui`, against develop @ 16c9edf962): **Test Files 1 passed (1), Tests 9 passed (9)** — re-run green after the biome format pass.
- `bunx biome check src/first-run/runtime-target.test.ts`: clean ("Checked 1 file … No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: grep for `runtime-target.test.ts` over the full output has **zero hits** — no type errors introduced by this file.
- `git diff --stat` vs develop @ 16c9edf962: exactly one file changed, `packages/ui/src/first-run/runtime-target.test.ts | 114 ++++`, insertions only.

## Notes

- Fork contributor: hosted CI does **not** run on this pull request; the local evidence above is the verification that exists.
- Test-only change; behaviour of the module under test is asserted as observed, nothing aspirational.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c73a59964792cbdd5a9f021bb3636b5ea6e4162a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
