### PR TITLE
test(ui): cover reload-into-first-run-runtime

### DIFF
--- a/packages/ui/src/first-run/reload-into-first-run-runtime.test.ts
+++ b/packages/ui/src/first-run/reload-into-first-run-runtime.test.ts
@@ -1,0 +1,235 @@
+/** Verifies the Switch-runtime reload helper through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Direct unit coverage for `./reload-into-first-run-runtime.ts` — the helper
+ * behind Settings > Runtime "Switch runtime" and the mobile deep-link entry.
+ *
+ * Storage assertions run against the real jsdom localStorage: the module
+ * clears two persisted keys through `shellLocalStorage`, and those removals
+ * are observable state. Only the final `location.href` assignment is recorded
+ * via a stubbed `window`, because jsdom cannot perform a navigation and offers
+ * no other observation point; every stub still hands the module the REAL
+ * localStorage object. `readFirstRunRuntimeTarget` is exercised as a pure
+ * parser over explicit inputs plus the live `window.location.search` default.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MOBILE_RUNTIME_MODE_STORAGE_KEY } from "./mobile-runtime-mode";
+import {
+  __TEST_ONLY__,
+  FIRST_RUN_QUERY_NAME,
+  FIRST_RUN_QUERY_VALUE,
+  FIRST_RUN_TARGET_QUERY_NAME,
+  readFirstRunRuntimeTarget,
+  reloadIntoFirstRunRuntime,
+} from "./reload-into-first-run-runtime";
+
+const ACTIVE_SERVER_STORAGE_KEY = __TEST_ONLY__.ACTIVE_SERVER_STORAGE_KEY;
+
+type LocationStub = { href: string };
+
+function firstRunSearch(target?: string): string {
+  const params = new URLSearchParams();
+  params.set(FIRST_RUN_QUERY_NAME, FIRST_RUN_QUERY_VALUE);
+  if (target !== undefined) {
+    params.set(FIRST_RUN_TARGET_QUERY_NAME, target);
+  }
+  return `?${params.toString()}`;
+}
+
+function stubWindowWith(location: LocationStub): void {
+  vi.stubGlobal("window", { location, localStorage: window.localStorage });
+}
+
+describe("first-run query contract", () => {
+  it("pins the query names/values deep-link-handler and hosts share", () => {
+    expect(FIRST_RUN_QUERY_NAME).toBe("runtime");
+    expect(FIRST_RUN_QUERY_VALUE).toBe("first-run");
+    expect(FIRST_RUN_TARGET_QUERY_NAME).toBe("runtimeTarget");
+  });
+
+  it("exposes the persisted keys it clears, mirroring their owners", () => {
+    expect(__TEST_ONLY__.ACTIVE_SERVER_STORAGE_KEY).toBe(
+      "elizaos:active-server",
+    );
+    expect(__TEST_ONLY__.MOBILE_RUNTIME_MODE_STORAGE_KEY).toBe(
+      MOBILE_RUNTIME_MODE_STORAGE_KEY,
+    );
+    expect(__TEST_ONLY__.MOBILE_RUNTIME_MODE_STORAGE_KEY).toBe(
+      "eliza:mobile-runtime-mode",
+    );
+  });
+});
+
+describe("readFirstRunRuntimeTarget", () => {
+  it.each(["cloud", "local", "remote"] as const)(
+    "parses a pinned %s target",
+    (target) => {
+      expect(
+        readFirstRunRuntimeTarget(`?runtime=first-run&runtimeTarget=${target}`),
+      ).toBe(target);
+    },
+  );
+
+  it("returns null unless runtime is exactly first-run", () => {
+    expect(readFirstRunRuntimeTarget("")).toBeNull();
+    expect(readFirstRunRuntimeTarget("?")).toBeNull();
+    expect(readFirstRunRuntimeTarget("?runtime=onboarding")).toBeNull();
+    expect(readFirstRunRuntimeTarget("?runtime=first-runX")).toBeNull();
+    expect(readFirstRunRuntimeTarget("?runtime=First-Run")).toBeNull();
+  });
+
+  it("falls back to local when the target is missing or invalid", () => {
+    expect(readFirstRunRuntimeTarget("?runtime=first-run")).toBe("local");
+    expect(readFirstRunRuntimeTarget("?runtime=first-run&runtimeTarget=")).toBe(
+      "local",
+    );
+    expect(
+      readFirstRunRuntimeTarget("?runtime=first-run&runtimeTarget=bogus"),
+    ).toBe("local");
+    expect(
+      readFirstRunRuntimeTarget("?runtime=first-run&runtimeTarget=CLOUD"),
+    ).toBe("local");
+  });
+
+  it("accepts a URLSearchParams instance directly", () => {
+    const params = new URLSearchParams(
+      "?runtime=first-run&runtimeTarget=remote",
+    );
+    expect(readFirstRunRuntimeTarget(params)).toBe("remote");
+    expect(readFirstRunRuntimeTarget(new URLSearchParams())).toBeNull();
+  });
+
+  it("reads the live window.location.search when no argument is given", () => {
+    window.history.replaceState(
+      null,
+      "",
+      `http://localhost/${firstRunSearch("cloud")}`,
+    );
+    expect(readFirstRunRuntimeTarget()).toBe("cloud");
+
+    window.history.replaceState(null, "", "http://localhost/settings");
+    expect(readFirstRunRuntimeTarget()).toBeNull();
+  });
+
+  it("returns null from the SSR default when window is undefined", () => {
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(readFirstRunRuntimeTarget()).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("reloadIntoFirstRunRuntime", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "http://localhost/");
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it.each(["cloud", "local", "remote"] as const)(
+    "clears both persisted keys and forces first-run pinned to %s",
+    (target) => {
+      window.localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, "local:mobile");
+      window.localStorage.setItem(
+        MOBILE_RUNTIME_MODE_STORAGE_KEY,
+        "remote-mac",
+      );
+      const location: LocationStub = {
+        href: "http://localhost/settings/runtime",
+      };
+      stubWindowWith(location);
+
+      reloadIntoFirstRunRuntime(target);
+
+      // The switch wipes the active-server record AND the persisted mobile
+      // runtime mode before reloading, so boot cannot restore the old runtime.
+      expect(window.localStorage.getItem(ACTIVE_SERVER_STORAGE_KEY)).toBeNull();
+      expect(
+        window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY),
+      ).toBeNull();
+      expect(location.href).toBe(
+        `http://localhost/settings/runtime${firstRunSearch(target)}`,
+      );
+    },
+  );
+
+  it("drops a stale runtimeTarget and keeps unrelated params when no target is passed", () => {
+    const location: LocationStub = {
+      href: "http://localhost/?runtime=first-run&runtimeTarget=cloud&tab=general",
+    };
+    stubWindowWith(location);
+
+    reloadIntoFirstRunRuntime();
+
+    expect(location.href).toBe(
+      "http://localhost/?runtime=first-run&tab=general",
+    );
+  });
+
+  it("overwrites a non-first-run runtime value in place", () => {
+    const location: LocationStub = {
+      href: "http://localhost/?runtime=onboarding&foo=1",
+    };
+    stubWindowWith(location);
+
+    reloadIntoFirstRunRuntime("remote");
+
+    expect(location.href).toBe(
+      "http://localhost/?runtime=first-run&foo=1&runtimeTarget=remote",
+    );
+  });
+
+  it("still navigates when removing the active-server record throws", () => {
+    window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
+    window.localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, "local:mobile");
+    const realRemoveItem = window.localStorage.removeItem.bind(
+      window.localStorage,
+    );
+    // Error injection on the real store: only the active-server key fails, so
+    // the mode-key removal still exercises the genuine write path.
+    vi.spyOn(window.localStorage, "removeItem").mockImplementation(
+      (key: string) => {
+        if (key === ACTIVE_SERVER_STORAGE_KEY) {
+          throw new DOMException("denied", "SecurityError");
+        }
+        realRemoveItem(key);
+      },
+    );
+    const location: LocationStub = { href: "http://localhost/" };
+    stubWindowWith(location);
+
+    expect(() => reloadIntoFirstRunRuntime("local")).not.toThrow();
+
+    // The best-effort cleanup swallows the failure and the query navigation
+    // still forces first-run — that navigation is the load-bearing effect.
+    expect(window.localStorage.getItem(ACTIVE_SERVER_STORAGE_KEY)).toBe(
+      "local:mobile",
+    );
+    expect(
+      window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY),
+    ).toBeNull();
+    expect(location.href).toBe(`http://localhost/${firstRunSearch("local")}`);
+  });
+
+  it("does nothing — including no persistence writes — when window is undefined", () => {
+    const storage = window.localStorage;
+    storage.setItem(ACTIVE_SERVER_STORAGE_KEY, "survivor");
+    storage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
+    vi.stubGlobal("window", undefined);
+
+    expect(() => reloadIntoFirstRunRuntime("cloud")).not.toThrow();
+
+    vi.unstubAllGlobals();
+    expect(storage.getItem(ACTIVE_SERVER_STORAGE_KEY)).toBe("survivor");
+    expect(storage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBe("cloud");
+  });
+});


### PR DESCRIPTION

Adds a direct unit suite for `packages/ui/src/first-run/reload-into-first-run-runtime.ts` — the helper behind Settings > Runtime "Switch runtime" and the mobile deep-link entry (`deep-link-handler` already delegates to it, but only through a mock; the module itself had no coverage on develop).

What the suite covers (17 cases):

- `readFirstRunRuntimeTarget`: each pinned target (`cloud`/`local`/`remote`), null unless `runtime` is exactly `first-run`, the `local` fallback for missing/empty/invalid/case-mismatched `runtimeTarget`, `URLSearchParams` instance input, the live `window.location.search` default, and the SSR default (`window` undefined → null).
- Query-contract constants: `FIRST_RUN_QUERY_NAME`/`VALUE` and `FIRST_RUN_TARGET_QUERY_NAME` are pinned to the values `deep-link-handler` and host apps depend on; `__TEST_ONLY__` keys are asserted against the real `MOBILE_RUNTIME_MODE_STORAGE_KEY`.
- `reloadIntoFirstRunRuntime`: clears both persisted keys (`elizaos:active-server` + the mobile runtime mode) against real jsdom localStorage while forcing first-run with a pinned target; drops a stale `runtimeTarget` and preserves unrelated params when no target is passed; overwrites a non-first-run runtime value; still navigates when removing the active-server record throws (the best-effort cleanup path); and performs no persistence writes at all under SSR.

Only the final `location.href` assignment is recorded via a stubbed `window` (jsdom cannot navigate); every stub hands the module the real jsdom localStorage, so storage assertions exercise genuine store behavior. No mocks of the subject module; no `vi.hoisted`; no type-level assertions.

Test-only diff: one new file, no production behavior changed. Evidence:

- `bunx vitest run src/first-run/reload-into-first-run-runtime.test.ts` (packages/ui): 1 file passed, 17 tests passed.
- `bunx biome check --write` on the file: clean (0 problems).
- `bunx tsc --noEmit` in packages/ui: zero mentions of the new test file in output.

Note: this PR comes from a fork, so hosted CI does not run on it — the counts above are from local runs at head 16c9edf962223b5a9d0ff326d7f3906969d7861d, verified byte-identical between the tested tree and current origin/develop for both the new suite's imports and the module under test.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:12ff044838e8a59455fdfdaed70075da38436d1f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
