### PR TITLE
test(ui): cover actions

### DIFF
--- a/packages/ui/src/genui/actions.test.ts
+++ b/packages/ui/src/genui/actions.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit coverage for the GenUI dispatch layer itself (`routeElizaGenUiAction`,
+ * the prefix-handler factory, and the routed error type): gate messages,
+ * first-match-wins handler ordering, argument identity, and result/rejection
+ * passthrough. Pure functions driven against the real boot-time registry; no
+ * live agent.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  createElizaGenUiPrefixActionHandler,
+  ElizaGenUiActionError,
+  routeElizaGenUiAction,
+} from "./actions";
+import type { ElizaGenUiAction, ElizaGenUiActionResult } from "./types";
+
+const act = (name: string): ElizaGenUiAction => ({ event: { name } });
+
+const context = {
+  target: "plugin" as const,
+  componentId: "comp-1",
+  sessionId: "session-1",
+};
+
+/** Counts invocations without replacing the behaviour under test. */
+const recordingHandler = (
+  prefixes: readonly string[],
+  result: Promise<ElizaGenUiActionResult> | ElizaGenUiActionResult,
+) => {
+  const seen: { actions: ElizaGenUiAction[]; contexts: unknown[] } = {
+    actions: [],
+    contexts: [],
+  };
+  const handler = createElizaGenUiPrefixActionHandler(
+    prefixes,
+    async (action, actionContext) => {
+      seen.actions.push(action);
+      seen.contexts.push(actionContext);
+      return await result;
+    },
+  );
+  return { handler, seen };
+};
+
+const rejectedValue = async <T>(promise: Promise<T>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
+};
+
+describe("ElizaGenUiActionError", () => {
+  it("is an Error named after itself and carrying the offending action", () => {
+    const action = act("model.pick");
+    const error = new ElizaGenUiActionError("bad action", action);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ElizaGenUiActionError);
+    expect(error.name).toBe("ElizaGenUiActionError");
+    expect(error.message).toBe("bad action");
+    expect(error.action).toBe(action);
+  });
+});
+
+describe("createElizaGenUiPrefixActionHandler", () => {
+  it("accepts a name under any of its prefixes", () => {
+    const { handler } = recordingHandler(["setup.", "model."], { ok: true });
+    expect(handler.canHandle("setup.provider")).toBe(true);
+    expect(handler.canHandle("model.pick")).toBe(true);
+  });
+
+  it("rejects a name that merely contains a prefix mid-string", () => {
+    const { handler } = recordingHandler(["model."], { ok: true });
+    expect(handler.canHandle("remodel.pick")).toBe(false);
+    expect(handler.canHandle("xmodel.y")).toBe(false);
+  });
+
+  it("handles nothing when constructed with no prefixes", () => {
+    const { handler } = recordingHandler([], { ok: true });
+    expect(handler.canHandle("")).toBe(false);
+    expect(handler.canHandle("anything.at.all")).toBe(false);
+  });
+
+  it("delegates handle and resolves the delegate's result", async () => {
+    const { handler } = recordingHandler(["voice."], {
+      ok: false,
+      error: "voice unavailable",
+    });
+    expect(handler.canHandle("voice.speak")).toBe(true);
+    await expect(handler.handle(act("voice.speak"), context)).resolves.toEqual({
+      ok: false,
+      error: "voice unavailable",
+    });
+  });
+});
+
+describe("routeElizaGenUiAction", () => {
+  it("throws a routed error naming an unregistered action and attaching it", async () => {
+    const action = act("regtest_actions_unregistered.doThing");
+    const { handler } = recordingHandler([""], { ok: true });
+    const error = (await rejectedValue(
+      routeElizaGenUiAction(action, context, [handler]),
+    )) as ElizaGenUiActionError;
+    expect(error).toBeInstanceOf(ElizaGenUiActionError);
+    expect(error.message).toBe(
+      'Generated UI action "regtest_actions_unregistered.doThing" is not allowed.',
+    );
+    expect(error.action).toBe(action);
+  });
+
+  it("throws a no-handler error when the allowed name has no matching handler", async () => {
+    const { handler } = recordingHandler(["connector."], { ok: true });
+    const error = (await rejectedValue(
+      routeElizaGenUiAction(act("model.pick"), context, [handler]),
+    )) as ElizaGenUiActionError;
+    expect(error).toBeInstanceOf(ElizaGenUiActionError);
+    expect(error.message).toBe(
+      'No generated UI action handler registered for "model.pick".',
+    );
+    expect(error.action.event.name).toBe("model.pick");
+  });
+
+  it("throws the no-handler error for an empty handler list", async () => {
+    const error = (await rejectedValue(
+      routeElizaGenUiAction(act("runtime.restart"), context, []),
+    )) as ElizaGenUiActionError;
+    expect(error.message).toBe(
+      'No generated UI action handler registered for "runtime.restart".',
+    );
+  });
+
+  it("gives the first matching handler priority over later ones", async () => {
+    const first = recordingHandler(["trace."], { ok: true, data: "first" });
+    const second = recordingHandler(["trace."], { ok: true, data: "second" });
+    const result = await routeElizaGenUiAction(act("trace.show"), context, [
+      first.handler,
+      second.handler,
+    ]);
+    expect(result).toEqual({ ok: true, data: "first" });
+    expect(first.seen.actions).toHaveLength(1);
+    expect(second.seen.actions).toHaveLength(0);
+  });
+
+  it("skips handlers that cannot handle the event name", async () => {
+    const skip = recordingHandler(["provider."], { ok: true, data: "wrong" });
+    const match = recordingHandler(["capability."], {
+      ok: true,
+      data: "right",
+    });
+    const result = await routeElizaGenUiAction(
+      act("capability.grant"),
+      context,
+      [skip.handler, match.handler],
+    );
+    expect(result).toEqual({ ok: true, data: "right" });
+    expect(skip.seen.actions).toHaveLength(0);
+    expect(match.seen.actions).toHaveLength(1);
+  });
+
+  it("passes the same action and context objects to the winning handler", async () => {
+    const action = act("setup.begin");
+    const payloadAction: ElizaGenUiAction = {
+      event: { name: "setup.begin", payload: { providerId: "openai" } },
+    };
+    const { handler, seen } = recordingHandler(["setup."], { ok: true });
+    await routeElizaGenUiAction(action, context, [handler]);
+    await routeElizaGenUiAction(payloadAction, context, [handler]);
+    expect(seen.actions[0]).toBe(action);
+    expect(seen.contexts[0]).toBe(context);
+    expect(seen.actions[1].event.payload).toEqual({ providerId: "openai" });
+  });
+
+  it("propagates a handler rejection unchanged", async () => {
+    const failure = new Error("handler exploded");
+    const failing = createElizaGenUiPrefixActionHandler(
+      ["dynamicView."],
+      async () => {
+        throw failure;
+      },
+    );
+    const error = await rejectedValue(
+      routeElizaGenUiAction(act("dynamicView.swap"), context, [failing]),
+    );
+    expect(error).toBe(failure);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/genui/actions.test.ts` — a new, additive-only unit suite for the GenUI dispatch layer in `packages/ui/src/genui/actions.ts`, which had no same-named test file on `develop`. The diff touches exactly one new test file (+186/-0); no production code changes.

## Why

The dispatch layer routes agent-generated UI actions behind an allowlist gate, so its failure modes (a generated component firing an unpermitted action, or a silently skipped handler) deserve pinned unit behavior. This complements `genui-action-registry.test.ts` (which pins the registry itself) by pinning the dispatcher's contract.

## What is covered

All assertions drive the real module against the real boot-time registry (no mocks of the system under test):

- `ElizaGenUiActionError`: `Error` subclass identity, `name`, message, and the offending `action` attached by reference.
- `createElizaGenUiPrefixActionHandler`: multi-prefix acceptance (`some` semantics), `startsWith` boundary (mid-string matches rejected), empty prefix list handles nothing, `handle` delegates and resolves the delegate's result.
- `routeElizaGenUiAction`:
  - unregistered name → `ElizaGenUiActionError` with the exact `Generated UI action "…" is not allowed.` message and the action attached;
  - allowed name with no matching handler → exact `No generated UI action handler registered for "…".` message (both for a non-matching handler list and an empty list);
  - first-match-wins ordering when several handlers can handle the event;
  - non-matching handlers are skipped, not invoked;
  - the winning handler receives the same action and context objects (identity, including event payload);
  - full result-object passthrough and unchanged propagation of a handler rejection.

## Evidence (test-only change)

- Runner: vitest (the owning package's lane, `bunx vitest run src/genui/actions.test.ts` in `packages/ui`, vitest v4.1.10):
  **Test Files 1 passed (1) · Tests 12 passed (12)** — re-run at this head immediately before filing.
- `bunx biome check src/genui/actions.test.ts`: **clean** ("No fixes applied", 0 errors).
- `bunx tsc --noEmit` in `packages/ui` grepped for `genui/actions.test.ts`: **no output** — the new file introduces zero type errors. (One pre-existing, unrelated error exists elsewhere in the package in `components/composites/chat/chat-message-actions.test.tsx`; untouched by this diff.)
- No `vi.mock` / `vi.hoisted` / `expectTypeOf` anywhere in the suite.

**Fork-contributor note:** hosted CI does not run on pull requests from our fork; the checks above are quoted from local runs at the pushed head (`c0fcd3bedc80d7a85236bb9affcbe1b502716dfb`).

## Risk

None beyond the added file: behavior-preserving test-only change, no exports, config, or runtime paths touched.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c0fcd3bedc80d7a85236bb9affcbe1b502716dfb -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
