### PR TITLE
test(core): cover target-sources index

### DIFF
--- a/packages/core/src/target-sources/index.test.ts
+++ b/packages/core/src/target-sources/index.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Exercises the `./index` barrel for the connector target-source registry:
+ * proves its re-exports are the live registry bindings (not dead copies) and
+ * drives the factory and service behavior reachable through it — register /
+ * get / list / unregister keyed by platform, insertion-order listing, missing
+ * keys, replacement, snapshot isolation, and service stop clearing — with
+ * deterministic fake sources. No mocks of the subject under test.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	CONNECTOR_TARGET_SOURCE_REGISTRY_SERVICE,
+	createTargetSourceRegistry,
+	type TargetSource,
+	TargetSourceRegistryService,
+} from "./index";
+import {
+	createTargetSourceRegistry as createTargetSourceRegistryFromRegistry,
+	TargetSourceRegistryService as TargetSourceRegistryServiceFromRegistry,
+} from "./registry";
+
+function fakeSource(platform: string): TargetSource {
+	return {
+		platform,
+		async enumerate() {
+			return [];
+		},
+	};
+}
+
+describe("target-sources index barrel", () => {
+	it("re-exports the live registry bindings", () => {
+		expect(CONNECTOR_TARGET_SOURCE_REGISTRY_SERVICE).toBe(
+			"ConnectorTargetSourceRegistry",
+		);
+		expect(createTargetSourceRegistry).toBe(
+			createTargetSourceRegistryFromRegistry,
+		);
+		expect(TargetSourceRegistryService).toBe(
+			TargetSourceRegistryServiceFromRegistry,
+		);
+	});
+});
+
+describe("createTargetSourceRegistry (via ./index)", () => {
+	it("starts empty and round-trips register / get / list / unregister", async () => {
+		const reg = createTargetSourceRegistry();
+		expect(reg.list()).toEqual([]);
+
+		const discord = fakeSource("discord");
+		reg.register(discord);
+		const slack = fakeSource("slack");
+		reg.register(slack);
+
+		expect(reg.get("discord")).toBe(discord);
+		expect(reg.get("slack")).toBe(slack);
+		expect(reg.list()).toEqual([discord, slack]);
+
+		reg.unregister("discord");
+		expect(reg.get("discord")).toBeUndefined();
+		expect(reg.list()).toEqual([slack]);
+	});
+
+	it("returns undefined for a platform that was never registered", () => {
+		const reg = createTargetSourceRegistry();
+		expect(reg.get("telegram")).toBeUndefined();
+	});
+
+	it("unregistering a missing platform is a no-op", () => {
+		const reg = createTargetSourceRegistry();
+		const discord = fakeSource("discord");
+		reg.register(discord);
+
+		expect(() => reg.unregister("gmail")).not.toThrow();
+		expect(reg.list()).toEqual([discord]);
+	});
+
+	it("keys by platform — re-registering replaces the prior source", async () => {
+		const reg = createTargetSourceRegistry();
+		const first = fakeSource("discord");
+		const second = fakeSource("discord");
+		const slack = fakeSource("slack");
+		reg.register(first);
+		reg.register(slack);
+		reg.register(second);
+
+		expect(reg.get("discord")).toBe(second);
+		expect(await reg.get("discord")?.enumerate({})).toEqual([]);
+		expect(reg.list()).toEqual([second, slack]);
+	});
+
+	it("list() hands out a fresh array — mutating it leaves the registry intact", () => {
+		const reg = createTargetSourceRegistry();
+		const discord = fakeSource("discord");
+		reg.register(discord);
+
+		const snapshot = reg.list();
+		snapshot.push(fakeSource("slack"));
+
+		expect(snapshot).toHaveLength(2);
+		expect(reg.list()).toEqual([discord]);
+		expect(reg.list()).not.toBe(snapshot);
+	});
+});
+
+describe("TargetSourceRegistryService (via ./index)", () => {
+	it("carries the barrel's service-type constant", () => {
+		expect(TargetSourceRegistryService.serviceType).toBe(
+			CONNECTOR_TARGET_SOURCE_REGISTRY_SERVICE,
+		);
+	});
+
+	it("delegates register / get / list / unregister to its registry", async () => {
+		const svc = await TargetSourceRegistryService.start({} as never);
+		expect(svc.list()).toEqual([]);
+
+		const discord = fakeSource("discord");
+		svc.register(discord);
+		const slack = fakeSource("slack");
+		svc.register(slack);
+
+		expect(svc.get("discord")).toBe(discord);
+		expect(svc.get("missing")).toBeUndefined();
+		expect(svc.list()).toEqual([discord, slack]);
+
+		svc.unregister("slack");
+		expect(svc.list()).toEqual([discord]);
+	});
+
+	it("stop() clears every source and the service accepts registrations again", async () => {
+		const svc = await TargetSourceRegistryService.start({} as never);
+		const discord = fakeSource("discord");
+		svc.register(discord);
+
+		await svc.stop();
+		expect(svc.list()).toEqual([]);
+		expect(svc.get("discord")).toBeUndefined();
+
+		const again = fakeSource("discord");
+		svc.register(again);
+		expect(svc.get("discord")).toBe(again);
+	});
+
+	it("stop() on a service with no sources does not throw", async () => {
+		const svc = await TargetSourceRegistryService.start({} as never);
+		await expect(svc.stop()).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/target-sources/index.test.ts` — a new vitest suite covering the `packages/core/src/target-sources/index.ts` barrel, which had no same-named test anywhere on `develop`.

The suite drives the real module (no mocks of the subject, no `vi.hoisted`, no `expectTypeOf`) and covers:

- **Barrel wiring:** the re-exports are the live registry bindings (`createTargetSourceRegistry` / `TargetSourceRegistryService` reference-equal their `./registry` counterparts; service-type constant is `"ConnectorTargetSourceRegistry"`).
- **Registry semantics via the barrel:** empty start; register/get/list/unregister round-trip; `get()` of an unregistered platform returns `undefined`; unregistering a missing platform is a no-op that leaves existing sources intact; re-registering a platform replaces the prior source (keyed by platform); `list()` hands out a fresh array each call so mutating it cannot corrupt registry state.
- **Service semantics via the barrel:** static `serviceType` matches the barrel-exported constant; `start()` delegates register/get/list/unregister; `stop()` clears every registered source and the service accepts registrations again afterward; `stop()` with zero sources resolves without throwing.

## Evidence (test-only change — no production behaviour touched)

- `bunx vitest run packages/core/src/target-sources/index.test.ts` → **Test Files 1 passed (1), Tests 10 passed (10)**, re-fetched and re-run against current `origin/develop` (`16c9edf96222`) immediately before filing.
- `bunx biome check --write packages/core/src/target-sources/index.test.ts` → clean ("Checked 1 file … no fixes applied"), against the repo's real root `biome.json`.
- `bunx tsc --noEmit` in `packages/core` → zero mentions of `target-sources/index.test` in output (the file adds no type errors).
- The diff touches **only** `packages/core/src/target-sources/index.test.ts` (+147/−0, new file).

## Notes

- Fork contribution: hosted CI does not run on this PR. The counts above are quoted from local runs as recorded.
- Behaviour-only assertions: every expectation records what the code does today; nothing aspirational.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2f6c6868e862996c24c2a08dc770f3e45688d92b -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
