### PR TITLE
test(ui): cover use-microphone-permission

### DIFF
--- a/packages/ui/src/first-run/use-microphone-permission.test.ts
+++ b/packages/ui/src/first-run/use-microphone-permission.test.ts
@@ -1,0 +1,324 @@
+/** Verifies useMicrophonePermission through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Drives the real hook with mocks only at the platform boundary: the shared
+ * `client` singleton stands in for the Electrobun/Capacitor permission
+ * bridges, and `navigator.mediaDevices.getUserMedia` is stubbed for the
+ * browser fallback probe. Every case asserts the controller state the
+ * onboarding UI would render — never a mock's own bookkeeping.
+ */
+
+import type { PermissionId, PermissionState } from "@elizaos/shared";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api", () => ({
+  client: {
+    requestPermission: vi.fn(),
+    openPermissionSettings: vi.fn(),
+  },
+}));
+
+import { client } from "../api";
+import { useMicrophonePermission } from "./use-microphone-permission";
+
+const requestPermission = vi.mocked(client.requestPermission);
+const openPermissionSettings = vi.mocked(client.openPermissionSettings);
+
+function permState(overrides: Partial<PermissionState> = {}): PermissionState {
+  return {
+    id: "microphone" as PermissionId,
+    status: "granted",
+    lastChecked: Date.now(),
+    canRequest: true,
+    platform: "darwin",
+    ...overrides,
+  };
+}
+
+function installMediaDevices(mediaDevices: unknown): void {
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: mediaDevices,
+    configurable: true,
+  });
+}
+
+function streamWithTracks(count: number): {
+  stops: Array<ReturnType<typeof vi.fn>>;
+  stream: unknown;
+} {
+  const stops = Array.from({ length: count }, () => vi.fn());
+  return {
+    stops,
+    stream: { getTracks: () => stops.map((stop) => ({ stop })) },
+  };
+}
+
+/**
+ * Simulates an older renderer whose bridge lacks the permission API: the hook
+ * branches on `typeof client.requestPermission === "function"`, so both
+ * methods are temporarily hidden. Restores them even when `run` throws.
+ */
+async function withoutClientPermissionApi(
+  run: () => Promise<void>,
+): Promise<void> {
+  const holder = client as {
+    requestPermission?: unknown;
+    openPermissionSettings?: unknown;
+  };
+  const savedRequest = holder.requestPermission;
+  const savedSettings = holder.openPermissionSettings;
+  holder.requestPermission = undefined;
+  holder.openPermissionSettings = undefined;
+  try {
+    await run();
+  } finally {
+    holder.requestPermission = savedRequest;
+    holder.openPermissionSettings = savedSettings;
+  }
+}
+
+const originalMediaDevices = Object.getOwnPropertyDescriptor(
+  navigator,
+  "mediaDevices",
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (originalMediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+  } else {
+    delete (navigator as { mediaDevices?: unknown }).mediaDevices;
+  }
+  cleanup();
+});
+
+describe("useMicrophonePermission", () => {
+  it("starts in the actionable idle state with both controls exposed", () => {
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    expect(result.current.status).toBe("unknown");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+    expect(typeof result.current.request).toBe("function");
+    expect(typeof result.current.openSettings).toBe("function");
+  });
+
+  it("mirrors the platform client's granted result and releases the requesting flag", async () => {
+    requestPermission.mockResolvedValue(
+      permState({ status: "granted", canRequest: true }),
+    );
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(requestPermission).toHaveBeenCalledWith("microphone");
+    expect(result.current.status).toBe("granted");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("passes a restricted client result through verbatim instead of recomputing it", async () => {
+    requestPermission.mockResolvedValue(
+      permState({ status: "restricted", canRequest: false }),
+    );
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(result.current.status).toBe("restricted");
+    expect(result.current.canRequest).toBe(false);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("ignores overlapping requests while one is already in flight", async () => {
+    let resolveFirst!: (value: PermissionState) => void;
+    requestPermission.mockImplementationOnce(
+      () =>
+        new Promise<PermissionState>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useMicrophonePermission());
+    const request = result.current.request;
+
+    let inFlight!: Promise<void>;
+    act(() => {
+      inFlight = request();
+    });
+    expect(result.current.requesting).toBe(true);
+
+    // A second invocation during flight must short-circuit, not queue.
+    await act(async () => {
+      await request();
+    });
+
+    resolveFirst(permState({ status: "granted", canRequest: true }));
+    await act(async () => {
+      await inFlight;
+    });
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("granted");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("falls back to the getUserMedia probe when the client bridge throws", async () => {
+    requestPermission.mockRejectedValue(new Error("bridge unavailable"));
+    const { stops, stream } = streamWithTracks(2);
+    const getUserMedia = vi.fn(async () => stream);
+    installMediaDevices({ getUserMedia });
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    for (const stop of stops) {
+      // The probe only wants the permission; every captured track is stopped.
+      expect(stop).toHaveBeenCalledTimes(1);
+    }
+    expect(result.current.status).toBe("granted");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("reads a rejected getUserMedia probe as denied when the client bridge throws", async () => {
+    requestPermission.mockRejectedValue(new Error("bridge unavailable"));
+    installMediaDevices({
+      getUserMedia: vi.fn(async () => {
+        throw new Error("NotAllowedError");
+      }),
+    });
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(result.current.status).toBe("denied");
+    expect(result.current.canRequest).toBe(false);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("probes getUserMedia directly when the renderer has no permission client", async () => {
+    const { stops, stream } = streamWithTracks(1);
+    const getUserMedia = vi.fn(async () => stream);
+    installMediaDevices({ getUserMedia });
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await withoutClientPermissionApi(async () => {
+      await act(async () => {
+        await result.current.request();
+      });
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("granted");
+    expect(result.current.canRequest).toBe(true);
+  });
+
+  it("reports not-applicable when navigator.mediaDevices is absent entirely", async () => {
+    installMediaDevices(undefined);
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await withoutClientPermissionApi(async () => {
+      await act(async () => {
+        await result.current.request();
+      });
+    });
+
+    expect(result.current.status).toBe("not-applicable");
+    // Only an explicit denial disables further requests.
+    expect(result.current.canRequest).toBe(true);
+  });
+
+  it("reports not-applicable when mediaDevices exists but exposes no getUserMedia", async () => {
+    installMediaDevices({});
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await withoutClientPermissionApi(async () => {
+      await act(async () => {
+        await result.current.request();
+      });
+    });
+
+    expect(result.current.status).toBe("not-applicable");
+    expect(result.current.canRequest).toBe(true);
+  });
+
+  it("delegates openSettings to the platform deep link without touching state", async () => {
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.openSettings();
+    });
+
+    expect(openPermissionSettings).toHaveBeenCalledTimes(1);
+    expect(openPermissionSettings).toHaveBeenCalledWith("microphone");
+    // No probe ran: state stays at its initial values.
+    expect(result.current.status).toBe("unknown");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("survives a failing settings deep link without throwing or probing", async () => {
+    openPermissionSettings.mockRejectedValue(new Error("no settings pane"));
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await act(async () => {
+      await result.current.openSettings();
+    });
+
+    expect(result.current.status).toBe("unknown");
+    expect(result.current.canRequest).toBe(true);
+  });
+
+  it("re-probes from openSettings when no client deep link exists (grant picked up)", async () => {
+    const { stream } = streamWithTracks(1);
+    const getUserMedia = vi.fn(async () => stream);
+    installMediaDevices({ getUserMedia });
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await withoutClientPermissionApi(async () => {
+      await act(async () => {
+        await result.current.openSettings();
+      });
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("granted");
+    expect(result.current.canRequest).toBe(true);
+    expect(result.current.requesting).toBe(false);
+  });
+
+  it("lands an out-of-band denial as denied/cannot-request when re-probing from openSettings", async () => {
+    installMediaDevices({
+      getUserMedia: vi.fn(async () => {
+        throw new Error("NotAllowedError");
+      }),
+    });
+    const { result } = renderHook(() => useMicrophonePermission());
+
+    await withoutClientPermissionApi(async () => {
+      await act(async () => {
+        await result.current.openSettings();
+      });
+    });
+
+    expect(result.current.status).toBe("denied");
+    expect(result.current.canRequest).toBe(false);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a co-located unit suite for `packages/ui/src/first-run/use-microphone-permission.ts`, which had no same-named test file anywhere on `develop`. The diff is a single new test file (+324/-0); no production code is touched.

## What is covered

13 cases driving the real hook (`@testing-library/react` `renderHook` in jsdom), mocking only the platform boundary (`client` singleton, `navigator.mediaDevices.getUserMedia`):

- initial controller state (`unknown` / `canRequest` / idle) and exposed controls
- `request()` mirrors the platform client's result verbatim, including a `restricted`+`canRequest:false` pass-through (no recomputation)
- concurrent-invocation guard: an overlapping `request()` short-circuits; exactly one client call; `requesting` true→false
- client-bridge throw falls back to the `getUserMedia` probe: granted path stops every captured track; rejection lands as `denied` with `canRequest:false`
- no-permission-client renderer probes directly; absent `navigator.mediaDevices` and `mediaDevices` without `getUserMedia` both resolve `not-applicable` with requests still allowed
- `openSettings()` delegates to the platform deep link without touching state, survives a rejected deep link, and re-probes when no deep link exists (grant picked up; out-of-band denial becomes denied/cannot-request)

## Evidence (test-only change)

- `bunx vitest run src/first-run/use-microphone-permission.test.ts` (packages/ui): **Test Files 1 passed (1), Tests 13 passed (13)** — verified against current `origin/develop` (`16c9edf962223b5a9d0ff326d7f3906969d7861d`); target module and its `../api` dependency are byte-identical between the working tree and that tip
- `bunx biome check --write src/first-run/use-microphone-permission.test.ts`: clean (1 file checked)
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mentioning the new file
- The diff touches only `packages/ui/src/first-run/use-microphone-permission.test.ts`

Note: this comes from a fork, so hosted CI does not run on this pull request; the counts above are from a local run of the package's own vitest config.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:71927d7e27bc1d58a7688ccc018e51936101d0fc -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
