### PR TITLE
test(app-core): cover electrobun-boot-config

### DIFF
--- a/packages/app-core/platforms/electrobun/src/electrobun-boot-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-boot-config.test.ts
@@ -48,4 +48,228 @@ describe("Electrobun boot config bridge", () => {
     expect(globalObject.__ELIZAOS_APP_BOOT_CONFIG__).toBe(nextConfig);
     expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
   });
+
+  it("falls back to the legacy key when the current key is absent", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZA_APP_BOOT_CONFIG__: {
+        apiToken: "legacy-token",
+        featureFlags: { kiosk: true },
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiToken: "next-token",
+    });
+
+    expect(nextConfig).toEqual({
+      apiToken: "next-token",
+      featureFlags: { kiosk: true },
+    });
+    expect(globalObject.__ELIZAOS_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+  });
+
+  it("reads the existing config from the symbol store when both window keys are absent", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      [ELECTROBUN_BOOT_CONFIG_STORE_KEY]: {
+        current: {
+          apiBase: "http://store.example",
+          surfaceMode: "kiosk",
+        },
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: "http://next.example",
+    });
+
+    expect(nextConfig).toEqual({
+      apiBase: "http://next.example",
+      surfaceMode: "kiosk",
+    });
+    expect(globalObject.__ELIZAOS_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
+  });
+
+  it("prefers the current key over the legacy key and the symbol store", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: { apiBase: "http://canonical.example" },
+      __ELIZA_APP_BOOT_CONFIG__: { apiBase: "http://legacy.example" },
+      [ELECTROBUN_BOOT_CONFIG_STORE_KEY]: {
+        current: { apiBase: "http://store.example" },
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {});
+
+    expect(nextConfig).toEqual({ apiBase: "http://canonical.example" });
+    expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+  });
+
+  it("prefers the legacy key over the symbol store", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZA_APP_BOOT_CONFIG__: { apiToken: "legacy-token" },
+      [ELECTROBUN_BOOT_CONFIG_STORE_KEY]: {
+        current: { apiToken: "store-token" },
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {});
+
+    expect(nextConfig).toEqual({ apiToken: "legacy-token" });
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+  });
+
+  it("starts from an empty config when every source is nullish", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: undefined,
+      __ELIZA_APP_BOOT_CONFIG__: undefined,
+      [ELECTROBUN_BOOT_CONFIG_STORE_KEY]: undefined,
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: "http://fresh.example",
+      apiToken: "fresh-token",
+    });
+
+    expect(nextConfig).toEqual({
+      apiBase: "http://fresh.example",
+      apiToken: "fresh-token",
+    });
+    expect(globalObject.__ELIZAOS_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+  });
+
+  it("resynchronizes every location with a fresh copy even when updates are empty", () => {
+    const original = {
+      apiBase: "http://old.example",
+      note: "keep me",
+    };
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: original,
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {});
+
+    expect(nextConfig).toEqual({
+      apiBase: "http://old.example",
+      note: "keep me",
+    });
+    expect(nextConfig).not.toBe(original);
+    expect(original).toEqual({
+      apiBase: "http://old.example",
+      note: "keep me",
+    });
+    expect(globalObject.__ELIZA_APP_BOOT_CONFIG__).toBe(nextConfig);
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+  });
+
+  it("replaces prior credentials while preserving unrelated fields", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: {
+        apiBase: "http://old.example",
+        apiToken: "old-token",
+        branding: { name: "Eliza" },
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: "http://new.example",
+      apiToken: "new-token",
+    });
+
+    expect(nextConfig).toEqual({
+      apiBase: "http://new.example",
+      apiToken: "new-token",
+      branding: { name: "Eliza" },
+    });
+  });
+
+  it("overwrites a field with an explicit undefined update instead of keeping the old value", () => {
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: {
+        apiBase: "http://old.example",
+        apiToken: "kept-token",
+      },
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: undefined,
+    });
+
+    expect(nextConfig.apiBase).toBeUndefined();
+    expect("apiBase" in nextConfig).toBe(true);
+    expect(nextConfig.apiToken).toBe("kept-token");
+  });
+
+  it("retains empty-string values exactly as provided", () => {
+    const globalObject: ElectrobunBootConfigWindow = {};
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: "",
+      apiToken: "",
+    });
+
+    expect(nextConfig).toEqual({ apiBase: "", apiToken: "" });
+    expect(globalObject.__ELIZAOS_APP_BOOT_CONFIG__).toBe(nextConfig);
+  });
+
+  it("replaces a pre-existing store wrapper without mutating the old one", () => {
+    const previousStore = { current: { apiBase: "http://old.example" } };
+    const globalObject: ElectrobunBootConfigWindow = {
+      [ELECTROBUN_BOOT_CONFIG_STORE_KEY]: previousStore,
+    };
+
+    const nextConfig = updateElectrobunBootConfig(globalObject, {
+      apiBase: "http://new.example",
+    });
+
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]).not.toBe(
+      previousStore,
+    );
+    expect(globalObject[ELECTROBUN_BOOT_CONFIG_STORE_KEY]?.current).toBe(
+      nextConfig,
+    );
+    expect(previousStore.current).toEqual({ apiBase: "http://old.example" });
+  });
+
+  it("does not mutate the config object used as the source", () => {
+    const source = {
+      apiBase: "http://old.example",
+      apiToken: "source-token",
+      note: "untouched",
+    };
+    const globalObject: ElectrobunBootConfigWindow = {
+      __ELIZAOS_APP_BOOT_CONFIG__: source,
+    };
+
+    updateElectrobunBootConfig(globalObject, {
+      apiBase: "http://new.example",
+    });
+
+    expect(source).toEqual({
+      apiBase: "http://old.example",
+      apiToken: "source-token",
+      note: "untouched",
+    });
+  });
+
+  it("registers the store key under the stable global symbol registry", () => {
+    expect(ELECTROBUN_BOOT_CONFIG_STORE_KEY).toBe(
+      Symbol.for("elizaos.app.boot-config"),
+    );
+  });
 });


### PR DESCRIPTION

Additive unit-test coverage for `packages/app-core/platforms/electrobun/src/bridge/electrobun-boot-config.ts`, extending the existing suite at `packages/app-core/platforms/electrobun/src/electrobun-boot-config.test.ts`.

## What changed

This is a test-only diff: **+224/-0, one file, pure additions** to the existing two-case suite (no line of the existing suite was modified or removed). Twelve new cases drive the real `updateElectrobunBootConfig` module directly — no mocks stand in for the subject:

- legacy-key fallback when the canonical key is absent
- symbol-store (`Symbol.for("elizaos.app.boot-config")`) `current` fallback when both window keys are absent
- source precedence: canonical over legacy over store, asserted independently
- nullish canonical/legacy/store sources fall through to an empty config
- empty updates still resynchronize all three locations onto a fresh copy without mutating the original source object
- prior `apiBase`/`apiToken` replaced while unrelated fields survive
- explicit `undefined` update overwrites the field rather than keeping the old value
- empty-string values retained exactly as provided
- pre-existing store wrapper replaced with `{ current }` and the old wrapper left unmutated
- source config object never mutated
- store key identity equals `Symbol.for("elizaos.app.boot-config")`

## Evidence

- `bunx vitest run packages/app-core/platforms/electrobun/src/electrobun-boot-config.test.ts` — re-run against current `origin/develop` (`16c9edf962223b5a9d0ff326d7f3906969d7861d`) immediately before filing: **Test Files 1 passed (1); Tests 14 passed (14)**.
- `bunx biome check --write <file>` — clean.
- `bunx tsc --noEmit` in `packages/app-core/platforms/electrobun` — output contains **zero** references to `electrobun-boot-config.test.ts`.
- The diff touches only this one test file (+224/-0).

## Notes

- This PR comes from a fork, so hosted CI does not run on it; the counts above are from local runs quoted verbatim.
- No production code paths are changed by this pull request.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4a428c0e80ce79531298ef202b2fde4c7e8bcfbe -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
