### PR TITLE
fix(cloud): release voice room after cancellation fence

### DIFF
--- a/packages/cloud/api/__tests__/shared-runtime-cutover-reminder.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/shared-runtime-cutover-reminder.miniflare.test.ts
@@ -67,6 +67,12 @@ const RUNTIME_STUBS = {
       AUTONOMOUS: "AUTONOMOUS",
       API: "API",
     };
+    export function isBlockedHostname() { return false; }
+    export function isPrivateIpAddress() { return false; }
+    export function stringToUuid(value) {
+      const suffix = String(value).length.toString(16).padStart(12, "0").slice(-12);
+      return "00000000-0000-5000-8000-" + suffix;
+    }
   `,
   databaseClient: `
     export async function runWithDbCacheAsync(operation) {
@@ -98,7 +104,37 @@ const RUNTIME_STUBS = {
         });
         throw new Error("Committed cutover reached Shared inference");
       },
-      async stream() {
+      async stream(agent, rpc, options) {
+        if (rpc.id === "barge-eviction") {
+          const roomId = rpc.params.roomId;
+          const interrupted = [
+            {
+              id: "workerd-interrupted-user",
+              role: "user",
+              content: rpc.params.text,
+              createdAt: 1787184001000,
+            },
+            {
+              id: "workerd-interrupted-assistant",
+              role: "assistant",
+              content: "partial answer",
+              createdAt: 1787184001001,
+              interrupted: true,
+            },
+          ];
+          return new Response(new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("event: chunk\\ndata: {}\\n\\n"));
+            },
+            async cancel() {
+              options.historyStore.stagePending(agent.id, roomId, interrupted);
+              options.executionCtx.waitUntil((async () => {
+                await fetch("https://finalization-gate.test/wait");
+                throw new Error("simulated off-queue finalization failure");
+              })());
+            },
+          }), { headers: { "content-type": "text/event-stream" } });
+        }
         await fetch("https://model-probe.test/v1/chat/completions", {
           method: "POST",
           body: "unexpected-shared-reminder-inference",
@@ -118,6 +154,10 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
   let buildDirectory: string;
   let miniflare: Miniflare;
   const modelRequests: string[] = [];
+  let releaseFinalizationGate = () => {};
+  const finalizationGate = new Promise<void>((resolve) => {
+    releaseFinalizationGate = resolve;
+  });
 
   beforeAll(async () => {
     const apiDirectory = fileURLToPath(new URL("../", import.meta.url));
@@ -148,6 +188,20 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
               await this.testState.storage.put("conversation", body.conversation);
               return Response.json({ success: true });
             }
+            if (new URL(request.url).pathname === "/__test/barge") {
+              const response = await super.fetch(new Request(
+                "https://runtime.test/stream",
+                {
+                  method: "POST",
+                  headers: { "content-type": "application/json" },
+                  body: await request.text(),
+                },
+              ));
+              const reader = response.body.getReader();
+              await reader.read();
+              await reader.cancel("barge-in");
+              return Response.json({ success: true });
+            }
             return await super.fetch(request);
           }
         }
@@ -157,7 +211,8 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
             const name = request.headers.get("x-test-room");
             if (!name) return new Response("missing room", { status: 400 });
             const id = env.SHARED_RUNTIME_CONVERSATIONS.idFromName(name);
-            return await env.SHARED_RUNTIME_CONVERSATIONS.get(id).fetch(request);
+            const stub = env.SHARED_RUNTIME_CONVERSATIONS.get(id);
+            return await stub.fetch(request);
           },
         };
       `,
@@ -275,6 +330,10 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
       modules: true,
       script: await readFile(outputPath, "utf8"),
       outboundService: async (request: Request) => {
+        if (new URL(request.url).hostname === "finalization-gate.test") {
+          await finalizationGate;
+          return new Response("released");
+        }
         modelRequests.push(request.url);
         return Response.json(
           { error: "unexpected inference" },
@@ -291,6 +350,7 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
   }, 120_000);
 
   afterAll(async () => {
+    releaseFinalizationGate();
     await miniflare?.dispose();
     if (buildDirectory) await rm(buildDirectory, { recursive: true });
   });
@@ -395,5 +455,89 @@ describe("Personal Shared cutover reminder containment in Workerd", () => {
     expect(after.status, afterBody).toBe(200);
     expect(JSON.parse(afterBody)).toEqual({ history });
     expect(modelRequests).toEqual([]);
+  }, 120_000);
+
+  test("an evicted object reloads a checkpointed interrupted turn before admission", async () => {
+    const within = async <T>(
+      label: string,
+      operation: Promise<T>,
+    ): Promise<T> =>
+      await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error(`${label} timed out`)), 5_000);
+        }),
+      ]);
+    const agent = {
+      id: "agent-barge-eviction-miniflare",
+      organization_id: "organization-barge-eviction",
+      user_id: "user-barge-eviction",
+      character_id: null,
+      agent_name: "Eliza",
+      agent_config: { character: { name: "Eliza" } },
+      execution_tier: "shared",
+    };
+    const room = "room-barge-eviction-miniflare";
+    const seeded = await post(room, "/__test/seed", {
+      conversation: {
+        agentId: agent.id,
+        channelId: room,
+        history: [],
+        dirty: false,
+        version: 1,
+      },
+    });
+    expect(seeded.status, await seeded.text()).toBe(200);
+
+    const barged = await post(room, "/__test/barge", {
+      operation: "stream",
+      agent,
+      rpc: {
+        jsonrpc: "2.0",
+        id: "barge-eviction",
+        method: "message.send",
+        params: { text: "interrupted request", roomId: room },
+      },
+    });
+    expect(barged.status, await barged.text()).toBe(200);
+    releaseFinalizationGate();
+
+    const admitted = await within(
+      "post-failure history",
+      post(room, "/history", {
+        operation: "history",
+        agentId: agent.id,
+        roomId: room,
+      }),
+    );
+    const admittedBody = (await admitted.json()) as {
+      history: Array<{ id?: string }>;
+    };
+    expect(admitted.status).toBe(200);
+    expect(admittedBody.history.map((message) => message.id)).toEqual([
+      "workerd-interrupted-user",
+      "workerd-interrupted-assistant",
+    ]);
+
+    await within(
+      "Durable Object eviction",
+      miniflare.unsafeEvictDurableObject("", "TestSharedRuntimeConversation", {
+        name: room,
+        webSockets: "close",
+      }),
+    );
+    const recovered = await post(room, "/history", {
+      operation: "history",
+      agentId: agent.id,
+      roomId: room,
+    });
+    const recoveredBody = (await recovered.json()) as {
+      history: Array<{ id?: string; interrupted?: boolean }>;
+    };
+    expect(recoveredBody.history).toMatchObject([
+      { id: "workerd-interrupted-user" },
+      { id: "workerd-interrupted-assistant", interrupted: true },
+    ]);
+    releaseFinalizationGate();
   }, 120_000);
 });

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -1987,7 +1987,7 @@ test("forwards the server-authenticated history cutoff across the Durable Object
   });
 });
 
-test("stream body cancellation persists before the room queue releases", async () => {
+test("stream body cancellation fences immediately and persists off the room queue", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;
   repositoryRow = [];
@@ -2039,12 +2039,14 @@ test("stream body cancellation persists before the room queue releases", async (
     return result;
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
-  expect(secondCompleted).toBe(false);
+  expect(secondCompleted).toBe(true);
 
-  resolveStreamMergeGate();
   await cancel;
   const secondResult = await second;
-  expect(secondResult).toMatchObject({ result: { historyLength: 3 } });
+  expect(secondResult).toMatchObject({ result: { historyLength: 1 } });
+
+  resolveStreamMergeGate();
+  await Promise.all(background.splice(0));
 
   const stored = (
     data.get("conversation") as {
@@ -2057,7 +2059,6 @@ test("stream body cancellation persists before the room queue releases", async (
     "turn-after-cancel",
   ]);
   expect(stored[1]?.interrupted).toBe(true);
-  await Promise.all(background.splice(0));
 });
 
 test("failed durable cancellation write is retryable on a later finalize", async () => {
@@ -2109,12 +2110,14 @@ test("failed durable cancellation write is retryable on a later finalize", async
     return reader.cancel("client disconnected");
   };
 
-  await expect(fetchStream()).rejects.toThrow("storage unavailable");
+  await expect(fetchStream()).resolves.toBeUndefined();
+  await Promise.all(background.splice(0));
   expect(
     (data.get("conversation") as { history: unknown[] }).history,
   ).toHaveLength(0);
 
-  await fetchStream();
+  await expect(fetchStream()).resolves.toBeUndefined();
+  await Promise.all(background.splice(0));
   const stored = (
     data.get("conversation") as {
       history: Array<{ content: string; interrupted?: boolean }>;

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -214,6 +214,11 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
         trustedMessageRole?: "system";
         trustedHistoryCutoffAt?: number;
         historyStore: {
+          stagePending?(
+            agentId: string,
+            channelId: string,
+            messages: unknown[],
+          ): void;
           merge(
             agentId: string,
             channelId: string,
@@ -233,8 +238,7 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
         },
         cancel: async () => {
           canceled = true;
-          if (streamMergeGate) await streamMergeGate;
-          await options.historyStore.merge(agent.id, channelId, [
+          const interrupted = [
             {
               id: `user-${rpc.id}`,
               role: "user",
@@ -248,7 +252,10 @@ mock.module("@/lib/services/shared-runtime/shared-runtime-chat", () => ({
               createdAt: 11,
               interrupted: true,
             },
-          ]);
+          ];
+          options.historyStore.stagePending?.(agent.id, channelId, interrupted);
+          if (streamMergeGate) await streamMergeGate;
+          await options.historyStore.merge(agent.id, channelId, interrupted);
         },
       });
       return new Response(body, {
@@ -1987,7 +1994,7 @@ test("forwards the server-authenticated history cutoff across the Durable Object
   });
 });
 
-test("stream body cancellation fences immediately and persists off the room queue", async () => {
+test("stream cancellation releases immediately with interrupted context staged", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;
   repositoryRow = [];
@@ -2043,7 +2050,12 @@ test("stream body cancellation fences immediately and persists off the room queu
 
   await cancel;
   const secondResult = await second;
-  expect(secondResult).toMatchObject({ result: { historyLength: 1 } });
+  expect(secondResult).toMatchObject({
+    result: {
+      historyLength: 3,
+      historyIds: ["user-cancelled", "assistant-cancelled"],
+    },
+  });
 
   resolveStreamMergeGate();
   await Promise.all(background.splice(0));
@@ -2115,6 +2127,24 @@ test("failed durable cancellation write is retryable on a later finalize", async
   expect(
     (data.get("conversation") as { history: unknown[] }).history,
   ).toHaveLength(0);
+
+  const pendingResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/history", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "history",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "room-1",
+      }),
+    }),
+  );
+  const pending = (await pendingResponse.json()) as {
+    history: Array<{ id?: string; interrupted?: boolean }>;
+  };
+  expect(pending.history).toMatchObject([
+    { id: "user-retryable" },
+    { id: "assistant-retryable", interrupted: true },
+  ]);
 
   await expect(fetchStream()).resolves.toBeUndefined();
   await Promise.all(background.splice(0));

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -1994,7 +1994,7 @@ test("forwards the server-authenticated history cutoff across the Durable Object
   });
 });
 
-test("stream cancellation releases immediately with interrupted context staged", async () => {
+test("stream cancellation releases after a durable interrupted-context checkpoint", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;
   repositoryRow = [];
@@ -2073,7 +2073,7 @@ test("stream cancellation releases immediately with interrupted context staged",
   expect(stored[1]?.interrupted).toBe(true);
 });
 
-test("failed durable cancellation write is retryable on a later finalize", async () => {
+test("a restarted object recovers interrupted context after finalization fails", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;
   const data = new Map<string, unknown>([
@@ -2089,20 +2089,20 @@ test("failed durable cancellation write is retryable on a later finalize", async
     ],
   ]);
   const background: Promise<unknown>[] = [];
-  let failNextPut = true;
+  let failNextConversationPut = true;
   const state = makeState(data, background);
   const originalPut = state.storage.put;
   state.storage.put = async (key: string, value: unknown) => {
-    if (failNextPut) {
-      failNextPut = false;
-      throw new Error("storage unavailable");
+    if (key === "conversation" && failNextConversationPut) {
+      failNextConversationPut = false;
+      throw new Error("final conversation write unavailable");
     }
     await originalPut(key, value);
   };
   const object = new SharedRuntimeConversation(state as never, {} as never);
 
-  const fetchStream = async () => {
-    const response = await object.fetch(
+  const fetchStream = async (target: SharedRuntimeConversationInstance) => {
+    const response = await target.fetch(
       new Request("https://shared-runtime.internal/stream", {
         method: "POST",
         body: JSON.stringify({
@@ -2122,13 +2122,21 @@ test("failed durable cancellation write is retryable on a later finalize", async
     return reader.cancel("client disconnected");
   };
 
-  await expect(fetchStream()).resolves.toBeUndefined();
+  await expect(fetchStream(object)).resolves.toBeUndefined();
   await Promise.all(background.splice(0));
   expect(
     (data.get("conversation") as { history: unknown[] }).history,
   ).toHaveLength(0);
 
-  const pendingResponse = await object.fetch(
+  // Workerd resets an object after a failed storage output gate. Construct a
+  // new instance over the surviving durable state to model that eviction
+  // boundary; no same-instance Map is available to satisfy this read.
+  const restartedBackground: Promise<unknown>[] = [];
+  const restarted = new SharedRuntimeConversation(
+    makeState(data, restartedBackground) as never,
+    {} as never,
+  );
+  const pendingResponse = await restarted.fetch(
     new Request("https://shared-runtime.internal/history", {
       method: "POST",
       body: JSON.stringify({
@@ -2146,8 +2154,9 @@ test("failed durable cancellation write is retryable on a later finalize", async
     { id: "assistant-retryable", interrupted: true },
   ]);
 
-  await expect(fetchStream()).resolves.toBeUndefined();
-  await Promise.all(background.splice(0));
+  const recoveredTurn = await makeInvoke(restarted)("after-restart");
+  expect(recoveredTurn).toMatchObject({ result: { historyLength: 3 } });
+  await Promise.all(restartedBackground.splice(0));
   const stored = (
     data.get("conversation") as {
       history: Array<{ content: string; interrupted?: boolean }>;
@@ -2156,6 +2165,7 @@ test("failed durable cancellation write is retryable on a later finalize", async
   expect(stored.map((message) => message.content)).toEqual([
     "stream-user-retryable",
     "partial",
+    "turn-after-restart",
   ]);
   expect(stored[1]?.interrupted).toBe(true);
 });

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -351,6 +351,7 @@ export class SharedRuntimeConversation {
   private readonly env: AppEnv["Bindings"];
   private conversation: StoredConversation | null | undefined;
   private readonly pendingHistory = new Map<string, SharedTurnMessage[]>();
+  private pendingHistoryCheckpoint: Promise<void> = Promise.resolve();
   private hydration: Promise<void> | undefined;
   private prewarmReady = false;
   private prewarm: Promise<void> | undefined;
@@ -940,6 +941,35 @@ export class SharedRuntimeConversation {
     } satisfies ChunkedArchivedMessage);
   }
 
+  private async checkpointPendingHistory(
+    messages: SharedTurnMessage[],
+  ): Promise<void> {
+    await this.state.storage.transaction(async (txn) => {
+      for (const message of messages) {
+        const key = archiveMessageKey(message);
+        const encoded = new TextEncoder().encode(JSON.stringify(message));
+        if (encoded.byteLength <= HISTORY_ARCHIVE_CHUNK_BYTES) {
+          await txn.put(key, message);
+          continue;
+        }
+        const chunkCount = Math.ceil(
+          encoded.byteLength / HISTORY_ARCHIVE_CHUNK_BYTES,
+        );
+        for (let index = 0; index < chunkCount; index += 1) {
+          const start = index * HISTORY_ARCHIVE_CHUNK_BYTES;
+          await txn.put(
+            `${HISTORY_ARCHIVE_BODY_PREFIX}${key.slice(HISTORY_ARCHIVE_PREFIX.length)}:${index}`,
+            encoded.slice(start, start + HISTORY_ARCHIVE_CHUNK_BYTES),
+          );
+        }
+        await txn.put(key, {
+          kind: "chunked-history-message",
+          chunkCount,
+        } satisfies ChunkedArchivedMessage);
+      }
+    });
+  }
+
   private async loadArchivedHistory(): Promise<SharedTurnMessage[]> {
     const archived = await this.state.storage.list<
       SharedTurnMessage | ChunkedArchivedMessage
@@ -1019,6 +1049,11 @@ export class SharedRuntimeConversation {
             messages,
             Number.MAX_SAFE_INTEGER,
           ),
+        );
+        this.pendingHistoryCheckpoint = this.pendingHistoryCheckpoint.then(
+          async () => {
+            await this.checkpointPendingHistory(messages);
+          },
         );
       },
       merge: async (agentId, channelId, messages) => {
@@ -1905,20 +1940,39 @@ export class SharedRuntimeConversation {
       // billing finalization, which can cross storage/provider boundaries and
       // must not hold later realtime turns behind the coordinator deadline.
       const cancellation = reader.cancel(reason);
-      settle();
+      const cancellationOutcome = cancellation.then(
+        () => null,
+        (error: unknown) => error,
+      );
+      const checkpoint = this.pendingHistoryCheckpoint;
       this.state.waitUntil(
-        cancellation.catch(async (error: unknown) => {
-          // error-policy:J7 cancellation durability remains observable and is
-          // retryable, but cannot poison the live room admission queue.
-          const { logger } = await import("@/lib/utils/logger");
-          logger.warn(
-            "[SharedRuntimeConversation] off-queue stream cancellation failed",
-            {
-              reason,
-              error: error instanceof Error ? error.message : String(error),
-            },
-          );
-        }),
+        (async () => {
+          let checkpointLanded = false;
+          try {
+            // Only the lossless interrupted-turn checkpoint holds admission.
+            // Full history merge, billing, and provider teardown remain off
+            // queue after a restart-safe recovery record exists.
+            await checkpoint;
+            checkpointLanded = true;
+            settle();
+            const cancellationError = await cancellationOutcome;
+            if (cancellationError !== null) throw cancellationError;
+          } catch (error) {
+            // error-policy:J7 a failed checkpoint keeps this object fail-closed;
+            // Workers resets it after the failed storage output gate, and the
+            // next instance admits only from the prior durable snapshot.
+            const { logger } = await import("@/lib/utils/logger");
+            logger.warn(
+              "[SharedRuntimeConversation] off-queue stream cancellation failed",
+              {
+                reason,
+                phase: checkpointLanded ? "finalization" : "checkpoint",
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+            if (!checkpointLanded) throw error;
+          }
+        })(),
       );
     };
     const armStallTimer = () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -1867,16 +1867,33 @@ export class SharedRuntimeConversation {
       if (stallTimer !== undefined) clearTimeout(stallTimer);
       release();
     };
+    const cancelOffQueue = (reason: string): void => {
+      // Calling reader.cancel synchronously fences the old generation before
+      // the room queue advances. Its promise includes interrupted-history and
+      // billing finalization, which can cross storage/provider boundaries and
+      // must not hold later realtime turns behind the coordinator deadline.
+      const cancellation = reader.cancel(reason);
+      settle();
+      this.state.waitUntil(
+        cancellation.catch(async (error: unknown) => {
+          // error-policy:J7 cancellation durability remains observable and is
+          // retryable, but cannot poison the live room admission queue.
+          const { logger } = await import("@/lib/utils/logger");
+          logger.warn(
+            "[SharedRuntimeConversation] off-queue stream cancellation failed",
+            {
+              reason,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }),
+      );
+    };
     const armStallTimer = () => {
       if (settled) return;
       if (stallTimer !== undefined) clearTimeout(stallTimer);
       stallTimer = setTimeout(() => {
-        reader
-          .cancel("shared-runtime room stream stalled past backstop")
-          // error-policy:J6 canceling an already-errored reader is teardown
-          // only; the lock release below is the recovery that matters.
-          .catch(() => undefined)
-          .finally(settle);
+        cancelOffQueue("shared-runtime room stream stalled past backstop");
       }, this.streamStallTimeoutMs);
     };
     armStallTimer();
@@ -1898,12 +1915,8 @@ export class SharedRuntimeConversation {
           controller.error(error);
         }
       },
-      cancel: async (reason) => {
-        try {
-          await reader.cancel(reason);
-        } finally {
-          settle();
-        }
+      cancel: (reason) => {
+        cancelOffQueue(String(reason));
       },
     });
     return new Response(body, {

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -350,6 +350,7 @@ export class SharedRuntimeConversation {
   private readonly state: DurableObjectState;
   private readonly env: AppEnv["Bindings"];
   private conversation: StoredConversation | null | undefined;
+  private readonly pendingHistory = new Map<string, SharedTurnMessage[]>();
   private hydration: Promise<void> | undefined;
   private prewarmReady = false;
   private prewarm: Promise<void> | undefined;
@@ -994,6 +995,8 @@ export class SharedRuntimeConversation {
   }
 
   private historyStore(startEmpty: boolean): SharedRuntimeHistoryStore {
+    const pendingKey = (agentId: string, channelId: string) =>
+      `${agentId}\u0000${channelId}`;
     return {
       load: async (agentId, channelId, _queryText) => {
         const current = await this.loadConversation(
@@ -1001,16 +1004,37 @@ export class SharedRuntimeConversation {
           channelId,
           startEmpty,
         );
-        return await this.loadCompleteHistory(current);
+        return mergeSharedRuntimeHistoryMessages(
+          await this.loadCompleteHistory(current),
+          this.pendingHistory.get(pendingKey(agentId, channelId)) ?? [],
+          Number.MAX_SAFE_INTEGER,
+        );
+      },
+      stagePending: (agentId, channelId, messages) => {
+        const key = pendingKey(agentId, channelId);
+        this.pendingHistory.set(
+          key,
+          mergeSharedRuntimeHistoryMessages(
+            this.pendingHistory.get(key) ?? [],
+            messages,
+            Number.MAX_SAFE_INTEGER,
+          ),
+        );
       },
       merge: async (agentId, channelId, messages) => {
+        const key = pendingKey(agentId, channelId);
+        const pending = this.pendingHistory.get(key) ?? [];
         const current = await this.loadConversation(
           agentId,
           channelId,
           startEmpty,
         );
         const merged = mergeSharedRuntimeHistoryMessages(
-          await this.loadCompleteHistory(current),
+          mergeSharedRuntimeHistoryMessages(
+            await this.loadCompleteHistory(current),
+            pending,
+            Number.MAX_SAFE_INTEGER,
+          ),
           messages,
           Number.MAX_SAFE_INTEGER,
         );
@@ -1035,6 +1059,14 @@ export class SharedRuntimeConversation {
         // response-body cancel/finalize path can attempt the write again.
         await this.state.storage.put(CONVERSATION_KEY, snapshot);
         this.conversation = snapshot;
+        if (pending.length > 0) {
+          const persistedKeys = new Set(pending.map(archiveMessageKey));
+          const remaining = (this.pendingHistory.get(key) ?? []).filter(
+            (message) => !persistedKeys.has(archiveMessageKey(message)),
+          );
+          if (remaining.length > 0) this.pendingHistory.set(key, remaining);
+          else this.pendingHistory.delete(key);
+        }
         this.scheduleMirror({ ...snapshot, history: merged });
         // Refresh the idle-expiry deadline on every save. Personal rooms are
         // exempt: their archive keys have no Postgres copy, so expiry could

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -446,6 +446,7 @@ type TestMessage = {
 
 function harness(initialHistory?: TestMessage[]) {
   let history: TestMessage[] = initialHistory ?? [{ role: "assistant", content: "prior" }];
+  let staged: TestMessage[] = [];
   const background: Promise<unknown>[] = [];
   const merge = (messages: TestMessage[]): TestMessage[] => {
     const byId = new Map<string, TestMessage>();
@@ -464,6 +465,9 @@ function harness(initialHistory?: TestMessage[]) {
     background,
     historyStore: {
       load: async () => history,
+      stagePending: (_agentId: string, _channelId: string, messages: TestMessage[]) => {
+        staged = messages;
+      },
       save: async (_agentId: string, _channelId: string, next: TestMessage[]) => {
         history = next;
       },
@@ -474,6 +478,7 @@ function harness(initialHistory?: TestMessage[]) {
       waitUntil: (promise: Promise<unknown>) => background.push(promise),
     },
     history: () => history,
+    staged: () => staged,
   };
 }
 
@@ -1423,6 +1428,10 @@ describe("SharedRuntimeChatService", () => {
     const first = await reader.read();
     expect(new TextDecoder().decode(first.value)).toContain("partial");
     const cancellation = reader.cancel("barge-in");
+    expect(h.staged()).toMatchObject([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "partial", interrupted: true },
+    ]);
     let guardTimer: ReturnType<typeof setTimeout> | undefined;
     const cancellationOutcome = await Promise.race([
       cancellation.then(() => "persisted" as const),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1606,10 +1606,15 @@ describe("SharedRuntimeChatService", () => {
     const service = new SharedRuntimeChatService();
     let attempts = 0;
     let history: TestMessage[] = [{ role: "assistant", content: "prior" }];
+    let staged: TestMessage[] = [];
+    const backgroundFailures: unknown[] = [];
     const h = {
       background: [] as Promise<unknown>[],
       historyStore: {
         load: async () => history,
+        stagePending: (_agentId: string, _channelId: string, messages: TestMessage[]) => {
+          staged = messages;
+        },
         save: async (_agentId: string, _channelId: string, next: TestMessage[]) => {
           history = next;
         },
@@ -1621,7 +1626,12 @@ describe("SharedRuntimeChatService", () => {
         },
       },
       executionCtx: {
-        waitUntil: (promise: Promise<unknown>) => h.background.push(promise),
+        waitUntil: (promise: Promise<unknown>) =>
+          h.background.push(
+            promise.catch((error: unknown) => {
+              backgroundFailures.push(error);
+            }),
+          ),
       },
     };
     let releaseProvider = () => {};
@@ -1640,13 +1650,20 @@ describe("SharedRuntimeChatService", () => {
     const response = await service.stream(agent, rpc, h);
     const reader = response.body!.getReader();
     await reader.read();
-    await expect(reader.cancel("first cancel")).rejects.toThrow("durable put failed");
+    await expect(reader.cancel("first cancel")).resolves.toBeUndefined();
+    expect(staged).toMatchObject([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "partial", interrupted: true },
+    ]);
     expect(history).toHaveLength(1);
 
     releaseProvider();
     await new Promise((resolve) => setTimeout(resolve, 0));
     await Promise.all(h.background);
 
+    expect(backgroundFailures).toContainEqual(
+      expect.objectContaining({ message: "durable put failed" }),
+    );
     expect(attempts).toBe(2);
     expect(history.at(-2)).toMatchObject({ role: "user", content: "hello" });
     expect(history.at(-1)).toMatchObject({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -152,6 +152,12 @@ export type BridgeExecutionContext = {
 
 export interface SharedRuntimeHistoryStore {
   load(agentId: string, channelId: string, queryText?: string): Promise<SharedTurnMessage[]>;
+  /**
+   * Makes a terminal turn visible to later room requests before asynchronous
+   * durability work finishes. Implementations that serialize on durable
+   * writes may omit this hook.
+   */
+  stagePending?(agentId: string, channelId: string, messages: SharedTurnMessage[]): void;
   merge(
     agentId: string,
     channelId: string,
@@ -1785,16 +1791,16 @@ export class SharedRuntimeChatService {
       interrupted: boolean,
       afterWrite?: () => Promise<void>,
       grounding?: SharedTurnMessage["grounding"],
+      stagePending = false,
     ): Promise<void> => {
       if (finalized) return finalizationPromise ?? Promise.resolve();
       if (finalizationPromise) return finalizationPromise;
+      const messages = makeTurnMessages(reply, interrupted, grounding);
+      if (stagePending) {
+        options.historyStore?.stagePending?.(agent.id, roomId, messages);
+      }
       finalizationPromise = (async () => {
-        await mergeHistory(
-          agent.id,
-          roomId,
-          makeTurnMessages(reply, interrupted, grounding),
-          options.historyStore,
-        );
+        await mergeHistory(agent.id, roomId, messages, options.historyStore);
         if (streamMemoryStore && !isProviderFreeTurn(turn)) {
           // The long-term-memory mirror is secondary to the durability boundary
           // above (merged history) and the claim completion below: a stalled
@@ -2081,11 +2087,16 @@ export class SharedRuntimeChatService {
           .then(() => undefined);
         observeProviderCancellationOffPath(agent.id, providerCancellation, options.executionCtx);
 
-        // The room may advance only after interrupted history is durable. It
-        // must not wait for provider teardown: abort is already signalled and
-        // consumerCanceled fences all late output from persistence/delivery.
-        await finalizeMessages(interruptedReply, true, () =>
-          settleInterruptedTurn("consumer canceled stream"),
+        // Stage the exact interrupted pair synchronously before the consumer's
+        // cancel promise can release room admission. Durable history, billing,
+        // and provider teardown may then finish off the room queue without
+        // hiding context from the next turn.
+        await finalizeMessages(
+          interruptedReply,
+          true,
+          () => settleInterruptedTurn("consumer canceled stream"),
+          undefined,
+          true,
         );
       },
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -2091,13 +2091,18 @@ export class SharedRuntimeChatService {
         // cancel promise can release room admission. Durable history, billing,
         // and provider teardown may then finish off the room queue without
         // hiding context from the next turn.
-        await finalizeMessages(
+        const finalization = finalizeMessages(
           interruptedReply,
           true,
           () => settleInterruptedTurn("consumer canceled stream"),
           undefined,
           true,
         );
+        if (options.executionCtx) {
+          options.executionCtx.waitUntil(finalization);
+          return;
+        }
+        await finalization;
       },
     });
     return withTurnTimingHeaders(


### PR DESCRIPTION
Closes #27245

## What changed
- fence the canceled upstream reader before releasing the per-room Durable Object queue
- checkpoint the exact interrupted user/partial-assistant pair synchronously into the existing lossless chunked history archive
- keep provider teardown, billing, and full finalization off the admission queue under `executionCtx.waitUntil`
- recover the checkpoint after a real Durable Object eviction even when the later full conversation write fails
- preserve retry and deduplication semantics without truncating prompt, response, history, or action content

Twilio/Blooio routing is unchanged.

## Production diagnosis
A controlled 148-second PSTN call stayed connected but produced only the greeting and 0/5 caller replies. Privacy-bounded telemetry recorded pre-response cancellation and coordinator response-header timeouts while Twilio reported no application or media termination. Cancellation finalization was retaining the room admission queue, so subsequent caller turns could not start reliably.

## Exact-head verification
Head: `c4b6e3ef955d2b14e5b6a6fd5a6233f8c001f411`
Validated base: `7f0cc1444f20a635da0e330b1740cd29a0f927b1`

- `bun install` — pass
- Durable Object unit lane — 36/36 pass
- real Miniflare/Workerd eviction lane — 2/2 pass
- coordinator fetch lane — 3/3 pass
- shared runtime chat cancellation/finalization lane — 42/42 pass
- focused cancellation/finalization regression — 3 pass
- cloud shared and API typechecks — pass
- production Worker dry-run bundle — pass
- `git diff --check` — pass
- `bun run verify` — pass on the identical lifecycle tree at pre-rebase head `d04db34bbe01b59aff87bdffbf477a0ebec9a28b` (workspace build/typecheck plus repository audits)
- post-rebase affected tests: DO 36/36, Workerd eviction 2/2, coordinator 3/3, shared runtime chat 42/42 — pass
- post-rebase cloud shared/API typechecks and production Worker dry-run — pass

## Evidence
- Before: real dual-channel PSTN recording, 148 seconds connected, greeting then continuous silence, 0/5 caller turns, and no Twilio application/media error
- Deterministic after: interrupted context is readable before room release, survives full-finalizer failure and actual Durable Object eviction, and converges without duplication
- Live after: pending exact-source staging/production deploy; the same deliberate-barge/recovery recording and privacy-bounded phase evidence will be repeated
- UI screenshots/video: N/A — no rendered UI changed
- Live-model trajectory: N/A before deploy — the changed contract is cancellation and queue serialization; production acceptance will supply audio timing and content-free telemetry
