### PR TITLE
test(core): cover http

### DIFF
--- a/packages/core/src/testing/http.test.ts
+++ b/packages/core/src/testing/http.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for the e2e HTTP helper: validates readConversationId extraction
+ * and failure branches, req() wire behavior against a real loopback server
+ * (content-type resolution, body serialization, extra headers, JSON parsing,
+ * non-JSON fallback, status propagation, timeouts, refused connections), and
+ * the createConversation / postConversationMessage wrappers.
+ */
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	createConversation,
+	type HttpRequestOptions,
+	postConversationMessage,
+	readConversationId,
+	req,
+} from "./http.ts";
+
+type RecordedRequest = {
+	method: string;
+	url: string | undefined;
+	headers: http.IncomingHttpHeaders;
+	rawBody: string;
+};
+
+type ResponderOutcome = {
+	status?: number;
+	contentType?: string;
+	body: string;
+};
+
+let server: http.Server;
+let port: number;
+let lastRequest: RecordedRequest | undefined;
+let responder: (request: RecordedRequest) => ResponderOutcome | undefined;
+
+beforeAll(async () => {
+	server = http.createServer((request, response) => {
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => chunks.push(chunk));
+		request.on("end", () => {
+			lastRequest = {
+				method: request.method ?? "",
+				url: request.url,
+				headers: request.headers,
+				rawBody: Buffer.concat(chunks).toString("utf-8"),
+			};
+			if (lastRequest.url?.startsWith("/hold")) {
+				return;
+			}
+			const outcome = responder(lastRequest);
+			if (!outcome) {
+				return;
+			}
+			response.statusCode = outcome.status ?? 200;
+			if (outcome.contentType) {
+				response.setHeader("Content-Type", outcome.contentType);
+			}
+			response.end(outcome.body);
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("loopback server did not report a numeric port");
+	}
+	port = address.port;
+});
+
+afterAll(() => {
+	server.closeAllConnections();
+	return new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function jsonResponder(body: unknown, status?: number): ResponderOutcome {
+	return {
+		status,
+		contentType: "application/json",
+		body: JSON.stringify(body),
+	};
+}
+
+describe("readConversationId", () => {
+	it("returns the id from a well-formed conversation object", () => {
+		expect(readConversationId({ conversation: { id: "conv-42" } })).toBe(
+			"conv-42",
+		);
+	});
+
+	it("throws when the conversation key is absent", () => {
+		expect(() => readConversationId({})).toThrow(
+			"Conversation response did not include an id",
+		);
+	});
+
+	it("rejects arrays even when they contain an id field", () => {
+		expect(() =>
+			readConversationId({ conversation: [{ id: "conv-42" }] }),
+		).toThrow("Conversation response did not include an id");
+	});
+
+	it("throws when the id is not a string", () => {
+		expect(() => readConversationId({ conversation: { id: 7 } })).toThrow(
+			"Conversation response did not include an id",
+		);
+	});
+
+	it("throws when the id is an empty string", () => {
+		expect(() => readConversationId({ conversation: { id: "" } })).toThrow(
+			"Conversation response did not include an id",
+		);
+	});
+});
+
+describe("req", () => {
+	it("serializes object bodies as JSON with the default content type and length", async () => {
+		responder = () => jsonResponder({ ok: true });
+		const payload = { hello: "world" };
+		const response = await req(port, "POST", "/echo", payload);
+
+		expect(response.status).toBe(200);
+		expect(lastRequest?.method).toBe("POST");
+		expect(lastRequest?.headers["content-type"]).toBe("application/json");
+		expect(lastRequest?.rawBody).toBe(JSON.stringify(payload));
+		expect(lastRequest?.headers["content-length"]).toBe(
+			String(Buffer.byteLength(JSON.stringify(payload))),
+		);
+	});
+
+	it("passes string bodies through verbatim", async () => {
+		responder = () => jsonResponder({ ok: true });
+		await req(port, "PUT", "/raw", "plain-text-body");
+
+		expect(lastRequest?.rawBody).toBe("plain-text-body");
+		expect(lastRequest?.headers["content-length"]).toBe(
+			String(Buffer.byteLength("plain-text-body")),
+		);
+	});
+
+	it("omits the body and content length when no body is given", async () => {
+		responder = () => jsonResponder({ ok: true });
+		const response = await req(port, "DELETE", "/nothing");
+
+		expect(lastRequest?.method).toBe("DELETE");
+		expect(lastRequest?.rawBody).toBe("");
+		expect(lastRequest?.headers["content-length"]).toBeUndefined();
+		expect(response.data).toEqual({ ok: true });
+	});
+
+	it("sends an empty string body with a zero content length", async () => {
+		responder = () => jsonResponder({ ok: true });
+		await req(port, "POST", "/empty", "");
+
+		expect(lastRequest?.rawBody).toBe("");
+		expect(lastRequest?.headers["content-length"]).toBe("0");
+	});
+
+	it("keeps application/json as content type when extra headers are an object", async () => {
+		responder = () => jsonResponder({ ok: true });
+		await req(port, "GET", "/h", undefined, { "X-Custom": "abc" });
+
+		expect(lastRequest?.headers["content-type"]).toBe("application/json");
+		expect(lastRequest?.headers["x-custom"]).toBe("abc");
+	});
+
+	it("uses a string header argument as the content type", async () => {
+		responder = () => jsonResponder({ ok: true });
+		await req(port, "POST", "/t", { a: 1 }, "text/plain");
+
+		expect(lastRequest?.headers["content-type"]).toBe("text/plain");
+	});
+
+	it("parses JSON response payloads into data", async () => {
+		responder = () => jsonResponder({ answer: 41, nested: { deep: true } });
+		const response = await req(port, "GET", "/json");
+
+		expect(response.status).toBe(200);
+		expect(response.data).toEqual({ answer: 41, nested: { deep: true } });
+		expect(response.headers["content-type"]).toBe("application/json");
+	});
+
+	it("wraps non-JSON response payloads under _raw", async () => {
+		responder = () => ({
+			contentType: "text/plain",
+			body: "definitely not json",
+		});
+		const response = await req(port, "GET", "/text");
+
+		expect(response.status).toBe(200);
+		expect(response.data).toEqual({ _raw: "definitely not json" });
+	});
+
+	it("propagates non-2xx statuses and their parsed payloads", async () => {
+		responder = () => jsonResponder({ error: "boom" }, 503);
+		const response = await req(port, "GET", "/failing");
+
+		expect(response.status).toBe(503);
+		expect(response.data).toEqual({ error: "boom" });
+	});
+
+	it("rejects with a descriptive timeout error past timeoutMs", async () => {
+		responder = () => undefined;
+		const options: HttpRequestOptions = { timeoutMs: 60 };
+
+		await expect(
+			req(port, "GET", "/hold-connection", undefined, undefined, options),
+		).rejects.toThrow("Request timed out after 60ms: GET /hold-connection");
+	});
+
+	it("rejects when nothing listens on the target port", async () => {
+		const doomed = http.createServer();
+		await new Promise<void>((resolve) =>
+			doomed.listen(0, "127.0.0.1", resolve),
+		);
+		const deadAddress = doomed.address();
+		if (!deadAddress || typeof deadAddress === "string") {
+			throw new Error("probe server did not report a numeric port");
+		}
+		const deadPort = deadAddress.port;
+		await new Promise<void>((resolve) => doomed.close(() => resolve()));
+
+		responder = () => jsonResponder({ ok: true });
+		await expect(req(deadPort, "GET", "/unreachable")).rejects.toThrow();
+	});
+});
+
+describe("createConversation", () => {
+	it("posts the options payload and surfaces the conversation id", async () => {
+		responder = () => jsonResponder({ conversation: { id: "conv-9" } });
+		const options = { title: "Hello", includeGreeting: true, lang: "en" };
+		const response = await createConversation(port, options);
+
+		expect(response.status).toBe(200);
+		expect(response.conversationId).toBe("conv-9");
+		expect(lastRequest?.method).toBe("POST");
+		expect(lastRequest?.url).toBe("/api/conversations");
+		expect(lastRequest?.rawBody).toBe(JSON.stringify(options));
+	});
+
+	it("forwards extra headers onto the request", async () => {
+		responder = () => jsonResponder({ conversation: { id: "conv-9" } });
+		await createConversation(
+			port,
+			{ title: "Hi" },
+			{ Authorization: "Bearer t" },
+		);
+
+		expect(lastRequest?.headers.authorization).toBe("Bearer t");
+	});
+
+	it("rejects when the server response carries no conversation id", async () => {
+		responder = () => jsonResponder({ unrelated: true });
+
+		await expect(createConversation(port, {})).rejects.toThrow(
+			"Conversation response did not include an id",
+		);
+	});
+});
+
+describe("postConversationMessage", () => {
+	it("encodes the conversation id into the request path", async () => {
+		responder = () => jsonResponder({ received: true });
+		const body = { text: "hi there" };
+		const response = await postConversationMessage(port, "a/b c", body);
+
+		expect(response.status).toBe(200);
+		expect(response.data).toEqual({ received: true });
+		expect(lastRequest?.method).toBe("POST");
+		expect(lastRequest?.url).toBe("/api/conversations/a%2Fb%20c/messages");
+		expect(lastRequest?.rawBody).toBe(JSON.stringify(body));
+	});
+
+	it("passes raw string bodies and a string content type through", async () => {
+		responder = () => jsonResponder({ received: true });
+		await postConversationMessage(port, "c1", "line1\nline2", "text/csv");
+
+		expect(lastRequest?.url).toBe("/api/conversations/c1/messages");
+		expect(lastRequest?.rawBody).toBe("line1\nline2");
+		expect(lastRequest?.headers["content-type"]).toBe("text/csv");
+	});
+
+	it("applies request options such as timeouts", async () => {
+		responder = () => undefined;
+
+		await expect(
+			postConversationMessage(port, "c1", { text: "slow" }, undefined, {
+				timeoutMs: 40,
+			}),
+		).rejects.toThrow(
+			"Request timed out after 40ms: POST /api/conversations/c1/messages",
+		);
+	});
+});


### PR DESCRIPTION

Adds `packages/core/src/testing/http.test.ts` with unit coverage for the e2e HTTP helper in `packages/core/src/testing/http.ts`, which previously had no same-named test suite anywhere in the repository.

## What is covered

- `readConversationId`: returns a well-formed conversation id; throws on missing conversation key, array-valued conversation (arrays are rejected even when they contain an id field), non-string id, and empty-string id.
- `req`: drives a real loopback `node:http` server (no mocks) and verifies object bodies are JSON-serialized with default `application/json` content type and correct `Content-Length`; string bodies pass through verbatim; omitted bodies send no payload or length; an empty-string body sends zero length; object header args keep the JSON content type while merging extra headers; string header args replace the content type; JSON responses parse into `data`; non-JSON responses wrap under `_raw`; non-2xx statuses propagate with parsed payloads; `timeoutMs` rejects with the descriptive `Request timed out after <ms>: <METHOD> <path>` error; connecting to a dead port rejects.
- `createConversation`: posts its options payload to `/api/conversations`, forwards extra headers, surfaces `conversationId`, and rejects when the server response carries no id.
- `postConversationMessage`: encodes the conversation id into the request path (`encodeURIComponent`), passes raw string bodies plus string content types through, and applies request options such as timeouts.

## Evidence

- `bunx vitest run packages/core/src/testing/http.test.ts` against current `origin/develop` (`35617f304e82`): **1 file passed, 22/22 tests passed**.
- `bunx biome check packages/core/src/testing/http.test.ts`: clean, no fixes needed.
- `bunx tsc --noEmit -p ./tsconfig.json` in `packages/core`: the new test file appears nowhere in the output (zero new type errors).
- The diff adds exactly one new test file (+292/-0); no existing file is modified or deleted and no production behavior changes.

## Notes

- This is a fork contribution, so hosted CI does not run on this pull request; the counts above are quoted from a local run at head `35617f304e82`.
- Two expectations record observed wire behavior of Node's HTTP client rather than assumptions: a POST with an empty-string body announces `Content-Length: 0`, while a DELETE with no body sends no `Content-Length` header.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:35617f304e825d8a049b5523e7289189c76c2d33 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
