### PR TITLE
test(ui): cover usePointerPressAndHold

### DIFF
--- a/packages/ui/src/gestures/usePointerPressAndHold.test.ts
+++ b/packages/ui/src/gestures/usePointerPressAndHold.test.ts
@@ -1,0 +1,279 @@
+/** Dedicated unit suite for the pointer-event press-and-hold recognizer hook. */
+// @vitest-environment jsdom
+//
+// Drives the real usePointerPressAndHold binding handlers with synthetic
+// pointer events and fake timers to pin contracts beyond the shared
+// gestures.test.ts coverage: the DEFAULT_* option fallbacks, the strictly-
+// greater-than slop boundary on either axis, restart-on-repress timing,
+// one-shot spend after a fired hold, and the canBegin/onHold event identity.
+import { act, renderHook } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_HOLD_MS, TOUCH_TAP_MOVE_SLOP } from "./constants";
+import { usePointerPressAndHold } from "./usePointerPressAndHold";
+
+describe("usePointerPressAndHold", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function pointer(x = 0, y = 0) {
+    return {
+      clientX: x,
+      clientY: y,
+    } as unknown as React.PointerEvent<HTMLElement>;
+  }
+
+  it("fires onHold once past durationMs with the originating pointerdown event", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const down = pointer(42, 24);
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onPointerDown(down));
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    expect(onHold).toHaveBeenCalledWith(down);
+    expect(onHold.mock.calls[0][0].clientX).toBe(42);
+    expect(onHold.mock.calls[0][0].clientY).toBe(24);
+  });
+
+  it("falls back to DEFAULT_HOLD_MS when durationMs is omitted", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS - 1);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to TOUCH_TAP_MOVE_SLOP and honours its strict boundary", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    // Travel of EXACTLY the default slop is not > slop, so the hold survives.
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    act(() =>
+      result.current.onPointerMove(pointer(100 + TOUCH_TAP_MOVE_SLOP, 100)),
+    );
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    // One pixel past it on either axis cancels.
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    act(() =>
+      result.current.onPointerMove(pointer(100, 100 + TOUCH_TAP_MOVE_SLOP + 1)),
+    );
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours an explicit tighter moveCancelPx on both axes", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        moveCancelPx: 5,
+      }),
+    );
+    act(() => result.current.onPointerDown(pointer(0, 0)));
+    act(() => result.current.onPointerMove(pointer(-6, 0)));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => result.current.onPointerDown(pointer(0, 0)));
+    act(() => result.current.onPointerMove(pointer(0, 6)));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => result.current.onPointerDown(pointer(0, 0)));
+    act(() => result.current.onPointerMove(pointer(5, -5)));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores moves made outside an active press", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() =>
+      result.current.onPointerMove(
+        pointer(TOUCH_TAP_MOVE_SLOP * 10, TOUCH_TAP_MOVE_SLOP * 10),
+      ),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts the timer on a re-press instead of stacking holds", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(90);
+    });
+    act(() => result.current.onPointerDown(pointer(7, 7)));
+    act(() => {
+      vi.advanceTimersByTime(90);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    expect(onHold.mock.calls[0][0].clientX).toBe(7);
+  });
+
+  it("is spent after firing and re-arms on the next press", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    // No pointerup was seen: straggler time and moves must not re-fire.
+    act(() => result.current.onPointerMove(pointer(500, 500)));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    // A fresh press runs a full fresh hold.
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onHold).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels on pointer up/cancel before the duration", () => {
+    for (const ender of ["onPointerUp", "onPointerCancel"] as const) {
+      vi.useFakeTimers();
+      const onHold = vi.fn();
+      const { result } = renderHook(() =>
+        usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+      );
+      act(() => result.current.onPointerDown(pointer()));
+      act(() => result.current[ender]());
+      act(() => {
+        vi.advanceTimersByTime(110);
+      });
+      expect(onHold).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes the pointerdown event to canBegin and skips rejected presses", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const canBegin = vi.fn(() => false);
+    const down = pointer(11, 13);
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        canBegin,
+      }),
+    );
+    act(() => result.current.onPointerDown(down));
+    expect(canBegin).toHaveBeenCalledTimes(1);
+    expect(canBegin).toHaveBeenCalledWith(down);
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+  });
+
+  it("runs accepted canBegin presses to completion", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const canBegin = vi.fn(() => true);
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        canBegin,
+      }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(canBegin).toHaveBeenCalledTimes(1);
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("is inert when enabled is false", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const canBegin = vi.fn(() => true);
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        canBegin,
+        enabled: false,
+      }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(canBegin).not.toHaveBeenCalled();
+    expect(onHold).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending hold on unmount", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

Adds a dedicated unit suite for the pointer-event press-and-hold recognizer at
`packages/ui/src/gestures/usePointerPressAndHold.test.ts` (+279/-0, test-only;
no production behaviour changes).

The hook currently has only partial coverage inside the shared
`gestures.test.ts`. This suite pins its remaining contracts by driving the real
binding handlers with synthetic pointer events and fake timers:

- fires `onHold` exactly once past `durationMs`, passing the originating
  pointerdown event through (clientX/clientY identity);
- falls back to `DEFAULT_HOLD_MS` when `durationMs` is omitted;
- falls back to `TOUCH_TAP_MOVE_SLOP` when `moveCancelPx` is omitted, with the
  strictly-greater-than boundary honoured on either axis (travel of exactly the
  slop survives, slop+1 cancels);
- honours an explicit tighter `moveCancelPx` on both axes while a diagonal at
  the boundary survives;
- ignores moves made outside an active press;
- restarts the timer on a re-press instead of stacking holds (the second
  press's event is the one delivered);
- is spent after firing — straggler time and moves cannot re-fire — and
  re-arms for a fresh full hold on the next press;
- cancels on `onPointerUp`/`onPointerCancel` before the duration;
- passes the pointerdown event to `canBegin` and skips rejected presses,
  runs accepted ones to completion, and never consults `canBegin` when
  `enabled: false`;
- clears the pending hold on unmount.

Evidence (quoted from the pushed head):

- `bunx vitest run src/gestures/usePointerPressAndHold.test.ts` in
  `packages/ui`: Test Files 1 passed (1), Tests 12 passed (12).
- `bunx biome check` on the new file: clean (0 problems).
- `bunx tsc --noEmit` in `packages/ui`: the package's pre-existing errors are
  unchanged and the new test file appears nowhere in the output.

The diff touches only the one new test file. As a fork contributor, hosted CI
does not run on this pull request; the local runs above are the verification.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:88cd105f2082db70e5f696cc5049d6e4be532e81 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
