### PR TITLE
test(ui): cover index

### DIFF
--- a/packages/ui/src/genui/index.test.ts
+++ b/packages/ui/src/genui/index.test.ts
@@ -1,0 +1,143 @@
+/** Pins the GenUI barrel surface (@elizaos/ui/genui) to its member modules. */
+// @vitest-environment jsdom
+
+/**
+ * index.ts is pure `export *` wiring over actions, catalog, renderer,
+ * starter-pack-demo, streaming, types, use-ui-stream, and validator. Every
+ * member runtime export must resolve through the barrel by identity (no
+ * shadowing), the namespace must equal exactly the union of member runtime
+ * exports (`export *` silently drops ambiguous collisions, so any drift here
+ * is a deliberate public-surface change), the type-only member types.ts must
+ * contribute no runtime keys, and re-exported bindings must stay live when
+ * driven through the barrel alone.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as actions from "./actions";
+import * as catalog from "./catalog";
+import * as genui from "./index";
+import * as renderer from "./renderer";
+import * as starterPackDemo from "./starter-pack-demo";
+import * as streaming from "./streaming";
+import type { ElizaGenUiAction } from "./types";
+import * as uiStream from "./use-ui-stream";
+import * as validator from "./validator";
+
+type RuntimeExports = Record<string, unknown>;
+
+const memberModules = [
+  ["./actions", actions],
+  ["./catalog", catalog],
+  ["./renderer", renderer],
+  ["./starter-pack-demo", starterPackDemo],
+  ["./streaming", streaming],
+  ["./use-ui-stream", uiStream],
+  ["./validator", validator],
+] as const;
+
+const derivedRuntimeNames = memberModules
+  .flatMap(([, member]) => Object.keys(member as RuntimeExports))
+  .sort();
+
+const pinnedRuntimeNames = [
+  "ELIZA_GENUI_ALLOWED_ACTION_PREFIXES",
+  "ELIZA_GENUI_ALLOWED_COMPONENTS",
+  "ELIZA_GENUI_DOMAIN_COMPONENTS",
+  "ELIZA_GENUI_PRIMITIVE_COMPONENTS",
+  "ELIZA_STARTER_PACK_SETUP_SPEC",
+  "MAX_GENUI_UNSAFE_FIELD_DEPTH",
+  "MAX_GENUI_UNSAFE_FIELD_NODES",
+  "ElizaGenUiActionError",
+  "ElizaGenUiRenderer",
+  "abortElizaGenUiStream",
+  "applyElizaGenUiPatch",
+  "assertValidElizaGenUiSpec",
+  "createElizaGenUiPrefixActionHandler",
+  "isElizaGenUiActionNameAllowed",
+  "isElizaGenUiKnownComponent",
+  "isElizaGenUiPrimitiveComponent",
+  "officialSpecToEliza",
+  "resetElizaGenUiSpec",
+  "routeElizaGenUiAction",
+  "useUIStream",
+  "validateElizaGenUiSpec",
+];
+
+const validPrimitiveSpec = {
+  version: "0.1",
+  a2uiVersion: "0.9",
+  root: "card",
+  components: [
+    { id: "card", component: "Card" },
+    { id: "title", component: "Text", text: "Hello", variant: "h2" },
+  ],
+} as const;
+
+describe("genui barrel surface", () => {
+  it("re-exports every member runtime symbol by identity", () => {
+    for (const [specifier, member] of memberModules) {
+      const exports = member as RuntimeExports;
+      for (const name of Object.keys(exports)) {
+        expect(
+          name in genui,
+          `${specifier} exports "${name}" but the barrel does not`,
+        ).toBe(true);
+        expect(
+          (genui as RuntimeExports)[name],
+          `barrel binding for ${specifier}:${name} diverged from its module`,
+        ).toBe(exports[name]);
+      }
+    }
+  });
+
+  it("exposes exactly the union of member runtime exports", () => {
+    expect(Object.keys(genui).sort()).toEqual(derivedRuntimeNames);
+  });
+
+  it("pins the public runtime surface; types.ts stays type-only", () => {
+    expect(Object.keys(genui)).toHaveLength(pinnedRuntimeNames.length);
+    expect(Object.keys(genui).sort()).toEqual([...pinnedRuntimeNames].sort());
+    expect(derivedRuntimeNames).toEqual([...pinnedRuntimeNames].sort());
+  });
+
+  it("keeps catalog bindings live through the barrel alone", () => {
+    expect(genui.isElizaGenUiKnownComponent("Card")).toBe(true);
+    expect(genui.isElizaGenUiKnownComponent("ProviderSetupCard")).toBe(true);
+    expect(genui.isElizaGenUiKnownComponent("NoSuchWidget")).toBe(false);
+    expect(genui.isElizaGenUiPrimitiveComponent("Card")).toBe(true);
+    expect(genui.isElizaGenUiPrimitiveComponent("ProviderSetupCard")).toBe(
+      false,
+    );
+    expect(genui.isElizaGenUiActionNameAllowed("setup.dismiss")).toBe(true);
+    expect(genui.isElizaGenUiActionNameAllowed("system.shutdown")).toBe(false);
+  });
+
+  it("keeps validator bindings live through the barrel alone", () => {
+    expect(genui.validateElizaGenUiSpec(validPrimitiveSpec).ok).toBe(true);
+
+    const rejected = genui.validateElizaGenUiSpec({
+      ...validPrimitiveSpec,
+      components: [{ id: "root", component: "Shell" }],
+      root: "root",
+    });
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) {
+      expect(
+        rejected.errors.some((error) => error.code === "unknown_component"),
+      ).toBe(true);
+    }
+  });
+
+  it("keeps action dispatch bindings live through the barrel alone", async () => {
+    const action: ElizaGenUiAction = { event: { name: "setup.dismiss" } };
+    const error = new genui.ElizaGenUiActionError("blocked", action);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("ElizaGenUiActionError");
+    expect(error.message).toBe("blocked");
+    expect(error.action).toBe(action);
+
+    await expect(
+      genui.routeElizaGenUiAction(action, {}, []),
+    ).rejects.toBeInstanceOf(genui.ElizaGenUiActionError);
+  });
+});


### PR DESCRIPTION

## What

Adds a new co-located unit suite, `packages/ui/src/genui/index.test.ts`, covering the GenUI public barrel (`packages/ui/src/genui/index.ts`). Test-only change: no production source is touched (+143/-0, one new file). No same-named suite exists anywhere on current `origin/develop` (verified via `git ls-tree -r --name-only origin/develop` immediately before filing), so nothing is rewritten or deleted.

The barrel is pure `export *` wiring over eight member modules, so the suite pins exactly that contract, driving the real modules with no mocks:

- every member runtime export resolves through the barrel **by identity** (`toBe` against the owning module's binding) — catches shadowing or rewiring;
- the namespace equals **exactly** the union of member runtime exports (21 names, pinned by an explicit list) — `export *` silently drops ambiguous collisions, so any surface drift fails loudly here rather than silently changing the public API of `@elizaos/ui/genui`;
- `types.ts` stays type-only and contributes zero runtime keys;
- re-exported bindings stay live when driven through the barrel alone: catalog guards (`isElizaGenUiKnownComponent`, `isElizaGenUiPrimitiveComponent`, `isElizaGenUiActionNameAllowed`) accept/reject real inputs, `validateElizaGenUiSpec` accepts a valid spec and rejects an unknown component with code `unknown_component`, and action dispatch constructs/routes `ElizaGenUiActionError` through `routeElizaGenUiAction`.

Assertions record observed behavior only; no aspirational expectations.

## Verification

Fork contributor: hosted CI does not run on this pull request; the checks below were run locally and are quoted verbatim.

- `bunx vitest run src/genui/index.test.ts` (in `packages/ui`, against sources byte-identical to current `origin/develop`): `Test Files 1 passed (1)` / `Tests 6 passed (6)`.
- `bunx biome check --write src/genui/index.test.ts`: `Checked 1 file in 39ms. No fixes applied.` (re-check clean).
- `bunx tsc --noEmit` in `packages/ui`: the new file appears nowhere in the output (the package's 9 reported errors are pre-existing, all in unrelated files).
- The diff touches only the new test file.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:81999a97f35d7daec99f30f8cc440dc4df8f63fa -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
