### PR TITLE
test(ui): cover validator

### DIFF
--- a/packages/ui/src/genui/validator.test.ts
+++ b/packages/ui/src/genui/validator.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Unit coverage for the GenUI spec validator's structural contract: header
+ * checks, component-array caps, catalog/id/action rules, reference integrity,
+ * image-source safety, size options, and the snapshot guarantees (severed
+ * prototypes, -0 normalization) the renderer relies on. Drives the real
+ * module; hostile-walk ceilings live in validator.unbounded.test.ts and the
+ * randomized never-throws contract in validator.fuzz.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { ELIZA_GENUI_ALLOWED_COMPONENTS } from "./catalog";
+import type { ElizaGenUiValidationOptions } from "./types";
+import { assertValidElizaGenUiSpec, validateElizaGenUiSpec } from "./validator";
+
+function validSpec(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "0.1",
+    root: "root-node",
+    components: [{ id: "root-node", component: "Text" }],
+    ...overrides,
+  };
+}
+
+function expectOk(value: unknown, options?: ElizaGenUiValidationOptions) {
+  const result = validateElizaGenUiSpec(value, options);
+  if (!result.ok) {
+    throw new Error(
+      `expected an ok spec but got: ${result.errors
+        .map((issue) => issue.message)
+        .join("\n")}`,
+    );
+  }
+  return result.spec;
+}
+
+function expectErrors(value: unknown, options?: ElizaGenUiValidationOptions) {
+  const result = validateElizaGenUiSpec(value, options);
+  if (result.ok) throw new Error("expected the spec to be rejected");
+  return result.errors;
+}
+
+describe("validateElizaGenUiSpec accepted specs", () => {
+  it("accepts a minimal connected spec and echoes its structure", () => {
+    const spec = expectOk(validSpec());
+    expect(spec.version).toBe("0.1");
+    expect(spec.root).toBe("root-node");
+    expect(spec.components).toHaveLength(1);
+    expect(spec.components[0]?.id).toBe("root-node");
+  });
+
+  it("returns a snapshot whose prototypes are severed", () => {
+    const spec = expectOk(validSpec({ data: { nested: { leaf: true } } }));
+    expect(Object.getPrototypeOf(spec)).toBeNull();
+    expect(Object.getPrototypeOf(spec.components[0])).toBeNull();
+    expect(
+      Object.getPrototypeOf((spec.data as Record<string, unknown>).nested),
+    ).toBeNull();
+  });
+
+  it("normalizes negative zero in data to positive zero", () => {
+    const spec = expectOk(validSpec({ data: { reading: -0 } }));
+    const data = spec.data as Record<string, number>;
+    expect(data.reading).toBe(0);
+    expect(Object.is(data.reading, -0)).toBe(false);
+  });
+
+  it("accepts every component name in the frozen catalog", () => {
+    for (const name of ELIZA_GENUI_ALLOWED_COMPONENTS) {
+      const spec = expectOk({
+        version: "0.1",
+        root: `c-${name}`,
+        components: [{ id: `c-${name}`, component: name }],
+      });
+      expect(spec.components[0]?.component).toBe(name);
+    }
+  });
+
+  it("accepts child refs declared across every binding slot", () => {
+    const spec = expectOk(
+      validSpec({
+        components: [
+          {
+            id: "panel",
+            component: "Row",
+            child: "alpha",
+            children: ["beta", "gamma"],
+            entryPointChild: "delta",
+            contentChild: "epsilon",
+            tabItems: [{ child: "zeta" }],
+          },
+          ...["alpha", "beta", "gamma", "delta", "epsilon", "zeta"].map(
+            (id) => ({ id, component: "Text" }),
+          ),
+        ],
+        root: "panel",
+      }),
+    );
+    expect(spec.components).toHaveLength(7);
+  });
+});
+
+describe("validateElizaGenUiSpec header validation", () => {
+  it('rejects a version other than "0.1"', () => {
+    const errors = expectErrors(validSpec({ version: "0.2" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_version");
+    expect(errors[0]?.path).toBe("version");
+  });
+
+  it('accepts an explicit A2UI compatibility version of "0.9"', () => {
+    const spec = expectOk(validSpec({ a2uiVersion: "0.9" }));
+    expect(spec.a2uiVersion).toBe("0.9");
+  });
+
+  it("rejects any other provided A2UI compatibility version", () => {
+    const errors = expectErrors(validSpec({ a2uiVersion: "1.0" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_version");
+    expect(errors[0]?.path).toBe("a2uiVersion");
+  });
+
+  it("rejects a blank root id once in the header and again as a dangling ref", () => {
+    const errors = expectErrors(validSpec({ root: "   " }));
+    expect(errors.map((issue) => issue.code)).toEqual([
+      "invalid_root",
+      "invalid_root",
+    ]);
+    expect(errors[0]?.message).toContain("Root component id must be");
+    expect(errors[1]?.message).toContain('"   "');
+  });
+
+  it("rejects non-object specs without throwing", () => {
+    for (const value of [null, [], "spec", 42]) {
+      const errors = expectErrors(value);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.code).toBe("invalid_spec");
+    }
+  });
+});
+
+describe("validateElizaGenUiSpec components array", () => {
+  it("rejects a spec whose components are not an array", () => {
+    const errors = expectErrors(validSpec({ components: {} }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_spec");
+    expect(errors[0]?.path).toBe("components");
+  });
+
+  it("accepts exactly 200 components under the default cap", () => {
+    const components = Array.from({ length: 200 }, (_, index) => ({
+      id: `node-${index}`,
+      component: "Text",
+    }));
+    const spec = expectOk(validSpec({ components, root: "node-0" }));
+    expect(spec.components).toHaveLength(200);
+  });
+
+  it("rejects 201 components with too_many_components by default", () => {
+    const components = Array.from({ length: 201 }, (_, index) => ({
+      id: `node-${index}`,
+      component: "Text",
+    }));
+    const errors = expectErrors(validSpec({ components, root: "node-0" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("too_many_components");
+    expect(errors[0]?.message).toContain("201");
+  });
+
+  it("honors a lower maxComponents override", () => {
+    const components = [
+      { id: "one", component: "Text" },
+      { id: "two", component: "Text" },
+    ];
+    const errors = expectErrors(validSpec({ components, root: "one" }), {
+      maxComponents: 1,
+    });
+    expect(errors.map((issue) => issue.code)).toEqual(["too_many_components"]);
+  });
+});
+
+describe("validateElizaGenUiSpec component records", () => {
+  it("rejects a component without a usable id", () => {
+    const errors = expectErrors(
+      validSpec({
+        components: [{ component: "Text" }],
+        root: "nowhere",
+      }),
+    );
+    expect(errors.map((issue) => issue.code)).toEqual([
+      "invalid_component",
+      "invalid_root",
+    ]);
+    expect(errors[0]?.message).toContain("id must be a non-empty string");
+    expect(errors[0]?.path).toBe("components/0");
+  });
+
+  it("rejects a whitespace-only id", () => {
+    const errors = expectErrors(
+      validSpec({
+        components: [{ id: "   ", component: "Text" }],
+        root: "nowhere",
+      }),
+    );
+    expect(errors.map((issue) => issue.code)).toEqual([
+      "invalid_component",
+      "invalid_root",
+    ]);
+  });
+
+  it("rejects a duplicate id and reports the offending component", () => {
+    const duplicated = { id: "twin", component: "Text" };
+    const errors = expectErrors(
+      validSpec({
+        components: [duplicated, duplicated],
+        root: "twin",
+      }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("duplicate_id");
+    expect(errors[0]?.componentId).toBe("twin");
+    expect(errors[0]?.path).toBe("components/1");
+  });
+
+  it("rejects a blank component name", () => {
+    const errors = expectErrors(
+      validSpec({
+        components: [{ id: "anon", component: "  " }],
+        root: "anon",
+      }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_component");
+    expect(errors[0]?.message).toContain("Component name must be a non-empty");
+    expect(errors[0]?.path).toBe("components/0/component");
+  });
+
+  it("flags component names outside the catalog as unknown", () => {
+    const errors = expectErrors(
+      validSpec({
+        components: [{ id: "odd", component: "Bogus" }],
+        root: "odd",
+      }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("unknown_component");
+    expect(errors[0]?.componentId).toBe("odd");
+    expect(errors[0]?.path).toBe("components/0/component");
+    expect(errors[0]?.message).toContain("Bogus");
+  });
+});
+
+describe("validateElizaGenUiSpec image sources", () => {
+  it.each([
+    "/absolute.png",
+    "./relative.png",
+    "../parent.png",
+    "data:image/png;base64,AAAA",
+    "http://example.com/picture.png",
+    "https://example.com/picture.png",
+    "blob:generated-id",
+    "assets/no-colon-relative.png",
+  ])("accepts safe Image src %s", (src) => {
+    expectOk(
+      validSpec({
+        components: [{ id: "img", component: "Image", src }],
+        root: "img",
+      }),
+    );
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "ftp://example.com/picture.png",
+    "data:text/html,<script>",
+  ])("rejects unsafe Image src %s", (src) => {
+    const errors = expectErrors(
+      validSpec({
+        components: [{ id: "img", component: "Image", src }],
+        root: "img",
+      }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("unsafe_url");
+    expect(errors[0]?.componentId).toBe("img");
+    expect(errors[0]?.path).toBe("components/0/src");
+  });
+});
+
+describe("validateElizaGenUiSpec action allow-list", () => {
+  function specWithAction(name: unknown, overrides: object = {}) {
+    return validSpec({
+      components: [
+        {
+          id: "button",
+          component: "Button",
+          action: { event: { name, ...overrides } },
+        },
+      ],
+      root: "button",
+    });
+  }
+
+  it("accepts event names matching an allowed prefix", () => {
+    expectOk(specWithAction("setup.begin"));
+    expectOk(specWithAction("voice.transcript.final"));
+  });
+
+  it("rejects event names outside every allowed prefix", () => {
+    const errors = expectErrors(specWithAction("system.shutdown"));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_action");
+    expect(errors[0]?.componentId).toBe("button");
+    expect(errors[0]?.path).toBe("components/button/action/event/name");
+  });
+
+  it.each([{}, { event: null }, { event: {} }])(
+    "rejects malformed action %j",
+    (action) => {
+      const value = validSpec({
+        components: [{ id: "button", component: "Button", action }],
+        root: "button",
+      });
+      const errors = expectErrors(value);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.code).toBe("invalid_action");
+      expect(errors[0]?.message).toContain(
+        "Action must use { event: { name, payload? } }",
+      );
+      expect(errors[0]?.path).toBe("components/button/action");
+    },
+  );
+
+  it("rejects a blank event name even inside a well-formed action", () => {
+    const errors = expectErrors(specWithAction("   "));
+    expect(errors[0]?.code).toBe("invalid_action");
+    expect(errors[0]?.message).toContain(
+      "Action must use { event: { name, payload? } }",
+    );
+    expect(errors[0]?.path).toBe("components/button/action");
+  });
+
+  it("admits exact names listed in allowedActionNames", () => {
+    const options = { allowedActionNames: ["app.custom"] };
+    expectOk(specWithAction("app.custom"), options);
+    const errors = expectErrors(specWithAction("app.custom"), {});
+    expect(errors[0]?.code).toBe("invalid_action");
+  });
+
+  it("replaces the default prefixes when allowedActionPrefixes is set", () => {
+    const options = { allowedActionPrefixes: ["app."] };
+    expectOk(specWithAction("app.go"), options);
+    const errors = expectErrors(specWithAction("setup.begin"), options);
+    expect(errors[0]?.code).toBe("invalid_action");
+  });
+});
+
+describe("validateElizaGenUiSpec reference integrity", () => {
+  it("rejects a root that points at no declared component", () => {
+    const errors = expectErrors(validSpec({ root: "ghost" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("invalid_root");
+    expect(errors[0]?.message).toContain('"ghost"');
+  });
+
+  it("reports each missing child reference once", () => {
+    const errors = expectErrors(
+      validSpec({
+        components: [
+          { id: "row", component: "Row", children: ["here", "gone"] },
+          { id: "here", component: "Text" },
+        ],
+        root: "row",
+      }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("missing_child");
+    expect(errors[0]?.message).toContain('"gone"');
+  });
+
+  it("accumulates every independent violation instead of stopping early", () => {
+    const errors = expectErrors(
+      validSpec({
+        version: "9",
+        root: "missing-root",
+        components: [{ id: "odd", component: "Nope" }],
+      }),
+    );
+    expect(errors.map((issue) => issue.code)).toEqual([
+      "invalid_version",
+      "unknown_component",
+      "invalid_root",
+    ]);
+  });
+});
+
+describe("validateElizaGenUiSpec hostile payloads", () => {
+  it("rejects cyclic data with unbounded_nest and never throws", () => {
+    const data: Record<string, unknown> = {};
+    data.self = data;
+    const errors = expectErrors(validSpec({ data }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.code).toBe("unbounded_nest");
+    expect(errors[0]?.message).toContain("cyclic");
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["function", () => "x"],
+    ["symbol", Symbol("s")],
+    ["bigint", 1n],
+  ])("rejects a %s data value as invalid_spec", (_label, value) => {
+    const errors = expectErrors(validSpec({ data: { field: value } }));
+    expect(errors[0]?.code).toBe("invalid_spec");
+    expect(errors[0]?.message).toContain("serializable JSON primitives");
+  });
+
+  it("flags script-bearing field names as unsafe_field", () => {
+    const errors = expectErrors(
+      validSpec({
+        data: { onClick: "steal()", innerHTML: "<b>x</b>" },
+      }),
+    );
+    const flagged = errors.filter((issue) => issue.code === "unsafe_field");
+    expect(flagged.map((issue) => issue.path)).toEqual([
+      "/data/onClick",
+      "/data/innerHTML",
+    ]);
+  });
+
+  it("skips symbol-keyed and non-enumerable properties silently", () => {
+    const symbolKey = Symbol("hidden");
+    const input: Record<PropertyKey, unknown> = {
+      ...validSpec(),
+      [symbolKey]: "ignored",
+    };
+    Object.defineProperty(input, "concealed", {
+      value: "ignored",
+      enumerable: false,
+    });
+    const spec = expectOk(input);
+    expect(spec.version).toBe("0.1");
+  });
+});
+
+describe("validateElizaGenUiSpec size options", () => {
+  it("rejects a spec over a lowered maxJsonBytes override", () => {
+    const errors = expectErrors(validSpec(), { maxJsonBytes: 16 });
+    expect(errors[0]?.code).toBe("too_large");
+    expect(errors[0]?.message).toContain("bytes");
+  });
+
+  it("keeps a small honest spec under a generous byte budget", () => {
+    const spec = expectOk(validSpec(), { maxJsonBytes: 65_536 });
+    expect(spec.root).toBe("root-node");
+  });
+});
+
+describe("assertValidElizaGenUiSpec", () => {
+  it("returns the validated spec on success", () => {
+    const spec = assertValidElizaGenUiSpec(validSpec());
+    expect(spec.root).toBe("root-node");
+    expect(spec.components[0]?.component).toBe("Text");
+  });
+
+  it("throws one Error joining every issue message with newlines", () => {
+    const invalid = validSpec({ version: "9" });
+    const expected = validateElizaGenUiSpec(invalid);
+    if (!expected.ok) {
+      let thrown: unknown;
+      try {
+        assertValidElizaGenUiSpec(invalid);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toBe(
+        expected.errors.map((issue) => issue.message).join("\n"),
+      );
+    } else {
+      throw new Error("fixture unexpectedly validated");
+    }
+  });
+});


### PR DESCRIPTION

Adds a real vitest unit suite for packages/ui/src/genui/validator.ts, which had no same-named test file on develop. The module's hostile-walk ceilings are covered by validator.unbounded.test.ts and its randomized never-throws contract by validator.fuzz.test.ts; this suite pins the structural spec-validation contract those specialized suites do not:

- accepted specs: minimal connected spec, snapshot prototypes severed, -0 normalized to +0, every frozen-catalog component name accepted, child refs honored across all binding slots (child, children, entryPointChild, contentChild, tabItems[].child)
- header validation: version/a2uiVersion rules, blank root, non-object specs
- components array: default 200-component cap boundary (200 ok, 201 rejected), maxComponents override, non-array rejection
- component records: missing/whitespace ids, duplicate ids, blank names, unknown catalog names
- image-source safety matrix: path-relative, data:image/, http(s)/blob accepted; javascript:, ftp:, data:text/html rejected as unsafe_url
- action allow-list: prefix matches accepted, unknown names rejected with the componentId-based path, malformed action shapes rejected, allowedActionNames exact-name admission, allowedActionPrefixes replacing (not unioning) the defaults
- reference integrity: dangling root, per-child missing_child reporting, multi-issue accumulation order
- hostile payloads: cyclic data, undefined/NaN/Infinity/function/symbol/bigint values, unsafe_field flagging for script-bearing keys, symbol-keyed and non-enumerable properties skipped silently
- size options: lowered maxJsonBytes override
- assertValidElizaGenUiSpec: passthrough on success and an Error whose message joins every issue message with newlines

All assertions record observed behavior of the real module driven end to end (no mocks); two initially aspirational expectations (index-based action paths, single-error counts where reference checks accumulate) were corrected to what the code actually does before landing.

Evidence (test-only diff, +484/−0, no production behavior changed):

1. bunx vitest run src/genui/validator.test.ts (packages/ui): Test Files 1 passed (1), Tests 54 passed (54). Re-verified against current origin/develop immediately before filing; packages/ui/src/genui/{validator,catalog,types}.ts are byte-identical between my base 65d589387d and current origin/develop, so the count reproduces.
2. bunx biome check src/genui/validator.test.ts: Checked 1 file in 15ms. No fixes applied. (Root biome.json present; checkout is not sparse.)
3. bunx tsc --noEmit in packages/ui: zero occurrences of validator.test.ts in output.
4. The diff touches exactly one new test file.

This is a fork contribution: hosted CI does not run on this PR; the counts above are quoted from local runs of the pinned toolchain (Bun 1.3.14).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7890c9d18d4659c51786cbcdaaa00c89c0bf5005 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
