### PR TITLE
test(ui): cover streaming

### DIFF
--- a/packages/ui/src/genui/streaming.test.ts
+++ b/packages/ui/src/genui/streaming.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Unit coverage for GenUI streamed-spec patching: add/replace/remove
+ * application, JSON Pointer parsing and escaping, per-operation failure
+ * reporting, input immutability, and post-patch revalidation. Pure unit
+ * harness driving the real module — no mocks and no renderer.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  abortElizaGenUiStream,
+  applyElizaGenUiPatch,
+  resetElizaGenUiSpec,
+} from "./streaming";
+import type {
+  ElizaGenUiComponent,
+  ElizaGenUiPatchResult,
+  ElizaGenUiSpec,
+} from "./types";
+
+function textComponent(id: string): ElizaGenUiComponent {
+  return { id, component: "Text" };
+}
+
+function baseSpec(): ElizaGenUiSpec {
+  return {
+    version: "0.1",
+    root: "root",
+    components: [
+      { id: "root", component: "Column", children: ["title"] },
+      textComponent("title"),
+    ],
+    data: { count: 1, items: ["a", "b"] },
+  };
+}
+
+function expectPatchOk(result: ElizaGenUiPatchResult): ElizaGenUiSpec {
+  if (!result.ok) {
+    throw new Error(`expected ok, got ${JSON.stringify(result.errors)}`);
+  }
+  return result.spec;
+}
+
+function expectPatchErrors(result: ElizaGenUiPatchResult) {
+  if (result.ok) {
+    throw new Error("expected patch application to fail");
+  }
+  return result.errors;
+}
+
+describe("applyElizaGenUiPatch", () => {
+  it("returns a fresh deep clone for an empty patch list", () => {
+    const spec = baseSpec();
+    const out = expectPatchOk(applyElizaGenUiPatch(spec, []));
+    expect(out).toEqual(spec);
+    expect(out).not.toBe(spec);
+    expect(out.data).not.toBe(spec.data);
+    expect(out.components).not.toBe(spec.components);
+  });
+
+  it("adds a new key under data", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/label", value: "hello" },
+      ]),
+    );
+    expect(out.data?.label).toBe("hello");
+  });
+
+  it("replaces an existing key under data", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/data/count", value: 7 },
+      ]),
+    );
+    expect(out.data?.count).toBe(7);
+  });
+
+  it("removes an existing key under data", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [{ op: "remove", path: "/data/count" }]),
+    );
+    expect(Object.hasOwn(out.data ?? {}, "count")).toBe(false);
+  });
+
+  it("inserts at array indices and appends with the - token", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/items/0", value: "z" },
+        { op: "add", path: "/data/items/-", value: "c" },
+      ]),
+    );
+    expect(out.data?.items).toEqual(["z", "a", "b", "c"]);
+  });
+
+  it("replaces an in-bounds array element", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/data/items/1", value: "q" },
+      ]),
+    );
+    expect(out.data?.items).toEqual(["a", "q"]);
+  });
+
+  it("removes an array element and shifts the tail left", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "remove", path: "/data/items/0" },
+      ]),
+    );
+    expect(out.data?.items).toEqual(["b"]);
+  });
+
+  it("decodes ~1 and ~0 escapes in pointer tokens", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/a~1b~0c", value: true },
+      ]),
+    );
+    expect(Object.hasOwn(out.data ?? {}, "a/b~c")).toBe(true);
+  });
+
+  it("collapses empty pointer segments while resolving", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data//extra", value: 5 },
+      ]),
+    );
+    expect(out.data?.extra).toBe(5);
+  });
+
+  it("applies patches in order so later patches see earlier writes", () => {
+    const out = expectPatchOk(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/name", value: "x" },
+        { op: "replace", path: "/data/name", value: "y" },
+        { op: "remove", path: "/data/count" },
+      ]),
+    );
+    expect(out.data).toEqual({ items: ["a", "b"], name: "y" });
+  });
+
+  it("rejects paths that are not JSON Pointers", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [{ op: "remove", path: "data/count" }]),
+    );
+    expect(errors).toMatchObject([
+      {
+        code: "invalid_spec",
+        path: "data/count",
+        message: expect.stringContaining("must be a JSON Pointer"),
+      },
+    ]);
+  });
+
+  it("reports the root pointer as non-resolving", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [{ op: "add", path: "/", value: 1 }]),
+    );
+    expect(errors).toMatchObject([
+      {
+        code: "invalid_spec",
+        path: "/",
+        message: expect.stringContaining("does not resolve"),
+      },
+    ]);
+  });
+
+  it("fails when the final container is a primitive", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/count/nested", value: 1 },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      {
+        code: "invalid_spec",
+        path: "/data/count/nested",
+        message: expect.stringContaining('failed at "/data/count/nested"'),
+      },
+    ]);
+  });
+
+  it("fails replacing a missing object key", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/data/nope", value: 1 },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/nope" },
+    ]);
+  });
+
+  it("fails removing a missing object key", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [{ op: "remove", path: "/data/nope" }]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/nope" },
+    ]);
+  });
+
+  it("fails adding without a value payload", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [{ op: "add", path: "/data/nope" }]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/nope" },
+    ]);
+  });
+
+  it("rejects out-of-bounds array replacement", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/data/items/5", value: "q" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/items/5" },
+    ]);
+  });
+
+  it("rejects array insertion past the append position", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/items/3", value: "gap" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/items/3" },
+    ]);
+  });
+
+  it("rejects negative array indices", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "add", path: "/data/items/-1", value: "x" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/items/-1" },
+    ]);
+  });
+
+  it("rejects removing past the end of an array", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "remove", path: "/data/items/2" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/items/2" },
+    ]);
+  });
+
+  it("rejects non-numeric array indices", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/data/items/abc", value: "x" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/items/abc" },
+    ]);
+  });
+
+  it("leaves the input spec untouched when any patch fails", () => {
+    const spec = baseSpec();
+    const result = applyElizaGenUiPatch(spec, [
+      { op: "add", path: "/data/progress", value: "half" },
+      { op: "replace", path: "/data/nope", value: 1 },
+    ]);
+    const errors = expectPatchErrors(result);
+    expect(errors).toMatchObject([
+      { code: "invalid_spec", path: "/data/nope" },
+    ]);
+    expect("spec" in result).toBe(false);
+    expect(Object.hasOwn(spec.data ?? {}, "progress")).toBe(false);
+    expect(spec).toEqual(baseSpec());
+  });
+
+  it("defers to spec validation when a patch breaks the header", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        { op: "replace", path: "/version", value: "9.9" },
+      ]),
+    );
+    expect(errors).toMatchObject([
+      { code: "invalid_version", path: "version" },
+    ]);
+  });
+
+  it("validates patched-in components against the catalog", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(baseSpec(), [
+        {
+          op: "add",
+          path: "/components/-",
+          value: { id: "mystery", component: "Widget" },
+        },
+      ]),
+    );
+    expect(errors.some((issue) => issue.code === "unknown_component")).toBe(
+      true,
+    );
+  });
+
+  it("forwards validation options such as maxComponents", () => {
+    const errors = expectPatchErrors(
+      applyElizaGenUiPatch(
+        baseSpec(),
+        [
+          {
+            op: "add",
+            path: "/components/-",
+            value: { id: "third", component: "Text" },
+          },
+        ],
+        { maxComponents: 2 },
+      ),
+    );
+    expect(errors.some((issue) => issue.code === "too_many_components")).toBe(
+      true,
+    );
+  });
+});
+
+describe("resetElizaGenUiSpec", () => {
+  it("returns an independent deep clone", () => {
+    const spec = baseSpec();
+    const reset = resetElizaGenUiSpec(spec);
+    expect(reset).toEqual(spec);
+    expect(reset).not.toBe(spec);
+    expect(reset.data).not.toBe(spec.data);
+    if (reset.data) {
+      reset.data.count = 99;
+    }
+    expect(spec.data?.count).toBe(1);
+  });
+});
+
+describe("abortElizaGenUiStream", () => {
+  it("wraps the reason as a single invalid_spec issue", () => {
+    const result = abortElizaGenUiStream("user cancelled the stream");
+    if (result.ok) {
+      throw new Error("expected an aborted stream to be unsuccessful");
+    }
+    expect(result.errors).toMatchObject([
+      { code: "invalid_spec", message: "user cancelled the stream" },
+    ]);
+    expect(
+      result.errors.every(
+        (issue) => issue.path === undefined && issue.componentId === undefined,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new co-located unit suite for `packages/ui/src/genui/streaming.ts`, which had no same-named test file anywhere on `develop`. Test-only change: no production file is touched (`+356/-0`, one new file).

Coverage drives the real module (no mocks) across every exported symbol and branch:

- **`applyElizaGenUiPatch`** — deep-clone isolation (empty patch list returns an equal-but-distinct spec); object `add`/`replace`/`remove`; array insert-by-index, `-` append, in-bounds replace, remove-with-shift; RFC-6902 `~1`/`~0` pointer unescaping; empty-segment collapse; patch ordering (later patches see earlier writes); failure reporting for non-pointer paths, non-resolving root `/`, primitive containers, missing replace/remove keys, value-less `add`, out-of-bounds/past-append/negative/non-numeric array indices; input spec left untouched when any patch fails (no partial result leaks); post-patch revalidation deferring to the validator (`invalid_version` on a broken header, `unknown_component` against the frozen catalog) and forwarding validation options (`maxComponents` → `too_many_components`).
- **`resetElizaGenUiSpec`** — independent deep clone (mutating the clone leaves the original intact).
- **`abortElizaGenUiStream`** — wraps its reason as exactly one `invalid_spec` issue with no `path`/`componentId`.

## Evidence

- `bunx vitest run src/genui/streaming.test.ts` (in `packages/ui`, vitest v4.1.10): **Test Files 1 passed (1), Tests 27 passed (27)** — observed against base `65d589387dac89ce1d01ba5f16c8b6f68fd98445` (origin/develop at branch time).
- `bunx biome check src/genui/streaming.test.ts`: clean ("Checked 1 file … No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics reference `streaming.test.ts` (one early TS2322 in the suite itself was caught and fixed before commit; remaining package output is pre-existing/unrelated to this diff).
- Diff scope: only `packages/ui/src/genui/streaming.test.ts` is added; no existing test file or source line is modified or deleted.

## CI note

This pull request is filed from a fork, so hosted CI does not run on it. The counts above are from local runs quoted verbatim; nothing here implies CI passed.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b2d5640515b86648aa7479373068ad65a609df7f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
