### PR TITLE
test(ui): cover useClickSuppression

### DIFF
--- a/packages/ui/src/gestures/useClickSuppression.test.tsx
+++ b/packages/ui/src/gestures/useClickSuppression.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Dedicated suite for the compat-click suppression hook: unarmed passthrough,
+ * consume-on-click (preventDefault + stopPropagation), boolean arm semantics,
+ * consumeArmed interplay, the autoDisarm macrotask (including the
+ * latest-rendered option value), instance isolation, and the end-to-end React
+ * wiring where a swallowed capture click never reaches the element's own
+ * onClick. jsdom-backed via @testing-library/react; the real touch pipeline
+ * stays with the CDP-touch e2e runners.
+ */
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+} from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ClickSuppressionOptions,
+  useClickSuppression,
+} from "./useClickSuppression";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function synthesizedClick() {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as React.MouseEvent;
+}
+
+describe("useClickSuppression", () => {
+  it("leaves an unarmed click untouched", () => {
+    const { result } = renderHook(() => useClickSuppression());
+    const evt = synthesizedClick();
+
+    act(() => result.current.onClickCapture(evt));
+
+    expect(evt.preventDefault).not.toHaveBeenCalled();
+    expect(evt.stopPropagation).not.toHaveBeenCalled();
+    expect(result.current.consumeArmed()).toBe(false);
+  });
+
+  it("swallows the armed click with preventDefault and stopPropagation", () => {
+    const { result } = renderHook(() => useClickSuppression());
+    const evt = synthesizedClick();
+
+    act(() => result.current.arm());
+    act(() => result.current.onClickCapture(evt));
+
+    expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+    expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("disarms on consume, so the immediately following click passes through", () => {
+    const { result } = renderHook(() => useClickSuppression());
+
+    act(() => result.current.arm());
+    act(() => result.current.onClickCapture(synthesizedClick()));
+    expect(result.current.consumeArmed()).toBe(false);
+
+    const later = synthesizedClick();
+    act(() => result.current.onClickCapture(later));
+    expect(later.preventDefault).not.toHaveBeenCalled();
+    expect(later.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("treats repeated arm() calls as one boolean arm, not a queue", () => {
+    const { result } = renderHook(() => useClickSuppression());
+
+    act(() => result.current.arm());
+    act(() => result.current.arm());
+
+    const first = synthesizedClick();
+    act(() => result.current.onClickCapture(first));
+    expect(first.preventDefault).toHaveBeenCalledTimes(1);
+
+    const second = synthesizedClick();
+    act(() => result.current.onClickCapture(second));
+    expect(second.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("consumeArmed() reads false fresh, then true exactly once per arm()", () => {
+    const { result } = renderHook(() => useClickSuppression());
+
+    expect(result.current.consumeArmed()).toBe(false);
+
+    act(() => result.current.arm());
+    expect(result.current.consumeArmed()).toBe(true);
+    expect(result.current.consumeArmed()).toBe(false);
+  });
+
+  it("still swallows a synthesized click that lands before the macrotask boundary", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useClickSuppression());
+
+    act(() => result.current.arm());
+    const pending = synthesizedClick();
+    act(() => result.current.onClickCapture(pending));
+    expect(pending.preventDefault).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    const afterBoundary = synthesizedClick();
+    act(() => result.current.onClickCapture(afterBoundary));
+    expect(afterBoundary.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("auto-disarms across the macrotask so an unrelated later click survives", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useClickSuppression());
+
+    act(() => result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    const unrelated = synthesizedClick();
+    act(() => result.current.onClickCapture(unrelated));
+    expect(unrelated.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.consumeArmed()).toBe(false);
+  });
+
+  it("holds the arm past the macrotask when autoDisarm is false", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useClickSuppression({ autoDisarm: false }),
+    );
+
+    act(() => result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    const trailing = synthesizedClick();
+    act(() => result.current.onClickCapture(trailing));
+    expect(trailing.preventDefault).toHaveBeenCalledTimes(1);
+    expect(trailing.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("governs the macrotask with the latest rendered autoDisarm value", () => {
+    vi.useFakeTimers();
+
+    const enabling = renderHook<
+      ReturnType<typeof useClickSuppression>,
+      ClickSuppressionOptions
+    >((props) => useClickSuppression(props), {
+      initialProps: { autoDisarm: false },
+    });
+    enabling.rerender({});
+    act(() => enabling.result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(enabling.result.current.consumeArmed()).toBe(false);
+
+    const disabling = renderHook<
+      ReturnType<typeof useClickSuppression>,
+      ClickSuppressionOptions
+    >((props) => useClickSuppression(props), {
+      initialProps: {},
+    });
+    disabling.rerender({ autoDisarm: false });
+    act(() => disabling.result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(disabling.result.current.consumeArmed()).toBe(true);
+  });
+
+  it("keeps separate instances independently armed", () => {
+    const pager = renderHook(() => useClickSuppression());
+    const toggle = renderHook(() => useClickSuppression());
+
+    act(() => pager.result.current.arm());
+
+    const bystander = synthesizedClick();
+    act(() => toggle.result.current.onClickCapture(bystander));
+    expect(bystander.preventDefault).not.toHaveBeenCalled();
+
+    const owner = synthesizedClick();
+    act(() => pager.result.current.onClickCapture(owner));
+    expect(owner.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents the element's own onClick when wired through React's event system", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useClickSuppression());
+    const onButtonClick = vi.fn();
+    const { getByRole } = render(
+      <button
+        type="button"
+        onClickCapture={result.current.onClickCapture}
+        onClick={onButtonClick}
+      >
+        release point
+      </button>,
+    );
+
+    act(() => result.current.arm());
+    fireEvent.click(getByRole("button"));
+    expect(onButtonClick).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    fireEvent.click(getByRole("button"));
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

## What

Adds a dedicated unit suite for `packages/ui/src/gestures/useClickSuppression.ts`, which had no same-named test file anywhere on `develop`. Test-only change: **+216/−0, one new file** (`packages/ui/src/gestures/useClickSuppression.test.tsx`), no production code touched.

The shared gesture-core suite (`src/gestures/gestures.test.ts`) already exercises four broad cases of this hook; this suite complements it with the branches that file does not cover:

- unarmed clicks pass through untouched (no `preventDefault`/`stopPropagation`, `consumeArmed()` stays false)
- a swallowed click calls both `preventDefault` and `stopPropagation` exactly once
- consume-on-click disarms: the immediately following click passes through
- repeated `arm()` before one click is one boolean arm, not a queue — exactly one swallow
- `consumeArmed()` reads false fresh, then true exactly once per `arm()`
- a synthesized click landing before the auto-disarm macrotask is still swallowed
- default options disarm across the macrotask so an unrelated later click survives
- `autoDisarm: false` holds the arm past the macrotask (touch long-press case)
- the latest rendered `autoDisarm` value governs the macrotask (both directions via `rerender`)
- separate hook instances keep independent armed state
- end-to-end wiring through React's event system (jsdom): while armed, a click never reaches the element's own `onClick`; after the macrotask it does

## Evidence

Test-only diff; no production behaviour changed.

- `bunx vitest run src/gestures/useClickSuppression.test.tsx` (packages/ui, jsdom env): **1 file passed, 11 tests passed**, re-run against current `develop` base `65d589387dac89ce1d01ba5f16c8b6f68fd98445` immediately before filing.
- `bunx biome check --write src/gestures/useClickSuppression.test.tsx`: clean ("No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero occurrences of `useClickSuppression.test` in output.
- Diff touches only the new test file.

Note: this PR comes from a fork (`ss25/eliza`), so hosted CI does not run on it — the counts above are quoted directly from local runs of the owning package's configured vitest lane.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:65d589387dac89ce1d01ba5f16c8b6f68fd98445 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
