### PR TITLE
test(app-core): cover database-mode

### DIFF
--- a/packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts
+++ b/packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts
@@ -63,6 +63,18 @@ describe("redactDatabaseTarget", () => {
   it("returns the trimmed string when parsing fails and no userinfo is present", () => {
     expect(redactDatabaseTarget("  not-a-url  ")).toBe("not-a-url");
   });
+
+  it("redacts only the password when the URL has no username", () => {
+    expect(
+      redactDatabaseTarget("postgres://:secret@localhost:5432/eliza"),
+    ).toBe("postgres://:%5Bpassword%5D@localhost:5432/eliza");
+  });
+
+  it("redacts credentials that use percent-encoded reserved characters", () => {
+    expect(
+      redactDatabaseTarget("postgres://user%40x:p%23ss@localhost:5432/eliza"),
+    ).toBe("postgres://%5Buser%5D:%5Bpassword%5D@localhost:5432/eliza");
+  });
 });
 
 describe("resolveDatabaseMode", () => {
@@ -259,6 +271,39 @@ describe("resolveDatabaseMode", () => {
     expect(result.mode).toBe("pglite-persistent");
     expect(result.pgliteDataDir).toBe(path.resolve(process.cwd(), "rel/db"));
   });
+
+  it("treats a whitespace-only PGLITE_DATA_DIR as absent", () => {
+    const appStateDir = "/Users/example/Library/Application Support/Eliza";
+    const result = resolveDatabaseMode(
+      options({
+        env: { PGLITE_DATA_DIR: "   " },
+        packagedDesktop: true,
+        appStateDir,
+      }),
+    );
+
+    expect(result).toEqual({
+      mode: "pglite-persistent",
+      pgliteDataDir: path.join(appStateDir, "database", "pglite"),
+      source: "packaged-desktop-default",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
+
+  it("does not treat a blank ELIZA_DB_MODE as explicit memory", () => {
+    const result = resolveDatabaseMode(
+      options({ env: { ELIZA_DB_MODE: "", PGLITE_DATA_DIR: "/abs/db" } }),
+    );
+
+    expect(result).toEqual({
+      mode: "pglite-persistent",
+      pgliteDataDir: "/abs/db",
+      source: "PGLITE_DATA_DIR",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+  });
 });
 
 describe("applyDatabaseResolutionToEnv", () => {
@@ -369,5 +414,24 @@ describe("applyDatabaseResolutionToEnv", () => {
     });
 
     expect(childEnv).toEqual({ POSTGRES_URL: "postgres://keep" });
+  });
+
+  it("does not mutate env when pglite-memory mode is missing a data dir", () => {
+    const childEnv: Record<string, string> = {
+      POSTGRES_URL: "postgres://keep",
+      DATABASE_URL: "postgres://also-keep",
+    };
+
+    applyDatabaseResolutionToEnv(childEnv, {
+      mode: "pglite-memory",
+      source: "explicit-memory",
+      warnings: [],
+      databaseUrlMapped: false,
+    });
+
+    expect(childEnv).toEqual({
+      POSTGRES_URL: "postgres://keep",
+      DATABASE_URL: "postgres://also-keep",
+    });
   });
 });


### PR DESCRIPTION

## What

Additive test-only extension of `packages/app-core/platforms/electrobun/src/database/__tests__/database-mode.test.ts` (+64/-0, single file). The base suite landed via #25771; this PR adds five cases that cover branches the current suite does not reach. No production code is touched and no existing case is modified or removed.

## New coverage

All expectations were written from behavior observed by driving the real module — no mocks.

`redactDatabaseTarget`
- Redacts only the password when a parseable URL has credentials but no username (`postgres://:secret@host/db`).
- Redacts credentials containing percent-encoded reserved characters (`user%40x`, `p%23ss`) end to end.

`resolveDatabaseMode`
- Treats a whitespace-only `PGLITE_DATA_DIR` as absent and falls through to the packaged-desktop default, proving env normalization applies to this source too.
- Does not treat a blank `ELIZA_DB_MODE` as explicit memory; resolution falls through to `PGLITE_DATA_DIR`.

`applyDatabaseResolutionToEnv`
- Leaves the child env untouched when a `pglite-memory` resolution is missing `pgliteDataDir` (the sibling `pglite-persistent` case was already covered).

## Evidence (local, at head `10b3e29b7313e67c16ab2e577d19291f8a1650b0`)

This is a fork contribution, so hosted CI does not run on this PR. Counts below are real local runs quoted verbatim:

- `bunx vitest run --config vitest.electrobun.config.ts src/database/__tests__/database-mode.test.ts` → **Test Files 1 passed (1), Tests 30 passed (30)** (25 pre-existing + 5 new), re-run green after formatting.
- `bunx biome check --write src/database/__tests__/database-mode.test.ts` → clean ("Checked 1 file", fixes applied, suite re-run green afterwards).
- `bunx tsc --noEmit` in the owning package → zero diagnostics mentioning `database-mode`.
- Diff is exactly one new-to-the-diff test file change, strictly additive: +64 insertions, 0 deletions.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:10b3e29b7313e67c16ab2e577d19291f8a1650b0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
