### PR TITLE
test(core): cover integration-runtime

### DIFF
--- a/packages/core/src/testing/integration-runtime.test.ts
+++ b/packages/core/src/testing/integration-runtime.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Exercises the integration-test runtime factory (`createIntegrationTestRuntime`,
+ * `withTestRuntime`, `DEFAULT_TEST_CHARACTER`) against a real AgentRuntime boot
+ * over the in-memory database adapter. Inference detection stays skipped so the
+ * suite is deterministic and touches no network.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import type { Plugin, UUID } from "../types";
+import {
+	createIntegrationTestRuntime,
+	DEFAULT_TEST_CHARACTER,
+	type IntegrationTestConfig,
+	withTestRuntime,
+} from "./integration-runtime";
+
+const UUID_V4_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type ConfigOverrides = Partial<
+	Omit<IntegrationTestConfig, "databaseAdapter" | "skipInferenceCheck">
+>;
+
+function baseConfig(overrides: ConfigOverrides = {}): IntegrationTestConfig {
+	return {
+		databaseAdapter: new InMemoryDatabaseAdapter(),
+		skipInferenceCheck: true,
+		...overrides,
+	};
+}
+
+const markerPlugin: Plugin = {
+	name: "integration-runtime-marker-plugin",
+	description: "Verifies that configured plugins reach initialization",
+	providers: [
+		{
+			name: "integration-runtime-marker-provider",
+			get: async () => ({ text: "marker" }),
+		},
+	],
+};
+
+function countStops(runtime: AgentRuntime): () => number {
+	let stops = 0;
+	const realStop = runtime.stop.bind(runtime);
+	runtime.stop = async () => {
+		stops += 1;
+		await realStop();
+	};
+	return () => stops;
+}
+
+describe("createIntegrationTestRuntime", () => {
+	it("rejects a config without the required database adapter and explains the fix", async () => {
+		await expect(
+			createIntegrationTestRuntime({} as IntegrationTestConfig),
+		).rejects.toThrow(/database adapter/i);
+		await expect(
+			createIntegrationTestRuntime({} as IntegrationTestConfig),
+		).rejects.toThrow("@elizaos/plugin-sql");
+		await expect(
+			createIntegrationTestRuntime({} as IntegrationTestConfig),
+		).rejects.toThrow("createDatabaseAdapter");
+	});
+
+	it("boots a fully initialized runtime over a real adapter and issues fresh v4 agent ids", async () => {
+		const first = await createIntegrationTestRuntime(baseConfig());
+		const second = await createIntegrationTestRuntime(baseConfig());
+
+		try {
+			expect(first.runtime).toBeInstanceOf(AgentRuntime);
+			expect(await first.runtime.isReady()).toBe(true);
+			expect(first.agentId).toMatch(UUID_V4_PATTERN);
+			expect(second.agentId).toMatch(UUID_V4_PATTERN);
+			expect(second.agentId).not.toBe(first.agentId);
+			expect(first.runtime.agentId).toBe(first.agentId);
+			expect(first.inferenceProvider).toBeNull();
+			expect(first.runtime.character.name).toBe(DEFAULT_TEST_CHARACTER.name);
+			expect(first.runtime.character.topics).toEqual(
+				DEFAULT_TEST_CHARACTER.topics,
+			);
+		} finally {
+			await first.cleanup();
+			await second.cleanup();
+		}
+	});
+
+	it("applies character overrides while forcing the generated agent id", async () => {
+		const callerSuppliedId = "00000000-0000-4000-8000-000000000001" as UUID;
+
+		const result = await createIntegrationTestRuntime(
+			baseConfig({
+				character: {
+					name: "CustomNamedAgent",
+					topics: ["override-topic"],
+					id: callerSuppliedId,
+				},
+			}),
+		);
+
+		try {
+			expect(result.runtime.character.name).toBe("CustomNamedAgent");
+			expect(result.runtime.character.topics).toEqual(["override-topic"]);
+			expect(result.runtime.character.system).toBe(
+				DEFAULT_TEST_CHARACTER.system,
+			);
+			expect(result.agentId).not.toBe(callerSuppliedId);
+			expect(result.runtime.character.id).toBe(result.agentId);
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("registers configured plugins during initialization", async () => {
+		const result = await createIntegrationTestRuntime(
+			baseConfig({ plugins: [markerPlugin] }),
+		);
+
+		try {
+			const providerNames = result.runtime.providers.map(
+				(provider) => provider.name,
+			);
+			expect(providerNames).toContain("integration-runtime-marker-provider");
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("cleanup stops the initialized runtime exactly once", async () => {
+		const result = await createIntegrationTestRuntime(baseConfig());
+		const stopCount = countStops(result.runtime);
+
+		await result.cleanup();
+
+		expect(stopCount()).toBe(1);
+	});
+
+	it("surfaces a stalled initialization through the configured timeout message", async () => {
+		const stalledAdapter = new InMemoryDatabaseAdapter();
+		stalledAdapter.isReady = async () => false;
+		stalledAdapter.initialize = () => new Promise<void>(() => {});
+
+		await expect(
+			createIntegrationTestRuntime({
+				databaseAdapter: stalledAdapter,
+				skipInferenceCheck: true,
+				initTimeout: 50,
+			}),
+		).rejects.toThrow("Runtime initialization timed out after 50ms");
+	});
+});
+
+describe("withTestRuntime", () => {
+	it("hands the initialized runtime and agent id to the body and cleans up on success", async () => {
+		let stopCount: () => number = () => 0;
+
+		const observed = await withTestRuntime(
+			async (runtime, agentId) => {
+				stopCount = countStops(runtime);
+				return {
+					matchingIds: runtime.agentId === agentId,
+					characterName: runtime.character.name,
+				};
+			},
+			baseConfig({ character: { name: "WithTestRuntimeAgent" } }),
+		);
+
+		expect(observed.matchingIds).toBe(true);
+		expect(observed.characterName).toBe("WithTestRuntimeAgent");
+		expect(stopCount()).toBe(1);
+	});
+
+	it("cleans up even when the test body throws, then rethrows the original failure", async () => {
+		let stopCount: () => number = () => 0;
+
+		await expect(
+			withTestRuntime(async (runtime) => {
+				stopCount = countStops(runtime);
+				throw new Error("test body exploded");
+			}, baseConfig()),
+		).rejects.toThrow("test body exploded");
+
+		expect(stopCount()).toBe(1);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/testing/integration-runtime.test.ts`, a new vitest suite (187 lines, test-only) covering `packages/core/src/testing/integration-runtime.ts`, which previously had no same-named suite anywhere in the repo. No production code is touched; the diff is a single new test file, +N/−0.

The suite drives the real module against a real `AgentRuntime` booted over `InMemoryDatabaseAdapter` — no mocks stand in for the system under test, and inference detection is skipped (`skipInferenceCheck`) so every case is deterministic and network-free:

**createIntegrationTestRuntime**
- rejects a config without the required `databaseAdapter`, and the thrown error names the actionable fix (`@elizaos/plugin-sql` / `createDatabaseAdapter`)
- boots a fully initialized runtime over a real adapter: instance check, `runtime.isReady()` true after init, fresh UUIDv4 `agentId`s that differ across calls and match `runtime.agentId`, `inferenceProvider === null` when detection is skipped, and `DEFAULT_TEST_CHARACTER` defaults applied
- applies caller character overrides (name, topics) over the defaults while forcing the generated agent id — a caller-supplied character `id` cannot override it (`runtime.character.id === result.agentId`, `result.agentId !== callerSuppliedId`)
- registers configured plugins during initialization (verified through the real provider registry)
- `cleanup()` stops the initialized runtime exactly once
- a stalled adapter initialization surfaces through the configured timeout as exactly `Runtime initialization timed out after <N>ms`

**withTestRuntime**
- hands the initialized runtime and matching agent id to the body, returns the body's value, and cleans up on success
- still cleans up when the body throws, then rethrows the original failure unchanged

## Evidence (test-only change)

- `bunx vitest run packages/core/src/testing/integration-runtime.test.ts` → **Test Files 1 passed (1), Tests 8 passed (8)** (~3.2s), re-run against current `origin/develop` (`65d589387dac89ce1d01ba5f16c8b6f68fd98445`) immediately before filing
- `bunx biome check --write packages/core/src/testing/integration-runtime.test.ts` → checked, clean
- `bunx tsc --noEmit` in `packages/core` → zero occurrences of `integration-runtime.test` in output (no new type errors introduced by this diff)
- The diff touches only `packages/core/src/testing/integration-runtime.test.ts` (new file). No `expectTypeOf`, no type-only subjects, no `vi.hoisted`.

Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are quoted from local runs of the pinned toolchain.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:32972adea9dde1ca09d7b9770689cf0971d863fb -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
