### PR TITLE
fix(ci): restore UI fixture script contract

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -84,10 +84,6 @@ jobs:
       - name: Background view e2e
         run: bun run --cwd packages/ui test:background-e2e
 
-      # Connector setup-panel config fields and screenshots.
-      - name: Connectors view e2e
-        run: bun run --cwd packages/ui test:connectors-e2e
-
       # Chat-sheet drag detents (open/peek/close pull-sheet state machine).
       - name: Chat sheet drag-gesture e2e
         run: bun run --cwd packages/ui test:chat-sheet-e2e
@@ -167,7 +163,6 @@ jobs:
             packages/ui/src/components/chat/widgets/__e2e__/output
             packages/ui/src/components/chat/widgets/__e2e__/output-ftu
             packages/ui/src/components/pages/__e2e__/output-background
-            packages/ui/src/components/pages/__e2e__/output-connectors
             packages/ui/src/components/views/__e2e__/output-view-lifecycle
             packages/ui/src/components/shell/__e2e__/output
             packages/ui/src/components/shell/__e2e__/output-chatux

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -37,6 +37,8 @@ const smokeLanesCoreBuildCondition =
   "needs.changes.outputs.cloud == 'true' || needs.changes.outputs.zero_key == 'true'";
 const liveSmokeCloudCondition =
   "inputs.suite == 'all' || inputs.suite == 'cloud'";
+const liveSmokeCoreCondition =
+  "inputs.suite == 'all' || inputs.suite == 'scenarios' || inputs.suite == 'group-chat' || inputs.suite == 'live-information' || inputs.suite == 'cloud'";
 
 function assertJobBrowserBootstrap(
   steps: WorkflowStep[],
@@ -132,7 +134,7 @@ function assertLiveSmokeCloudCoreBootstrap(source: string): void {
     );
   }
   if (
-    steps[buildIndex]?.if !== liveSmokeCloudCondition ||
+    steps[buildIndex]?.if !== liveSmokeCoreCondition ||
     steps[e2eIndex]?.if !== liveSmokeCloudCondition
   ) {
     throw new Error(
@@ -268,6 +270,27 @@ describe("GitHub action supply-chain references", () => {
     expect([...core].filter((suite) => extended.has(suite))).toEqual([]);
   });
 
+  test("runs only declared packages/ui scripts from UI fixture workflows", () => {
+    const scripts = JSON.parse(
+      readFileSync(join(repoRoot, "packages", "ui", "package.json"), "utf8"),
+    ).scripts as Record<string, string>;
+    const workflows = ["ui-e2e-gate.yml", "ui-fixture-e2e.yml"];
+    const invocations = workflows.flatMap((workflow) =>
+      [
+        ...readFileSync(
+          join(githubRoot, "workflows", workflow),
+          "utf8",
+        ).matchAll(
+          /^\s*run:\s+(?:[A-Z_][A-Z0-9_]*=\S+\s+)*bun run --cwd packages\/ui ([^\s#]+)/gmu,
+        ),
+      ].map((match) => ({ script: match[1], workflow })),
+    );
+
+    expect(invocations.filter(({ script }) => !(script in scripts))).toEqual(
+      [],
+    );
+  });
+
   test("keeps the WebKit fixture lane on a provisionable hosted runner", () => {
     const source = readFileSync(
       join(githubRoot, "workflows", "ui-fixture-e2e.yml"),
@@ -390,11 +413,11 @@ describe("GitHub action supply-chain references", () => {
       "Live Smoke must retain workspace setup, core build, and Cloud e2e steps",
     );
 
-    const buildStep = `      # Cloud API e2e loads the compiled Workerd export from
-      # @elizaos/core/edge. The lean install above skips lifecycle scripts, so
-      # this artifact must be built explicitly on a clean runner.
+    const buildStep = `      # Both the scenario graph and cloud API load the compiled
+      # @elizaos/core/edge export. The lean install above skips lifecycle
+      # scripts, so build that contract before either consumer starts.
       - name: Build core runtime contract
-        if: ${liveSmokeCloudCondition}
+        if: ${liveSmokeCoreCondition}
         run: bun run build:core
 
 `;
@@ -480,9 +503,9 @@ describe("GitHub action supply-chain references", () => {
   });
 
   test("routes homepage deploys through the consolidated Cloudflare workflow", () => {
-    // The entry workflow owns the homepage trigger paths and the unprivileged
-    // preview build; the Pages project it deploys into is bound in the reusable
-    // release workflow it calls.
+    // Develop Full calls Quality for homepage-source validation and the
+    // consolidated build. The deployment workflow consumes that same app
+    // artifact contract when the reconciler dispatches an exact SHA.
     const source = readFileSync(
       join(githubRoot, "workflows", "cloud-cf-deploy.yml"),
       "utf8",
@@ -491,7 +514,12 @@ describe("GitHub action supply-chain references", () => {
       join(githubRoot, "workflows", "cloud-cf-release.yml"),
       "utf8",
     );
-    expect(source).toContain('      - "packages/homepage/**"');
+    const qualitySource = readFileSync(
+      join(githubRoot, "workflows", "quality.yml"),
+      "utf8",
+    );
+    expect(qualitySource).toContain("packages/homepage/");
+    expect(qualitySource).toContain("Build the only deployable frontend");
     expect(source).toContain("Build consolidated frontend artifact");
     expect(releaseSource).toContain("Build consolidated frontend artifact");
     expect(releaseSource).toContain("PAGES_PROJECT: eliza-app");


### PR DESCRIPTION
Closes #27384

## What changed
- remove the retired `test:connectors-e2e` invocation and stale output path from the UI extended workflow
- guard UI fixture workflows against invoking undeclared `packages/ui` scripts
- restore current Live Smoke and reconciler-driven homepage workflow assertions after they were reverted to older contracts

## Verification
- `bun test packages/scripts/__tests__/github-action-pinning.test.ts` (16 pass)
- `bun run audit:workflow-triggers`
- `bunx @biomejs/biome check packages/scripts/__tests__/github-action-pinning.test.ts`
- `bun install`
- `bun run verify` (375/375 tasks; 11,208 test files scanned; no focused or orphaned skips)