### PR TITLE
test(ui): cover useRafCoalescer

### DIFF
--- a/packages/ui/src/gestures/useRafCoalescer.test.ts
+++ b/packages/ui/src/gestures/useRafCoalescer.test.ts
@@ -1,0 +1,218 @@
+/** Verifies useRafCoalescer through the package's configured test harness. */
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRafCoalescer } from "./useRafCoalescer";
+
+/**
+ * Manual rAF clock: schedule() captures callbacks under increasing positive
+ * handles, drainFrames() paints them in order. Mirrors the stub style of
+ * use-pull-gesture.test.ts so frame timing stays fully under test control.
+ */
+function installManualRaf() {
+  const frames = new Map<number, (t: number) => void>();
+  let nextHandle = 1;
+  const rafStub = vi.fn((cb: FrameRequestCallback) => {
+    const handle = nextHandle;
+    nextHandle += 1;
+    frames.set(handle, cb);
+    return handle;
+  });
+  const cancelStub = vi.fn((handle: number) => {
+    frames.delete(handle);
+  });
+  vi.stubGlobal("requestAnimationFrame", rafStub);
+  vi.stubGlobal("cancelAnimationFrame", cancelStub);
+  const drainFrames = () => {
+    const pending = [...frames.entries()];
+    frames.clear();
+    for (const [handle, cb] of pending) cb(handle * 16);
+  };
+  return { rafStub, cancelStub, drainFrames };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useRafCoalescer", () => {
+  it("delivers only the LATEST scheduled value, exactly once, on the next frame", () => {
+    const { drainFrames } = installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(1);
+    result.current.schedule(2);
+    result.current.schedule(3);
+
+    // Nothing may fan out before the frame paints.
+    expect(sink).not.toHaveBeenCalled();
+
+    drainFrames();
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(3);
+  });
+
+  it("coalesces a whole burst into ONE rAF, then schedules a fresh frame for the next burst", () => {
+    const { rafStub, drainFrames } = installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(10);
+    result.current.schedule(11);
+    result.current.schedule(12);
+    expect(rafStub).toHaveBeenCalledTimes(1);
+
+    drainFrames();
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenLastCalledWith(12);
+
+    // After the frame ran, the next schedule must book a NEW frame — a stale
+    // pending marker here would swallow the rest of the gesture.
+    result.current.schedule(13);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    drainFrames();
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink).toHaveBeenLastCalledWith(13);
+  });
+
+  it("flush forces the pending value out NOW, cancels the queued frame, and never double-delivers", () => {
+    const { cancelStub, drainFrames } = installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(7);
+    result.current.flush();
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(7);
+    expect(cancelStub).toHaveBeenCalled();
+
+    // Even if the already-booked frame were to fire, the value must not be
+    // delivered twice.
+    drainFrames();
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush with an empty queue is a silent no-op", () => {
+    installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    expect(() => result.current.flush()).not.toThrow();
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("cancel drops the pending value so neither the frame nor a later flush delivers it", () => {
+    const { drainFrames } = installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(9);
+    result.current.cancel();
+
+    drainFrames();
+    result.current.flush();
+
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("cancel/flush with nothing pending never touches cancelAnimationFrame", () => {
+    const { cancelStub } = installManualRaf();
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.flush();
+    result.current.cancel();
+
+    expect(cancelStub).not.toHaveBeenCalled();
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("delivers synchronously when requestAnimationFrame is unavailable so the final value is never lost", () => {
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(5);
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(5);
+  });
+
+  it("survives a synchronous rAF (inline callback): every schedule keeps delivering", () => {
+    // Some test environments run the rAF callback INLINE during schedule().
+    // The coalescer must mark the frame pending BEFORE booking, or the handle
+    // assigned afterwards would re-mark a dead frame as pending forever and
+    // swallow every later value.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(1);
+    result.current.schedule(2);
+    result.current.schedule(3);
+
+    expect(sink).toHaveBeenCalledTimes(3);
+    expect(sink).toHaveBeenNthCalledWith(1, 1);
+    expect(sink).toHaveBeenNthCalledWith(2, 2);
+    expect(sink).toHaveBeenNthCalledWith(3, 3);
+  });
+
+  it("keeps a stable identity across renders and always calls the LATEST sink", () => {
+    const { drainFrames } = installManualRaf();
+    const firstSink = vi.fn();
+    const latestSink = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onValue }: { onValue: (v: string) => void }) =>
+        useRafCoalescer<string>(onValue),
+      { initialProps: { onValue: firstSink } },
+    );
+    const stableSchedule = result.current.schedule;
+    const stableFlush = result.current.flush;
+    const stableCancel = result.current.cancel;
+
+    rerender({ onValue: latestSink });
+
+    // The three callbacks are useCallback-stable across renders (safe as
+    // effect deps); the wrapper object itself is rebuilt per render.
+    expect(result.current.schedule).toBe(stableSchedule);
+    expect(result.current.flush).toBe(stableFlush);
+    expect(result.current.cancel).toBe(stableCancel);
+
+    result.current.schedule("drag-end");
+    drainFrames();
+
+    expect(latestSink).toHaveBeenCalledTimes(1);
+    expect(latestSink).toHaveBeenCalledWith("drag-end");
+    expect(firstSink).not.toHaveBeenCalled();
+  });
+
+  it("drops an in-flight frame when the consumer unmounts mid-gesture", () => {
+    const { cancelStub, drainFrames } = installManualRaf();
+    const sink = vi.fn();
+    const { result, unmount } = renderHook(() => useRafCoalescer<number>(sink));
+
+    result.current.schedule(21);
+    unmount();
+
+    expect(cancelStub).toHaveBeenCalled();
+
+    drainFrames();
+    result.current.flush();
+
+    expect(sink).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located vitest unit suite for `packages/ui/src/gestures/useRafCoalescer.ts`, which had no same-named test file anywhere in the repo. Test-only change: one new file, +218/-0, no production code touched.

## Coverage (all assertions drive the real hook via `renderHook`; no mock-theater)

- Coalescing contract: a burst of `schedule` calls fans out to exactly ONE sink call per frame carrying the LATEST value; nothing delivers before the frame paints.
- Frame bookkeeping: one rAF per burst, a fresh frame booked for the next burst (no stale-pending marker swallowing the rest of a gesture).
- `flush`: forces the pending value out now, cancels the queued frame (`cancelAnimationFrame` asserted), and never double-delivers if the frame still fires.
- `cancel`: drops the pending value so neither the frame nor a later `flush` delivers it.
- Empty-queue no-ops: `flush`/`cancel` with nothing pending neither throws nor touches `cancelAnimationFrame`.
- No-rAF environments (SSR / jsdom without a stub): delivery happens synchronously so the final value is never lost.
- Synchronous-rAF test environments (callback runs inline during `schedule`): every schedule keeps delivering — regression guard for the mark-pending-before-booking invariant documented in the source.
- Sink identity across rerenders: the three returned callbacks are stable (`useCallback`) and safe as effect deps; the wrapper object itself is rebuilt per render. The suite asserts this OBSERVED behavior rather than the doc comment's stronger "stable object" claim — the doc overstates it; behavior is what reviewers can rely on.
- Latest-sink wins: after a rerender swaps sinks, only the newest sink receives values.
- Unmount mid-gesture: teardown cancels the in-flight frame; no delivery after unmount.

Harness matches the package's established pattern (`use-pull-gesture.test.ts`): jsdom environment docblock, manual rAF stub via `vi.stubGlobal`, RTL `renderHook`.

## Evidence

- `bunx vitest run src/gestures/useRafCoalescer.test.ts` (packages/ui, vitest 4.1.10) on current `origin/develop` base immediately before filing: **Test Files 1 passed (1); Tests 10 passed (10)**.
- `bunx biome check --write packages/ui/src/gestures/useRafCoalescer.test.ts`: clean ("Checked 1 file... No fixes applied"); root `biome.json` present, worktree not sparse-checked-out.
- `tsc --noEmit` in `packages/ui`: the new file appears NOWHERE in output. The 9 reported errors are pre-existing, all in files this diff does not touch.
- Diff scope: exactly one NEW test file (`git diff --stat origin/develop...head`: 1 file changed, 218 insertions, 0 deletions).

## Notes for reviewers

- Fork contribution: hosted CI does not run on this PR; the counts above are from local runs against the exact head commit.
- No production behavior changed, so no behavioral-fix evidence (origin repro / revert corpus) applies.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0a49bf219475434c8e836d2f57a3266e3751c40f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
