### PR TITLE
test(core): cover model-provider-runtime

### DIFF
--- a/packages/core/src/testing/model-provider-runtime.test.ts
+++ b/packages/core/src/testing/model-provider-runtime.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Exercises `createTestRuntimeWithModelProvider` against fully booted PGLite
+ * runtimes: fixture consumption is proven through real `useModel` dispatch,
+ * and every option forward (character, embeddings, priority, extra plugins,
+ * explicit resolver, streaming) is observed on the resulting runtime.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ModelType } from "../types/model";
+import type { Plugin } from "../types/plugin";
+import { createTestRuntimeWithModelProvider } from "./model-provider-runtime";
+
+const markerPlugin: Plugin = {
+	name: "model-provider-runtime-marker-plugin",
+	description: "Verifies that caller plugins reach registration",
+	providers: [
+		{
+			name: "model-provider-runtime-marker-provider",
+			get: async () => ({ text: "marker" }),
+		},
+	],
+};
+
+describe("createTestRuntimeWithModelProvider", () => {
+	it("serves a matched fixture through a real useModel call and records its consumption", async () => {
+		const result = await createTestRuntimeWithModelProvider({
+			fixtures: [
+				{
+					name: "greeting",
+					match: { modelType: ModelType.TEXT_SMALL, prompt: "say hi" },
+					response: "fixture-hi",
+				},
+			],
+		});
+
+		try {
+			const observed = await result.runtime.useModel(ModelType.TEXT_SMALL, {
+				prompt: "say hi",
+			});
+
+			expect(observed).toBe("fixture-hi");
+
+			const diagnostics = result.getFixtureDiagnostics();
+			expect(diagnostics.calls).toHaveLength(1);
+			expect(diagnostics.calls[0]?.matchedFixtureName).toBe("greeting");
+			expect(diagnostics.calls[0]?.modelType).toBe(ModelType.TEXT_SMALL);
+			expect(diagnostics.fixtures[0]).toMatchObject({
+				name: "greeting",
+				consumed: 1,
+			});
+			expect(() => result.assertFixturesConsumed()).not.toThrow();
+
+			expect(result.fixtures).toBe(result.modelProvider.fixtures);
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("flags an unconsumed required fixture through assertFixturesConsumed", async () => {
+		const result = await createTestRuntimeWithModelProvider({
+			fixtures: [
+				{
+					name: "never-called",
+					match: { modelType: ModelType.TEXT_SMALL },
+					response: "unused",
+				},
+			],
+		});
+
+		try {
+			expect(() => result.assertFixturesConsumed()).toThrow(
+				/deterministic model fixtures were not consumed/,
+			);
+			expect(() => result.assertFixturesConsumed()).toThrow(/never-called/);
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("defaults to the model-provider test agent character, an in-memory database, and 384-dimension embeddings", async () => {
+		const result = await createTestRuntimeWithModelProvider();
+
+		try {
+			expect(result.runtime.character.name).toBe("ModelProviderTestAgent");
+			expect(result.pgliteDir.startsWith("memory://")).toBe(true);
+			expect(process.env.EMBEDDING_DIMENSION).toBe("384");
+			expect(process.env.LOCAL_EMBEDDING_DIMENSIONS).toBe("384");
+			expect(typeof result.runtime.agentId).toBe("string");
+			expect(result.runtime.agentId.length > 0).toBe(true);
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("honors caller overrides for character name, embedding width, provider priority, and extra plugins", async () => {
+		const result = await createTestRuntimeWithModelProvider({
+			characterName: "CustomNamedAgent",
+			embeddingDimensions: 512,
+			priority: 77,
+			plugins: [markerPlugin],
+		});
+
+		try {
+			expect(result.runtime.character.name).toBe("CustomNamedAgent");
+			expect(process.env.EMBEDDING_DIMENSION).toBe("512");
+			expect(process.env.LOCAL_EMBEDDING_DIMENSIONS).toBe("512");
+			expect(result.modelProvider.priority).toBe(77);
+			expect(
+				result.runtime.providers.map((provider) => provider.name),
+			).toContain("model-provider-runtime-marker-provider");
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("falls back to the forwarded resolver only for calls no fixture matches", async () => {
+		const result = await createTestRuntimeWithModelProvider({
+			resolve: (call) =>
+				call.modelType === ModelType.TEXT_COMPLETION
+					? "resolver-fallback"
+					: undefined,
+		});
+
+		try {
+			const observed = await result.runtime.useModel(
+				ModelType.TEXT_COMPLETION,
+				{ prompt: "unmatched completion" },
+			);
+			expect(observed).toBe("resolver-fallback");
+			expect(() => result.assertFixturesConsumed()).not.toThrow();
+
+			await expect(
+				result.runtime.useModel(ModelType.TEXT_MEDIUM, {
+					prompt: "nothing can serve this",
+				}),
+			).rejects.toThrow(/no fixture matched/);
+		} finally {
+			await result.cleanup();
+		}
+	});
+
+	it("streams fixture responses chunk by chunk through the forwarded stream configuration", async () => {
+		const result = await createTestRuntimeWithModelProvider({
+			stream: { chunkSize: 5, intervalMs: 0 },
+			fixtures: [
+				{
+					name: "streamed-greeting",
+					match: { modelType: ModelType.TEXT_SMALL },
+					response: "0123456789ABCDEFGHIJK",
+				},
+			],
+		});
+
+		try {
+			const chunks: string[] = [];
+			const observed = await result.runtime.useModel(ModelType.TEXT_SMALL, {
+				prompt: "stream please",
+				onStreamChunk: (chunk: string) => {
+					chunks.push(chunk);
+				},
+			});
+
+			expect(observed).toBe("0123456789ABCDEFGHIJK");
+			expect(chunks.join("")).toBe("0123456789ABCDEFGHIJK");
+			expect(chunks.every((chunk) => chunk.length <= 5)).toBe(true);
+			expect(chunks.length).toBe(Math.ceil(21 / 5));
+			expect(() => result.assertFixturesConsumed()).not.toThrow();
+		} finally {
+			await result.cleanup();
+		}
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/testing/model-provider-runtime.test.ts`, a new vitest suite covering `packages/core/src/testing/model-provider-runtime.ts` (`createTestRuntimeWithModelProvider`), which previously had no same-named test file anywhere in the repository.

Test-only change: no production source is modified. The diff is one new file, +N/-0.

## How it is tested

Every case boots a real PGLite-backed `AgentRuntime` through the factory and drives real `useModel` dispatch — no mocks stand in for the module under test:

- A matched fixture is served end-to-end through `runtime.useModel(ModelType.TEXT_SMALL)`, and consumption is observed via `getFixtureDiagnostics()` and `assertFixturesConsumed()`; the returned `fixtures` registry is identity-verified against `modelProvider.fixtures`.
- An unconsumed required fixture makes `assertFixturesConsumed()` throw naming the fixture.
- Defaults are observed on the booted runtime: character name `ModelProviderTestAgent`, an in-memory `memory://` data directory, and 384-dimension embeddings applied to `EMBEDDING_DIMENSION` / `LOCAL_EMBEDDING_DIMENSIONS`.
- Caller overrides reach their collaborators: custom character name, embedding width 512, provider priority 77, and extra plugins registered alongside the injected model provider.
- The forwarded explicit resolver serves an unmatched `TEXT_COMPLETION` call, returns undefined for another unmatched type, and that second call rejects with "no fixture matched".
- Streamed fixture responses arrive chunk-by-chunk through `onStreamChunk` under the forwarded stream configuration (chunk size honored, concatenation exact).

## Verification (quoted from this branch's head)

- `bunx vitest run src/testing/model-provider-runtime.test.ts` (packages/core): **1 file passed, 6 tests passed / 0 failed**, re-run immediately before filing against current `origin/develop`.
- `bunx biome check src/testing/model-provider-runtime.test.ts`: clean ("Checked 1 file... No fixes applied" after `--write`).
- `bunx tsc --noEmit` in `packages/core`: zero output; the new file appears nowhere.
- Diff touches only `packages/core/src/testing/model-provider-runtime.test.ts`.

Note: this pull request comes from a fork, so hosted CI does not run on it; the counts above were executed locally against this exact head.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:24f79d5a66d2518d38922c4d4b3a1571622a623a -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
