### PR TITLE
test(ui): cover native-bridge

### DIFF
--- a/packages/ui/src/glass/native-bridge.test.ts
+++ b/packages/ui/src/glass/native-bridge.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Unit coverage for the GlassBridge native side of the glass tier — the TS
+ * half of the Capacitor plugin contract in native-bridge.ts. Drives the REAL
+ * module against a bridge-injected `globalThis.Capacitor`: platform gating,
+ * lazy double memoization (plugin proxy + availability promise), the legacy
+ * `Plugins` fallback, the J4 capability-probe error policy, and the explicit
+ * `false`/no-op fallback signals callers rely on. Fakes exist only at the
+ * `globalThis.Capacitor` seam the module itself defines; no vi.mock.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearNativeBackdrop,
+  glassBridge,
+  isNativeGlassAvailable,
+  type NativeBackdropOptions,
+  nativeGlassPlatform,
+  resetGlassBridgeForTests,
+  resetNativeGlassHost,
+  setNativeBackdrop,
+} from "./native-bridge";
+
+type GlassBridgePlugin = NonNullable<ReturnType<typeof glassBridge>>;
+
+const capacitorSlot = globalThis as { Capacitor?: unknown };
+
+/** A complete plugin double; patch individual members per case. */
+function pluginWith(
+  patch: Partial<Record<keyof GlassBridgePlugin, unknown>> = {},
+): GlassBridgePlugin {
+  const base: GlassBridgePlugin = {
+    attachGlass: () => Promise.resolve({ attached: true }),
+    updateRect: () => Promise.resolve(),
+    detachGlass: () => Promise.resolve(),
+    setGrouping: () => Promise.resolve(),
+    setBackdrop: () => Promise.resolve({ applied: true }),
+    clearBackdrop: () => Promise.resolve(),
+    reset: () => Promise.resolve(),
+    isAvailable: () => Promise.resolve({ available: true }),
+    getRegionState: () => Promise.resolve({ exists: false, regionCount: 0 }),
+  };
+  for (const [key, value] of Object.entries(patch)) {
+    (base as unknown as Record<string, unknown>)[key] = value;
+  }
+  return base;
+}
+
+interface NativeCapacitor {
+  isNativePlatform: () => boolean;
+  getPlatform?: () => string;
+  registerPlugin?: <T>(name: string) => T;
+  Plugins?: Record<string, unknown>;
+}
+
+function installCapacitor(cap: NativeCapacitor): void {
+  capacitorSlot.Capacitor = cap;
+}
+
+function nativeCap(overrides: Partial<NativeCapacitor> = {}): NativeCapacitor {
+  return {
+    isNativePlatform: () => true,
+    getPlatform: () => "ios",
+    ...overrides,
+  };
+}
+
+describe("glassBridge resolution", () => {
+  let registerCalls: string[];
+
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+    registerCalls = [];
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("resolves null with no Capacitor global at all", () => {
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("caches the negative answer even once a Capacitor global appears later", () => {
+    expect(glassBridge()).toBeNull();
+    installCapacitor(nativeCap());
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("resolves null on a web (non-native) runtime even when the registry exists", () => {
+    installCapacitor({
+      isNativePlatform: () => false,
+      getPlatform: () => "web",
+      registerPlugin: <T>(name: string) => {
+        registerCalls.push(name);
+        return pluginWith() as T;
+      },
+    });
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("resolves null when native but the platform is neither ios nor android", () => {
+    installCapacitor(nativeCap({ getPlatform: () => "electron" }));
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("resolves null when native and getPlatform is not implemented", () => {
+    installCapacitor(nativeCap({ getPlatform: undefined }));
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("registers GlassBridge by name and memoizes the same proxy instance", () => {
+    const plugin = pluginWith();
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>(name: string) => {
+          registerCalls.push(name);
+          return plugin as T;
+        },
+      }),
+    );
+    const first = glassBridge();
+    const second = glassBridge();
+    expect(registerCalls).toEqual(["GlassBridge"]);
+    expect(first).toBe(plugin);
+    expect(second).toBe(plugin);
+  });
+
+  it("falls back to the legacy Plugins map when registerPlugin is absent", () => {
+    const plugin = pluginWith();
+    installCapacitor(nativeCap({ Plugins: { GlassBridge: plugin } }));
+    expect(glassBridge()).toBe(plugin);
+  });
+
+  it("resolves null when native with neither registerPlugin nor a Plugins entry", () => {
+    installCapacitor(nativeCap({}));
+    expect(glassBridge()).toBeNull();
+  });
+
+  it("resolves null when registration throws instead of crashing the caller", () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <_T>() => {
+          throw new Error("plugin not registered");
+        },
+      }),
+    );
+    expect(glassBridge()).toBeNull();
+  });
+});
+
+describe("nativeGlassPlatform", () => {
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("reports null with no Capacitor global", () => {
+    expect(nativeGlassPlatform()).toBeNull();
+  });
+
+  it("reports null on a web runtime", () => {
+    installCapacitor({
+      isNativePlatform: () => false,
+      getPlatform: () => "web",
+    });
+    expect(nativeGlassPlatform()).toBeNull();
+  });
+
+  it("reports ios and android natively, independent of any plugin registration", () => {
+    installCapacitor(nativeCap({ getPlatform: () => "ios" }));
+    expect(nativeGlassPlatform()).toBe("ios");
+    installCapacitor(nativeCap({ getPlatform: () => "android" }));
+    expect(nativeGlassPlatform()).toBe("android");
+  });
+
+  it("reports null for an unrecognized native platform string", () => {
+    installCapacitor(nativeCap({ getPlatform: () => "windows" }));
+    expect(nativeGlassPlatform()).toBeNull();
+  });
+
+  it("re-reads the live global instead of caching a platform verdict", () => {
+    installCapacitor(nativeCap({ getPlatform: () => "ios" }));
+    expect(nativeGlassPlatform()).toBe("ios");
+    installCapacitor(nativeCap({ getPlatform: () => "android" }));
+    expect(nativeGlassPlatform()).toBe("android");
+  });
+});
+
+describe("isNativeGlassAvailable", () => {
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("resolves false off-native and keeps the memoized verdict even once a capable shell appears", async () => {
+    const first = isNativeGlassAvailable();
+    const second = isNativeGlassAvailable();
+    expect(second).toBe(first);
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toBe(false);
+    // The probe ran before any plugin existed; the memo must not re-probe.
+    installCapacitor(nativeCap());
+    await expect(isNativeGlassAvailable()).resolves.toBe(false);
+  });
+
+  it("resolves true on a registered plugin that reports itself available", async () => {
+    installCapacitor(nativeCap({ registerPlugin: <T>() => pluginWith() as T }));
+    await expect(isNativeGlassAvailable()).resolves.toBe(true);
+  });
+
+  it("resolves false when the bridge answers unavailable (pre-iOS 26 shell)", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            isAvailable: () => Promise.resolve({ available: false }),
+          }) as T,
+      }),
+    );
+    await expect(isNativeGlassAvailable()).resolves.toBe(false);
+  });
+
+  it("resolves false when the availability probe rejects", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            isAvailable: () => Promise.reject(new Error("old shell")),
+          }) as T,
+      }),
+    );
+    await expect(isNativeGlassAvailable()).resolves.toBe(false);
+  });
+
+  it("runs a fresh probe after resetGlassBridgeForTests clears the memo", async () => {
+    installCapacitor(nativeCap({ registerPlugin: <T>() => pluginWith() as T }));
+    const first = isNativeGlassAvailable();
+    await first;
+    resetGlassBridgeForTests();
+    const second = isNativeGlassAvailable();
+    expect(second).not.toBe(first);
+    await expect(second).resolves.toBe(true);
+  });
+});
+
+describe("setNativeBackdrop", () => {
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("answers false off-native without ever reaching the native side", async () => {
+    let reachedNative = false;
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            isAvailable: () => Promise.resolve({ available: false }),
+            setBackdrop: () => {
+              reachedNative = true;
+              return Promise.resolve({ applied: true });
+            },
+          }) as T,
+      }),
+    );
+    await expect(setNativeBackdrop({ color: "#000000" })).resolves.toBe(false);
+    expect(reachedNative).toBe(false);
+  });
+
+  it("forwards the byte payload verbatim and returns the applied verdict", async () => {
+    installCapacitor(nativeCap());
+    const sent: NativeBackdropOptions[] = [];
+    // Reach the resolved proxy and instrument setBackdrop through the same
+    // plugin instance the module registered.
+    const plugin = pluginWith({
+      setBackdrop: (options: NativeBackdropOptions) => {
+        sent.push(options);
+        return Promise.resolve({ applied: true });
+      },
+    });
+    installCapacitor(nativeCap({ registerPlugin: <T>() => plugin as T }));
+    const payload: NativeBackdropOptions = {
+      imageBase64: "aGVsbG8=",
+      color: "#101010",
+    };
+    await expect(setNativeBackdrop(payload)).resolves.toBe(true);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ imageBase64: "aGVsbG8=", color: "#101010" });
+  });
+
+  it("returns false as the explicit fallback signal when applied is false", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            setBackdrop: () => Promise.resolve({ applied: false }),
+          }) as T,
+      }),
+    );
+    await expect(setNativeBackdrop({ color: "#111111" })).resolves.toBe(false);
+  });
+
+  it("returns false when the native shell predates setBackdrop and throws", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            setBackdrop: () => Promise.reject(new Error("no setBackdrop")),
+          }) as T,
+      }),
+    );
+    await expect(setNativeBackdrop({ color: "#222222" })).resolves.toBe(false);
+  });
+});
+
+describe("clearNativeBackdrop", () => {
+  let clearCalls: number;
+
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+    clearCalls = 0;
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("resolves as a no-op when no bridge can be resolved", async () => {
+    await expect(clearNativeBackdrop()).resolves.toBeUndefined();
+  });
+
+  it("clears through the bridge on a native runtime", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            clearBackdrop: () => {
+              clearCalls += 1;
+              return Promise.resolve();
+            },
+          }) as T,
+      }),
+    );
+    await expect(clearNativeBackdrop()).resolves.toBeUndefined();
+    expect(clearCalls).toBe(1);
+  });
+
+  it("still resolves when the old shell has no clearBackdrop and throws", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            clearBackdrop: () => Promise.reject(new Error("missing")),
+          }) as T,
+      }),
+    );
+    await expect(clearNativeBackdrop()).resolves.toBeUndefined();
+  });
+});
+
+describe("resetNativeGlassHost", () => {
+  let resetCalls: number;
+
+  beforeEach(() => {
+    resetGlassBridgeForTests();
+    delete capacitorSlot.Capacitor;
+    resetCalls = 0;
+  });
+
+  afterEach(() => {
+    delete capacitorSlot.Capacitor;
+    resetGlassBridgeForTests();
+  });
+
+  it("resolves as a no-op off-native", async () => {
+    await expect(resetNativeGlassHost()).resolves.toBeUndefined();
+    expect(resetCalls).toBe(0);
+  });
+
+  it("resets the native host so no previous document's regions survive", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            reset: () => {
+              resetCalls += 1;
+              return Promise.resolve();
+            },
+          }) as T,
+      }),
+    );
+    await expect(resetNativeGlassHost()).resolves.toBeUndefined();
+    expect(resetCalls).toBe(1);
+  });
+
+  it("still resolves when the shell predates reset() and throws", async () => {
+    installCapacitor(
+      nativeCap({
+        registerPlugin: <T>() =>
+          pluginWith({
+            reset: () => Promise.reject(new Error("missing")),
+          }) as T,
+      }),
+    );
+    await expect(resetNativeGlassHost()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for `packages/ui/src/glass/native-bridge.ts`, which had no same-named test file anywhere on `develop` at filing time. The diff is one new test file, **+425 / −0** — no production code, config, or docs are touched.

The suite drives the real module (no `vi.mock`, no module interception) through the seam the module itself defines — the bridge-injected `globalThis.Capacitor` — and pins the behavior callers depend on:

- **`glassBridge()` resolution and lazy caching:** null with no Capacitor global; null stays cached even once a global appears later; null on web/non-native runtimes; null when native but platform is neither `ios` nor `android` or `getPlatform` is unimplemented; registration by the `"GlassBridge"` name with memoized proxy identity (second call returns the same instance without re-registering); legacy `Plugins.GlassBridge` fallback when `registerPlugin` is absent; null when neither path exists; null (not a crash) when registration throws.
- **`nativeGlassPlatform()`:** reports `ios`/`android` only natively and independent of plugin registration; null for unrecognized platforms and non-native runtimes; deliberately NOT memoized — re-reads the live global.
- **`isNativeGlassAvailable()` memoized probe:** false off-native with the verdict memoized across repeated/concurrent calls (same promise identity) and kept even after a capable shell appears; true on an available plugin; false when an older shell answers `{ available: false }`; false when the probe rejects; `resetGlassBridgeForTests()` provably forces a fresh probe.
- **Backdrop lifecycle fallback policy:** `setNativeBackdrop` returns `false` off-native without ever reaching the native side, forwards the byte payload (`imageBase64`/`color`) verbatim to `setBackdrop` and returns its `applied` verdict, returns `false` on both an explicit `applied: false` and a throwing pre-`setBackdrop` shell; `clearNativeBackdrop`/`resetNativeGlassHost` resolve as documented no-ops off-native, act once on-native, and swallow rejections from shells predating those methods.

## Evidence (test-only PR)

Fork contributor: hosted CI does not run on this PR.

1. `bunx vitest run src/glass/native-bridge.test.ts` (in `packages/ui`) → **Test Files 1 passed (1), Tests 29 passed (29)**.
2. `bunx biome check --write src/glass/native-bridge.test.ts` → clean ("Checked 1 file ... No fixes applied" on re-check).
3. `bunx tsc --noEmit` in `packages/ui`, grepped for `native-bridge.test` → zero mentions of the new file. (Vitest does not typecheck; two type errors found in the first draft were fixed before filing.)
4. Diff touches only `packages/ui/src/glass/native-bridge.test.ts`.

No production behavior changes; per the evidence-scope rule for test-only diffs, no behavioral-fix proof package is attached.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:44735465d4f7d3adc7ba0a34f59b70503b26287f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
