### PR TITLE
test(app-core): cover errors

### DIFF
--- a/packages/app-core/platforms/electrobun/src/dynamic-views/errors.test.ts
+++ b/packages/app-core/platforms/electrobun/src/dynamic-views/errors.test.ts
@@ -1,0 +1,119 @@
+/** Exercises dynamic view error construction and throw-boundary behavior. */
+import type { JsonValue } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { DynamicViewError } from "./errors";
+
+const ALL_CODES = [
+  "DYNAMIC_VIEW_DUPLICATE",
+  "DYNAMIC_VIEW_INVALID_MANIFEST",
+  "DYNAMIC_VIEW_NOT_FOUND",
+  "DYNAMIC_VIEW_SESSION_NOT_FOUND",
+  "DYNAMIC_VIEW_ENTRYPOINT_UNAVAILABLE",
+  "DYNAMIC_VIEW_UNSUPPORTED_ENTRYPOINT",
+  "DYNAMIC_VIEW_UNSUPPORTED_PLACEMENT",
+  "DYNAMIC_VIEW_OPEN_FAILED",
+  "DYNAMIC_VIEW_PUSH_FAILED",
+] as const;
+
+describe("DynamicViewError", () => {
+  it("constructs with name, message, code, and details preserved", () => {
+    const details: JsonValue = { viewId: "agent.run.trace", attempt: 2 };
+    const error = new DynamicViewError(
+      "DYNAMIC_VIEW_DUPLICATE",
+      "view already registered",
+      details,
+    );
+
+    expect(error).toBeInstanceOf(DynamicViewError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("DynamicViewError");
+    expect(error.message).toBe("view already registered");
+    expect(error.code).toBe("DYNAMIC_VIEW_DUPLICATE");
+    expect(error.details).toBe(details);
+  });
+
+  it("round-trips every declared error code", () => {
+    for (const code of ALL_CODES) {
+      const error = new DynamicViewError(code, `failure: ${code}`);
+      expect(error.code).toBe(code);
+    }
+  });
+
+  it("leaves details undefined when omitted", () => {
+    const error = new DynamicViewError(
+      "DYNAMIC_VIEW_NOT_FOUND",
+      "no such dynamic view",
+    );
+
+    expect(error.details).toBeUndefined();
+  });
+
+  it("preserves explicit null details instead of defaulting them away", () => {
+    const error = new DynamicViewError(
+      "DYNAMIC_VIEW_OPEN_FAILED",
+      "window open failed",
+      null,
+    );
+
+    expect(error.details).toBeNull();
+  });
+
+  it.each([false, 0, ""])(
+    "preserves falsy JSON detail %s without truthiness defaulting",
+    (value) => {
+      const error = new DynamicViewError(
+        "DYNAMIC_VIEW_PUSH_FAILED",
+        "push failed",
+        value,
+      );
+
+      expect(error.details).toBe(value);
+    },
+  );
+
+  it("preserves structured JSON details by reference without transformation", () => {
+    const details: JsonValue = {
+      manifest: {
+        id: "agent.run.trace",
+        entrypoints: ["trace.html", null],
+        retry: false,
+      },
+      history: [1, -0.5, "", null, { ok: true }],
+    };
+    const error = new DynamicViewError(
+      "DYNAMIC_VIEW_INVALID_MANIFEST",
+      "manifest rejected",
+      details,
+    );
+
+    expect(error.details).toBe(details);
+  });
+
+  it("allows an empty message", () => {
+    const error = new DynamicViewError("DYNAMIC_VIEW_SESSION_NOT_FOUND", "");
+
+    expect(error.message).toBe("");
+    expect(error.code).toBe("DYNAMIC_VIEW_SESSION_NOT_FOUND");
+  });
+
+  it("survives a throw/catch boundary with every field intact", () => {
+    const details: JsonValue = ["trace.html", 2, true];
+    let caught: unknown;
+    try {
+      throw new DynamicViewError(
+        "DYNAMIC_VIEW_ENTRYPOINT_UNAVAILABLE",
+        "entrypoint missing on disk",
+        details,
+      );
+    } catch (thrown) {
+      caught = thrown;
+    }
+
+    expect(caught).toBeInstanceOf(DynamicViewError);
+    const error = caught as DynamicViewError;
+    expect(error.name).toBe("DynamicViewError");
+    expect(error.message).toBe("entrypoint missing on disk");
+    expect(error.code).toBe("DYNAMIC_VIEW_ENTRYPOINT_UNAVAILABLE");
+    expect(error.details).toBe(details);
+  });
+});


### PR DESCRIPTION

# test(app-core): cover electrobun dynamic view errors

## What does this PR do?

Adds a new unit test suite for `packages/app-core/platforms/electrobun/src/dynamic-views/errors.ts`, which previously had no same-named test anywhere in the repository. The diff is one new file, +119/-0. No production code is changed.

The suite drives the real `DynamicViewError` class (no mocks) and covers:

- construction preserving `name` (`"DynamicViewError"`), `message`, `code`, and `details`;
- round-trip of every declared `DynamicViewErrorCode` literal;
- omitted `details` staying `undefined`;
- explicit `null` details preserved as `null` (no defaulting away);
- falsy JSON details (`false`, `0`, `""`) preserved exactly, no truthiness defaulting;
- structured nested JSON details stored by reference without transformation;
- empty-string message allowed;
- throw/catch boundary: instance caught as `DynamicViewError` with every field intact.

Per module contract, the type-only export `DynamicViewErrorCode` is exercised through real runtime construction only (it has no runtime surface), invalid codes are intentionally NOT asserted to be rejected (the constructor performs no validation), and stack formatting is not asserted.

## What kind of change is this?

Improvements — test coverage only. Behavior-preserving; no runtime source touched.

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/dynamic-views/errors.test.ts` against `errors.ts` beside it.

## Testing

Ran with the owning package runner (`packages/app-core/platforms/electrobun`, config `vitest.electrobun.config.ts`):

```
bunx vitest run --config vitest.electrobun.config.ts src/dynamic-views/errors.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Re-fetched origin/develop immediately before filing: develop was still at `65d589387dac` (this branch's base), no competing `errors.test.*` existed on current develop, and the suite re-run reproduced **1 file passed / 10 tests passed**.

Formatting/lint on the touched file:

```
bunx biome check --write packages/app-core/platforms/electrobun/src/dynamic-views/errors.test.ts
Checked 1 file in 114ms. No fixes applied.
```

Typecheck of the owning package (`bunx tsc --noEmit -p tsconfig.json` in `packages/app-core/platforms/electrobun`): the output contains **zero** mentions of `errors.test.ts`. The package has pre-existing unrelated TS errors elsewhere; none reference any test file. Inclusion of the new file in the project graph was verified via `tsc --listFilesOnly` (the tsconfig includes `src/**/*.ts` with no test exclusion), so this is a real clean result, not a skipped file.

## Risks

Low. Test-only addition; nothing imports the new file except vitest. No exports, routes, schemas, or runtime behavior change.

## Notes for review

- This is a fork contribution: hosted CI does not run on this PR. The checks quoted above were run locally at head `1bd4f5f4c6747b2536826cb1d112f93d0ffdc983` and are reproducible with the commands shown.
- No `vi.hoisted`, no `expectTypeOf`, no mocks: assertions record observed behavior of the real module.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1bd4f5f4c6747b2536826cb1d112f93d0ffdc983 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
