### PR TITLE
test(ui): cover useViewEvent

### DIFF
--- a/packages/ui/src/hooks/useViewEvent.test.ts
+++ b/packages/ui/src/hooks/useViewEvent.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Verifies useViewEvent / useEmitViewEvent — subscription lifecycle over the
+ * real window-CustomEvent view-event bus (jsdom, synchronous delivery).
+ * Covers the contracts mounted views depend on: teardown on unmount,
+ * re-subscription on type/deps change without stale-handler leakage,
+ * latest-inline-handler swap with single delivery, and the stable emit
+ * reference shared across renders.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ViewEvent } from "../views/view-event-bus";
+import * as viewEventBus from "../views/view-event-bus";
+import { useEmitViewEvent, useViewEvent } from "./useViewEvent";
+
+const { emitViewEvent } = viewEventBus;
+
+let typeSeq = 0;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useViewEvent", () => {
+  it("delivers an emitted event with payload, source, and timestamp to the live subscriber", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const received: ViewEvent[] = [];
+    renderHook(() => useViewEvent(type, (event) => received.push(event)));
+
+    emitViewEvent(type, { count: 3 }, "view-a");
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe(type);
+    expect(received[0].payload).toEqual({ count: 3 });
+    expect(received[0].sourceViewId).toBe("view-a");
+    expect(typeof received[0].timestamp).toBe("number");
+  });
+
+  it("ignores events emitted under other types", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const other = `${type}:other`;
+    const received: ViewEvent[] = [];
+    renderHook(() => useViewEvent(type, (event) => received.push(event)));
+
+    emitViewEvent(other, { step: 1 });
+    emitViewEvent(type, { step: 2 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({ step: 2 });
+  });
+
+  it("stops delivering after unmount", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const received: ViewEvent[] = [];
+    const { unmount } = renderHook(() =>
+      useViewEvent(type, (event) => received.push(event)),
+    );
+
+    emitViewEvent(type, { phase: "mounted" });
+    expect(received).toHaveLength(1);
+
+    unmount();
+    emitViewEvent(type, { phase: "unmounted" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({ phase: "mounted" });
+  });
+
+  it("re-subscribes when the type changes and no longer receives the previous type", () => {
+    const firstType = `test:view-event:${++typeSeq}`;
+    const secondType = `test:view-event:${++typeSeq}`;
+    const received: ViewEvent[] = [];
+    const { rerender } = renderHook(
+      ({ type }: { type: string }) =>
+        useViewEvent(type, (event) => received.push(event)),
+      { initialProps: { type: firstType } },
+    );
+
+    rerender({ type: secondType });
+
+    emitViewEvent(firstType, { generation: 1 });
+    emitViewEvent(secondType, { generation: 2 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe(secondType);
+    expect(received[0].payload).toEqual({ generation: 2 });
+  });
+
+  it("routes deliveries to the latest inline handler without duplicating them", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const calls: string[] = [];
+    let generation = 1;
+    const { rerender } = renderHook(() =>
+      useViewEvent(type, (event) =>
+        calls.push(`gen${generation}:${String(event.payload.step)}`),
+      ),
+    );
+
+    generation = 2;
+    rerender();
+
+    emitViewEvent(type, { step: "emit" });
+
+    expect(calls).toEqual(["gen2:emit"]);
+  });
+
+  it("re-subscribes through the real bus when extra deps change", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const busSpy = vi.spyOn(viewEventBus, "onViewEvent");
+    const received: viewEventBus.ViewEvent[] = [];
+    const { rerender } = renderHook(
+      ({ gate }: { gate: number }) =>
+        useViewEvent(type, (event) => received.push(event), [gate]),
+      { initialProps: { gate: 0 } },
+    );
+    expect(busSpy).toHaveBeenCalledTimes(1);
+    expect(busSpy.mock.calls[0]?.[0]).toBe(type);
+
+    rerender({ gate: 1 });
+    expect(busSpy).toHaveBeenCalledTimes(2);
+
+    emitViewEvent(type, { after: "resubscribe" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({ after: "resubscribe" });
+  });
+
+  it("delivers one emission to every independent subscriber of the same type", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const first: ViewEvent[] = [];
+    const second: ViewEvent[] = [];
+    renderHook(() => useViewEvent(type, (event) => first.push(event)));
+    renderHook(() => useViewEvent(type, (event) => second.push(event)));
+
+    emitViewEvent(type, { broadcast: true });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(first[0]).toEqual(second[0]);
+  });
+});
+
+describe("useEmitViewEvent", () => {
+  it("returns a referentially stable emit function across rerenders", () => {
+    const { result, rerender } = renderHook(() => useEmitViewEvent());
+    const first = result.current;
+
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it("publishes through the real bus to a useViewEvent subscriber", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const received: ViewEvent[] = [];
+    renderHook(() => useViewEvent(type, (event) => received.push(event)));
+    const { result } = renderHook(() => useEmitViewEvent());
+
+    result.current(type, { ok: true }, "view-emitter");
+
+    expect(received).toHaveLength(1);
+    expect(received[0].sourceViewId).toBe("view-emitter");
+    expect(received[0].payload).toEqual({ ok: true });
+  });
+
+  it("defaults the payload to an empty object when emitted without one", () => {
+    const type = `test:view-event:${++typeSeq}`;
+    const received: ViewEvent[] = [];
+    renderHook(() => useViewEvent(type, (event) => received.push(event)));
+    const { result } = renderHook(() => useEmitViewEvent());
+
+    result.current(type);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({});
+    expect(received[0].sourceViewId).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new behavioral unit suite for `packages/ui/src/hooks/useViewEvent.ts` (`useViewEvent` + `useEmitViewEvent`), which had no co-located test on `develop`. Test-only change: no production file is touched (diff is one new file, +180/-0).

## What the suite covers

All cases drive the real hooks against the real `src/views/view-event-bus.ts` window-CustomEvent transport in jsdom — no module mocks stand in for the system under test:

- delivered event carries the emitted `type`, `payload`, `sourceViewId`, and a numeric `timestamp`
- events emitted under other types are filtered out by the typed subscription
- teardown: after `unmount()`, later emissions are not delivered
- changing the subscribed `type` re-subscribes and the previous type stops delivering
- swapping to the latest inline handler does not duplicate delivery (handlerRef contract)
- extra `deps` re-subscribe through the real bus (verified with a call-through spy on `onViewEvent`; original implementation stays live and delivery still works)
- one emission fans out to every independent subscriber of the same type
- `useEmitViewEvent()` returns a referentially stable emit function across rerenders
- end-to-end: an emit from `useEmitViewEvent` reaches a `useViewEvent` subscriber through the real bus
- emitting without a payload defaults it to `{}` and preserves the omitted `sourceViewId`

## Verification (observed at base `6e340eeb`, current `origin/develop`)

- `vitest` (package lane): `bun run --cwd packages/ui test src/hooks/useViewEvent.test.ts` → **Test Files 1 passed (1), Tests 10 passed (10)** (vitest 4.1.10)
- `biome check --write packages/ui/src/hooks/useViewEvent.test.ts` → formatting applied once, then **clean ("No fixes applied")**
- `tsc --noEmit -p tsconfig.json` in `packages/ui` → **zero diagnostics reference `useViewEvent.test.ts`** (remaining output lines are pre-existing errors in unrelated files)
- `git diff --stat origin/develop..HEAD`: exactly one new test file, 180 insertions, 0 deletions

## Notes

- Fork contributor: hosted CI does not run on this pull request; the counts above are from a local run at the exact pushed head's base.
- No `vi.hoisted` and no `expectTypeOf` are used; assertions record observed behavior only.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

None - standalone coverage-gap fill (no co-located suite existed for this module on `develop`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Test-only diff (one new `*.test.ts`, +180/-0); no production file, export, or runtime behavior is touched.

# Background

## What does this PR do?

Adds `packages/ui/src/hooks/useViewEvent.test.ts` — a behavioral vitest suite for the previously untested `useViewEvent` / `useEmitViewEvent` hooks, driven against the real view-event bus.

## What kind of change is this?

Improvements (misc. changes to existing features) — test coverage only.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/hooks/useViewEvent.test.ts` — every case imports the real hooks (`./useViewEvent`) and the real bus (`../views/view-event-bus`); no module mocks replace the system under test.

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/hooks/useViewEvent.test.ts
```

Expected: `Test Files 1 passed (1)`, `Tests 10 passed (10)` (vitest 4.1.10, jsdom). Observed exactly this at base `6e340eeb`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4313a30c9d84c5b99473904410edc7f7be77703c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only diff; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only diff; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only diff; nothing to walk through in the UI.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - no backend code path touched.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - vitest pass counts quoted above serve as the observable output.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no model/provider/action change.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - none produced by a test-only diff.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - test-only diff; no rendered surface changed.

### After

N/A - test-only diff; no rendered surface changed.

### Walkthrough video

N/A - test-only diff; nothing to walk through in the UI.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS surface touched.

## Known gaps / failures

- Full `bun run verify` lane was not run for this scoped test-only change; the quoted gates are the owning package's own runner (`vitest`, 10 passed / 10 at base `6e340eeb`), `biome check` (clean), and `tsc --noEmit` (zero diagnostics referencing the new file). The remaining `tsc` output lines are pre-existing errors in unrelated files (`src/cloud/mcps/lib/use-mcps.test.tsx`, `src/cloud/organization/data/use-credentials.test.tsx`, `src/components/settings/cloud-model-schema.test.ts`, `../core/src/cloud-routing.ts`) present on the working base and not touched by this diff.
- Fork contributor: hosted CI does not run on this PR; all counts above are from a local run at the pushed head's base.
- Evidence receipt waived (`FACTORY_NO_EVIDENCE`): an unattended session cannot finalize an interactive identity.slop.cash OAuth trace; this PR therefore scores no evidence bonus.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
