### PR TITLE
test(app-core): cover types

### DIFF
--- a/packages/app-core/platforms/electrobun/src/dynamic-views/types.test.ts
+++ b/packages/app-core/platforms/electrobun/src/dynamic-views/types.test.ts
@@ -1,0 +1,131 @@
+/** Drives the dynamic-view placement and source vocabulary through the registry validation boundary that consumes it. */
+import { describe, expect, it } from "vitest";
+import { DynamicViewError } from "./errors";
+import { DynamicViewRegistry } from "./registry";
+import type {
+  DynamicViewManifest,
+  DynamicViewPlacement,
+  DynamicViewSource,
+} from "./types";
+import { DYNAMIC_VIEW_PLACEMENTS, DYNAMIC_VIEW_SOURCES } from "./types";
+
+function manifest(
+  placement: DynamicViewPlacement,
+  source: DynamicViewSource,
+  id: string,
+): DynamicViewManifest {
+  return {
+    id,
+    title: "Vocabulary Probe",
+    source,
+    entrypoint: "./probe.html",
+    placement,
+  };
+}
+
+describe("dynamic view placement and source vocabulary", () => {
+  it("declares a non-empty placement and source vocabulary so the boundary sweeps below execute", () => {
+    expect(DYNAMIC_VIEW_PLACEMENTS.length).toBeGreaterThan(0);
+    expect(DYNAMIC_VIEW_SOURCES.length).toBeGreaterThan(0);
+  });
+
+  it.each([...DYNAMIC_VIEW_PLACEMENTS].map((placement) => [placement]))(
+    "accepts declared placement %s at the registry boundary",
+    (placement) => {
+      const registry = new DynamicViewRegistry();
+
+      const registered = registry.register(
+        manifest(placement, "agent", "vocab.placement"),
+      );
+
+      expect(registered.placement).toBe(placement);
+      expect(registry.get("vocab.placement")?.placement).toBe(placement);
+    },
+  );
+
+  it.each([...DYNAMIC_VIEW_SOURCES].map((source) => [source]))(
+    "accepts declared source %s at the registry boundary",
+    (source) => {
+      const registry = new DynamicViewRegistry();
+
+      const registered = registry.register(
+        manifest("floating", source, "vocab.source"),
+      );
+
+      expect(registered.source).toBe(source);
+      expect(registry.get("vocab.source")?.source).toBe(source);
+    },
+  );
+
+  const INVALID_PLACEMENT_VALUES: unknown[] = [
+    undefined,
+    null,
+    42,
+    true,
+    {},
+    [],
+    "",
+    "CANVAS",
+  ];
+
+  it.each(INVALID_PLACEMENT_VALUES.map((value) => [value]))(
+    "rejects placement value %j outside the declared vocabulary",
+    (value) => {
+      const registry = new DynamicViewRegistry();
+      let caught: unknown;
+
+      try {
+        registry.register(
+          manifest(value as DynamicViewPlacement, "agent", "vocab.invalid"),
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      if (!(caught instanceof DynamicViewError)) {
+        throw new Error(
+          "register() must reject invalid placement values with DynamicViewError",
+        );
+      }
+      expect(caught.code).toBe("DYNAMIC_VIEW_INVALID_MANIFEST");
+      expect(caught.message).toContain("Unsupported dynamic view placement");
+      expect(registry.list()).toHaveLength(0);
+    },
+  );
+
+  const INVALID_SOURCE_VALUES: unknown[] = [
+    undefined,
+    null,
+    42,
+    true,
+    {},
+    [],
+    "",
+    "AGENT",
+  ];
+
+  it.each(INVALID_SOURCE_VALUES.map((value) => [value]))(
+    "rejects source value %j outside the declared vocabulary",
+    (value) => {
+      const registry = new DynamicViewRegistry();
+      let caught: unknown;
+
+      try {
+        registry.register(
+          manifest("floating", value as DynamicViewSource, "vocab.invalid"),
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      if (!(caught instanceof DynamicViewError)) {
+        throw new Error(
+          "register() must reject invalid source values with DynamicViewError",
+        );
+      }
+      expect(caught.code).toBe("DYNAMIC_VIEW_INVALID_MANIFEST");
+      expect(caught.message).toContain("Unsupported dynamic view source");
+      expect(registry.list()).toHaveLength(0);
+    },
+  );
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/app-core/platforms/electrobun/src/dynamic-views/types.ts`, which had no same-named test file anywhere in the repository.

The module's runtime surface is the two exported vocabulary constants, `DYNAMIC_VIEW_PLACEMENTS` and `DYNAMIC_VIEW_SOURCES` (everything else it exports is compile-time-only types). Those constants are consumed at a real runtime boundary: `validatePlacement()` and `validateSource()` in `dynamic-views/registry.ts` gate every manifest registration through `DYNAMIC_VIEW_PLACEMENTS.includes(...)` / `DYNAMIC_VIEW_SOURCES.includes(...)`. The new suite drives that boundary with the real registry (no mocks), rather than restating the constants' literals back at themselves:

- accepts **every declared placement** and **every declared source** end-to-end through `DynamicViewRegistry.register()`, asserting the registered and re-read value (previously only `"floating"`/`"agent"` were ever exercised as accepted values);
- rejects adversarial out-of-vocabulary values at the same boundary (`undefined`, `null`, numbers, booleans, objects, arrays, empty string, wrong-case strings), asserting the typed `DynamicViewError` with code `DYNAMIC_VIEW_INVALID_MANIFEST` and the correct per-field message;
- asserts a rejected registration leaves the registry untouched (no partial state).

This is additive coverage of an existing contract; no production code is changed.

## Diff scope

Single new file: `packages/app-core/platforms/electrobun/src/dynamic-views/types.test.ts` (+131/-0). No deletions, no other files touched.

## Verification

Test-only change; counts below are from this exact head.

- `bunx vitest run --config vitest.electrobun.config.ts src/dynamic-views/types.test.ts` (in `packages/app-core/platforms/electrobun`, the owning package's own vitest config): **1 test file passed, 27/27 tests passed**.
- `bunx biome check --write` on the touched file: clean (formatting auto-applied, exit 0).
- `tsc --noEmit` for the owning package (`packages/app-core/platforms/electrobun`): full-package run completed; the output contains 83 errors, all pre-existing in unrelated files (e.g. `../../../agent/src/api/accounts-routes.ts` TS2305/TS2554 against `@elizaos/auth/account-storage`). The new file `types.test.ts` appears **nowhere** in the output (grep count 0).

**Note on CI:** this PR comes from a fork, so hosted CI does not run on it; the local runs quoted above are the verification record.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e95b850641b634347e3966c547f0aaa611e69372 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
