### PR TITLE
test(ui): cover useChatPrefill

### DIFF
--- a/packages/ui/src/hooks/useChatPrefill.test.ts
+++ b/packages/ui/src/hooks/useChatPrefill.test.ts
@@ -1,0 +1,148 @@
+/** Verifies useChatPrefill - floating-composer prefill dispatch through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Unit lock for the chat-prefill seeding hook.
+ *
+ * Any view can populate the single floating chat composer through this hook;
+ * the always-mounted ChatOverlay consumes the result as a real
+ * `eliza:chat:prefill` CustomEvent on `window`. The binding properties:
+ *  1. `prefill(text)` dispatches CHAT_PREFILL_EVENT on window with detail
+ *     `{ text, select: true }` — select defaults to true at this layer.
+ *  2. An explicit second argument passes through unchanged.
+ *  3. Text is delivered verbatim — no trimming, guarding, or transformation
+ *     (an empty string still reaches the composer).
+ *  4. Every call dispatches its own event, in call order, on `window`
+ *     (the overlay's listen target).
+ *  5. The returned `prefill` keeps a stable identity across re-renders so
+ *     consumers can safely list it in effect dependencies.
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CHAT_PREFILL_EVENT } from "../events";
+import { useChatPrefill } from "./useChatPrefill";
+
+interface PrefillDetail {
+  text: string;
+  select?: boolean;
+}
+
+/** Attach one real window listener; the overlay's consumption boundary. */
+function listenForPrefill(): {
+  events: CustomEvent<PrefillDetail>[];
+  dispose: () => void;
+} {
+  const events: CustomEvent<PrefillDetail>[] = [];
+  const handle = (event: Event): void => {
+    events.push(event as CustomEvent<PrefillDetail>);
+  };
+  window.addEventListener(CHAT_PREFILL_EVENT, handle);
+  return {
+    events,
+    dispose: () => window.removeEventListener(CHAT_PREFILL_EVENT, handle),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useChatPrefill", () => {
+  it("dispatches CHAT_PREFILL_EVENT on window with the text and select=true default", () => {
+    const { result } = renderHook(() => useChatPrefill());
+    const { events, dispose } = listenForPrefill();
+    // The overlay listens on window, not document — a document-level listener
+    // must not see this event.
+    const documentEvents: CustomEvent<PrefillDetail>[] = [];
+    const documentHandle = (event: Event): void => {
+      documentEvents.push(event as CustomEvent<PrefillDetail>);
+    };
+    document.addEventListener(CHAT_PREFILL_EVENT, documentHandle);
+    try {
+      act(() => {
+        result.current.prefill("Summarize my notes");
+      });
+
+      expect(events).toHaveLength(1);
+      expect(documentEvents).toHaveLength(0);
+      expect(events[0].detail).toEqual({
+        text: "Summarize my notes",
+        select: true,
+      });
+    } finally {
+      dispose();
+      document.removeEventListener(CHAT_PREFILL_EVENT, documentHandle);
+    }
+  });
+
+  it("passes an explicit select argument through unchanged", () => {
+    const { result } = renderHook(() => useChatPrefill());
+    const { events, dispose } = listenForPrefill();
+    try {
+      act(() => {
+        result.current.prefill("draft without selection", false);
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({
+        text: "draft without selection",
+        select: false,
+      });
+
+      act(() => {
+        result.current.prefill("draft with selection", true);
+      });
+      expect(events).toHaveLength(2);
+      expect(events[1].detail).toEqual({
+        text: "draft with selection",
+        select: true,
+      });
+    } finally {
+      dispose();
+    }
+  });
+
+  it("delivers empty-string text verbatim without guarding it away", () => {
+    const { result } = renderHook(() => useChatPrefill());
+    const { events, dispose } = listenForPrefill();
+    try {
+      act(() => {
+        result.current.prefill("");
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({ text: "", select: true });
+    } finally {
+      dispose();
+    }
+  });
+
+  it("dispatches one event per prefill call, in call order", () => {
+    const { result } = renderHook(() => useChatPrefill());
+    const { events, dispose } = listenForPrefill();
+    try {
+      act(() => {
+        result.current.prefill("first");
+        result.current.prefill("second");
+        result.current.prefill("third");
+      });
+
+      expect(events.map((event) => event.detail.text)).toEqual([
+        "first",
+        "second",
+        "third",
+      ]);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("keeps a stable prefill identity across re-renders", () => {
+    const { result, rerender } = renderHook(() => useChatPrefill());
+    const first = result.current.prefill;
+
+    rerender();
+
+    expect(result.current.prefill).toBe(first);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a unit suite for `packages/ui/src/hooks/useChatPrefill.ts`, which previously had no same-named test anywhere in the repo. This is a test-only diff: one new file, `+148/-0`. No production code is touched.

`useChatPrefill` is the seam every view uses to seed the single floating chat composer: `prefill(text)` reaches the always-mounted ChatOverlay as a real `eliza:chat:prefill` CustomEvent dispatched on `window` (via `dispatchChatPrefill` in `src/events`). The suite drives that real boundary — a genuine `window.addEventListener` listener observes each dispatch; nothing is mocked out.

## What is covered

- `prefill(text)` dispatches `CHAT_PREFILL_EVENT` on window with detail `{ text, select: true }` — select defaults to true at this layer
- an explicit second `select` argument passes through unchanged (`false` and `true`)
- empty-string text is delivered verbatim (the hook adds no guard)
- one event per call, in call order
- document-level listeners do NOT see the event (window-only delivery — the overlay's listen target)
- the returned `prefill` keeps a stable identity across re-renders (`useCallback`), so consumers can depend on it

## Verification

All commands run in `packages/ui` at head `405ea6e0521b4fc3c3bb13c9c9753774b8ad628a`, re-run immediately before filing against content identical to current `origin/develop` for `useChatPrefill.ts`, `src/events/index.ts`, and `vitest.config.ts`:

- `bunx vitest run src/hooks/useChatPrefill.test.ts` — **Test Files 1 passed (1); Tests 5 passed (5)**, 0 failed
- `bunx biome check --write src/hooks/useChatPrefill.test.ts` — clean: "Checked 1 file ... No fixes applied"
- `bunx tsc --noEmit -p tsconfig.json` — zero diagnostics mentioning the new test file

Note: this PR comes from a contributor fork, so hosted CI does not run on it; the counts above are quoted from local runs of the package's own vitest/biome/tsc configuration.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:405ea6e0521b4fc3c3bb13c9c9753774b8ad628a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
