### PR TITLE
test(ui): cover useCachedResource

### DIFF
--- a/packages/ui/src/hooks/useCachedResource.test.tsx
+++ b/packages/ui/src/hooks/useCachedResource.test.tsx
@@ -161,4 +161,213 @@ describe("useCachedResource", () => {
     });
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
+
+  it("null key disables the resource: loading forever, no fetch, safe no-op controls", async () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const { result } = renderHook(() => useCachedResource(null, fetcher));
+
+    expect(result.current.status).toBe("loading");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetcher).not.toHaveBeenCalled();
+
+    await expect(result.current.refetch()).resolves.toBeUndefined();
+    expect(fetcher).not.toHaveBeenCalled();
+    // A disabled resource has no cache slot, but mutate(updaterFn) must not
+    // take the missing-data throw path — the null-key guard runs first.
+    expect(() => result.current.mutate((prev: string) => prev)).not.toThrow();
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("enabled:false skips mount revalidation on a cold cache", async () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const { result } = renderHook(() =>
+      useCachedResource("k-disabled-cold", fetcher, { enabled: false }),
+    );
+
+    expect(result.current.status).toBe("loading");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("enabled:false still paints an already cached value without fetching", async () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const warm = renderHook(() =>
+      useCachedResource("k-disabled-warm", fetcher, { staleTime: 10_000 }),
+    );
+    await waitFor(() => expect(warm.result.current.status).toBe("success"));
+    warm.unmount();
+    fetcher.mockClear();
+
+    const second = renderHook(() =>
+      useCachedResource("k-disabled-warm", fetcher, {
+        enabled: false,
+        staleTime: 10_000,
+      }),
+    );
+    expect(second.result.current.status).toBe("success");
+    if (second.result.current.status === "success") {
+      expect(second.result.current.data).toBe("v1");
+    }
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("a rejected cold fetch surfaces the error state with a normalized message", async () => {
+    let reject: (e: unknown) => void = () => {};
+    const fetcher = vi.fn(
+      (_signal: AbortSignal) =>
+        new Promise<string>((_r, rej) => {
+          reject = rej;
+        }),
+    );
+    const { result } = renderHook(() =>
+      useCachedResource("k-error", fetcher, { staleTime: 10_000 }),
+    );
+
+    expect(result.current.isValidating).toBe(true);
+    reject("boom");
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      // Non-Error rejections are wrapped so callers always get .message.
+      expect(result.current.error.message).toBe("boom");
+    }
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it("a failed forced refetch keeps the previous cached value visible", async () => {
+    let shouldFail = false;
+    const fetcher = vi.fn((_signal: AbortSignal) =>
+      shouldFail
+        ? Promise.reject(new Error("net down"))
+        : Promise.resolve("v1"),
+    );
+    const { result } = renderHook(() =>
+      useCachedResource("k-stale-on-error", fetcher, { staleTime: 10_000 }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    shouldFail = true;
+    // The returned promise never rejects — failures land in state instead.
+    await result.current.refetch();
+    // With a cached value present, success outranks the recorded error.
+    expect(result.current.status).toBe("success");
+    if (result.current.status === "success") {
+      expect(result.current.data).toBe("v1");
+    }
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it("recovers to success when a refetch succeeds after a failure", async () => {
+    let attempt = 0;
+    const fetcher = vi.fn((_signal: AbortSignal) => {
+      attempt += 1;
+      if (attempt === 1) return Promise.reject(new Error("cold fail"));
+      return Promise.resolve("recovered");
+    });
+    const { result } = renderHook(() =>
+      useCachedResource("k-recover", fetcher, { staleTime: 10_000 }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    await result.current.refetch();
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    if (result.current.status === "success") {
+      expect(result.current.data).toBe("recovered");
+    }
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it("mutate replaces the cached value immediately", async () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const { result } = renderHook(() =>
+      useCachedResource("k-mutate-set", fetcher, { staleTime: 10_000 }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    result.current.mutate("optimistic");
+    await waitFor(() => {
+      if (result.current.status === "success") {
+        expect(result.current.data).toBe("optimistic");
+      }
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("mutate accepts an updater function derived from current data", async () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const { result } = renderHook(() =>
+      useCachedResource("k-mutate-updater", fetcher, { staleTime: 10_000 }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    result.current.mutate((prev: string) => `${prev}!`);
+    await waitFor(() => {
+      if (result.current.status === "success") {
+        expect(result.current.data).toBe("v1!");
+      }
+    });
+  });
+
+  it("mutate(updaterFn) without cached data throws", () => {
+    const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+    const { result } = renderHook(() =>
+      useCachedResource("k-mutate-missing", fetcher, { enabled: false }),
+    );
+    expect(() => result.current.mutate((prev: string) => `${prev}!`)).toThrow(
+      "useCachedResource: mutate(updaterFn) called without cached data.",
+    );
+  });
+
+  it("isValidating tracks an in-flight revalidation", async () => {
+    let resolve: (v: string) => void = () => {};
+    const fetcher = vi.fn(
+      (_signal: AbortSignal) =>
+        new Promise<string>((r) => {
+          resolve = r;
+        }),
+    );
+    const { result } = renderHook(() =>
+      useCachedResource("k-validating", fetcher),
+    );
+
+    expect(result.current.isValidating).toBe(true);
+    resolve("v1");
+    await waitFor(() => expect(result.current.isValidating).toBe(false));
+    await waitFor(() => expect(result.current.status).toBe("success"));
+  });
+
+  it("persist mirrors to localStorage so a wiped memory cache still paints instantly", async () => {
+    const storageKey = "eliza:rc:k-persist";
+    window.localStorage.removeItem(storageKey);
+    try {
+      const fetcher = vi.fn(async (_signal: AbortSignal) => "v1");
+      const first = renderHook(() =>
+        useCachedResource("k-persist", fetcher, {
+          persist: true,
+          staleTime: 10_000,
+        }),
+      );
+      await waitFor(() => expect(first.result.current.status).toBe("success"));
+      expect(window.localStorage.getItem(storageKey)).not.toBeNull();
+      first.unmount();
+
+      // Simulate a reload: the in-memory store is gone, the mirror survives.
+      __resetResourceCache();
+      fetcher.mockClear();
+
+      const second = renderHook(() =>
+        useCachedResource("k-persist", fetcher, {
+          persist: true,
+          staleTime: 10_000,
+        }),
+      );
+      expect(second.result.current.status).toBe("success");
+      if (second.result.current.status === "success") {
+        expect(second.result.current.data).toBe("v1");
+      }
+      expect(fetcher).not.toHaveBeenCalled();
+    } finally {
+      window.localStorage.removeItem(storageKey);
+    }
+  });
 });


### PR DESCRIPTION

## What

Extends the existing `packages/ui/src/hooks/useCachedResource.test.tsx` suite with 11 new cases covering hook-level behavior branches that had no coverage. **Additive only: +209/−0, one test file, no production code touched.**

## Newly covered behavior

- **`key === null`** disables the resource: permanent `loading`, fetcher never invoked, `refetch()` resolves without fetching, and updater-form `mutate` takes the null-key early return instead of the missing-data throw.
- **`enabled: false`** skips mount revalidation on a cold cache (stays `loading`, zero fetches), while an already-cached value still paints without a refetch (documents observed snapshot precedence).
- **Error paths:** a rejected cold fetch surfaces `status: "error"` with non-Error rejections normalized to `Error` (`"boom"` → `.message === "boom"`) and `isValidating` reset to `false`.
- **Failure precedence:** a forced refetch that fails keeps the previous cached value visible (`success` outranks the recorded error) and its returned promise resolves rather than rejecting, as the contract promises.
- **Recovery:** after a failure, a succeeding `refetch()` returns the hook to `success` with the fresh value.
- **`mutate`:** direct replacement propagates immediately through the shared cache; updater form derives from current data; updater form with no cached entry throws `"useCachedResource: mutate(updaterFn) called without cached data."`.
- **`isValidating`** lifecycle: `true` while a revalidation is in flight, `false` once it settles.
- **`persist: true`** mirrors entries to localStorage under the documented prefix, so wiping the in-memory store (simulated reload) still paints instantly on the next mount with zero fetches.

All assertions record observed behavior of the module as shipped; nothing aspirational.

## Evidence (test-only diff — no behavioral change)

Run at head `bf1a369cdb` against `origin/develop` (base verified identical for both `useCachedResource.ts` and `resource-cache.ts`, so these counts reproduce on current develop):

1. `bunx vitest run src/hooks/useCachedResource.test.tsx` in `packages/ui`:
   `Test Files  1 passed (1)` / `Tests  17 passed (17)` (6 pre-existing + 11 new)
2. `bunx biome check --write src/hooks/useCachedResource.test.tsx` → clean (second read-only pass: "No fixes applied")
3. `bunx tsc --noEmit` in `packages/ui`: zero diagnostics reference this test file (the 9 reported errors are pre-existing, in unrelated files)
4. Diff scope: exactly one file, `packages/ui/src/hooks/useCachedResource.test.tsx`, +209/−0

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:bf1a369cdbe3d181717a35569207d10daa5ee73e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
