### PR TITLE
test(core): cover components

### DIFF
--- a/packages/core/src/types/components.test.ts
+++ b/packages/core/src/types/components.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Runtime component contracts from `./components`: the action-mode taxonomy
+ * that positions hooks in the message pipeline, the non-blocking
+ * classification the dispatcher consults, and confirmation-status narrowing
+ * used to pause action chains. Deterministic unit tests against the real
+ * module — no mocks, no runtime instance.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	ACTION_CONFIRMATION_STATUS_VALUES,
+	ActionMode,
+	FOLLOW_UP_CAPABLE_ACTION_TAG,
+	HOOK_MODES,
+	isActionConfirmationStatus,
+	NON_BLOCKING_MODES,
+} from "./components";
+
+const CANONICAL_CONFIRMATION_STATUSES = [
+	"CONFIRMATION_REQUIRED",
+	"NOT_CONFIRMED",
+	"REQUIRES_CONFIRMATION",
+	"AWAITING_CONFIRMATION",
+	"NEEDS_CONFIRMATION",
+] as const;
+
+describe("isActionConfirmationStatus", () => {
+	it("accepts every canonical confirmation status", () => {
+		for (const status of CANONICAL_CONFIRMATION_STATUSES) {
+			expect(isActionConfirmationStatus(status)).toBe(true);
+		}
+	});
+
+	it("accepts every member of the exported runtime set", () => {
+		for (const status of ACTION_CONFIRMATION_STATUS_VALUES) {
+			expect(isActionConfirmationStatus(status)).toBe(true);
+		}
+	});
+
+	it("rejects non-string values", () => {
+		const nonStrings: unknown[] = [
+			undefined,
+			null,
+			42,
+			0,
+			true,
+			false,
+			{},
+			["REQUIRES_CONFIRMATION"],
+			Symbol("REQUIRES_CONFIRMATION"),
+		];
+		for (const value of nonStrings) {
+			expect(isActionConfirmationStatus(value)).toBe(false);
+		}
+	});
+
+	it("rejects strings that are not exact canonical statuses", () => {
+		const nearMisses = [
+			"",
+			"confirmation_required",
+			"requires_confirmation",
+			"REQUIRES CONFIRMATION",
+			" REQUIRES_CONFIRMATION",
+			"REQUIRES_CONFIRMATION ",
+			"CONFIRMATION",
+			"NOT_CONFIRMED.",
+		];
+		for (const value of nearMisses) {
+			expect(isActionConfirmationStatus(value)).toBe(false);
+		}
+	});
+});
+
+describe("ACTION_CONFIRMATION_STATUS_VALUES", () => {
+	it("holds exactly the canonical statuses with no duplicates", () => {
+		expect(ACTION_CONFIRMATION_STATUS_VALUES.size).toBe(
+			CANONICAL_CONFIRMATION_STATUSES.length,
+		);
+		for (const status of CANONICAL_CONFIRMATION_STATUSES) {
+			expect(ACTION_CONFIRMATION_STATUS_VALUES.has(status)).toBe(true);
+		}
+	});
+});
+
+describe("ActionMode", () => {
+	it("maps every key to its identical canonical string value", () => {
+		const entries = Object.entries(ActionMode) as Array<[string, ActionMode]>;
+		for (const [key, value] of entries) {
+			expect(key).toBe(value);
+		}
+	});
+
+	it("declares ten unique modes spanning the scope-times-phase taxonomy plus PLANNER", () => {
+		const values = Object.values(ActionMode);
+		expect(values).toHaveLength(10);
+		expect(new Set(values).size).toBe(values.length);
+		const scopes = ["ALWAYS_", "CONTEXT_", "RESPONSE_HANDLER_"];
+		const phases = ["BEFORE", "DURING", "AFTER"];
+		for (const mode of values) {
+			if (mode === "PLANNER") {
+				continue;
+			}
+			const matchesTaxonomy = scopes.some((scope) =>
+				phases.some((phase) => mode === `${scope}${phase}`),
+			);
+			expect(matchesTaxonomy).toBe(true);
+		}
+	});
+});
+
+describe("NON_BLOCKING_MODES", () => {
+	it("classifies exactly the three *_DURING hooks as non-blocking", () => {
+		expect(NON_BLOCKING_MODES.size).toBe(3);
+		expect(NON_BLOCKING_MODES.has(ActionMode.ALWAYS_DURING)).toBe(true);
+		expect(NON_BLOCKING_MODES.has(ActionMode.CONTEXT_DURING)).toBe(true);
+		expect(NON_BLOCKING_MODES.has(ActionMode.RESPONSE_HANDLER_DURING)).toBe(
+			true,
+		);
+	});
+
+	it("leaves PLANNER and every BEFORE/AFTER hook blocking", () => {
+		for (const mode of Object.values(ActionMode)) {
+			if (mode.endsWith("_DURING")) {
+				continue;
+			}
+			expect(NON_BLOCKING_MODES.has(mode)).toBe(false);
+		}
+	});
+});
+
+describe("HOOK_MODES", () => {
+	it("covers every non-PLANNER mode exactly once", () => {
+		expect(HOOK_MODES).toHaveLength(9);
+		expect(new Set(HOOK_MODES).size).toBe(HOOK_MODES.length);
+		expect(HOOK_MODES).not.toContain(ActionMode.PLANNER);
+		for (const mode of Object.values(ActionMode)) {
+			if (mode === ActionMode.PLANNER) {
+				continue;
+			}
+			expect(HOOK_MODES).toContain(mode);
+		}
+	});
+
+	it("opens the pipeline with the always-scope BEFORE hook", () => {
+		expect(HOOK_MODES[0]).toBe(ActionMode.ALWAYS_BEFORE);
+	});
+
+	it("orders each scope's phases BEFORE, then DURING, then AFTER", () => {
+		const order = (mode: ActionMode): number => {
+			const at = HOOK_MODES.indexOf(mode);
+			expect(at).toBeGreaterThanOrEqual(0);
+			return at;
+		};
+		const scopes = ["ALWAYS_", "RESPONSE_HANDLER_", "CONTEXT_"] as const;
+		for (const scope of scopes) {
+			expect(order(`${scope}BEFORE` as ActionMode)).toBeLessThan(
+				order(`${scope}DURING` as ActionMode),
+			);
+			expect(order(`${scope}DURING` as ActionMode)).toBeLessThan(
+				order(`${scope}AFTER` as ActionMode),
+			);
+		}
+	});
+});
+
+describe("FOLLOW_UP_CAPABLE_ACTION_TAG", () => {
+	it("exposes a non-empty tag string usable in capability-tag checks", () => {
+		expect(typeof FOLLOW_UP_CAPABLE_ACTION_TAG).toBe("string");
+		expect(FOLLOW_UP_CAPABLE_ACTION_TAG.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION

## What

Adds one new test file, `packages/core/src/types/components.test.ts` (+171/-0, no other files touched). The module previously had no same-named suite anywhere in the repo.

## Why

`components.ts` defines the runtime half of the plugin-component contract that the message loop dispatches against: the `ActionMode` taxonomy positioning hooks in the pipeline, `NON_BLOCKING_MODES` (the blocking-vs-parallel classification the dispatcher consults via `Set.has`), `HOOK_MODES` (the canonical hook firing order), and the confirmation-status pair (`ACTION_CONFIRMATION_STATUS_VALUES` + `isActionConfirmationStatus`) used to pause action chains. None of these branches were covered.

The suite drives the real module — no mocks, no type-level assertions:

- `isActionConfirmationStatus`: accepts all five canonical statuses and every member of the exported set; rejects non-strings (`undefined`, `null`, numbers, booleans, objects, arrays, symbols) and near-miss strings (case variants, whitespace padding, prefixes, punctuation).
- `ACTION_CONFIRMATION_STATUS_VALUES`: holds exactly the canonical statuses with no duplicates (set/predicate consistency).
- `ActionMode`: key-to-value identity for every entry; ten unique modes spanning the documented scope-times-phase taxonomy plus `PLANNER`.
- `NON_BLOCKING_MODES`: classifies exactly the three `*_DURING` hooks as non-blocking; leaves `PLANNER` and every BEFORE/AFTER hook blocking.
- `HOOK_MODES`: covers every non-PLANNER mode exactly once; opens with `ALWAYS_BEFORE`; each scope's phases run BEFORE -> DURING -> AFTER.
- `FOLLOW_UP_CAPABLE_ACTION_TAG`: exports a non-empty tag string usable in capability-tag checks.

Test-only change: no production behavior is modified.

## Evidence

Run on this branch's base, current `origin/develop` @ `de774b875774f478ef5b879dbdae8fd2997a3470`, immediately before filing:

- `bunx vitest run packages/core/src/types/components.test.ts` — Test Files: 1 passed (1); Tests: 13 passed (13)
- `bunx biome check --write packages/core/src/types/components.test.ts` — clean (1 file checked)
- `bunx tsc --noEmit` in `packages/core`, grepped for `components.test.ts` — zero matches (no new type errors from this diff)

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are quoted from local runs of the real runner.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7b89e6832171ed621761f43637c2a3892b954061 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
