### PR TITLE
test(ui): cover useDesktopTabs

### DIFF
--- a/packages/ui/src/hooks/useDesktopTabs.test.tsx
+++ b/packages/ui/src/hooks/useDesktopTabs.test.tsx
@@ -318,4 +318,176 @@ describe("useDesktopTabs", () => {
 
     expect(result.current.tabs).toEqual([]);
   });
+
+  it("starts with an empty dock when persisted state is corrupt or not an array", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    const corrupted = renderHook(() => useDesktopTabs());
+    expect(corrupted.result.current.tabs).toEqual([]);
+    cleanup();
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ viewId: "not-an-array" }),
+    );
+    const nonArray = renderHook(() => useDesktopTabs());
+    expect(nonArray.result.current.tabs).toEqual([]);
+  });
+
+  it("drops malformed persisted entries and restores only well-formed tabs", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        null,
+        "junk-string",
+        { label: "Missing ViewId", path: "/apps/missing-view-id" },
+        { viewId: "missing.label", path: "/apps/missing-label" },
+        { viewId: "missing.path", label: "Missing Path" },
+        {
+          viewId: "remote.ledger",
+          label: "Remote Ledger",
+          path: "/apps/remote-ledger",
+          pinned: true,
+          pinnedAt: 100,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useDesktopTabs());
+
+    expect(result.current.tabs).toEqual([
+      {
+        viewId: "remote.ledger",
+        label: "Remote Ledger",
+        path: "/apps/remote-ledger",
+        pinned: true,
+        pinnedAt: 100,
+      },
+    ]);
+  });
+
+  it("treats legacy persisted tabs without pinnedAt as holding the oldest pins, ties broken by open order", () => {
+    // Pre-pinnedAt persisted data: two pinned tabs carrying no pin timestamp.
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          viewId: "legacy.a",
+          label: "Legacy A",
+          path: "/apps/legacy-a",
+          pinned: true,
+        },
+        {
+          viewId: "legacy.b",
+          label: "Legacy B",
+          path: "/apps/legacy-b",
+          pinned: true,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useDesktopTabs());
+    expect(result.current.tabs.map((tab) => tab.viewId)).toEqual([
+      "legacy.a",
+      "legacy.b",
+    ]);
+    expect(
+      result.current.tabs.every(
+        (tab) => !("pinnedAt" in tab) || tab.pinnedAt === undefined,
+      ),
+    ).toBe(true);
+
+    act(() => {
+      for (const id of ["new.c", "new.d"]) {
+        result.current.openTab(view(id), { pinned: true });
+      }
+    });
+    expect(
+      result.current.tabs.filter((tab) => tab.pinned).map((tab) => tab.viewId),
+    ).toHaveLength(4);
+
+    // Fifth pin overflows the dock. Both legacy entries lack pinnedAt so both
+    // sort as oldest; the tie breaks by open order, so legacy.a pops first.
+    act(() => {
+      result.current.openTab(view("new.e"), { pinned: true });
+    });
+
+    expect(
+      result.current.tabs.filter((tab) => tab.pinned).map((tab) => tab.viewId),
+    ).toEqual(["legacy.b", "new.c", "new.d", "new.e"]);
+  });
+
+  it("derives /apps/<viewId> for registry entries without an explicit path", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      result.current.openTab(view("notes"));
+    });
+
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0]?.path).toBe("/apps/notes");
+  });
+
+  it("ignores closing an unknown tab and drops a closed pinned tab from persistence", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      result.current.openTab(view("local.notes"), { pinned: true });
+      result.current.openTab(view("remote.ledger"));
+    });
+
+    act(() => {
+      result.current.closeTab("does.not.exist");
+    });
+    expect(result.current.tabs.map((tab) => tab.viewId)).toEqual([
+      "local.notes",
+      "remote.ledger",
+    ]);
+
+    act(() => {
+      result.current.closeTab("local.notes");
+    });
+    expect(result.current.tabs.map((tab) => tab.viewId)).toEqual([
+      "remote.ledger",
+    ]);
+    expect(
+      JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]"),
+    ).toEqual([]);
+  });
+
+  it("ignores pinning a view that is not open", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      result.current.openTab(view("local.notes"));
+      result.current.pinTab("does.not.exist");
+    });
+
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0]?.pinned).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("[]");
+  });
+
+  it("re-pinning an already-pinned tab does not refresh its pin age", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      for (const id of ["a", "b", "c", "d"]) {
+        result.current.openTab(view(id));
+      }
+      for (const id of ["a", "b", "c", "d"]) {
+        result.current.pinTab(id);
+      }
+      // Duplicate pin: if it restamped, "a" would become the newest pin…
+      result.current.pinTab("a");
+    });
+    // …so filling the dock must still evict "a" as the oldest pin, not "b".
+    act(() => {
+      result.current.openTab(view("e"));
+      result.current.pinTab("e");
+    });
+
+    expect(
+      result.current.tabs.filter((tab) => tab.pinned).map((tab) => tab.viewId),
+    ).toEqual(["b", "c", "d", "e"]);
+  });
 });


### PR DESCRIPTION

## What

Extends the existing co-located suite for `useDesktopTabs`
(`packages/ui/src/hooks/useDesktopTabs.test.tsx`) with seven new cases reaching
branches the current suite does not cover:

- persisted-state recovery (`error-policy:J3`): corrupt JSON and non-array JSON
  under `elizaos.desktop.pinned-tabs` start an empty dock instead of wedging boot
- malformed persisted entries (nulls, non-objects, missing `viewId`/`label`/`path`)
  are filtered while the well-formed entry restores intact
- legacy entries without `pinnedAt` sort as the oldest pins with ties broken by
  open order (the documented migration contract), proven through a real dock
  overflow eviction rather than shape inspection
- default `/apps/<viewId>` path derivation when the registry entry carries no `path`
- closing an unknown tab is a no-op; closing a pinned tab removes it from persistence
- pinning a view that is not open is a no-op (state and persistence untouched)
- re-pinning an already-pinned tab must not refresh its pin age — discriminated by
  which tab the next overflow evicts, not by reading internals

Strictly additive: +172/-0. No existing case was modified or removed; the module
acquired its suite on develop after this target was planned, so this PR extends
rather than replaces it.

## Evidence

Test-only pull request — no production behavior changes.

- `bunx vitest run src/hooks/useDesktopTabs.test.tsx` in `packages/ui`, run against
  current `origin/develop` immediately before filing: **Test Files 1 passed (1);
  Tests 15 passed (15)** — 8 pre-existing cases plus the 7 added here.
- `bunx biome check --write src/hooks/useDesktopTabs.test.tsx`: clean,
  "Checked 1 file ... No fixes applied" after formatting settled.
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics referencing
  `useDesktopTabs`; the diff adds no type errors.
- The diff touches only `packages/ui/src/hooks/useDesktopTabs.test.tsx`.

Fork contributor: hosted CI does not run on this pull request; the counts above
were executed locally at the pushed head (`def97769e8`) against the shared
node_modules of this machine's checkout.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:def97769e8814970e2697a9e8d733c459eb50291 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
