### PR TITLE
test(ui): cover useDebouncedValue

### DIFF
--- a/packages/ui/src/hooks/useDebouncedValue.test.ts
+++ b/packages/ui/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,174 @@
+/** Verifies useDebouncedValue — timer hold, restart, and commit semantics through the package's configured test harness. */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDebouncedValue } from "./useDebouncedValue";
+
+type Props = { value: string; delayMs: number };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useDebouncedValue — initial render", () => {
+  it("surfaces the initial value immediately, before any delay elapses", () => {
+    const { result } = renderHook(() => useDebouncedValue("first", 100));
+
+    expect(result.current).toBe("first");
+  });
+});
+
+describe("useDebouncedValue — delayed commit", () => {
+  it("holds the previous value until the full delay has elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "first", delayMs: 100 } },
+    );
+
+    rerender({ value: "second", delayMs: 100 });
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+
+    expect(result.current).toBe("first");
+  });
+
+  it("commits the new value once delayMs has elapsed since the change", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "first", delayMs: 100 } },
+    );
+
+    rerender({ value: "second", delayMs: 100 });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe("second");
+  });
+
+  it("commits a zero-delay change on the next macrotask tick", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "first", delayMs: 0 } },
+    );
+
+    rerender({ value: "second", delayMs: 0 });
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(result.current).toBe("second");
+  });
+});
+
+describe("useDebouncedValue — rapid successive changes", () => {
+  it("restarts the timer on every change so only the latest value lands", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "a", delayMs: 50 } },
+    );
+
+    rerender({ value: "b", delayMs: 50 });
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+    rerender({ value: "c", delayMs: 50 });
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+    rerender({ value: "d", delayMs: 50 });
+
+    // "d" landed at t=40ms; its own window closes at t=90ms.
+    act(() => {
+      vi.advanceTimersByTime(49);
+    });
+    // Neither intermediate value ever surfaced.
+    expect(result.current).not.toBe("b");
+    expect(result.current).not.toBe("c");
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe("d");
+  });
+});
+
+describe("useDebouncedValue — delay changes mid-window", () => {
+  it("re-arms the pending timer when delayMs changes before the commit", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "first", delayMs: 100 } },
+    );
+
+    rerender({ value: "second", delayMs: 100 });
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+
+    // Extending the delay re-arms the effect: the commit now needs a fresh
+    // 200ms measured from this render, not the original 100ms from the value
+    // change.
+    rerender({ value: "second", delayMs: 200 });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe("first");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe("second");
+  });
+});
+
+describe("useDebouncedValue — unmount", () => {
+  it("cancels the pending commit without throwing when unmounted mid-window", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ value, delayMs }: Props) => useDebouncedValue(value, delayMs),
+      { initialProps: { value: "first", delayMs: 100 } },
+    );
+
+    rerender({ value: "second", delayMs: 100 });
+    unmount();
+
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+    }).not.toThrow();
+    // The cancelled commit never rendered.
+    expect(result.current).toBe("first");
+  });
+});
+
+describe("useDebouncedValue — generic values", () => {
+  it("passes object values through by reference in both directions", () => {
+    const first = { n: 1 };
+    const second = { n: 2 };
+
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }: { value: { n: number }; delayMs: number }) =>
+        useDebouncedValue(value, delayMs),
+      { initialProps: { value: first, delayMs: 10 } },
+    );
+
+    // Initial object is surfaced by identity, not cloned.
+    expect(result.current).toBe(first);
+
+    rerender({ value: second, delayMs: 10 });
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe(second);
+  });
+});


### PR DESCRIPTION

Adds a unit suite for `useDebouncedValue` (`packages/ui/src/hooks/useDebouncedValue.ts`), which previously had no same-named test file anywhere on develop.

## What is covered

The hook returns a value only after it has stayed unchanged for `delayMs`; it is consumed by `WorkflowEditor` so the React Flow viewer does not re-parse JSON on every keystroke. The suite drives the real hook through `@testing-library/react`'s `renderHook` with fake timers — no mocks of the module under test — and covers every branch:

- initial value surfaces immediately, before any delay elapses
- previous value holds through `delayMs − 1` after a change; new value commits exactly at the full delay
- `delayMs = 0` commits on the next macrotask tick
- rapid successive changes restart the timer each time, so intermediate values never surface and only the latest lands one delay after the last change
- changing `delayMs` mid-window re-arms the pending timer (the effect's dependency array includes it): the commit then needs a fresh delay measured from that render
- unmounting mid-window cancels the pending commit without throwing (the effect cleanup path)
- generic values pass through by reference in both directions

## Evidence (test-only change; production code untouched)

Recorded against current `origin/develop` (`de774b8757`) in the exact tree pushed here:

- `bunx vitest run src/hooks/useDebouncedValue.test.ts` → **Test Files 1 passed (1), Tests 8 passed (8)**
- `bunx biome check --write src/hooks/useDebouncedValue.test.ts` → clean ("Checked 1 file… No fixes applied")
- `bunx tsc --noEmit` in `packages/ui` → zero diagnostics referencing `useDebouncedValue.test`
- diff is a single new file, **+174/−0**; no existing test was modified or deleted

## Notes for reviewers

- This is a fork contribution, so hosted CI does not run on this pull request; the counts above are quoted from local runs at this exact head rather than implied from checks.
- No `expectTypeOf` / type-only assertions; all cases assert runtime behaviour through React rendering.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6555a31d89a91d00337778a6a9260663be67f1f4 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
