### PR TITLE
test(ui): cover useAuthStatus

### DIFF
--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -617,3 +617,309 @@ describe("isAuthenticatedNow + subscribeAuthStatus (non-hook seam, #16242)", () 
     expect(seen).not.toContain("unauthenticated");
   });
 });
+
+// Additive coverage: the option contracts, module seams, and failure mappings
+// outside startup priming — skip/observeOnly, the #11084 zero-traffic gate,
+// forced revalidation through the non-hook seam, unknown-failure-reason
+// mapping, the local-agent 503 retry budget, visibility-gated polling, and the
+// Steward cleared guard on non-shared targets. Same harness contract as above:
+// real modules under test; only global fetch (the network boundary) is stubbed.
+
+const { getAuthStatusSnapshot, revalidateAuthStatus, useIsAuthenticated } =
+  await import("./useAuthStatus");
+const { STEWARD_SESSION_CHANGE_EVENT } = await import(
+  "@elizaos/shared/steward-session-client"
+);
+
+function setDocumentVisibility(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+function restoreDocumentVisibility(): void {
+  delete (document as unknown as Record<string, unknown>).visibilityState;
+}
+
+describe("useAuthStatus option contracts, seams, and failure mapping", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    delete (window as Window & { __electrobunWindowId?: number })
+      .__electrobunWindowId;
+    localStorage.clear();
+    setStewardAuthedCookie(false);
+    setBootConfig({ branding: {} });
+    __resetAuthStatusForTests();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(async () => {
+    // Restore real timers before draining: the React 19 scheduler drain below
+    // relies on setImmediate, which vitest fake timers also virtualise.
+    vi.useRealTimers();
+    cleanup();
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    globalThis.fetch = realFetch;
+    restoreDocumentVisibility();
+    setStewardAuthedCookie(false);
+    delete (window as Window & { __electrobunWindowId?: number })
+      .__electrobunWindowId;
+    vi.restoreAllMocks();
+    __resetAuthStatusForTests();
+  });
+
+  it("skip mounts fail-closed on loading without probing; refetch forces the deferred probe", async () => {
+    const { result } = renderHook(() =>
+      useAuthStatus({ skip: true, pollIntervalMs: 0 }),
+    );
+    await act(async () => {});
+    expect(result.current.state.phase).toBe("loading");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    fetchMock.mockResolvedValue(jsonResponse(200, AUTH_ME_BODY));
+    await act(async () => {
+      await result.current.refetch();
+    });
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("observeOnly tracks external publishes without ever starting a probe", async () => {
+    const { result } = renderHook(() =>
+      useAuthStatus({ observeOnly: true, pollIntervalMs: 0 }),
+    );
+    await act(async () => {});
+    expect(result.current.state.phase).toBe("loading");
+
+    let restore: (() => void) | undefined;
+    act(() => {
+      restore = __setAuthStatusForTests({
+        phase: "authenticated",
+        identity: { id: "owner", displayName: "Owner", kind: "owner" },
+        session: { id: "s1", kind: "browser", expiresAt: null },
+        access: {
+          mode: "session",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+
+    act(() => {
+      restore?.();
+    });
+    expect(result.current.state.phase).toBe("loading");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("useIsAuthenticated gates on the shared snapshot with zero network traffic (#11084)", async () => {
+    const { result } = renderHook(() => useIsAuthenticated());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    let restore: (() => void) | undefined;
+    act(() => {
+      restore = __setAuthStatusForTests({
+        phase: "authenticated",
+        identity: { id: "owner", displayName: "Owner", kind: "owner" },
+        session: { id: "s1", kind: "browser", expiresAt: null },
+        access: {
+          mode: "session",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      });
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+
+    act(() => {
+      restore?.();
+    });
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("revalidateAuthStatus forces real sequential probes and publishes the shared snapshot", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, AUTH_ME_BODY));
+
+    await act(async () => {
+      await revalidateAuthStatus();
+    });
+    expect(getAuthStatusSnapshot()).toMatchObject({
+      phase: "authenticated",
+      identity: AUTH_ME_BODY.identity,
+      session: AUTH_ME_BODY.session,
+      access: AUTH_ME_BODY.access,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await revalidateAuthStatus();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps an unrecognized 401 reason to unauthenticated without a reason, preserving access", async () => {
+    const access = {
+      mode: "session",
+      passwordConfigured: false,
+      ownerConfigured: false,
+    };
+    fetchMock.mockResolvedValue(
+      jsonResponse(401, { reason: "totally_unknown", access }),
+    );
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("unauthenticated"),
+    );
+    expect(result.current.state).toEqual({
+      phase: "unauthenticated",
+      reason: undefined,
+      access,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces remote_password_not_configured so the gate can route to setup", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(401, {
+        reason: "remote_password_not_configured",
+        access: {
+          mode: "remote",
+          passwordConfigured: false,
+          ownerConfigured: false,
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "unauthenticated",
+        reason: "remote_password_not_configured",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays loading through the local-agent 503 boot budget, then publishes server_unavailable after exactly 11 probes", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(503, {}));
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // First probe in flight; the hook must remain fail-closed on loading
+    // while the retry budget is still running.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.state.phase).toBe("loading");
+
+    for (let round = 0; round < 12; round += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      if (result.current.state.phase === "server_unavailable") break;
+    }
+
+    expect(result.current.state.phase).toBe("server_unavailable");
+    // 1 initial probe + SERVER_UNAVAILABLE_RETRIES (10) retries.
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+  });
+
+  it("background polling fires only while the document is visible", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, {}));
+    vi.useFakeTimers();
+    setDocumentVisibility("visible");
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 50 }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    setDocumentVisibility("hidden");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    setDocumentVisibility("visible");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.current.state.phase).toBe("unauthenticated");
+  });
+
+  it("ignores a Steward cleared event on a self-hosted target instead of tearing down the session", async () => {
+    const apiBase = "https://vps.example/api/v1/eliza/agents/agent-1";
+    setBootConfig({ branding: {}, apiBase });
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "remote",
+        apiBase,
+        accessToken: "selfhost-token",
+      }),
+    );
+    fetchMock.mockResolvedValue(jsonResponse(200, AUTH_ME_BODY));
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(STEWARD_SESSION_CHANGE_EVENT, {
+          detail: { state: "cleared" },
+        }),
+      );
+    });
+    await act(async () => {});
+
+    expect(result.current.state.phase).toBe("authenticated");
+    expect(loadPersistedActiveServer()?.accessToken).toBe("selfhost-token");
+    expect(getBootConfig().apiBase).toBe(apiBase);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores storage events whose key is not the canonical Steward token", async () => {
+    const apiBase = "https://vps.example/api/v1/eliza/agents/agent-1";
+    setBootConfig({ branding: {}, apiBase });
+    fetchMock.mockResolvedValue(jsonResponse(200, AUTH_ME_BODY));
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "some_other_app_key" }),
+      );
+    });
+    await act(async () => {});
+
+    expect(result.current.state.phase).toBe("authenticated");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

## What

Adds 10 behavior-driven cases to the existing `packages/ui/src/hooks/useAuthStatus.prime.test.tsx` suite, covering the runtime surface of `useAuthStatus.ts` that sat outside startup priming. The diff is strictly additive to the existing suite (+306/−0); no existing case is modified or removed.

## Why

`useAuthStatus` is the shell's auth gate, but its covered surface was concentrated on Steward/cloud priming. These paths had no coverage:

- `skip` mounts fail-closed on `loading` without probing; `refetch()` forces the deferred probe exactly once.
- `observeOnly` subscribes to external publishes and never starts a probe or poll loop (zero network traffic).
- `useIsAuthenticated()` (#11084 gate) tracks the shared snapshot with zero fetches, verified through a set/restore cycle.
- `revalidateAuthStatus()` forces real sequential probes and publishes through `getAuthStatusSnapshot()` for module seams.
- A 401 whose body reason is unrecognized must publish `unauthenticated` with `reason: undefined` while preserving `access`.
- `remote_password_not_configured` is surfaced verbatim so the gate can route to password setup.
- The local-agent 503 boot-race budget keeps the hook fail-closed on `loading`, then publishes `server_unavailable` after exactly 11 probes (1 initial + 10 retries).
- Background polling fires only while the document is visible; hidden tabs are skipped by the interval callback.
- A Steward `cleared` event on a self-hosted (non-managed-cloud) target leaves session state and persisted binding untouched.
- Storage events whose key is not the canonical Steward token are ignored.

Same harness contract as the existing suite: real modules under test; only global fetch (the network boundary) is stubbed. No `expectTypeOf`; assertions observe published state transitions and probe counts at the module boundary.

## Evidence (test-only change; no production behavior touched)

- `bunx vitest run src/hooks/useAuthStatus.prime.test.tsx` (in `packages/ui`): **Test Files 1 passed (1), Tests 30 passed (30)** — 20 pre-existing + 10 new; re-run twice for stability, identical result.
- `bunx biome check --write src/hooks/useAuthStatus.prime.test.tsx`: clean ("No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: the touched file appears nowhere in output; remaining diagnostics are pre-existing workspace-resolution errors in files this PR does not touch (`../core/src/cloud-routing.ts` TS2307 ×2, `plugins/plugin-task-coordinator/src/TaskCardList.tsx` TS2307).
- Diff touches only `packages/ui/src/hooks/useAuthStatus.prime.test.tsx`: +306/−0 against `origin/develop` (`de774b87`).

Note: we are a fork contributor — hosted CI does not run on this PR; the counts above are quoted from local runs at the pushed head.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2e8cf9ebcab61e0485e3a64ae56a80ff968a5312 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
