### PR TITLE
test(ui): cover useAutomationDeepLink

### DIFF
--- a/packages/ui/src/hooks/useAutomationDeepLink.test.ts
+++ b/packages/ui/src/hooks/useAutomationDeepLink.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Verifies useAutomationDeepLink — the automations feed's hash router.
+ * Covers the parse/format pair's branch behaviour and the hook's real
+ * location-hash sync: mount-time read, setLink writes, hashchange-driven
+ * back/forward navigation, and listener teardown on unmount.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  formatAutomationHash,
+  parseAutomationHash,
+  useAutomationDeepLink,
+} from "./useAutomationDeepLink";
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "http://localhost/");
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, "", "http://localhost/");
+});
+
+describe("parseAutomationHash", () => {
+  it("maps non-matching hashes to the list view", () => {
+    expect(parseAutomationHash("")).toEqual({ kind: "list" });
+    expect(parseAutomationHash("#settings")).toEqual({ kind: "list" });
+    // Shorter than the prefix: startsWith must not match a partial name.
+    expect(parseAutomationHash("#automation")).toEqual({ kind: "list" });
+  });
+
+  it("maps the bare feed hash to the list view", () => {
+    expect(parseAutomationHash("#automations")).toEqual({ kind: "list" });
+  });
+
+  it("maps the trailing-slash-only hash to the list view", () => {
+    expect(parseAutomationHash("#automations/")).toEqual({ kind: "list" });
+  });
+
+  it("rejects an empty task id", () => {
+    expect(parseAutomationHash("#automations/task/")).toEqual({
+      kind: "list",
+    });
+  });
+
+  it("parses a workflow deep link", () => {
+    expect(parseAutomationHash("#automations/wf-123")).toEqual({
+      kind: "workflow",
+      id: "wf-123",
+    });
+  });
+
+  it("parses a task deep link", () => {
+    expect(parseAutomationHash("#automations/task/t-9")).toEqual({
+      kind: "task",
+      id: "t-9",
+    });
+  });
+
+  it("keeps slashes inside ids so composite ids survive parsing", () => {
+    expect(parseAutomationHash("#automations/a/b/c")).toEqual({
+      kind: "workflow",
+      id: "a/b/c",
+    });
+    expect(parseAutomationHash("#automations/task/a/b")).toEqual({
+      kind: "task",
+      id: "a/b",
+    });
+  });
+});
+
+describe("formatAutomationHash", () => {
+  it("formats each link kind to its canonical hash", () => {
+    expect(formatAutomationHash({ kind: "list" })).toBe("#automations");
+    expect(formatAutomationHash({ kind: "workflow", id: "wf-1" })).toBe(
+      "#automations/wf-1",
+    );
+    expect(formatAutomationHash({ kind: "task", id: "t-1" })).toBe(
+      "#automations/task/t-1",
+    );
+  });
+
+  it("round-trips every link kind losslessly through parse", () => {
+    const links = [
+      { kind: "list" },
+      { kind: "workflow", id: "wf 42" },
+      { kind: "task", id: "task/../id" },
+    ] as const;
+    for (const link of links) {
+      expect(parseAutomationHash(formatAutomationHash(link))).toEqual(link);
+    }
+  });
+});
+
+describe("useAutomationDeepLink", () => {
+  it("starts on the list view when no hash is present", () => {
+    const { result } = renderHook(() => useAutomationDeepLink());
+
+    expect(result.current.link).toEqual({ kind: "list" });
+  });
+
+  it("reads the deep link present at mount time", () => {
+    window.location.hash = "#automations/task/mounted-task";
+
+    const { result } = renderHook(() => useAutomationDeepLink());
+
+    expect(result.current.link).toEqual({ kind: "task", id: "mounted-task" });
+  });
+
+  it("setLink updates state and mirrors the canonical hash into the URL", async () => {
+    const { result } = renderHook(() => useAutomationDeepLink());
+
+    act(() => {
+      result.current.setLink({ kind: "workflow", id: "wf-open" });
+    });
+
+    expect(result.current.link).toEqual({ kind: "workflow", id: "wf-open" });
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#automations/wf-open");
+    });
+  });
+
+  it("returning to the list rewrites the hash back to the feed root", async () => {
+    window.location.hash = "#automations/task/t-1";
+    const { result } = renderHook(() => useAutomationDeepLink());
+
+    act(() => {
+      result.current.setLink({ kind: "list" });
+    });
+
+    expect(result.current.link).toEqual({ kind: "list" });
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#automations");
+    });
+  });
+
+  it("follows browser back/forward navigation via hashchange", async () => {
+    const { result } = renderHook(() => useAutomationDeepLink());
+    expect(result.current.link).toEqual({ kind: "list" });
+
+    act(() => {
+      window.location.hash = "#automations/task/nav-task";
+    });
+    await waitFor(() => {
+      expect(result.current.link).toEqual({ kind: "task", id: "nav-task" });
+    });
+
+    act(() => {
+      window.location.hash = "#automations/back-wf";
+    });
+    await waitFor(() => {
+      expect(result.current.link).toEqual({
+        kind: "workflow",
+        id: "back-wf",
+      });
+    });
+  });
+
+  it("stops following hash changes after unmount", async () => {
+    const { result, unmount } = renderHook(() => useAutomationDeepLink());
+    act(() => {
+      result.current.setLink({ kind: "workflow", id: "wf-live" });
+    });
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#automations/wf-live");
+    });
+
+    unmount();
+    // Fire the exact DOM event browsers emit on back/forward so this holds
+    // regardless of whether jsdom auto-fires one for the assignment itself.
+    act(() => {
+      window.location.hash = "#automations/task/after-unmount";
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.current.link).toEqual({ kind: "workflow", id: "wf-live" });
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/hooks/useAutomationDeepLink.test.ts` — unit coverage for the automations feed hash router (`parseAutomationHash`, `formatAutomationHash`, and the `useAutomationDeepLink` hook), which had no same-named suite anywhere on develop.

## Coverage

- `parseAutomationHash`: non-matching hashes fall back to list, bare and trailing-slash-only feed hashes, empty task id rejection, workflow and task deep links, slash-preserving ids.
- `formatAutomationHash`: canonical hash per link kind, plus lossless parse-after-format round-trips for every kind.
- `useAutomationDeepLink` (jsdom): mount-time hash read, `setLink` updating both hook state and `window.location.hash`, return-to-list rewrite back to the feed root, real `hashchange`-driven updates simulating browser back/forward navigation, and listener teardown after unmount.

All cases drive the real module against real jsdom browser state — no mocks stand in for the system under test.

## Evidence

Test-only change; no production behaviour is modified.

- `bunx vitest run src/hooks/useAutomationDeepLink.test.ts` (packages/ui, vitest 4.1.10): **1 file passed, 15 tests passed / 15 total** — re-run against current `develop` (`de774b8757`) immediately before filing.
- `bunx biome check --write src/hooks/useAutomationDeepLink.test.ts`: clean ("Checked 1 file in 55ms. No fixes applied.").
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: grep for the new file returns nothing — zero new type errors introduced.
- Diff: one NEW test file, +181/−0.

## CI note

This PR comes from a fork contributor, so hosted CI does not run on it. The counts above are from local runs against current `develop`, not a hosted CI pass.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d32d60c8b0c8ba919151ec3ba3c129a18ad24ae0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
