### PR TITLE
fix(shared): require boundary delimiter for question-tag matching in scoreEndOfTurnHeuristic

### DIFF
--- a/packages/shared/src/voice-eot.test.ts
+++ b/packages/shared/src/voice-eot.test.ts
@@ -27,6 +27,12 @@ describe("scoreEndOfTurnHeuristic — canonical heuristic", () => {
     expect(score("that makes sense correct")).toBe(0.85);
   });
 
+  it("does not misclassify words ending in question-tag substrings as question tags", () => {
+    expect(score("the sun is bright")).toBe(0.5);
+    expect(score("this statement is incorrect")).toBe(0.5);
+    expect(score("register a copyright")).toBe(0.5);
+  });
+
   it("rule 4: trailing conjunction → mid-clause (0.15)", () => {
     expect(score("buy milk and")).toBe(0.15);
     expect(score("i can't do that because")).toBe(0.15);

--- a/packages/shared/src/voice-eot.ts
+++ b/packages/shared/src/voice-eot.ts
@@ -179,7 +179,15 @@ export function scoreEndOfTurnHeuristic(transcript: string): number {
 
   const lower = text.toLowerCase();
   for (const tag of QUESTION_TAGS) {
-    if (lower.endsWith(tag)) return 0.85;
+    if (lower.endsWith(tag)) {
+      const prefixLength = lower.length - tag.length;
+      if (
+        prefixLength === 0 ||
+        /[\s,;:-]/.test(lower[prefixLength - 1] ?? "")
+      ) {
+        return 0.85;
+      }
+    }
   }
 
   const words = lower


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This modifies `scoreEndOfTurnHeuristic` in `@elizaos/shared` so question tags require a preceding token/boundary delimiter (such as whitespace or punctuation), preventing words like "bright" or "copyright" or "incorrect" from falsely matching the "right" or "correct" question tags.

# Background

## What does this PR do?

Ensures that question tags in `scoreEndOfTurnHeuristic` are only matched when they occur at a word/token boundary, rather than as accidental substrings of other words (e.g. "bright", "copyright", "incorrect").

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/voice-eot.ts` and `packages/shared/src/voice-eot.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice-eot.test.ts`.

# Evidence Gate

<!-- evidence-head:6e0cf985aa84cdf846fe0d62ab918b5831a17636 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual pure shared voice utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual pure shared voice utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual pure shared voice utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit test coverage`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - pure utility function with unit test coverage`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit test coverage`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/shared/src/voice-eot.test.ts:
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 1: trailing ellipsis → trail-off (0.2)
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 2: sentence-final punctuation → complete (0.95) [0.18ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 3: question-tag suffix → complete (0.85), bare and punctuated [0.04ms]
26 |     expect(score("it is ready yeah")).toBe(0.85);
27 |     expect(score("that makes sense correct")).toBe(0.85);
28 |   });
29 | 
30 |   it("does not misclassify words ending in question-tag substrings as question tags", () => {
31 |     expect(score("the sun is bright")).toBe(0.5);
                                            ^
error: expect(received).toBe(expected)

Expected: 0.5
Received: 0.85

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-voice-eot-tag-boundary/packages/shared/src/voice-eot.test.ts:31:40)
(fail) scoreEndOfTurnHeuristic — canonical heuristic > does not misclassify words ending in question-tag substrings as question tags [0.09ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 4: trailing conjunction → mid-clause (0.15) [0.27ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 6: trailing preposition/article → incomplete NP (0.2) [0.07ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 5: trailing filler or hedge → tail-off hold (0.2) [0.02ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 7: dangling modal/auxiliary → incomplete clause (0.2) [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 8: short utterance with no trail-off → complete (0.7) [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 9: no signal → neutral (0.5) [0.01ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > conjunction/preposition checks precede the short-utterance rule (ordering fix) [0.01ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > sentence-final punctuation still commits within budget [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > empty / whitespace → neutral (0.5)
(pass) scoreEndOfTurnHeuristic — canonical heuristic > never throws and stays in [0,1] for adversarial input [0.12ms]

 13 pass
 1 fail
 63 expect() calls
Ran 14 tests across 1 file. [91.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/shared/src/voice-eot.test.ts:
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 1: trailing ellipsis → trail-off (0.2) [0.12ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 2: sentence-final punctuation → complete (0.95) [0.04ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 3: question-tag suffix → complete (0.85), bare and punctuated
(pass) scoreEndOfTurnHeuristic — canonical heuristic > does not misclassify words ending in question-tag substrings as question tags [0.32ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 4: trailing conjunction → mid-clause (0.15) [0.04ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 6: trailing preposition/article → incomplete NP (0.2) [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 5: trailing filler or hedge → tail-off hold (0.2) [0.02ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 7: dangling modal/auxiliary → incomplete clause (0.2) [0.04ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 8: short utterance with no trail-off → complete (0.7) [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > rule 9: no signal → neutral (0.5) [0.02ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > conjunction/preposition checks precede the short-utterance rule (ordering fix) [0.03ms]
(pass) scoreEndOfTurnHeuristic — canonical heuristic > sentence-final punctuation still commits within budget
(pass) scoreEndOfTurnHeuristic — canonical heuristic > empty / whitespace → neutral (0.5)
(pass) scoreEndOfTurnHeuristic — canonical heuristic > never throws and stays in [0,1] for adversarial input [0.11ms]

 14 pass
 0 fail
 65 expect() calls
Ran 14 tests across 1 file. [191.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual pure shared voice utility change.

## Audio / voice walkthrough

N/A - non-voice-generation heuristic parser change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
