### PR TITLE
fix(agent): safe tie-breaking and missing id handling in conversation recency comparator

### DIFF
--- a/packages/agent/src/api/conversation-sort.test.ts
+++ b/packages/agent/src/api/conversation-sort.test.ts
@@ -55,6 +55,23 @@ describe("compareConversationsByRecency", () => {
       ),
     ).toBeLessThan(0);
   });
+
+  it("tolerates missing or undefined id in recency tie-breaking without throwing", () => {
+    const convos = [
+      { id: "c-2", updatedAt: "2026-08-23T10:00:00Z" },
+      { id: undefined as unknown as string, updatedAt: "2026-08-23T10:00:00Z" },
+    ];
+    expect(() => convos.sort(compareConversationsByRecency)).not.toThrow();
+    expect(
+      compareConversationsByRecency(
+        {
+          id: undefined as unknown as string,
+          updatedAt: "2026-08-23T10:00:00Z",
+        },
+        { id: "c-1", updatedAt: "2026-08-23T10:00:00Z" },
+      ),
+    ).toBeLessThan(0);
+  });
 });
 
 describe("compareMemoriesByCreatedAt", () => {

--- a/packages/agent/src/api/conversation-sort.ts
+++ b/packages/agent/src/api/conversation-sort.ts
@@ -36,7 +36,10 @@ export function compareConversationsByRecency(
 ): number {
   const bVal = finiteOrZero(new Date(b.updatedAt).getTime());
   const aVal = finiteOrZero(new Date(a.updatedAt).getTime());
-  return bVal - aVal || a.id.localeCompare(b.id);
+  return (
+    bVal - aVal ||
+    (a.id ? String(a.id) : "").localeCompare(b.id ? String(b.id) : "")
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Ensures `compareConversationsByRecency` safely coerces missing/undefined conversation IDs before calling `localeCompare`, preventing unexpected `TypeError: Cannot read properties of undefined (reading 'localeCompare')` when sorting untrusted or partial conversation summaries.

# Background

## What does this PR do?

Hardens `compareConversationsByRecency` to safely handle missing or non-string conversation `id` during recency tie-breaking (mirroring `compareMemoriesByCreatedAt`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/agent/src/api/conversation-sort.ts` and `packages/agent/src/api/conversation-sort.test.ts`.

## Detailed testing steps

Run `bun test packages/agent/src/api/conversation-sort.test.ts`.

# Evidence Gate

<!-- evidence-head:8aaa8ade91c1ca9e1a9c89bd8b1accfffe2259a4 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend sort comparator change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend sort comparator change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend sort comparator change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit-tested comparator function`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - backend sort comparator change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - unit-tested comparator function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/agent/src/api/conversation-sort.test.ts:
(pass) compareConversationsByRecency > orders newest updatedAt first [0.13ms]
(pass) compareConversationsByRecency > keeps a total order when an updatedAt is unparseable [0.05ms]
(pass) compareConversationsByRecency > tie-breaks two equally stale conversations on id [0.21ms]
59 |   it("tolerates missing or undefined id in recency tie-breaking without throwing", () => {
60 |     const convos = [
61 |       { id: "c-2", updatedAt: "2026-08-23T10:00:00Z" },
62 |       { id: undefined as unknown as string, updatedAt: "2026-08-23T10:00:00Z" },
63 |     ];
64 |     expect(() => convos.sort(compareConversationsByRecency)).not.toThrow();
                                                                      ^
error: expect(received).not.toThrow()

Error name: "TypeError"
Error message: "undefined is not an object (evaluating 'a.id.localeCompare')"

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-agent-conversation-sort-id/packages/agent/src/api/conversation-sort.test.ts:64:66)
(fail) compareConversationsByRecency > tolerates missing or undefined id in recency tie-breaking without throwing [0.24ms]
(pass) compareMemoriesByCreatedAt > orders oldest createdAt first [0.03ms]
(pass) compareMemoriesByCreatedAt > treats a NaN or missing createdAt as epoch 0 instead of returning NaN [0.02ms]
(pass) compareMemoriesByCreatedAt > tie-breaks equal timestamps on id and tolerates a missing id

 6 pass
 1 fail
 13 expect() calls
Ran 7 tests across 1 file. [288.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/agent/src/api/conversation-sort.test.ts:
(pass) compareConversationsByRecency > orders newest updatedAt first [0.22ms]
(pass) compareConversationsByRecency > keeps a total order when an updatedAt is unparseable [0.10ms]
(pass) compareConversationsByRecency > tie-breaks two equally stale conversations on id [0.25ms]
(pass) compareConversationsByRecency > tolerates missing or undefined id in recency tie-breaking without throwing [0.23ms]
(pass) compareMemoriesByCreatedAt > orders oldest createdAt first
(pass) compareMemoriesByCreatedAt > treats a NaN or missing createdAt as epoch 0 instead of returning NaN [0.16ms]
(pass) compareMemoriesByCreatedAt > tie-breaks equal timestamps on id and tolerates a missing id

 7 pass
 0 fail
 14 expect() calls
Ran 7 tests across 1 file. [430.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - backend sort comparator change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
