### PR TITLE
fix(core): reject prototype pollution and sparse-array abuse in TOON parser

### DIFF
--- a/packages/core/src/utils.parsing.test.ts
+++ b/packages/core/src/utils.parsing.test.ts
@@ -78,6 +78,42 @@ describe("parseToonKeyValue", () => {
 			parseToonKeyValue(`name${spacing}:${spacing}eliza\nitems[2]: ready`),
 		).toEqual({ name: "eliza", items: [undefined, undefined, "ready"] });
 	});
+
+	it("rejects prototype-pollution keys and does not mutate the result prototype", () => {
+		const proto = parseToonKeyValue("```__proto__: polluted```") as Record<
+			string,
+			unknown
+		> | null;
+		expect(proto).toBeNull();
+		const ctor = parseToonKeyValue("```constructor: evil```");
+		expect(ctor).toBeNull();
+		const protoPolluted = parseToonKeyValue(
+			'```__proto__: {"polluted": true}```',
+		) as Record<string, unknown> | null;
+		expect(protoPolluted).toBeNull();
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+
+		const mixed = parseToonKeyValue(
+			"```name: ok\n__proto__: bad\nconstructor: bad2\nvalid: yes```",
+		) as Record<string, unknown> | null;
+		expect(mixed).toEqual({ name: "ok", valid: "yes" });
+	});
+
+	it("rejects out-of-range array indices to prevent sparse-array abuse", () => {
+		const huge = parseToonKeyValue("```items[99999]: boom```") as Record<
+			string,
+			unknown
+		> | null;
+		expect(huge).toBeNull();
+		const negative = parseToonKeyValue("```items[-1]: bad```");
+		expect(negative).toBeNull();
+		const valid = parseToonKeyValue("```items[2]: ok```") as Record<
+			string,
+			unknown
+		> | null;
+		expect(valid).toEqual({ items: [undefined, undefined, "ok"] });
+	});
 });
 
 describe("parseBooleanFromText", () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -669,6 +669,8 @@ function parseToonKey(
 		arrayIndex = candidateIndex;
 	}
 	if (!/^[A-Za-z_][\w.-]*$/.test(key)) return null;
+	if (key === "__proto__" || key === "constructor" || key === "prototype")
+		return null;
 	return arrayIndex === undefined ? { key } : { key, arrayIndex };
 }
 
@@ -696,8 +698,18 @@ export function parseToonKeyValue<T = Record<string, unknown>>(
 		const parsedKey = parseToonKey(line.slice(0, colonIndex));
 		if (!parsedKey) continue;
 
-		found = true;
 		const { key, arrayIndex } = parsedKey;
+		let parsedIndex: number | undefined;
+		if (arrayIndex !== undefined) {
+			parsedIndex = Number.parseInt(arrayIndex, 10);
+			if (
+				!Number.isSafeInteger(parsedIndex) ||
+				parsedIndex < 0 ||
+				parsedIndex > 10000
+			)
+				continue;
+		}
+		found = true;
 		const rawValue = line.slice(colonIndex + 1).trimStart();
 		const value = parseToonScalar(rawValue.trim());
 		if (arrayIndex === undefined) {
@@ -705,10 +717,9 @@ export function parseToonKeyValue<T = Record<string, unknown>>(
 			continue;
 		}
 
-		const index = Number.parseInt(arrayIndex, 10);
 		const current = result[key];
 		const values = Array.isArray(current) ? current : [];
-		values[index] = value;
+		values[parsedIndex as number] = value;
 		result[key] = values;
 	}
 


### PR DESCRIPTION
# Relates to

N/A - harden TOON parser against prototype pollution and sparse-array DoS

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Additive validation only: blocks `__proto__`/`constructor`/`prototype` keys and out-of-range array indices (>10000). Valid TOON inputs unchanged; existing tests still pass. Single module `packages/core/src/utils.ts`.

# Background

## What does this PR do?

Fixes `parseToonKeyValue` in `packages/core/src/utils.ts`:
- Rejects `__proto__`, `constructor`, `prototype` keys at `parseToonKey` level to prevent prototype pollution via model-controlled TOON output. Previously `result["__proto__"] = value` mutated the result object's prototype, making `result.polluted` truthy via prototype chain.
- Bounds array indices to `0..10000` and requires `Number.isSafeInteger` to prevent sparse-array abuse (e.g. `items[99999]: x` creating 100k-length sparse arrays).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils.ts:657` (`parseToonKey`) and `packages/core/src/utils.parsing.test.ts`

## Detailed testing steps

```bash
bun --cwd packages/core test src/utils.parsing.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:890841d5a9ae2dca4def846d5a4987a253d0ca75 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - pure unit logic, no server path`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit parsing logic, no domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model change.

## Backend + frontend logs

N/A - pure unit logic, no server path. Verified via `bun test` output below.

**Red (production reverted, new tests fail):**
```
2 fail
(fail) parseToonKeyValue > rejects prototype-pollution keys ... [0.23ms]
  error: expect(received).toBeNull() Received: {}
(fail) parseToonKeyValue > rejects out-of-range array indices ... [0.69ms]
  error: expect(received).toBeNull() Received: { items: [ 99999 x empty items, "boom" ] }
Ran 17 tests across 1 file.
```

**Green (fix restored, all pass):**
```
17 pass
0 fail
57 expect() calls
Ran 17 tests across 1 file. [247.00ms]
```

**Existing suite:**
```
bun --cwd packages/core test src/utils.parsing.test.ts  # 17 pass
```

**Typecheck:**
```
bun run --cwd packages/core typecheck  # pass (no errors)
```

**Biome:**
```
bunx biome check packages/core/src/utils.ts  # no errors
bunx biome check --write packages/core/src/utils.parsing.test.ts  # fixed 1 file
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
