### PR TITLE
fix(cloud): count in-range exclusions and validate bounds in allocatePort

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -611,6 +611,18 @@ describe("port + metadata helpers", () => {
     expect(() => allocatePort(5000, 5002, full)).toThrow(/No available ports/);
   });
 
+  test("allocatePort ignores excluded ports outside the target range", () => {
+    const excludedOutside = new Set([1000, 1001, 1002, 1003, 1004]);
+    const port = allocatePort(5000, 5003, excludedOutside);
+    expect(port).toBeGreaterThanOrEqual(5000);
+    expect(port).toBeLessThan(5003);
+  });
+
+  test("allocatePort rejects invalid ranges where max <= min", () => {
+    expect(() => allocatePort(5000, 5000, new Set())).toThrow(/Invalid port range/);
+    expect(() => allocatePort(5005, 5000, new Set())).toThrow(/Invalid port range/);
+  });
+
   test("readDockerHostPortFromMetadata returns positive ints only", () => {
     expect(readDockerHostPortFromMetadata({ hostPort: 8080 })).toBe(8080);
     expect(readDockerHostPortFromMetadata({ hostPort: -1 })).toBeNull();

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -673,8 +673,17 @@ export function extractDockerCreateContainerId(output: string): string {
  * should retry the entire provisioning flow.
  */
 export function allocatePort(min: number, max: number, excluded: Set<number>): number {
+  if (max <= min) {
+    throw new Error(`[docker-sandbox] Invalid port range [${min}, ${max}).`);
+  }
   const range = max - min;
-  if (excluded.size >= range) {
+  let excludedInRange = 0;
+  for (const port of excluded) {
+    if (port >= min && port < max) {
+      excludedInRange++;
+    }
+  }
+  if (excludedInRange >= range) {
     throw new Error(
       `[docker-sandbox] No available ports in range [${min}, ${max}). All ${range} ports are allocated.`,
     );


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `allocatePort` (`packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts`), exhaustion detection now counts only excluded ports that actually fall within `[min, max)`, preventing false allocation failures when caller exclusion sets contain out-of-range ports. Also rejects invalid ranges where `max <= min`.

# Background

## What does this PR do?

1. Counts only in-range ports when checking whether `[min, max)` is exhausted in `allocatePort`.
2. Validates that `max > min` and throws an explicit `[docker-sandbox] Invalid port range [min, max).` error otherwise.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts` and `packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts`.

## Detailed testing steps

Run `bun test packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts -t "allocatePort"`.

# Evidence Gate

<!-- evidence-head:af22cbf459d7a82cf784456ee4e510a04f4e2337 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend cloud utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend cloud utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend cloud utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - backend cloud utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
(fail) port + metadata helpers > allocatePort ignores excluded ports outside the target range [0.23ms]
617 |     expect(port).toBeGreaterThanOrEqual(5000);
618 |     expect(port).toBeLessThan(5003);
619 |   });
620 | 
621 |   test("allocatePort rejects invalid ranges where max <= min", () => {
622 |     expect(() => allocatePort(5000, 5000, new Set())).toThrow(/Invalid port range/);
                                                            ^
error: expect(received).toThrow(expected)

Expected pattern: /Invalid port range/

(fail) port + metadata helpers > allocatePort rejects invalid ranges where max <= min [0.09ms]
```

### Green Output (passing after fix)
```
(pass) port + metadata helpers > allocatePort stays in range and avoids the exclusion set [0.15ms]
(pass) port + metadata helpers > allocatePort ignores excluded ports outside the target range [0.02ms]
(pass) port + metadata helpers > allocatePort rejects invalid ranges where max <= min [0.02ms]
(pass) port + metadata helpers > readDockerHostPortFromMetadata returns positive ints only [0.04ms]
```

## Screenshots (before / after) + video walkthrough

N/A - backend cloud utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
