### PR TITLE
fix(cloud): validate app ID and port bounds in app-network-utils

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts
@@ -19,6 +19,11 @@ describe("appNetworkName", () => {
     // never the shared agent network
     expect(n).not.toBe("containers-isolated");
   });
+
+  test("throws on empty or non-alphanumeric app ID", () => {
+    expect(() => appNetworkName("")).toThrow(/Invalid app ID/);
+    expect(() => appNetworkName("---")).toThrow(/Invalid app ID/);
+  });
 });
 
 describe("buildEnsureAppNetworkCmd — isolation is real (--internal)", () => {
@@ -63,6 +68,21 @@ describe("buildLoopbackPortPublishFlag", () => {
   test("binds published ports to host loopback only", () => {
     expect(buildLoopbackPortPublishFlag(49001, 3000)).toBe("-p 127.0.0.1:49001:3000");
     expect(buildLoopbackPortPublishFlag(49002, "8080")).toBe("-p 127.0.0.1:49002:8080");
+  });
+
+  test("rejects invalid host ports", () => {
+    expect(() => buildLoopbackPortPublishFlag(0, 3000)).toThrow(/Invalid host port/);
+    expect(() => buildLoopbackPortPublishFlag(-1, 3000)).toThrow(/Invalid host port/);
+    expect(() => buildLoopbackPortPublishFlag(70000, 3000)).toThrow(/Invalid host port/);
+    expect(() => buildLoopbackPortPublishFlag(Number.NaN, 3000)).toThrow(/Invalid host port/);
+  });
+
+  test("rejects invalid or injection-like container ports", () => {
+    expect(() => buildLoopbackPortPublishFlag(8080, "3000; rm -rf /")).toThrow(
+      /Invalid container port/,
+    );
+    expect(() => buildLoopbackPortPublishFlag(8080, 0)).toThrow(/Invalid container port/);
+    expect(() => buildLoopbackPortPublishFlag(8080, 70000)).toThrow(/Invalid container port/);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/app-network-utils.ts
+++ b/packages/cloud/shared/src/lib/services/app-network-utils.ts
@@ -28,6 +28,9 @@ export function appNetworkName(appId: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "")
     .slice(0, 24);
+  if (!short) {
+    throw new Error("Invalid app ID: must contain alphanumeric characters.");
+  }
   return `app-net-${short}`;
 }
 
@@ -59,7 +62,18 @@ export function buildLoopbackPortPublishFlag(
   hostPort: number,
   containerPort: number | string,
 ): string {
-  return `-p 127.0.0.1:${hostPort}:${containerPort}`;
+  if (!Number.isInteger(hostPort) || hostPort < 1 || hostPort > 65535) {
+    throw new Error(`Invalid host port: ${hostPort}`);
+  }
+  const portStr = String(containerPort).trim();
+  if (!/^[0-9]+(?:\/(?:tcp|udp))?$/.test(portStr)) {
+    throw new Error(`Invalid container port: ${containerPort}`);
+  }
+  const numericPort = Number.parseInt(portStr, 10);
+  if (numericPort < 1 || numericPort > 65535) {
+    throw new Error(`Invalid container port: ${containerPort}`);
+  }
+  return `-p 127.0.0.1:${hostPort}:${portStr}`;
 }
 
 /**


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds input validation to `appNetworkName` and `buildLoopbackPortPublishFlag` to ensure that empty/non-alphanumeric app IDs throw cleanly and port numbers are validated within the valid TCP/UDP 1-65535 range.

# Background

## What does this PR do?

1. Validates that `appId` in `appNetworkName` produces a non-empty alphanumeric suffix, preventing malformed network names like `app-net-`.
2. Validates that `hostPort` and `containerPort` in `buildLoopbackPortPublishFlag` are integers within 1-65535 and reject invalid or injection-like values.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/cloud/shared/src/lib/services/app-network-utils.ts` and `packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts`.

## Detailed testing steps

Run `bun test packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts`.

# Evidence Gate

<!-- evidence-head:e16b7a6233180f67242d4c75655afa0c45f9a598 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend cloud network utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend cloud network utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend cloud network utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility functions covered by unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - backend cloud network utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility functions covered by unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
(fail) appNetworkName > throws on empty or non-alphanumeric app ID [0.15ms]
(fail) buildLoopbackPortPublishFlag > rejects invalid host ports [0.04ms]
(fail) buildLoopbackPortPublishFlag > rejects invalid or injection-like container ports [0.04ms]
```

### Green Output (passing after fix)
```
(pass) appNetworkName > derives a stable per-app network name
(pass) appNetworkName > throws on empty or non-alphanumeric app ID [0.07ms]
(pass) buildEnsureAppNetworkCmd — isolation is real (--internal) > creates an --internal bridge (the load-bearing flag) [0.02ms]
(pass) buildEnsureAppNetworkCmd — isolation is real (--internal) > never references the shared agent network name
(pass) buildAppContainerSecurityFlags — untrusted-image hardening > drops all caps, forbids privilege escalation, bounds pids
(pass) buildAppContainerSecurityFlags — untrusted-image hardening > NEVER grants the agent-only network escapes
(pass) buildAppContainerSecurityFlags — untrusted-image hardening > honors a custom pids limit
(pass) buildLoopbackPortPublishFlag > binds published ports to host loopback only [0.08ms]
(pass) buildLoopbackPortPublishFlag > rejects invalid host ports [0.03ms]
(pass) buildLoopbackPortPublishFlag > rejects invalid or injection-like container ports
(pass) buildAppEgressEnv > routes all HTTP(S) egress through the proxy, bypassing localhost
(pass) buildSquidAllowlistConf — default deny > allows only listed hosts and denies everything else
(pass) buildSquidAllowlistConf — default deny > an empty allowlist denies everything (no allow line)
(pass) buildSquidAllowlistConf — default deny > ignores malformed/injection-y host entries
```

## Screenshots (before / after) + video walkthrough

N/A - backend cloud network utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
