### PR TITLE
fix(core): support enabled and disabled variants in parseBooleanText

### DIFF
--- a/packages/core/src/utils/boolean.test.ts
+++ b/packages/core/src/utils/boolean.test.ts
@@ -76,4 +76,11 @@ describe("parseBooleanText", () => {
 		expect(parseBooleanText(null)).toBe(false);
 		expect(parseBooleanText(undefined)).toBe(false);
 	});
+
+	it("parses enabled and disabled text variants", () => {
+		expect(parseBooleanText("enabled")).toBe(true);
+		expect(parseBooleanText("ENABLED")).toBe(true);
+		expect(parseBooleanText("disabled")).toBe(false);
+		expect(parseBooleanText("DISABLED")).toBe(false);
+	});
 });

--- a/packages/core/src/utils/boolean.ts
+++ b/packages/core/src/utils/boolean.ts
@@ -14,8 +14,26 @@ const DEFAULT_TRUTHY = ["true", "1", "yes", "on"] as const;
 const DEFAULT_FALSY = ["false", "0", "no", "off"] as const;
 const DEFAULT_TRUTHY_SET = new Set<string>(DEFAULT_TRUTHY);
 const DEFAULT_FALSY_SET = new Set<string>(DEFAULT_FALSY);
-const TEXT_TRUTHY = ["yes", "y", "true", "t", "1", "on", "enable"] as const;
-const TEXT_FALSY = ["no", "n", "false", "f", "0", "off", "disable"] as const;
+const TEXT_TRUTHY = [
+	"yes",
+	"y",
+	"true",
+	"t",
+	"1",
+	"on",
+	"enable",
+	"enabled",
+] as const;
+const TEXT_FALSY = [
+	"no",
+	"n",
+	"false",
+	"f",
+	"0",
+	"off",
+	"disable",
+	"disabled",
+] as const;
 
 /**
  * Parse a value as a boolean.


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Extends `TEXT_TRUTHY` and `TEXT_FALSY` in `packages/core/src/utils/boolean.ts` to recognize common "enabled" and "disabled" user/config text variants (e.g. from environment settings or prompt configs).

# Background

## What does this PR do?

Adds `"enabled"` to `TEXT_TRUTHY` and `"disabled"` to `TEXT_FALSY` so `parseBooleanText("enabled")` returns `true` and `parseBooleanText("disabled")` returns `false` (matching existing "enable" and "disable").

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/boolean.ts` and `packages/core/src/utils/boolean.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/boolean.test.ts`.

# Evidence Gate

<!-- evidence-head:1f0f595da0d9cbffc5fa37b1ff8e953e125dc522 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual core boolean utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual core boolean utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual core boolean utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - non-visual core boolean utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/boolean.test.ts:
(pass) parseBooleanValue > passes boolean literals through unchanged [0.02ms]
(pass) parseBooleanValue > parses default truthy string representations [0.03ms]
(pass) parseBooleanValue > parses default falsy string representations [0.02ms]
(pass) parseBooleanValue > returns undefined for unrecognized strings and non-string inputs [0.02ms]
(pass) parseBooleanValue > matches custom truthy and falsy options case-insensitively with whitespace trimming [0.09ms]
(pass) parseBooleanText > parses extended text booleans (y/n, enable/disable) with false fallback [0.07ms]
76 | 		expect(parseBooleanText(null)).toBe(false);
77 | 		expect(parseBooleanText(undefined)).toBe(false);
78 | 	});
79 | 
80 | 	it("parses enabled and disabled text variants", () => {
81 | 		expect(parseBooleanText("enabled")).toBe(true);
                                           ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-core-boolean-enabled/packages/core/src/utils/boolean.test.ts:81:39)
(fail) parseBooleanText > parses enabled and disabled text variants [0.09ms]

 6 pass
 1 fail
 38 expect() calls
Ran 7 tests across 1 file. [142.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/boolean.test.ts:
(pass) parseBooleanValue > passes boolean literals through unchanged [0.04ms]
(pass) parseBooleanValue > parses default truthy string representations [0.04ms]
(pass) parseBooleanValue > parses default falsy string representations [0.05ms]
(pass) parseBooleanValue > returns undefined for unrecognized strings and non-string inputs
(pass) parseBooleanValue > matches custom truthy and falsy options case-insensitively with whitespace trimming [0.07ms]
(pass) parseBooleanText > parses extended text booleans (y/n, enable/disable) with false fallback [0.08ms]
(pass) parseBooleanText > parses enabled and disabled text variants [0.04ms]

 7 pass
 0 fail
 41 expect() calls
Ran 7 tests across 1 file. [329.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual core boolean utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
