### PR TITLE
fix(core): safely fall back when Date toISOString throws in text-normalize

### DIFF
--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -146,6 +146,22 @@ describe("flattenTextValues", () => {
 			expect(flattenTextValues(new Date(Number.NaN))).toEqual(["Invalid Date"]);
 		});
 
+		it("safely falls back to toString if toISOString throws RangeError", () => {
+			const throwingDate = new Date(1700000000000);
+			const originalToISO = Date.prototype.toISOString;
+			try {
+				Date.prototype.toISOString = () => {
+					throw new RangeError("Invalid time value");
+				};
+				expect(() => flattenTextValues(throwingDate)).not.toThrow();
+				expect(flattenTextValues(throwingDate)).toEqual([
+					Date.prototype.toString.call(throwingDate),
+				]);
+			} finally {
+				Date.prototype.toISOString = originalToISO;
+			}
+		});
+
 		it("recognizes Dates created in another JavaScript realm", () => {
 			const crossRealmDate = runInNewContext(
 				`new Date(${JSON.stringify(timestamp)})`,

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -127,9 +127,15 @@ function flattenTextValuesWithAncestors(
 	if (typeof value === "object") {
 		const dateTimestamp = getDateTimestamp(value);
 		if (dateTimestamp !== undefined) {
-			return Number.isNaN(dateTimestamp)
-				? [Date.prototype.toString.call(value)]
-				: [Date.prototype.toISOString.call(value)];
+			if (Number.isNaN(dateTimestamp)) {
+				return [Date.prototype.toString.call(value)];
+			}
+			try {
+				return [Date.prototype.toISOString.call(value)];
+			} catch {
+				// error-policy:J4 Degrade to Date.prototype.toString when ISO formatting fails on extreme timestamps.
+				return [Date.prototype.toString.call(value)];
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `packages/core/src/utils/text-normalize.ts`, `Date.prototype.toISOString` formatting is guarded with a fallback to `Date.prototype.toString`, preventing unexpected `RangeError: Invalid time value` from unhandled extreme date values when normalizing prompt text.

# Background

## What does this PR do?

Catches `RangeError` if `Date.prototype.toISOString` fails on an extreme or unrepresentable timestamp during prompt text normalization, cleanly falling back to `Date.prototype.toString`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/text-normalize.ts` and `packages/core/src/utils/text-normalize.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/text-normalize.test.ts`.

# Evidence Gate

<!-- evidence-head:b32aea4aa2d1ab99f05142f77513f0ff141b1fd1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual core text normalization change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual core text normalization change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual core text normalization change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - non-visual core text normalization change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/text-normalize.test.ts:
151 | 			const originalToISO = Date.prototype.toISOString;
152 | 			try {
153 | 				Date.prototype.toISOString = function () {
154 | 					throw new RangeError("Invalid time value");
155 | 				};
156 | 				expect(() => flattenTextValues(throwingDate)).not.toThrow();
                                                            ^
error: expect(received).not.toThrow()

Error name: "RangeError"
Error message: "Invalid time value"

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-core-text-normalize-date/packages/core/src/utils/text-normalize.test.ts:156:55)
(fail) flattenTextValues > dates > safely falls back to toString if toISOString throws RangeError [0.18ms]

 29 pass
 1 fail
 52 expect() calls
Ran 30 tests across 1 file. [119.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/text-normalize.test.ts:
(pass) flattenTextValues > strings > trims and keeps a non-empty string [0.13ms]
(pass) flattenTextValues > strings > drops an empty or whitespace-only string [0.03ms]
(pass) flattenTextValues > nullish > drops null and undefined, keeping their siblings
(pass) flattenTextValues > scalars > keeps falsy-but-present scalars
(pass) flattenTextValues > scalars > stringifies other scalars
(pass) flattenTextValues > arrays > flattens arbitrarily nested arrays in order
(pass) flattenTextValues > arrays > yields nothing for an empty array or an array of empties
(pass) flattenTextValues > objects > renders each entry as `key: value` [0.13ms]
(pass) flattenTextValues > objects > joins a nested collection into one entry with `, `
(pass) flattenTextValues > objects > drops an entry whose value coerces to nothing [0.08ms]
(pass) flattenTextValues > objects > keeps an entry whose value is a falsy scalar
(pass) flattenTextValues > objects > handles circular objects and arrays without stack overflow [0.02ms]
(pass) flattenTextValues > objects > preserves repeated references that are not cycles
(pass) flattenTextValues > dates > renders a Date as a deterministic ISO-8601 fragment [0.03ms]
(pass) flattenTextValues > dates > preserves Dates nested in arrays and object properties [0.03ms]
(pass) flattenTextValues > dates > renders an invalid Date without throwing
(pass) flattenTextValues > dates > safely falls back to toString if toISOString throws RangeError [0.50ms]
(pass) flattenTextValues > dates > recognizes Dates created in another JavaScript realm [0.31ms]
(pass) flattenTextValues > dates > uses intrinsic Date operations instead of overridden methods [0.05ms]
(pass) flattenTextValues > dates > does not trust a spoofed Date toStringTag [0.05ms]
(pass) flattenTextValues > non-plain objects have no enumerable own entries and are dropped > drops a Map
(pass) flattenTextValues > non-plain objects have no enumerable own entries and are dropped > drops a Set [0.01ms]
(pass) toMultilineText > joins the flattened fragments with newlines [0.03ms]
(pass) toMultilineText > returns an empty string when nothing survives [0.01ms]
(pass) flattenTextValues budget > accepts a 64-deep array nest [0.05ms]
(pass) flattenTextValues budget > throws TEXT_NORMALIZE_UNBOUNDED one past depth 64 [0.12ms]
(pass) flattenTextValues budget > throws TEXT_NORMALIZE_UNBOUNDED past 2048 nodes [0.58ms]
(pass) flattenTextValues budget > counts sparse array holes against the work budget [0.11ms]
(pass) flattenTextValues budget > does not eagerly read object properties beyond the work budget [0.76ms]
(pass) flattenTextValues budget > does not RangeError a 20k array nest [0.68ms]

 30 pass
 0 fail
 53 expect() calls
Ran 30 tests across 1 file. [134.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual core text normalization change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
