### PR TITLE
fix(shared): normalize typographic curly apostrophes to ascii apostrophe in normalizeWerText

### DIFF
--- a/packages/shared/src/voice-wer.test.ts
+++ b/packages/shared/src/voice-wer.test.ts
@@ -26,6 +26,11 @@ describe("normalizeWerText", () => {
     expect(normalizeWerText("It's 42, really?!")).toBe("it's 42 really");
   });
 
+  it("normalizes typographic/curly apostrophes to ascii apostrophe", () => {
+    expect(normalizeWerText("don’t it’s we‘re")).toBe("don't it's we're");
+    expect(wordErrorRate("don't it's we're", "don’t it’s we‘re")).toBe(0);
+  });
+
   it("retains unicode letters/numbers", () => {
     expect(normalizeWerText("Café déjà 3")).toBe("café déjà 3");
   });

--- a/packages/shared/src/voice-wer.ts
+++ b/packages/shared/src/voice-wer.ts
@@ -17,6 +17,7 @@
 export function normalizeWerText(text: string): string {
   return text
     .toLowerCase()
+    .replace(/[’‘ʼʻ]/gu, "'")
     .replace(/[^\p{L}\p{N}'\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `packages/shared/src/voice-wer.ts`, typographic/curly apostrophes (`’`, `‘`, `ʼ`, `ʻ`) are mapped to ASCII apostrophe `'` prior to non-word punctuation stripping. This prevents contractions like `don’t` in STT transcripts from splitting into multiple tokens (`don t`) when comparing against ASCII reference text.

# Background

## What does this PR do?

Normalizes typographical apostrophe variants to `'` in `normalizeWerText`, ensuring contractions output by Speech-to-Text engines match ASCII reference transcripts without generating spurious token deletions/insertions.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/voice-wer.ts` and `packages/shared/src/voice-wer.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice-wer.test.ts`.

# Evidence Gate

<!-- evidence-head:b9f8bc14d522f6ab189265e5bd7d335cea747c21 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual shared voice WER utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual shared voice WER utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual shared voice WER utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - non-visual shared voice WER utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/shared/src/voice-wer.test.ts:
29 |   it("normalizes typographic/curly apostrophes to ascii apostrophe", () => {
30 |     expect(normalizeWerText("don’t it’s we‘re")).toBe("don't it's we're");
                                                     ^
error: expect(received).toBe(expected)

Expected: "don't it's we're"
Received: "don t it s we re"

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-shared-voice-wer-apostrophe/packages/shared/src/voice-wer.test.ts:30:49)
(fail) normalizeWerText > normalizes typographic/curly apostrophes to ascii apostrophe [0.44ms]

 22 pass
 1 fail
 33 expect() calls
Ran 23 tests across 1 file. [161.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/shared/src/voice-wer.test.ts:
(pass) normalizeWerText > lowercases and collapses whitespace [0.26ms]
(pass) normalizeWerText > strips punctuation but keeps letters, numbers, and apostrophes
(pass) normalizeWerText > normalizes typographic/curly apostrophes to ascii apostrophe [0.48ms]
(pass) normalizeWerText > retains unicode letters/numbers [0.02ms]
(pass) normalizeWerText > turns a punctuation-only string into empty
(pass) wordErrorRate > is 0 for identical strings [0.02ms]
(pass) wordErrorRate > is case- and punctuation-insensitive (still 0) [0.01ms]
(pass) wordErrorRate > scores a single substitution as 1/N [0.01ms]
(pass) wordErrorRate > scores a single insertion as 1/N
(pass) wordErrorRate > scores a single deletion as 1/N [0.01ms]
(pass) wordErrorRate > an empty reference scores 0 against an empty hypothesis
(pass) wordErrorRate > an empty reference scores 1 against a non-empty hypothesis
(pass) wordErrorRate > can exceed 1 when the hypothesis is much longer (insertions dominate)
(pass) wordErrorRate > scores a fully wrong same-length hypothesis as 1 [0.01ms]
(pass) wordErrorRate > fails closed before a hostile word pair can exhaust the edit budget [3.21ms]
(pass) wordErrorRate > bounds normalization work even for a single enormous token
(pass) wordErrorRate > allows asymmetric inputs when their edit work stays bounded [2.26ms]
(pass) wordErrorRate > accepts the edit-cell boundary and rejects the next cell [2.33ms]
(pass) WER discriminates real vs degraded ASR (self-test gate = 0.34) > a perfect transcript passes the gate (WER 0) [0.09ms]
(pass) WER discriminates real vs degraded ASR (self-test gate = 0.34) > a near-perfect transcript (1 slip in 9) passes the gate [0.02ms]
(pass) WER discriminates real vs degraded ASR (self-test gate = 0.34) > a heavily degraded transcript FAILS the gate (WER > 0.34)
(pass) WER discriminates real vs degraded ASR (self-test gate = 0.34) > garbage / hallucinated output FAILS the gate
(pass) WER discriminates real vs degraded ASR (self-test gate = 0.34) > an empty transcript (silent / dropped capture) FAILS the gate

 23 pass
 0 fail
 34 expect() calls
Ran 23 tests across 1 file. [128.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual shared voice WER utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
