### PR TITLE
fix(cloud): reject non-canonical Retry-After values in response attempts

### DIFF
--- a/packages/cloud/services/_common/src/response-attempts.test.ts
+++ b/packages/cloud/services/_common/src/response-attempts.test.ts
@@ -64,4 +64,59 @@ describe("executeResponseAttempts", () => {
     ).rejects.toThrow("still unavailable");
     expect(request).toHaveBeenCalledTimes(3);
   });
+
+  test("treats only canonical decimal Retry-After as valid delay", async () => {
+    const cases: Array<{
+      header: string | null;
+      shouldBeCanonical: boolean;
+    }> = [
+      { header: "5", shouldBeCanonical: true },
+      { header: "0", shouldBeCanonical: true },
+      { header: " 5 ", shouldBeCanonical: true },
+      { header: "5.9", shouldBeCanonical: false },
+      { header: "10, 20", shouldBeCanonical: false },
+      { header: "0x10", shouldBeCanonical: false },
+      { header: "  ", shouldBeCanonical: false },
+      { header: null, shouldBeCanonical: false },
+    ];
+
+    for (const { header, shouldBeCanonical } of cases) {
+      const observations: Array<{
+        retryAfterSeconds: number | null;
+        retryDelayMs: number | null;
+      }> = [];
+      let first = true;
+      await executeResponseAttempts({
+        maxAttempts: 2,
+        retryDelayCapMs: 10,
+        retryStatuses: true,
+        retryTransport: false,
+        request: async () => {
+          if (first) {
+            first = false;
+            const headers = new Headers();
+            if (header !== null) headers.set("Retry-After", header);
+            return new Response("retry", { status: 429, headers });
+          }
+          return new Response("ok", { status: 200 });
+        },
+        observe: (observation) => {
+          observations.push({
+            retryAfterSeconds: observation.retryAfterSeconds,
+            retryDelayMs: observation.retryDelayMs,
+          });
+        },
+      });
+
+      const firstObs = observations[0];
+      if (shouldBeCanonical) {
+        const expected = Number.parseInt((header ?? "").trim(), 10);
+        expect(firstObs.retryAfterSeconds).toBe(expected);
+        expect(firstObs.retryDelayMs).toBe(Math.min(expected * 1_000, 10));
+      } else {
+        expect(firstObs.retryAfterSeconds).toBeNull();
+        expect(firstObs.retryDelayMs).toBe(200);
+      }
+    }
+  });
 });

--- a/packages/cloud/services/_common/src/response-attempts.ts
+++ b/packages/cloud/services/_common/src/response-attempts.ts
@@ -100,12 +100,9 @@ export async function executeResponseAttempts(
         retryable &&
         options.retryStatuses &&
         budgetAttempts < options.maxAttempts;
-      const parsedRetryAfter = Number.parseInt(
-        response.headers.get("Retry-After") ?? "",
-        10,
-      );
-      const retryAfterSeconds = Number.isFinite(parsedRetryAfter)
-        ? parsedRetryAfter
+      const rawRetryAfter = (response.headers.get("Retry-After") ?? "").trim();
+      const retryAfterSeconds = /^\d+$/.test(rawRetryAfter)
+        ? Number.parseInt(rawRetryAfter, 10)
         : null;
       const retryDelayMs = shouldRetry
         ? retryAfterSeconds === null


### PR DESCRIPTION
# Relates to

N/A - harden Retry-After parsing to canonical decimal only

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Additive strict validation only: `Retry-After` now requires `^\d+$` (canonical decimal) before parseInt. Invalid forms (`5.9`, `10, 20`, `0x10`, whitespace-only) correctly fall through to fallback delay. Valid integers unchanged. Single file `packages/cloud/services/_common/src/response-attempts.ts`.

# Background

## What does this PR do?

Fixes `executeResponseAttempts` in `packages/cloud/services/_common/src/response-attempts.ts`. Previously `Number.parseInt("5.9",10)` returned `5`, `Number.parseInt("10, 20",10)` returned `10`, and `Number.parseInt("0x10",10)` returned `0`, causing truncated Retry-After values and potential retry storms (under-wait). Now validates raw header with `/^\d+$/` after trim before parsing; non-canonical values are treated as missing (fallback `200 * attempt`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/services/_common/src/response-attempts.ts:103` and `src/response-attempts.test.ts`

## Detailed testing steps

```bash
bun --cwd packages/cloud/services/_common test src/response-attempts.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e6647ccc18eb3cccb4668eec0f0fc72502fa5a96 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - server utility, verified via unit test logs below`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit retry logic`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model change.

## Backend + frontend logs

Verified via `bun test` output below.

**Red (production reverted, new test fails):**
```
(fail) executeResponseAttempts > treats only canonical decimal Retry-After as valid delay [35ms]
  error: expect(received).toBeNull() Received: 5
  at treats only canonical decimal ... expect(firstObs.retryAfterSeconds).toBeNull()
2 pass 1 fail
```

**Green (fix restored, all pass):**
```
3 pass 0 fail
22 expect() calls
Ran 3 tests across 1 file. [2.34s]
```

**Existing suite + typecheck/lint:**
```
bun --cwd packages/cloud/services/_common test src/response-attempts.test.ts  # 3 pass
bun run --cwd packages/cloud/services/_common lint  # fixed 1 file, now clean
typecheck: pre-existing missing bun-types/node (verified on develop same error, not blocker)
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- `bun run --cwd packages/cloud/services/_common typecheck` reports `Cannot find type definition file for 'bun-types'/'node'` on both develop and this branch (pre-existing, not introduced by this PR).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
