### PR TITLE
test(app-core): cover index

### DIFF
--- a/packages/app-core/src/services/sensitive-requests/index.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/index.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for `registerCoreSensitiveRequestAdapters`: registration order of
+ * the six first-party delivery adapters, per-target uniqueness, the canonical
+ * registry service lookup, and the non-registry guard branches (missing or
+ * non-callable `register`). Complements, and does not repeat, the standalone
+ * registration suite in `__tests__/`.
+ */
+import {
+  SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE,
+  type SensitiveRequestDeliveryAdapter,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { registerCoreSensitiveRequestAdapters } from "./index";
+
+describe("registerCoreSensitiveRequestAdapters", () => {
+  function makeRecordingRuntime() {
+    const registered: SensitiveRequestDeliveryAdapter[] = [];
+    const lookedUpServiceNames: string[] = [];
+    const runtime = {
+      getService: (name: string) => {
+        lookedUpServiceNames.push(name);
+        return {
+          register: (adapter: SensitiveRequestDeliveryAdapter) => {
+            registered.push(adapter);
+          },
+        };
+      },
+    };
+    return { registered, lookedUpServiceNames, runtime };
+  }
+
+  it("registers exactly one adapter per first-party target, each with a callable deliver", () => {
+    const { registered, runtime } = makeRecordingRuntime();
+    registerCoreSensitiveRequestAdapters(runtime);
+
+    expect(registered).toHaveLength(6);
+    const targets = registered.map((adapter) => adapter.target);
+    expect(new Set(targets).size).toBe(6);
+    for (const adapter of registered) {
+      expect(typeof adapter.deliver).toBe("function");
+    }
+  });
+
+  it("registers the adapters in the composed Wave A order", () => {
+    const { registered, runtime } = makeRecordingRuntime();
+    registerCoreSensitiveRequestAdapters(runtime);
+
+    expect(registered.map((adapter) => adapter.target)).toEqual([
+      "owner_app_inline",
+      "owner_app_oauth",
+      "cloud_authenticated_link",
+      "tunnel_authenticated_link",
+      "instruct_dm_only",
+      "public_link",
+    ]);
+  });
+
+  it("looks up only the canonical dispatch registry service", () => {
+    const { lookedUpServiceNames, runtime } = makeRecordingRuntime();
+    registerCoreSensitiveRequestAdapters(runtime);
+
+    expect(lookedUpServiceNames).toEqual([
+      SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE,
+    ]);
+  });
+
+  it("no-ops without throwing when the resolved service lacks a callable register", () => {
+    expect(() =>
+      registerCoreSensitiveRequestAdapters({
+        getService: () => ({ register: "not-a-function" }),
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      registerCoreSensitiveRequestAdapters({
+        getService: () => ({}),
+      }),
+    ).not.toThrow();
+  });
+
+  it("no-ops without throwing when the service resolves to a non-object", () => {
+    let serviceLookups = 0;
+    expect(() =>
+      registerCoreSensitiveRequestAdapters({
+        getService: () => {
+          serviceLookups += 1;
+          return "bogus";
+        },
+      }),
+    ).not.toThrow();
+    expect(serviceLookups).toBe(1);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/app-core/src/services/sensitive-requests/index.test.ts`, a new unit suite for `packages/app-core/src/services/sensitive-requests/index.ts`, which previously had no same-named test file anywhere in the repo.

## Why

The barrel's runtime surface is `registerCoreSensitiveRequestAdapters(runtime)`, the startup hook that registers app-core's six first-party sensitive-request delivery adapters with the runtime's `SensitiveRequestDispatchRegistry` service (consumed by the deferred boot tail in `runtime/startup/app-contributors.ts`). The recent standalone registration suite covers happy-path registration and the missing-service no-op; this suite additively covers the branches it does not touch. It modifies no production code.

## Coverage (all assertions drive the real function against a recording registry)

- Registers exactly one adapter per first-party target (six total), no duplicate targets, and every registered adapter exposes a callable `deliver` â the property dispatch actually consumes.
- Pins the composed Wave A registration order: `owner_app_inline`, `owner_app_oauth`, `cloud_authenticated_link`, `tunnel_authenticated_link`, `instruct_dm_only`, `public_link`.
- Asserts the helper looks up exactly the canonical `SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE` name.
- No-op without throwing when the resolved service lacks a callable `register` (`isRegistry` guard).
- No-op without throwing when the service resolves to a non-object, proving the lookup happened once rather than short-circuiting vacuously.

No mocks of the module under test are used; the fake runtime object is the boundary the real function already accepts (`runtime: unknown`). No `expectTypeOf`, no `vi.hoisted`.

## Evidence

- `bunx vitest run src/services/sensitive-requests/index.test.ts` (from `packages/app-core`): **Test Files 1 passed (1) Â· Tests 5 passed (5)**.
- `bunx biome check --write packages/app-core/src/services/sensitive-requests/index.test.ts`: clean ("Checked 1 file â¦ No fixes applied").
- `bunx tsc --noEmit -p tsconfig.json` in `packages/app-core`: the new test file appears nowhere in the output.
- Diff touches **only** the new test file: 1 file changed, +93/â0, based on current `develop` (`de774b87`).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c90701f0176d73f1c730b47250ea2cc5167e60b4 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
