### PR TITLE
test(ui): cover workspace-mobile-sidebar-controls.hooks

### DIFF
--- a/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks.test.tsx
+++ b/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks.test.tsx
@@ -1,0 +1,178 @@
+/** Verifies the mobile sidebar controls context hooks through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Verifies `WorkspaceMobileSidebarControlsContext`,
+ * `useWorkspaceMobileSidebarControls`, and `useWorkspaceMobileSidebarHeader`
+ * against the real hooks: null outside a provider, drawer-to-header wiring
+ * through the real context, first-registered-drawer exposure, same-id
+ * replacement in place, unregister-by-id teardown with next-in-line
+ * promotion, and safe disposal of an already-removed id. Renders through
+ * @testing-library/react on jsdom (no real viewport).
+ */
+
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  useWorkspaceMobileSidebarControls,
+  useWorkspaceMobileSidebarHeader,
+  type WorkspaceMobileSidebarControl,
+  WorkspaceMobileSidebarControlsContext,
+} from "./workspace-mobile-sidebar-controls.hooks";
+
+function makeControl(id: string, open = false): WorkspaceMobileSidebarControl {
+  return { id, label: `Label ${id}`, open, setOpen: () => {} };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useWorkspaceMobileSidebarControls", () => {
+  it("returns null when no provider above the consumer owns the controls", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarControls());
+
+    expect(result.current).toBeNull();
+  });
+
+  it("hands a nested drawer the owner's controls so its registration surfaces in the header", () => {
+    const header = renderHook(() => useWorkspaceMobileSidebarHeader());
+    let dispose: (() => void) | undefined;
+
+    function Provider({ children }: { children: React.ReactNode }) {
+      return (
+        <WorkspaceMobileSidebarControlsContext.Provider
+          value={header.result.current.controls}
+        >
+          {children}
+        </WorkspaceMobileSidebarControlsContext.Provider>
+      );
+    }
+
+    const drawer = renderHook(() => useWorkspaceMobileSidebarControls(), {
+      wrapper: Provider,
+    });
+
+    expect(drawer.result.current).not.toBeNull();
+    act(() => {
+      dispose = drawer.result.current?.register(makeControl("drawer-nested"));
+    });
+
+    expect(header.result.current.control?.id).toBe("drawer-nested");
+
+    act(() => {
+      dispose?.();
+    });
+
+    expect(header.result.current.control).toBeNull();
+  });
+});
+
+describe("useWorkspaceMobileSidebarHeader", () => {
+  it("reports no control before any drawer registers", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarHeader());
+
+    expect(result.current.control).toBeNull();
+    expect(typeof result.current.controls.register).toBe("function");
+  });
+
+  it("exposes the first registered drawer even after later registrations", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarHeader());
+
+    act(() => {
+      result.current.controls.register(makeControl("drawer-first"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-second"));
+    });
+
+    expect(result.current.control?.id).toBe("drawer-first");
+  });
+
+  it("replaces an existing registration in place when the same id registers again", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarHeader());
+
+    act(() => {
+      result.current.controls.register(makeControl("drawer-a"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-b"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-a", true));
+    });
+
+    // Same slot, updated value — not an append behind the older registration.
+    expect(result.current.control?.id).toBe("drawer-a");
+    expect(result.current.control?.open).toBe(true);
+  });
+
+  it("unregisters by id and promotes the next registered drawer", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarHeader());
+    let disposeFirst: () => void = () => {};
+
+    act(() => {
+      disposeFirst = result.current.controls.register(makeControl("drawer-a"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-b"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-c"));
+    });
+
+    act(() => {
+      disposeFirst();
+    });
+
+    expect(result.current.control?.id).toBe("drawer-b");
+  });
+
+  it("treats repeated disposal as a no-op that keeps remaining drawers intact", () => {
+    const { result } = renderHook(() => useWorkspaceMobileSidebarHeader());
+    let dispose: () => void = () => {};
+
+    act(() => {
+      dispose = result.current.controls.register(makeControl("drawer-a"));
+    });
+    act(() => {
+      result.current.controls.register(makeControl("drawer-b"));
+    });
+
+    act(() => {
+      dispose();
+      dispose();
+    });
+
+    expect(result.current.control?.id).toBe("drawer-b");
+  });
+
+  it("clears the header control when an effect-driven drawer unmounts", () => {
+    const header = renderHook(() => useWorkspaceMobileSidebarHeader());
+
+    function DrawerFixture() {
+      const controls = React.useContext(WorkspaceMobileSidebarControlsContext);
+      React.useEffect(() => {
+        if (!controls) return undefined;
+        return controls.register(makeControl("drawer-effect"));
+      }, [controls]);
+      return null;
+    }
+
+    const mounted = render(
+      <WorkspaceMobileSidebarControlsContext.Provider
+        value={header.result.current.controls}
+      >
+        <DrawerFixture />
+      </WorkspaceMobileSidebarControlsContext.Provider>,
+    );
+
+    expect(header.result.current.control?.id).toBe("drawer-effect");
+
+    mounted.unmount();
+
+    expect(header.result.current.control).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a dedicated unit suite for `packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks.ts`, which had no same-named test file anywhere on `develop`. This is a **test-only** diff: one new file, +178/−0, no production behaviour changed.

The suite drives the real module — the React context and both hooks — through `@testing-library/react` on jsdom (the package's configured harness, matching the sibling `workspace-mobile-sidebar-header.test.tsx`). No mocks stand in for the system under test; fixtures supply only plain control objects as data.

Covered behaviour:

- `useWorkspaceMobileSidebarControls` returns null when no provider is above the consumer.
- A nested drawer wired through the real context registers into the owner's header state, and its disposer clears it (end-to-end consumer boundary).
- `useWorkspaceMobileSidebarHeader` reports `control === null` before any registration.
- First registered drawer wins even after later registrations (ordering).
- Re-registering an existing id replaces in place — same slot, updated value, still first.
- Unregistering by id promotes the next registered drawer (`a,b,c` → dispose `a` → `b`).
- Double disposal is a safe no-op that keeps remaining drawers intact.
- An effect-driven drawer (mount → register, unmount → dispose) appears in and clears from header state — the production drawer lifecycle.

## Evidence (fork contributor — hosted CI does not run on this PR)

- `bunx vitest run src/layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks.test.tsx` (in `packages/ui`): **Test Files 1 passed (1), Tests 8 passed (8)** — re-verified after formatting and immediately before filing against current `origin/develop`; the module under test is byte-identical between the run tree and `origin/develop`.
- `bunx biome check --write` on the new file: clean (`Checked 1 file … Fixed 1 file`, exit 0).
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output (grep for its name returns nothing).
- The diff touches only `packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks.test.tsx` (+178/−0).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:985ee9787400f285e01f5b6cf701a191d16028ce -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
