### PR TITLE
test(ui): cover useSecretsManagerModal

### DIFF
--- a/packages/ui/src/hooks/useSecretsManagerModal.test.tsx
+++ b/packages/ui/src/hooks/useSecretsManagerModal.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Verifies the Vault modal trigger surface - the window-event dispatchers
+ * and useSecretsManagerModalState - through the package's configured
+ * test harness.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchSecretsManagerClose,
+  dispatchSecretsManagerOpen,
+  dispatchSecretsManagerToggle,
+  useSecretsManagerModalState,
+  type VaultTab,
+} from "./useSecretsManagerModal";
+
+const TOGGLE_EVENT = "eliza:secrets-manager-toggle";
+
+afterEach(cleanup);
+
+function openViaEvent(
+  options?: Parameters<typeof dispatchSecretsManagerOpen>[0],
+): void {
+  act(() => {
+    dispatchSecretsManagerOpen(options);
+  });
+}
+
+function closeViaEvent(): void {
+  act(() => {
+    dispatchSecretsManagerClose();
+  });
+}
+
+function toggleViaEvent(tab?: VaultTab): void {
+  act(() => {
+    dispatchSecretsManagerToggle(tab);
+  });
+}
+
+describe("useSecretsManagerModalState", () => {
+  it("starts closed with no tab or focus targets", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("open(), close() and setOpen() drive the flag without inventing focus params", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBeNull();
+
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("dispatchSecretsManagerOpen() with no options opens with null tab and focus", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent();
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("dispatchSecretsManagerOpen() carries tab and focus targets into state", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({
+      tab: "secrets",
+      focusKey: "provider_key_openai",
+      focusProfileId: "prof_1",
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBe("secrets");
+    expect(result.current.focusKey).toBe("provider_key_openai");
+    expect(result.current.focusProfileId).toBe("prof_1");
+  });
+
+  it("a later open without options drops stale focus targets", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({ tab: "secrets", focusKey: "k1", focusProfileId: "p1" });
+    openViaEvent();
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("close event hides the modal but keeps the last open parameters", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({ tab: "routing", focusKey: "rule_chip" });
+    closeViaEvent();
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.initialTab).toBe("routing");
+    expect(result.current.focusKey).toBe("rule_chip");
+  });
+
+  it("toggle event opens a closed modal and adopts the requested tab", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    toggleViaEvent("overview");
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBe("overview");
+
+    toggleViaEvent();
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.initialTab).toBe("overview");
+  });
+
+  it("toggling an already-open modal closes it without adopting a new tab", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({ tab: "logins" });
+    toggleViaEvent("routing");
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.initialTab).toBe("logins");
+  });
+
+  it("openOnTab() opens on the requested tab and clears omitted focus fields", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({ tab: "secrets", focusKey: "stale" });
+
+    act(() => {
+      result.current.openOnTab({
+        tab: "routing",
+        focusProfileId: "prof_2",
+      });
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBe("routing");
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBe("prof_2");
+
+    act(() => {
+      result.current.openOnTab({});
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("clearFocus() clears tab and focus targets while staying open", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    openViaEvent({
+      tab: "overview",
+      focusKey: "k",
+      focusProfileId: "p",
+    });
+
+    act(() => {
+      result.current.clearFocus();
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("ignores an event that carries no detail", () => {
+    const { result } = renderHook(() => useSecretsManagerModalState());
+    act(() => {
+      window.dispatchEvent(new Event(TOGGLE_EVENT));
+    });
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.initialTab).toBeNull();
+    expect(result.current.focusKey).toBeNull();
+    expect(result.current.focusProfileId).toBeNull();
+  });
+
+  it("every mounted instance reacts to one dispatch", () => {
+    const modal = renderHook(() => useSecretsManagerModalState());
+    const launcher = renderHook(() => useSecretsManagerModalState());
+
+    openViaEvent({ tab: "secrets", focusKey: "k1" });
+    expect(modal.result.current.isOpen).toBe(true);
+    expect(launcher.result.current.isOpen).toBe(true);
+    expect(modal.result.current.initialTab).toBe("secrets");
+    expect(launcher.result.current.focusKey).toBe("k1");
+
+    closeViaEvent();
+    expect(modal.result.current.isOpen).toBe(false);
+    expect(launcher.result.current.isOpen).toBe(false);
+  });
+
+  it("keeps every control callback stable across re-renders", () => {
+    const { result, rerender } = renderHook(() =>
+      useSecretsManagerModalState(),
+    );
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current.open).toBe(first.open);
+    expect(result.current.close).toBe(first.close);
+    expect(result.current.toggle).toBe(first.toggle);
+    expect(result.current.setOpen).toBe(first.setOpen);
+    expect(result.current.openOnTab).toBe(first.openOnTab);
+    expect(result.current.clearFocus).toBe(first.clearFocus);
+  });
+
+  it("removes its window listener on unmount", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useSecretsManagerModalState());
+    expect(addSpy).toHaveBeenCalledWith(TOGGLE_EVENT, expect.any(Function));
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith(TOGGLE_EVENT, expect.any(Function));
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});
+
+describe("dispatcher window guards", () => {
+  it("dispatchers no-op instead of throwing when window is unavailable", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Reflect.deleteProperty(globalThis, "window");
+    try {
+      expect(() => {
+        dispatchSecretsManagerOpen({ tab: "secrets" });
+        dispatchSecretsManagerClose();
+        dispatchSecretsManagerToggle("overview");
+      }).not.toThrow();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, "window", descriptor);
+      }
+    }
+  });
+});


### PR DESCRIPTION

Adds a co-located unit suite for packages/ui/src/hooks/useSecretsManagerModal.ts, which had no same-named test file anywhere on develop at the time of this branch.

The module is the Vault (secrets manager) modal's trigger surface: three window-event dispatchers plus the `useSecretsManagerModalState()` hook that consumes their CustomEvent contract. The suite drives that real boundary end to end in jsdom — dispatchers fire actual window events and the hook's listener reacts through React state — with no mocks standing in for the subject:

- initial state: closed with null tab/focus fields
- direct controls: open/close/setOpen drive only the flag and never invent focus params
- dispatched open: bare open yields null tab/focus defaults; parameterized open carries tab, focusKey and focusProfileId into state; a later bare open drops stale focus targets
- dispatched close: hides the modal but preserves the last open parameters
- toggle semantics: toggling a closed modal opens on the requested tab; toggling an already-open modal closes without adopting the new tab; closing leaves the previous initialTab intact
- hook-level openOnTab clears omitted focus fields; clearFocus nulls all three while staying open
- robustness: an event carrying no detail is ignored; every mounted instance (modal + launcher row) reacts to one dispatch; control callbacks stay stable across re-renders; the window listener is removed on unmount; all three dispatchers no-op safely when window is unavailable

Test-only change — no production code is touched (+243/-0, one new file).

Evidence (fork contributor; hosted CI does not run on this PR):

- bunx vitest run src/hooks/useSecretsManagerModal.test.tsx (packages/ui): Test Files 1 passed (1), Tests 15 passed (15)
- bunx biome check src/hooks/useSecretsManagerModal.test.tsx: "Checked 1 file … No fixes applied" (clean)
- bunx tsc --noEmit in packages/ui: zero occurrences of useSecretsManagerModal.test in output (no new type errors introduced by this diff)

All runs executed against origin/develop head de774b8757 immediately before filing; the target module is identical between the branch base and current develop.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:de774b875774f478ef5b879dbdae8fd2997a3470 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
