### PR TITLE
test(shared): cover awareness-contract

### DIFF
--- a/packages/shared/src/contracts/awareness.test.ts
+++ b/packages/shared/src/contracts/awareness.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  type AwarenessContributor,
+  type AwarenessInvalidationEvent,
+  DEFAULT_CACHE_TTL_MS,
+  SELF_STATUS_SCHEMA_VERSION,
+  SUMMARY_CHAR_LIMIT,
+  SUMMARY_TOTAL_CHAR_LIMIT,
+} from "./awareness.ts";
+
+describe("awareness contract constants", () => {
+  it("pins the self-status schema version", () => {
+    expect(SELF_STATUS_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("pins the default cache TTL to one minute", () => {
+    expect(DEFAULT_CACHE_TTL_MS).toBe(60_000);
+  });
+
+  it("keeps the deprecated summary limits for backward compatibility", () => {
+    // Deprecated but still exported: summaries are no longer character-limited,
+    // yet removing these constants would break existing importers.
+    expect(SUMMARY_CHAR_LIMIT).toBe(80);
+    expect(SUMMARY_TOTAL_CHAR_LIMIT).toBe(1200);
+  });
+});
+
+describe("AwarenessInvalidationEvent union", () => {
+  it("covers every documented invalidation trigger", () => {
+    const events: AwarenessInvalidationEvent[] = [
+      "permission-changed",
+      "plugin-changed",
+      "wallet-updated",
+      "provider-changed",
+      "config-changed",
+      "runtime-restarted",
+      "opinion-updated",
+    ];
+    expect(events).toHaveLength(7);
+    // Every member is a string literal; no duplicates.
+    expect(new Set(events).size).toBe(events.length);
+  });
+});
+
+describe("AwarenessContributor contract", () => {
+  it("requires id, position, and summary", () => {
+    expectTypeOf<AwarenessContributor>().toHaveProperty("id");
+    expectTypeOf<AwarenessContributor>().toHaveProperty("position");
+    expectTypeOf<AwarenessContributor>().toHaveProperty("summary");
+  });
+
+  it("keeps detail, cacheTtl, invalidateOn, and trusted optional", () => {
+    expectTypeOf<AwarenessContributor>().toHaveProperty("detail");
+    expectTypeOf<AwarenessContributor>().toHaveProperty("cacheTtl");
+    expectTypeOf<AwarenessContributor>().toHaveProperty("invalidateOn");
+    expectTypeOf<AwarenessContributor>().toHaveProperty("trusted");
+  });
+
+  it("accepts a plain minimal contributor object", () => {
+    const contributor: AwarenessContributor = {
+      id: "wallet",
+      position: 30,
+      summary: async () => "wallet summary",
+    };
+    expect(contributor.id).toBe("wallet");
+    expect(contributor.position).toBe(30);
+    expect(typeof contributor.summary).toBe("function");
+  });
+
+  it("accepts a full contributor with all optional fields", () => {
+    const contributor: AwarenessContributor = {
+      id: "permissions",
+      position: 20,
+      summary: async () => "permissions summary",
+      detail: async (_runtime, level) => `${level} detail`,
+      cacheTtl: 5000,
+      invalidateOn: ["permission-changed", "config-changed"],
+      trusted: true,
+    };
+    expect(contributor.cacheTtl).toBe(5000);
+    expect(contributor.invalidateOn).toEqual([
+      "permission-changed",
+      "config-changed",
+    ]);
+    expect(contributor.trusted).toBe(true);
+  });
+
+  it("allows summary to return an empty string (contributor is silent)", async () => {
+    const contributor: AwarenessContributor = {
+      id: "silent",
+      position: 90,
+      summary: async () => "",
+    };
+    await expect(contributor.summary({} as never)).resolves.toBe("");
+  });
+});


### PR DESCRIPTION
## Relates to

None (direct coverage addition for an uncovered module).

## Background

`packages/shared/src/contracts/awareness.ts` exports the Self-Awareness v1 contract constants (`SELF_STATUS_SCHEMA_VERSION`, `DEFAULT_CACHE_TTL_MS`, deprecated summary limits) and the `AwarenessContributor` / `AwarenessInvalidationEvent` contracts, but has no direct test coverage. This PR pins the constants and the required-vs-optional field surface of the contributor contract.

## Testing

```bash
cd packages/shared && bun x vitest run src/contracts/awareness.test.ts
```

- 9 passed (9) — 420ms
- `bunx biome check` clean

<!-- evidence-row:backend-logs -->
- [x] backend-logs: 9/9 vitest passed, biome clean

<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: Hermes agent session (deepseek / deepseek-v4-flash)

<!-- slop-contribution-attribution:v1 -->

AI provider/model: deepseek / deepseek-v4-flash
