### PR TITLE
test(ui): extend useWhatsAppPairing coverage to probe, socket stream and lifecycle verbs

### DIFF
--- a/packages/ui/src/hooks/useWhatsAppPairing.test.tsx
+++ b/packages/ui/src/hooks/useWhatsAppPairing.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getWhatsAppStatus = vi.fn();
 const stopWhatsAppPairing = vi.fn();
+const startWhatsAppPairing = vi.fn();
 const disconnectWhatsApp = vi.fn();
 const onWsEvent = vi.fn<(...args: unknown[]) => () => void>(() => () => {});
 
@@ -18,11 +19,13 @@ vi.mock("../api/client", () => ({
   client: {
     getWhatsAppStatus: (...args: unknown[]) => getWhatsAppStatus(...args),
     stopWhatsAppPairing: (...args: unknown[]) => stopWhatsAppPairing(...args),
+    startWhatsAppPairing: (...args: unknown[]) => startWhatsAppPairing(...args),
     disconnectWhatsApp: (...args: unknown[]) => disconnectWhatsApp(...args),
     onWsEvent: (...args: unknown[]) => onWsEvent(...args),
   },
 }));
 
+import { DEFAULT_CONNECTOR_ACCOUNT_ID } from "./useConnectorAccounts";
 import { useWhatsAppPairing } from "./useWhatsAppPairing";
 
 type HookResult = ReturnType<typeof useWhatsAppPairing>;
@@ -33,10 +36,28 @@ function HookProbe(props: { onState: (r: HookResult) => void }): null {
   return null;
 }
 
+function DefaultAccountProbe(props: {
+  onState: (r: HookResult) => void;
+}): null {
+  const result = useWhatsAppPairing();
+  props.onState(result);
+  return null;
+}
+
+function wsHandler(event: string): (data: Record<string, unknown>) => void {
+  const matches = onWsEvent.mock.calls.filter(([name]) => name === event);
+  const call = matches[matches.length - 1];
+  if (!call) {
+    throw new Error(`no ${event} subscription was bound`);
+  }
+  return call[1] as (data: Record<string, unknown>) => void;
+}
+
 beforeEach(() => {
   getWhatsAppStatus.mockReset();
   stopWhatsAppPairing.mockReset();
   disconnectWhatsApp.mockReset();
+  startWhatsAppPairing.mockReset();
   onWsEvent.mockReset();
   onWsEvent.mockReturnValue(() => {});
   // Initial-status probe: keep it benign so the mount effect settles at "idle".
@@ -93,5 +114,285 @@ describe("useWhatsAppPairing write failures surface to the user", () => {
     const last = seen[seen.length - 1];
     expect(last?.status).toBe("idle");
     expect(last?.error).toBeNull();
+  });
+});
+
+describe("useWhatsAppPairing initial probe and socket stream", () => {
+  it("reports connected when the initial probe finds existing auth", async () => {
+    getWhatsAppStatus.mockResolvedValueOnce({ authExists: true });
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {});
+
+    const last = seen[seen.length - 1];
+    expect(getWhatsAppStatus).toHaveBeenCalledWith("acct-1");
+    expect(last?.status).toBe("connected");
+    expect(last?.error).toBeNull();
+  });
+
+  it("keeps the designed idle default when the initial probe fails", async () => {
+    getWhatsAppStatus.mockRejectedValueOnce(new Error("probe down"));
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {});
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+    expect(last?.qrDataUrl).toBeNull();
+    expect(last?.error).toBeNull();
+  });
+
+  it("stores qr payloads for its account and moves to waiting_for_qr", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitQr = wsHandler("whatsapp-qr");
+    await act(async () => {
+      emitQr({ accountId: "acct-1", qrDataUrl: "data:image/png;base64,QQ==" });
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("waiting_for_qr");
+    expect(last?.qrDataUrl).toBe("data:image/png;base64,QQ==");
+  });
+
+  it("ignores qr payloads for other accounts", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitQr = wsHandler("whatsapp-qr");
+    await act(async () => {
+      emitQr({ accountId: "other", qrDataUrl: "data:image/png;base64,QQ==" });
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+    expect(last?.qrDataUrl).toBeNull();
+  });
+
+  it("ignores qr payloads whose data url is not a string", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitQr = wsHandler("whatsapp-qr");
+    await act(async () => {
+      emitQr({ accountId: "acct-1", qrDataUrl: 42 });
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+    expect(last?.qrDataUrl).toBeNull();
+  });
+
+  it("applies valid status events, keeps the phone sticky, and clears the qr once connected", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitStatus = wsHandler("whatsapp-status");
+    const emitQr = wsHandler("whatsapp-qr");
+
+    await act(async () => {
+      emitStatus({
+        accountId: "acct-1",
+        status: "disconnected",
+        phoneNumber: "+15550001111",
+      });
+    });
+    await act(async () => {
+      emitQr({ accountId: "acct-1", qrDataUrl: "data:image/png;base64,QQ==" });
+    });
+    await act(async () => {
+      emitStatus({ accountId: "acct-1", status: "connected" });
+    });
+
+    const afterFirst = seen.find((r) => r.status === "disconnected");
+    expect(afterFirst?.phoneNumber).toBe("+15550001111");
+
+    const afterQr = seen.find((r) => r.status === "waiting_for_qr");
+    expect(afterQr?.phoneNumber).toBe("+15550001111");
+    expect(afterQr?.qrDataUrl).toBe("data:image/png;base64,QQ==");
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("connected");
+    expect(last?.phoneNumber).toBe("+15550001111");
+    expect(last?.qrDataUrl).toBeNull();
+    expect(last?.error).toBeNull();
+  });
+
+  it("ignores status events carrying an unknown status value", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitStatus = wsHandler("whatsapp-status");
+    await act(async () => {
+      emitStatus({ accountId: "acct-1", status: "carrier-pigeon" });
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+  });
+
+  it("ignores status events for other accounts", async () => {
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitStatus = wsHandler("whatsapp-status");
+    await act(async () => {
+      emitStatus({ accountId: "other", status: "connected" });
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+  });
+});
+
+describe("useWhatsAppPairing lifecycle verbs beyond write failures", () => {
+  it("startPairing surfaces the server refusal message as an error state", async () => {
+    startWhatsAppPairing.mockResolvedValueOnce({
+      ok: false,
+      error: "pairing busy",
+    });
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.startPairing();
+    });
+
+    expect(startWhatsAppPairing).toHaveBeenCalledWith("acct-1");
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("pairing busy");
+  });
+
+  it("startPairing refusal without an error field falls back to the default message", async () => {
+    startWhatsAppPairing.mockResolvedValueOnce({ ok: false });
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.startPairing();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("Failed to start pairing");
+  });
+
+  it("startPairing success holds initializing until the socket stream reports", async () => {
+    startWhatsAppPairing.mockResolvedValueOnce({ ok: true });
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.startPairing();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("initializing");
+    expect(last?.qrDataUrl).toBeNull();
+    expect(last?.phoneNumber).toBeNull();
+    expect(last?.error).toBeNull();
+  });
+
+  it("startPairing thrown Error reaches the user as its message", async () => {
+    startWhatsAppPairing.mockRejectedValueOnce(new Error("boom"));
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.startPairing();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("boom");
+  });
+
+  it("startPairing non-Error throw values are stringified", async () => {
+    startWhatsAppPairing.mockRejectedValueOnce("nope");
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.startPairing();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("nope");
+  });
+
+  it("successful stop resets every pairing field", async () => {
+    stopWhatsAppPairing.mockResolvedValueOnce({ ok: true });
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    const emitQr = wsHandler("whatsapp-qr");
+    await act(async () => {
+      emitQr({ accountId: "acct-1", qrDataUrl: "data:image/png;base64,QQ==" });
+    });
+    expect(seen[seen.length - 1]?.status).toBe("waiting_for_qr");
+
+    await act(async () => {
+      await seen[seen.length - 1]?.stopPairing();
+    });
+
+    expect(stopWhatsAppPairing).toHaveBeenCalledWith("acct-1");
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("idle");
+    expect(last?.qrDataUrl).toBeNull();
+    expect(last?.phoneNumber).toBeNull();
+    expect(last?.error).toBeNull();
+  });
+
+  it("stop failure with a non-Error rejection uses the fallback text", async () => {
+    stopWhatsAppPairing.mockRejectedValueOnce("nope");
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.stopPairing();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("Failed to stop pairing");
+  });
+
+  it("disconnect failure with a non-Error rejection uses the fallback text", async () => {
+    disconnectWhatsApp.mockRejectedValueOnce("nope");
+
+    const seen: HookResult[] = [];
+    render(<HookProbe onState={(r) => seen.push(r)} />);
+
+    await act(async () => {
+      await seen[seen.length - 1]?.disconnect();
+    });
+
+    const last = seen[seen.length - 1];
+    expect(last?.status).toBe("error");
+    expect(last?.error).toBe("Failed to disconnect");
+  });
+
+  it("mounts against the shared connector account when called without arguments", () => {
+    const seen: HookResult[] = [];
+    render(<DefaultAccountProbe onState={(r) => seen.push(r)} />);
+
+    expect(getWhatsAppStatus).toHaveBeenCalledWith(
+      DEFAULT_CONNECTOR_ACCOUNT_ID,
+    );
+    expect(seen[seen.length - 1]?.status).toBe("idle");
   });
 });


### PR DESCRIPTION

## What

Additive coverage extension for `packages/ui/src/hooks/useWhatsAppPairing.ts` in
`packages/ui/src/hooks/useWhatsAppPairing.test.tsx`: **17 new cases** added to the
existing suite. The three pre-existing cases and every existing line are untouched —
the diff is **+301 / −0** against `origin/develop` (`de774b8757`), a single test
file, no production code changed.

## Why

The existing suite covered only the write-failure paths (disconnect/stop rejections
and the disconnect reset). The hook's read path, socket stream handling, and the
`startPairing` verb had no coverage at all. The new cases pin the behavior that is
actually implemented today:

- initial probe: `authExists: true` flips to `connected`; a rejected probe keeps the
  designed `idle` default instead of crashing or surfacing an error (advisory probe).
- `whatsapp-qr` stream: payload stored + `waiting_for_qr`; events for other accounts
  ignored; non-string `qrDataUrl` ignored.
- `whatsapp-status` stream: valid statuses applied; `phoneNumber` is sticky across
  events that omit it; QR data clears when `connected` arrives; unknown status values
  and other-account events are ignored.
- `startPairing`: server refusal message surfaced; missing `error` field falls back
  to `"Failed to start pairing"`; success holds `initializing` until the socket
  stream reports; thrown `Error` messages reach the user; non-Error throws are
  stringified.
- `stopPairing` success resets every pairing field; non-Error rejections use the
  `"Failed to stop pairing"` / `"Failed to disconnect"` fallback texts.
- mounting without arguments binds to `DEFAULT_CONNECTOR_ACCOUNT_ID`.

## Verification (local, fork PR — hosted CI does not run on this repository's forks)

- `bunx vitest run src/hooks/useWhatsAppPairing.test.tsx` (in `packages/ui`,
  jsdom environment): **Test Files 1 passed (1) — Tests 20 passed (20)**,
  re-run immediately before filing against the current `origin/develop`
  (suite blob `7f41723ff5f0abcb635aa2b51529087495a67fbb`, unchanged upstream).
- `bunx biome check src/hooks/useWhatsAppPairing.test.tsx`: clean
  ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mention
  `useWhatsAppPairing`.
- `git diff --numstat origin/develop`: `301 0` on the single test file — purely
  additive, no deletions.

Test-only change: no runtime behavior of the hook or any consumer is modified.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:cb6e0f3bc5fbc6cb15e5ac39194733ef06aa0e13 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
