### PR TITLE
test(app-core): cover process-management

### DIFF
--- a/packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/__tests__/process-management.test.ts
@@ -236,4 +236,52 @@ describe("pipeOutput", () => {
     await pipeOutput(bytesStream(["café — 你好"]), "stdout", onLog);
     expect(onLog).toHaveBeenCalledWith("café — 你好", "stdout");
   });
+
+  it("keeps already-delivered lines when the reader rejects asynchronously", async () => {
+    const onLog = vi.fn();
+    let errored = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("first-line"));
+      },
+      pull(controller) {
+        if (!errored) {
+          errored = true;
+          controller.error(new Error("pipe broke"));
+        }
+      },
+    });
+
+    await expect(pipeOutput(stream, "stdout", onLog)).resolves.toBeUndefined();
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(onLog).toHaveBeenCalledWith("first-line", "stdout");
+    expect(logger.info).toHaveBeenCalledWith("[Steward] first-line");
+  });
+
+  it("swallows a throwing onLog callback and stops processing further chunks", async () => {
+    const onLog = vi.fn((line: string) => {
+      throw new Error(`callback failed on ${line}`);
+    });
+    await expect(
+      pipeOutput(bytesStream(["boom", "after"]), "stdout", onLog),
+    ).resolves.toBeUndefined();
+    expect(onLog).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith("[Steward] boom");
+  });
+
+  it("emits one replacement character per chunk of a split multi-byte character", async () => {
+    // Observed: decode() without { stream: true } treats each chunk as a
+    // complete unit, so an incomplete trailing sequence becomes U+FFFD.
+    const onLog = vi.fn();
+    await pipeOutput(
+      bytesStream([new Uint8Array([0xe4, 0xbd]), new Uint8Array([0xa0])]),
+      "stdout",
+      onLog,
+    );
+    expect(onLog.mock.calls).toEqual([
+      ["\uFFFD", "stdout"],
+      ["\uFFFD", "stdout"],
+    ]);
+  });
 });


### PR DESCRIPTION

## What

Extends the existing Steward sidecar process-management suite with three behavioural cases (additive only: +48/-0, no existing case modified or removed):

1. **Asynchronous reader failure after delivered chunks** — when the stream's reader rejects on a later pull, `pipeOutput` still resolves and every already-delivered line stays logged through `logger.info` and forwarded to `onLog`.
2. **Throwing `onLog` callback** — a callback that throws is swallowed by the stream-closed catch; the triggering chunk was already logged, no further chunks are processed, and the promise resolves.
3. **Multi-byte UTF-8 character split across chunk boundaries** — because `TextDecoder.decode()` is called without `{ stream: true }`, each incomplete trailing fragment decodes to exactly one U+FFFD replacement character per chunk. The expectation was recorded from observed behaviour of the real module.

All three drive the real `pipeOutput` implementation with real `ReadableStream`s; the logger spies only observe the logging contract, as in the existing suite.

## Why

Merged PR #25979 established this suite (ordering, trimming, empty/whitespace chunks, stdout/stderr routing, same-turn enqueue-then-error, single-chunk multi-byte decoding). These three cases pin the remaining boundary behaviour: mid-stream failure recovery after partial delivery, the per-line callback error contract, and non-streaming decode semantics at arbitrary pipe chunk boundaries.

## Evidence (local runs against current develop @ de774b875774)

This pull request comes from a fork, so hosted CI does not run on it. Counts are from local runs at the exact head commit:

- `bunx vitest run src/services/steward-sidecar/__tests__/process-management.test.ts` (packages/app-core): **Test Files 1 passed (1), Tests 21 passed (21)** — 18 pre-existing cases still green plus 3 new.
- origin/develop was re-fetched immediately before filing; the base was unchanged (`de774b875774`) and the suite re-ran: same 21 passed / 21.
- `bunx biome check --write` on the test file: clean ("Checked 1 file ... No fixes applied"), with the repository `biome.json` present (checkout verified non-sparse).
- `bunx tsc --noEmit -p tsconfig.json` in packages/app-core: grepping the output for `process-management` returns nothing — this diff introduces zero type errors.
- Diff shape: 1 file changed, 48 insertions(+), 0 deletions(-). Test-only; touches no production code.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da3c1a736fae68de969fcbcd805774810c0a0b32 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
