### PR TITLE
test(ui): cover useChatAvatarVoiceBridge

### DIFF
--- a/packages/ui/src/hooks/useChatAvatarVoiceBridge.test.tsx
+++ b/packages/ui/src/hooks/useChatAvatarVoiceBridge.test.tsx
@@ -1,0 +1,174 @@
+/** Verifies useChatAvatarVoiceBridge through the package's configured test harness. */
+// @vitest-environment jsdom
+//
+// useChatAvatarVoiceBridge pushes the chat avatar's lip-sync inputs onto the
+// window as CHAT_AVATAR_VOICE_EVENT and forwards speaking-state transitions
+// into chat shell state via onSpeakingChange. Covers the consumer contract:
+//   • every mouthOpen / isSpeaking change reaches the window event stream,
+//     and idle re-renders dispatch nothing;
+//   • onSpeakingChange is edge-triggered — never fired for the mount value,
+//     once per actual transition, and not spooked by a callback identity change.
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CHAT_AVATAR_VOICE_EVENT,
+  type ChatAvatarVoiceEventDetail,
+} from "../events";
+import { useChatAvatarVoiceBridge } from "./useChatAvatarVoiceBridge";
+
+function collectVoiceEvents(): {
+  received: ChatAvatarVoiceEventDetail[];
+  detach: () => void;
+} {
+  const received: ChatAvatarVoiceEventDetail[] = [];
+  const listener = (event: Event) => {
+    received.push((event as CustomEvent<ChatAvatarVoiceEventDetail>).detail);
+  };
+  window.addEventListener(CHAT_AVATAR_VOICE_EVENT, listener);
+  return {
+    received,
+    detach: () => window.removeEventListener(CHAT_AVATAR_VOICE_EVENT, listener),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useChatAvatarVoiceBridge — avatar voice event stream", () => {
+  it("dispatches CHAT_AVATAR_VOICE_EVENT with the mount-time mouth/speaking detail", () => {
+    const { received, detach } = collectVoiceEvents();
+
+    renderHook(() =>
+      useChatAvatarVoiceBridge({
+        mouthOpen: 0.25,
+        isSpeaking: false,
+        onSpeakingChange: vi.fn(),
+      }),
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ mouthOpen: 0.25, isSpeaking: false });
+
+    detach();
+  });
+
+  it("re-dispatches when mouthOpen changes while speaking state holds", () => {
+    const { received, detach } = collectVoiceEvents();
+
+    const { rerender } = renderHook(
+      ({ mouthOpen, isSpeaking }: { mouthOpen: number; isSpeaking: boolean }) =>
+        useChatAvatarVoiceBridge({
+          mouthOpen,
+          isSpeaking,
+          onSpeakingChange: vi.fn(),
+        }),
+      { initialProps: { mouthOpen: 0, isSpeaking: true } },
+    );
+    rerender({ mouthOpen: 0.6, isSpeaking: true });
+
+    expect(received).toEqual([
+      { mouthOpen: 0, isSpeaking: true },
+      { mouthOpen: 0.6, isSpeaking: true },
+    ]);
+
+    detach();
+  });
+
+  it("emits exactly one combined event when mouth and speaking change in the same commit", () => {
+    const { received, detach } = collectVoiceEvents();
+
+    const { rerender } = renderHook(
+      ({ mouthOpen, isSpeaking }: { mouthOpen: number; isSpeaking: boolean }) =>
+        useChatAvatarVoiceBridge({
+          mouthOpen,
+          isSpeaking,
+          onSpeakingChange: vi.fn(),
+        }),
+      { initialProps: { mouthOpen: 0.1, isSpeaking: false } },
+    );
+    rerender({ mouthOpen: 0.9, isSpeaking: true });
+
+    // The mount dispatch plus one event for the combined commit — never two.
+    expect(received).toEqual([
+      { mouthOpen: 0.1, isSpeaking: false },
+      { mouthOpen: 0.9, isSpeaking: true },
+    ]);
+
+    detach();
+  });
+
+  it("dispatches nothing when neither input changes between renders", () => {
+    const { received, detach } = collectVoiceEvents();
+    const onSpeakingChange = vi.fn();
+
+    const { rerender } = renderHook(() =>
+      useChatAvatarVoiceBridge({
+        mouthOpen: 0.4,
+        isSpeaking: true,
+        onSpeakingChange,
+      }),
+    );
+    rerender();
+    rerender();
+    rerender();
+
+    expect(received).toHaveLength(1);
+    expect(onSpeakingChange).not.toHaveBeenCalled();
+
+    detach();
+  });
+});
+
+describe("useChatAvatarVoiceBridge — speaking-state edge detection", () => {
+  it("never reports the mount value and reports each real transition once", () => {
+    const onSpeakingChange = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ isSpeaking }: { isSpeaking: boolean }) =>
+        useChatAvatarVoiceBridge({
+          mouthOpen: isSpeaking ? 0.5 : 0,
+          isSpeaking,
+          onSpeakingChange,
+        }),
+      { initialProps: { isSpeaking: false } },
+    );
+
+    expect(onSpeakingChange).not.toHaveBeenCalled();
+
+    rerender({ isSpeaking: true });
+    expect(onSpeakingChange).toHaveBeenCalledTimes(1);
+    expect(onSpeakingChange).toHaveBeenLastCalledWith(true);
+
+    // Same value again: no duplicate transition report.
+    rerender({ isSpeaking: true });
+    expect(onSpeakingChange).toHaveBeenCalledTimes(1);
+
+    rerender({ isSpeaking: false });
+    expect(onSpeakingChange).toHaveBeenCalledTimes(2);
+    expect(onSpeakingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does not fire a spurious transition when only the callback identity changes", () => {
+    const onSpeakingChange = vi.fn();
+    const replacementCallback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ cb }: { cb: (isSpeaking: boolean) => void }) =>
+        useChatAvatarVoiceBridge({
+          mouthOpen: 0,
+          isSpeaking: false,
+          onSpeakingChange: cb,
+        }),
+      { initialProps: { cb: onSpeakingChange } },
+    );
+
+    // New identity, same underlying speaking state — the bridge must stay quiet.
+    rerender({ cb: replacementCallback });
+
+    expect(onSpeakingChange).not.toHaveBeenCalled();
+    expect(replacementCallback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `useChatAvatarVoiceBridge` (`packages/ui/src/hooks/useChatAvatarVoiceBridge.test.tsx`), a hook that previously had no same-basename test file anywhere in the repo (verified against `origin/develop` via `git ls-tree -r`). This is a test-only change: **+174/−0 across one new file**, no production code touched.

## Coverage

Six cases driving the real module through `renderHook`, asserting against a real `window` listener for `CHAT_AVATAR_VOICE_EVENT` — no mocks of the system under test:

- dispatches `CHAT_AVATAR_VOICE_EVENT` with the mount-time `{ mouthOpen, isSpeaking }` detail;
- re-dispatches when `mouthOpen` changes while speaking state holds;
- emits exactly one combined event when mouth and speaking change in the same commit;
- dispatches nothing when neither input changes between renders;
- `onSpeakingChange` is edge-triggered: never fired for the mount value, once per actual transition (`false→true`, dedup on repeated value, then `true→false`);
- no spurious transition when only the callback identity changes.

## Verification (observed on current `origin/develop` @ `de774b87`)

- `bunx vitest run src/hooks/useChatAvatarVoiceBridge.test.tsx` (packages/ui): **Test Files 1 passed (1), Tests 6 passed (6)** — re-fetched and re-run immediately before filing.
- `bunx biome check --write packages/ui/src/hooks/useChatAvatarVoiceBridge.test.tsx`: clean ("Checked 1 file… No fixes applied", exit 0).
- `bunx tsc --noEmit` in `packages/ui`: the new file appears nowhere in the output (zero new type errors).
- The diff touches only the one new test file.

Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are quoted from local runs.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5f5e83dcc1ea784cdea8ca798a06daa863030d67 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
