### PR TITLE
fix(agent): fail closed when isRouteInScope throws in isRegisteredTokenRoleAuthorized

### DIFF
--- a/packages/agent/src/api/boundary-role-resolver.test.ts
+++ b/packages/agent/src/api/boundary-role-resolver.test.ts
@@ -172,4 +172,20 @@ describe("isRegisteredTokenRoleAuthorized", () => {
     expect(isRegisteredTokenRoleAuthorized(req, "get", "/api/me")).toBe(true);
     expect(spy).toHaveBeenCalledWith("GET", "/api/me");
   });
+
+  it("fails closed when isRouteInScope throws", () => {
+    const access = makeAccess("user", {
+      isAdmin: false,
+      isRouteInScope: () => {
+        throw new Error("malformed route path");
+      },
+    });
+    registerTokenRoleResolver(makeResolver("user", access));
+    expect(() =>
+      isRegisteredTokenRoleAuthorized(req, "GET", "/api/boom"),
+    ).not.toThrow();
+    expect(isRegisteredTokenRoleAuthorized(req, "GET", "/api/boom")).toBe(
+      false,
+    );
+  });
 });

--- a/packages/agent/src/api/boundary-role-resolver.ts
+++ b/packages/agent/src/api/boundary-role-resolver.ts
@@ -133,5 +133,10 @@ export function isRegisteredTokenRoleAuthorized(
   const access = resolveRegisteredTokenRoleAccess(req);
   if (!access) return false;
   if (access.isAdmin) return true;
-  return access.isRouteInScope(method.toUpperCase(), pathname);
+  try {
+    return Boolean(access.isRouteInScope(method.toUpperCase(), pathname));
+  } catch {
+    // error-policy:J3 Fail closed if the product's scope check throws.
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `packages/agent/src/api/boundary-role-resolver.ts`, `isRegisteredTokenRoleAuthorized` now wraps calls to `access.isRouteInScope(...)` in a try/catch to fail closed (`false`) if a custom product resolver's scope-check function throws.

# Background

## What does this PR do?

Catches unexpected errors thrown by `access.isRouteInScope(method, pathname)` in `isRegisteredTokenRoleAuthorized` and fails closed (`false`), preventing uncaught errors in third-party product resolvers from crashing HTTP route authorization.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/agent/src/api/boundary-role-resolver.ts` and `packages/agent/src/api/boundary-role-resolver.test.ts`.

## Detailed testing steps

Run `bun test packages/agent/src/api/boundary-role-resolver.test.ts`.

# Evidence Gate

<!-- evidence-head:2ac04a99e1994834cffbfed06abf60730d8eb8c2 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual agent auth utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual agent auth utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual agent auth utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - non-visual agent auth utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
bun test v1.3.11 (af24e281)

packages/agent/src/api/boundary-role-resolver.test.ts:
181 |       },
182 |     });
183 |     registerTokenRoleResolver(makeResolver("user", access));
184 |     expect(() =>
185 |       isRegisteredTokenRoleAuthorized(req, "GET", "/api/boom"),
186 |     ).not.toThrow();
                ^
error: expect(received).not.toThrow()

Error name: "Error"
Error message: "malformed route path"

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/fix-agent-boundary-role-scope-error/packages/agent/src/api/boundary-role-resolver.test.ts:186:11)
(fail) isRegisteredTokenRoleAuthorized > fails closed when isRouteInScope throws [0.11ms]

 11 pass
 1 fail
 19 expect() calls
Ran 12 tests across 1 file. [112.00ms]
```

### Green Output (passing after fix)
```
bun test v1.3.11 (af24e281)

packages/agent/src/api/boundary-role-resolver.test.ts:
(pass) boundary-role resolver registry > returns null when no resolvers are registered [0.07ms]
(pass) boundary-role resolver registry > returns the first non-null resolver in registration order [0.14ms]
(pass) boundary-role resolver registry > skips resolvers that return null and continues [0.03ms]
(pass) boundary-role resolver registry > treats a throwing resolver as a non-match (fail-closed) and continues [0.09ms]
(pass) boundary-role resolver registry > stops at the first match even if later resolvers would match
(pass) boundary-role resolver registry > re-registering the same id replaces the prior resolver [0.03ms]
(pass) boundary-role resolver registry > unregister removes only the same instance [0.04ms]
(pass) isRegisteredTokenRoleAuthorized > returns false when nothing recognises the request [0.02ms]
(pass) isRegisteredTokenRoleAuthorized > authorizes admins unconditionally [0.02ms]
(pass) isRegisteredTokenRoleAuthorized > authorizes non-admins only for in-scope routes [0.03ms]
(pass) isRegisteredTokenRoleAuthorized > normalizes method to uppercase before the scope check [0.05ms]
(pass) isRegisteredTokenRoleAuthorized > fails closed when isRouteInScope throws [0.04ms]

 12 pass
 0 fail
 20 expect() calls
Ran 12 tests across 1 file. [93.00ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual agent auth utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
