### PR TITLE
fix(agent): handle non-string inputs and support ZAI and Qwen in resolveProviderFromModel

### DIFF
--- a/packages/agent/src/api/agent-model.test.ts
+++ b/packages/agent/src/api/agent-model.test.ts
@@ -8,7 +8,7 @@
 import type { AgentRuntime, ModelRegistrationInfo } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { detectRuntimeModel } from "./agent-model";
+import { detectRuntimeModel, resolveProviderFromModel } from "./agent-model";
 
 const ELIZA_CLOUD_PROVIDER_NAME = "elizaOSCloud";
 const LOCAL_INFERENCE_PROVIDER_NAME = "eliza-local-inference";
@@ -186,5 +186,22 @@ describe("detectRuntimeModel — the #20124 reproduced state", () => {
     const model = detectRuntimeModel(runtime, reproducedUnsignedCloudProxy);
     expect(model).toBe(LOCAL_INFERENCE_PROVIDER_NAME);
     expect(model).not.toBe("elizacloud");
+  });
+});
+
+describe("resolveProviderFromModel", () => {
+  it("handles non-string and empty inputs safely without throwing", () => {
+    expect(resolveProviderFromModel(null as unknown as string)).toBeNull();
+    expect(resolveProviderFromModel(undefined as unknown as string)).toBeNull();
+    expect(resolveProviderFromModel("")).toBeNull();
+    expect(resolveProviderFromModel("   ")).toBeNull();
+  });
+
+  it("resolves canonical providers from model strings", () => {
+    expect(resolveProviderFromModel("gpt-4o")).toBe("OpenAI");
+    expect(resolveProviderFromModel("claude-3-5-sonnet")).toBe("Anthropic");
+    expect(resolveProviderFromModel("gemini-1.5-pro")).toBe("Google");
+    expect(resolveProviderFromModel("zai-coding")).toBe("ZAI");
+    expect(resolveProviderFromModel("qwen-2.5-72b")).toBe("Qwen");
   });
 });

--- a/packages/agent/src/api/agent-model.ts
+++ b/packages/agent/src/api/agent-model.ts
@@ -266,6 +266,7 @@ export function detectRuntimeModel(
 }
 
 export function resolveProviderFromModel(model: string): string | null {
+  if (typeof model !== "string") return null;
   const lower = model.trim().toLowerCase();
   if (!lower) return null;
 
@@ -286,6 +287,8 @@ export function resolveProviderFromModel(model: string): string | null {
     { match: "cohere", label: "Cohere" },
     { match: "moonshot", label: "Moonshot" },
     { match: "kimi", label: "Kimi" },
+    { match: "zai", label: "ZAI" },
+    { match: "qwen", label: "Qwen" },
   ];
   for (const { match, label } of providers) {
     if (lower.includes(match)) return label;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `packages/agent/src/api/agent-model.ts`, `resolveProviderFromModel` now guards against non-string arguments and maps `zai` and `qwen` model strings to their respective canonical provider labels (`ZAI` and `Qwen`).

# Background

## What does this PR do?

1. Guards `resolveProviderFromModel` with a `typeof model !== "string"` check to safely return `null` instead of throwing `TypeError: model.trim is not a function`.
2. Adds `"zai"` -> `"ZAI"` and `"qwen"` -> `"Qwen"` to `resolveProviderFromModel`, matching existing `PROVIDER_HINTS` and `ENV_PROVIDER_SIGNALS`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/agent/src/api/agent-model.ts` and `packages/agent/src/api/agent-model.test.ts`.

## Detailed testing steps

Run `bun test packages/agent/src/api/agent-model.test.ts`.

# Evidence Gate

<!-- evidence-head:323fc9dc2c3ab6c67facb3eb606ebe6adef61303 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual agent model resolution utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-visual agent model resolution utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-visual agent model resolution utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - non-visual agent model resolution utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model/prompt changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable, or marked `N/A - pure utility function with unit tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt changed.

## Backend + frontend logs

### Red Output (failing before fix)
```
(fail) resolveProviderFromModel > handles non-string and empty inputs safely without throwing [0.18ms]
199 | 
200 |   it("resolves canonical providers from model strings", () => {
201 |     expect(resolveProviderFromModel("gpt-4o")).toBe("OpenAI");
202 |     expect(resolveProviderFromModel("claude-3-5-sonnet")).toBe("Anthropic");
203 |     expect(resolveProviderFromModel("gemini-1.5-pro")).toBe("Google");
204 |     expect(resolveProviderFromModel("zai-coding")).toBe("ZAI");
                                                         ^
error: expect(received).toBe(expected)

Expected: "ZAI"
Received: null
(fail) resolveProviderFromModel > resolves canonical providers from model strings [0.10ms]
```

### Green Output (passing after fix)
```
(pass) detectRuntimeModel — cloud-proxy branch > returns elizacloud when the cloud text handler is registered [0.61ms]
(pass) detectRuntimeModel — cloud-proxy branch > falls through when cloud-proxy is configured but no cloud handler is registered [0.06ms]
(pass) detectRuntimeModel — cloud-proxy branch > falls through to a local provider plugin name when cloud handlers are absent [0.02ms]
(pass) detectRuntimeModel — cloud-proxy branch > returns elizacloud even when local handlers are also registered (cloud wins) [0.05ms]
(pass) detectRuntimeModel — non-cloud branches unaffected > returns undefined when no runtime is provided
(pass) detectRuntimeModel — non-cloud branches unaffected > falls back to the character model when nothing has served yet
(pass) detectRuntimeModel — non-cloud branches unaffected > prefers the provider that actually served over a character pin [0.02ms]
(pass) detectRuntimeModel — non-cloud branches unaffected > prefers the serving provider over a registered-but-losing cloud handler [0.03ms]
(pass) detectRuntimeModel — non-cloud branches unaffected > reports elizacloud once a Cloud handler has actually served [0.02ms]
(pass) detectRuntimeModel — non-cloud branches unaffected > returns the direct-transport primary model [0.04ms]
(pass) detectRuntimeModel — the #20124 reproduced state > no longer reports elizacloud once local inference has served a turn [0.01ms]
(pass) resolveProviderFromModel > handles non-string and empty inputs safely without throwing [0.01ms]
(pass) resolveProviderFromModel > resolves canonical providers from model strings [0.08ms]
```

## Screenshots (before / after) + video walkthrough

N/A - non-visual agent model resolution utility change.

## Audio / voice walkthrough

N/A - non-voice change.

## Known gaps / failures

N/A - no known gaps.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
