### PR TITLE
test(app-core): cover owner-confidence

### DIFF
--- a/packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts
@@ -83,4 +83,74 @@ describe("scoreOwnerConfidence", () => {
     );
     expect(r.score).toBe(0);
   });
+
+  it("challenge alone scores exactly its weight with only its reason", () => {
+    const r = scoreOwnerConfidence(input({ challengeRecentlyPassed: true }));
+    expect(r.score).toBe(0.45);
+    expect(r.reasons).toEqual(["challenge-recently-passed"]);
+  });
+
+  it("recent auth alone scores exactly its weight with only its reason", () => {
+    const r = scoreOwnerConfidence(input({ recentlyAuthenticated: true }));
+    expect(r.score).toBe(0.35);
+    expect(r.reasons).toEqual(["recently-authenticated"]);
+  });
+
+  it("full-similarity voice contributes exactly the cap and tags the reason", () => {
+    const r = scoreOwnerConfidence(input({ voiceSimilarityToOwnerProfile: 1 }));
+    expect(r.score).toBe(0.25);
+    expect(r.reasons).toEqual(["voice-similarity:1.00"]);
+  });
+
+  it("partial voice similarity scales linearly inside the cap", () => {
+    const r = scoreOwnerConfidence(
+      input({ voiceSimilarityToOwnerProfile: 0.5 }),
+    );
+    expect(r.score).toBe(0.125);
+    expect(r.reasons).toEqual(["voice-similarity:0.50"]);
+  });
+
+  it("voice similarity above one clamps to the same contribution as one", () => {
+    const r = scoreOwnerConfidence(input({ voiceSimilarityToOwnerProfile: 7 }));
+    expect(r.score).toBe(0.25);
+    expect(r.reasons).toEqual(["voice-similarity:1.00"]);
+  });
+
+  it("device trust steps carry exact weights and tags; low adds nothing", () => {
+    const low = scoreOwnerConfidence(input({ deviceTrustLevel: "low" }));
+    expect(low.score).toBe(0);
+    expect(low.reasons).toEqual([]);
+    const medium = scoreOwnerConfidence(input({ deviceTrustLevel: "medium" }));
+    expect(medium.score).toBe(0.1);
+    expect(medium.reasons).toEqual(["device-trust:medium"]);
+    const high = scoreOwnerConfidence(input({ deviceTrustLevel: "high" }));
+    expect(high.score).toBe(0.2);
+    expect(high.reasons).toEqual(["device-trust:high"]);
+  });
+
+  it("context expectation alone scores exactly its weight and tag", () => {
+    const r = scoreOwnerConfidence(input({ contextExpectsOwner: true }));
+    expect(r.score).toBe(0.1);
+    expect(r.reasons).toEqual(["context-expects-owner"]);
+  });
+
+  it("reasons follow fixed signal order and the saturated total clamps to 1", () => {
+    const r = scoreOwnerConfidence(
+      input({
+        challengeRecentlyPassed: true,
+        recentlyAuthenticated: true,
+        voiceSimilarityToOwnerProfile: 1,
+        deviceTrustLevel: "high",
+        contextExpectsOwner: true,
+      }),
+    );
+    expect(r.score).toBe(1);
+    expect(r.reasons).toEqual([
+      "challenge-recently-passed",
+      "recently-authenticated",
+      "voice-similarity:1.00",
+      "device-trust:high",
+      "context-expects-owner",
+    ]);
+  });
 });


### PR DESCRIPTION

## Summary

Additive-only test coverage extension for `scoreOwnerConfidence` in `packages/app-core/src/services/voice-profiles/owner-confidence.ts`.

The existing suite at `packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts` covered loose thresholds (>= 0.4 floor, < 0.6 cap), ordering of trust levels, and clamping of negative voice similarity and the saturated total. This PR adds 8 cases that pin the remaining untested behavior:

- Exact per-signal weights in isolation: challenge 0.45, recent auth 0.35, voice cap 0.25, device-trust steps low 0 / medium 0.1 / high 0.2, context expectation 0.1.
- The reason-tag contract for every contributing signal (`voice-similarity:*`, `device-trust:*`, `context-expects-owner`), which was previously asserted for none of them.
- Linear voice scaling inside the cap (similarity 0.5 -> score 0.125) and the input-side clamp of voice similarity above one (7 behaves identically to 1).
- Deterministic reason ordering across all five signals and saturation to exactly 1.

## Diff shape

Test-only. One file touched: the existing suite gains cases (+70/-0). No production code changed, no existing case was rewritten or removed.

## Verification

- Fork contributor: hosted CI does not run on this PR. All checks below were run locally.
- Runner: vitest owns this package (`packages/app-core/package.json` test script uses `../scripts/run-vitest.mjs`).
- `bunx vitest run packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts` — Test Files: 1 passed (1); Tests: **16 passed (16)** (8 pre-existing + 8 added). Re-fetched `origin/develop` immediately before filing; develop tip unchanged at `de774b875774f478ef5b879dbdae8fd2997a3470`, so these counts reproduce against current develop verbatim.
- `bunx biome check --write packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts` — clean ("Checked 1 file", formatting applied).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/app-core` — zero mentions of `owner-confidence` in output.
- Tooling sanity: `biome.json` and root `tsconfig.json` present; worktree is not sparse (`git sparse-checkout list` reports not sparse).
- No `vi.hoisted`, no `expectTypeOf`; assertions drive the real module directly.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ace1f808c52ba0149d757d2c5de6e7a677de04ca -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
