### PR TITLE
test(ui): cover first-run-reset

### DIFF
--- a/packages/ui/src/platform/first-run-reset.test.ts
+++ b/packages/ui/src/platform/first-run-reset.test.ts
@@ -1,0 +1,399 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit suite for the platform first-run-reset force-fresh state machine
+ * (`src/platform/first-run-reset.ts`), driven entirely through its public API.
+ *
+ * The module is the shell's escape hatch for stranded startup screens: arm
+ * `elizaos:first-run:force-fresh`, consume a `?reset` query param into that
+ * directive plus an "applied" marker, and overlay a patched API client until
+ * onboarding completes. The suite pins the contracts downstream consumers rely
+ * on: arming clears a stale applied-marker (an interrupted query-param reset
+ * must not suppress the next restore), consuming `?reset` clears the three
+ * boot keys and the shell-reserved `elizaos_api_base` from BOTH storages,
+ * history is rewritten to strip the param, submission lifts the overlay by
+ * clearing the flag, and double installation is inert while uninstall restores
+ * the original client methods verbatim.
+ *
+ * Harness: real module, real jsdom `localStorage`/`sessionStorage`, functional
+ * in-memory `StorageLike`/`HistoryLike` doubles injected through the module's
+ * own seams. No network, nothing under test mocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyForceFreshFirstRunReset,
+  clearForceFreshFirstRun,
+  enableForceFreshFirstRun,
+  installForceFreshFirstRunClientPatch,
+  isForceFreshFirstRunEnabled,
+  startFreshFirstRunReload,
+  wasForceFreshResetApplied,
+} from "./first-run-reset";
+import type { FirstRunClientLike, HistoryLike, StorageLike } from "./types";
+
+const FORCE_FRESH_KEY = "elizaos:first-run:force-fresh";
+const RESET_APPLIED_KEY = "elizaos:first-run:reset-applied";
+const ACTIVE_SERVER_KEY = "elizaos:active-server";
+const SETUP_STEP_KEY = "eliza:setup:step";
+const FIRST_RUN_COMPLETE_KEY = "eliza:first-run-complete";
+
+/**
+ * Functional Map-backed storage double: every mutation is recorded in `ops`
+ * so tests can assert that a path mutated NOTHING, not merely that a getter
+ * returned a value the double itself produced.
+ */
+function makeStorage(seed?: Record<string, string>): StorageLike & {
+  ops: string[];
+  get: (key: string) => string | null;
+} {
+  const map = new Map<string, string>(Object.entries(seed ?? {}));
+  const ops: string[] = [];
+  return {
+    ops,
+    get: (key) => map.get(key) ?? null,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      ops.push(`set:${key}`);
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      ops.push(`remove:${key}`);
+      map.delete(key);
+    },
+  };
+}
+
+function makeHistory(): HistoryLike & { calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  return {
+    calls,
+    replaceState: (...args: unknown[]) => {
+      calls.push(args);
+    },
+  };
+}
+
+function resetUrl(): URL {
+  return new URL("https://app.eliza.local/?reset&tab=chat");
+}
+
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+
+/** Swap `window.location` for a plain object recording reload() invocations. */
+function stubLocationReload(): { reloads: () => number } {
+  let reloads = 0;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      reload: () => {
+        reloads += 1;
+      },
+      toString: () => "https://app.eliza.local/",
+    },
+  });
+  return { reloads: () => reloads };
+}
+
+/** Spy client matching the narrow FirstRunClientLike seam, onboarding-replay style. */
+function makeClient(status: { complete: boolean } & Record<string, unknown>) {
+  const getConfig = vi.fn(async () => ({
+    meta: { firstRunComplete: true },
+  }));
+  const getFirstRunStatus = vi.fn(async () => status);
+  const submitFirstRun = vi.fn(async () => {});
+  const client = {
+    getConfig,
+    getFirstRunStatus,
+    submitFirstRun,
+  } as unknown as FirstRunClientLike;
+  return { client, getConfig, getFirstRunStatus, submitFirstRun };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  if (originalLocationDescriptor) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  }
+  vi.restoreAllMocks();
+});
+
+describe("isForceFreshFirstRunEnabled", () => {
+  it("reads the durable directive from the resolved storage", () => {
+    const storage = makeStorage({ [FORCE_FRESH_KEY]: "1" });
+    expect(isForceFreshFirstRunEnabled(storage)).toBe(true);
+  });
+
+  it("is false when the key holds any value other than '1' or is absent", () => {
+    const storage = makeStorage({ [FORCE_FRESH_KEY]: "0" });
+    expect(isForceFreshFirstRunEnabled(storage)).toBe(false);
+    expect(isForceFreshFirstRunEnabled(makeStorage())).toBe(false);
+  });
+
+  it("is false when no storage can be resolved", () => {
+    expect(isForceFreshFirstRunEnabled(null)).toBe(false);
+  });
+
+  it("reports a hostile (throwing) store as disabled instead of crashing", () => {
+    const hostile: StorageLike = {
+      getItem: () => {
+        throw new Error("storage guard denied");
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    expect(isForceFreshFirstRunEnabled(hostile)).toBe(false);
+  });
+});
+
+describe("enableForceFreshFirstRun / clearForceFreshFirstRun", () => {
+  it("arming sets the flag AND clears a stale applied-marker so the next restore runs", () => {
+    const storage = makeStorage({
+      [FORCE_FRESH_KEY]: "",
+      [RESET_APPLIED_KEY]: "1",
+    });
+    enableForceFreshFirstRun(storage);
+    expect(storage.get(FORCE_FRESH_KEY)).toBe("1");
+    expect(storage.get(RESET_APPLIED_KEY)).toBeNull();
+  });
+
+  it("clearing removes both keys and tolerates repeated or absent clears", () => {
+    const storage = makeStorage({
+      [FORCE_FRESH_KEY]: "1",
+      [RESET_APPLIED_KEY]: "1",
+    });
+    clearForceFreshFirstRun(storage);
+    expect(storage.get(FORCE_FRESH_KEY)).toBeNull();
+    expect(storage.get(RESET_APPLIED_KEY)).toBeNull();
+    expect(() => clearForceFreshFirstRun(storage)).not.toThrow();
+  });
+
+  it("both operations are safe no-ops without resolvable storage", () => {
+    expect(() => enableForceFreshFirstRun(null)).not.toThrow();
+    expect(() => clearForceFreshFirstRun(null)).not.toThrow();
+  });
+
+  it("arming swallows a hostile store failure during startup", () => {
+    const hostile: StorageLike = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+      removeItem: () => {},
+    };
+    expect(() => enableForceFreshFirstRun(hostile)).not.toThrow();
+  });
+});
+
+describe("wasForceFreshResetApplied", () => {
+  it("only reports applied once the ?reset boot path has marked it", () => {
+    const storage = makeStorage();
+    const history = makeHistory();
+    expect(wasForceFreshResetApplied(storage)).toBe(false);
+
+    applyForceFreshFirstRunReset({ url: resetUrl(), storage, history });
+    expect(wasForceFreshResetApplied(storage)).toBe(true);
+    expect(storage.get(RESET_APPLIED_KEY)).toBe("1");
+
+    clearForceFreshFirstRun(storage);
+    expect(wasForceFreshResetApplied(storage)).toBe(false);
+  });
+});
+
+describe("applyForceFreshFirstRunReset", () => {
+  it("returns false and mutates nothing when the URL carries no ?reset", () => {
+    const storage = makeStorage();
+    const history = makeHistory();
+
+    const applied = applyForceFreshFirstRunReset({
+      url: new URL("https://app.eliza.local/?tab=chat"),
+      storage,
+      history,
+    });
+
+    expect(applied).toBe(false);
+    expect(storage.ops).toEqual([]);
+    expect(history.calls).toEqual([]);
+  });
+
+  it("consuming ?reset clears the three boot keys, arms force-fresh, marks applied, and strips the param from history", () => {
+    const storage = makeStorage({
+      [ACTIVE_SERVER_KEY]: '{"label":"old"}',
+      [SETUP_STEP_KEY]: "pairing",
+      [FIRST_RUN_COMPLETE_KEY]: "1",
+    });
+    const history = makeHistory();
+
+    const applied = applyForceFreshFirstRunReset({
+      url: resetUrl(),
+      storage,
+      history,
+    });
+
+    expect(applied).toBe(true);
+    expect(storage.get(ACTIVE_SERVER_KEY)).toBeNull();
+    expect(storage.get(SETUP_STEP_KEY)).toBeNull();
+    expect(storage.get(FIRST_RUN_COMPLETE_KEY)).toBeNull();
+    expect(storage.get(FORCE_FRESH_KEY)).toBe("1");
+    expect(storage.get(RESET_APPLIED_KEY)).toBe("1");
+
+    expect(history.calls).toHaveLength(1);
+    const rewritten = String(history.calls[0]?.[2]);
+    expect(rewritten).toContain("tab=chat");
+    expect(rewritten).not.toContain("reset");
+  });
+
+  it("still strips the param and reports applied when storage is unavailable", () => {
+    const history = makeHistory();
+    const applied = applyForceFreshFirstRunReset({
+      url: resetUrl(),
+      storage: null,
+      history,
+    });
+    expect(applied).toBe(true);
+    expect(history.calls).toHaveLength(1);
+  });
+
+  it("clears the shell-reserved elizaos_api_base from BOTH browser storages", () => {
+    window.localStorage.setItem("elizaos_api_base", "https://stale.example");
+    window.sessionStorage.setItem("elizaos_api_base", "https://stale.example");
+    const storage = makeStorage();
+    const history = makeHistory();
+
+    const applied = applyForceFreshFirstRunReset({
+      url: resetUrl(),
+      storage,
+      history,
+    });
+
+    expect(applied).toBe(true);
+    expect(window.localStorage.getItem("elizaos_api_base")).toBeNull();
+    expect(window.sessionStorage.getItem("elizaos_api_base")).toBeNull();
+  });
+});
+
+describe("startFreshFirstRunReload", () => {
+  it("persists the durable directive, then reloads exactly once", () => {
+    const location = stubLocationReload();
+    const storage = makeStorage();
+
+    startFreshFirstRunReload(storage);
+
+    expect(storage.get(FORCE_FRESH_KEY)).toBe("1");
+    expect(location.reloads()).toBe(1);
+  });
+});
+
+describe("installForceFreshFirstRunClientPatch", () => {
+  it("delegates verbatim to the real client while the directive is disarmed", async () => {
+    const storage = makeStorage();
+    const spies = makeClient({ complete: true });
+
+    const uninstall = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+
+    const status = await spies.client.getFirstRunStatus();
+    expect(status.complete).toBe(true);
+    const config = await spies.client.getConfig();
+    expect(config).toEqual({ meta: { firstRunComplete: true } });
+    expect(spies.getFirstRunStatus).toHaveBeenCalledTimes(1);
+    expect(spies.getConfig).toHaveBeenCalledTimes(1);
+
+    uninstall();
+  });
+
+  it("while armed: config reads answer empty WITHOUT reaching the stranded backend, and status reports incomplete preserving extra fields", async () => {
+    const storage = makeStorage();
+    enableForceFreshFirstRun(storage);
+    const spies = makeClient({ complete: true, agentName: "Real Agent" });
+
+    const uninstall = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+
+    expect(await spies.client.getConfig()).toEqual({});
+    expect(spies.getConfig).not.toHaveBeenCalled();
+
+    const status = await spies.client.getFirstRunStatus();
+    expect(status).toEqual({ complete: false, agentName: "Real Agent" });
+    expect(spies.getFirstRunStatus).toHaveBeenCalledTimes(1);
+
+    uninstall();
+  });
+
+  it("submitting first run lifts the overlay by clearing the durable directive", async () => {
+    const storage = makeStorage();
+    enableForceFreshFirstRun(storage);
+    const spies = makeClient({ complete: true });
+
+    const uninstall = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+
+    await spies.client.submitFirstRun({} as never);
+    expect(spies.submitFirstRun).toHaveBeenCalledTimes(1);
+    expect(isForceFreshFirstRunEnabled(storage)).toBe(false);
+
+    await spies.client.getConfig();
+    expect(spies.getConfig).toHaveBeenCalledTimes(1);
+
+    uninstall();
+  });
+
+  it("double installation is inert: the second handle is a no-op and only the first uninstall restores", async () => {
+    const storage = makeStorage();
+    enableForceFreshFirstRun(storage);
+    const spies = makeClient({ complete: true });
+
+    const uninstallFirst = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+    const uninstallSecond = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+
+    uninstallSecond();
+    const status = await spies.client.getFirstRunStatus();
+    expect(status.complete).toBe(false);
+
+    uninstallFirst();
+    const restored = await spies.client.getFirstRunStatus();
+    expect(restored).toEqual({ complete: true });
+  });
+
+  it("uninstall restores the original method identities and a fresh patch can be installed again", async () => {
+    const storage = makeStorage();
+    const spies = makeClient({ complete: true });
+
+    const uninstall = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+    uninstall();
+
+    expect(spies.client.getConfig).toBe(spies.getConfig);
+    expect(spies.client.getFirstRunStatus).toBe(spies.getFirstRunStatus);
+    expect(spies.client.submitFirstRun).toBe(spies.submitFirstRun);
+
+    enableForceFreshFirstRun(storage);
+    const reinstall = installForceFreshFirstRunClientPatch(
+      spies.client,
+      storage,
+    );
+    expect(await spies.client.getConfig()).toEqual({});
+    reinstall();
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located unit suite for `packages/ui/src/platform/first-run-reset.ts`, which had no same-named test file anywhere in the repository. Test-only change: one new file, +399/-0, no production code touched.

The module is the shell's escape hatch for stranded startup screens. The suite drives every exported symbol through its public API against real behavior:

- `isForceFreshFirstRunEnabled` — reads the durable directive (`"1"` only), false when absent, other values, no resolvable storage, or a throwing store.
- `enableForceFreshFirstRun` / `clearForceFreshFirstRun` — arming sets the flag AND clears a stale applied-marker (an interrupted query-param reset must not suppress the next startup restore); clearing removes both keys; both tolerate repeated calls, missing storage, and hostile stores.
- `wasForceFreshResetApplied` — flips true only after the `?reset` boot path marks it, back to false after a clear.
- `applyForceFreshFirstRunReset` — returns `false` and mutates nothing without the param; consuming it clears the three boot keys (`elizaos:active-server`, `eliza:setup:step`, `eliza:first-run-complete`), arms force-fresh, sets the applied marker, strips `elizaos_api_base` from BOTH browser storages, rewrites history to drop the param while preserving other params, and still succeeds when storage is unavailable.
- `startFreshFirstRunReload` — persists the directive, then reloads exactly once.
- `installForceFreshFirstRunClientPatch` — delegates verbatim while disarmed; while armed, `getConfig` answers empty without reaching the backend and `getFirstRunStatus` reports incomplete while preserving extra fields; submission lifts the overlay by clearing the directive; double installation is inert (second handle is a no-op); uninstall restores original method identities and re-patching works.

## Harness

Real module under test, jsdom environment (`// @vitest-environment jsdom`) with real `localStorage`/`sessionStorage`; functional Map-backed `StorageLike` / recording `HistoryLike` doubles injected through the module's own seams so "mutated nothing" is asserted on recorded operations. Spies exist only on the injected client seam the module patches over. No network, nothing under test mocked, no type-level assertions.

## Evidence (test-only PR)

- `bunx vitest run src/platform/first-run-reset.test.ts` (packages/ui): **Test Files 1 passed (1), Tests 19 passed (19)** — run twice at this head, most recently immediately before push at `d86a667c865fa7c606b1739dffa566e4fcb3c5e5`.
- `bunx biome check --write src/platform/first-run-reset.test.ts`: clean ("Checked 1 file … No fixes applied"), against the repo's real root `biome.json`.
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mentioning `first-run-reset.test.ts`.
- The diff touches only the new test file (+399/-0).

**Fork contributor:** hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d86a667c865fa7c606b1739dffa566e4fcb3c5e5 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
