### PR TITLE
test(app-core): cover store

### DIFF
--- a/packages/app-core/src/services/voice-profiles/__tests__/store.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/store.test.ts
@@ -85,3 +85,110 @@ describe("InMemoryVoiceProfileStore", () => {
     }
   });
 });
+
+describe("InMemoryVoiceProfileStore edge branches", () => {
+  it("search on an empty store returns no hits", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    expect(await s.search([1, 0], 5)).toEqual([]);
+  });
+
+  it("skips profiles whose embeddings list is empty", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    const hollow: VoiceProfile = {
+      ...makeProfile("hollow", [1, 0]),
+      embeddings: [],
+    };
+    await s.upsert(hollow);
+    await s.upsert(makeProfile("voiced", [1, 0]));
+    const hits = await s.search([1, 0], 10);
+    expect(hits.map((h) => h.profile.id)).toEqual(["voiced"]);
+  });
+
+  it("scores a zero-magnitude stored vector as similarity 0 instead of dropping it", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("flat", [0, 0]));
+    const hits = await s.search([1, 0], 10);
+    expect(hits.map((h) => h.profile.id)).toEqual(["flat"]);
+    expect(hits[0]?.similarity).toBe(0);
+  });
+
+  it("scores an empty query vector as similarity 0 against stored profiles", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("a", [1, 0]));
+    const hits = await s.search([], 10);
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.similarity).toBe(0);
+  });
+
+  it("compares only the overlapping prefix when vector lengths differ", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("short", [1]));
+    const hits = await s.search([1, 0, 0], 10);
+    expect(hits[0]?.profile.id).toBe("short");
+    expect(hits[0]?.similarity).toBe(1);
+  });
+
+  it("uses the best similarity across all stored embeddings of a profile", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    const mixed: VoiceProfile = {
+      ...makeProfile("mixed", [0, 1]),
+      embeddings: [
+        { vectorPreview: [0, 1], modelId: "ecapa-voxceleb", createdAt: 1 },
+        { vectorPreview: [1, 0], modelId: "ecapa-voxceleb", createdAt: 2 },
+        { vectorPreview: [-1, 0], modelId: "ecapa-voxceleb", createdAt: 3 },
+      ],
+    };
+    await s.upsert(mixed);
+    const hits = await s.search([1, 0], 10);
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.similarity).toBe(1);
+  });
+
+  it("defaults the limit to 10 hits when omitted", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    for (let i = 0; i < 14; i++) {
+      await s.upsert(makeProfile(`p${i}`, [Math.cos(i), Math.sin(i)]));
+    }
+    const hits = await s.search([1, 0]);
+    expect(hits.length).toBe(10);
+  });
+
+  it("negative similarities sort below zero-similarity hits", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("opposite", [-1, 0]));
+    await s.upsert(makeProfile("orthogonal", [0, 1]));
+    const hits = await s.search([1, 0], 10);
+    expect(hits.map((h) => h.profile.id)).toEqual(["orthogonal", "opposite"]);
+    expect(hits[1]?.similarity).toBe(-1);
+  });
+
+  it("ties keep insertion order across equal similarities", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("first", [1, 0]));
+    await s.upsert(makeProfile("second", [1, 0]));
+    const hits = await s.search([2, 0], 10);
+    expect(hits.map((h) => h.profile.id)).toEqual(["first", "second"]);
+    expect(hits[0]?.similarity).toBe(1);
+    expect(hits[1]?.similarity).toBe(1);
+  });
+
+  it("upsert replaces the profile stored under an existing id", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("a", [1, 0]));
+    const replacement: VoiceProfile = {
+      ...makeProfile("a", [0, 1]),
+      consent: "unknown",
+    };
+    await s.upsert(replacement);
+    expect((await s.list()).length).toBe(1);
+    const got = await s.get("a");
+    expect(got?.consent).toBe("unknown");
+  });
+
+  it("delete of a missing id resolves without side effects", async () => {
+    const s = new InMemoryVoiceProfileStore();
+    await s.upsert(makeProfile("kept", [1, 0]));
+    await expect(s.delete("ghost")).resolves.toBeUndefined();
+    expect((await s.list()).map((p) => p.id)).toEqual(["kept"]);
+  });
+});


### PR DESCRIPTION

## Summary

Additive test coverage for `packages/app-core/src/services/voice-profiles/store.ts`. The existing suite (`__tests__/store.test.ts`) covered roundtrips, list/delete, descending sort, explicit limit, and a scale case; this PR appends 11 cases for branches it did not exercise, all driven through the public `InMemoryVoiceProfileStore` API with no mocks:

- search on an empty store returns no hits
- profiles with an empty `embeddings` list are skipped from results (the `-Infinity → continue` path)
- zero-magnitude stored vectors score similarity 0 but still appear as hits
- an empty query vector scores similarity 0
- cosine comparison uses only the overlapping prefix when vector lengths differ
- a profile's score is its best similarity across all stored embeddings (not the first or an average)
- the limit defaults to 10 when omitted
- negative similarities sort below zero-similarity hits
- ties keep insertion order across equal similarities
- upserting an existing id replaces the stored profile
- deleting a missing id resolves without side effects

The diff touches only this one test file: **+107/-0**, purely additive — no existing case was modified or removed.

## Evidence

Test-only change; no production behavior is modified.

- `vitest`: `bunx vitest run src/services/voice-profiles/__tests__/store.test.ts --config vitest.config.ts` in `packages/app-core` → **Test Files 1 passed (1), Tests 18 passed (18)** (7 pre-existing + 11 new), re-run against current `origin/develop` (`de774b87`) immediately before filing.
- Biome: `bunx @biomejs/biome check --write src/services/voice-profiles/__tests__/store.test.ts` → clean ("No fixes applied").
- TypeScript: `bunx tsc --noEmit -p tsconfig.json` in `packages/app-core` → zero diagnostics mention `store.test.ts`.
- This is a fork contribution, so hosted CI does not run on this PR; the counts above are quoted from local runs of the real runner that owns this package's src lane (vitest via `run-vitest.mjs`).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:de774b875774f478ef5b879dbdae8fd2997a3470 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
