### PR TITLE
test(app-core): cover private-challenge

### DIFF
--- a/packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts
@@ -7,6 +7,16 @@
 import { describe, expect, it } from "vitest";
 import { InMemoryChallengeService } from "../private-challenge.ts";
 
+async function sha256Hex(value: string): Promise<string> {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(bytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 describe("InMemoryChallengeService", () => {
   it("issues a challenge with hashed expected answer", async () => {
     const svc = new InMemoryChallengeService({ expectedAnswer: "open sesame" });
@@ -50,5 +60,70 @@ describe("InMemoryChallengeService", () => {
     const svc = new InMemoryChallengeService();
     const c = await svc.issue("seedval");
     expect(await svc.verify(c.id, `${c.id}:seedval`)).toBe(true);
+  });
+
+  it("verifies at exactly expiresAt (inclusive boundary)", async () => {
+    let t = 0;
+    const svc = new InMemoryChallengeService({
+      now: () => t,
+      ttlMs: 1_000,
+      expectedAnswer: "ok",
+    });
+    const c = await svc.issue();
+    t = c.expiresAt;
+    expect(await svc.verify(c.id, "ok")).toBe(true);
+  });
+
+  it("expiry permanently consumes the challenge", async () => {
+    let t = 0;
+    const svc = new InMemoryChallengeService({
+      now: () => t,
+      ttlMs: 1_000,
+      expectedAnswer: "ok",
+    });
+    const c = await svc.issue();
+    t = c.expiresAt + 1;
+    expect(await svc.verify(c.id, "ok")).toBe(false);
+    t = c.createdAt;
+    expect(await svc.verify(c.id, "ok")).toBe(false);
+  });
+
+  it("does not consume the challenge on a wrong answer", async () => {
+    const svc = new InMemoryChallengeService({ expectedAnswer: "open sesame" });
+    const c = await svc.issue();
+    expect(await svc.verify(c.id, "wrong")).toBe(false);
+    expect(await svc.verify(c.id, "open sesame")).toBe(true);
+  });
+
+  it("hashes the configured expected answer with sha256 hex encoding", async () => {
+    const svc = new InMemoryChallengeService({ expectedAnswer: "open sesame" });
+    const c = await svc.issue();
+    expect(c.expectedAnswerHash).toBe(await sha256Hex("open sesame"));
+  });
+
+  it("keeps concurrent challenges independent", async () => {
+    const svc = new InMemoryChallengeService({ expectedAnswer: "open sesame" });
+    const a = await svc.issue("first");
+    const b = await svc.issue("second");
+    expect(a.id).not.toBe(b.id);
+    expect(a.prompt).toBe("first");
+    expect(b.prompt).toBe("second");
+    expect(await svc.verify(a.id, "open sesame")).toBe(true);
+    expect(await svc.verify(b.id, "open sesame")).toBe(true);
+    expect(await svc.verify(b.id, "open sesame")).toBe(false);
+  });
+
+  it("applies the requested ttl window and the default five-minute window", async () => {
+    const t = 500;
+    const custom = new InMemoryChallengeService({
+      now: () => t,
+      ttlMs: 1_234,
+    });
+    const c = await custom.issue();
+    expect(c.createdAt).toBe(500);
+    expect(c.expiresAt - c.createdAt).toBe(1_234);
+    const def = new InMemoryChallengeService({ now: () => t });
+    const d = await def.issue();
+    expect(d.expiresAt - d.createdAt).toBe(5 * 60_000);
   });
 });


### PR DESCRIPTION

## What this adds

`packages/app-core/src/services/voice-profiles/private-challenge.ts` gained a
same-named suite on develop recently; this PR **extends that existing suite
additively** (+75/-0, one file, no deletions, no production changes) with six
new cases covering branches the current six cases do not reach:

- **Inclusive expiry boundary** — `verify()` succeeds at exactly `expiresAt`
  (the check is strictly `>`), pinning the boundary the old suite only tested
  from the expired side (`expiresAt + 1`).
- **Expiry permanently consumes the challenge** — after an expired rejection,
  rewinding the injectable clock to before `expiresAt` still returns `false`,
  proving the entry was deleted rather than merely stale.
- **A wrong answer does not consume the challenge** — a failed attempt leaves
  the challenge verifiable, so a retry with the correct phrase still succeeds.
- **Exact digest contract** — `expectedAnswerHash` equals an independently
  computed sha256 hex digest of the configured answer (via WebCrypto in the
  test), strengthening the existing length-64 assertion into an algorithmic
  one.
- **Concurrent challenges are independent** — two live challenges verify and
  consume without affecting each other; ids differ and seeded prompts echo the
  seed.
- **TTL windows** — a custom `ttlMs` is honored exactly, and the default
  window is five minutes as documented on the module.

## Evidence (test-only change)

Hosted CI does not run on fork PRs, so local counts below are the evidence:

1. `bunx vitest run packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts`
   against current origin/develop immediately before filing:
   **Test Files 1 passed (1), Tests 12 passed (12)** — 6 pre-existing cases
   untouched plus these 6 new ones.
2. `bunx biome check --write <file>` — clean ("Checked 1 file … Fixed 1
   file" applied formatting to the new lines only).
3. `bunx tsc --noEmit -p tsconfig.json` in `packages/app-core` — output
   contains zero mentions of `private-challenge.test`.
4. The diff touches only
   `packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts`,
   +75/-0. No assertions use mocks standing in for the subject, no
   `expectTypeOf`, and every expectation records behaviour observed by
   running the suite.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f95c7132cd0d55465dab582b839105fe40b7265b -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
