### PR TITLE
test(core): cover wallet

### DIFF
--- a/packages/core/src/__tests__/wallet-contracts-suite.test.ts
+++ b/packages/core/src/__tests__/wallet-contracts-suite.test.ts
@@ -70,6 +70,39 @@ describe("wallet contracts", () => {
 			expect(normalizeWalletRpcProviderId("evm", null)).toBeNull();
 			expect(normalizeWalletRpcProviderId("evm", undefined)).toBeNull();
 		});
+
+		it("trims surrounding whitespace and folds case before matching", () => {
+			expect(normalizeWalletRpcProviderId("evm", "  Alchemy ")).toBe("alchemy");
+			expect(normalizeWalletRpcProviderId("bsc", "QUICKNODE")).toBe(
+				"quicknode",
+			);
+			expect(normalizeWalletRpcProviderId("evm", "\tinfura\n")).toBe("infura");
+		});
+
+		it("applies aliases after trimming and lowercasing", () => {
+			expect(normalizeWalletRpcProviderId("evm", "  ELIZACLOUD  ")).toBe(
+				"eliza-cloud",
+			);
+			expect(normalizeWalletRpcProviderId("solana", "\tHelius\n")).toBe(
+				"helius-birdeye",
+			);
+			expect(normalizeWalletRpcProviderId("bsc", "ElizaCloud")).toBe(
+				"eliza-cloud",
+			);
+		});
+
+		it("rejects whitespace-only values and truthy non-string inputs", () => {
+			expect(normalizeWalletRpcProviderId("evm", "   ")).toBeNull();
+			expect(normalizeWalletRpcProviderId("bsc", "\t\n")).toBeNull();
+			expect(
+				normalizeWalletRpcProviderId("evm", 42 as unknown as string),
+			).toBeNull();
+			expect(
+				normalizeWalletRpcProviderId("solana", {
+					id: "alchemy",
+				} as unknown as string),
+			).toBeNull();
+		});
 	});
 
 	describe("normalizeWalletRpcSelections", () => {
@@ -96,6 +129,34 @@ describe("wallet contracts", () => {
 			expect(normalizeWalletRpcSelections({})).toEqual(
 				DEFAULT_WALLET_RPC_SELECTIONS,
 			);
+		});
+
+		it("falls back per chain while preserving valid selections", () => {
+			expect(
+				normalizeWalletRpcSelections({
+					evm: "not-a-provider",
+					bsc: "quicknode",
+					solana: "HELIUS",
+				}),
+			).toEqual({
+				evm: "eliza-cloud",
+				bsc: "quicknode",
+				solana: "helius-birdeye",
+			});
+		});
+
+		it("treats explicit null and undefined fields as missing", () => {
+			expect(
+				normalizeWalletRpcSelections({
+					evm: null,
+					bsc: "ankr",
+					solana: undefined,
+				}),
+			).toEqual({
+				evm: "eliza-cloud",
+				bsc: "ankr",
+				solana: "eliza-cloud",
+			});
 		});
 	});
 });


### PR DESCRIPTION

## What

Adds five test cases (+61/-0) to the existing
`packages/core/src/__tests__/wallet-contracts-suite.test.ts`, covering branches
of `packages/core/src/contracts/wallet.ts` that had no coverage on develop:

- `normalizeWalletRpcProviderId`: trim + case-folding before allowlist matching;
  alias resolution applied *after* trim/lowercase (`"  ELIZACLOUD  "` →
  `"eliza-cloud"`, `"\tHelius\n"` → `"helius-birdeye"`);
- rejection of whitespace-only values and truthy non-string inputs (the runtime
  guard that protects callers passing raw JSON-decoded config values);
- `normalizeWalletRpcSelections`: per-chain fallback independence (an invalid
  chain falls back to its default while valid chains are preserved) and explicit
  `null` / `undefined` fields treated as missing.

## Why additive only

The suite already existed on current origin/develop, so this diff strictly adds
cases to it — no existing line is modified or removed (`+61/-0`). Assertions
record observed behaviour only; no production code changed.

## Evidence (local runs at head; fork PR — hosted CI does not run on this PR)

- `bunx vitest run packages/core/src/__tests__/wallet-contracts-suite.test.ts`
  → **Test Files: 1 passed (1), Tests: 12 passed (12)** (vitest v4.1.10 under
  bun; re-fetched and re-run against current `origin/develop`
  `de774b875774f478ef5b879dbdae8fd2997a3470` immediately before filing — same
  counts).
- `bunx biome check --write <file>` → clean after formatting pass; final plain
  check reports no fixes needed.
- `bunx tsc --noEmit` in `packages/core` → zero occurrences of
  `wallet-contracts-suite` in output.
- The diff touches only the one test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:016440e2af0ae32074463fc53b9c15d070b04386 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
