### PR TITLE
test(ui): cover ios-runtime

### DIFF
--- a/packages/ui/src/platform/ios-runtime.test.ts
+++ b/packages/ui/src/platform/ios-runtime.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Pins iOS runtime-config resolution: mode normalization, the IOS → MOBILE →
+ * legacy-ANDROID env-key precedence, fullBun detection, cloud-base fallback,
+ * and device-bridge/tunnel derivation. Env is injected per case because the
+ * sibling resolvers take a plain RuntimeEnv record rather than reading the
+ * Vite-inlined import.meta.env of their own module, so every branch here
+ * exercises the real exported functions with no fakes.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  apiBaseToDeviceBridgeUrl,
+  DEFAULT_ELIZA_CLOUD_BASE,
+  resolveCloudApiBase,
+  resolveIosRuntimeConfig,
+} from "./ios-runtime";
+
+describe("resolveCloudApiBase", () => {
+  it("falls back to the shipped Eliza Cloud base when no override is set", () => {
+    expect(resolveCloudApiBase({})).toBe(DEFAULT_ELIZA_CLOUD_BASE);
+    expect(resolveCloudApiBase({})).toBe("https://eliza.app");
+  });
+
+  it("prefers VITE_ELIZA_CLOUD_BASE over VITE_CLOUD_BASE", () => {
+    expect(
+      resolveCloudApiBase({
+        VITE_ELIZA_CLOUD_BASE: "https://primary.example",
+        VITE_CLOUD_BASE: "https://secondary.example",
+      }),
+    ).toBe("https://primary.example");
+  });
+
+  it("uses VITE_CLOUD_BASE when the primary key is absent", () => {
+    expect(
+      resolveCloudApiBase({ VITE_CLOUD_BASE: "https://legacy.example" }),
+    ).toBe("https://legacy.example");
+  });
+
+  it("strips trailing slashes but keeps interior path segments", () => {
+    for (const [input, expected] of [
+      ["https://cloud.example/", "https://cloud.example"],
+      ["https://cloud.example///", "https://cloud.example"],
+      ["https://cloud.example/base///", "https://cloud.example/base"],
+    ] as const) {
+      expect(resolveCloudApiBase({ VITE_ELIZA_CLOUD_BASE: input })).toBe(
+        expected,
+      );
+    }
+  });
+
+  it("skips whitespace-only overrides and falls through to the next key", () => {
+    expect(
+      resolveCloudApiBase({
+        VITE_ELIZA_CLOUD_BASE: "   ",
+        VITE_CLOUD_BASE: "https://fallback.example",
+      }),
+    ).toBe("https://fallback.example");
+    expect(resolveCloudApiBase({ VITE_CLOUD_BASE: "\t\n" })).toBe(
+      "https://eliza.app",
+    );
+  });
+});
+
+describe("apiBaseToDeviceBridgeUrl", () => {
+  it("upgrades https to wss and replaces the whole path", () => {
+    expect(apiBaseToDeviceBridgeUrl("https://mac.example/base/path")).toBe(
+      "wss://mac.example/api/local-inference/device-bridge",
+    );
+  });
+
+  it("downgrades http to ws", () => {
+    expect(apiBaseToDeviceBridgeUrl("http://10.0.0.2:3000")).toBe(
+      "ws://10.0.0.2:3000/api/local-inference/device-bridge",
+    );
+  });
+
+  it("keeps the port and drops query and fragment", () => {
+    expect(
+      apiBaseToDeviceBridgeUrl(
+        "https://mac.example:8443/sub?token=secret#frag",
+      ),
+    ).toBe("wss://mac.example:8443/api/local-inference/device-bridge");
+  });
+
+  it("throws on input that is not a URL", () => {
+    expect(() => apiBaseToDeviceBridgeUrl("not a url")).toThrow(TypeError);
+  });
+});
+
+describe("resolveIosRuntimeConfig mode resolution", () => {
+  const KEY = "VITE_ELIZA_IOS_RUNTIME_MODE";
+
+  it("maps every documented alias to its runtime mode", () => {
+    const aliases = [
+      ["remote", "remote-mac"],
+      ["remote-mac", "remote-mac"],
+      ["mac", "remote-mac"],
+      ["hybrid", "cloud-hybrid"],
+      ["cloud-hybrid", "cloud-hybrid"],
+      ["cloud+local", "cloud-hybrid"],
+      ["cloud-local", "cloud-hybrid"],
+      ["local", "local"],
+      ["tunnel-to-mobile", "tunnel-to-mobile"],
+      ["mobile-tunnel", "tunnel-to-mobile"],
+      ["host-with-tunnel", "tunnel-to-mobile"],
+      ["tunneled", "tunnel-to-mobile"],
+    ] as const;
+    for (const [value, expected] of aliases) {
+      expect(resolveIosRuntimeConfig({ [KEY]: value }).mode).toBe(expected);
+    }
+  });
+
+  it("tolerates casing and surrounding whitespace", () => {
+    for (const value of [
+      "REMOTE-MAC",
+      "Local",
+      "  tunnel-to-mobile  ",
+      "\ttunneled\n",
+    ]) {
+      expect(resolveIosRuntimeConfig({ [KEY]: value }).mode).toBe(
+        resolveIosRuntimeConfig({ [KEY]: value.trim().toLowerCase() }).mode,
+      );
+    }
+  });
+
+  it("defaults to cloud when the key is missing, blank, or unrecognised", () => {
+    for (const value of [undefined, "", "   ", "bogus", "ssh"]) {
+      expect(resolveIosRuntimeConfig({ [KEY]: value }).mode).toBe("cloud");
+    }
+    expect(resolveIosRuntimeConfig({}).mode).toBe("cloud");
+  });
+
+  it("prefers the IOS key over MOBILE and the legacy ANDROID key", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_IOS_RUNTIME_MODE: "remote-mac",
+        VITE_ELIZA_MOBILE_RUNTIME_MODE: "local",
+        VITE_ELIZA_ANDROID_RUNTIME_MODE: "tunneled",
+      }).mode,
+    ).toBe("remote-mac");
+  });
+
+  it("falls back to MOBILE when the IOS key is absent", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_MOBILE_RUNTIME_MODE: "local",
+        VITE_ELIZA_ANDROID_RUNTIME_MODE: "tunneled",
+      }).mode,
+    ).toBe("local");
+  });
+
+  it("still honours the legacy ANDROID key when it is all that is set", () => {
+    expect(
+      resolveIosRuntimeConfig({ VITE_ELIZA_ANDROID_RUNTIME_MODE: "remote" })
+        .mode,
+    ).toBe("remote-mac");
+  });
+
+  it("skips a blank higher-priority key and uses the lower-priority one", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_IOS_RUNTIME_MODE: "   ",
+        VITE_ELIZA_MOBILE_RUNTIME_MODE: "hybrid",
+      }).mode,
+    ).toBe("cloud-hybrid");
+  });
+});
+
+describe("resolveIosRuntimeConfig api base and token", () => {
+  it("omits apiBase and apiToken entirely when unset", () => {
+    const config = resolveIosRuntimeConfig({});
+    expect(config.apiBase).toBeUndefined();
+    expect(config.apiToken).toBeUndefined();
+    expect("apiBase" in config).toBe(false);
+    expect("apiToken" in config).toBe(false);
+  });
+
+  it("prefers the IOS keys over MOBILE and strips trailing slashes from apiBase", () => {
+    const config = resolveIosRuntimeConfig({
+      VITE_ELIZA_IOS_API_BASE: "https://a.example//",
+      VITE_ELIZA_MOBILE_API_BASE: "https://b.example",
+      VITE_ELIZA_IOS_API_TOKEN: " ios-token ",
+    });
+    expect(config.apiBase).toBe("https://a.example");
+    expect(config.apiToken).toBe("ios-token");
+  });
+
+  it("uses the MOBILE keys when the IOS keys are absent", () => {
+    const config = resolveIosRuntimeConfig({
+      VITE_ELIZA_MOBILE_API_BASE: "https://b.example/",
+      VITE_ELIZA_MOBILE_API_TOKEN: " mobile-token ",
+    });
+    expect(config.apiBase).toBe("https://b.example");
+    expect(config.apiToken).toBe("mobile-token");
+  });
+});
+
+describe("resolveIosRuntimeConfig fullBun detection", () => {
+  it("is false by default", () => {
+    expect(resolveIosRuntimeConfig({}).fullBun).toBe(false);
+  });
+
+  it("accepts the truthy string forms case-insensitively", () => {
+    for (const value of ["1", "true", "TRUE", "yes", "On"]) {
+      expect(
+        resolveIosRuntimeConfig({ VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: value })
+          .fullBun,
+      ).toBe(true);
+    }
+  });
+
+  it("lets an explicit boolean false win before later truthy keys are read", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: false,
+        VITE_ELIZA_IOS_FULL_BUN_STRICT: "true",
+      }).fullBun,
+    ).toBe(false);
+  });
+
+  it("keeps scanning later keys when an earlier string is not truthy", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "off",
+        VITE_ELIZA_IOS_FULL_BUN_SMOKE: "1",
+      }).fullBun,
+    ).toBe(true);
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "maybe",
+        VITE_ELIZA_IOS_FULL_BUN_STRICT: "0",
+        VITE_ELIZA_IOS_FULL_BUN_SMOKE: "no",
+      }).fullBun,
+    ).toBe(false);
+  });
+});
+
+describe("resolveIosRuntimeConfig device bridge derivation", () => {
+  it("derives a wss device-bridge URL from apiBase only in cloud-hybrid mode", () => {
+    const hybrid = resolveIosRuntimeConfig({
+      VITE_ELIZA_IOS_RUNTIME_MODE: "cloud-hybrid",
+      VITE_ELIZA_IOS_API_BASE: "https://192.168.1.10:3124/",
+    });
+    expect(hybrid.deviceBridgeUrl).toBe(
+      "wss://192.168.1.10:3124/api/local-inference/device-bridge",
+    );
+
+    const remoteMac = resolveIosRuntimeConfig({
+      VITE_ELIZA_IOS_RUNTIME_MODE: "remote-mac",
+      VITE_ELIZA_IOS_API_BASE: "https://192.168.1.10:3124/",
+    });
+    expect(remoteMac.deviceBridgeUrl).toBeUndefined();
+  });
+
+  it("gives the explicit device-bridge URL precedence over the derived one, in any mode", () => {
+    const explicit = {
+      VITE_ELIZA_DEVICE_BRIDGE_URL: " wss://bridge.example/ws ",
+    };
+    expect(
+      resolveIosRuntimeConfig({
+        ...explicit,
+        VITE_ELIZA_IOS_RUNTIME_MODE: "cloud-hybrid",
+        VITE_ELIZA_IOS_API_BASE: "https://192.168.1.10:3124/",
+      }).deviceBridgeUrl,
+    ).toBe("wss://bridge.example/ws");
+    expect(resolveIosRuntimeConfig({ ...explicit }).deviceBridgeUrl).toBe(
+      "wss://bridge.example/ws",
+    );
+  });
+
+  it("derives nothing in cloud-hybrid without an apiBase", () => {
+    expect(
+      resolveIosRuntimeConfig({ VITE_ELIZA_IOS_RUNTIME_MODE: "cloud-hybrid" })
+        .deviceBridgeUrl,
+    ).toBeUndefined();
+  });
+
+  it("passes through the device-bridge token when set", () => {
+    const without = resolveIosRuntimeConfig({});
+    expect(without.deviceBridgeToken).toBeUndefined();
+    expect("deviceBridgeToken" in without).toBe(false);
+    expect(
+      resolveIosRuntimeConfig({ VITE_ELIZA_DEVICE_BRIDGE_TOKEN: " tok " })
+        .deviceBridgeToken,
+    ).toBe("tok");
+  });
+});
+
+describe("resolveIosRuntimeConfig tunnel fields", () => {
+  it("passes through relay URL and pairing token trimmed, only when set", () => {
+    const unset = resolveIosRuntimeConfig({});
+    expect(unset.tunnelRelayUrl).toBeUndefined();
+    expect(unset.tunnelPairingToken).toBeUndefined();
+
+    const config = resolveIosRuntimeConfig({
+      VITE_ELIZA_IOS_RUNTIME_MODE: "tunneled",
+      VITE_ELIZA_TUNNEL_RELAY_URL: " wss://relay.example/tunnel ",
+      VITE_ELIZA_TUNNEL_PAIRING_TOKEN: " pair-123 ",
+    });
+    expect(config.mode).toBe("tunnel-to-mobile");
+    expect(config.tunnelRelayUrl).toBe("wss://relay.example/tunnel");
+    expect(config.tunnelPairingToken).toBe("pair-123");
+  });
+});
+
+describe("resolveIosRuntimeConfig shape and purity", () => {
+  it("returns exactly the minimal contract for an empty environment", () => {
+    expect(resolveIosRuntimeConfig({})).toEqual({
+      mode: "cloud",
+      fullBun: false,
+      cloudApiBase: "https://eliza.app",
+    });
+  });
+
+  it("respects the cloud-base override inside the resolved config too", () => {
+    expect(
+      resolveIosRuntimeConfig({
+        VITE_ELIZA_CLOUD_BASE: "https://cloud.internal//",
+      }).cloudApiBase,
+    ).toBe("https://cloud.internal");
+  });
+
+  it("ignores unrelated keys", () => {
+    const config = resolveIosRuntimeConfig({
+      ELIZA_RUNTIME_MODE: "remote-mac",
+      NODE_ENV: "production",
+    });
+    expect(config.mode).toBe("cloud");
+  });
+
+  it("is pure — repeated calls with the same env agree", () => {
+    const env = {
+      VITE_ELIZA_IOS_RUNTIME_MODE: "cloud-hybrid",
+      VITE_ELIZA_IOS_API_BASE: "https://mac.example/",
+      VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "yes",
+    };
+    expect(resolveIosRuntimeConfig(env)).toEqual(resolveIosRuntimeConfig(env));
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/ui/src/platform/ios-runtime.ts`, which had no same-named test file anywhere on `develop`. This is a test-only change: **one new file, +339/-0**, no production behaviour touched.

The module routes the iOS app's agent connection, so the suite pins the real consumer-visible contract of its three exported functions:

- `resolveCloudApiBase` — shipped-default fallback (`https://eliza.app` when no override is set), `VITE_ELIZA_CLOUD_BASE` > `VITE_CLOUD_BASE` precedence, trailing-slash stripping that preserves interior path segments, and whitespace-only overrides falling through to the next key.
- `apiBaseToDeviceBridgeUrl` — https→wss and http→ws upgrades, whole-path replacement with `/api/local-inference/device-bridge`, port preservation, query/fragment clearing, and `TypeError` on non-URL input.
- `resolveIosRuntimeConfig` — every documented mode alias (`remote*`/`mac`, `hybrid`/`cloud±local`, `local`, `tunnel-to-mobile`/`mobile-tunnel`/`host-with-tunnel`/`tunneled`) plus default-to-cloud for missing/blank/unrecognised values; `IOS` → `MOBILE` → legacy `ANDROID` key precedence including blank-key fall-through; `apiBase`/`apiToken` trimming and full key omission when unset; `fullBun` detection (explicit boolean short-circuit in both polarities, case-insensitive `1|true|yes|on`, keep-scanning on non-matching strings); device-bridge derivation only in `cloud-hybrid` with an api base, with an explicit `VITE_ELIZA_DEVICE_BRIDGE_URL` winning in any mode; tunnel relay/pairing-token pass-through trimmed and omitted when unset; the exact minimal result shape for an empty environment; and purity across repeated calls.

Tests drive the real exported functions with plain env records (the resolvers take a `RuntimeEnv` parameter) — no mocks, no `vi.hoisted`, no type-level assertions.

## Verification

Fork contributor — hosted CI does not run on this pull request; local results below.

- `bunx vitest run --config ./vitest.config.ts src/platform/ios-runtime.test.ts` (in `packages/ui`) → **Test Files 1 passed (1), Tests 32 passed (32)**, re-run green against current `origin/develop` (`de774b8757`) immediately before filing.
- `bunx biome check --write packages/ui/src/platform/ios-runtime.test.ts` → **Checked 1 file … No fixes applied** (config present, checkout not sparse).
- `bunx tsc --noEmit` in `packages/ui` → the new test file appears nowhere in the output (zero errors introduced by this diff).
- `git diff --stat origin/develop..test/ui-ios-runtime-coverage` → `packages/ui/src/platform/ios-runtime.test.ts | 339 +++… — 1 file changed, 339 insertions(+)`.

Evidence note: unattended session cannot finalize an interactive identity.slop.cash OAuth trace, so no evidence trace is attached for this test-only change.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6a5fc0456358b4a9704abd30630e84de409ff2f1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
