### PR TITLE
test(app): cover vercel-oidc

### DIFF
--- a/packages/app/src/shims/__tests__/vercel-oidc.test.ts
+++ b/packages/app/src/shims/__tests__/vercel-oidc.test.ts
@@ -27,4 +27,40 @@ describe("vercel-oidc browser stub", () => {
     expect(new AccessTokenMissingError()).toBeInstanceOf(Error);
     expect(new RefreshAccessTokenFailedError()).toBeInstanceOf(Error);
   });
+
+  it("keeps the two error classes distinct so callers classify failures", () => {
+    const access = new AccessTokenMissingError();
+    const refresh = new RefreshAccessTokenFailedError();
+    expect(access).toBeInstanceOf(AccessTokenMissingError);
+    expect(refresh).toBeInstanceOf(RefreshAccessTokenFailedError);
+    expect(access).not.toBeInstanceOf(RefreshAccessTokenFailedError);
+    expect(refresh).not.toBeInstanceOf(AccessTokenMissingError);
+  });
+
+  it("propagates constructor messages through the Error contract", () => {
+    expect(new AccessTokenMissingError("missing token").message).toBe(
+      "missing token",
+    );
+    expect(new RefreshAccessTokenFailedError("refresh failed").message).toBe(
+      "refresh failed",
+    );
+  });
+
+  it("is catchable as a thrown Error", () => {
+    try {
+      throw new RefreshAccessTokenFailedError("refresh failed");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RefreshAccessTokenFailedError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty("message", "refresh failed");
+    }
+  });
+
+  it("returns a fresh context object on every call", () => {
+    const first = getContext();
+    const second = getContext();
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(Object.keys(getContext())).toHaveLength(0);
+  });
 });


### PR DESCRIPTION

## What

Adds four unit cases to the existing browser-shim contract suite `packages/app/src/shims/__tests__/vercel-oidc.test.ts` (+36/-0, single test file, purely additive — no existing case is modified or removed).

The suite already covered the empty-token getters, empty context, and `instanceof Error` membership. This change extends coverage onto real, consumer-visible behavior of the shim that callers rely on:

- **Error-class distinctness** — `AccessTokenMissingError` instances are not `instanceof RefreshAccessTokenFailedError` and vice versa. Catch sites classify OIDC failures by these classes; a subclassing accident would silently misroute refresh failures into access-token handling.
- **Error-contract message propagation** — constructor messages survive on `.message` for both classes, preserving the standard `Error` contract callers log and display.
- **Throw/catch boundary** — a thrown `RefreshAccessTokenFailedError` is catchable as itself and as `Error`, with the message intact through the `catch` binding.
- **Fresh context allocation** — `getContext()` returns a new object per call (never a shared mutable singleton), and the returned record stays key-empty.

All cases drive the real module (`../vercel-oidc.ts`) directly — no mocks, no stubs, no type-level assertions.

## Verification

- `bunx vitest run src/shims/__tests__/vercel-oidc.test.ts` (in `packages/app`): **1 test file passed, 7 tests passed** (3 pre-existing + 4 added), re-run against current `origin/develop` (`de774b87`) immediately before filing.
- `bunx biome check --write packages/app/src/shims/__tests__/vercel-oidc.test.ts`: clean ("Checked 1 file. No fixes applied.") against the repository `biome.json` (worktree confirmed non-sparse, config present).
- `bunx tsc --noEmit -p tsconfig.typecheck.json` in `packages/app`: zero occurrences of `vercel-oidc` in the output — this PR introduces no type errors.
- The diff touches only the one test file; `git diff --stat` shows `36 insertions(+), 0 deletions(-)`.

## Notes

- This is a fork contribution, so hosted CI does not run on this pull request; the local results above are the complete evidence set. No production behavior is changed by this diff.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d34ccc8d63cf5a10dd88f8a15bae876027ad32b0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
