### PR TITLE
test(ui): cover index

### DIFF
--- a/packages/ui/src/platform/index.test.ts
+++ b/packages/ui/src/platform/index.test.ts
@@ -1,0 +1,239 @@
+/** Verifies the platform barrel's uncovered runtime surface through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Covers consumer-visible behaviour exported through
+ * `packages/ui/src/platform/index.ts` that no sibling module suite pins today:
+ * `handleDeepLink` routing (including the connect URL validation and the share
+ * file parsing), the `dispatchShareTarget` hand-off queue, `isPopoutWindow`
+ * detection, the local-runtime capability predicates as observed under this
+ * web runtime, and one launch round-trip proving the aggregate surface wires
+ * together. Deeper per-module contracts live beside their own modules; this
+ * suite drives everything through the barrel exactly as `@elizaos/ui/platform`
+ * consumers import it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetAssistantLaunchPayloadClaimsForTests } from "./assistant-launch-payload";
+import {
+  buildAssistantLaunchMetadata,
+  canHostLocalAgent,
+  canRunLocal,
+  canSelectLocalRuntime,
+  consumeAssistantLaunchPayloadFromHash,
+  type DeepLinkHandlers,
+  dispatchShareTarget,
+  handleDeepLink,
+  isAndroid,
+  isDesktopPlatform,
+  isElizaOS,
+  isIOS,
+  isNative,
+  isPopoutWindow,
+  isWebPlatform,
+  platform,
+  readAssistantLaunchPayloadFromHash,
+  type ShareTargetPayload,
+} from "./index";
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/");
+  delete window.__ELIZAOS_SHARE_QUEUE__;
+});
+
+afterEach(() => {
+  __resetAssistantLaunchPayloadClaimsForTests();
+});
+
+describe("handleDeepLink — eliza:// route table", () => {
+  it("routes the chat path to onChat", () => {
+    const onChat = vi.fn();
+    handleDeepLink("eliza://chat", "eliza", { onChat });
+    expect(onChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes the settings path to onSettings", () => {
+    const onSettings = vi.fn();
+    handleDeepLink("eliza://settings", "eliza", { onSettings });
+    expect(onSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores URLs whose protocol does not match the app scheme", () => {
+    const handlers: DeepLinkHandlers = {
+      onChat: vi.fn(),
+      onUnknown: vi.fn(),
+    };
+    handleDeepLink("https://example.com/chat", "eliza", handlers);
+    expect(handlers.onChat).not.toHaveBeenCalled();
+    expect(handlers.onUnknown).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed deep links without throwing (untrusted input)", () => {
+    const onUnknown = vi.fn();
+    expect(() =>
+      handleDeepLink(":://not a url", "eliza", { onUnknown }),
+    ).not.toThrow();
+    expect(onUnknown).not.toHaveBeenCalled();
+  });
+
+  it("hands unknown paths to onUnknown with leading slashes stripped", () => {
+    const onUnknown = vi.fn();
+    handleDeepLink("eliza:///wallet", "eliza", { onUnknown });
+    expect(onUnknown).toHaveBeenCalledWith("wallet");
+  });
+
+  it("forwards https gateway URLs to onConnect as normalized hrefs", () => {
+    const onConnect = vi.fn();
+    handleDeepLink(
+      "eliza://connect?url=https%3A%2F%2Fgw.example.com%2Fapi",
+      "eliza",
+      { onConnect },
+    );
+    expect(onConnect).toHaveBeenCalledWith("https://gw.example.com/api");
+  });
+
+  it("accepts plaintext http only for the gateway hand-off, not other schemes", () => {
+    const onConnectHttp = vi.fn();
+    handleDeepLink(
+      "eliza://connect?url=http%3A%2F%2F192.168.1.10%3A3000",
+      "eliza",
+      { onConnect: onConnectHttp },
+    );
+    expect(onConnectHttp).toHaveBeenCalledWith("http://192.168.1.10:3000/");
+
+    const onConnectJs = vi.fn();
+    handleDeepLink("eliza://connect?url=javascript%3Aalert(1)", "eliza", {
+      onConnect: onConnectJs,
+    });
+    expect(onConnectJs).not.toHaveBeenCalled();
+  });
+
+  it("ignores a connect action with no url parameter or an unparseable one", () => {
+    const onConnect = vi.fn();
+    handleDeepLink("eliza://connect", "eliza", { onConnect });
+    handleDeepLink("eliza://connect?url=%3A%2F%2Fbad", "eliza", { onConnect });
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+
+  it("parses share payloads including file basenames from both slash styles", () => {
+    const onShare = vi.fn();
+    handleDeepLink(
+      "eliza://share?title=Hello&text=World&url=https%3A%2F%2Fx.example%2Fa" +
+        "&file=%2Fstorage%2Femulated%2F0%2Fpic.jpg&file=D%3A%5CUsers%5Cn.png" +
+        "&file=",
+      "eliza",
+      { onShare },
+    );
+    expect(onShare).toHaveBeenCalledWith({
+      source: "deep-link",
+      title: "Hello",
+      text: "World",
+      url: "https://x.example/a",
+      files: [
+        { name: "pic.jpg", path: "/storage/emulated/0/pic.jpg" },
+        { name: "n.png", path: "D:\\Users\\n.png" },
+      ],
+    });
+  });
+
+  it("still reports a bare share with defaults when nothing was attached", () => {
+    const onShare = vi.fn();
+    handleDeepLink("eliza://share", "eliza", { onShare });
+    expect(onShare).toHaveBeenCalledWith({
+      source: "deep-link",
+      title: undefined,
+      text: undefined,
+      url: undefined,
+      files: [],
+    });
+  });
+});
+
+describe("dispatchShareTarget — queued hand-off to the shell", () => {
+  it("queues the payload and notifies the dispatcher with the event name", () => {
+    const dispatchEvent = vi.fn();
+    const payload: ShareTargetPayload = { title: "t", text: "hi" };
+    dispatchShareTarget(payload, dispatchEvent, "eliza:share");
+    expect(dispatchEvent).toHaveBeenCalledWith("eliza:share", payload);
+    expect(window.__ELIZAOS_SHARE_QUEUE__).toEqual([payload]);
+  });
+
+  it("accumulates queued payloads across calls in arrival order", () => {
+    const dispatchEvent = vi.fn();
+    dispatchShareTarget({ title: "a" }, dispatchEvent, "eliza:share");
+    dispatchShareTarget({ title: "b" }, dispatchEvent, "eliza:share");
+    const queue = window.__ELIZAOS_SHARE_QUEUE__;
+    if (!queue) throw new Error("dispatchShareTarget must create the queue");
+    expect(queue.map((entry) => entry.title)).toEqual(["a", "b"]);
+  });
+});
+
+describe("isPopoutWindow — renderer pop-out detection", () => {
+  it("reports false on a plain renderer location", () => {
+    expect(isPopoutWindow()).toBe(false);
+  });
+
+  it("detects ?popout in the search string", () => {
+    window.history.replaceState(null, "", "/?popout=1");
+    expect(isPopoutWindow()).toBe(true);
+  });
+
+  it("detects popout inside the hash route query", () => {
+    window.history.replaceState(null, "", "/#/chat?popout=1");
+    expect(isPopoutWindow()).toBe(true);
+  });
+});
+
+describe("platform capability surface under this web runtime", () => {
+  // Observed contract of the vitest/jsdom environment: Capacitor has no native
+  // bridge here, so detection falls back to web. These pin what every
+  // browser-context consumer of the barrel sees in that situation.
+  it("resolves to the non-native web platform with no mobile flags", () => {
+    expect(platform).toBe("web");
+    expect(isNative).toBe(false);
+    expect(isIOS).toBe(false);
+    expect(isAndroid).toBe(false);
+    expect(isWebPlatform()).toBe(true);
+    expect(isDesktopPlatform()).toBe(false);
+  });
+
+  it("offers local runtime capability in dev and on any hostable device", () => {
+    expect(canRunLocal()).toBe(true); // import.meta.env.DEV under vitest
+    expect(canSelectLocalRuntime()).toBe(true);
+    expect(canHostLocalAgent()).toBe(true);
+  });
+
+  it("never brands a non-Android host as the AOSP ElizaOS device", () => {
+    expect(isElizaOS()).toBe(false);
+  });
+});
+
+describe("assistant launch pipeline reachable over the public barrel", () => {
+  it("carries one launch from read through consume exactly once", async () => {
+    const hash =
+      "#/?source=siri&text=Run%20the%20demo&action=compose" +
+      "&assistant.launchId=launch-1";
+    const payload = readAssistantLaunchPayloadFromHash(hash);
+    if (!payload) throw new Error("trusted launch payload must parse");
+
+    const sent: Array<{ text: string; metadata: Record<string, unknown> }> = [];
+    const delivered = await consumeAssistantLaunchPayloadFromHash(hash, {
+      sendText: (text, options) => {
+        sent.push({ text, metadata: options.metadata });
+      },
+    });
+    expect(delivered).toEqual(payload);
+    expect(sent).toEqual([
+      { text: "Run the demo", metadata: buildAssistantLaunchMetadata(payload) },
+    ]);
+
+    // The claim registry behind the barrel is shared state: replaying the same
+    // launch id must be a no-op even though the hash string still parses.
+    const replayed = await consumeAssistantLaunchPayloadFromHash(hash, {
+      sendText: () => {
+        throw new Error("a claimed launch must never resend");
+      },
+    });
+    expect(replayed).toBeNull();
+  });
+});


### PR DESCRIPTION

Adds a first unit suite for `packages/ui/src/platform/index.ts`, which has no same-named test file anywhere on current `origin/develop` (verified via `git ls-tree -r --name-only origin/develop` immediately before filing). Test-only change: one new file (`packages/ui/src/platform/index.test.ts`, +239/-0), no production code touched.

The barrel's per-module contracts already have their own co-located suites on develop; this suite covers the consumer-visible surface that nothing else pins today, driven entirely through `./index` — exactly how `@elizaos/ui/platform` consumers import it:

- **`handleDeepLink` route table** (uncovered anywhere): chat/settings routing, wrong-protocol and malformed-URL rejection without throwing, unknown-path hand-off with leading slashes stripped, connect forwarding only http(s) gateway URLs as normalized hrefs while rejecting `javascript:` and unparseable values, and share payload parsing including file basenames across both slash styles with empty entries dropped.
- **`dispatchShareTarget`** queue contract: payload queued into `window.__ELIZAOS_SHARE_QUEUE__`, dispatcher notified with the event name, arrival order preserved across calls.
- **`isPopoutWindow`**: false on a plain renderer location, true via `?popout` in search or inside the hash-route query.
- **Platform capability predicates under the web runtime** (observed contract: Capacitor has no native bridge under vitest/jsdom): `platform === "web"`, non-native, no iOS/Android flags, `isWebPlatform()` true, `isDesktopPlatform()` false, local-runtime capability offered in dev, and `isElizaOS()` false off-Android.
- **Assistant-launch round-trip over the public barrel**: read → consume delivers once with built metadata; replaying the same launch id is a no-op even though the hash string still parses.

Assertions are behaviour, not mocks: every case drives the real module (jsdom provides window/location/history); the only stubbing is none. No `expectTypeOf`, no `vi.hoisted`.

## Verification

- `bunx vitest run src/platform/index.test.ts` (in `packages/ui`, sources byte-identical to current `origin/develop` @ `de774b875774f478ef5b879dbdae8fd2997a3470`): `Test Files 1 passed (1)` / `Tests 19 passed (19)`.
- `bunx biome check --write src/platform/index.test.ts`: clean (`Checked 1 file ... No fixes applied.` after formatting; repo `biome.json` verified present, checkout not sparse).
- `bunx tsc --noEmit` in `packages/ui`: `src/platform/index.test.ts` appears nowhere in the output (the remaining diagnostics are pre-existing errors owned by other modules/files).
- The diff is exactly one new test file (+239/-0).

Note: this comes from a fork, so hosted CI does not run on this pull request; the quoted commands above are the verification record.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3464887ae20cdbef821a8fbb68de0c1b416878b4 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
