### PR TITLE
test(ui): cover remote-controller

### DIFF
--- a/packages/ui/src/platform/remote-controller.test.ts
+++ b/packages/ui/src/platform/remote-controller.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Covers the renderer remote-control adapter's desktop-bridge contract
+ * against a recording fake installed at window.__ELIZA_ELECTROBUN_RPC__
+ * (jsdom, deterministic, no native host): per-operation RPC routing,
+ * controller/target field flattening, platform-derived display-name
+ * defaults, fail-closed errors when the bridge cannot answer, and result
+ * unwrapping including the clear-session false fallback.
+ */
+// @vitest-environment jsdom
+
+import type {
+  EncryptedRemoteControlEnvelope,
+  RemoteControllerPublicIdentity,
+  RemoteTargetPublicIdentity,
+  SignedRemoteCommand,
+} from "@elizaos/shared/contracts/remote-control";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElectrobunRendererRpc } from "../bridge/electrobun-rpc";
+import {
+  acknowledgeRemoteCommandEnqueue,
+  clearRemoteControllerSessionState,
+  createRemoteCommand,
+  getOrCreateRemoteControllerIdentity,
+  openRemoteCommandResult,
+  openRemoteCommandStartReceipt,
+} from "./remote-controller";
+
+interface BridgeCall {
+  method: string;
+  params?: unknown;
+}
+
+interface BridgeHarness {
+  request: Record<string, (params?: unknown) => Promise<unknown>>;
+  calls: BridgeCall[];
+  onMessage: ReturnType<typeof vi.fn>;
+  offMessage: ReturnType<typeof vi.fn>;
+  rpc: ElectrobunRendererRpc;
+  /** Register a handler that records its invocation and responds. */
+  handle(method: string, respond?: (params?: unknown) => unknown): void;
+}
+
+function createBridgeHarness(): BridgeHarness {
+  const calls: BridgeCall[] = [];
+  const request: Record<string, (params?: unknown) => Promise<unknown>> = {};
+  const onMessage = vi.fn();
+  const offMessage = vi.fn();
+  const rpc: ElectrobunRendererRpc = { request, onMessage, offMessage };
+  return {
+    request,
+    calls,
+    onMessage,
+    offMessage,
+    rpc,
+    handle(method, respond) {
+      request[method] = async (params?: unknown) => {
+        calls.push({ method, params });
+        return respond ? respond(params) : undefined;
+      };
+    },
+  };
+}
+
+function installOnWindow(rpc: ElectrobunRendererRpc): void {
+  (
+    window as { __ELIZA_ELECTROBUN_RPC__?: ElectrobunRendererRpc }
+  ).__ELIZA_ELECTROBUN_RPC__ = rpc;
+}
+
+function uninstallFromWindow(): void {
+  delete (window as { __ELIZA_ELECTROBUN_RPC__?: ElectrobunRendererRpc })
+    .__ELIZA_ELECTROBUN_RPC__;
+}
+
+function controllerIdentity(): RemoteControllerPublicIdentity {
+  return {
+    version: 1,
+    role: "controller",
+    ownerId: "owner-1",
+    deviceId: "controller-device-1",
+    keyId: "controller-key-1",
+    displayName: "My Mac",
+    platform: "macos",
+    signingPublicKeyJwk: { kty: "EC", crv: "P-256" },
+    encryptionPublicKeyJwk: { kty: "EC", crv: "P-256" },
+    createdAt: 1_700_000_000_000,
+  };
+}
+
+function targetIdentity(): RemoteTargetPublicIdentity {
+  return {
+    version: 1,
+    role: "target",
+    ownerId: "owner-1",
+    runtimeId: "runtime-1",
+    keyId: "target-key-1",
+    displayName: "Studio Mac",
+    platform: "macos",
+    signingPublicKeyJwk: { kty: "EC", crv: "P-256" },
+    encryptionPublicKeyJwk: { kty: "EC", crv: "P-256" },
+    createdAt: 1_700_000_000_000,
+  };
+}
+
+function signedCommand(): SignedRemoteCommand {
+  return {
+    body: {
+      version: 1,
+      ownerId: "owner-1",
+      grantId: "grant-1",
+      grantRevision: 3,
+      sessionId: "session-1",
+      controllerDeviceId: "controller-device-1",
+      controllerKeyId: "controller-key-1",
+      targetRuntimeId: "runtime-1",
+      targetKeyId: "target-key-1",
+      commandId: "command-1",
+      sequence: 7,
+      nonce: "nonce-7",
+      issuedAt: 1_700_000_000_000,
+      expiresAt: 1_700_000_005_000,
+      action: "agent.status",
+      payload: {},
+      payloadDigest: "dGVzdC1kaWdlc3QtdGVzdC1kaWdlc3QtdGVzdC1kaWdlc3Q",
+    },
+    signatureAlgorithm: "ECDSA-P256-SHA256",
+    signature: "c2lnbmF0dXJlLXZhbHVl",
+  };
+}
+
+function encryptedEnvelope(): EncryptedRemoteControlEnvelope {
+  return {
+    messageKind: "result",
+    version: 1,
+    ownerId: "owner-1",
+    grantId: "grant-1",
+    grantRevision: 3,
+    sessionId: "session-1",
+    controllerDeviceId: "controller-device-1",
+    controllerKeyId: "controller-key-1",
+    targetRuntimeId: "runtime-1",
+    targetKeyId: "target-key-1",
+    commandId: "command-1",
+    algorithm: "ECDH-P256-HKDF-SHA256+A256GCM",
+    senderKeyId: "target-key-1",
+    recipientKeyId: "controller-key-1",
+    messageDigest: "bWVzc2FnZS1kaWdlc3QtbWVzc2FnZS1kaWdlc3QtbWVzc2FnZQ",
+    ephemeralPublicKeyJwk: { kty: "EC", crv: "P-256" },
+    salt: "c2FsdC1zYWx0LXNhbHQtc2FsdC1zYWx0LXNhbHQ",
+    iv: "aXZpdmVjdG9yMTIzNDU2",
+    ciphertext: "Y2lwaGVydGV4dC12YWx1ZS1mb3ItdGVzdA",
+  };
+}
+
+afterEach(() => {
+  uninstallFromWindow();
+  vi.unstubAllGlobals();
+});
+
+describe("getOrCreateRemoteControllerIdentity", () => {
+  it("routes the identity request over the desktop bridge and returns the stored identity", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    const identity = controllerIdentity();
+    harness.handle("remoteControllerGetOrCreateIdentity", () => identity);
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+
+    const result = await getOrCreateRemoteControllerIdentity({
+      ownerId: "owner-1",
+    });
+
+    expect(result).toEqual(identity);
+    expect(harness.calls).toHaveLength(1);
+    expect(harness.calls[0]?.method).toBe(
+      "remoteControllerGetOrCreateIdentity",
+    );
+    expect(harness.calls[0]?.params).toEqual({
+      ownerId: "owner-1",
+      displayName: "My Mac",
+      platform: "macos",
+    });
+  });
+
+  it("defaults the display name for Windows when no explicit name is given", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerGetOrCreateIdentity", () =>
+      controllerIdentity(),
+    );
+    vi.stubGlobal("navigator", { platform: "Win32" });
+
+    await getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" });
+
+    expect(harness.calls[0]?.params).toMatchObject({
+      displayName: "My Windows PC",
+      platform: "windows",
+    });
+  });
+
+  it("defaults the display name for Linux when no explicit name is given", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerGetOrCreateIdentity", () =>
+      controllerIdentity(),
+    );
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+
+    await getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" });
+
+    expect(harness.calls[0]?.params).toMatchObject({
+      displayName: "My Linux computer",
+      platform: "linux",
+    });
+  });
+
+  it("prefers an explicit displayName over the platform default", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerGetOrCreateIdentity", () =>
+      controllerIdentity(),
+    );
+    vi.stubGlobal("navigator", { platform: "Win32" });
+
+    await getOrCreateRemoteControllerIdentity({
+      ownerId: "owner-1",
+      displayName: "Studio PC",
+    });
+
+    expect(harness.calls[0]?.params).toMatchObject({
+      displayName: "Studio PC",
+      platform: "windows",
+    });
+  });
+
+  it("fails closed when the desktop bridge has no identity to return", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerGetOrCreateIdentity", () => null);
+
+    await expect(
+      getOrCreateRemoteControllerIdentity({ ownerId: "owner-1" }),
+    ).rejects.toThrow(
+      "Secure device pairing requires the Eliza desktop app so private keys stay in OS credential storage.",
+    );
+  });
+});
+
+describe("createRemoteCommand", () => {
+  it("flattens controller and target identities into the signing request and returns the signed result", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    const command = signedCommand();
+    const envelope = encryptedEnvelope();
+    harness.handle("remoteControllerCreateCommand", () => ({
+      commandId: "command-1",
+      expiresAt: 1_700_000_005_000,
+      command,
+      envelope,
+      recoveredPending: false,
+      bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+    }));
+    const controller = controllerIdentity();
+    const target = targetIdentity();
+
+    const result = await createRemoteCommand({
+      ownerId: "owner-1",
+      grantId: "grant-1",
+      grantRevision: 3,
+      sessionId: "session-1",
+      controller,
+      target,
+      action: "agent.request",
+      payload: { prompt: "restart the agent" },
+    });
+
+    expect(result.command).toEqual(command);
+    expect(result.envelope).toEqual(envelope);
+    expect(result.recoveredPending).toBe(false);
+    expect(harness.calls).toHaveLength(1);
+    expect(harness.calls[0]?.method).toBe("remoteControllerCreateCommand");
+    expect(harness.calls[0]?.params).toEqual({
+      ownerId: "owner-1",
+      grantId: "grant-1",
+      grantRevision: 3,
+      sessionId: "session-1",
+      controllerDeviceId: "controller-device-1",
+      controllerKeyId: "controller-key-1",
+      targetRuntimeId: "runtime-1",
+      targetKeyId: "target-key-1",
+      targetEncryptionPublicKeyJwk: { kty: "EC", crv: "P-256" },
+      action: "agent.request",
+      payload: { prompt: "restart the agent" },
+    });
+  });
+
+  it("surfaces a recovered pending command when the main process reports one", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerCreateCommand", () => ({
+      commandId: "command-1",
+      expiresAt: 1_700_000_005_000,
+      command: signedCommand(),
+      envelope: encryptedEnvelope(),
+      recoveredPending: true,
+      bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+    }));
+
+    const result = await createRemoteCommand({
+      ownerId: "owner-1",
+      grantId: "grant-1",
+      grantRevision: 3,
+      sessionId: "session-1",
+      controller: controllerIdentity(),
+      target: targetIdentity(),
+      action: "agent.status",
+      payload: null,
+    });
+
+    expect(result.recoveredPending).toBe(true);
+  });
+
+  it("rejects when remote command signing is unavailable", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerCreateCommand", () => null);
+
+    await expect(
+      createRemoteCommand({
+        ownerId: "owner-1",
+        grantId: "grant-1",
+        grantRevision: 3,
+        sessionId: "session-1",
+        controller: controllerIdentity(),
+        target: targetIdentity(),
+        action: "agent.stop",
+        payload: null,
+      }),
+    ).rejects.toThrow("Secure remote command signing is unavailable.");
+  });
+});
+
+describe("acknowledgeRemoteCommandEnqueue", () => {
+  it("forwards its input verbatim and unwraps the acknowledgement flag", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerAcknowledgeEnqueue", () => ({
+      acknowledged: true,
+    }));
+
+    const acknowledged = await acknowledgeRemoteCommandEnqueue({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      sessionId: "session-1",
+      commandId: "command-1",
+      bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+    });
+
+    expect(acknowledged).toBe(true);
+    expect(harness.calls[0]?.method).toBe("remoteControllerAcknowledgeEnqueue");
+    expect(harness.calls[0]?.params).toEqual({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      sessionId: "session-1",
+      commandId: "command-1",
+      bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+    });
+  });
+
+  it("resolves false when the main process reports the enqueue was not acknowledged", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerAcknowledgeEnqueue", () => ({
+      acknowledged: false,
+    }));
+
+    await expect(
+      acknowledgeRemoteCommandEnqueue({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        sessionId: "session-1",
+        commandId: "command-1",
+        bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects when the acknowledgement channel is unavailable", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerAcknowledgeEnqueue", () => null);
+
+    await expect(
+      acknowledgeRemoteCommandEnqueue({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        sessionId: "session-1",
+        commandId: "command-1",
+        bindingDigest: "YmluZGluZy1kaWdlc3QtYmluZGluZy1kaWdlc3Q",
+      }),
+    ).rejects.toThrow("Secure remote enqueue acknowledgement is unavailable.");
+  });
+});
+
+describe("openRemoteCommandResult", () => {
+  it("sends the sealed envelope for decryption and returns the opened result", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    const envelope = encryptedEnvelope();
+    const command = signedCommand();
+    const target = targetIdentity();
+    harness.handle("remoteControllerOpenResult", () => ({
+      status: "completed",
+      result: { output: "agent stopped" },
+      errorCode: undefined,
+    }));
+
+    const result = await openRemoteCommandResult({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      envelope,
+      command,
+      targetIdentity: target,
+    });
+
+    expect(result).toEqual({
+      status: "completed",
+      result: { output: "agent stopped" },
+      errorCode: undefined,
+    });
+    expect(harness.calls[0]?.method).toBe("remoteControllerOpenResult");
+    expect(harness.calls[0]?.params).toEqual({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      envelope,
+      command,
+      targetIdentity: target,
+    });
+  });
+
+  it("rejects when result decryption is unavailable", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerOpenResult", () => null);
+
+    await expect(
+      openRemoteCommandResult({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        envelope: encryptedEnvelope(),
+        command: signedCommand(),
+        targetIdentity: targetIdentity(),
+      }),
+    ).rejects.toThrow("Secure remote result decryption is unavailable.");
+  });
+});
+
+describe("openRemoteCommandStartReceipt", () => {
+  it("returns the verified start receipt fields", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerOpenStartReceipt", () => ({
+      startedAt: 1_700_000_001_000,
+      executionId: "execution-1",
+    }));
+
+    const receipt = await openRemoteCommandStartReceipt({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      envelope: encryptedEnvelope(),
+      command: signedCommand(),
+      targetIdentity: targetIdentity(),
+    });
+
+    expect(receipt).toEqual({
+      startedAt: 1_700_000_001_000,
+      executionId: "execution-1",
+    });
+    expect(harness.calls[0]?.method).toBe("remoteControllerOpenStartReceipt");
+  });
+
+  it("rejects when start-receipt verification is unavailable", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerOpenStartReceipt", () => null);
+
+    await expect(
+      openRemoteCommandStartReceipt({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        envelope: encryptedEnvelope(),
+        command: signedCommand(),
+        targetIdentity: targetIdentity(),
+      }),
+    ).rejects.toThrow(
+      "Secure remote start receipt verification is unavailable.",
+    );
+  });
+});
+
+describe("clearRemoteControllerSessionState", () => {
+  it("resolves true when the main process cleared the session state", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerClearSessionState", () => ({
+      cleared: true,
+    }));
+
+    const cleared = await clearRemoteControllerSessionState({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      sessionId: "session-1",
+    });
+
+    expect(cleared).toBe(true);
+    expect(harness.calls[0]?.method).toBe("remoteControllerClearSessionState");
+    expect(harness.calls[0]?.params).toEqual({
+      ownerId: "owner-1",
+      controllerDeviceId: "controller-device-1",
+      sessionId: "session-1",
+    });
+  });
+
+  it("resolves false without throwing when the main process did not clear", async () => {
+    const harness = createBridgeHarness();
+    installOnWindow(harness.rpc);
+    harness.handle("remoteControllerClearSessionState", () => ({
+      cleared: false,
+    }));
+
+    await expect(
+      clearRemoteControllerSessionState({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        sessionId: "session-1",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("resolves false when the desktop bridge is absent entirely", async () => {
+    await expect(
+      clearRemoteControllerSessionState({
+        ownerId: "owner-1",
+        controllerDeviceId: "controller-device-1",
+        sessionId: "session-1",
+      }),
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/ui/src/platform/remote-controller.ts` — the renderer adapter for the desktop remote-control identity — co-located as `packages/ui/src/platform/remote-controller.test.ts`. This is a **test-only** change: one new file, no production code touched (+548/-0 against `develop`).

The suite drives the real module through its real dependency seam: a recording fake `ElectrobunRendererRpc` installed at `window.__ELIZA_ELECTROBUN_RPC__` (the same injection point the Electrobun main process uses), so every assertion exercises the actual adapter code path over the actual bridge helper (`invokeDesktopBridgeRequest`) rather than mocking the module under test.

## Coverage

18 cases across all six exported functions:

- **`getOrCreateRemoteControllerIdentity`** — exact RPC routing (`remoteControllerGetOrCreateIdentity`) and params; platform-derived display-name defaults for macOS (`MacIntel` → "My Mac"), Windows (`Win32` → "My Windows PC"), and Linux (`Linux x86_64` → "My Linux computer"); explicit `displayName` winning over the platform default; fail-closed rejection when the bridge returns no identity.
- **`createRemoteCommand`** — flattening of controller/target identities into `controllerDeviceId` / `controllerKeyId` / `targetRuntimeId` / `targetKeyId` / `targetEncryptionPublicKeyJwk`; passthrough of the signed result including the `recoveredPending` recovery flag in both states; rejection when signing is unavailable.
- **`acknowledgeRemoteCommandEnqueue`** — input forwarded verbatim as request params; `acknowledged` unwrapping for both `true` and `false`; rejection when the acknowledgement channel is unavailable.
- **`openRemoteCommandResult`** — envelope/command/target identity forwarded verbatim; decrypted result passthrough; rejection when decryption is unavailable.
- **`openRemoteCommandStartReceipt`** — start-receipt field passthrough; rejection when verification is unavailable.
- **`clearRemoteControllerSessionState`** — resolves `true` on success, resolves `false` without throwing when the main process reports `cleared: false`, and resolves `false` when the desktop bridge is absent entirely (no throw — distinct from the other operations).

Each of the five distinct fail-closed error messages is asserted verbatim.

## Evidence (test-only change)

Run at base `de774b875774f478ef5b879dbdae8fd2997a3470` (= current `origin/develop` at filing time), head `de66ed2290c61a0298f31310a54191385fe4c905`:

1. `bunx vitest run src/platform/remote-controller.test.ts` (packages/ui lane, jsdom): **Test Files 1 passed (1), Tests 18 passed (18)** — observed twice (pre- and post-format).
2. `bunx @biomejs/biome check src/platform/remote-controller.test.ts`: clean ("Checked 1 file ... No fixes applied" after the `--write` pass).
3. `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: grep for `remote-controller.test.ts` returns zero lines — the new file introduces no type errors.
4. The diff touches only the new test file (`git diff --cached --stat`: `1 file changed, 548 insertions(+)`, zero deletions). No existing suite was modified or rewritten.

Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are from local runs quoted verbatim. No `vi.hoisted`, no `expectTypeOf`, no type-only assertions — runtime behavior only.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:de66ed2290c61a0298f31310a54191385fe4c905 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
