### PR TITLE
test(core): cover task-completion

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/__tests__/task-completion.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/__tests__/task-completion.test.ts
@@ -24,6 +24,12 @@ describe("getTaskCompletionCacheKey", () => {
 			"reflection-task-completion:m1",
 		);
 	});
+
+	it("keeps distinct message ids in distinct cache slots", () => {
+		expect(getTaskCompletionCacheKey("m1")).not.toBe(
+			getTaskCompletionCacheKey("m2"),
+		);
+	});
 });
 
 describe("formatTaskCompletionStatus", () => {
@@ -42,5 +48,54 @@ describe("formatTaskCompletionStatus", () => {
 		expect(formatTaskCompletionStatus(undefined)).toContain(
 			"No task completion reflection",
 		);
+	});
+
+	it("renders the false arm of assessed and completed independently", () => {
+		const notAssessed = formatTaskCompletionStatus({
+			assessed: false,
+			completed: true,
+			reason: "still running",
+			source: "reflection",
+			evaluatedAt: 124,
+		});
+		expect(notAssessed).toContain("assessed: false");
+		expect(notAssessed).toContain("task_completed: true");
+
+		const notCompleted = formatTaskCompletionStatus({
+			assessed: true,
+			completed: false,
+			reason: "subtask pending",
+			source: "reflection",
+			evaluatedAt: 125,
+		});
+		expect(notCompleted).toContain("assessed: true");
+		expect(notCompleted).toContain("task_completed: false");
+	});
+
+	it("renders an unfinished assessment as the exact provider-facing document", () => {
+		expect(
+			formatTaskCompletionStatus({
+				assessed: false,
+				completed: false,
+				reason: "waiting on user input",
+				source: "reflection",
+				evaluatedAt: 126,
+			}),
+		).toBe(
+			[
+				"# Reflection Task Completion",
+				"assessed: false",
+				"task_completed: false",
+				"task_completion_reason: waiting on user input",
+			].join("\n"),
+		);
+	});
+
+	it("renders the complete document without leaking message ids", () => {
+		const out = formatTaskCompletionStatus(assessment);
+		expect(out).toBe(
+			"# Reflection Task Completion\nassessed: true\ntask_completed: true\ntask_completion_reason: goal reached",
+		);
+		expect(out).not.toContain("m1");
 	});
 });


### PR DESCRIPTION

## Summary

Adds unit coverage for the task-completion contract shared by the reflection `success` evaluator (`packages/core/src/features/advanced-capabilities/evaluators/task-completion.ts`). This is a **test-only** change: one file touched, +55/−0, no production behaviour modified.

The existing suite on develop already covered the cache-key happy path, the formatter happy path (`assessed: true` / `completed: true`), and nullish input. This PR adds four cases for branches that had no coverage:

- `getTaskCompletionCacheKey` keeps distinct message ids in distinct cache slots — the reflection-items writer caches assessments by message id, so a collision would silently overwrite another message's assessment.
- `formatTaskCompletionStatus` renders the false arm of each ternary independently (`assessed: false` with `completed: true`, then `completed: false` with `assessed: true`).
- An unfinished assessment (`false`/`false`) renders the exact joined provider-facing document downstream providers parse.
- A complete assessment renders as the exact four-line document and does not leak the optional `messageId`.

All expectations were written from observed behaviour of the real module — no mocks, no type-level assertions.

## Verification

Test-only PR from a fork: hosted CI does not run on this pull request. Local evidence, quoted from real runs against current origin/develop (de774b875):

- `bunx vitest run src/features/advanced-capabilities/evaluators/__tests__/task-completion.test.ts` (in packages/core): **Test Files 1 passed (1), Tests 7 passed (7)** — re-fetched and re-run immediately before filing; origin/develop unchanged at de774b875.
- `bunx biome check --write <file>`: Checked 1 file, **No fixes applied** (clean).
- `bunx tsc --noEmit` in `packages/core`: grep for `task-completion.test` over full output returns **zero matches** — the new file introduces no type errors.
- `git diff` vs base touches exactly one test file: **+55 insertions(−)**, 0 deletions; purely additive to the existing suite.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:50aee417986c87683dc6b504455358d357d249b7 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
