### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/index.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/index.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic unit tests for the advanced-capabilities evaluator barrel
+ * (index.ts): importing the barrel must register its bundle-safety anchor on
+ * `globalThis` under the documented per-barrel key, that anchor must cover
+ * exactly the barrel's public export surface (no unanchored export a
+ * Bun.build tree-shake could drop, no stale anchored binding), and every
+ * anchored binding must be live rather than an empty-init stub — the failure
+ * class behind the on-device ReferenceError incidents (#10727, #11030,
+ * #11248, #11276). Real module init against real global state; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import * as evaluators from "./index.ts";
+
+const ANCHOR_KEY =
+	"__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__";
+
+function anchoredValues(): unknown[] {
+	const stashed = (globalThis as Record<string, unknown>)[ANCHOR_KEY];
+	expect(Array.isArray(stashed)).toBe(true);
+	return stashed as unknown[];
+}
+
+describe("advanced-capabilities evaluators barrel", () => {
+	it("registers its bundle-safety anchor on globalThis when imported", () => {
+		const stashed = (globalThis as Record<string, unknown>)[ANCHOR_KEY];
+		expect(Array.isArray(stashed)).toBe(true);
+	});
+
+	it("anchors every public export exactly once — none missing, none stale", () => {
+		const anchored = anchoredValues();
+		const exported = Object.values(evaluators);
+		expect(anchored.length).toBe(exported.length);
+
+		const leftover = new Map<unknown, number>();
+		for (const value of anchored) {
+			leftover.set(value, (leftover.get(value) ?? 0) + 1);
+		}
+		for (const value of exported) {
+			const remaining = leftover.get(value) ?? 0;
+			expect(remaining).toBeGreaterThan(0);
+			if (remaining === 1) leftover.delete(value);
+			else leftover.set(value, remaining - 1);
+		}
+		expect(leftover.size).toBe(0);
+	});
+
+	it("keeps every anchored binding live, never an empty-init stub", () => {
+		for (const value of anchoredValues()) {
+			expect(value).toBeDefined();
+			expect(value).not.toBeNull();
+		}
+	});
+});


### PR DESCRIPTION

Adds a deterministic vitest suite for packages/core/src/features/advanced-capabilities/evaluators/index.ts — the advanced-capabilities evaluator barrel — which had no same-named test file anywhere in the repo.

The barrel's load-bearing behavior is its eager bundle-safety anchor: importing the module must register `__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__` on `globalThis` holding every exported binding, which is what keeps Bun.build's CJS-interop tree-shake from dropping these re-export-only bindings on the on-device mobile agent (incidents #10727, #11030, #11248, #11276). The suite drives the real module init against real global state, no mocks:

- registering the anchor under the documented per-barrel key on import;
- the anchored multiset covering exactly the barrel's public export surface (an unanchored export would silently vanish from the mobile bundle; a stale anchored binding would be dead weight) — checked dynamically via the namespace object, so adding an evaluator without anchoring it fails this test;
- every anchored binding being live rather than an empty-init stub (the ReferenceError failure class).

Test-only change: no production behavior is touched, diff is one new file (+53/-0).

Evidence (fork contributor: hosted CI does not run on this PR):

- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/index.test.ts` → Test Files 1 passed (1), Tests 3 passed (3)
- `bunx biome check --write <file>` → clean ("Checked 1 file", no fixes applied)
- `bunx tsc --noEmit` in packages/core → zero output lines mention the new test file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:de774b875774f478ef5b879dbdae8fd2997a3470 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
