### PR TITLE
fix(cloud): preserve years 0-99 in google calendar local parts conversion via setUTCFullYear

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.local-time.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.local-time.test.ts
@@ -71,6 +71,20 @@ describe("buildUtcDateFromLocalParts compatible disambiguation", () => {
     expect(repeated.toISOString()).toBe("2026-11-01T05:30:00.000Z");
     expect(skipped.toISOString()).toBe("2026-03-08T07:30:00.000Z");
   });
+
+  test("preserves years 0-99 without Date.UTC 1900-1999 remapping", () => {
+    const instant = buildUtcDateFromLocalParts("UTC", {
+      year: 25,
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    });
+
+    expect(instant.getUTCFullYear()).toBe(25);
+    expect(instant.toISOString()).toBe("0025-01-01T00:00:00.000Z");
+  });
 });
 
 async function fetchAllDayEvent(args: { startDate: string; endDate: string; timeZone: string }) {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -134,7 +134,10 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
 }
 
 function localPartsToEpochMs(parts: LocalDateTimeParts): number {
-  return Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  const date = new Date(0);
+  date.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  date.setUTCHours(parts.hour, parts.minute, parts.second, 0);
+  return date.getTime();
 }
 
 function sameZonedParts(left: LocalDateTimeParts, right: LocalDateTimeParts): boolean {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Replaces `Date.UTC` with `setUTCFullYear` on local calendar parts so years 0-99 retain their literal year rather than remapping to 1900-1999.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts`, `localPartsToEpochMs` used `Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second)`. In JavaScript, `Date.UTC` with a year between 0 and 99 remaps to `1900 + year`. Using `setUTCFullYear` preserves the exact year across all ranges.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts` and `calendar.local-time.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/agent-google-connector/calendar.local-time.test.ts`.

# Evidence Gate

<!-- evidence-head:6c6b249e5af17b57c59a583754c5d7316030815a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - date helper logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
RangeError: Local date-time cannot be resolved in timezone UTC
      at buildUtcDateFromLocalParts (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts:206:84)
(fail) buildUtcDateFromLocalParts compatible disambiguation > preserves years 0-99 without Date.UTC 1900-1999 remapping
5 pass, 1 fail
```

## Green (restored)
```
(pass) buildUtcDateFromLocalParts compatible disambiguation > preserves years 0-99 without Date.UTC 1900-1999 remapping
6 pass, 0 fail, 10 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

