### PR TITLE
fix(cloud): preserve years 0-99 in user metrics calculations via setUTCFullYear

### DIFF
--- a/packages/cloud/shared/src/lib/services/user-metrics.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-metrics.error-policy.test.ts
@@ -38,7 +38,7 @@ const dbStub = {
 
 mock.module("../../db/client", () => ({ dbRead: dbStub, dbWrite: dbStub }));
 
-const { userMetricsService } = await import("./user-metrics");
+const { userMetricsService, startOfDayUtc } = await import("./user-metrics");
 
 beforeEach(() => {
   selectResolver = () => [{ cnt: 0 }];
@@ -107,5 +107,12 @@ describe("UserMetricsService fail-closed contract", () => {
     await expect(userMetricsService.getOAuthConnectionRate()).rejects.toThrow(
       "relation platform_credentials does not exist",
     );
+  });
+
+  test("startOfDayUtc preserves years 0-99 without Date.UTC remapping", () => {
+    const d = new Date("0025-06-15T12:34:56.789Z");
+    const midnight = startOfDayUtc(d);
+    expect(midnight.getUTCFullYear()).toBe(25);
+    expect(midnight.toISOString()).toBe("0025-06-15T00:00:00.000Z");
   });
 });

--- a/packages/cloud/shared/src/lib/services/user-metrics.ts
+++ b/packages/cloud/shared/src/lib/services/user-metrics.ts
@@ -63,6 +63,16 @@ const PLATFORM_TO_SOURCES: Record<MetricsPlatform, string[]> = {
 };
 const ALL_SOURCES = ["web", "telegram", "discord", "blooio", "elizaos"];
 
+/**
+ * Returns UTC midnight for a given date, preserving years 0-99 via setUTCFullYear.
+ */
+export function startOfDayUtc(d: Date): Date {
+  const date = new Date(0);
+  date.setUTCFullYear(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -319,9 +329,7 @@ class UserMetricsService {
 
   private async _buildOverview(rangeDays: number): Promise<MetricsOverview> {
     const now = new Date();
-    const todayStart = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-    );
+    const todayStart = startOfDayUtc(now);
     const sevenDaysAgo = new Date(todayStart.getTime() - 7 * 86_400_000);
     const rangeStart = new Date(todayStart.getTime() - rangeDays * 86_400_000);
 
@@ -379,9 +387,7 @@ class UserMetricsService {
    * Compute and upsert daily_metrics for a given date across all platforms.
    */
   async computeDailyMetrics(date: Date): Promise<void> {
-    const dayStart = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-    );
+    const dayStart = startOfDayUtc(date);
     const dayEnd = new Date(dayStart.getTime() + 86_400_000);
 
     logger.info("[UserMetrics] Computing daily metrics", {
@@ -452,9 +458,7 @@ class UserMetricsService {
    * retention cohorts are supported by the schema but not yet computed.
    */
   async computeRetentionCohorts(date: Date): Promise<void> {
-    const dayStart = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-    );
+    const dayStart = startOfDayUtc(date);
 
     logger.info("[UserMetrics] Computing retention cohorts", {
       date: dayStart.toISOString(),
@@ -539,9 +543,7 @@ class UserMetricsService {
 
   private _rangeSince(range: "day" | "7d" | "30d"): Date {
     const now = new Date();
-    const todayMidnight = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-    );
+    const todayMidnight = startOfDayUtc(now);
     const daysBack = { day: 0, "7d": 6, "30d": 29 };
     return new Date(todayMidnight.getTime() - daysBack[range] * 86_400_000);
   }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Introduces `startOfDayUtc` which uses `setUTCFullYear` to preserve years 0-99 without JavaScript's `Date.UTC` 1900-1999 remapping.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/user-metrics.ts`, calculations for daily metrics, retention cohorts, and date ranges used `Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())`. For years 0 through 99, `Date.UTC` maps the year to `1900 + year`. Adding and using the `startOfDayUtc` helper preserves exact UTC dates across all years.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/user-metrics.ts` and `user-metrics.error-policy.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/user-metrics.error-policy.test.ts`.

# Evidence Gate

<!-- evidence-head:a987b4061239eab2c668681057691da5d3dd04c5 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - metrics helper logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: startOfDayUtc is not a function. (In 'startOfDayUtc(new Date("0025-06-15T12:34:56.789Z"))', 'startOfDayUtc' is undefined)
      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/shared/src/lib/services/user-metrics.error-policy.test.ts:114:22)
(fail) UserMetricsService fail-closed contract > startOfDayUtc preserves years 0-99 without Date.UTC remapping
4 pass, 1 fail
```

## Green (restored)
```
(pass) UserMetricsService fail-closed contract > startOfDayUtc preserves years 0-99 without Date.UTC remapping [0.05ms]
5 pass, 0 fail, 9 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

