### PR TITLE
fix(cloud): preserve years 0-99 in billing breakdown firstOfCurrentMonthUtc via setUTCFullYear

### DIFF
--- a/packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.test.ts
+++ b/packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Exercises the billing breakdown route and firstOfCurrentMonthUtc helper.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/db/helpers", () => ({
+  dbRead: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          groupBy: () => [],
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module("@/db/schemas/usage-records", () => ({
+  usageRecords: {
+    user_id: "user_id",
+    recorded_at: "recorded_at",
+    type: "type",
+    provider: "provider",
+    raw_cost: "raw_cost",
+    markup: "markup",
+    billed_cost: "billed_cost",
+  },
+}));
+
+mock.module("@/lib/auth/admin", () => ({
+  requireAdminWithResponse: async () => null,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+const { firstOfCurrentMonthUtc } = await import("./route");
+
+describe("firstOfCurrentMonthUtc", () => {
+  test("returns the first day of the current month at UTC midnight", () => {
+    const fixed = new Date("2026-08-24T15:30:00.000Z");
+    const first = firstOfCurrentMonthUtc(fixed);
+
+    expect(first.getUTCFullYear()).toBe(2026);
+    expect(first.getUTCMonth()).toBe(7); // 0-indexed August
+    expect(first.getUTCDate()).toBe(1);
+    expect(first.getUTCHours()).toBe(0);
+    expect(first.getUTCMinutes()).toBe(0);
+    expect(first.getUTCSeconds()).toBe(0);
+    expect(first.toISOString()).toBe("2026-08-01T00:00:00.000Z");
+  });
+
+  test("preserves years 0-99 without Date.UTC 1900-1999 remapping", () => {
+    const fixed = new Date("0025-06-15T12:00:00.000Z");
+    const first = firstOfCurrentMonthUtc(fixed);
+
+    expect(first.getUTCFullYear()).toBe(25);
+    expect(first.getUTCMonth()).toBe(5); // June
+    expect(first.getUTCDate()).toBe(1);
+    expect(first.toISOString()).toBe("0025-06-01T00:00:00.000Z");
+  });
+});

--- a/packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.ts
+++ b/packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.ts
@@ -28,9 +28,11 @@ interface BreakdownRow {
   recordCount: number;
 }
 
-function firstOfCurrentMonthUtc(): Date {
-  const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+export function firstOfCurrentMonthUtc(now: Date = new Date()): Date {
+  const date = new Date(0);
+  date.setUTCFullYear(now.getUTCFullYear(), now.getUTCMonth(), 1);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
 }
 
 async function __hono_GET(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Export `firstOfCurrentMonthUtc` with default parameter `now` and use `setUTCFullYear` to preserve years 0-99.

# Background

## What does this PR do?

In `packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.ts`, `firstOfCurrentMonthUtc()` used `Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)`. In JavaScript, `Date.UTC` remaps years 0-99 to 1900-1999. Using `setUTCFullYear` preserves the exact year and exports the helper for unit testing.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.ts` and `route.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/api v1/admin/users/[userId]/billing/breakdown/route.test.ts`.

# Evidence Gate

<!-- evidence-head:a3049c37736c89d42aae703f72368c4a5770c068 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - admin billing helper logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: firstOfCurrentMonthUtc is not a function. (In 'firstOfCurrentMonthUtc(new Date("2026-08-24T15:30:00.000Z"))', 'firstOfCurrentMonthUtc' is undefined)
      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/api/v1/admin/users/[userId]/billing/breakdown/route.test.ts:47:19)
(fail) firstOfCurrentMonthUtc > returns the first day of the current month at UTC midnight
(fail) firstOfCurrentMonthUtc > preserves years 0-99 without Date.UTC 1900-1999 remapping
0 pass, 2 fail
```

## Green (restored)
```
(pass) firstOfCurrentMonthUtc > returns the first day of the current month at UTC midnight [0.87ms]
(pass) firstOfCurrentMonthUtc > preserves years 0-99 without Date.UTC 1900-1999 remapping [0.04ms]
2 pass, 0 fail, 11 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

