### PR TITLE
fix(core): safe error formatting in stringifyActionResultError for non-standard error objects

### DIFF
--- a/packages/core/src/utils/action-results.test.ts
+++ b/packages/core/src/utils/action-results.test.ts
@@ -45,6 +45,21 @@ describe("stringifyActionResultError", () => {
 		expect(stringifyActionResultError("raw")).toBe("raw");
 		expect(stringifyActionResultError(42)).toBe("42");
 	});
+
+	it("safely handles null-prototype objects and poisoned toString without throwing", () => {
+		const nullProto = Object.create(null);
+		nullProto.code = "FAIL";
+		expect(stringifyActionResultError(nullProto)).toBe("[object Object]");
+
+		const throwingToString = {
+			toString() {
+				throw new Error("poisoned toString");
+			},
+		};
+		expect(stringifyActionResultError(throwingToString)).toBe(
+			"[object Object]",
+		);
+	});
 });
 
 describe("getActionResultReference", () => {

--- a/packages/core/src/utils/action-results.ts
+++ b/packages/core/src/utils/action-results.ts
@@ -5,6 +5,7 @@
  * sizes explicitly instead of silently changing the prompt.
  */
 import type { ActionResult, ProviderDataRecord } from "../types/components";
+import { formatError } from "./format-error.ts";
 
 export const ACTION_RESULT_OVERSIZE_WARNING_TOKENS = 10000;
 export const ACTION_RESULT_TOKEN_ESTIMATE_CHARS = 4;
@@ -77,7 +78,7 @@ export function stringifyActionResultError(
 	if (error === undefined || error === null) {
 		return undefined;
 	}
-	return error instanceof Error ? error.message : String(error);
+	return formatError(error);
 }
 
 function getReferenceFromData(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Replaces direct `String(error)` in `stringifyActionResultError` with canonical `formatError(error)`.

# Background

## What does this PR do?

In `packages/core/src/utils/action-results.ts`, `stringifyActionResultError` used `error instanceof Error ? error.message : String(error)`. `String(error)` throws a `TypeError: Cannot convert object to primitive value` when passed a null-prototype object (e.g. `Object.create(null)`) or an object with a throwing `toString` getter. Delegating to `formatError` from `./format-error.ts` safely converts any error value without throwing or crashing prompt construction.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/action-results.ts` and `action-results.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/action-results.test.ts`.

# Evidence Gate

<!-- evidence-head:c72cfb0bd2f0576de5bcbad9a3524f507ead8368 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - error stringifier logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: No default value
      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/core/src/utils/action-results.test.ts:52:10)
(fail) stringifyActionResultError > safely handles null-prototype objects and poisoned toString without throwing
9 pass, 1 fail
```

## Green (restored)
```
(pass) stringifyActionResultError > safely handles null-prototype objects and poisoned toString without throwing
10 pass, 0 fail, 25 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

