### PR TITLE
fix(shared): validate defaultUnit in parseDurationMs to reject invalid multiplier fallback

### DIFF
--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -20,7 +20,11 @@ describe("parseDurationMs", () => {
   it("uses the default unit only when no suffix is present", () => {
     expect(parseDurationMs("250")).toBe(250); // default ms
     expect(parseDurationMs("5", { defaultUnit: "s" })).toBe(5000);
+    expect(parseDurationMs("5", { defaultUnit: "d" })).toBe(432_000_000);
     expect(parseDurationMs("5s", { defaultUnit: "m" })).toBe(5000); // suffix wins
+    expect(() =>
+      parseDurationMs("5", { defaultUnit: "invalid" as unknown as "s" }),
+    ).toThrow("invalid duration");
   });
 
   it("throws on empty / malformed / negative input", () => {

--- a/packages/shared/src/cli/parse-duration.ts
+++ b/packages/shared/src/cli/parse-duration.ts
@@ -29,12 +29,7 @@ export function parseDurationMs(
     throw new Error(`invalid duration: ${raw}`);
   }
 
-  const unit = (m[2] ?? opts?.defaultUnit ?? "ms") as
-    | "ms"
-    | "s"
-    | "m"
-    | "h"
-    | "d";
+  const unit = m[2] ?? opts?.defaultUnit ?? "ms";
   const multiplier =
     unit === "ms"
       ? 1
@@ -44,7 +39,12 @@ export function parseDurationMs(
           ? 60_000
           : unit === "h"
             ? 3_600_000
-            : 86_400_000;
+            : unit === "d"
+              ? 86_400_000
+              : undefined;
+  if (multiplier === undefined) {
+    throw new Error(`invalid duration: ${raw} (unknown unit ${String(unit)})`);
+  }
   const milliseconds = value * multiplier;
   if (
     !Number.isFinite(milliseconds) ||


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Strict unit multiplier resolution throws on unrecognized unit string instead of falling through to the 86,400,000 (day) multiplier.

# Background

## What does this PR do?

In `packages/shared/src/cli/parse-duration.ts`, the ternary chain for `multiplier` ended with `: 86_400_000`. If an invalid `defaultUnit` option was passed (e.g. `{ defaultUnit: "invalid" }`), `parseDurationMs` silently defaulted to multiplying by 86,400,000 (1 day per unit). Explicitly validating the unit and throwing an error on unrecognized units prevents silent calculation bugs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/cli/parse-duration.ts` and `parse-duration.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/cli/parse-duration.test.ts`.

# Evidence Gate

<!-- evidence-head:317b0759b90238d9384c02726f584b59ebd83a6e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - duration parser logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toThrow(expected)

Expected substring: "invalid duration"

Received function did not throw
Received value: 432000000

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/shared/src/cli/parse-duration.test.ts:27:7)
(fail) parseDurationMs > uses the default unit only when no suffix is present [0.36ms]
8 pass, 1 fail
```

## Green (restored)
```
(pass) parseDurationMs > uses the default unit only when no suffix is present [0.05ms]
9 pass, 0 fail, 26 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

