### PR TITLE
fix(shared): support carriage return in firstSentenceSnip and normalize typographic apostrophes in wordCount

### DIFF
--- a/packages/shared/src/voice/first-sentence-snip.test.ts
+++ b/packages/shared/src/voice/first-sentence-snip.test.ts
@@ -29,6 +29,8 @@ describe("wordCount", () => {
   });
   it("counts contractions as one word", () => {
     expect(wordCount("it's")).toBe(1);
+    expect(wordCount("it’s")).toBe(1);
+    expect(wordCount("it‘s")).toBe(1);
     expect(wordCount("don't worry")).toBe(2);
   });
   it("counts hyphenated words as one word", () => {
@@ -101,6 +103,12 @@ describe("firstSentenceSnip — happy path", () => {
   });
   it("excludes a newline-only boundary from raw text and its end offset", () => {
     const r = firstSentenceSnip("Hello there\nSecond line.");
+    expect(r?.raw).toBe("Hello there");
+    expect(r?.normalized).toBe("hello there");
+    expect(r?.endOffset).toBe("Hello there".length);
+  });
+  it("excludes a carriage return boundary from raw text", () => {
+    const r = firstSentenceSnip("Hello there\rSecond line.");
     expect(r?.raw).toBe("Hello there");
     expect(r?.normalized).toBe("hello there");
     expect(r?.endOffset).toBe("Hello there".length);

--- a/packages/shared/src/voice/first-sentence-snip.ts
+++ b/packages/shared/src/voice/first-sentence-snip.ts
@@ -120,7 +120,7 @@ function findTerminatorEnd(text: string, start: number): number {
     const ch = text[i] ?? "";
 
     // Newline acts as a soft terminator (e.g. message body broken into lines).
-    if (ch === "\n") {
+    if (ch === "\n" || ch === "\r") {
       // Neither the delimiter nor horizontal spacing before it is spoken.
       let end = i - 1;
       while (end >= start && /\s/u.test(text[end] ?? "")) end--;
@@ -247,7 +247,7 @@ export function wordCount(s: string): number {
     //   - decimal number (digits . digits, possibly multi-segment)
     //   - dotted acronym (≥2 single-letter dot pairs)
     //   - regular word with optional hyphen/apostrophe internal joiners
-    /\p{N}+(?:\.\p{N}+)+|(?:\p{L}\.){2,}|[\p{L}\p{N}]+(?:[’'-][\p{L}\p{N}]+)*/gu,
+    /\p{N}+(?:\.\p{N}+)+|(?:\p{L}\.){2,}|[\p{L}\p{N}]+(?:[’'‘-][\p{L}\p{N}]+)*/gu,
   );
   return matches ? matches.length : 0;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds `\r` support to newline soft terminators and includes typographic left single quotation marks (`‘` U+2018) in `wordCount` regex joiners.

# Background

## What does this PR do?

In `packages/shared/src/voice/first-sentence-snip.ts`:
1. `findTerminatorEnd` checked only `ch === "\n"` for soft newlines, ignoring standalone `\r` (CR) line endings.
2. `wordCount` included `’` and `'` as internal word joiners but missed `‘` (U+2018), causing contractions like `it‘s` to be split into two words.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/voice/first-sentence-snip.ts` and `first-sentence-snip.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice/first-sentence-snip.test.ts`.

# Evidence Gate

<!-- evidence-head:6b406e63a087d7533f47e72ebfeced5138bfe399 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - sentence snipping helper logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
2 tests failed:
(fail) wordCount > counts contractions as one word [0.02ms]
(fail) firstSentenceSnip — happy path > excludes a carriage return boundary from raw text [0.05ms]
34 pass, 2 fail
```

## Green (restored)
```
(pass) wordCount > counts contractions as one word [0.02ms]
(pass) firstSentenceSnip — happy path > excludes a carriage return boundary from raw text
36 pass, 0 fail, 71 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

