### PR TITLE
fix(cloud): validate exact integer timestamp format in verifyWalletSignature

### DIFF
--- a/packages/cloud/shared/src/lib/auth/wallet-auth.test.ts
+++ b/packages/cloud/shared/src/lib/auth/wallet-auth.test.ts
@@ -209,4 +209,16 @@ describe("verifyWalletSignature payload binding", () => {
     });
     expect(user?.id).toBe("user-1");
   });
+
+  test("rejects malformed timestamp formats with non-integer strings", async () => {
+    const invalidHeaders = new Request("https://api.eliza.app/api/v1/user/wallets", {
+      method: "GET",
+      headers: {
+        "X-Wallet-Address": account.address,
+        "X-Timestamp": "1700000000junk",
+        "X-Wallet-Signature": "0x1234",
+      },
+    });
+    await expect(verifyWalletSignature(invalidHeaders)).rejects.toThrow("Invalid timestamp format");
+  });
 });

--- a/packages/cloud/shared/src/lib/auth/wallet-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/wallet-auth.ts
@@ -59,8 +59,11 @@ export async function verifyWalletSignature(
     throw new Error("Invalid wallet address format");
   }
 
-  const timestamp = parseInt(timestampStr, 10);
-  if (isNaN(timestamp)) {
+  if (!/^\d+$/.test(timestampStr.trim())) {
+    throw new Error("Invalid timestamp format");
+  }
+  const timestamp = Number(timestampStr.trim());
+  if (!Number.isSafeInteger(timestamp)) {
     throw new Error("Invalid timestamp format");
   }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Replaces permissive `parseInt` on `X-Timestamp` header with exact decimal integer validation and safe integer checks.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/auth/wallet-auth.ts`, `verifyWalletSignature` used `parseInt(timestampStr, 10)` to parse the `X-Timestamp` header. `parseInt` permissively truncates non-numeric suffixes (e.g. `1700000000junk` is parsed as `1700000000`). Validating `X-Timestamp` with `/^\d+$/` and `Number.isSafeInteger` ensures only exact decimal timestamps are accepted into the authentication nonce.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/auth/wallet-auth.ts` and `wallet-auth.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/auth/wallet-auth.test.ts`.

# Evidence Gate

<!-- evidence-head:36685102cbe359d80c73b6ba3e7f202a63b88037 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - wallet auth header validation change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toThrow(expected)

Expected substring: "Invalid timestamp format"
Received message: "Signature timestamp expired"

      at <anonymous> (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/shared/src/lib/auth/wallet-auth.test.ts:222:65)
(fail) verifyWalletSignature payload binding > rejects malformed timestamp formats with non-integer strings [0.44ms]
9 pass, 1 fail
```

## Green (restored)
```
(pass) verifyWalletSignature payload binding > rejects malformed timestamp formats with non-integer strings [0.02ms]
10 pass, 0 fail, 10 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

