### PR TITLE
fix(cloud): preserve TTL and validate integer value in memory-cache-adapter incr

### DIFF
--- a/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for MemoryCacheAdapter verifying Redis-compliant incr behavior,
+ * TTL preservation, and non-integer error handling.
+ */
+import { describe, expect, it } from "vitest";
+import { MemoryCacheAdapter } from "./memory-cache-adapter";
+
+describe("MemoryCacheAdapter", () => {
+  it("increments unset and existing integer keys", async () => {
+    const cache = new MemoryCacheAdapter();
+    expect(await cache.incr("counter")).toBe(1);
+    expect(await cache.incr("counter")).toBe(2);
+    expect(await cache.get("counter")).toBe("2");
+  });
+
+  it("preserves key TTL when calling incr", async () => {
+    const cache = new MemoryCacheAdapter();
+    await cache.setex("expiring-counter", 60, "10");
+
+    const ttlBefore = await cache.pttl("expiring-counter");
+    expect(ttlBefore).toBeGreaterThan(0);
+
+    const next = await cache.incr("expiring-counter");
+    expect(next).toBe(11);
+
+    const ttlAfter = await cache.pttl("expiring-counter");
+    expect(ttlAfter).toBeGreaterThan(0);
+    expect(ttlAfter).toBeLessThanOrEqual(ttlBefore!);
+  });
+
+  it("throws for non-integer or malformed values on incr", async () => {
+    const cache = new MemoryCacheAdapter();
+    await cache.set("text", "hello");
+    await expect(cache.incr("text")).rejects.toThrow("ERR value is not an integer or out of range");
+
+    await cache.set("prefixed", "10abc");
+    await expect(cache.incr("prefixed")).rejects.toThrow(
+      "ERR value is not an integer or out of range",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
@@ -96,8 +96,24 @@ export class MemoryCacheAdapter implements CacheRedisClient {
   }
 
   async incr(key: string): Promise<number> {
-    const next = Number.parseInt(this.getValue(key) ?? "0", 10) + 1;
-    this.setValue(key, String(next));
+    const raw = this.getValue(key);
+    const existingExpireAt = this.values.get(key)?.expireAt ?? null;
+    let current = 0;
+    if (raw !== null) {
+      if (!/^-?\d+$/.test(raw.trim())) {
+        throw new Error("ERR value is not an integer or out of range");
+      }
+      current = Number(raw.trim());
+      if (!Number.isSafeInteger(current)) {
+        throw new Error("ERR value is not an integer or out of range");
+      }
+    }
+    const next = current + 1;
+    this.values.set(key, {
+      value: String(next),
+      expireAt: existingExpireAt,
+    });
+    this.lists.delete(key);
     return next;
   }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Aligns `MemoryCacheAdapter.incr` with Redis semantics: preserves existing TTL on the key and rejects non-integer strings with a typed error.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts`:
1. `incr` previously called `this.setValue(key, String(next))` which reset `expireAt` to `null`, silently wiping out existing TTL on the key.
2. `incr` parsed values with `Number.parseInt(..., 10)` which produced `NaN` on non-numeric strings or truncated prefixes (e.g. `10abc` -> `10`).
Updating `incr` preserves the key's existing `expireAt` timestamp and rejects invalid integer values.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts` and `memory-cache-adapter.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/cache/adapters/memory-cache-adapter.test.ts`.

# Evidence Gate

<!-- evidence-head:cb1561196c0d83b599b8999f09f8bb19b5ad12a1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - in-memory cache adapter logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBeGreaterThan(expected)
Expected: > 0
Received: -1
(fail) MemoryCacheAdapter > preserves key TTL when calling incr

error: Expected promise that rejects, Received promise that resolved
(fail) MemoryCacheAdapter > throws for non-integer or malformed values on incr
1 pass, 2 fail
```

## Green (restored)
```
(pass) MemoryCacheAdapter > increments unset and existing integer keys
(pass) MemoryCacheAdapter > preserves key TTL when calling incr [0.27ms]
(pass) MemoryCacheAdapter > throws for non-integer or malformed values on incr [0.24ms]
3 pass, 0 fail, 9 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

