### PR TITLE
fix(cloud): reject bare integer and whitespace values in parseDateRangeParams

### DIFF
--- a/packages/cloud/shared/src/lib/api/date-range-params.test.ts
+++ b/packages/cloud/shared/src/lib/api/date-range-params.test.ts
@@ -30,6 +30,10 @@ describe("parseDateRangeParams", () => {
     const r = parseDateRangeParams(new URLSearchParams("start_date=invalid"));
     expect(r.success).toBe(false);
     if (!r.success) expect(r.error).toContain("Invalid start_date");
+
+    const rNum = parseDateRangeParams(new URLSearchParams("start_date=12345"));
+    expect(rNum.success).toBe(false);
+    if (!rNum.success) expect(rNum.error).toContain("Invalid start_date");
   });
 
   it("rejects invalid end", () => {

--- a/packages/cloud/shared/src/lib/api/date-range-params.ts
+++ b/packages/cloud/shared/src/lib/api/date-range-params.ts
@@ -7,10 +7,12 @@ const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 function parseOptionalDate(raw: string | null): Date | undefined {
   if (raw === null) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed || /^-?\d+$/.test(trimmed)) return undefined;
 
-  const date = new Date(raw);
+  const date = new Date(trimmed);
   if (Number.isNaN(date.getTime())) return undefined;
-  if (ISO_DATE_ONLY.test(raw) && date.toISOString().slice(0, 10) !== raw) {
+  if (ISO_DATE_ONLY.test(trimmed) && date.toISOString().slice(0, 10) !== trimmed) {
     return undefined;
   }
   return date;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Rejects bare integers and empty/whitespace strings from being accepted as valid dates in analytics queries.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/api/date-range-params.ts`, `parseOptionalDate` passed the raw input directly to `new Date(raw)`. Bare integer strings like `"12345"` coerced to year `12345` instead of being rejected as invalid date parameters. Adding regex guards for bare integers and trimming whitespace ensures only valid date formats are parsed.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/api/date-range-params.ts` and `date-range-params.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/api/date-range-params.test.ts`.

# Evidence Gate

<!-- evidence-head:33c22d54490bc0211492e9648ea906ed6236de4b -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - analytics date range validation logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) parseDateRangeParams > rejects invalid start
6 pass, 1 fail
```

## Green (restored)
```
(pass) parseDateRangeParams > returns success with no params [0.17ms]
(pass) parseDateRangeParams > parses valid range [0.11ms]
(pass) parseDateRangeParams > rejects invalid start [0.02ms]
7 pass, 0 fail, 17 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

