### PR TITLE
fix(shared): normalize typographic curly apostrophes in shouldRespondToVoiceTurn words helper

### DIFF
--- a/packages/shared/src/voice/respond-gate.test.ts
+++ b/packages/shared/src/voice/respond-gate.test.ts
@@ -34,6 +34,23 @@ describe("shouldRespondToVoiceTurn", () => {
       }),
     ).toBe(true);
   });
+
+  it("normalizes typographic curly apostrophes when matching echoes", () => {
+    const reply = "it's time to go now";
+    expect(
+      shouldRespondToVoiceTurn("it’s time to go now", {
+        recentAgentReply: reply,
+        agentSpeaking: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("handles non-string or undefined inputs gracefully", () => {
+    expect(shouldRespondToVoiceTurn(undefined as unknown as string)).toBe(
+      false,
+    );
+    expect(shouldRespondToVoiceTurn(null as unknown as string)).toBe(false);
+  });
 });
 
 describe("buildVoiceTurnSignal — bystander + wake word", () => {

--- a/packages/shared/src/voice/respond-gate.ts
+++ b/packages/shared/src/voice/respond-gate.ts
@@ -44,8 +44,10 @@ export const ECHO_WINDOW_MS = 9000;
 export const ECHO_OVERLAP_THRESHOLD = 0.7;
 
 function words(text: string): string[] {
+  if (typeof text !== "string") return [];
   return text
     .toLowerCase()
+    .replace(/[’‘]/g, "'")
     .replace(/[^a-z0-9'\s-]/gi, "")
     .split(/\s+/)
     .filter(Boolean);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Normalizes typographic curly apostrophes (`[’‘]`) to ASCII apostrophe (`'`) in `words()` and safely returns empty array for non-string inputs.

# Background

## What does this PR do?

In `packages/shared/src/voice/respond-gate.ts`, the `words(text)` helper:
1. Threw a `TypeError: text.toLowerCase is not a function` when given non-string or undefined inputs.
2. Stripped curly apostrophes (`’`, `‘`) via `/[^a-z0-9'\s-]/`, turning `"it’s"` into `"its"` which failed to match `"it's"` in echo overlap comparison sets.
Normalizing curly apostrophes to ASCII apostrophes ensures consistent tokenization across transcribed voice inputs and agent replies.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/voice/respond-gate.ts` and `respond-gate.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice/respond-gate.test.ts`.

# Evidence Gate

<!-- evidence-head:f82ab3f3b57d0b0b1ad282642e3e7ce771d83f7f -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - voice turn response gate logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'text.toLowerCase')
      at words (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/shared/src/voice/respond-gate.ts:47:10)
(fail) shouldRespondToVoiceTurn > handles non-string or undefined inputs gracefully
10 pass, 1 fail
```

## Green (restored)
```
(pass) shouldRespondToVoiceTurn > handles non-string or undefined inputs gracefully
11 pass, 0 fail, 19 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

