### PR TITLE
test(core): cover character-gate-notice

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/character-gate-notice.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/character-gate-notice.test.ts
@@ -392,4 +392,77 @@ describe("CHARACTER_GATE_NOTICE", () => {
 		expect(result.text).toContain("requires the MEMBER role");
 		expect(result.text).not.toContain("only your owner/admins");
 	});
+
+	// Provider-resolution branches below the classifier: gating additionally
+	// requires a registered CHARACTER action and a resolvable minimum role, and
+	// a sender already at or above the resolved gate is never refused.
+	test("stays silent when the runtime registers no CHARACTER action", async () => {
+		const runtime = gateRuntime();
+		(runtime as unknown as { actions: unknown[] }).actions = [];
+		expectNoNotice(
+			await characterGateNoticeProvider.get(
+				runtime,
+				connectorMessage(runtime, GUEST, EXPLICIT_ASK),
+			),
+		);
+	});
+
+	test("stays silent when the runtime exposes no action list at all", async () => {
+		const fake = makeFakeRuntime({ owner: OWNER });
+		(fake.runtime as unknown as { reportError: () => void }).reportError =
+			() => {};
+		expectNoNotice(
+			await characterGateNoticeProvider.get(
+				fake.runtime,
+				connectorMessage(fake.runtime, GUEST, EXPLICIT_ASK),
+			),
+		);
+	});
+
+	test("falls back to contextGate.roleGate.minRole when roleGate is absent", async () => {
+		const runtime = gateRuntime();
+		(runtime as unknown as { actions: unknown[] }).actions = [
+			{
+				name: "CHARACTER",
+				contextGate: { roleGate: { minRole: "OWNER" } },
+			},
+		];
+		const result = await characterGateNoticeProvider.get(
+			runtime,
+			connectorMessage(runtime, GUEST, EXPLICIT_ASK),
+		);
+		expect(result.values?.characterModificationGated).toBe(true);
+		expect(result.values?.requiredRole).toBe("OWNER");
+		expect(result.text).toContain("requires the OWNER role");
+	});
+
+	test("stays silent when the CHARACTER action declares no resolvable gate role", async () => {
+		const runtime = gateRuntime();
+		(runtime as unknown as { actions: unknown[] }).actions = [
+			{ name: "CHARACTER" },
+		];
+		expectNoNotice(
+			await characterGateNoticeProvider.get(
+				runtime,
+				connectorMessage(runtime, GUEST, EXPLICIT_ASK),
+			),
+		);
+	});
+
+	test("does not refuse a sender holding the gate role through world roles", async () => {
+		const admin = "00000000-0000-4000-8000-0000000000cc" as UUID;
+		const fake = makeFakeRuntime({ owner: OWNER, admins: [admin] });
+		const runtimeMutable = fake.runtime as unknown as {
+			actions: unknown[];
+			reportError: () => void;
+		};
+		runtimeMutable.actions = [characterAction];
+		runtimeMutable.reportError = () => {};
+		expectNoNotice(
+			await characterGateNoticeProvider.get(
+				fake.runtime,
+				connectorMessage(fake.runtime, admin, EXPLICIT_ASK),
+			),
+		);
+	});
 });


### PR DESCRIPTION

## Summary

Appends five cases to the existing CHARACTER_GATE_NOTICE suite covering provider-resolution branches of `characterGateNoticeProvider` that no existing case reaches. The classification grammar was already exhaustively covered; this diff goes below the classifier into the notice's own preconditions:

- an explicit persistent request stays **silent** when no CHARACTER action is registered on the runtime (the `find` miss);
- silent, without throwing, when the runtime exposes no action list at all (the `runtime.actions ?? []` path);
- the gate role falls back to `contextGate.roleGate.minRole` when `roleGate.minRole` is absent — the notice fires with `requiredRole: "OWNER"` and its text names the required role;
- silent when the CHARACTER action declares no resolvable gate role (the `!minRole` early return);
- a sender holding the gate role through world roles — rather than the canonical-owner setting — passes `hasRoleAccess` and is not refused.

All assertions drive the real provider end to end through its public `get()` surface against FakeRuntime's real role resolver. No mocks asserting their own returns.

## Test plan

- [x] `bunx vitest run packages/core/src/features/advanced-capabilities/personality/__tests__/character-gate-notice.test.ts` → **248 passed (248)**, 1 test file passed, on origin/develop @ de774b875774.
- [x] `bunx biome check --write <test file>` → clean, "Checked 1 file ... No fixes applied" (biome.json present; worktree is not sparse).
- [x] `bunx tsc --noEmit` in `packages/core` → exit 0, empty output; the new test file appears nowhere in it.
- [x] The diff is additive only: one test file, +73/-0. No production code changed, so no behavioral evidence beyond the suite applies.

Fork contributor: hosted CI does not run on this pull request; all counts above were executed locally against current origin/develop and quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f7d01264f04ea09a738c6f3b1882cb3324bad8f0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
