### PR TITLE
fix(cloud): unquote RFC 6265 cookie values in getCookieValueFromHeader

### DIFF
--- a/packages/cloud/shared/src/lib/http/cookie-header.test.ts
+++ b/packages/cloud/shared/src/lib/http/cookie-header.test.ts
@@ -5,6 +5,7 @@ describe("cookie-header", () => {
   it("parses single cookie", () => {
     expect(getCookieValueFromHeader("a=1; b=2", "b")).toBe("2");
     expect(getCookieValueFromHeader("token=abc%20def", "token")).toBe("abc def");
+    expect(getCookieValueFromHeader('token="abc%20def"', "token")).toBe("abc def");
   });
 
   it("returns undefined for missing or null", () => {

--- a/packages/cloud/shared/src/lib/http/cookie-header.ts
+++ b/packages/cloud/shared/src/lib/http/cookie-header.ts
@@ -8,7 +8,10 @@ export function getCookieValueFromHeader(header: string | null, name: string): s
   for (const segment of segments) {
     const trimmed = segment.trim();
     if (!trimmed.startsWith(`${name}=`)) continue;
-    const raw = trimmed.slice(name.length + 1).trimStart();
+    let raw = trimmed.slice(name.length + 1).trimStart();
+    if (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) {
+      raw = raw.slice(1, -1);
+    }
     try {
       return decodeURIComponent(raw);
     } catch {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Aligns `getCookieValueFromHeader` with RFC 6265 §4.1.1 cookie value unquoting prior to URL decoding.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/http/cookie-header.ts`, `getCookieValueFromHeader` did not strip enclosing double quotes (`"..."`) allowed by RFC 6265 for cookie values. Quoted cookies like `token="abc%20def"` retained the literal quotes around the decoded string.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/http/cookie-header.ts` and `cookie-header.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/http/cookie-header.test.ts`.

# Evidence Gate

<!-- evidence-head:5197b6b2ac9c3ca9e091d299006d965db0b4f2c8 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - HTTP cookie header parsing logic change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: "abc def"
Received: "\"abc def\""
(fail) cookie-header > parses single cookie
3 pass, 1 fail
```

## Green (restored)
```
(pass) cookie-header > parses single cookie
(pass) cookie-header > returns undefined for missing or null
(pass) cookie-header > handles malformed encoding as undefined
(pass) cookie-header > reads from Request
4 pass, 0 fail, 8 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

