### PR TITLE
fix(cloud): handle IPv6 host bracket syntax in checkElizaMutatingRequestOrigin

### DIFF
--- a/packages/cloud/shared/src/lib/auth/browser-origin-policy.test.ts
+++ b/packages/cloud/shared/src/lib/auth/browser-origin-policy.test.ts
@@ -107,4 +107,16 @@ describe("Steward browser origin policy", () => {
     // An empty marker value is not a marker.
     expect(hasElizaNonSimpleRequestMarker(headers({ "x-eliza-csrf": "  " }))).toBe(false);
   });
+
+  it("extracts IPv6 host header correctly for same-origin matching", () => {
+    expect(
+      checkElizaMutatingRequestOrigin(
+        headers({
+          host: "[::1]:8787",
+          origin: "http://[::1]:8787",
+        }),
+        false,
+      ),
+    ).toEqual({ ok: true });
+  });
 });

--- a/packages/cloud/shared/src/lib/auth/browser-origin-policy.ts
+++ b/packages/cloud/shared/src/lib/auth/browser-origin-policy.ts
@@ -72,7 +72,13 @@ export function checkElizaMutatingRequestOrigin(
 ): BrowserOriginCheck {
   const origin = browserOriginHost(req.header("origin"));
   const referer = browserOriginHost(req.header("referer"));
-  const requestHost = (req.header("host") ?? "").split(":")[0]?.toLowerCase() ?? "";
+  const rawHost = req.header("host") ?? "";
+  let requestHost = "";
+  try {
+    requestHost = new URL(`http://${rawHost.trim()}`).hostname.toLowerCase();
+  } catch {
+    requestHost = (rawHost.split(":")[0]?.toLowerCase() ?? "").trim();
+  }
   if (!origin && !referer) {
     return { ok: false, reason: "missing_origin_and_referer" };
   }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Parses host header with URL hostname parser fallback to correctly handle IPv6 literal bracket syntax (e.g. `[::1]:8787`).

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/auth/browser-origin-policy.ts`, `checkElizaMutatingRequestOrigin` extracted `requestHost` using `(req.header("host") ?? "").split(":")[0]`. When requests use IPv6 bracket notation (e.g. `[::1]:8787` in local/container environments), splitting on `:` resulted in `"["` rather than the true hostname `"[::1]"`. Parsing via `new URL("http://" + rawHost).hostname` safely handles IPv6 host header formats.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/auth/browser-origin-policy.ts` and `browser-origin-policy.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/auth/browser-origin-policy.test.ts`.

# Evidence Gate

<!-- evidence-head:483a71cfb77fb3ce18efcb86133575b69b7572b0 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - browser origin policy host parsing change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toEqual(expected)
  {
-   "ok": true,
+   "ok": false,
+   "reason": "origin=[::1] referer=null",
  }
(fail) Steward browser origin policy > extracts IPv6 host header correctly for same-origin matching
7 pass, 1 fail
```

## Green (restored)
```
(pass) Steward browser origin policy > extracts IPv6 host header correctly for same-origin matching
8 pass, 0 fail, 28 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

