### PR TITLE
test(core): cover types

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/types.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/types.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for personality capability types: the emptyPersonalitySlot
+ * factory contract (unset traits, per-call instance freshness, identity
+ * passthrough, global-scope wiring) and the canonical value vocabularies
+ * consumed by the store validator and action schema enums. Deterministic
+ * harness with no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	emptyPersonalitySlot,
+	FORMALITY_VALUES,
+	GLOBAL_PERSONALITY_SCOPE,
+	PersonalityServiceType,
+	REPLY_GATE_VALUES,
+	SCOPE_VALUES,
+	TONE_VALUES,
+	TRAIT_VALUES,
+	VERBOSITY_VALUES,
+} from "./types.ts";
+
+const AGENT_ID = "123e4567-e89b-42d3-a456-426614174000";
+const OTHER_AGENT_ID = "123e4567-e89b-42d3-a456-426614174001";
+const USER_ID = "987e6543-e21b-42d3-a456-426614174999";
+
+describe("personality/types", () => {
+	describe("emptyPersonalitySlot", () => {
+		it("returns a slot with every personality trait unset", () => {
+			const slot = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			expect(slot.verbosity).toBeNull();
+			expect(slot.tone).toBeNull();
+			expect(slot.formality).toBeNull();
+			expect(slot.reply_gate).toBeNull();
+		});
+
+		it("starts with no custom directives and no trait provenance", () => {
+			const slot = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			expect(slot.custom_directives).toEqual([]);
+			expect(slot.trait_sources).toEqual({});
+		});
+
+		it("defaults source to an explicit user write and updated_at to the epoch", () => {
+			const slot = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			expect(slot.source).toBe("user");
+			expect(new Date(slot.updated_at).getTime()).toBe(0);
+		});
+
+		it("passes user and agent identities through verbatim", () => {
+			const slot = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			expect(slot.userId).toBe(USER_ID);
+			expect(slot.agentId).toBe(AGENT_ID);
+
+			const other = emptyPersonalitySlot(USER_ID, OTHER_AGENT_ID);
+			expect(other.userId).toBe(USER_ID);
+			expect(other.agentId).toBe(OTHER_AGENT_ID);
+		});
+
+		it("addresses the global slot through the exported scope token", () => {
+			const slot = emptyPersonalitySlot(GLOBAL_PERSONALITY_SCOPE, AGENT_ID);
+			expect(slot.userId).toBe(GLOBAL_PERSONALITY_SCOPE);
+			expect(slot.userId).not.toBe(USER_ID);
+			expect(slot.agentId).toBe(AGENT_ID);
+		});
+
+		it("returns independent instances per call with no shared collections", () => {
+			const first = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			const second = emptyPersonalitySlot(USER_ID, AGENT_ID);
+			expect(first).not.toBe(second);
+
+			first.custom_directives.push("be terser");
+			first.trait_sources.tone = "agent_inferred";
+
+			expect(second.custom_directives).toEqual([]);
+			expect(second.trait_sources).toEqual({});
+			expect(second.source).toBe("user");
+		});
+	});
+
+	describe("canonical value lists", () => {
+		it("exposes non-empty duplicate-free string vocabularies for schema enums", () => {
+			for (const values of [
+				VERBOSITY_VALUES,
+				TONE_VALUES,
+				FORMALITY_VALUES,
+				REPLY_GATE_VALUES,
+				TRAIT_VALUES,
+				SCOPE_VALUES,
+			]) {
+				expect(values.length).toBeGreaterThan(0);
+				for (const value of values) {
+					expect(typeof value).toBe("string");
+				}
+				expect(new Set(values).size).toBe(values.length);
+			}
+		});
+	});
+
+	describe("PersonalityServiceType", () => {
+		it("registers distinct service type strings under their own keys", () => {
+			const entries = Object.entries(PersonalityServiceType);
+			expect(entries.length).toBeGreaterThan(0);
+			for (const [key, value] of entries) {
+				expect(value).toBe(key);
+				expect(typeof value).toBe("string");
+			}
+			expect(new Set(Object.values(PersonalityServiceType)).size).toBe(
+				entries.length,
+			);
+		});
+	});
+});


### PR DESCRIPTION

## Summary

Adds a colocated unit suite for `packages/core/src/features/advanced-capabilities/personality/types.ts`, which previously had no same-named test file anywhere in the repo.

The module is not type-only: it ships the `emptyPersonalitySlot` factory plus the canonical value vocabularies that `personality-store.ts` validates slots against and that the PERSONALITY action spreads into its JSON-schema enums. The suite drives those real runtime surfaces (no mocks, no `expectTypeOf`):

- `emptyPersonalitySlot` defaults: every trait unset, no custom directives, no trait provenance, `source: "user"`, epoch `updated_at` (a fresh slot sorts before any real write).
- Identity passthrough for user UUID + agent UUID, and global-scope wiring: the factory addresses the global slot through the exported `GLOBAL_PERSONALITY_SCOPE` token, exactly the discriminator the store keys on.
- Per-call instance freshness: two calls return independent objects; mutating one slot's `custom_directives` / `trait_sources` cannot leak into another (guards the shared-reference factory bug class).
- Canonical value lists (`VERBOSITY_VALUES`, `TONE_VALUES`, `FORMALITY_VALUES`, `REPLY_GATE_VALUES`, `TRAIT_VALUES`, `SCOPE_VALUES`) are non-empty, string-typed, duplicate-free vocabularies — the contract their spread into action schema enums depends on.
- `PersonalityServiceType` registers distinct, key-matching service-type strings.

## Evidence (test-only change; run locally — this PR comes from a fork, so hosted CI does not run on it)

- `bunx vitest run packages/core/src/features/advanced-capabilities/personality/types.test.ts` → **1 file passed, 8 tests passed** (vitest 4.1.10).
- `bunx biome check --write packages/core/src/features/advanced-capabilities/personality/types.test.ts` → clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/core` → exit 0; the new test file appears nowhere in diagnostics.
- Diff is one new file, **+110/−0**, based on current `develop` (`de774b875774`). No existing test was modified or deleted.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:581fd34363bd5dce0744d72fc1da9db29bdf35c5 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
