### PR TITLE
fix(cloud): tolerate whitespace and case-insensitive bearer scheme in extractBearerToken

### DIFF
--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -316,4 +316,15 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       expect(lastRedisEnv?.REDIS_URL).toBe("redis://railway.internal:6379");
     });
   });
+
+  describe("extractBearerToken", () => {
+    test("extracts token from canonical and whitespace/case-variant headers", () => {
+      expect(mod.extractBearerToken("Bearer token123")).toBe("token123");
+      expect(mod.extractBearerToken("bearer   token123  ")).toBe("token123");
+      expect(mod.extractBearerToken("BEARER token123")).toBe("token123");
+      expect(mod.extractBearerToken("Basic abc")).toBeNull();
+      expect(mod.extractBearerToken(null)).toBeNull();
+      expect(mod.extractBearerToken("")).toBeNull();
+    });
+  });
 });

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -216,11 +216,6 @@ export async function verifyInternalRequestToken(token: string): Promise<Verific
  */
 export function extractBearerToken(authHeader: string | null): string | null {
   if (!authHeader) return null;
-
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer") {
-    return null;
-  }
-
-  return parts[1];
+  const match = /^Bearer\s+(\S+)$/i.exec(authHeader.trim());
+  return match ? match[1] : null;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Extracts bearer token via standard case-insensitive regex `/^Bearer\s+(\S+)$/i` to tolerate whitespace variants and casing per RFC 6750.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/auth/jwt-internal.ts`, `extractBearerToken` previously used `authHeader.split(" ")` and checked `parts.length === 2 && parts[0] === "Bearer"`. Header values with multiple spaces between `Bearer` and the token, trailing whitespace, or lowercase `bearer` failed parsing and returned `null`. Updating to regex matching improves RFC 6750 compliance.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/auth/jwt-internal.ts` and `jwt-internal.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/auth/jwt-internal.test.ts`.

# Evidence Gate

<!-- evidence-head:98acc433c12d7e317ba8b4dfd82049def41ad905 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - authorization header parsing change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: "token123"
Received: null
(fail) internal JWT jti revocation denylist (#12879) > extractBearerToken > extracts token from canonical and whitespace/case-variant headers
15 pass, 1 fail
```

## Green (restored)
```
(pass) internal JWT jti revocation denylist (#12879) > extractBearerToken > extracts token from canonical and whitespace/case-variant headers [0.03ms]
16 pass, 0 fail, 41 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

