### PR TITLE
fix(cloud): validate token type and safe integer exp in verifyPlaywrightTestSessionToken

### DIFF
--- a/packages/cloud/shared/src/lib/auth/playwright-test-session.test.ts
+++ b/packages/cloud/shared/src/lib/auth/playwright-test-session.test.ts
@@ -61,6 +61,8 @@ describe("playwright test session auth", () => {
     expect(verifyPlaywrightTestSessionToken(`${payload}.tampered`, env)).toBeNull();
     expect(verifyPlaywrightTestSessionToken(`${payload}.${signature}.extra`, env)).toBeNull();
     expect(verifyPlaywrightTestSessionToken("not-a-token", env)).toBeNull();
+    expect(verifyPlaywrightTestSessionToken(undefined as unknown as string, env)).toBeNull();
+    expect(verifyPlaywrightTestSessionToken(null as unknown as string, env)).toBeNull();
   });
 
   it("rejects expired tokens and non-string required claims", () => {

--- a/packages/cloud/shared/src/lib/auth/playwright-test-session.ts
+++ b/packages/cloud/shared/src/lib/auth/playwright-test-session.ts
@@ -62,6 +62,10 @@ export function verifyPlaywrightTestSessionToken(
   token: string,
   env: PlaywrightTestAuthEnv = process.env,
 ): PlaywrightTestSessionClaims | null {
+  if (typeof token !== "string") {
+    return null;
+  }
+
   const secret = getPlaywrightTestAuthSecret(env);
   if (!isPlaywrightTestAuthEnabled(env) || !secret) {
     return null;
@@ -94,10 +98,11 @@ export function verifyPlaywrightTestSessionToken(
 
     if (
       typeof claims?.userId !== "string" ||
-      !claims.userId ||
+      !claims.userId.trim() ||
       typeof claims.organizationId !== "string" ||
-      !claims.organizationId ||
-      typeof claims.exp !== "number"
+      !claims.organizationId.trim() ||
+      typeof claims.exp !== "number" ||
+      !Number.isSafeInteger(claims.exp)
     ) {
       return null;
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns `null` for non-string token inputs and verifies `claims.exp` is a safe integer to prevent invalid expiration bypasses.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/auth/playwright-test-session.ts`, `verifyPlaywrightTestSessionToken`:
1. Directly called `token.split(".")` without checking if `token` is a string, throwing `TypeError: token.split is not a function` on `null`/`undefined`/non-string values.
2. Verified `claims.exp` only with `typeof claims.exp === "number"`, which could evaluate `NaN <= Date.now()` as `false`.
Adding a string guard and checking `Number.isSafeInteger(claims.exp)` ensures robust rejection of malformed tokens.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/auth/playwright-test-session.ts` and `playwright-test-session.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/auth/playwright-test-session.test.ts`.

# Evidence Gate

<!-- evidence-head:c20ca1899a8ad5232ed950f3cc66db4c2ba3c0d1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - test session authentication helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'token.split')
      at verifyPlaywrightTestSessionToken (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/shared/src/lib/auth/playwright-test-session.ts:70:17)
(fail) playwright test session auth > rejects tampered, multi-part, and malformed tokens
6 pass, 1 fail
```

## Green (restored)
```
(pass) playwright test session auth > rejects tampered, multi-part, and malformed tokens [0.04ms]
7 pass, 0 fail, 26 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

