### PR TITLE
fix(core): safely handle non-string and empty inputs in stripHtmlRawTextElements

### DIFF
--- a/packages/core/src/utils/html-raw-text.test.ts
+++ b/packages/core/src/utils/html-raw-text.test.ts
@@ -140,4 +140,10 @@ describe("stripHtmlRawTextElements", () => {
 			),
 		).toBe("before after");
 	});
+
+	it("handles non-string, null, or empty inputs gracefully", () => {
+		expect(stripHtmlRawTextElements("")).toBe("");
+		expect(stripHtmlRawTextElements(undefined as unknown as string)).toBe("");
+		expect(stripHtmlRawTextElements(null as unknown as string)).toBe("");
+	});
 });

--- a/packages/core/src/utils/html-raw-text.ts
+++ b/packages/core/src/utils/html-raw-text.ts
@@ -155,6 +155,9 @@ function findScriptClosingEnd(value: string, index: number): number | null {
 
 /** Remove script/style elements, including parser-accepted malformed end tags. */
 export function stripHtmlRawTextElements(value: string): string {
+	if (typeof value !== "string" || !value) {
+		return "";
+	}
 	const output: string[] = [];
 	let copiedThrough = 0;
 	let cursor = 0;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns empty string for non-string/null/undefined/empty input in `stripHtmlRawTextElements`.

# Background

## What does this PR do?

In `packages/core/src/utils/html-raw-text.ts`, `stripHtmlRawTextElements` assumed `value` was always a non-null string, immediately evaluating `value.length` and indexing `value[cursor]`. Non-string or undefined inputs caused uncaught `TypeError: Cannot read properties of undefined (reading 'length')`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/html-raw-text.ts` and `html-raw-text.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/html-raw-text.test.ts`.

# Evidence Gate

<!-- evidence-head:0e7eddf0b5b3e6c35b53245271d28542092c8991 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - HTML raw text sanitizer helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'value.length')
      at stripHtmlRawTextElements (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/core/src/utils/html-raw-text.ts:162:18)
(fail) stripHtmlRawTextElements > handles non-string, null, or empty inputs gracefully
38 pass, 1 fail
```

## Green (restored)
```
(pass) stripHtmlRawTextElements > handles non-string, null, or empty inputs gracefully [0.09ms]
39 pass, 0 fail, 47 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

