### PR TITLE
fix(core): safely handle non-string inputs in reasoning-tags residue and strip helpers

### DIFF
--- a/packages/core/src/utils/reasoning-tags.test.ts
+++ b/packages/core/src/utils/reasoning-tags.test.ts
@@ -58,6 +58,9 @@ describe("hasReasoningResidue", () => {
 		).toBe(false);
 		expect(hasReasoningResidue("<b>bold</b> <div>x</div>")).toBe(false);
 		expect(hasReasoningResidue("")).toBe(false);
+		expect(hasReasoningResidue(undefined as unknown as string)).toBe(false);
+		expect(hasReasoningResidue(null as unknown as string)).toBe(false);
+		expect(stripReasoningPrefixes(undefined as unknown as string)).toBe("");
 	});
 
 	it("returns the same verdict on repeated calls with identical input", () => {

--- a/packages/core/src/utils/reasoning-tags.ts
+++ b/packages/core/src/utils/reasoning-tags.ts
@@ -51,6 +51,7 @@ export function findNextOpenTag(
 	from: number,
 	tagAlternation: string,
 ): TagMatch | null {
+	if (typeof text !== "string") return null;
 	const openRe = new RegExp(`<\\s*(?:${tagAlternation})(?=[\\s/>])`, "gi");
 	openRe.lastIndex = from;
 	const match = openRe.exec(text);
@@ -78,6 +79,7 @@ export function findNextCloseTag(
 	from: number,
 	tagAlternation: string,
 ): TagMatch | null {
+	if (typeof text !== "string") return null;
 	const closeRe = new RegExp(
 		`<\\s*\\/\\s*(?:${tagAlternation})(?=[\\s>])`,
 		"gi",
@@ -115,6 +117,7 @@ export function stripPairedTagBlocks(
 	text: string,
 	tagAlternation: string,
 ): string {
+	if (typeof text !== "string") return "";
 	let lastCloseEnd = -1;
 	for (
 		let close = findNextCloseTag(text, 0, tagAlternation);
@@ -154,6 +157,7 @@ export function stripUnclosedTagSuffix(
 	text: string,
 	tagAlternation: string,
 ): string {
+	if (typeof text !== "string") return "";
 	const open = findNextOpenTag(text, 0, tagAlternation);
 	return open ? text.slice(0, open.start) : text;
 }
@@ -185,6 +189,7 @@ const REASONING_TAG_PREFIX_TEST_RE = new RegExp(
  * the residue lets evaluator parsing and final-egress checks fail closed.
  */
 export function stripReasoningPrefixes(text: string): string {
+	if (typeof text !== "string") return "";
 	let lastCloseEnd = -1;
 	for (
 		let close = findNextCloseTag(text, 0, REASONING_TAG_ALTERNATION);
@@ -213,5 +218,6 @@ export function stripReasoningPrefixes(text: string): string {
  * too — verifying only one of the legs above cannot reveal the other.
  */
 export function hasReasoningResidue(text: string): boolean {
+	if (typeof text !== "string") return false;
 	return REASONING_TAG_PREFIX_TEST_RE.test(text);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns empty string / null / false when non-string values reach reasoning-tag residue and strip helpers.

# Background

## What does this PR do?

In `packages/core/src/utils/reasoning-tags.ts`, helpers like `findNextCloseTag`, `stripReasoningPrefixes`, and `stripPairedTagBlocks` directly accessed `text.length` or evaluated regexes on unvalidated inputs. Passing `undefined` or non-string values caused `TypeError: undefined is not an object (evaluating 'text.length')`. Adding early string type guards ensures safe degradation at the boundary.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/reasoning-tags.ts` and `reasoning-tags.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/reasoning-tags.test.ts`.

# Evidence Gate

<!-- evidence-head:a3c6ffa29383da8eefd8b2fca1ead52a18baab0e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - reasoning tags parsing helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'text.length')
      at findNextCloseTag (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/core/src/utils/reasoning-tags.ts:86:16)
      at stripReasoningPrefixes (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/core/src/utils/reasoning-tags.ts:190:15)
(fail) hasReasoningResidue > allows ordinary prose and unrelated markup
20 pass, 1 fail
```

## Green (restored)
```
(pass) hasReasoningResidue > allows ordinary prose and unrelated markup
21 pass, 0 fail, 52 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

