### PR TITLE
fix(shared): reject BigInt scalar values via onUnbounded in canonicalJsonString

### DIFF
--- a/packages/shared/src/canonical-json.test.ts
+++ b/packages/shared/src/canonical-json.test.ts
@@ -380,4 +380,9 @@ describe("canonical JSON fail-closed bounds", () => {
     expect(() => canonicalJsonString(cyclic, options)).toThrow(DomainError);
     expect(typeof failCanonicalJsonUnbounded).toBe("function");
   });
+
+  it("rejects BigInt values through onUnbounded", () => {
+    const error = expectUnbounded(() => canonicalJsonString(10n, OPTIONS));
+    expect(error.code).toBe(CANONICAL_JSON_UNBOUNDED);
+  });
 });

--- a/packages/shared/src/canonical-json.ts
+++ b/packages/shared/src/canonical-json.ts
@@ -289,6 +289,9 @@ function canonicalWalk(
     // Object keys carrying these were already dropped by the snapshot; reaching
     // one here means an array slot, which `JSON.stringify` renders as `null`.
     if (isJsonInvisible(value)) return emit(ctx, "null");
+    if (typeof value === "bigint") {
+      ctx.options.onUnbounded({ bigint: true });
+    }
     return emit(ctx, JSON.stringify(value));
   }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Rejects `BigInt` values through `onUnbounded` error hook rather than throwing uncaught `TypeError: Do not know how to serialize a BigInt`.

# Background

## What does this PR do?

In `packages/shared/src/canonical-json.ts`, scalar serialization directly called `JSON.stringify(value)`. When a `BigInt` value was passed, `JSON.stringify` threw an uncaught `TypeError` that bypassed the configured `onUnbounded` error handling contract. Invoking `ctx.options.onUnbounded({ bigint: true })` ensures typed fail-closed behavior across all callers.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/canonical-json.ts` and `canonical-json.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/shared src/canonical-json.test.ts`.

# Evidence Gate

<!-- evidence-head:65b60302fae70338300809da59638a2c33aabadf -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - canonical JSON walk helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: TypeError: Do not know how to serialize a BigInt
(fail) canonical JSON fail-closed bounds > rejects BigInt values through onUnbounded
49 pass, 1 fail
```

## Green (restored)
```
(pass) canonical JSON fail-closed bounds > rejects BigInt values through onUnbounded [0.03ms]
50 pass, 0 fail, 105 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

