### PR TITLE
fix(shared): safely guard runId and non-integer slot in createVoiceCancellationToken

### DIFF
--- a/packages/shared/src/voice/voice-cancellation-token.test.ts
+++ b/packages/shared/src/voice/voice-cancellation-token.test.ts
@@ -79,6 +79,15 @@ describe("createVoiceCancellationToken", () => {
     expect(token.slot).toBe(7);
   });
 
+  it("safely handles non-string runId and ignores non-safe-integer slot", () => {
+    const token = createVoiceCancellationToken({
+      runId: undefined as unknown as string,
+      slot: NaN,
+    });
+    expect(token.runId).toBe("");
+    expect(token.slot).toBeUndefined();
+  });
+
   it("aborts when the linked signal aborts (reason=external)", () => {
     const ctrl = new AbortController();
     const token = createVoiceCancellationToken({

--- a/packages/shared/src/voice/voice-cancellation-token.ts
+++ b/packages/shared/src/voice/voice-cancellation-token.ts
@@ -141,8 +141,10 @@ export function createVoiceCancellationToken(
   }
 
   const token: VoiceCancellationToken = {
-    runId: opts.runId,
-    ...(opts.slot !== undefined ? { slot: opts.slot } : {}),
+    runId: typeof opts?.runId === "string" ? opts.runId : "",
+    ...(typeof opts?.slot === "number" && Number.isSafeInteger(opts.slot)
+      ? { slot: opts.slot }
+      : {}),
     get aborted() {
       return state.aborted;
     },


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Normalizes `runId` string and ensures optional `slot` is only attached when it is a safe integer.

# Background

## What does this PR do?

In `packages/shared/src/voice/voice-cancellation-token.ts`, `createVoiceCancellationToken` directly assigned `opts.runId` and attached `slot` whenever `opts.slot !== undefined`. Passing `NaN` or non-numeric slot values attached invalid slot keys, while non-string `runId` caused uninitialized string fields.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/voice/voice-cancellation-token.ts` and `voice-cancellation-token.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice/voice-cancellation-token.test.ts`.

# Evidence Gate

<!-- evidence-head:3e61e4187d2721d5f07a77624798c77a37016773 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - voice cancellation token helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: ""
Received: undefined
(fail) createVoiceCancellationToken > safely handles non-string runId and ignores non-safe-integer slot
17 pass, 1 fail
```

## Green (restored)
```
(pass) createVoiceCancellationToken > safely handles non-string runId and ignores non-safe-integer slot [0.01ms]
18 pass, 0 fail, 42 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

