### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/index.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/index.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the advanced-capabilities provider barrel (index.ts):
+ * importing it must register its bundle-safety anchor on `globalThis` under
+ * the documented per-barrel key, that anchor must cover exactly the barrel's
+ * public export surface (no unanchored export a Bun.build tree-shake could
+ * drop, no stale anchored binding), every anchored binding must be live
+ * rather than an empty-init stub, and each re-export must bind identity-equal
+ * to its leaf module export — the failure class behind the on-device
+ * ReferenceError incidents (#10727, #11030, #11248, #11276). Real module init
+ * against real global state; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { advancedContactsProvider } from "./contacts.ts";
+import { factsProvider } from "./facts.ts";
+import { followUpsProvider } from "./followUps.ts";
+import * as providers from "./index.ts";
+import { relationshipsProvider } from "./relationships.ts";
+import { roleProvider } from "./roles.ts";
+import { settingsProvider } from "./settings.ts";
+
+const ANCHOR_KEY =
+	"__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX__";
+
+function anchoredValues(): unknown[] {
+	const stashed = (globalThis as Record<string, unknown>)[ANCHOR_KEY];
+	expect(Array.isArray(stashed)).toBe(true);
+	return stashed as unknown[];
+}
+
+describe("advanced-capabilities providers barrel", () => {
+	it("registers its bundle-safety anchor on globalThis when imported", () => {
+		const stashed = (globalThis as Record<string, unknown>)[ANCHOR_KEY];
+		expect(Array.isArray(stashed)).toBe(true);
+	});
+
+	it("anchors every public export exactly once — none missing, none stale", () => {
+		const anchored = anchoredValues();
+		const exported = Object.values(providers);
+		expect(anchored.length).toBe(exported.length);
+
+		const leftover = new Map<unknown, number>();
+		for (const value of anchored) {
+			leftover.set(value, (leftover.get(value) ?? 0) + 1);
+		}
+		for (const value of exported) {
+			const remaining = leftover.get(value) ?? 0;
+			expect(remaining).toBeGreaterThan(0);
+			if (remaining === 1) leftover.delete(value);
+			else leftover.set(value, remaining - 1);
+		}
+		expect(leftover.size).toBe(0);
+	});
+
+	it("keeps every anchored binding live, never an empty-init stub", () => {
+		for (const value of anchoredValues()) {
+			expect(value).toBeDefined();
+			expect(value).not.toBeNull();
+		}
+	});
+
+	it("re-exports each leaf binding by identity, not a copy or dangling getter", () => {
+		expect(providers.advancedContactsProvider).toBe(advancedContactsProvider);
+		expect(providers.factsProvider).toBe(factsProvider);
+		expect(providers.followUpsProvider).toBe(followUpsProvider);
+		expect(providers.relationshipsProvider).toBe(relationshipsProvider);
+		expect(providers.roleProvider).toBe(roleProvider);
+		expect(providers.settingsProvider).toBe(settingsProvider);
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the advanced-capabilities **providers** barrel,
`packages/core/src/features/advanced-capabilities/providers/index.ts`, which had
no same-named test file on `develop`.

The barrel is load-bearing beyond plain re-exports: it value-imports all six
providers and calls `anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX", …)`
so Bun.build's tree-shake cannot collapse re-export-only barrels into empty-init
stubs — the failure class behind the on-device `ReferenceError` incidents
(#10727, #11030, #11248, #11276). The suite drives the real module init against
real global state; no mocks, no `vi.hoisted`, no type-level assertions:

- importing the module registers its bundle-safety anchor on `globalThis` under
  the documented per-barrel key;
- the anchored array covers exactly the public export surface — none missing,
  none stale (multiset comparison);
- every anchored binding is live (`defined`, non-null), never an empty-init stub;
- each re-export binds identity-equal to its leaf-module export
  (`toBe` against direct imports of `./contacts.ts`, `./facts.ts`,
  `./followUps.ts`, `./relationships.ts`, `./roles.ts`, `./settings.ts`),
  proving no copy or dangling namespace getter sits between consumers and the
  leaf providers.

## Evidence (test-only diff; touches exactly one new test file, +69/−0)

- `bunx vitest run src/features/advanced-capabilities/providers/index.test.ts`
  → **Test Files 1 passed (1), Tests 4 passed (4)** (re-fetched and re-run
  immediately before filing against current `origin/develop` @ `de774b875774`;
  both runs reproduced).
- `bunx biome check --write <file>` → clean ("Checked 1 file … No fixes
  applied") with the repository's real `biome.json` present.
- `bunx tsc --noEmit` in `packages/core` → the new test file appears nowhere in
  the output (zero errors introduced).
- This pull request changes **no production behaviour**; the diff adds only
  `packages/core/src/features/advanced-capabilities/providers/index.test.ts`.
- Fork contribution: hosted CI does **not** run on this pull request; the local
  vitest/biome/tsc results above are the verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a6855442d8ce4681f8495bd8c9d1547da6448105 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
