### PR TITLE
fix(shared): validate observations array and non-string entityId in resolveOwnerCandidate

### DIFF
--- a/packages/shared/src/voice/owner-inference.test.ts
+++ b/packages/shared/src/voice/owner-inference.test.ts
@@ -75,6 +75,15 @@ describe("resolveOwnerCandidate", () => {
     },
   );
 
+  it("rejects non-array observations and non-string entityId types", () => {
+    expect(() => resolveOwnerCandidate([C(123 as unknown as string)])).toThrow(
+      "observations[0].entityId must be null or a non-empty string",
+    );
+    expect(() => resolveOwnerCandidate([C({} as unknown as string)])).toThrow(
+      "observations[0].entityId must be null or a non-empty string",
+    );
+  });
+
   it("accepts the documented confidence and margin boundaries", () => {
     const zeroConfidence = resolveOwnerCandidate([C("owner", 0)], {
       minObservations: 1,

--- a/packages/shared/src/voice/owner-inference.ts
+++ b/packages/shared/src/voice/owner-inference.ts
@@ -87,13 +87,17 @@ export function resolveOwnerCandidate(
     throw new RangeError("minMargin must be a finite non-negative number");
   }
 
+  if (!Array.isArray(observations)) {
+    throw new TypeError("observations must be an array");
+  }
+
   const scores = new Map<string, number>();
   let qualifying = 0;
   let totalScore = 0;
   for (const [index, obs] of observations.entries()) {
     assertUnitInterval(obs.confidence, `observations[${index}].confidence`);
     if (obs.entityId === null) continue;
-    if (obs.entityId.trim().length === 0) {
+    if (typeof obs.entityId !== "string" || obs.entityId.trim().length === 0) {
       throw new TypeError(
         `observations[${index}].entityId must be null or a non-empty string`,
       );


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Validates observations input array and ensures non-null `entityId` values are strings before evaluating `.trim()`.

# Background

## What does this PR do?

In `packages/shared/src/voice/owner-inference.ts`, `resolveOwnerCandidate`:
1. Called `observations.entries()` without ensuring `observations` is an array.
2. Evaluated `obs.entityId.trim()` on non-null values without confirming `typeof obs.entityId === "string"`, resulting in `TypeError: obs.entityId.trim is not a function` for non-string entity objects/numbers instead of the documented descriptive `TypeError`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/voice/owner-inference.ts` and `owner-inference.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/voice/owner-inference.test.ts`.

# Evidence Gate

<!-- evidence-head:1ae2b5cc22c49a96c7093bbcdc84e76bebdc1f33 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - voice owner candidate inference helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
Expected substring: "observations[0].entityId must be null or a non-empty string"
Received message: "obs.entityId.trim is not a function. (In 'obs.entityId.trim()', 'obs.entityId.trim' is undefined)"
(fail) resolveOwnerCandidate > rejects non-array observations and non-string entityId types
31 pass, 1 fail
```

## Green (restored)
```
(pass) resolveOwnerCandidate > rejects non-array observations and non-string entityId types [0.02ms]
32 pass, 0 fail, 42 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

