### PR TITLE
fix(skills): degrade non-string frontmatter name to a diagnostic instead of crashing the loader

### DIFF
--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -135,7 +135,21 @@ function loadSkillFromFile(
     diagnostics.push({ type: "warning", message: error, path: filePath });
   }
 
-  const name = frontmatter.name || expectedName;
+  // YAML does not enforce the SkillFrontmatter.name: string contract at parse
+  // time, so a scalar like `name: 123` arrives as a number/boolean/Date. Keep
+  // validateName on the string path by degrading a non-string name to a warning
+  // diagnostic and falling back to the derived expectedName; a single malformed
+  // skill must never crash loading for every other skill.
+  const rawName = frontmatter.name;
+  if (rawName !== undefined && typeof rawName !== "string") {
+    diagnostics.push({
+      type: "warning",
+      message: `name must be a string (got ${typeof rawName})`,
+      path: filePath,
+    });
+  }
+  const name =
+    typeof rawName === "string" && rawName.length > 0 ? rawName : expectedName;
 
   const nameErrors = validateName(name, expectedName, isSkillMd);
   for (const error of nameErrors) {

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -191,6 +191,81 @@ name: no-desc
     }
   });
 
+  it("degrades a non-string frontmatter name to a warning and keeps a valid sibling loading", () => {
+    // Regression for #27522: a YAML scalar that is not a string (number,
+    // boolean, or date) used to reach validateName("...".startsWith) and throw
+    // an uncaught TypeError, taking down ALL skill loading instead of dropping
+    // just the offending skill with a diagnostic.
+    const cases: Array<{ dir: string; frontmatterName: string; kind: string }> =
+      [
+        { dir: "numeric-name", frontmatterName: "123", kind: "number" },
+        { dir: "boolean-name", frontmatterName: "true", kind: "boolean" },
+        {
+          // A YAML 1.2 core-schema bare date parses as a string; force a real
+          // Date scalar with an explicit timestamp tag to cover the object path.
+          dir: "date-name",
+          frontmatterName: "!!timestamp 2024-01-02",
+          kind: "date",
+        },
+      ];
+
+    for (const { dir, frontmatterName, kind } of cases) {
+      const tempDir = createTempDir(`skill-loader-nonstring-${kind}`);
+      try {
+        // Offending skill: SKILL.md whose frontmatter name is a non-string scalar.
+        const badDir = join(tempDir, dir);
+        mkdirSync(badDir, { recursive: true });
+        writeFileSync(
+          join(badDir, "SKILL.md"),
+          `---\nname: ${frontmatterName}\ndescription: Bad ${kind} name still has a description\n---\n# Bad ${kind}`,
+        );
+
+        // Valid sibling in the same root directory.
+        const goodDir = join(tempDir, "good-neighbor");
+        mkdirSync(goodDir, { recursive: true });
+        writeFileSync(
+          join(goodDir, "SKILL.md"),
+          `---\nname: good-neighbor\ndescription: Valid sibling skill description\n---\n# Good`,
+        );
+
+        // (a) The loader must not throw on the malformed skill.
+        let result: ReturnType<typeof loadSkillsFromDir> | undefined;
+        assert.doesNotThrow(() => {
+          result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+        }, `non-string name (${kind}) must not crash the loader`);
+        assert.ok(result);
+
+        // (b) A warning diagnostic naming the type violation is emitted.
+        const typeDiag = result.diagnostics.find((d) =>
+          d.message.includes("name must be a string"),
+        );
+        assert.ok(
+          typeDiag,
+          `expected a "name must be a string" diagnostic for ${kind}`,
+        );
+        assert.strictEqual(typeDiag?.type, "warning");
+        assert.ok(typeDiag?.path.endsWith(join(dir, "SKILL.md")));
+
+        // (c) The valid sibling still loads normally.
+        const good = result.skills.find((s) => s.name === "good-neighbor");
+        assert.ok(good, `valid sibling must load despite ${kind} name`);
+        assert.strictEqual(good.description, "Valid sibling skill description");
+
+        // (d) The bad skill falls back to its directory name, consistent with
+        // how an omitted name derives expectedName; it is not dropped because it
+        // still carries a valid description.
+        const fallback = result.skills.find((s) => s.name === dir);
+        assert.ok(
+          fallback,
+          `bad ${kind} skill must fall back to its directory name`,
+        );
+        assert.strictEqual(fallback.name, dir);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("reports malformed YAML instead of a fabricated metadata error", () => {
     const tempDir = createTempDir("skill-loader-malformed-yaml");
     try {


### PR DESCRIPTION
# Relates to

Closes #27522

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused checks were run after sync; the full
      `bun run verify` blocker is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`HEAD..origin/develop` = 0 commits); zero conflicts.
- [x] Focused package `test` + `typecheck` + `lint:check` pass post-sync; the exact `bun run verify` blocker is documented in **Known gaps / failures**.

# Risks

Low. The change is confined to one branch in `loadSkillFromFile` in
`packages/skills/src/loader.ts`. It removes an uncaught-throw path and replaces
it with an already-supported per-skill warning diagnostic. No public API,
signature, or export changes. The empty-string fallback semantics of the
previous `frontmatter.name || expectedName` are preserved.

# Background

## What does this PR do?

`loadSkills()` / `loadSkillsFromDir()` are contractually documented to degrade a
bad `SKILL.md` into a per-skill warning diagnostic and keep loading the rest
(`packages/skills/CLAUDE.md`: "must match directory name … The loader validates
this and warns on mismatch"). But when frontmatter supplies a **truthy
non-string `name`** — a YAML number, boolean, or timestamp, e.g. `name: 123` —
YAML does not enforce `SkillFrontmatter.name: string` at parse time, and
`const name = frontmatter.name || expectedName` kept the non-string scalar.
`validateName` then called `name.startsWith("-")` and threw an uncaught
`TypeError: name.startsWith is not a function`.

Nothing on the load path (`loadSkillFromFile` → `loadSkillsFromDirInternal` →
`loadSkills`) caught it, so the exception propagated out of the top-level
`loadSkills()` the agent runtime calls at startup and the
`plugin-agent-skills` discovery path. A single malformed skill file — which can
legitimately arrive from a project `.elizaos/skills` dir, an explicit
`skillPaths` entry, or an agent-generated skill promoted into curated/active —
took down **all** skill loading for the agent, not just the offending skill.
That is a graceful-degradation/contract break with an availability impact.

The fix: `loadSkillFromFile` now detects a present-but-non-string `name`, pushes
a `name must be a string (got <type>)` warning diagnostic, and falls back to the
derived `expectedName` (parent directory name for `SKILL.md`, filename slug for
flat `.md`) so `validateName` always receives a string. The offending skill
degrades exactly like every other invalid-metadata case, and valid siblings keep
loading.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The documented
contract ("the loader validates … and warns") is what this PR restores; the code
now matches the docs.

# Testing

## Where should a reviewer start?

`packages/skills/test/loader.test.ts` →
`degrades a non-string frontmatter name to a warning and keeps a valid sibling loading`,
and the changed branch in `packages/skills/src/loader.ts` (`loadSkillFromFile`).

## Detailed testing steps

```bash
node packages/shared/scripts/generate-keywords.mjs   # one-time generated-source prereq
bun run --cwd packages/skills test                   # 113 pass, 0 fail
bun run --cwd packages/skills typecheck              # clean
bun run --cwd packages/skills lint                   # clean
```

The added regression test drives the real loader against temp dirs for three
non-string `name` scalars (number `123`, boolean `true`, and an explicit
`!!timestamp 2024-01-02` — a bare date is a string under the YAML 1.2 core
schema, so a tag forces the Date/object path). For each it asserts: (a) the
loader does **not** throw; (b) a `name must be a string` **warning** diagnostic
is emitted with the offending file path; (c) a valid sibling skill in the same
root still loads with its description intact; and (d) the bad skill falls back to
its directory name, consistent with the omitted-name path.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9ea42958c68a2b42131c0a7f2a23385066f62f66 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; @elizaos/skills is a pure loader/utility package with no rendered views.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; @elizaos/skills is a pure loader/utility package with no rendered views.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the change is a library load-path fix exercised by node:test.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - external-fork contributor lacks write access to elizaOS/eliza releases and has no interactive session to mint user-attachment URLs in this environment; the complete failing-then-passing library logs (pre-fix TypeError stack out of validateName->loadSkillFromFile->loadSkillsFromDirInternal, and post-fix green loader.test.ts) are inlined verbatim in Evidence Details -> Backend + frontend logs below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend; library package with no request/response surface.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a frontmatter parsing/validation fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - external-fork contributor (push:false on elizaOS/eliza) cannot upload to the pr-evidence release, and a headless session cannot mint a `github.com/user-attachments/files/…` URL (browser-only); both immutable-artifact routes are unavailable. The concrete loaded-skills/diagnostics JSON returned by the real `loadSkillsFromDir` for all three non-string `name` scalar cases is inlined verbatim under Evidence Details -> Domain artifacts below, alongside the added regression test.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes.`

## Backend + frontend logs

Frontend: `N/A - library package, no frontend`.

Backend/library: failing-then-passing reproduction of the exact contract.

<details>
<summary>Pre-fix — probe reproduces the uncaught TypeError out of validateName (before the fix on this branch)</summary>

```
bun test v1.3.14 (0d9b296a)

probe.test.ts:
66 |   if (name.startsWith("-") || name.endsWith("-")) {
                ^
TypeError: name.startsWith is not a function. (In 'name.startsWith("-")', 'name.startsWith' is undefined)
      at validateName (.../packages/skills/src/loader.ts:66:12)
      at loadSkillFromFile (.../packages/skills/src/loader.ts:140:22)
      at loadSkillsFromDirInternal (.../packages/skills/src/loader.ts:239:20)
      at loadSkillsFromDirInternal (.../packages/skills/src/loader.ts:223:25)
      at <anonymous> (.../packages/skills/probe.test.ts:18:22)
      at fn (node:test:215:18)
(fail) probe #27522 > non-string name does not crash loader [25.15ms]

 0 pass
 1 fail
Ran 1 test across 1 file.
```

The probe wrote `foo/SKILL.md` (`name: 123`) and `good/SKILL.md`
(`name: good`) under a temp root and called
`loadSkillsFromDir({ dir: root, source: "probe" })`; the whole call threw and
the valid `good` sibling never loaded.
</details>

<details>
<summary>Post-fix — packages/skills loader.test.ts green (regression test included)</summary>

```
bun test v1.3.14 (0d9b296a)

test/loader.test.ts:
(pass) loadSkillsFromDir > returns empty result for non-existent directory
(pass) loadSkillsFromDir > loads valid skills from direct markdown files and SKILL.md subdirectories
(pass) loadSkillsFromDir > defaults flat markdown skill name to filename slug when name is omitted
(pass) loadSkillsFromDir > emits warning diagnostic when flat markdown skill name does not match filename slug
(pass) loadSkillsFromDir > safely ignores dangling symlinks and emits warning diagnostic
(pass) loadSkillsFromDir > emits warning diagnostics for missing or invalid metadata
(pass) loadSkillsFromDir > degrades a non-string frontmatter name to a warning and keeps a valid sibling loading
(pass) loadSkillsFromDir > reports malformed YAML instead of a fabricated metadata error
(pass) loadSkills and loadSkillEntries > detects name collisions across skill sources
(pass) loadSkills and loadSkillEntries > loadSkills honors both kebab-case and snake_case disable-model-invocation
(pass) loadSkills and loadSkillEntries > loadSkills keeps a skill visible when disable_model_invocation is false
(pass) loadSkills and loadSkillEntries > loadSkillEntries parses full metadata and invocation policy

 12 pass
 0 fail
Ran 12 tests across 1 file.
```
</details>

<details>
<summary>Post-fix — full @elizaos/skills package test + typecheck + lint</summary>

```
$ bun run --cwd packages/skills test
 113 pass
 0 fail
Ran 113 tests across 7 files.

$ bun run --cwd packages/skills typecheck
$ tsc --noEmit -p tsconfig.build.json      # (no output = clean)

$ bun run --cwd packages/skills lint
$ bunx @biomejs/biome check --write ./src
Checked 6 files in 56ms. No fixes applied.
```

Repo gates run on this machine:

```
$ bun run audit:focused-tests
[anti-larp] scanned 11208 test files — 0 focused, 0 orphaned skip(s)

$ bun run check:agents-claude
[assert-agents-claude-identical] PASS: 161 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.

$ bun run check:biome-version
Biome version consistency passed.
```
</details>

## Domain artifacts — real loadSkillsFromDir output (loaded skills + diagnostics)

<details>
<summary>Post-fix — <code>loadSkillsFromDir</code> output for the three non-string <code>name</code> scalar types (number, boolean, YAML <code>!!timestamp</code>), each next to a valid sibling. Independently re-captured against the reviewed head <code>9ea42958</code> by driving the real loader over temp dirs and serializing its returned <code>skills</code> + <code>diagnostics</code>.</summary>

```json
{
  "pr": 27534,
  "head": "9ea42958c68a2b42131c0a7f2a23385066f62f66",
  "package": "@elizaos/skills",
  "description": "loadSkillsFromDir degrades a non-string frontmatter name to a warning diagnostic, falls back to the directory name, and keeps the valid sibling loading.",
  "cases": [
    {
      "case": "number",
      "badFrontmatter": "name: 123",
      "skills": [
        {
          "name": "bad",
          "description": "malformed name should degrade"
        },
        {
          "name": "good",
          "description": "a valid sibling skill"
        }
      ],
      "diagnostics": [
        {
          "type": "warning",
          "message": "name must be a string (got number)"
        }
      ]
    },
    {
      "case": "boolean",
      "badFrontmatter": "name: true",
      "skills": [
        {
          "name": "bad",
          "description": "malformed name should degrade"
        },
        {
          "name": "good",
          "description": "a valid sibling skill"
        }
      ],
      "diagnostics": [
        {
          "type": "warning",
          "message": "name must be a string (got boolean)"
        }
      ]
    },
    {
      "case": "timestamp",
      "badFrontmatter": "name: !!timestamp 2024-01-02",
      "skills": [
        {
          "name": "bad",
          "description": "malformed name should degrade"
        },
        {
          "name": "good",
          "description": "a valid sibling skill"
        }
      ],
      "diagnostics": [
        {
          "type": "warning",
          "message": "name must be a string (got object)"
        }
      ]
    }
  ]
}
```

For every case the malformed skill degrades to its directory name (`bad`), a `name must be a string (got <type>)` warning diagnostic is emitted, and the valid `good` sibling loads with its description intact — no throw. The `object` type for the timestamp case is the parsed `Date` node forced by the `!!timestamp` tag.
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface. @elizaos/skills is a pure loader/utility package; there is
no rendered `.tsx`/`.css`/`.svg` in this diff.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- **Full `bun run verify` not run to completion here.** `verify` fans out a
  turbo typecheck+lint across every workspace plus ~15 repository audits; on this
  16 GB Raspberry Pi (Node 22, not the pinned 24) a full run is impractical
  within the session. I instead ran the owning package's `test` + `typecheck` +
  `lint`, plus the directly-relevant repo gates `audit:focused-tests`,
  `check:agents-claude`, and `check:biome-version` (all green, above). The diff
  is 2 files under `packages/skills`, so no other workspace's compiled output is
  affected. CI on the PR will run the complete gate.
- **Immutable GitHub attachment URLs not minted.** The evidence-upload helper
  requires an interactive GitHub browser session unavailable in this
  environment, so logs are inlined above in `<details>` blocks rather than linked
  as `user-attachments` URLs. No evidence content is omitted.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@9ea42958c68a2b42131c0a7f2a23385066f62f66:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@9ea42958c68a2b42131c0a7f2a23385066f62f66:packages/skills/skills/contribute-to-eliza"} -->
