### PR TITLE
test(ui): cover recommendation

### DIFF
--- a/packages/ui/src/services/local-inference/recommendation.test.ts
+++ b/packages/ui/src/services/local-inference/recommendation.test.ts
@@ -1,0 +1,763 @@
+/**
+ * Unit tests for first-run model recommendation. Drives the real recommender
+ * against synthetic catalog/hardware inputs to pin platform classification,
+ * download sizing, per-class fit thresholds, slot ladder ordering (including
+ * the long-context bump), kernel filtering, fallback candidate rules, and
+ * first-run resolution order.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FIRST_RUN_DEFAULT_MODEL_ID, MODEL_CATALOG } from "./catalog.js";
+import {
+  assessCatalogModelFit,
+  catalogDownloadSizeBytes,
+  catalogDownloadSizeGb,
+  chooseSmallerFallbackModel,
+  classifyRecommendationPlatform,
+  recommendForFirstRun,
+  selectRecommendedModelForSlot,
+  selectRecommendedModels,
+} from "./recommendation.js";
+import type { CatalogModel, HardwareProbe } from "./types.js";
+
+function createCatalogModel(
+  id: string,
+  overrides?: Partial<CatalogModel>,
+): CatalogModel {
+  return {
+    id,
+    displayName: `Model ${id}`,
+    hfRepo: "elizaos/eliza-1",
+    ggufFile: `${id}.gguf`,
+    params: "2B",
+    quant: "Q4_K_M",
+    sizeGb: 1.4,
+    minRamGb: 4,
+    category: "chat",
+    bucket: "small",
+    blurb: `Curated model ${id}`,
+    hiddenFromCatalog: false,
+    contextLength: 131072,
+    ...overrides,
+  };
+}
+
+function createProbe(overrides?: Partial<HardwareProbe>): HardwareProbe {
+  return {
+    totalRamGb: 16,
+    freeRamGb: 12,
+    gpu: null,
+    cpuCores: 8,
+    platform: "darwin",
+    arch: "arm64",
+    appleSilicon: false,
+    recommendedBucket: "mid",
+    source: "os-fallback",
+    ...overrides,
+  };
+}
+
+/** Sizes/minRam mirror the real tiers so fit math is realistic. */
+const tierCatalog: CatalogModel[] = [
+  createCatalogModel("eliza-1-2b", { sizeGb: 1.4, minRamGb: 4 }),
+  createCatalogModel("eliza-1-4b", { sizeGb: 2.6, minRamGb: 6 }),
+  createCatalogModel("eliza-1-9b", { sizeGb: 5.4, minRamGb: 12 }),
+  createCatalogModel("eliza-1-27b", {
+    params: "27B",
+    bucket: "large",
+    sizeGb: 16.8,
+    minRamGb: 32,
+  }),
+];
+
+const appleSilicon32 = createProbe({
+  totalRamGb: 32,
+  freeRamGb: 24,
+  appleSilicon: true,
+});
+
+describe("recommendation", () => {
+  describe("classifyRecommendationPlatform", () => {
+    it("classifies top-level android as mobile", () => {
+      expect(
+        classifyRecommendationPlatform(
+          createProbe({ platform: "android", arch: "arm64" }),
+        ),
+      ).toBe("mobile");
+    });
+
+    it("prefers hardware.mobile.platform over the OS platform", () => {
+      expect(
+        classifyRecommendationPlatform(
+          createProbe({
+            appleSilicon: true,
+            mobile: { platform: "ios" },
+          }),
+        ),
+      ).toBe("mobile");
+    });
+
+    it("classifies apple silicon even with a GPU present", () => {
+      expect(
+        classifyRecommendationPlatform(
+          createProbe({
+            appleSilicon: true,
+            gpu: { backend: "metal", totalVramGb: 16, freeVramGb: 8 },
+          }),
+        ),
+      ).toBe("apple-silicon");
+    });
+
+    it("splits linux into gpu/cpu classes on GPU presence", () => {
+      const linux = { platform: "linux" as const, arch: "x64" as const };
+      expect(
+        classifyRecommendationPlatform(
+          createProbe({
+            ...linux,
+            gpu: { backend: "vulkan", totalVramGb: 8, freeVramGb: 4 },
+          }),
+        ),
+      ).toBe("linux-gpu");
+      expect(classifyRecommendationPlatform(createProbe(linux))).toBe(
+        "linux-cpu",
+      );
+    });
+
+    it("falls back to desktop classes for other platforms", () => {
+      const win = { platform: "win32" as const, arch: "x64" as const };
+      expect(
+        classifyRecommendationPlatform(
+          createProbe({
+            ...win,
+            gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 12 },
+          }),
+        ),
+      ).toBe("desktop-gpu");
+      expect(classifyRecommendationPlatform(createProbe(win))).toBe(
+        "desktop-cpu",
+      );
+    });
+  });
+
+  describe("catalogDownloadSizeGb", () => {
+    it("returns the model's own sizeGb regardless of the catalog passed", () => {
+      const model = createCatalogModel("eliza-1-4b", { sizeGb: 3.7 });
+      expect(catalogDownloadSizeGb(model)).toBe(3.7);
+      expect(catalogDownloadSizeGb(model, [])).toBe(3.7);
+      expect(catalogDownloadSizeGb(model, tierCatalog)).toBe(3.7);
+    });
+  });
+
+  describe("catalogDownloadSizeBytes", () => {
+    it("converts GiB sizes to rounded byte counts", () => {
+      expect(
+        catalogDownloadSizeBytes(createCatalogModel("m", { sizeGb: 2 })),
+      ).toBe(2147483648);
+      expect(
+        catalogDownloadSizeBytes(createCatalogModel("m", { sizeGb: 1.4 })),
+      ).toBe(1503238554);
+    });
+  });
+
+  describe("assessCatalogModelFit", () => {
+    it("applies mobile RAM-floor and 80%/65% size thresholds", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      expect(
+        assessCatalogModelFit(phone, createCatalogModel("m", { minRamGb: 6 })),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          phone,
+          createCatalogModel("m", { sizeGb: 4.1, minRamGb: 4 }),
+        ),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          phone,
+          createCatalogModel("m", { sizeGb: 3.4, minRamGb: 4 }),
+        ),
+      ).toBe("tight");
+      expect(
+        assessCatalogModelFit(
+          phone,
+          createCatalogModel("m", { sizeGb: 3.0, minRamGb: 4 }),
+        ),
+      ).toBe("fits");
+    });
+
+    it("uses half of system RAM as effective memory on CPU-only desktops", () => {
+      const desktop = createProbe({
+        platform: "linux",
+        arch: "x64",
+        totalRamGb: 20,
+      });
+      expect(
+        assessCatalogModelFit(
+          desktop,
+          createCatalogModel("m", { minRamGb: 12 }),
+        ),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          desktop,
+          createCatalogModel("m", { sizeGb: 9.7, minRamGb: 4 }),
+        ),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          desktop,
+          createCatalogModel("m", { sizeGb: 8.5, minRamGb: 4 }),
+        ),
+      ).toBe("tight");
+      expect(
+        assessCatalogModelFit(
+          desktop,
+          createCatalogModel("m", { sizeGb: 6.9, minRamGb: 4 }),
+        ),
+      ).toBe("fits");
+    });
+
+    it("uses full RAM on Apple Silicon", () => {
+      const mac = createProbe({ totalRamGb: 8, appleSilicon: true });
+      expect(
+        assessCatalogModelFit(mac, createCatalogModel("m", { minRamGb: 9 })),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          mac,
+          createCatalogModel("m", { sizeGb: 7.5, minRamGb: 4 }),
+        ),
+      ).toBe("wontfit");
+    });
+
+    it("prefers VRAM over half-RAM when a discrete GPU exists", () => {
+      const rig = createProbe({
+        platform: "win32",
+        arch: "x64",
+        totalRamGb: 32,
+        gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 20 },
+      });
+      expect(
+        assessCatalogModelFit(
+          rig,
+          createCatalogModel("m", { sizeGb: 22, minRamGb: 4 }),
+        ),
+      ).toBe("wontfit");
+      expect(
+        assessCatalogModelFit(
+          rig,
+          createCatalogModel("m", { sizeGb: 20, minRamGb: 4 }),
+        ),
+      ).toBe("tight");
+      expect(
+        assessCatalogModelFit(
+          rig,
+          createCatalogModel("m", { sizeGb: 16, minRamGb: 4 }),
+        ),
+      ).toBe("fits");
+    });
+  });
+
+  describe("selectRecommendedModelForSlot", () => {
+    it("walks the apple-silicon TEXT_LARGE ladder largest-first when everything fits", () => {
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        appleSilicon32,
+        tierCatalog,
+      );
+      expect(pick.platformClass).toBe("apple-silicon");
+      expect(pick.slot).toBe("TEXT_LARGE");
+      expect(pick.model?.id).toBe("eliza-1-27b");
+      expect(pick.fit).toBe("fits");
+      expect(pick.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-27b",
+        "eliza-1-9b",
+        "eliza-1-4b",
+        "eliza-1-2b",
+      ]);
+      expect(pick.reason).toBe(
+        "apple-silicon TEXT_LARGE ladder selected eliza-1-27b",
+      );
+    });
+
+    it("keeps the smallest-fitting ladder entry for TEXT_SMALL", () => {
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_SMALL",
+        appleSilicon32,
+        tierCatalog,
+      );
+      expect(pick.model?.id).toBe("eliza-1-2b");
+      expect(pick.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-2b",
+        "eliza-1-4b",
+      ]);
+      expect(pick.reason).toBe(
+        "apple-silicon TEXT_SMALL ladder selected eliza-1-2b",
+      );
+    });
+
+    it("skips ladder entries that cannot fit and picks the first survivor", () => {
+      const laptop = createProbe({ totalRamGb: 8, appleSilicon: true });
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        laptop,
+        tierCatalog,
+      );
+      expect(pick.model?.id).toBe("eliza-1-4b");
+      expect(pick.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-4b",
+        "eliza-1-2b",
+      ]);
+    });
+
+    it("bumps long-context entries ahead of shorter ones on TEXT_LARGE when RAM allows", () => {
+      const mixed: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          contextLength: 4096,
+        }),
+        createCatalogModel("eliza-1-2b", {
+          sizeGb: 1.4,
+          minRamGb: 4,
+          contextLength: 131072,
+        }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        createProbe({ totalRamGb: 16, freeRamGb: 12, appleSilicon: true }),
+        mixed,
+      );
+      expect(pick.model?.id).toBe("eliza-1-2b");
+      expect(pick.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-2b",
+        "eliza-1-4b",
+      ]);
+    });
+
+    it("keeps ladder order below the 16 GB long-context threshold", () => {
+      const mixed: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          contextLength: 4096,
+        }),
+        createCatalogModel("eliza-1-2b", {
+          sizeGb: 1.4,
+          minRamGb: 4,
+          contextLength: 131072,
+        }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        createProbe({ totalRamGb: 15, freeRamGb: 11, appleSilicon: true }),
+        mixed,
+      );
+      expect(pick.model?.id).toBe("eliza-1-4b");
+    });
+
+    it("counts VRAM toward the long-context headroom threshold", () => {
+      const mixed: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          contextLength: 4096,
+        }),
+        createCatalogModel("eliza-1-2b", {
+          sizeGb: 1.4,
+          minRamGb: 4,
+          contextLength: 131072,
+        }),
+      ];
+      const rig = createProbe({
+        platform: "win32",
+        arch: "x64",
+        totalRamGb: 8,
+        freeRamGb: 4,
+        gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 20 },
+      });
+      const pick = selectRecommendedModelForSlot("TEXT_LARGE", rig, mixed);
+      expect(pick.model?.id).toBe("eliza-1-2b");
+    });
+
+    it("never applies the long-context bump on TEXT_SMALL", () => {
+      const mixed: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", {
+          sizeGb: 1.4,
+          minRamGb: 4,
+          contextLength: 4096,
+        }),
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          contextLength: 131072,
+        }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_SMALL",
+        createProbe({ totalRamGb: 16, freeRamGb: 12, appleSilicon: true }),
+        mixed,
+      );
+      expect(pick.model?.id).toBe("eliza-1-2b");
+    });
+
+    it("returns a null model when nothing fits anywhere", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 2 });
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        phone,
+        tierCatalog,
+      );
+      expect(pick.model).toBeNull();
+      expect(pick.fit).toBeNull();
+      expect(pick.alternatives).toEqual([]);
+      expect(pick.platformClass).toBe("mobile");
+      expect(pick.reason).toBe(
+        "mobile TEXT_LARGE ladder has no fitting catalog model",
+      );
+    });
+
+    it("degrades past the mobile 4B floor to a fitting 2B fallback", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        phone,
+        tierCatalog,
+      );
+      expect(pick.model?.id).toBe("eliza-1-2b");
+      expect(pick.fit).toBe("fits");
+      expect(pick.alternatives.map((m) => m.id)).toEqual(["eliza-1-2b"]);
+    });
+
+    it("orders fallback candidates largest-first for TEXT_LARGE", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { sizeGb: 1.4, minRamGb: 4 }),
+        createCatalogModel("eliza-1-9b", { sizeGb: 2.0, minRamGb: 4 }),
+      ];
+      const large = selectRecommendedModelForSlot("TEXT_LARGE", phone, catalog);
+      expect(large.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-9b",
+        "eliza-1-2b",
+      ]);
+    });
+
+    it("orders fallback candidates smallest-first for TEXT_SMALL", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { sizeGb: 1.4, minRamGb: 4 }),
+        createCatalogModel("eliza-1-9b", { sizeGb: 2.0, minRamGb: 4 }),
+      ];
+      const small = selectRecommendedModelForSlot("TEXT_SMALL", phone, catalog);
+      expect(small.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-2b",
+        "eliza-1-9b",
+      ]);
+    });
+
+    it("excludes hidden models from the fallback pool", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const hiddenOnly: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { hiddenFromCatalog: true }),
+      ];
+      expect(
+        selectRecommendedModelForSlot("TEXT_LARGE", phone, hiddenOnly).model,
+      ).toBeNull();
+
+      const visibleOnly: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { hiddenFromCatalog: false }),
+      ];
+      expect(
+        selectRecommendedModelForSlot("TEXT_LARGE", phone, visibleOnly).model
+          ?.id,
+      ).toBe("eliza-1-2b");
+    });
+
+    it("excludes models outside the default-eligible set from the fallback pool", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const thirdParty: CatalogModel[] = [
+        createCatalogModel("acme-mini", { sizeGb: 0.5, minRamGb: 2 }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_LARGE",
+        phone,
+        thirdParty,
+      );
+      expect(pick.model).toBeNull();
+    });
+
+    it("filters ladder entries whose required kernels are not advertised", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", {
+          runtime: { optimizations: { requiresKernel: ["qjl_full"] } },
+        }),
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          runtime: {
+            optimizations: { requiresKernel: ["turbo3", "turbo4"] },
+          },
+        }),
+      ];
+      const kernels = { turbo3: true, turbo4: true };
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_SMALL",
+        appleSilicon32,
+        catalog,
+        { binaryKernels: kernels },
+      );
+      expect(pick.model?.id).toBe("eliza-1-4b");
+      expect(pick.alternatives.map((m) => m.id)).toEqual(["eliza-1-4b"]);
+    });
+
+    it("trusts the catalog when no binary kernel probe exists", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", {
+          runtime: { optimizations: { requiresKernel: ["qjl_full"] } },
+        }),
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          runtime: {
+            optimizations: { requiresKernel: ["turbo3", "turbo4"] },
+          },
+        }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_SMALL",
+        appleSilicon32,
+        catalog,
+      );
+      expect(pick.model?.id).toBe("eliza-1-2b");
+      expect(pick.alternatives.map((m) => m.id)).toEqual([
+        "eliza-1-2b",
+        "eliza-1-4b",
+      ]);
+    });
+
+    it("drops unsupported-backend-only models when the binary advertises that backend", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", {
+          runtime: {
+            optimizations: { unsupportedKernels: ["openvino"] },
+          },
+        }),
+      ];
+      const openvinoBinary = { openvino: true };
+      expect(
+        selectRecommendedModelForSlot("TEXT_SMALL", appleSilicon32, catalog, {
+          binaryKernels: openvinoBinary,
+        }).model,
+      ).toBeNull();
+      expect(
+        selectRecommendedModelForSlot("TEXT_SMALL", appleSilicon32, catalog, {
+          binaryKernels: {},
+        }).model?.id,
+      ).toBe("eliza-1-2b");
+      expect(
+        selectRecommendedModelForSlot("TEXT_SMALL", appleSilicon32, catalog)
+          .model?.id,
+      ).toBe("eliza-1-2b");
+    });
+
+    it("keeps a model whose required kernels are satisfied even when an unsupported backend is advertised", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", {
+          sizeGb: 2.6,
+          minRamGb: 6,
+          runtime: {
+            optimizations: {
+              requiresKernel: ["turbo3", "turbo4"],
+              unsupportedKernels: ["openvino"],
+            },
+          },
+        }),
+      ];
+      const pick = selectRecommendedModelForSlot(
+        "TEXT_SMALL",
+        appleSilicon32,
+        catalog,
+        {
+          binaryKernels: { turbo3: true, turbo4: true, openvino: true },
+        },
+      );
+      expect(pick.model?.id).toBe("eliza-1-4b");
+    });
+  });
+
+  describe("selectRecommendedModels", () => {
+    it("returns both slots with echoed slot labels on one classification", () => {
+      const picks = selectRecommendedModels(appleSilicon32, tierCatalog);
+      expect(Object.keys(picks).sort()).toEqual(["TEXT_LARGE", "TEXT_SMALL"]);
+      expect(picks.TEXT_SMALL.slot).toBe("TEXT_SMALL");
+      expect(picks.TEXT_LARGE.slot).toBe("TEXT_LARGE");
+      expect(picks.TEXT_SMALL.platformClass).toBe("apple-silicon");
+      expect(picks.TEXT_LARGE.platformClass).toBe("apple-silicon");
+      expect(picks.TEXT_SMALL.model?.id).toBe("eliza-1-2b");
+      expect(picks.TEXT_LARGE.model?.id).toBe("eliza-1-27b");
+    });
+  });
+
+  describe("recommendForFirstRun", () => {
+    it("resolves the shipped default tier from the real catalog", () => {
+      const picked = recommendForFirstRun();
+      expect(picked?.id).toBe(FIRST_RUN_DEFAULT_MODEL_ID);
+      expect(picked).toBe(
+        MODEL_CATALOG.find((m) => m.id === FIRST_RUN_DEFAULT_MODEL_ID),
+      );
+    });
+
+    it("prefers the configured first-run id over later published entries", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { publishStatus: "published" }),
+        createCatalogModel("eliza-1-4b", { publishStatus: "published" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-2b");
+    });
+
+    it("falls back to the first published eligible entry when the preferred id is absent", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", { publishStatus: "published" }),
+        createCatalogModel("eliza-1-9b", { publishStatus: "published" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-4b");
+    });
+
+    it("skips a pending preferred id in favor of the next published entry", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { publishStatus: "pending" }),
+        createCatalogModel("eliza-1-4b"),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-4b");
+    });
+
+    it("consults the shared tier publish-status map when the field is unset", () => {
+      // eliza-1-9b is marked pending in the shared catalog hints, so the
+      // earlier entry must lose to the later explicitly published one.
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-9b"),
+        createCatalogModel("eliza-1-4b", { publishStatus: "published" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-4b");
+    });
+
+    it("last-resorts to the preferred id when every eligible tier is pending", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { publishStatus: "pending" }),
+        createCatalogModel("eliza-1-4b", { publishStatus: "pending" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-2b");
+    });
+
+    it("last-resorts to any eligible tier when the preferred id is absent and everything is pending", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-4b", { publishStatus: "pending" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-4b");
+    });
+
+    it("skips hidden eligible entries even when they are the preferred id", () => {
+      const catalog: CatalogModel[] = [
+        createCatalogModel("eliza-1-2b", { hiddenFromCatalog: true }),
+        createCatalogModel("eliza-1-4b", { publishStatus: "published" }),
+      ];
+      expect(recommendForFirstRun(catalog)?.id).toBe("eliza-1-4b");
+    });
+
+    it("returns null when no default-eligible entry exists", () => {
+      expect(recommendForFirstRun([])).toBeNull();
+      expect(
+        recommendForFirstRun([createCatalogModel("mistral-small")]),
+      ).toBeNull();
+    });
+  });
+
+  describe("chooseSmallerFallbackModel", () => {
+    it("descends the TEXT_LARGE ladder to the largest strictly-smaller fitting tier", () => {
+      const fallback = chooseSmallerFallbackModel(
+        "eliza-1-9b",
+        appleSilicon32,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      expect(fallback?.id).toBe("eliza-1-4b");
+    });
+
+    it("treats an unknown current id as unbounded and offers the first fitting ladder entry", () => {
+      const fallback = chooseSmallerFallbackModel(
+        "not-installed",
+        appleSilicon32,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      expect(fallback?.id).toBe("eliza-1-27b");
+    });
+
+    it("skips equal-sized tiers because the comparison is strictly smaller", () => {
+      const bigMac = createProbe({
+        totalRamGb: 64,
+        freeRamGb: 56,
+        appleSilicon: true,
+      });
+      const fallback = chooseSmallerFallbackModel(
+        "eliza-1-27b-256k",
+        bigMac,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      // eliza-1-27b is also 16.8 GB, so it is skipped for the 9B tier.
+      expect(fallback?.id).toBe("eliza-1-9b");
+    });
+
+    it("skips ladder entries that cannot fit on the host", () => {
+      const laptop = createProbe({ totalRamGb: 8, appleSilicon: true });
+      const fallback = chooseSmallerFallbackModel(
+        "eliza-1-27b",
+        laptop,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      expect(fallback?.id).toBe("eliza-1-4b");
+    });
+
+    it("falls back outside the ladder when the mobile slot has no smaller rung", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const fallback = chooseSmallerFallbackModel(
+        "eliza-1-4b",
+        phone,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      expect(fallback?.id).toBe("eliza-1-2b");
+    });
+
+    it("returns null when no smaller fitting candidate exists", () => {
+      const phone = createProbe({ platform: "android", totalRamGb: 5 });
+      const fallback = chooseSmallerFallbackModel(
+        "eliza-1-2b",
+        phone,
+        "TEXT_LARGE",
+        MODEL_CATALOG,
+      );
+      expect(fallback).toBeNull();
+    });
+
+    it("defaults to TEXT_LARGE and honours the slot argument", () => {
+      const linuxCpu = createProbe({
+        platform: "linux",
+        arch: "x64",
+        totalRamGb: 48,
+        freeRamGb: 40,
+      });
+      expect(chooseSmallerFallbackModel("eliza-1-9b", linuxCpu)?.id).toBe(
+        "eliza-1-4b",
+      );
+      expect(
+        chooseSmallerFallbackModel("eliza-1-9b", linuxCpu, "TEXT_LARGE")?.id,
+      ).toBe("eliza-1-4b");
+      expect(
+        chooseSmallerFallbackModel("eliza-1-9b", linuxCpu, "TEXT_SMALL")?.id,
+      ).toBe("eliza-1-2b");
+    });
+  });
+});


### PR DESCRIPTION

Adds `packages/ui/src/services/local-inference/recommendation.test.ts` — the first unit suite for `recommendation.ts`, which had no same-named test file anywhere on `develop`. Test-only change: +45 cases in one new file, no production code touched.

## What is covered

Every exported runtime symbol of `packages/ui/src/services/local-inference/recommendation.ts`:

- **`classifyRecommendationPlatform`** — android/ios (top-level and `hardware.mobile` precedence over the OS platform), apple-silicon even with a GPU present, linux-gpu/linux-cpu split, desktop-gpu/desktop-cpu fallback.
- **`catalogDownloadSizeGb` / `catalogDownloadSizeBytes`** — size comes from the model record itself regardless of catalog argument; GiB-to-bytes rounding.
- **`assessCatalogModelFit`** — mobile RAM floor plus the 80% wontfit / 65% tight thresholds; desktop CPU-only half-RAM effective memory; Apple Silicon full-RAM; discrete-GPU VRAM preference — each across fits/tight/wontfit bands.
- **`selectRecommendedModelForSlot`** — ladder walk largest-first for TEXT_LARGE and smallest-first for TEXT_SMALL, skipping unfitting rungs; the long-context bump reordering TEXT_LARGE on hosts with >= 16 GB RAM or VRAM headroom (and NOT applying below the threshold or on TEXT_SMALL); empty-result shape (`model: null`, `fit: null`, exact reason string); mobile degradation past the 4B ladder floor to a fitting 2B fallback candidate; fallback ordering by slot direction; hidden and non-default-eligible models excluded from fallbacks; kernel gating via `binaryKernels` (required-kernel filtering, trust-the-catalog when no probe exists, unsupported-backend-only drop, satisfied-anchor coexisting with an advertised unsupported backend).
- **`selectRecommendedModels`** — both slots returned with echoed labels and one shared platform classification.
- **`recommendForFirstRun`** — the full resolution order against synthetic catalogs plus the real `MODEL_CATALOG`: preferred published tier, first published eligible fallback, pending-preferred skip, consultation of the shared tier publish-status hint map, last-resort to preferred-then-any eligible tier when everything is pending, hidden-entry skip, and `null` only with no default-eligible entry.
- **`chooseSmallerFallbackModel`** — strictly-smaller descent of the slot ladder (equal-sized tiers skipped), unknown current id treated as unbounded, fit-gate skipping, out-of-ladder mobile fallback, `null` when nothing smaller fits, TEXT_LARGE default and slot-parameter routing.

## Evidence

- `bunx vitest run src/services/local-inference/recommendation.test.ts` (in `packages/ui`): **1 file passed, 45/45 tests passed**.
- `bunx biome check src/services/local-inference/recommendation.test.ts`: clean, no fixes applied.
- `bunx tsc --noEmit` in `packages/ui`: zero mentions of `recommendation.test.ts` in output.
- The diff adds exactly one new file (+N/-0). Assertions were written from observed behavior of the module on current `develop`; where an expectation disagreed with actual behavior during development, the expectation was corrected to match the code, not vice versa.

Note: as a fork contributor, hosted CI does not run on this pull request; the counts above are quoted from local runs at head `de774b875774f478ef5b879dbdae8fd2997a3470`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Test-only change: the diff adds one new `*.test.ts` file and touches no
production code, so there is no behavioral risk. The only maintenance coupling
is that cases pin current recommender behavior (ladder order, thresholds,
first-run resolution order); if that behavior changes intentionally, the
affected cases should be updated in the same PR.

# Background

## What does this PR do?

Adds unit coverage for `packages/ui/src/services/local-inference/recommendation.ts`,
which previously had no test file on `develop`. 45 cases across all seven
exported runtime functions, written against observed behavior.

## What kind of change is this?

Improvements (misc. changes to existing features) — test-only coverage add.

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/services/local-inference/recommendation.test.ts`, then the
module under test beside it.

## Detailed testing steps

```bash
cd packages/ui
bunx vitest run src/services/local-inference/recommendation.test.ts
```

Expected: 1 file passed, 45/45 tests passed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:de774b875774f478ef5b879dbdae8fd2997a3470 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
  - N/A - test-only diff; no UI surface rendered or changed.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
  - N/A - test-only diff; no UI surface rendered or changed.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
  - N/A - test-only diff; no user-facing flow exists to walk through.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
  - N/A - no runtime/backend path changed; vitest output quoted above is the
    execution evidence.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
  - N/A - no network or frontend state path touched.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
  - N/A - no model call, prompt, or provider code involved.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
  - N/A - no domain artifacts produced by a unit-test addition.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
  - N/A - no rendered visual surface; pure logic module.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

- `bun run verify` was not run: this lane is a scoped test-coverage add; the
  owning package gates were run directly (vitest, biome, tsc — counts above).
  No unrelated blocker encountered.
- Hosted CI does not run on fork PRs; all counts are from local runs at head
  `de774b875774f478ef5b879dbdae8fd2997a3470`.
- Screenshot/video/OCR/trajectory evidence rows are N/A for a test-only diff;
  see rows above.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
