### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/advanced-planning/index.test.ts
+++ b/packages/core/src/features/advanced-planning/index.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Behavior tests for createAdvancedPlanningPlugin — the advanced-planning
+ * barrel consumed by the plugin loader.
+ *
+ * Drives the real module: asserts the assembled plugin registers the actual
+ * PLAN action instance and PlanningService class by identity with no
+ * providers, passes the loader's own validation gates, returns fresh
+ * registration arrays per call, and disposes through
+ * runtime.getService(PlanningService.serviceType) -> stop(), including the
+ * unregistered-service path and propagation of a failing stop.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { isValidPluginShape, validatePlugin } from "../../plugin.ts";
+import type { IAgentRuntime } from "../../types/index.ts";
+import { planAction } from "./actions/plan.ts";
+import { createAdvancedPlanningPlugin, PlanningService } from "./index.ts";
+
+function makeRuntime(service?: { stop: () => Promise<void> }): {
+	runtime: IAgentRuntime;
+	getService: ReturnType<typeof vi.fn>;
+} {
+	const getService = vi.fn().mockReturnValue(service);
+	return { runtime: { getService } as unknown as IAgentRuntime, getService };
+}
+
+describe("createAdvancedPlanningPlugin", () => {
+	it("names the plugin and describes the capability", () => {
+		const plugin = createAdvancedPlanningPlugin();
+		expect(plugin.name).toBe("advanced-planning");
+		expect(typeof plugin.description).toBe("string");
+		expect(plugin.description?.length).toBeGreaterThan(0);
+	});
+
+	it("registers the real PLAN action instance and the exported PlanningService class", () => {
+		const plugin = createAdvancedPlanningPlugin();
+		expect(plugin.actions).toEqual([planAction]);
+		expect(plugin.actions?.[0]).toBe(planAction);
+		expect(plugin.services).toEqual([PlanningService]);
+		expect(plugin.providers).toEqual([]);
+	});
+
+	it("passes the loader's own shape and validation gates", () => {
+		const plugin = createAdvancedPlanningPlugin();
+		expect(isValidPluginShape(plugin)).toBe(true);
+		const verdict = validatePlugin(plugin);
+		expect(verdict.isValid).toBe(true);
+		expect(verdict.errors).toEqual([]);
+	});
+
+	it("returns fresh registration arrays on every call", () => {
+		const first = createAdvancedPlanningPlugin();
+		const second = createAdvancedPlanningPlugin();
+
+		expect(second).not.toBe(first);
+
+		first.actions?.push(planAction);
+		if (first.services) first.services.length = 0;
+
+		expect(second.actions).toEqual([planAction]);
+		expect(second.services).toEqual([PlanningService]);
+	});
+
+	it("stops the registered PlanningService on dispose, looked up by serviceType", async () => {
+		const stop = vi.fn().mockResolvedValue(undefined);
+		const { runtime, getService } = makeRuntime({ stop });
+		const plugin = createAdvancedPlanningPlugin();
+
+		await plugin.dispose?.(runtime);
+
+		expect(getService).toHaveBeenCalledTimes(1);
+		expect(getService).toHaveBeenCalledWith(PlanningService.serviceType);
+		expect(stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("resolves without stopping anything when no PlanningService is registered", async () => {
+		const { runtime, getService } = makeRuntime(undefined);
+		const plugin = createAdvancedPlanningPlugin();
+
+		await expect(plugin.dispose?.(runtime)).resolves.toBeUndefined();
+		expect(getService).toHaveBeenCalledWith(PlanningService.serviceType);
+	});
+
+	it("propagates a failing stop instead of swallowing it", async () => {
+		const boom = new Error("planning teardown failed");
+		const { runtime } = makeRuntime({ stop: vi.fn().mockRejectedValue(boom) });
+		const plugin = createAdvancedPlanningPlugin();
+
+		await expect(plugin.dispose?.(runtime)).rejects.toBe(boom);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/advanced-planning/index.test.ts` — the first same-named unit suite for the advanced-planning barrel (`packages/core/src/features/advanced-planning/index.ts`). Test-only diff: **one new file, +91/-0**; no production code is touched.

## Why

The module had no dedicated `index` suite. A plugin-factory suite (`__tests__/advanced-planning-plugin-standalone.test.ts`, landed via #27015) covers basic metadata and two dispose paths; this suite is complementary and strictly additive — it pins behavior that suite does not:

- **Registration identity at the source boundary:** the assembled plugin registers the actual `planAction` instance from `actions/plan.ts` (object identity, not just the `"PLAN"` name string) and the barrel-exported `PlanningService` class, with zero providers.
- **Loader gates:** the produced definition passes core's own consumer validation — `isValidPluginShape` and `validatePlugin` return valid with no errors.
- **Factory freshness/isolation:** each call returns a distinct definition whose registration arrays are independent, so callers mutating one plugin's arrays cannot cross-contaminate another.
- **Dispose lifecycle:** stops the service resolved via `runtime.getService(PlanningService.serviceType)`; resolves without touching anything when no service is registered; and **propagates a failing `stop()` rejection** instead of swallowing it (branch not covered by the standalone suite).

All expectations record observed behavior of the current module; nothing asserts behaviour the code does not have.

## Verification (local, real runs)

Fork-contributor note: hosted CI does not run on this PR; all checks were run locally in the shared checkout at head `409a61a1e719411199970aa69c3a5116cdc84509` (base `origin/develop` @ `de774b87`, target module byte-identical between working tree and the develop tip).

| Check | Command | Result |
| --- | --- | --- |
| Unit suite | `bunx vitest run packages/core/src/features/advanced-planning/index.test.ts` | **Test Files 1 passed (1), Tests 7 passed (7)** |
| Lint/format | `bunx biome check --write packages/core/src/features/advanced-planning/index.test.ts` | Clean ("Checked 1 file", no fixes needed); repo config present (`biome.json`, non-sparse checkout) |
| Types | `bunx tsc --noEmit` in `packages/core`, output grepped for the new file | **Zero occurrences of `advanced-planning/index.test`** — no new type errors |

The suite was re-run against the current `origin/develop` immediately before filing (develop tip unchanged at `de774b875774f478ef5b879dbdae8fd2997a3470`; 7/7 still passing).

No `expectTypeOf`, no type-only assertions, no `vi.hoisted`; the only stubs are deterministic `getService` collaborators at the `IAgentRuntime` boundary, matching the convention of sibling suites (`features/advanced-memory/index.test.ts`). `packages/core` is owned by the repository vitest lane.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:409a61a1e719411199970aa69c3a5116cdc84509 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
