### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/index.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/index.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Deterministic unit tests for the basic-capabilities actions barrel. The real
+ * module runs with no model, database, or transport mocks: every case asserts
+ * the exported binding identities and the eager bundle-safety anchor that the
+ * mobile build depends on.
+ */
+import { describe, expect, it } from "vitest";
+import { choiceAction } from "./choice.ts";
+import { ignoreAction } from "./ignore.ts";
+import * as actionsIndex from "./index.ts";
+import { noneAction } from "./none.ts";
+import { replyAction } from "./reply.ts";
+
+describe("basic-capabilities actions barrel", () => {
+	it("binds every basic action under its canonical export name", () => {
+		expect(Object.keys(actionsIndex).sort()).toEqual([
+			"choiceAction",
+			"ignoreAction",
+			"noneAction",
+			"replyAction",
+		]);
+
+		expect(actionsIndex.choiceAction).toBe(choiceAction);
+		expect(actionsIndex.ignoreAction).toBe(ignoreAction);
+		expect(actionsIndex.noneAction).toBe(noneAction);
+		expect(actionsIndex.replyAction).toBe(replyAction);
+	});
+
+	it("exports live action objects carrying their dispatch names", () => {
+		expect(actionsIndex.choiceAction.name).toBe("CHOOSE_OPTION");
+		expect(actionsIndex.ignoreAction.name).toBe("IGNORE");
+		expect(actionsIndex.noneAction.name).toBe("NONE");
+		expect(actionsIndex.replyAction.name).toBe("REPLY");
+
+		for (const action of [
+			actionsIndex.choiceAction,
+			actionsIndex.ignoreAction,
+			actionsIndex.noneAction,
+			actionsIndex.replyAction,
+		]) {
+			expect(action.description).toBeTruthy();
+			expect(action.examples).toBeInstanceOf(Array);
+		}
+	});
+
+	it("eagerly anchors the four action identities on globalThis at module init", () => {
+		const anchor = (globalThis as Record<string, unknown>)
+			.__bundle_safety_FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX__;
+
+		expect(anchor).toEqual([
+			choiceAction,
+			ignoreAction,
+			noneAction,
+			replyAction,
+		]);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/basic-capabilities/actions/index.test.ts` — a new deterministic unit suite for `packages/core/src/features/basic-capabilities/actions/index.ts`, which had no same-named test anywhere on `develop`. Test-only diff: one new file, +57/−0. No production behaviour is changed.

## Why this module

The barrel has two real runtime contracts nothing covered:

1. **Public re-export bindings** — parents `export *` these barrels, so consumers depend on `choiceAction` / `ignoreAction` / `noneAction` / `replyAction` being bound under exactly those names to the exact identities of their source modules.
2. **The eager bundle-safety anchor** — module init calls `anchorBundleSafety("FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX", [...])`, writing `globalThis.__bundle_safety_FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX__`. This side effect is what stops Bun.build's tree-shake from collapsing the re-export-only barrel into an empty init stub on the mobile bundle (incidents #10727, #11030, #11248, #11276). `src/bundle-safety.test.ts` covers the helper itself; no test verified that *this* barrel actually anchors its four actions under its unique key.

## The suite

Three cases, all driving the real module — no mocks, no `vi.mock`, no `expectTypeOf`:

- binds every basic action under its canonical export name (identity `toBe` against direct source imports);
- exports live action objects carrying their dispatch names (`CHOOSE_OPTION`, `IGNORE`, `NONE`, `REPLY`) with truthy descriptions and example arrays;
- asserts the eager anchor ran at module init with the four action identities in order.

## Evidence (test-only PR)

- `bunx vitest run packages/core/src/features/basic-capabilities/actions/index.test.ts` against current `origin/develop`: **1 test file passed (1), 3 tests passed (3)**.
- `bunx biome check packages/core/src/features/basic-capabilities/actions/index.test.ts`: clean ("Checked 1 file … No fixes applied" after `--write`).
- `bunx tsc --noEmit` in `packages/core`: zero occurrences of `basic-capabilities/actions/index.test` in output.
- Diff touches only the new test file (+57/−0).

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ef6b9437a382103377c61443817cb4d7b456aa1a -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
