### PR TITLE
fix(cloud): fail closed on boolean and non-string/number inputs in parseRedeemableEarningsNumber

### DIFF
--- a/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.test.ts
@@ -66,6 +66,18 @@ describe("parseRedeemableEarningsNumber", () => {
     );
   });
 
+  test("throws on boolean, object, and array inputs", () => {
+    expect(() =>
+      parseRedeemableEarningsNumber(true as unknown as number, "available_balance"),
+    ).toThrow(/empty or missing/);
+    expect(() =>
+      parseRedeemableEarningsNumber(false as unknown as number, "available_balance"),
+    ).toThrow(/empty or missing/);
+    expect(() =>
+      parseRedeemableEarningsNumber([10.5] as unknown as number, "available_balance"),
+    ).toThrow(/empty or missing/);
+  });
+
   test("names the field in the error so corrupt columns are identifiable", () => {
     expect(() => parseRedeemableEarningsNumber("x", "total_redeemed")).toThrow(/total_redeemed/);
     expect(() => parseRedeemableEarningsNumber("x", "total_pending")).toThrow(/total_pending/);

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts
@@ -38,10 +38,13 @@ export function parseRedeemableEarningsNumber(
   value: string | number | null | undefined,
   fieldName: string,
 ): number {
-  if (value === null || value === undefined || String(value).trim() === "") {
+  if (typeof value !== "string" && typeof value !== "number") {
     throw new CorruptRedeemableEarningsNumberError(fieldName, value, "value is empty or missing");
   }
-  const parsed = Number(value);
+  if (typeof value === "string" && value.trim() === "") {
+    throw new CorruptRedeemableEarningsNumberError(fieldName, value, "value is empty or missing");
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed)) {
     throw new CorruptRedeemableEarningsNumberError(
       fieldName,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Strict type validation prevents booleans (`true` -> 1, `false` -> 0) and array inputs from evaluating as numbers in redeemable earnings balances.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts`, `parseRedeemableEarningsNumber` performed string coercion via `String(value).trim()` before calling `Number(value)`. In JavaScript, `Number(true)` evaluates to `1`, `Number(false)` evaluates to `0`, and `Number([10.5])` evaluates to `10.5`. This caused boolean or array values to bypass fail-closed error handling and fabricate balances. Requiring `typeof value === "string" || typeof value === "number"` closes this gap.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/redeemable-earnings-numeric.ts` and `redeemable-earnings-numeric.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/redeemable-earnings-numeric.test.ts`.

# Evidence Gate

<!-- evidence-head:44b16e1a72876d3342363daf9b98ccdf66b00f52 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - redeemable earnings numeric parser change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toThrow(expected)
Expected pattern: /empty or missing/
Received function did not throw
Received value: 1
(fail) parseRedeemableEarningsNumber > throws on boolean, object, and array inputs
14 pass, 1 fail
```

## Green (restored)
```
(pass) parseRedeemableEarningsNumber > throws on boolean, object, and array inputs [0.20ms]
15 pass, 0 fail, 28 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

