### PR TITLE
test(core): cover channel-topic-search

### DIFF
--- a/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
@@ -200,3 +200,117 @@ describe("GET /api/channel-topics/search (#8927)", () => {
 		expect(res.code).toBe(503);
 	});
 });
+
+describe("SEARCH_CHANNEL_TOPICS handler branch coverage (#8927)", () => {
+	it("returns the unavailable result from the handler when the service is absent", async () => {
+		const res = await channelTopicSearchAction.handler(
+			runtimeWith(null),
+			{ content: { text: "billing" } } as never,
+			undefined,
+			undefined,
+		);
+		expect(res.success).toBe(false);
+		expect(res.text).toBe("Channel topic search is unavailable.");
+		expect(res.values?.success).toBe(false);
+		expect((res.data as { actionName: string }).actionName).toBe(
+			"SEARCH_CHANNEL_TOPICS",
+		);
+	});
+
+	it("validate rejects a service whose searchTopics is not callable", async () => {
+		expect(
+			await channelTopicSearchAction.validate?.(
+				runtimeWith({ searchTopics: "not-a-function" }),
+				{} as never,
+			),
+		).toBe(false);
+	});
+
+	it("asks for a topic when neither params nor message text supply a query", async () => {
+		const searchTopics = vi.fn(() => HITS);
+		const res = await channelTopicSearchAction.handler(
+			runtimeWith({ searchTopics }),
+			{ content: { text: "" } } as never,
+			undefined,
+			undefined,
+		);
+		expect(searchTopics).not.toHaveBeenCalled();
+		expect(res.success).toBe(false);
+		expect(res.text).toBe("Provide a topic to search for.");
+		expect(res.values?.success).toBe(false);
+	});
+
+	it("ignores a whitespace-only param query and uses the message text", async () => {
+		const searchTopics = vi.fn(() => []);
+		await channelTopicSearchAction.handler(
+			runtimeWith({ searchTopics }),
+			{ content: { text: "invoice delays" } } as never,
+			undefined,
+			{ parameters: { query: "   " } },
+		);
+		expect(searchTopics).toHaveBeenCalledWith("invoice delays");
+	});
+
+	it("trims surrounding whitespace from an explicit param query", async () => {
+		const searchTopics = vi.fn(() => []);
+		await channelTopicSearchAction.handler(
+			runtimeWith({ searchTopics }),
+			{ content: { text: "" } } as never,
+			undefined,
+			{ parameters: { query: "  stripe payouts  " } },
+		);
+		expect(searchTopics).toHaveBeenCalledWith("stripe payouts");
+	});
+
+	it("renders joined matched topics and the null-room-count scope without getTopicsForAllRooms", async () => {
+		const res = await channelTopicSearchAction.handler(
+			runtimeWith({
+				searchTopics: () => [
+					{
+						roomId: "room-9",
+						matchedTopics: ["billing", "refunds"],
+						topics: ["billing", "refunds"],
+					},
+				],
+			}),
+			{ content: { text: "" } } as never,
+			undefined,
+			{ parameters: { query: "billing" } },
+		);
+		expect(res.success).toBe(true);
+		expect(res.values?.matchCount).toBe(1);
+		expect(res.text).toContain("- room-9: billing, refunds");
+		expect(res.text).toContain(
+			"Scope: searched the in-memory room topic index",
+		);
+		const data = res.data as {
+			scope: { kind: string; roomCount: number | null };
+			hits: unknown[];
+		};
+		expect(data.scope.kind).toBe("in_memory_lru");
+		expect(data.scope.roomCount).toBeNull();
+		expect(data.hits).toHaveLength(1);
+	});
+
+	it("counts in-memory rooms in the no-hit scope message when getTopicsForAllRooms is present", async () => {
+		const res = await channelTopicSearchAction.handler(
+			runtimeWith({
+				searchTopics: () => [],
+				getTopicsForAllRooms: () => ({
+					"room-a": ["pricing"],
+					"room-b": ["roadmap"],
+				}),
+			}),
+			{ content: { text: "" } } as never,
+			undefined,
+			{ parameters: { query: "nonexistent-topic" } },
+		);
+		expect(res.success).toBe(true);
+		expect(res.values?.matchCount).toBe(0);
+		expect(res.values?.hasMore).toBe(false);
+		expect(res.text).toContain(
+			"No channels in 2 active or hydrated room(s) in memory",
+		);
+		expect(res.text).toContain('"nonexistent-topic"');
+	});
+});


### PR DESCRIPTION

## What

Adds 7 new cases to the existing suite `packages/core/src/features/basic-capabilities/channel-topic-search.test.ts`, covering previously untested branches of the `SEARCH_CHANNEL_TOPICS` action handler in `packages/core/src/features/basic-capabilities/actions/channel-topic-search.ts`. The diff is purely additive (+114/-0, one test file); no existing case, import, or line was modified or removed.

## Newly covered behaviour (all driven through the real module)

- Handler returns the typed unavailable result when the `channel_topics` service is absent (`success: false`, exact text, `data.actionName`) — only `validate()`'s false path was covered before.
- `validate` rejects a service whose `searchTopics` is not callable (the `typeof` guard).
- Empty resolved query (no params, blank message text) short-circuits with "Provide a topic to search for." and never calls the service.
- A whitespace-only param query falls back to the message text (the `param.trim()` branch).
- Surrounding whitespace on an explicit param query is trimmed before the service call.
- Hit rendering joins multiple matched topics per room (`- room-9: billing, refunds`) and the null-room-count scope line ("in-memory room topic index") is emitted when `getTopicsForAllRooms` is absent; `scope.kind`, `roomCount: null`, and hit count are asserted on `data`.
- No-hit scope message counts rooms ("2 active or hydrated room(s) in memory") when `getTopicsForAllRooms` is present, with `matchCount: 0` and `hasMore: false`.

No production code is touched. Expectations record observed behaviour of the current implementation.

## Verification (test-only PR — no behavioural change to prove)

- `bunx vitest run src/features/basic-capabilities/channel-topic-search.test.ts` (packages/core): **1 file passed, 18 passed / 0 failed** (11 pre-existing + 7 new), re-run against current `origin/develop` immediately before filing.
- `bunx biome check packages/core/src/features/basic-capabilities/channel-topic-search.test.ts`: **clean** ("Checked 1 file… No fixes applied").
- `bunx tsc --noEmit` in `packages/core`: the new test file appears **nowhere** in the output (grep exit 1); no new type errors introduced.
- Diff scope: single test file, +114/-0.
- Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9d198e4d4faedb7e61b1d7262af04f555d78dc56 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
