### PR TITLE
fix(cloud): safely handle non-string and empty input in discord maskId and isValidSnowflake

### DIFF
--- a/packages/cloud/shared/src/lib/utils/discord-helpers.test.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-helpers.test.ts
@@ -43,8 +43,12 @@ describe("isValidSnowflake / maskId", () => {
     expect(isValidSnowflake("123")).toBe(false);
     expect(isValidSnowflake("12345678901234567890")).toBe(false); // 20 digits
     expect(isValidSnowflake("abc")).toBe(false);
+    expect(isValidSnowflake(undefined as unknown as string)).toBe(false);
+    expect(isValidSnowflake(null as unknown as string)).toBe(false);
     expect(maskId("1234567890")).toBe("123...890");
     expect(maskId("short")).toBe("short");
+    expect(maskId(undefined as unknown as string)).toBe("");
+    expect(maskId(null as unknown as string)).toBe("");
   });
 });
 

--- a/packages/cloud/shared/src/lib/utils/discord-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-helpers.ts
@@ -190,7 +190,8 @@ export function truncate(text: string, maxLength: number): string {
  * Mask a guild/channel ID for logging (privacy)
  */
 export function maskId(id: string): string {
-  if (!id || id.length <= 6) return id;
+  if (typeof id !== "string" || !id) return "";
+  if (id.length <= 6) return id;
   return `${id.slice(0, 3)}...${id.slice(-3)}`;
 }
 
@@ -198,6 +199,7 @@ export function maskId(id: string): string {
  * Validate Discord snowflake ID format
  */
 export function isValidSnowflake(id: string): boolean {
+  if (typeof id !== "string" || !id) return false;
   // Discord snowflakes are 17-19 digit numbers
   return /^\d{17,19}$/.test(id);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns false for `isValidSnowflake` and empty string for `maskId` when non-string inputs are provided.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/utils/discord-helpers.ts`:
1. `isValidSnowflake` evaluated a regex without checking if `id` is a non-null string, which could fail when non-string arguments were passed.
2. `maskId` checked `!id || id.length <= 6` without confirming `typeof id === "string"`, returning `undefined` rather than an empty string on non-string input.
Adding early type guards prevents unexpected type coercion and undefined propagation in logs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/utils/discord-helpers.ts` and `discord-helpers.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/utils/discord-helpers.test.ts`.

# Evidence Gate

<!-- evidence-head:0b8e1e748c3c5f509bae8ae0c6e986fdfe263f39 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - discord utility helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: ""
Received: undefined
(fail) isValidSnowflake / maskId > validates 17-19 digit ids and masks for logs
3 pass, 1 fail
```

## Green (restored)
```
(pass) isValidSnowflake / maskId > validates 17-19 digit ids and masks for logs [0.04ms]
4 pass, 0 fail, 27 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

