### PR TITLE
fix(core): safely validate array and function inputs in sliceToFitBudget

### DIFF
--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -51,6 +51,22 @@ describe("sliceToFitBudget", () => {
 		expect(sliceToFitBudget([], byLength, 100)).toEqual([]);
 	});
 
+	it("returns empty for non-array items or invalid estimator functions", () => {
+		expect(
+			sliceToFitBudget(undefined as unknown as string[], byLength, 100),
+		).toEqual([]);
+		expect(
+			sliceToFitBudget(null as unknown as string[], byLength, 100),
+		).toEqual([]);
+		expect(
+			sliceToFitBudget(
+				["a"],
+				undefined as unknown as (item: string) => number,
+				100,
+			),
+		).toEqual([]);
+	});
+
 	it("returns empty for a zero or negative budget", () => {
 		expect(sliceToFitBudget(["a"], byLength, 0)).toEqual([]);
 		expect(sliceToFitBudget(["a"], byLength, -10)).toEqual([]);

--- a/packages/core/src/utils/slice-to-fit-budget.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.ts
@@ -16,7 +16,13 @@ export function sliceToFitBudget<T>(
 	targetChars: number,
 	options?: { fromEnd?: boolean },
 ): T[] {
-	if (items.length === 0) return [];
+	if (
+		!Array.isArray(items) ||
+		items.length === 0 ||
+		typeof estimateChars !== "function"
+	) {
+		return [];
+	}
 	// Zero, negative, or non-finite budget means no room - return empty array
 	if (!Number.isFinite(targetChars) || targetChars <= 0) return [];
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns empty array when non-array `items` or non-function `estimateChars` are provided.

# Background

## What does this PR do?

In `packages/core/src/utils/slice-to-fit-budget.ts`, `sliceToFitBudget` directly called `items.length` and `items.map(...)` without verifying that `items` is an array and `estimateChars` is a function. Passing `undefined` or non-array inputs threw `TypeError: Cannot read properties of undefined (reading 'length')`. Adding early validation guards ensures safe degradation.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/slice-to-fit-budget.ts` and `slice-to-fit-budget.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/slice-to-fit-budget.test.ts`.

# Evidence Gate

<!-- evidence-head:9beee40c8a1d0d30d74ccddc1af2cd56b367f12b -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - context budgeting helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'items.length')
      at sliceToFitBudget (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/core/src/utils/slice-to-fit-budget.ts:19:6)
(fail) sliceToFitBudget > returns empty for non-array items or invalid estimator functions
17 pass, 1 fail
```

## Green (restored)
```
(pass) sliceToFitBudget > returns empty for non-array items or invalid estimator functions [0.01ms]
18 pass, 0 fail, 34 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

