### PR TITLE
fix(agent): safely guard non-string sqlText in checkReadOnly

### DIFF
--- a/packages/agent/src/security/sql-readonly-guard.test.ts
+++ b/packages/agent/src/security/sql-readonly-guard.test.ts
@@ -289,6 +289,12 @@ describe("checkReadOnly", () => {
     expect(checkReadOnly("SELECT ';' AS punctuation")).toEqual({ ok: true });
   });
 
+  it("safely accepts non-string or empty sqlText inputs", () => {
+    expect(checkReadOnly(undefined as unknown as string)).toEqual({ ok: true });
+    expect(checkReadOnly(null as unknown as string)).toEqual({ ok: true });
+    expect(checkReadOnly("")).toEqual({ ok: true });
+  });
+
   it("passes through an unterminated block comment from the scanner", () => {
     expect(checkReadOnly("SELECT 1 /* never closed")).toEqual({
       ok: false,

--- a/packages/agent/src/security/sql-readonly-guard.ts
+++ b/packages/agent/src/security/sql-readonly-guard.ts
@@ -81,6 +81,9 @@ export function checkReadOnly(
   sqlText: string,
   writeOverride = "allowWrites:true",
 ): { ok: true } | { ok: false; reason: string } {
+  if (typeof sqlText !== "string" || !sqlText) {
+    return { ok: true };
+  }
   const scan = scanSqlForReadOnly(sqlText);
   if (!scan.ok) return scan;
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns `{ ok: true }` for non-string or empty `sqlText` inputs in `checkReadOnly`.

# Background

## What does this PR do?

In `packages/agent/src/security/sql-readonly-guard.ts`, `checkReadOnly` passed `sqlText` directly to `scanSqlForReadOnly(sqlText)`. If `sqlText` was `undefined` or a non-string value, `scanSqlForReadOnly` threw `TypeError: Cannot read properties of undefined (reading 'length')`. Adding an early guard safely short-circuits empty/non-string inputs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/agent/src/security/sql-readonly-guard.ts` and `sql-readonly-guard.test.ts`.

## Detailed testing steps

Run `bun test packages/agent/src/security/sql-readonly-guard.test.ts`.

# Evidence Gate

<!-- evidence-head:d411f79de965224be41eba28ef898698aaedc5bd -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - sql read-only guard helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: undefined is not an object (evaluating 'sql.length')
      at scanSqlForReadOnly (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/agent/src/shared/sql-sanitizers.ts:145:7)
      at checkReadOnly (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/agent/src/security/sql-readonly-guard.ts:84:16)
(fail) checkReadOnly > safely accepts non-string or empty sqlText inputs
98 pass, 1 fail
```

## Green (restored)
```
(pass) checkReadOnly > safely accepts non-string or empty sqlText inputs [0.01ms]
99 pass, 0 fail, 106 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

