### PR TITLE
test(core): cover basic-capabilities evaluators barrel

### DIFF
--- a/packages/core/src/features/basic-capabilities/evaluators/__tests__/index.test.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/__tests__/index.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for the basic-capabilities inbound evaluators barrel
+ * (`evaluators/index.ts`): the `basicCapabilitiesEvaluators` collection the
+ * runtime evaluator registry consumes and the fidelity of the
+ * `linkExtractionEvaluator` re-export (one shared instance across import
+ * paths). The harness is fully deterministic — `shouldRun` is driven through
+ * the exported array over plain message text, so no network, model, or
+ * database is touched. Evaluator internals are covered by
+ * `./link-extraction.test.ts`; only the wiring is proven here.
+ */
+import { describe, expect, it } from "vitest";
+import type { EvaluatorRunContext, Memory } from "../../../../types/index.ts";
+import {
+	basicCapabilitiesEvaluators,
+	linkExtractionEvaluator as reExportedLinkExtraction,
+} from "../index.ts";
+import { linkExtractionEvaluator } from "../link-extraction.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const ENTITY_ID = "00000000-0000-0000-0000-000000000002";
+const ROOM_ID = "00000000-0000-0000-0000-000000000003";
+
+function makeMessage(content: Memory["content"]): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000aa",
+		entityId: ENTITY_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content,
+		createdAt: Date.now(),
+	} as Memory;
+}
+
+function makeContext(message: Memory): EvaluatorRunContext {
+	return {
+		runtime: {} as EvaluatorRunContext["runtime"],
+		message,
+		options: {},
+	};
+}
+
+describe("basicCapabilitiesEvaluators barrel", () => {
+	it("registers the link-extraction evaluator instance, not a copy", () => {
+		expect(Array.isArray(basicCapabilitiesEvaluators)).toBe(true);
+		expect(basicCapabilitiesEvaluators).toHaveLength(1);
+		expect(basicCapabilitiesEvaluators[0]).toBe(linkExtractionEvaluator);
+	});
+
+	it("re-exports the same linkExtractionEvaluator instance as the source module", () => {
+		expect(reExportedLinkExtraction).toBe(linkExtractionEvaluator);
+	});
+
+	it("exposes registry-consumable evaluators with unique string names", () => {
+		expect(basicCapabilitiesEvaluators.length).toBeGreaterThan(0);
+		const names = basicCapabilitiesEvaluators.map(
+			(evaluator) => evaluator.name,
+		);
+		for (const name of names) {
+			expect(typeof name).toBe("string");
+			expect(name.length).toBeGreaterThan(0);
+		}
+		expect(new Set(names).size).toBe(names.length);
+		for (const evaluator of basicCapabilitiesEvaluators) {
+			expect(typeof evaluator.shouldRun).toBe("function");
+			expect(typeof evaluator.prompt).toBe("function");
+			expect(evaluator.schema).toEqual(
+				expect.objectContaining({ type: "object" }),
+			);
+		}
+	});
+
+	it("runs the registered URL gate through the exported array", async () => {
+		const [registered] = basicCapabilitiesEvaluators;
+		await expect(
+			registered.shouldRun(
+				makeContext(makeMessage({ text: "read https://example.com/post now" })),
+			),
+		).resolves.toBe(true);
+		await expect(
+			registered.shouldRun(
+				makeContext(makeMessage({ text: "no links in this message" })),
+			),
+		).resolves.toBe(false);
+	});
+
+	it("treats empty or textless content as no-link through the array", async () => {
+		const [registered] = basicCapabilitiesEvaluators;
+		await expect(
+			registered.shouldRun(makeContext(makeMessage({ text: "" }))),
+		).resolves.toBe(false);
+		await expect(
+			registered.shouldRun(makeContext(makeMessage({}))),
+		).resolves.toBe(false);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/basic-capabilities/evaluators/__tests__/index.test.ts`, a new vitest suite for the basic-capabilities inbound evaluators barrel (`evaluators/index.ts`), which previously had no same-named test file anywhere in the repo.

The suite covers exactly this file's own responsibility — the wiring the runtime evaluator registry consumes:

- `basicCapabilitiesEvaluators` registers the real `linkExtractionEvaluator` instance (identity, not a copy or wrapper), so name-based registration dedupe sees one shared object.
- The barrel's named re-export of `linkExtractionEvaluator` resolves to the same instance as a direct import from `./link-extraction.ts`.
- Every element satisfies what `registerEvaluator(RegisteredEvaluator)` consumes: non-empty string names, unique names within the array, callable `shouldRun`/`prompt`, and an object schema.
- The registered gate is live when driven through the exported array: URL-bearing message text runs `shouldRun` → `true`; link-free text → `false`; empty and textless content → `false`.

Evaluator internals are deliberately not re-covered here — `__tests__/link-extraction.test.ts` already owns them. The harness is fully deterministic: hand-built contexts over plain message text, no network, model, or database.

## Evidence

- `bunx vitest run src/features/basic-capabilities/evaluators/__tests__/index.test.ts` (from `packages/core`, at head `84dbec3c2682be021423faadf5ca17e76d7370f9`, base = current `origin/develop` `de774b875774`): **1 file passed, 5 tests passed**.
- `bunx biome check --write packages/core/src/features/basic-capabilities/evaluators/__tests__/index.test.ts`: clean, `Checked 1 file ... No fixes applied`, exit 0 (config verified present at repo root).
- `bunx tsc --noEmit` in `packages/core`, output grepped for `index.test.ts`: **no matches** — the new file introduces zero type errors.
- The diff touches only the one new test file (+95/−0). No production behavior changes.

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are quoted from local runs against current `origin/develop`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:84dbec3c2682be021423faadf5ca17e76d7370f9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
