### PR TITLE
fix(cloud): safely handle non-string and empty code in phoneErrorHasCode

### DIFF
--- a/packages/cloud/shared/src/lib/services/phone-error-diagnostics.test.ts
+++ b/packages/cloud/shared/src/lib/services/phone-error-diagnostics.test.ts
@@ -7,6 +7,7 @@ import {
   isPhoneSchemaMigrationRequired,
   isPostgresUndefinedTableError,
   phoneErrorDiagnostic,
+  phoneErrorHasCode,
 } from "./phone-error-diagnostics";
 
 describe("phone error diagnostics", () => {
@@ -87,5 +88,14 @@ describe("phone error diagnostics", () => {
     expect(phoneErrorDiagnostic(hostile)).toEqual({
       errorClass: "unexpected_phone_failure",
     });
+  });
+
+  test("safely returns false for non-string or empty expectedCode", () => {
+    const error = { code: "PHONE_MESSAGE_PERSISTENCE_FAILED" };
+    const emptyError = { code: "" };
+    expect(phoneErrorHasCode(error, undefined as unknown as string)).toBe(false);
+    expect(phoneErrorHasCode(error, null as unknown as string)).toBe(false);
+    expect(phoneErrorHasCode(error, "")).toBe(false);
+    expect(phoneErrorHasCode(emptyError, "")).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/services/phone-error-diagnostics.ts
+++ b/packages/cloud/shared/src/lib/services/phone-error-diagnostics.ts
@@ -68,6 +68,7 @@ function visitErrorChain(error: unknown, visitor: (code: string) => boolean): bo
 
 /** Match only an exact stable error code, including through bounded causes. */
 export function phoneErrorHasCode(error: unknown, expectedCode: string): boolean {
+  if (typeof expectedCode !== "string" || expectedCode.trim() === "") return false;
   return visitErrorChain(error, (code) => code === expectedCode);
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns false when non-string or empty expected error codes are checked against phone error chains.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/phone-error-diagnostics.ts`, `phoneErrorHasCode` directly evaluated `code === expectedCode` without validating that `expectedCode` was a non-empty string. If an error contained an empty string `code: ""`, passing `expectedCode: ""` matched as true rather than failing closed. Adding a non-empty string guard ensures error-code matching remains strictly bounded to valid codes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/phone-error-diagnostics.ts` and `phone-error-diagnostics.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/phone-error-diagnostics.test.ts`.

# Evidence Gate

<!-- evidence-head:200df4e391e31f349f1184a5739eef58c3e02eb7 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - phone error diagnostics helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) phone error diagnostics > safely returns false for non-string or empty expectedCode
5 pass, 1 fail
```

## Green (restored)
```
(pass) phone error diagnostics > safely returns false for non-string or empty expectedCode
6 pass, 0 fail, 20 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

