### PR TITLE
fix(cloud): safely reject non-string input in parsePhoneJsonLosslessly

### DIFF
--- a/packages/cloud/shared/src/lib/services/phone-lossless-json.test.ts
+++ b/packages/cloud/shared/src/lib/services/phone-lossless-json.test.ts
@@ -43,6 +43,11 @@ describe("phone lossless JSON hydration", () => {
       "Persisted phone metadata is not a JSON object",
     );
   });
+
+  test("rejects non-string input with TypeError", () => {
+    expect(() => parsePhoneJsonLosslessly(undefined as unknown as string)).toThrow(TypeError);
+    expect(() => parsePhoneJsonLosslessly(null as unknown as string)).toThrow(TypeError);
+  });
 });
 
 // A runtime without reviver source access must not reject every payload that

--- a/packages/cloud/shared/src/lib/services/phone-lossless-json.ts
+++ b/packages/cloud/shared/src/lib/services/phone-lossless-json.ts
@@ -45,6 +45,9 @@ function numberRoundTripsExactly(source: string, value: number): boolean {
  * `Infinity`, zero, or a rounded integer.
  */
 export function parsePhoneJsonLosslessly(raw: string): unknown {
+  if (typeof raw !== "string") {
+    throw new TypeError("Raw JSON payload must be a string");
+  }
   const api = rawJsonApi();
   return JSON.parse(raw, (_key: string, value: unknown, context?: JsonParseContext) => {
     if (typeof value !== "number") return value;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Throws `TypeError` when non-string payloads are passed to `parsePhoneJsonLosslessly` rather than parsing string coerced `"undefined"`.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/phone-lossless-json.ts`, `parsePhoneJsonLosslessly` directly called `JSON.parse(raw)` without verifying `typeof raw === "string"`. Non-string values like `undefined` were coerced to `"undefined"` and threw `SyntaxError: JSON Parse error: Unexpected identifier "undefined"`. Adding a string guard throws a typed `TypeError` at the boundary.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/phone-lossless-json.ts` and `phone-lossless-json.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/phone-lossless-json.test.ts`.

# Evidence Gate

<!-- evidence-head:9814bf3970ad2c390c159f5b3fa87e8932107016 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - phone lossless json parser helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toThrow(expected)
Expected constructor: TypeError
Received constructor: SyntaxError
Received message: "JSON Parse error: Unexpected identifier \"undefined\""
(fail) phone lossless JSON hydration > rejects non-string input with TypeError
4 pass, 1 fail
```

## Green (restored)
```
(pass) phone lossless JSON hydration > rejects non-string input with TypeError [0.22ms]
5 pass, 0 fail, 15 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

