### PR TITLE
fix(core): safely handle non-string inputs in extractUserText

### DIFF
--- a/packages/core/src/utils/message-text.test.ts
+++ b/packages/core/src/utils/message-text.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../types/memory";
 import {
+	extractUserText,
 	getUserMessageText,
 	hasDocumentAugmentationEnvelope,
 	stripAugmentationForPersistence,
@@ -115,5 +116,26 @@ describe("stripAugmentationForPersistence", () => {
 		expect(hasDocumentAugmentationEnvelope(augmentedText("hi"))).toBe(true);
 		expect(hasDocumentAugmentationEnvelope("plain user text")).toBe(false);
 		expect(hasDocumentAugmentationEnvelope(undefined)).toBe(false);
+	});
+});
+
+describe("extractUserText", () => {
+	it("returns empty for non-string inputs and handles edge wrappers", () => {
+		expect(extractUserText(undefined as unknown as string)).toBe("");
+		expect(extractUserText(null as unknown as string)).toBe("");
+		expect(extractUserText(42 as unknown as string)).toBe("");
+		expect(extractUserText({} as unknown as string)).toBe("");
+		expect(extractUserText("")).toBe("");
+		expect(extractUserText("  hello  ")).toBe("hello");
+		// Strips trailing language instruction suffix
+		expect(
+			extractUserText("hello\n[language instruction: translate to French]"),
+		).toBe("hello");
+		// Unwraps document augmentation envelope
+		const wrapped = [
+			"Answer the user request using the contextual documents below as the source of truth when they contain the answer.",
+			"<user_request>  clean text  </user_request>",
+		].join("\n");
+		expect(extractUserText(wrapped)).toBe("clean text");
 	});
 });

--- a/packages/core/src/utils/message-text.ts
+++ b/packages/core/src/utils/message-text.ts
@@ -13,6 +13,7 @@ const USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i;
 const LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i;
 
 export function extractUserText(raw: string): string {
+	if (typeof raw !== "string") return "";
 	let text = raw;
 	if (text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX)) {
 		const match = text.match(USER_REQUEST_WRAPPER);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Isolated guard in pure string utility; returns empty string for non-string inputs. No behavioral change for valid string inputs.

# Background

## What does this PR do?

In `packages/core/src/utils/message-text.ts` `extractUserText` assumed its argument was always a string and called `trimStart()`/`match`/`replace` directly. When called with `null`/`undefined`/`number`/`object` (e.g. malformed memory content or direct export usage), it threw `TypeError: null is not an object`. Adds `if (typeof raw !== "string") return "";` fail-closed guard matching the pattern used for `hasDocumentAugmentationEnvelope` in the same file.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/message-text.ts` and `packages/core/src/utils/message-text.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/message-text.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f63bc6c8feee470ad33ae0af3b903fe9c7ae54f5 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure string utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function, no persisted artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure string utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/message-text.test.ts` and `bun run --cwd packages/core typecheck` pass. Biome clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 7 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/message-text.test.ts:
(pass) getUserMessageText > prefers connector-provided current-turn text over rendered envelopes [0.33ms]
(pass) getUserMessageText > preserves user text beyond the former 100,000-character ceiling [1.80ms]
(pass) stripAugmentationForPersistence > unwraps the document augmentation envelope so persisted text is what the user typed
(pass) stripAugmentationForPersistence > does not mutate the in-flight message (LLM turn keeps its wrap)
(pass) stripAugmentationForPersistence > is a no-op passthrough for ordinary unwrapped user messages
(pass) stripAugmentationForPersistence > leaves lookalike text that lacks the augmentation preamble untouched
(pass) stripAugmentationForPersistence > detects the envelope via hasDocumentAugmentationEnvelope
12 | const USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i;
13 | const LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i;
14 | 
15 | export function extractUserText(raw: string): string {
16 | 	let text = raw;
17 | 	if (text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX)) {
          ^
TypeError: undefined is not an object (evaluating 'text.trimStart')
      at extractUserText (/private/tmp/wt-main-1787569365/packages/core/src/utils/message-text.ts:17:6)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/core/src/utils/message-text.test.ts:124:10)
(fail) extractUserText > returns empty for non-string inputs and handles edge wrappers
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
All files                                |   80.00 |   94.23 |
 packages/core/src/utils/message-text.ts |   80.00 |   94.23 | 45-47
-----------------------------------------|---------|---------|-------------------

 7 pass
 1 fail
 16 expect() calls
Ran 8 tests across 1 file. [74.00ms]
```

**Green (restored, 8 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/message-text.test.ts:
(pass) getUserMessageText > prefers connector-provided current-turn text over rendered envelopes
(pass) getUserMessageText > preserves user text beyond the former 100,000-character ceiling [1.99ms]
(pass) stripAugmentationForPersistence > unwraps the document augmentation envelope so persisted text is what the user typed [0.23ms]
(pass) stripAugmentationForPersistence > does not mutate the in-flight message (LLM turn keeps its wrap)
(pass) stripAugmentationForPersistence > is a no-op passthrough for ordinary unwrapped user messages
(pass) stripAugmentationForPersistence > leaves lookalike text that lacks the augmentation preamble untouched
(pass) stripAugmentationForPersistence > detects the envelope via hasDocumentAugmentationEnvelope [0.06ms]
(pass) extractUserText > returns empty for non-string inputs and handles edge wrappers
-----------------------------------------|---------|---------|-------------------
File                                     | % Funcs | % Lines | Uncovered Line #s
-----------------------------------------|---------|---------|-------------------
All files                                |   80.00 |   94.34 |
 packages/core/src/utils/message-text.ts |   80.00 |   94.34 | 46-48
-----------------------------------------|---------|---------|-------------------

 8 pass
 0 fail
 24 expect() calls
Ran 8 tests across 1 file. [100.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/message-text.test.ts` → Green 8 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean after auto-fix
