### PR TITLE
fix(shared): safely handle non-finite and negative input in maxRawBytesForBase64

### DIFF
--- a/packages/shared/src/chat-upload-limits.test.ts
+++ b/packages/shared/src/chat-upload-limits.test.ts
@@ -47,6 +47,14 @@ describe("maxRawBytesForBase64", () => {
     );
   });
 
+  it("safely returns 0 for non-finite, negative, or invalid base64 caps", () => {
+    expect(maxRawBytesForBase64(0)).toBe(0);
+    expect(maxRawBytesForBase64(-100)).toBe(0);
+    expect(maxRawBytesForBase64(Number.NaN)).toBe(0);
+    expect(maxRawBytesForBase64(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(maxRawBytesForBase64(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+
   it("exports derived raw caps consistent with the base64 caps", () => {
     expect(MAX_CHAT_IMAGE_RAW_BYTES).toBe(
       maxRawBytesForBase64(MAX_CHAT_IMAGE_BASE64_BYTES),

--- a/packages/shared/src/chat-upload-limits.ts
+++ b/packages/shared/src/chat-upload-limits.ts
@@ -37,6 +37,7 @@ export const MAX_CHAT_ATTACHMENT_NAME_LENGTH = 255;
  * `raw <= floor(cap / 4) * 3` guarantees `base64Length <= cap`.
  */
 export function maxRawBytesForBase64(base64Cap: number): number {
+  if (!Number.isFinite(base64Cap) || base64Cap <= 0) return 0;
   return Math.floor(base64Cap / 4) * 3;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely clamps negative and non-finite caps to 0 raw bytes in `maxRawBytesForBase64`.

# Background

## What does this PR do?

In `packages/shared/src/chat-upload-limits.ts`, `maxRawBytesForBase64` computed `Math.floor(base64Cap / 4) * 3` directly without verifying that `base64Cap` is a positive finite number. Passing negative numbers produced negative raw byte budgets, and non-finite values produced `NaN` or `Infinity`. Adding an early guard safely returns 0 for non-positive or non-finite inputs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/chat-upload-limits.ts` and `chat-upload-limits.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/shared src/chat-upload-limits.test.ts`.

# Evidence Gate

<!-- evidence-head:4604eb9da606bc280c4bcd172970c674c3161c42 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - chat upload limits calculation helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: 0
Received: -75
(fail) maxRawBytesForBase64 > safely returns 0 for non-finite, negative, or invalid base64 caps
7 pass, 1 fail
```

## Green (restored)
```
(pass) maxRawBytesForBase64 > safely returns 0 for non-finite, negative, or invalid base64 caps [0.03ms]
8 pass, 0 fail, 46 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

