### PR TITLE
fix(app-core): safely fallback to canonicalStateDir when non-string passed to deriveAgentVaultId

### DIFF
--- a/packages/app-core/src/security/agent-vault-id.test.ts
+++ b/packages/app-core/src/security/agent-vault-id.test.ts
@@ -24,6 +24,13 @@ describe("deriveAgentVaultId", () => {
       deriveAgentVaultId("/Users/y/.eliza"),
     );
   });
+
+  it("safely falls back when non-string state dir is passed", () => {
+    const a = deriveAgentVaultId(null as unknown as string);
+    const b = deriveAgentVaultId();
+    expect(a).toBe(b);
+    expect(a).toMatch(/^mldy1-[A-Za-z0-9_-]{16}$/);
+  });
 });
 
 describe("keychainAccountForSecretKind", () => {

--- a/packages/app-core/src/security/agent-vault-id.ts
+++ b/packages/app-core/src/security/agent-vault-id.ts
@@ -56,7 +56,11 @@ export function resolveCanonicalStateDir(): string {
 export function deriveAgentVaultId(
   canonicalStateDir = resolveCanonicalStateDir(),
 ): string {
-  const hash = createHash("sha256").update(canonicalStateDir, "utf8").digest();
+  const dir =
+    typeof canonicalStateDir === "string" && canonicalStateDir
+      ? canonicalStateDir
+      : resolveCanonicalStateDir();
+  const hash = createHash("sha256").update(dir, "utf8").digest();
   const token = Buffer.from(hash).toString("base64url").slice(0, 16);
   return `mldy1-${token}`;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely falls back to `resolveCanonicalStateDir()` when a non-string or empty `canonicalStateDir` argument is passed to `deriveAgentVaultId`.

# Background

## What does this PR do?

In `packages/app-core/src/security/agent-vault-id.ts`, `deriveAgentVaultId` passed `canonicalStateDir` directly to `createHash("sha256").update(canonicalStateDir, "utf8")`. If callers explicitly passed a non-string (e.g. `null` or `undefined`), `crypto.update` threw `TypeError: The "data" argument must be of type string`. Adding a fallback to `resolveCanonicalStateDir()` prevents crashes when callers omit or pass non-string arguments.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/app-core/src/security/agent-vault-id.ts` and `agent-vault-id.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/app-core src/security/agent-vault-id.test.ts`.

# Evidence Gate

<!-- evidence-head:1b7dcdf35a40d56eb237673cb4861ed7707b72d6 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - agent vault id derivation helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received null
      at deriveAgentVaultId (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/app-core/src/security/agent-vault-id.ts:59:37)
(fail) deriveAgentVaultId > safely falls back when non-string state dir is passed
3 pass, 1 fail
```

## Green (restored)
```
(pass) deriveAgentVaultId > safely falls back when non-string state dir is passed [0.23ms]
4 pass, 0 fail, 6 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

