### PR TITLE
fix(core): safely handle non-string inputs in string-boundaries

### DIFF
--- a/packages/core/src/utils/string-boundaries.test.ts
+++ b/packages/core/src/utils/string-boundaries.test.ts
@@ -23,4 +23,26 @@ describe("core string boundary scanners", () => {
 			`root${sameLowSurrogate}`,
 		);
 	});
+
+	it("returns safe defaults for non-string inputs", () => {
+		expect(trimEndCharacters(null as unknown as string, "/")).toBe("");
+		expect(trimEndCharacters(undefined as unknown as string, "/")).toBe("");
+		expect(trimEndCharacters(42 as unknown as string, "/")).toBe("");
+		expect(trimEndCharacters("abc///", null as unknown as string)).toBe(
+			"abc///",
+		);
+		expect(trimEndCharacters("abc///", undefined as unknown as string)).toBe(
+			"abc///",
+		);
+		expect(trimEndCharacters("abc///", 42 as unknown as string)).toBe("abc///");
+		expect(trimEndCharacters("abc///", "")).toBe("abc///");
+		expect(trimEndCharacters("https://example.test///", "/")).toBe(
+			"https://example.test",
+		);
+		expect(trimEndWhitespace(null as unknown as string)).toBe("");
+		expect(trimEndWhitespace(undefined as unknown as string)).toBe("");
+		expect(trimEndWhitespace(123 as unknown as string)).toBe("");
+		expect(trimEndWhitespace("")).toBe("");
+		expect(trimEndWhitespace("hello   ")).toBe("hello");
+	});
 });

--- a/packages/core/src/utils/string-boundaries.ts
+++ b/packages/core/src/utils/string-boundaries.ts
@@ -1,6 +1,8 @@
 /** Provides linear boundary trimming for explicit character sets and whitespace. */
 
 export function trimEndCharacters(value: string, characters: string): string {
+	if (typeof value !== "string") return "";
+	if (typeof characters !== "string" || characters.length === 0) return value;
 	const accepted = new Set(characters);
 	let end = value.length;
 	while (end > 0) {
@@ -17,6 +19,7 @@ export function trimEndCharacters(value: string, characters: string): string {
 }
 
 export function trimEndWhitespace(value: string): string {
+	if (typeof value !== "string") return "";
 	let end = value.length;
 	while (end > 0 && /\s/u.test(value[end - 1])) end -= 1;
 	return end === value.length ? value : value.slice(0, end);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Pure string utility guards; returns safe defaults for non-string inputs. No change for valid string paths.

# Background

## What does this PR do?

In `packages/core/src/utils/string-boundaries.ts` both `trimEndCharacters` and `trimEndWhitespace` assumed string inputs and accessed `value.length`/`charCodeAt` and `new Set(characters)` directly. Passing `null`/`undefined`/`number` threw `TypeError: null is not an object`. Adds fail-closed guards: `typeof value !== "string" => ""` and `typeof characters !== "string" || empty => return value` unchanged, matching the project's recent string-guard pattern.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/string-boundaries.ts` and `.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/string-boundaries.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:30e5b36ad3bab9e37d75e30849366ed5a790618c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure string utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure string utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/string-boundaries.test.ts` and `bun run --cwd packages/core typecheck` pass. Biome clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 3 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/string-boundaries.test.ts:
(pass) core string boundary scanners > trims only the requested suffix [0.08ms]
(pass) core string boundary scanners > handles 100k-character suffixes in linear time [2.07ms]
(pass) core string boundary scanners > does not split an unmatched Unicode code point [0.17ms]
1 | /** Provides linear boundary trimming for explicit character sets and whitespace. */
2 | 
3 | export function trimEndCharacters(value: string, characters: string): string {
4 | 	const accepted = new Set(characters);
5 | 	let end = value.length;
               ^
TypeError: null is not an object (evaluating 'value.length')
      at trimEndCharacters (/private/tmp/wt-main-1787569365/packages/core/src/utils/string-boundaries.ts:5:12)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/core/src/utils/string-boundaries.test.ts:28:10)
(fail) core string boundary scanners > returns safe defaults for non-string inputs [0.10ms]
----------------------------------------------|---------|---------|-------------------
File                                          | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------|---------|---------|-------------------
All files                                     |  100.00 |  100.00 |
 packages/core/src/utils/string-boundaries.ts |  100.00 |  100.00 | 
----------------------------------------------|---------|---------|-------------------

 3 pass
 1 fail
 5 expect() calls
Ran 4 tests across 1 file. [73.00ms]
```

**Green (restored, 4 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/string-boundaries.test.ts:
(pass) core string boundary scanners > trims only the requested suffix
(pass) core string boundary scanners > handles 100k-character suffixes in linear time [1.59ms]
(pass) core string boundary scanners > does not split an unmatched Unicode code point
(pass) core string boundary scanners > returns safe defaults for non-string inputs
----------------------------------------------|---------|---------|-------------------
File                                          | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------|---------|---------|-------------------
All files                                     |  100.00 |  100.00 |
 packages/core/src/utils/string-boundaries.ts |  100.00 |  100.00 | 
----------------------------------------------|---------|---------|-------------------

 4 pass
 0 fail
 18 expect() calls
Ran 4 tests across 1 file. [100.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/string-boundaries.test.ts` → Green 4 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean
