### PR TITLE
fix(core): safely handle non-string inputs in text-splitting

### DIFF
--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -290,3 +290,42 @@ describe("createFirstSentenceStreamTracker", () => {
 		expect(tracker.finish()).toBe(160_005);
 	});
 });
+describe("non-string guardrails", () => {
+	it("returns safe defaults for non-string inputs and handles non-string chunks", () => {
+		expect(extractFirstSentence(null as unknown as string)).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+		expect(extractFirstSentence(undefined as unknown as string)).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+		expect(extractFirstSentence(42 as unknown as string)).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+		expect(hasFirstSentence(null as unknown as string)).toBe(false);
+		expect(hasFirstSentence(123 as unknown as string)).toBe(false);
+		expect(hasFirstSentence(undefined as unknown as string)).toBe(false);
+
+		const scanner = createFirstSentenceScanner();
+		expect(scanner.push(null as unknown as string)).toBeUndefined();
+		expect(scanner.push(undefined as unknown as string)).toBeUndefined();
+		expect(scanner.push(42 as unknown as string)).toBeUndefined();
+		expect(scanner.push("Hello. Next.")).toBe(6);
+		expect(scanner.push("more")).toBe(6);
+
+		const tracker = createFirstSentenceStreamTracker();
+		expect(
+			tracker.push(null as unknown as string, "hello" as unknown as string),
+		).toBeUndefined();
+		expect(
+			tracker.push("hi" as unknown as string, null as unknown as string),
+		).toBeUndefined();
+		expect(tracker.push("Hello. ", "Hello. ")).toBe(6);
+		expect(tracker.push("Next.", "Hello. Next.")).toBe(6);
+	});
+});

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -76,6 +76,7 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 
 	return {
 		push(chunk: string, endOfInput = false): number | undefined {
+			if (typeof chunk !== "string") return completeAt;
 			if (completeAt !== undefined) return completeAt;
 			if (pendingBoundary && (chunk.length > 0 || endOfInput)) {
 				if (!ABBREVIATIONS.has(pendingBoundary.normalizedWord)) {
@@ -178,6 +179,8 @@ export function createFirstSentenceStreamTracker(): FirstSentenceStreamTracker {
 			accumulated: string,
 			streamRevision?: number,
 		): number | undefined {
+			if (typeof chunk !== "string" || typeof accumulated !== "string")
+				return undefined;
 			if (
 				streamRevision !== undefined &&
 				activeRevision !== undefined &&
@@ -212,6 +215,7 @@ export function extractFirstSentence(text: string): {
 	/** Whether a sentence boundary was actually found in `text`. */
 	complete: boolean;
 } {
+	if (typeof text !== "string") return { first: "", rest: "", complete: false };
 	const boundaryIndex = createFirstSentenceScanner().push(text, true);
 
 	if (boundaryIndex !== undefined) {
@@ -228,6 +232,7 @@ export function extractFirstSentence(text: string): {
  * Useful for streaming to know when to call extractFirstSentence.
  */
 export function hasFirstSentence(text: string): boolean {
+	if (typeof text !== "string") return false;
 	// A boundary at the end of the text still completes a sentence, so this
 	// cannot key off `rest`: a reply that is exactly one sentence leaves it
 	// empty and would report false.


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Pure text-splitting guards; non-string inputs return safe defaults and string chunks continue to scan linearly. No change for valid inputs.

# Background

## What does this PR do?

In `packages/core/src/utils/text-splitting.ts` four exported helpers assumed string inputs: `extractFirstSentence`, `hasFirstSentence`, `createFirstSentenceScanner().push`, and `createFirstSentenceStreamTracker().push`. Passing `null`/`undefined`/`number` caused `TypeError: null is not an object` on `chunk.length`/`text.trim`/`accumulated.length`. Adds fail-closed guards mirroring recent string-guard fixes: `typeof !== "string"` returns empty/false/undefined and leaves scanner state uncorrupted, so malformed streaming deltas do not crash the reply/TTS path.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/text-splitting.ts` and `.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/text-splitting.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:71941cb91130058de876c3f9beb6d320ad7c617c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure string utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure string utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/text-splitting.test.ts` and `bun run --cwd packages/core typecheck` pass. Biome clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 26 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/text-splitting.test.ts:
(pass) extractFirstSentence > does not split inside dotted abbreviations (e.g. / i.e.) [0.60ms]
(pass) extractFirstSentence > still honors the name-title abbreviations (Mr./Dr.)
(pass) extractFirstSentence > does not split at abbreviations preceded by quotes/parens/asterisks
(pass) extractFirstSentence > splits normal sentences at the first real boundary [0.10ms]
(pass) extractFirstSentence > includes trailing closing quotes and brackets in the first sentence [0.05ms]
(pass) extractFirstSentence > returns the whole text when there is no boundary
(pass) extractFirstSentence > preserves Unicode text while recognizing Unicode whitespace [0.04ms]
(pass) hasFirstSentence > reports true when the whole text is one complete sentence
(pass) hasFirstSentence > still reports true when more text follows the first sentence [0.05ms]
(pass) hasFirstSentence > reports false for an incomplete fragment
(pass) hasFirstSentence > is not fooled by an abbreviation mid-fragment
(pass) extractFirstSentence quadratic abbreviation runs > scans stacked title abbreviations without finding a false boundary [6.46ms]
(pass) createFirstSentenceScanner > scans abbreviation-heavy streaming deltas only once [6.31ms]
(pass) createFirstSentenceScanner > does not early-emit a dotted abbreviation split across chunks
(pass) createFirstSentenceScanner > resolves an ambiguous dotted prefix when the next chunk is not an abbreviation
(pass) createFirstSentenceScanner > preserves title state across arbitrary chunk boundaries [0.50ms]
(pass) createFirstSentenceScanner > includes a closer delivered after terminal Hello. [0.02ms]
(pass) createFirstSentenceScanner > includes a closer delivered after terminal Stop! [0.01ms]
(pass) createFirstSentenceScanner > includes a closer delivered after terminal What?
(pass) createFirstSentenceScanner > defers terminal punctuation that becomes a decimal continuation
(pass) createFirstSentenceScanner > consumes closers split across multiple chunks and resolves punctuation at EOF
(pass) createFirstSentenceScanner > matches direct semantics at every split and one-code-unit chunking [0.11ms]
(pass) createFirstSentenceStreamTracker > ignores a late callback from an older structured-stream revision [0.09ms]
(pass) createFirstSentenceStreamTracker > reconciles equal-length prefix rewrites instead of trusting the delta [0.04ms]
(pass) createFirstSentenceStreamTracker > resets and replays authoritative accumulation after a structured retry [0.02ms]
(pass) createFirstSentenceStreamTracker > keeps abbreviation-heavy authoritative streaming append-only [8.59ms]
105 | 					}
106 | 				}
107 | 				pendingBoundary = undefined;
108 | 			}
109 | 
110 | 			for (let offset = 0; offset < chunk.length; offset += 1) {
                                       ^
TypeError: null is not an object (evaluating 'chunk.length')
      at push (/private/tmp/wt-main-1787569365/packages/core/src/utils/text-splitting.ts:110:34)
      at extractFirstSentence (/private/tmp/wt-main-1787569365/packages/core/src/utils/text-splitting.ts:215:53)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/core/src/utils/text-splitting.test.ts:295:10)
(fail) non-string guardrails > returns safe defaults for non-string inputs and handles non-string chunks

1 tests failed:
(fail) non-string guardrails > returns safe defaults for non-string inputs and handles non-string chunks
-------------------------------------------|---------|---------|-------------------
File                                       | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|---------|-------------------
All files                                  |  100.00 |  100.00 |
 packages/core/src/utils/text-splitting.ts |  100.00 |  100.00 | 
-------------------------------------------|---------|---------|-------------------

 26 pass
 1 fail
 40212 expect() calls
Ran 27 tests across 1 file. [131.00ms]
```

**Green (restored, 27 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/text-splitting.test.ts:
(pass) extractFirstSentence > does not split inside dotted abbreviations (e.g. / i.e.) [0.26ms]
(pass) extractFirstSentence > still honors the name-title abbreviations (Mr./Dr.)
(pass) extractFirstSentence > does not split at abbreviations preceded by quotes/parens/asterisks [0.11ms]
(pass) extractFirstSentence > splits normal sentences at the first real boundary [0.02ms]
(pass) extractFirstSentence > includes trailing closing quotes and brackets in the first sentence [0.06ms]
(pass) extractFirstSentence > returns the whole text when there is no boundary
(pass) extractFirstSentence > preserves Unicode text while recognizing Unicode whitespace
(pass) hasFirstSentence > reports true when the whole text is one complete sentence
(pass) hasFirstSentence > still reports true when more text follows the first sentence
(pass) hasFirstSentence > reports false for an incomplete fragment
(pass) hasFirstSentence > is not fooled by an abbreviation mid-fragment
(pass) extractFirstSentence quadratic abbreviation runs > scans stacked title abbreviations without finding a false boundary [5.95ms]
(pass) createFirstSentenceScanner > scans abbreviation-heavy streaming deltas only once [7.23ms]
(pass) createFirstSentenceScanner > does not early-emit a dotted abbreviation split across chunks
(pass) createFirstSentenceScanner > resolves an ambiguous dotted prefix when the next chunk is not an abbreviation
(pass) createFirstSentenceScanner > preserves title state across arbitrary chunk boundaries
(pass) createFirstSentenceScanner > includes a closer delivered after terminal Hello.
(pass) createFirstSentenceScanner > includes a closer delivered after terminal Stop!
(pass) createFirstSentenceScanner > includes a closer delivered after terminal What?
(pass) createFirstSentenceScanner > defers terminal punctuation that becomes a decimal continuation
(pass) createFirstSentenceScanner > consumes closers split across multiple chunks and resolves punctuation at EOF
(pass) createFirstSentenceScanner > matches direct semantics at every split and one-code-unit chunking [0.12ms]
(pass) createFirstSentenceStreamTracker > ignores a late callback from an older structured-stream revision [0.06ms]
(pass) createFirstSentenceStreamTracker > reconciles equal-length prefix rewrites instead of trusting the delta
(pass) createFirstSentenceStreamTracker > resets and replays authoritative accumulation after a structured retry
(pass) createFirstSentenceStreamTracker > keeps abbreviation-heavy authoritative streaming append-only [8.74ms]
(pass) non-string guardrails > returns safe defaults for non-string inputs and handles non-string chunks [0.15ms]
-------------------------------------------|---------|---------|-------------------
File                                       | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|---------|-------------------
All files                                  |  100.00 |  100.00 |
 packages/core/src/utils/text-splitting.ts |  100.00 |  100.00 | 
-------------------------------------------|---------|---------|-------------------

 27 pass
 0 fail
 40227 expect() calls
Ran 27 tests across 1 file. [102.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/text-splitting.test.ts` → Green 27 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean
