### PR TITLE
fix(core): safely handle non-string inputs in buffer utils

### DIFF
--- a/packages/core/src/utils/buffer.test.ts
+++ b/packages/core/src/utils/buffer.test.ts
@@ -71,3 +71,17 @@ describe("byte ops", () => {
 		expect(toHex(randomBytes(8))).not.toBe(toHex(randomBytes(8)));
 	});
 });
+
+describe("non-string guardrails", () => {
+	it("returns empty buffer for non-string hex and string inputs", () => {
+		expect(byteLength(fromHex(null as unknown as string))).toBe(0);
+		expect(byteLength(fromHex(undefined as unknown as string))).toBe(0);
+		expect(byteLength(fromHex(42 as unknown as string))).toBe(0);
+		expect(byteLength(fromHex({} as unknown as string))).toBe(0);
+		expect(toHex(fromHex(""))).toBe("");
+		expect(byteLength(fromString(null as unknown as string))).toBe(0);
+		expect(byteLength(fromString(undefined as unknown as string))).toBe(0);
+		expect(byteLength(fromString(123 as unknown as string))).toBe(0);
+		expect(bufferToString(fromString(""))).toBe("");
+	});
+});

--- a/packages/core/src/utils/buffer.ts
+++ b/packages/core/src/utils/buffer.ts
@@ -25,6 +25,8 @@ function hasNativeBuffer(): boolean {
  * @returns A BufferLike object
  */
 export function fromHex(hex: string): BufferLike {
+	if (typeof hex !== "string")
+		return hasNativeBuffer() ? Buffer.alloc(0) : new Uint8Array(0);
 	// Clean the hex string to remove non-hex characters
 	const cleanHex = hex.replace(/[^0-9a-fA-F]/g, "");
 
@@ -50,6 +52,8 @@ export function fromString(
 	str: string,
 	encoding: "utf8" | "utf-8" | "base64" = "utf8",
 ): BufferLike {
+	if (typeof str !== "string")
+		return hasNativeBuffer() ? Buffer.alloc(0) : new Uint8Array(0);
 	if (hasNativeBuffer()) {
 		const enc = encoding === "utf-8" ? "utf8" : encoding;
 		return Buffer.from(str, enc as BufferEncoding);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Isolated buffer guards; non-string hex/string inputs return empty buffer (0 bytes). No change for valid string inputs.

# Background

## What does this PR do?

In `packages/core/src/utils/buffer.ts` both `fromHex` and `fromString` assumed string inputs and called `hex.replace`/`Buffer.from`/`atob` directly. Passing `null`/`undefined`/`number`/`object` (e.g. malformed secret or API payload) threw `TypeError: null is not an object`. Adds `typeof !== "string"` guards returning an empty `Buffer`/`Uint8Array` (0 bytes), fail-closed and consistent with prior string-guard fixes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/buffer.ts` and `buffer.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/buffer.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a68f19060f957724bcd762960125481fa310deb3 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure buffer utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure buffer utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/buffer.test.ts` and `bun run --cwd packages/core typecheck` pass. Biome clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 8 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/buffer.test.ts:
(pass) hex / string round-trips > utf8 ⇄ hex ⇄ string
(pass) hex / string round-trips > base64 ⇄ utf8
(pass) hex / string round-trips > hex via bufferToString
(pass) isBuffer > recognizes buffer-likes only
(pass) byte ops > alloc fills zeros; fromBytes preserves values
(pass) byte ops > concat and slice compose bytes
(pass) byte ops > equals compares contents and length
(pass) byte ops > randomBytes returns the requested length and varies [0.01ms]
24 |  * @param hex - The hexadecimal string to convert
25 |  * @returns A BufferLike object
26 |  */
27 | export function fromHex(hex: string): BufferLike {
28 | 	// Clean the hex string to remove non-hex characters
29 | 	const cleanHex = hex.replace(/[^0-9a-fA-F]/g, "");
                       ^
TypeError: null is not an object (evaluating 'hex.replace')
      at fromHex (/private/tmp/wt-main-1787569365/packages/core/src/utils/buffer.ts:29:19)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/core/src/utils/buffer.test.ts:77:21)
(fail) non-string guardrails > returns empty buffer for non-string hex and string inputs [0.11ms]
-----------------------------------|---------|---------|-------------------
File                               | % Funcs | % Lines | Uncovered Line #s
-----------------------------------|---------|---------|-------------------
All files                          |  100.00 |   69.34 |
 packages/core/src/utils/buffer.ts |  100.00 |   69.34 | 33,36-39,56,59-66,104,106-108,110-116,149,161,173,176-179,182-187,206,254,257-258
-----------------------------------|---------|---------|-------------------

 8 pass
 1 fail
 21 expect() calls
Ran 9 tests across 1 file. [94.00ms]
```

**Green (restored, 9 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/buffer.test.ts:
(pass) hex / string round-trips > utf8 ⇄ hex ⇄ string [0.66ms]
(pass) hex / string round-trips > base64 ⇄ utf8 [0.05ms]
(pass) hex / string round-trips > hex via bufferToString
(pass) isBuffer > recognizes buffer-likes only
(pass) byte ops > alloc fills zeros; fromBytes preserves values
(pass) byte ops > concat and slice compose bytes
(pass) byte ops > equals compares contents and length
(pass) byte ops > randomBytes returns the requested length and varies [0.02ms]
(pass) non-string guardrails > returns empty buffer for non-string hex and string inputs [0.09ms]
-----------------------------------|---------|---------|-------------------
File                               | % Funcs | % Lines | Uncovered Line #s
-----------------------------------|---------|---------|-------------------
All files                          |  100.00 |   70.21 |
 packages/core/src/utils/buffer.ts |  100.00 |   70.21 | 35,38-41,60,63-70,108,110-112,114-120,153,165,177,180-183,186-191,210,258,261-262
-----------------------------------|---------|---------|-------------------

 9 pass
 0 fail
 30 expect() calls
Ran 9 tests across 1 file. [78.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/buffer.test.ts` → Green 9 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean
