### PR TITLE
fix(core): safely handle non-string inputs in deterministic hash helpers

### DIFF
--- a/packages/core/src/utils/deterministic.test.ts
+++ b/packages/core/src/utils/deterministic.test.ts
@@ -94,6 +94,42 @@ describe("getDeterministicNames / buildDeterministicSeed", () => {
 	});
 });
 
+describe("hashStringToUint32 / shortStringHash non-string guard", () => {
+	it("returns empty-string hash for non-string inputs without throwing", () => {
+		const emptyHash = 0x811c9dc5;
+		const emptyShort = "1505";
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32(null)).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32(undefined)).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32(123)).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32(true)).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32({})).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(hashStringToUint32([])).toBe(emptyHash);
+		// @ts-expect-error runtime guard check
+		expect(shortStringHash(null)).toBe(emptyShort);
+		// @ts-expect-error runtime guard check
+		expect(shortStringHash(undefined)).toBe(emptyShort);
+		// @ts-expect-error runtime guard check
+		expect(shortStringHash(123)).toBe(emptyShort);
+		// @ts-expect-error runtime guard check
+		expect(shortStringHash(false)).toBe(emptyShort);
+		// @ts-expect-error runtime guard check
+		expect(shortStringHash({})).toBe(emptyShort);
+	});
+
+	it("still hashes string inputs correctly after guard", () => {
+		expect(hashStringToUint32("hello")).toBe(hashStringToUint32("hello"));
+		expect(hashStringToUint32("hello")).not.toBe(0x811c9dc5);
+		expect(shortStringHash("hello")).toBe("e2f5ecef");
+		expect(shortStringHash("hello")).not.toBe("1505");
+	});
+});
+
 describe("stableStringify", () => {
 	it("is independent of key insertion order", () => {
 		expect(stableStringify({ b: 1, a: 2 })).toBe(

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -21,6 +21,7 @@ export function buildDeterministicSeed(
 }
 
 export function hashStringToUint32(value: string): number {
+	if (typeof value !== "string") return 0x811c9dc5;
 	let hash = 0x811c9dc5;
 	for (let i = 0; i < value.length; i += 1) {
 		hash ^= value.charCodeAt(i);
@@ -31,6 +32,7 @@ export function hashStringToUint32(value: string): number {
 
 /** Produce the compact non-cryptographic fingerprint used for trace keys. */
 export function shortStringHash(value: string): string {
+	if (typeof value !== "string") return "1505";
 	let hash = 5381;
 	for (let index = 0; index < value.length; index += 1) {
 		hash = ((hash * 31) ^ value.charCodeAt(index)) >>> 0;


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Pure guard addition returning empty-string hash constants for non-string inputs. No behavioral change for valid string inputs. Only affects callers passing null/undefined/number/object which previously threw TypeError.

# Background

## What does this PR do?

Guards `hashStringToUint32` and `shortStringHash` in `packages/core/src/utils/deterministic.ts` against non-string inputs. Previously `null`, `undefined`, `number`, `boolean`, `object` caused `TypeError: value.length` / `value.charCodeAt is not a function`. Now returns the empty-string hash constants (`0x811c9dc5` and `"1505"`) without throwing, preserving the deterministic contract for invalid inputs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/deterministic.ts` (2-line guards) and `packages/core/src/utils/deterministic.test.ts` (new non-string guard suite).

## Detailed testing steps

- `bun test packages/core/src/utils/deterministic.test.ts` — expect 14 pass (2 new guard tests)
- Revert `deterministic.ts` guard, re-run same suite — expect 1 fail (`TypeError: null is not an object (evaluating 'value.length')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:12bc2f9ef4e0a3fa7013e7ea70ebec8b269f17d2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure utility fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - utility unit test, no backend service`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure utility`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - utility unit test. Test output:

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 14 pass
 0 fail
 54 expect() calls
Ran 14 tests across 1 file. [75.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
bun test v1.3.11 (af24e281)

TypeError: null is not an object (evaluating 'value.length')
      at hashStringToUint32 (/private/tmp/wt-batch-20260824/packages/core/src/utils/deterministic.ts:25:22)
      at <anonymous> (/private/tmp/wt-batch-20260824/packages/core/src/utils/deterministic.test.ts:102:10)
(fail) hashStringToUint32 / shortStringHash non-string guard > returns empty-string hash for non-string inputs without throwing [0.11ms]

 13 pass
 1 fail
 43 expect() calls
Ran 14 tests across 1 file. [97.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, pure utility fix.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` / `bun run check` fails pre-existing: `Cannot find package 'yaml' imported from packages/scripts/ci-bun-version-contract.mjs` — reproducible on origin/develop without this diff.
- `bun run --cwd packages/core typecheck` fails pre-existing: `error TS2688: Cannot find type definition file for 'node'` and `TS5103: Invalid value for '--ignoreDeprecations'` — reproducible on origin/develop without this diff.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
