### PR TITLE
fix(core): safely handle non-string inputs in buffer helpers

### DIFF
--- a/packages/core/src/utils/buffer.test.ts
+++ b/packages/core/src/utils/buffer.test.ts
@@ -48,6 +48,36 @@ describe("isBuffer", () => {
 	});
 });
 
+describe("non-string inputs", () => {
+	it("fromHex and fromString return empty buffer without throwing on non-string", () => {
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromHex(null))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromHex(undefined))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromHex(123))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromHex({}))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(toHex(fromHex(null))).toBe("");
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromString(null))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromString(undefined))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromString(123))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(byteLength(fromString({} as unknown as string))).toBe(0);
+		// @ts-expect-error runtime guard check
+		expect(toHex(fromString(null))).toBe("");
+	});
+
+	it("still round-trips string inputs after guard", () => {
+		expect(toHex(fromString("Hello"))).toBe("48656c6c6f");
+		expect(bufferToString(fromHex("48656c6c6f"))).toBe("Hello");
+	});
+});
+
 describe("byte ops", () => {
 	it("alloc fills zeros; fromBytes preserves values", () => {
 		expect(toHex(alloc(4))).toBe("00000000");

--- a/packages/core/src/utils/buffer.ts
+++ b/packages/core/src/utils/buffer.ts
@@ -25,6 +25,9 @@ function hasNativeBuffer(): boolean {
  * @returns A BufferLike object
  */
 export function fromHex(hex: string): BufferLike {
+	if (typeof hex !== "string") {
+		return hasNativeBuffer() ? Buffer.alloc(0) : new Uint8Array(0);
+	}
 	// Clean the hex string to remove non-hex characters
 	const cleanHex = hex.replace(/[^0-9a-fA-F]/g, "");
 
@@ -50,6 +53,9 @@ export function fromString(
 	str: string,
 	encoding: "utf8" | "utf-8" | "base64" = "utf8",
 ): BufferLike {
+	if (typeof str !== "string") {
+		return hasNativeBuffer() ? Buffer.alloc(0) : new Uint8Array(0);
+	}
 	if (hasNativeBuffer()) {
 		const enc = encoding === "utf-8" ? "utf8" : encoding;
 		return Buffer.from(str, enc as BufferEncoding);


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds early return for non-string inputs in two pure utility functions. Returns empty buffer (same as empty string) without throwing. No change for valid string inputs.

# Background

## What does this PR do?

Guards `fromHex` and `fromString` in `packages/core/src/utils/buffer.ts` against non-string inputs. Previously `null`, `undefined`, `number`, `object` caused `TypeError: hex.replace` / `Buffer.from` throws. Now returns an empty buffer (`Buffer.alloc(0)` / `new Uint8Array(0)`) without throwing.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/buffer.ts` (2 guards) and `packages/core/src/utils/buffer.test.ts` (new non-string suite).

## Detailed testing steps

- `bun test packages/core/src/utils/buffer.test.ts` — expect 10 pass
- Revert `buffer.ts` guards, re-run same suite — expect 1 fail (`TypeError: null is not an object (evaluating 'hex.replace')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:79fa4f3a3fe4a5ae70fa9ecdfb08ddcc4167dc9d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure utility`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure utility`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - utility unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 10 pass
 0 fail
 33 expect() calls
Ran 10 tests across 1 file. [73.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: null is not an object (evaluating 'hex.replace')
      at fromHex (/private/tmp/wt-batch-20260824/packages/core/src/utils/buffer.ts:29:19)
      at <anonymous> (/private/tmp/wt-batch-20260824/packages/core/src/utils/buffer.test.ts:54:21)
(fail) non-string inputs > fromHex and fromString return empty buffer without throwing on non-string [0.14ms]
 9 pass
 1 fail
 23 expect() calls
Ran 10 tests across 1 file. [78.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- `bun run --cwd packages/core typecheck` fails pre-existing: `TS2688: Cannot find type definition file for 'node'` — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
