### PR TITLE
fix(agent): safely handle non-string inputs in telegram command normalization

### DIFF
--- a/packages/agent/src/config/telegram-custom-commands.test.ts
+++ b/packages/agent/src/config/telegram-custom-commands.test.ts
@@ -48,6 +48,22 @@ describe("normalizeTelegramCommandName", () => {
   it("does not strip a second leading slash after the first", () => {
     expect(normalizeTelegramCommandName("//help")).toBe("/help");
   });
+
+  it("returns empty string for non-string inputs without throwing", () => {
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName(null)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName(undefined)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName(123)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName({})).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName([])).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandName(true)).toBe("");
+    expect(normalizeTelegramCommandName("")).toBe("");
+  });
 });
 
 describe("normalizeTelegramCommandDescription", () => {
@@ -57,6 +73,21 @@ describe("normalizeTelegramCommandDescription", () => {
     );
     expect(normalizeTelegramCommandDescription("   ")).toBe("");
     expect(normalizeTelegramCommandDescription("")).toBe("");
+  });
+
+  it("returns empty string for non-string inputs without throwing", () => {
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription(null)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription(undefined)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription(123)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription({})).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription([])).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(normalizeTelegramCommandDescription(false)).toBe("");
   });
 });
 

--- a/packages/agent/src/config/telegram-custom-commands.ts
+++ b/packages/agent/src/config/telegram-custom-commands.ts
@@ -19,6 +19,7 @@ export type TelegramCustomCommandIssue = {
 };
 
 export function normalizeTelegramCommandName(value: string): string {
+  if (typeof value !== "string") return "";
   const trimmed = value.trim();
   if (!trimmed) {
     return "";
@@ -28,6 +29,7 @@ export function normalizeTelegramCommandName(value: string): string {
 }
 
 export function normalizeTelegramCommandDescription(value: string): string {
+  if (typeof value !== "string") return "";
   return value.trim();
 }
 


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds type guard returning empty string for non-string inputs. Previously threw TypeError. No change for valid string inputs. Affects config loading where runtime may pass null/undefined/number via untyped boundaries.

# Background

## What does this PR do?

Guards `normalizeTelegramCommandName` and `normalizeTelegramCommandDescription` in `packages/agent/src/config/telegram-custom-commands.ts` against non-string inputs. Previously `null`/`undefined`/`number`/`object`/`boolean` caused `TypeError: value.trim`. Now returns `""` without throwing, letting `resolveTelegramCustomCommands` surface proper "missing command name/description" issues.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/config/telegram-custom-commands.ts` (2 guards) and `packages/agent/src/config/telegram-custom-commands.test.ts` (2 new suites).

## Detailed testing steps

- `bun test packages/agent/src/config/telegram-custom-commands.test.ts` — expect 24 pass
- Revert guards, re-run same suite — expect 22 pass 2 fail (`TypeError: null is not an object (evaluating 'value.trim')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0ef88efa0440e36f812553c5754c519ac375e8d3 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure config fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure config fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure config fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure config fix`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 24 pass
 0 fail
 64 expect() calls
Ran 24 tests across 1 file. [72.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: null is not an object (evaluating 'value.trim')
      at normalizeTelegramCommandName (/private/tmp/wt-batch-20260824/packages/agent/src/config/telegram-custom-commands.ts:22:19)
(fail) normalizeTelegramCommandName > returns empty string for non-string inputs without throwing [0.48ms]
TypeError: null is not an object (evaluating 'value.trim')
      at normalizeTelegramCommandDescription (/private/tmp/wt-batch-20260824/packages/agent/src/config/telegram-custom-commands.ts:31:10)
(fail) normalizeTelegramCommandDescription > returns empty string for non-string inputs without throwing
 22 pass
 2 fail
 51 expect() calls
Ran 24 tests across 1 file. [74.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- `bun run --cwd packages/agent typecheck` / core typecheck fails pre-existing: `TS2688: Cannot find type definition file for 'node'` — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
