### PR TITLE
test(core): cover documents ModelConfigSchema

### DIFF
--- a/packages/core/src/features/documents/types.test.ts
+++ b/packages/core/src/features/documents/types.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Covers `ModelConfigSchema`, the documents capability's model-configuration
+ * validation boundary consumed by `validateModelConfig` at service startup:
+ * required keys without defaults, provider enum membership, boolean flag
+ * defaults, the safe-integer ceiling, and union rejection of non-string /
+ * non-number inputs. Deterministic: every case drives the real exported
+ * schema with no mocks and no environment coupling.
+ */
+import { describe, expect, it } from "vitest";
+import { ModelConfigSchema } from "./types.ts";
+
+const minimalValidConfig = {
+	TEXT_EMBEDDING_MODEL: "local-embedding",
+	MAX_INPUT_TOKENS: 4000,
+};
+
+describe("ModelConfigSchema", () => {
+	it("requires TEXT_EMBEDDING_MODEL", () => {
+		const result = ModelConfigSchema.safeParse({
+			MAX_INPUT_TOKENS: 4000,
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some((issue) =>
+					issue.path.includes("TEXT_EMBEDDING_MODEL"),
+				),
+			).toBe(true);
+		}
+	});
+
+	it("requires MAX_INPUT_TOKENS because it carries no default", () => {
+		const result = ModelConfigSchema.safeParse({
+			TEXT_EMBEDDING_MODEL: "local-embedding",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some((issue) =>
+					issue.path.includes("MAX_INPUT_TOKENS"),
+				),
+			).toBe(true);
+		}
+	});
+
+	it("accepts every supported embedding provider and preserves it", () => {
+		for (const provider of ["local", "openai", "google"] as const) {
+			expect(
+				ModelConfigSchema.parse({
+					...minimalValidConfig,
+					EMBEDDING_PROVIDER: provider,
+				}).EMBEDDING_PROVIDER,
+			).toBe(provider);
+		}
+	});
+
+	it("rejects an embedding provider outside the supported set", () => {
+		expect(
+			ModelConfigSchema.safeParse({
+				...minimalValidConfig,
+				EMBEDDING_PROVIDER: "azure",
+			}).success,
+		).toBe(false);
+	});
+
+	it.each(["openai", "anthropic", "openrouter", "google"] as const)(
+		"accepts %s as a text provider",
+		(provider) => {
+			expect(
+				ModelConfigSchema.parse({
+					...minimalValidConfig,
+					TEXT_PROVIDER: provider,
+				}).TEXT_PROVIDER,
+			).toBe(provider);
+		},
+	);
+
+	it("rejects a text provider outside the supported set", () => {
+		expect(
+			ModelConfigSchema.safeParse({
+				...minimalValidConfig,
+				TEXT_PROVIDER: "cohere",
+			}).success,
+		).toBe(false);
+	});
+
+	it("leaves optional providers unset when omitted", () => {
+		const parsed = ModelConfigSchema.parse(minimalValidConfig);
+
+		expect(parsed.EMBEDDING_PROVIDER).toBeUndefined();
+		expect(parsed.TEXT_PROVIDER).toBeUndefined();
+	});
+
+	it("defaults the document-loading and rate-limit flags", () => {
+		expect(ModelConfigSchema.parse(minimalValidConfig)).toMatchObject({
+			LOAD_DOCS_ON_STARTUP: false,
+			CTX_DOCUMENTS_ENABLED: false,
+			RATE_LIMIT_ENABLED: true,
+		});
+	});
+
+	it("lets explicit flag overrides win over the defaults", () => {
+		expect(
+			ModelConfigSchema.parse({
+				...minimalValidConfig,
+				LOAD_DOCS_ON_STARTUP: true,
+				CTX_DOCUMENTS_ENABLED: true,
+				RATE_LIMIT_ENABLED: false,
+			}),
+		).toMatchObject({
+			LOAD_DOCS_ON_STARTUP: true,
+			CTX_DOCUMENTS_ENABLED: true,
+			RATE_LIMIT_ENABLED: false,
+		});
+	});
+
+	it("rejects settings matching neither string nor number union member", () => {
+		for (const value of [null, true, { tokens: 4000 }, [4000]]) {
+			const result = ModelConfigSchema.safeParse({
+				...minimalValidConfig,
+				MAX_INPUT_TOKENS: value,
+			});
+
+			expect(result.success, `unexpectedly accepted ${String(value)}`).toBe(
+				false,
+			);
+		}
+	});
+
+	it("accepts Number.MAX_SAFE_INTEGER as the unbounded setting ceiling", () => {
+		const numberForm = ModelConfigSchema.parse({
+			...minimalValidConfig,
+			TOKENS_PER_MINUTE: Number.MAX_SAFE_INTEGER,
+		});
+
+		expect(numberForm.TOKENS_PER_MINUTE).toBe(Number.MAX_SAFE_INTEGER);
+
+		const stringForm = ModelConfigSchema.parse({
+			TEXT_EMBEDDING_MODEL: "local-embedding",
+			MAX_INPUT_TOKENS: "9007199254740991",
+			TOKENS_PER_MINUTE: "9007199254740991",
+		});
+
+		expect(stringForm.MAX_INPUT_TOKENS).toBe(Number.MAX_SAFE_INTEGER);
+		expect(stringForm.TOKENS_PER_MINUTE).toBe(Number.MAX_SAFE_INTEGER);
+	});
+});


### PR DESCRIPTION

## What

Adds a deterministic unit suite for `packages/core/src/features/documents/types.ts`, which previously had no same-named test file anywhere in the repository.

`types.ts` carries a real runtime validation boundary: `ModelConfigSchema`, the zod schema that `validateModelConfig` (`packages/core/src/features/documents/config.ts`) runs against model/embedding settings at document-service startup. Environment values arrive as strings, so the schema's string-to-safe-integer coercion path is load-bearing behavior, not an implementation detail.

The new suite drives only the real exported schema — no mocks, no environment coupling:

- **Required keys:** `TEXT_EMBEDDING_MODEL` and `MAX_INPUT_TOKENS` (which carries no default) must be present; missing either fails with an issue on the right path.
- **Provider enums:** each supported `EMBEDDING_PROVIDER` (`local`, `openai`, `google`) and `TEXT_PROVIDER` (`openai`, `anthropic`, `openrouter`, `google`) value round-trips; unsupported providers are rejected; omitted optional providers stay unset.
- **Boolean flag defaults:** `LOAD_DOCS_ON_STARTUP` / `CTX_DOCUMENTS_ENABLED` default to `false`, `RATE_LIMIT_ENABLED` defaults to `true`; explicit overrides win.
- **Union strictness:** settings matching neither union member (`null`, `true`, object, array) are rejected rather than coerced.
- **Safe-integer ceiling:** `Number.MAX_SAFE_INTEGER` is accepted for unbounded settings in both numeric and string form.

It intentionally does not duplicate `config-numeric-validation.test.ts`, which already covers malformed-value rejection, numeric defaults, and the `BATCH_DELAY_MS` runtime ceiling; this suite covers the disjoint branches above.

## Test-only

This diff adds one new test file and changes no production behavior: +149/-0, single file.

## Evidence

- `bunx vitest run packages/core/src/features/documents/types.test.ts` — **Test Files 1 passed (1), Tests 14 passed (14)**, re-run immediately before filing against current `origin/develop` (`de774b87`).
- `bunx biome check --write packages/core/src/features/documents/types.test.ts` — clean, "No fixes applied".
- `bunx tsc --noEmit` in `packages/core` — exits 0 with zero output; the new file appears nowhere.
- The diff touches only `packages/core/src/features/documents/types.test.ts`.

Note: this comes from a fork, so hosted CI does not run on this pull request; the counts above are from local runs of the pinned toolchain.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6af077b7961bbdd8d259a1cc5e616f9500b1b4d9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
