### PR TITLE
fix(cloud): safely handle non-string inputs in agent username helpers

### DIFF
--- a/packages/cloud/shared/src/lib/utils/agent-username.test.ts
+++ b/packages/cloud/shared/src/lib/utils/agent-username.test.ts
@@ -71,3 +71,49 @@ describe("extractUsernameFromPath", () => {
     expect(extractUsernameFromPath("/other/path")).toBeNull();
   });
 });
+
+describe("non-string guards", () => {
+  test("validateUsername rejects non-string without throwing", () => {
+    // @ts-expect-error runtime guard check
+    expect(validateUsername(null).valid).toBe(false);
+    // @ts-expect-error runtime guard check
+    expect(validateUsername(undefined).valid).toBe(false);
+    // @ts-expect-error runtime guard check
+    expect(validateUsername(123).valid).toBe(false);
+    // @ts-expect-error runtime guard check
+    expect(validateUsername({}).valid).toBe(false);
+    // @ts-expect-error runtime guard check
+    expect(validateUsername([]).valid).toBe(false);
+    // @ts-expect-error runtime guard check
+    expect(validateUsername(true).valid).toBe(false);
+  });
+
+  test("slugify and generate helpers return safe defaults for non-string", () => {
+    // @ts-expect-error runtime guard check
+    expect(slugify(null)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(slugify(undefined)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(slugify(123)).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(slugify({})).toBe("");
+    // @ts-expect-error runtime guard check
+    expect(generateUsernameFromName(null).length).toBeGreaterThanOrEqual(3);
+    // @ts-expect-error runtime guard check
+    expect(generateUsernameFromName(undefined).length).toBeGreaterThanOrEqual(3);
+    // @ts-expect-error runtime guard check
+    expect(generateUsernameFromName(123).length).toBeGreaterThanOrEqual(3);
+    // @ts-expect-error runtime guard check
+    expect(generateUniqueUsername(null, new Set())).toBeDefined();
+    // @ts-expect-error runtime guard check
+    expect(generateUniqueUsername(undefined, new Set())).toBeDefined();
+    // @ts-expect-error runtime guard check
+    expect(extractUsernameFromPath(null)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(extractUsernameFromPath(undefined)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(extractUsernameFromPath(123)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(extractUsernameFromPath({})).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/agent-username.ts
+++ b/packages/cloud/shared/src/lib/utils/agent-username.ts
@@ -70,6 +70,9 @@ export const RESERVED_USERNAMES = new Set([
  * Validates a username against all rules.
  */
 export function validateUsername(username: string): UsernameValidationResult {
+  if (typeof username !== "string") {
+    return { valid: false, error: "Username must be a string" };
+  }
   // Normalize to lowercase
   const normalized = username.toLowerCase().trim();
 
@@ -135,6 +138,7 @@ export function validateUsername(username: string): UsernameValidationResult {
  * slugify("___Test---Agent___") // "test-agent"
  */
 export function slugify(name: string): string {
+  if (typeof name !== "string") return "";
   return (
     name
       .toLowerCase()
@@ -166,6 +170,7 @@ function padToMinLength(str: string): string {
  * Result may still need a uniqueness check.
  */
 export function generateUsernameFromName(name: string): string {
+  if (typeof name !== "string") return padToMinLength("");
   let slug = slugify(name);
 
   // Ensure minimum length
@@ -204,6 +209,7 @@ export function generateUniqueUsername(
   baseUsername: string,
   existingUsernames: Set<string>,
 ): string {
+  if (typeof baseUsername !== "string") return padToMinLength("");
   // If base doesn't exist, use it
   if (!existingUsernames.has(baseUsername)) {
     return baseUsername;
@@ -239,6 +245,7 @@ export function generateUniqueUsername(
  * Extracts username from a URL path like /chat/@username
  */
 export function extractUsernameFromPath(path: string): string | null {
+  if (typeof path !== "string") return null;
   const match = path.match(/\/@([a-z0-9]+(?:-[a-z0-9]+)*)/);
   return match ? match[1] : null;
 }


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds type guards returning invalid/empty defaults for non-string inputs. No change for valid string inputs. Affects cloud routing/username validation where untyped JSON may pass non-string.

# Background

## What does this PR do?

Guards five helpers in `packages/cloud/shared/src/lib/utils/agent-username.ts` (`validateUsername`, `slugify`, `generateUsernameFromName`, `generateUniqueUsername`, `extractUsernameFromPath`) against non-string inputs. Previously `null`, `undefined`, `number`, `object` caused `TypeError: toLowerCase` / `path.match`. Now returns safe defaults without throwing (`validateUsername` → invalid result, `slugify` → `""`, `extractUsernameFromPath` → `null`, generators → padded safe username).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/agent-username.ts` (5 guards) and `packages/cloud/shared/src/lib/utils/agent-username.test.ts` (2 new suites).

## Detailed testing steps

- `bun test packages/cloud/shared/src/lib/utils/agent-username.test.ts` — expect 8 pass
- Revert guards, re-run same suite — expect 6 pass 2 fail (`TypeError: null is not an object (evaluating 'username.toLowerCase')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:cc41eacc583dffbf1ad19bd8aca3d8bf70a73efd -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure utility`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure utility`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 8 pass
 0 fail
 39 expect() calls
Ran 8 tests across 1 file. [73.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: null is not an object (evaluating 'username.toLowerCase')
      at validateUsername (/private/tmp/wt-batch-20260824/packages/cloud/shared/src/lib/utils/agent-username.ts:74:22)
(fail) non-string guards > validateUsername rejects non-string without throwing [0.49ms]
TypeError: null is not an object (evaluating 'name.toLowerCase')
      at slugify (/private/tmp/wt-batch-20260824/packages/cloud/shared/src/lib/utils/agent-username.ts:139:5)
(fail) non-string guards > slugify and generate helpers return safe defaults for non-string [0.01ms]
 6 pass
 2 fail
 20 expect() calls
Ran 8 tests across 1 file. [70.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- `bun run --cwd packages/cloud typecheck` (if applicable) pre-existing similar TS config issues — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
