### PR TITLE
fix(cloud): safely handle non-string inputs in sanitizeUUID

### DIFF
--- a/packages/cloud/shared/src/lib/utils/validation.test.ts
+++ b/packages/cloud/shared/src/lib/utils/validation.test.ts
@@ -54,4 +54,17 @@ describe("sanitizeUUID", () => {
     expect(sanitizeUUID(null)).toBeUndefined();
     expect(sanitizeUUID(undefined)).toBeUndefined();
   });
+
+  it("returns undefined for non-string without throwing", () => {
+    // @ts-expect-error runtime guard check
+    expect(sanitizeUUID(123)).toBeUndefined();
+    // @ts-expect-error runtime guard check
+    expect(sanitizeUUID(true)).toBeUndefined();
+    // @ts-expect-error runtime guard check
+    expect(sanitizeUUID({} as unknown as string)).toBeUndefined();
+    // @ts-expect-error runtime guard check
+    expect(sanitizeUUID([] as unknown as string)).toBeUndefined();
+    // @ts-expect-error runtime guard check
+    expect(sanitizeUUID(0 as unknown as string)).toBeUndefined();
+  });
 });

--- a/packages/cloud/shared/src/lib/utils/validation.ts
+++ b/packages/cloud/shared/src/lib/utils/validation.ts
@@ -40,6 +40,7 @@ export function isValidUUID(value: string): boolean {
  * @returns The sanitized UUID if valid, undefined otherwise.
  */
 export function sanitizeUUID(value: string | undefined | null): string | undefined {
+  if (typeof value !== "string") return undefined;
   if (!value) return undefined;
 
   // Remove URL-encoded garbage that commonly appends to UUIDs:


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds typeof guard returning undefined for non-string inputs. No change for valid string/undefined/null inputs. Previously number/boolean/object threw TypeError.

# Background

## What does this PR do?

Guards `sanitizeUUID` in `packages/cloud/shared/src/lib/utils/validation.ts` against non-string inputs. Previously `sanitizeUUID(123)` or `sanitizeUUID(true)` threw `TypeError: value.trim is not a function`. Now returns `undefined` without throwing, preserving fail-closed contract. `isValidUUID` already safe via regex coercion, so only `sanitizeUUID` needed guard.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/utils/validation.ts` (1 guard) and `packages/cloud/shared/src/lib/utils/validation.test.ts` (1 new suite).

## Detailed testing steps

- `bun test packages/cloud/shared/src/lib/utils/validation.test.ts` — expect 9 pass
- Revert guard, re-run same suite — expect 8 pass 1 fail (`TypeError: value.trim is not a function`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9d0eb0f82d6dba7ba1b56b6a62436232bb499cab -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure utility`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure utility`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure utility`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 9 pass
 0 fail
 20 expect() calls
Ran 9 tests across 1 file. [71.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: value.trim is not a function. (In 'value.trim()', 'value.trim' is undefined)
      at sanitizeUUID (/private/tmp/wt-batch-20260824/packages/cloud/shared/src/lib/utils/validation.ts:49:25)
(fail) sanitizeUUID > returns undefined for non-string without throwing [0.50ms]
 8 pass
 1 fail
 15 expect() calls
Ran 9 tests across 1 file. [69.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- Full `packages/cloud/shared` test suite has pre-existing failures (tenant-scope, drizzle, etc.) unrelated to this change — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
