### PR TITLE
fix(shared): safely handle non-string inputs in eliza cloud domain contract

### DIFF
--- a/packages/shared/src/elizacloud/domain-contract.test.ts
+++ b/packages/shared/src/elizacloud/domain-contract.test.ts
@@ -185,4 +185,29 @@ describe("Eliza domain contract", () => {
     expect(canonicalCloudPathForLegacyDashboard("/cloud/agents")).toBeNull();
     expect(canonicalCloudPathForLegacyDashboard("/dashboard-old")).toBeNull();
   });
+
+  it("returns safe defaults for non-string inputs without throwing", () => {
+    // @ts-expect-error runtime guard check
+    expect(canonicalElizaServiceHostname(null)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(canonicalElizaServiceHostname(undefined)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(canonicalElizaServiceHostname(123)).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(canonicalElizaServiceHostname({})).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(canonicalElizaServiceHostname([])).toBeNull();
+    // @ts-expect-error runtime guard check
+    expect(classifyElizaHostname(null).role).toBe("unknown");
+    // @ts-expect-error runtime guard check
+    expect(classifyElizaHostname(undefined).role).toBe("unknown");
+    // @ts-expect-error runtime guard check
+    expect(classifyElizaHostname(123).role).toBe("unknown");
+    // @ts-expect-error runtime guard check
+    expect(classifyElizaHostname({}).role).toBe("unknown");
+    // @ts-expect-error runtime guard check
+    expect(classifyElizaHostname(true).role).toBe("unknown");
+    expect(canonicalElizaServiceHostname("")).toBeNull();
+    expect(classifyElizaHostname("").role).toBe("unknown");
+  });
 });

--- a/packages/shared/src/elizacloud/domain-contract.ts
+++ b/packages/shared/src/elizacloud/domain-contract.ts
@@ -207,6 +207,7 @@ function mapServiceHostname(
 export function canonicalElizaServiceHostname(
   rawHostname: string,
 ): string | null {
+  if (typeof rawHostname !== "string") return null;
   const hostname = rawHostname.trim().toLowerCase().replace(/\.$/, "");
   for (const environment of ["staging", "production"] as const) {
     const mapped = mapServiceHostname(
@@ -284,6 +285,14 @@ function classification(
 export function classifyElizaHostname(
   rawHostname: string,
 ): ElizaHostnameClassification {
+  if (typeof rawHostname !== "string") {
+    return {
+      role: "unknown",
+      environment: null,
+      canonicalHostname: null,
+      agentId: null,
+    };
+  }
   const hostname = rawHostname.trim().toLowerCase().replace(/\.$/, "");
 
   // Staging suffixes are more specific (`*.staging.elizacloud.ai`) than the


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds type guards returning safe defaults for non-string hostnames. No change for valid string inputs. Previously non-string caused TypeError.

# Background

## What does this PR do?

Guards `canonicalElizaServiceHostname` and `classifyElizaHostname` in `packages/shared/src/elizacloud/domain-contract.ts` against non-string inputs. Previously `null`/`undefined`/`number`/`object` caused `TypeError: rawHostname.trim`. Now returns `null` / `unknown` role without throwing, preserving fail-closed routing contract.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/elizacloud/domain-contract.ts` (2 guards) and `packages/shared/src/elizacloud/domain-contract.test.ts` (1 new suite).

## Detailed testing steps

- `bun test packages/shared/src/elizacloud/domain-contract.test.ts` — expect 46 pass
- Revert guards, re-run same suite — expect 45 pass 1 fail (`TypeError: null is not an object (evaluating 'rawHostname.trim')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:bf511aef4950063a3370314d8883667e8448786b -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure routing contract`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure routing contract`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure routing contract`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure routing contract`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no routing contract change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 46 pass
 0 fail
 68 expect() calls
Ran 46 tests across 1 file. [72.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: null is not an object (evaluating 'rawHostname.trim')
      at canonicalElizaServiceHostname (/private/tmp/wt-batch-20260824/packages/shared/src/elizacloud/domain-contract.ts:210:20)
(fail) Eliza domain contract > returns safe defaults for non-string inputs without throwing [0.07ms]
 45 pass
 1 fail
 56 expect() calls
Ran 46 tests across 1 file. [76.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- `bun run --cwd packages/shared typecheck` may show pre-existing TS config issues — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
