### PR TITLE
fix(shared): safely handle non-string inputs in validateHostExecutionPath

### DIFF
--- a/packages/shared/src/host-execution-env.test.ts
+++ b/packages/shared/src/host-execution-env.test.ts
@@ -55,6 +55,15 @@ describe("host execution boot baseline", () => {
     expect(validateHostExecutionPath("/bin\0/tmp")).toBeUndefined();
   });
 
+  it("returns undefined for non-string inputs", () => {
+    expect(
+      validateHostExecutionPath(null as unknown as string),
+    ).toBeUndefined();
+    expect(validateHostExecutionPath(42 as unknown as string)).toBeUndefined();
+    expect(validateHostExecutionPath({} as unknown as string)).toBeUndefined();
+    expect(validateHostExecutionPath("" as unknown as string)).toBeUndefined();
+  });
+
   it("accepts the Windows Path casing but rejects ambiguous case variants", () => {
     expect(
       createHostExecutionBaseline({ Path: "C:\\Windows\\System32" }, "win32")

--- a/packages/shared/src/host-execution-env.ts
+++ b/packages/shared/src/host-execution-env.ts
@@ -30,7 +30,8 @@ export function validateHostExecutionPath(
   value: string | undefined,
   platform: NodeJS.Platform = process.platform,
 ): string | undefined {
-  if (!value || value.includes("\0")) return undefined;
+  if (typeof value !== "string" || !value || value.includes("\0"))
+    return undefined;
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   const entries = value.split(pathApi.delimiter);
   if (


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Isolated guard in host execution path validation; non-string inputs return undefined fail-closed. No change for valid string paths.

# Background

## What does this PR do?

In `packages/shared/src/host-execution-env.ts` `validateHostExecutionPath` assumed `value` was string-or-undefined and called `value.includes("\0")` and `value.split` directly. Passing `null`/`number`/`object` (e.g. corrupted env mirror or malformed caller) threw `TypeError: value.includes is not a function`. Adds `typeof value !== "string"` guard returning `undefined` fail-closed, matching the project's recent string-guard pattern.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/shared/src/host-execution-env.ts` and `host-execution-env.test.ts`.

## Detailed testing steps

Run `bun test packages/shared/src/host-execution-env.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:057e38b0e0a1382edf671ba9d9abf9794ca2c22f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure env utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure env utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

- `bun run --cwd packages/shared typecheck` fails with pre-existing unrelated errors: `core/src/cloud-routing.ts: Cannot find module '@elizaos/cloud-routing'` and `src/todo-cutover.ts: Cannot find module '@elizaos/core/edge'`. `bun run --cwd packages/core typecheck` passes. Verified by running same typecheck on clean `origin/develop` (same errors).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 9 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/shared/src/host-execution-env.test.ts:
(pass) host execution boot baseline > captures before a later PATH write in a fresh process [14.53ms]
(pass) host execution boot baseline > keeps a fresh process capture after later environment mutation [0.12ms]
(pass) host execution boot baseline > fails closed for absent, relative, empty-entry, and NUL paths
28 | 
29 | export function validateHostExecutionPath(
30 |   value: string | undefined,
31 |   platform: NodeJS.Platform = process.platform,
32 | ): string | undefined {
33 |   if (!value || value.includes("\0")) return undefined;
                           ^
TypeError: value.includes is not a function. (In 'value.includes("\x00")', 'value.includes' is undefined)
      at validateHostExecutionPath (/private/tmp/wt-main-1787569365/packages/shared/src/host-execution-env.ts:33:23)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/shared/src/host-execution-env.test.ts:62:12)
(fail) host execution boot baseline > returns undefined for non-string inputs
(pass) host execution boot baseline > accepts the Windows Path casing but rejects ambiguous case variants
(pass) host execution boot baseline > adds only PATH to an already-sanitized environment
(pass) host execution boot baseline > rejects executable paths outside the captured PATH directories [0.91ms]
(pass) host execution baseline env mirror > capture publishes the authority for uncaptured module instances [13.14ms]
(pass) host execution baseline env mirror > rejects an invalid mirrored value instead of trusting it [13.05ms]
(pass) host execution baseline env mirror > stays empty when no capture ran and no mirror is set [13.22ms]
-------------------------------------------|---------|---------|-------------------
File                                       | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|---------|-------------------
All files                                  |  100.00 |   85.42 |
 packages/shared/src/host-execution-env.ts |  100.00 |   85.42 | 81-85,122-129
-------------------------------------------|---------|---------|-------------------

 9 pass
 1 fail
 17 expect() calls
Ran 10 tests across 1 file. [158.00ms]
```

**Green (restored, 10 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/shared/src/host-execution-env.test.ts:
(pass) host execution boot baseline > captures before a later PATH write in a fresh process [14.89ms]
(pass) host execution boot baseline > keeps a fresh process capture after later environment mutation [0.03ms]
(pass) host execution boot baseline > fails closed for absent, relative, empty-entry, and NUL paths
(pass) host execution boot baseline > returns undefined for non-string inputs
(pass) host execution boot baseline > accepts the Windows Path casing but rejects ambiguous case variants
(pass) host execution boot baseline > adds only PATH to an already-sanitized environment
(pass) host execution boot baseline > rejects executable paths outside the captured PATH directories [0.84ms]
(pass) host execution baseline env mirror > capture publishes the authority for uncaptured module instances [13.23ms]
(pass) host execution baseline env mirror > rejects an invalid mirrored value instead of trusting it [12.76ms]
(pass) host execution baseline env mirror > stays empty when no capture ran and no mirror is set [12.77ms]
-------------------------------------------|---------|---------|-------------------
File                                       | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|---------|-------------------
All files                                  |  100.00 |   85.42 |
 packages/shared/src/host-execution-env.ts |  100.00 |   85.42 | 81-85,122-129
-------------------------------------------|---------|---------|-------------------

 10 pass
 0 fail
 20 expect() calls
Ran 10 tests across 1 file. [151.00ms]
```

**Package checks:**
- `bun test packages/shared/src/host-execution-env.test.ts` → Green 10 pass
- `bun run --cwd packages/core typecheck` → pass (shared typecheck has pre-existing unrelated cloud-routing error)
- `bunx biome check` → clean
