### PR TITLE
test(ui): cover task-coordinator-slots.helpers

### DIFF
--- a/packages/ui/src/slots/task-coordinator-slots.helpers.test.ts
+++ b/packages/ui/src/slots/task-coordinator-slots.helpers.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Covers the task-coordinator slot registry: the live
+ * `registeredTaskCoordinatorSlots` object and the merge semantics of
+ * `registerTaskCoordinatorSlots` that app plugins call at boot and
+ * `task-coordinator-slots.tsx` reads at render time. Runs the real module in
+ * the node environment with a fresh ESM instance per case via vi.resetModules;
+ * no DOM and no mocks.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Helpers = typeof import("./task-coordinator-slots.helpers");
+
+async function loadHelpers(): Promise<Helpers> {
+  return import("./task-coordinator-slots.helpers");
+}
+
+function fakeComponent(): null {
+  return null;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("registerTaskCoordinatorSlots", () => {
+  it("exposes an empty registry before any registration", async () => {
+    const { registeredTaskCoordinatorSlots } = await loadHelpers();
+
+    expect(Object.keys(registeredTaskCoordinatorSlots)).toEqual([]);
+  });
+
+  it("stores a provided component on the registry under its slot key", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+
+    registerTaskCoordinatorSlots({ CodingAgentControlChip: fakeComponent });
+
+    expect(registeredTaskCoordinatorSlots.CodingAgentControlChip).toBe(
+      fakeComponent,
+    );
+  });
+
+  it("leaves slots not included in a partial registration unset", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+
+    registerTaskCoordinatorSlots({ CodingAgentControlChip: fakeComponent });
+
+    expect(
+      registeredTaskCoordinatorSlots.CodingAgentTasksPanel,
+    ).toBeUndefined();
+    expect(registeredTaskCoordinatorSlots.PtyConsoleBase).toBeUndefined();
+    expect(Object.keys(registeredTaskCoordinatorSlots)).toEqual([
+      "CodingAgentControlChip",
+    ]);
+  });
+
+  it("merges later registrations without dropping earlier slots", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+    const panel = (): null => null;
+
+    registerTaskCoordinatorSlots({ CodingAgentTasksPanel: fakeComponent });
+    registerTaskCoordinatorSlots({ PtyConsoleBase: panel });
+
+    expect(registeredTaskCoordinatorSlots.CodingAgentTasksPanel).toBe(
+      fakeComponent,
+    );
+    expect(registeredTaskCoordinatorSlots.PtyConsoleBase).toBe(panel);
+  });
+
+  it("replaces a slot when the same key is registered again", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+    const replacement = (): null => null;
+
+    registerTaskCoordinatorSlots({
+      CodingAgentSettingsSection: fakeComponent,
+    });
+    registerTaskCoordinatorSlots({
+      CodingAgentSettingsSection: replacement,
+    });
+
+    expect(registeredTaskCoordinatorSlots.CodingAgentSettingsSection).toBe(
+      replacement,
+    );
+    expect(Object.keys(registeredTaskCoordinatorSlots)).toHaveLength(1);
+  });
+
+  it("keeps the registry identity stable so earlier readers observe new slots", async () => {
+    const helpers = await loadHelpers();
+    const liveView = helpers.registeredTaskCoordinatorSlots;
+
+    helpers.registerTaskCoordinatorSlots({
+      CodingAgentControlChip: fakeComponent,
+    });
+
+    expect(helpers.registeredTaskCoordinatorSlots).toBe(liveView);
+    expect(liveView.CodingAgentControlChip).toBe(fakeComponent);
+  });
+
+  it("treats an empty registration as a no-op", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+
+    registerTaskCoordinatorSlots({});
+
+    expect(Object.keys(registeredTaskCoordinatorSlots)).toEqual([]);
+  });
+
+  it("accepts all four coordinator slots in a single call", async () => {
+    const { registerTaskCoordinatorSlots, registeredTaskCoordinatorSlots } =
+      await loadHelpers();
+
+    registerTaskCoordinatorSlots({
+      CodingAgentSettingsSection: fakeComponent,
+      CodingAgentTasksPanel: fakeComponent,
+      CodingAgentControlChip: fakeComponent,
+      PtyConsoleBase: fakeComponent,
+    });
+
+    expect(registeredTaskCoordinatorSlots.CodingAgentSettingsSection).toBe(
+      fakeComponent,
+    );
+    expect(registeredTaskCoordinatorSlots.CodingAgentTasksPanel).toBe(
+      fakeComponent,
+    );
+    expect(registeredTaskCoordinatorSlots.CodingAgentControlChip).toBe(
+      fakeComponent,
+    );
+    expect(registeredTaskCoordinatorSlots.PtyConsoleBase).toBe(fakeComponent);
+  });
+});


### PR DESCRIPTION

Adds `packages/ui/src/slots/task-coordinator-slots.helpers.test.ts`, a colocated unit suite for the task-coordinator slot registry, which previously had no test coverage anywhere in the repository.

`task-coordinator-slots.helpers.ts` owns two runtime surfaces that other modules depend on: the live `registeredTaskCoordinatorSlots` object and `registerTaskCoordinatorSlots`, which app plugins call at boot and which `task-coordinator-slots.tsx` reads at render time to decide whether a coding-agent slot has an implementation. The suite pins the consumer-visible behavior of that boundary:

- the registry starts empty before any registration;
- `registerTaskCoordinatorSlots` stores provided components under their slot keys by identity;
- partial registrations leave unregistered slots unset (`undefined`) and add exactly one key;
- later registrations merge with, rather than replace, earlier slots;
- re-registering an existing key replaces that slot's implementation while keeping key count stable;
- the exported registry reference stays stable across registrations, so code that captured it earlier (as the `*Slot` components do) observes new registrations;
- an empty registration is a no-op;
- all four coordinator slots can be supplied in one call.

The suite drives the real module — no mocks stand in for the subject — using `vi.resetModules()` plus dynamic import so every case evaluates a fresh ESM instance of the singleton and cases stay order-independent.

## Evidence

Test-only change; no production code is modified. The diff is one new file, +133/−0. Hosted CI does not run on fork pull requests, so results are quoted from local runs on this exact head:

- `vitest run src/slots/task-coordinator-slots.helpers.test.ts` (packages/ui config, re-run against current `origin/develop` immediately before filing): **1 test file passed, 8 tests passed**.
- `biome check packages/ui/src/slots/task-coordinator-slots.helpers.test.ts`: clean, no fixes remaining.
- `tsc --noEmit -p tsconfig.json` in `packages/ui`: the new test filename appears nowhere in the output (the package's pre-existing diagnostics are unchanged and untouched).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2bc6675e34c8ec342af208a5a502d2900435bb4f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
