### PR TITLE
fix(core): safely handle non-string inputs in resolveUserPath

### DIFF
--- a/packages/core/src/utils/state-dir.test.ts
+++ b/packages/core/src/utils/state-dir.test.ts
@@ -131,6 +131,14 @@ describe("resolveUserPath", () => {
 		expect(resolveUserPath("")).toBe("");
 	});
 
+	it("returns empty for non-string inputs", () => {
+		expect(resolveUserPath(null as unknown as string)).toBe("");
+		expect(resolveUserPath(undefined as unknown as string)).toBe("");
+		expect(resolveUserPath(42 as unknown as string)).toBe("");
+		expect(resolveUserPath({} as unknown as string)).toBe("");
+		expect(resolveUserPath("   ")).toBe("");
+	});
+
 	it("expands a leading ~", () => {
 		const result = resolveUserPath("~/foo");
 		expect(result.endsWith(`${sep}foo`)).toBe(true);

--- a/packages/core/src/utils/state-dir.ts
+++ b/packages/core/src/utils/state-dir.ts
@@ -24,6 +24,7 @@ import { readEnv } from "./read-env.ts";
 
 /** Expand a leading `~` segment and resolve to an absolute path. */
 export function resolveUserPath(input: string): string {
+	if (typeof input !== "string") return "";
 	const trimmed = input.trim();
 	if (!trimmed) return trimmed;
 	if (trimmed.startsWith("~")) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Isolated guard in path resolver; non-string inputs return empty string. No behavioral change for valid paths.

# Background

## What does this PR do?

In `packages/core/src/utils/state-dir.ts` `resolveUserPath` assumed a string and called `input.trim()` directly. Passing `null`/`undefined`/`number`/`object` (e.g. malformed env or caller bug) threw `TypeError: null is not an object`. Adds `if (typeof input !== "string") return "";` fail-closed guard, consistent with recent string-guard fixes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/state-dir.ts` and `state-dir.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/state-dir.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6d58d70d4cbe36c7669716a8b49a2c3a25287738 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure path utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure path utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/state-dir.test.ts` and `bun run --cwd packages/core typecheck` pass. Biome clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 20 pass 1 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/state-dir.test.ts:
(pass) resolveStateDir > honors ELIZA_STATE_DIR [0.09ms]
(pass) resolveStateDir > uses the namespace default when ELIZA_STATE_DIR is unset [0.02ms]
(pass) resolveStateDir > derives ~/.local/state/<namespace> from ELIZA_NAMESPACE when no override is set
(pass) resolveStateDir > defaults the namespace to 'eliza' when nothing is set
(pass) resolveStateDir > treats whitespace-only env values as unset, falling through to the default
(pass) resolveStateDir > honors XDG_STATE_HOME when ELIZA_STATE_DIR is unset
(pass) resolveStateDir > resolves a relative XDG_STATE_HOME under the user home
(pass) resolveStateDir > expands a leading ~ in env overrides via the real homedir [0.07ms]
(pass) getElizaNamespace > returns 'eliza' by default
(pass) getElizaNamespace > returns the override when ELIZA_NAMESPACE is set [0.04ms]
(pass) getOptimizationRootDir > preserves an explicit optimization directory
(pass) resolveOAuthDir > defaults to <state-dir>/credentials [0.03ms]
(pass) resolveOAuthDir > honors ELIZA_OAUTH_DIR override
(pass) resolveUserPath > returns an empty string for empty input
22 | 
23 | import { readEnv } from "./read-env.ts";
24 | 
25 | /** Expand a leading `~` segment and resolve to an absolute path. */
26 | export function resolveUserPath(input: string): string {
27 | 	const trimmed = input.trim();
                      ^
TypeError: null is not an object (evaluating 'input.trim')
      at resolveUserPath (/private/tmp/wt-main-1787569365/packages/core/src/utils/state-dir.ts:27:18)
      at <anonymous> (/private/tmp/wt-main-1787569365/packages/core/src/utils/state-dir.test.ts:135:10)
(fail) resolveUserPath > returns empty for non-string inputs [0.09ms]
(pass) resolveUserPath > expands a leading ~ [0.02ms]
(pass) resolveUserPath > resolves a relative path to absolute
(pass) migrateStateDir > returns { migrated: false } when source does not exist [0.62ms]
(pass) migrateStateDir > returns { migrated: false } when fromPath === toPath [0.31ms]
(pass) migrateStateDir > recursively copies contents and is idempotent [1.58ms]
(pass) migrateStateDir > does not overwrite existing destination files (force: false) [0.77ms]
--------------------------------------|---------|---------|-------------------
File                                  | % Funcs | % Lines | Uncovered Line #s
--------------------------------------|---------|---------|-------------------
All files                             |   50.00 |   53.47 |
 packages/core/src/utils/boolean.ts   |    0.00 |   15.91 | 43-72,83-89
 packages/core/src/utils/read-env.ts  |   50.00 |   46.15 | 6-8,36-46
 packages/core/src/utils/state-dir.ts |  100.00 |   98.36 | 
--------------------------------------|---------|---------|-------------------

 20 pass
 1 fail
 26 expect() calls
Ran 21 tests across 1 file. [105.00ms]
```

**Green (restored, 21 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/state-dir.test.ts:
(pass) resolveStateDir > honors ELIZA_STATE_DIR [0.11ms]
(pass) resolveStateDir > uses the namespace default when ELIZA_STATE_DIR is unset [0.04ms]
(pass) resolveStateDir > derives ~/.local/state/<namespace> from ELIZA_NAMESPACE when no override is set [0.02ms]
(pass) resolveStateDir > defaults the namespace to 'eliza' when nothing is set
(pass) resolveStateDir > treats whitespace-only env values as unset, falling through to the default
(pass) resolveStateDir > honors XDG_STATE_HOME when ELIZA_STATE_DIR is unset [0.03ms]
(pass) resolveStateDir > resolves a relative XDG_STATE_HOME under the user home
(pass) resolveStateDir > expands a leading ~ in env overrides via the real homedir [0.06ms]
(pass) getElizaNamespace > returns 'eliza' by default
(pass) getElizaNamespace > returns the override when ELIZA_NAMESPACE is set
(pass) getOptimizationRootDir > preserves an explicit optimization directory [0.01ms]
(pass) resolveOAuthDir > defaults to <state-dir>/credentials [0.01ms]
(pass) resolveOAuthDir > honors ELIZA_OAUTH_DIR override
(pass) resolveUserPath > returns an empty string for empty input [0.02ms]
(pass) resolveUserPath > returns empty for non-string inputs [0.01ms]
(pass) resolveUserPath > expands a leading ~
(pass) resolveUserPath > resolves a relative path to absolute [0.03ms]
(pass) migrateStateDir > returns { migrated: false } when source does not exist [0.58ms]
(pass) migrateStateDir > returns { migrated: false } when fromPath === toPath [0.34ms]
(pass) migrateStateDir > recursively copies contents and is idempotent [1.57ms]
(pass) migrateStateDir > does not overwrite existing destination files (force: false) [0.84ms]
--------------------------------------|---------|---------|-------------------
File                                  | % Funcs | % Lines | Uncovered Line #s
--------------------------------------|---------|---------|-------------------
All files                             |   50.00 |   53.48 |
 packages/core/src/utils/boolean.ts   |    0.00 |   15.91 | 43-72,83-89
 packages/core/src/utils/read-env.ts  |   50.00 |   46.15 | 6-8,36-46
 packages/core/src/utils/state-dir.ts |  100.00 |   98.39 | 
--------------------------------------|---------|---------|-------------------

 21 pass
 0 fail
 31 expect() calls
Ran 21 tests across 1 file. [100.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/state-dir.test.ts` → Green 21 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean
