### PR TITLE
fix(core): safely handle non-string inputs in code fence parser

### DIFF
--- a/packages/core/src/utils/code-fence.test.ts
+++ b/packages/core/src/utils/code-fence.test.ts
@@ -28,4 +28,24 @@ describe("unwrapWholeCodeFence", () => {
 			"x",
 		);
 	});
+
+	it("returns null for non-string inputs without throwing", () => {
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence(null, ["json"])).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence(undefined, ["json"])).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence(123, ["json"])).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence({}, ["json"])).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence([], ["json"])).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence("```json\nx\n```", null)).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence("```json\nx\n```", undefined)).toBeNull();
+		// @ts-expect-error runtime guard check
+		expect(unwrapWholeCodeFence("```json\nx\n```", "json" as unknown as string[])).toBeNull();
+		expect(unwrapWholeCodeFence("", ["json"])).toBeNull();
+	});
 });

--- a/packages/core/src/utils/code-fence.ts
+++ b/packages/core/src/utils/code-fence.ts
@@ -4,6 +4,8 @@ export function unwrapWholeCodeFence(
 	value: string,
 	languages: readonly string[],
 ): string | null {
+	if (typeof value !== "string") return null;
+	if (!Array.isArray(languages)) return null;
 	if (!value.startsWith("```") || !value.endsWith("```") || value.length < 6) {
 		return null;
 	}


### PR DESCRIPTION
# Relates to

N/A - small bug fix, no issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds type guards returning null for non-string/non-array inputs. No change for valid string/array inputs. Previously non-string threw TypeError.

# Background

## What does this PR do?

Guards `unwrapWholeCodeFence` in `packages/core/src/utils/code-fence.ts` against non-string `value` and non-array `languages` that previously threw `TypeError: value.startsWith`. Now returns `null` without throwing, preserving the existing null-rejection contract for invalid fences.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/code-fence.ts` (2 guards) and `packages/core/src/utils/code-fence.test.ts` (1 new suite).

## Detailed testing steps

- `bun test packages/core/src/utils/code-fence.test.ts` — expect 4 pass
- Revert guards, re-run same suite — expect 3 pass 1 fail (`TypeError: null is not an object (evaluating 'value.startsWith')`)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:2c1edefc96fb0f164a8e57bd888ec5b113eaf67e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure parser`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface, pure parser`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI flow, pure parser`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - unit test only`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend, pure parser`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no parser change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test only`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/prompt/model change.

## Backend + frontend logs

N/A - unit test.

<details>

<summary>Green (with fix)</summary>

```
bun test v1.3.11 (af24e281)
 4 pass
 0 fail
 16 expect() calls
Ran 4 tests across 1 file. [82.00ms]
```

</details>

<details>

<summary>Red (reverted, without fix)</summary>

```
TypeError: null is not an object (evaluating 'value.startsWith')
      at unwrapWholeCodeFence (/private/tmp/wt-batch-20260824/packages/core/src/utils/code-fence.ts:7:7)
(fail) unwrapWholeCodeFence > returns null for non-string inputs without throwing [0.20ms]
 3 pass
 1 fail
 7 expect() calls
Ran 4 tests across 1 file. [87.00ms]
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` fails pre-existing: `Cannot find package 'yaml'` — reproducible on origin/develop.
- `bun run --cwd packages/core typecheck` fails pre-existing: `TS2688` / `TS5103` — reproducible on origin/develop.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
