### PR TITLE
test(core): extend listInbox coverage

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
@@ -285,6 +285,177 @@ describe("listInboxAction", () => {
 		});
 	});
 
+	it("matches requested sources case-insensitively", async () => {
+		getDefaultMessageRefStore().saveMessages([
+			messageRef({
+				id: "gmail-cased",
+				externalId: "gmail-cased-external",
+				snippet: "gmail hit",
+				receivedAtMs: 3_000,
+			}),
+			messageRef({
+				id: "discord-cased",
+				source: "discord",
+				externalId: "discord-cased-external",
+				snippet: "discord miss",
+				receivedAtMs: 2_000,
+			}),
+		]);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{ parameters: { sources: ["GMAIL"] } } as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({ total: 1, returned: 1 });
+		const casedMessages = result.data?.messages;
+		expect(casedMessages).toBeDefined();
+		if (!casedMessages) {
+			throw new Error("Expected filtered inbox messages");
+		}
+		expect(
+			(casedMessages as Array<{ id: string }>).map((message) => message.id),
+		).toEqual(["gmail-cased"]);
+	});
+
+	it("treats unrecognized source names as no filter instead of an empty inbox", async () => {
+		getDefaultMessageRefStore().saveMessages([
+			messageRef({
+				id: "gmail-any",
+				externalId: "gmail-any-external",
+				snippet: "gmail hit",
+				receivedAtMs: 3_000,
+			}),
+			messageRef({
+				id: "discord-any",
+				source: "discord",
+				externalId: "discord-any-external",
+				snippet: "discord hit",
+				receivedAtMs: 2_000,
+			}),
+		]);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{ parameters: { sources: ["carrier-pigeon"] } } as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({ total: 2, returned: 2 });
+	});
+
+	it("coerces a numeric-string limit at the parameter boundary", async () => {
+		getDefaultMessageRefStore().saveMessages([
+			messageRef({
+				id: "oldest",
+				externalId: "oldest-external",
+				receivedAtMs: 1_000,
+			}),
+			messageRef({
+				id: "older",
+				externalId: "older-external",
+				receivedAtMs: 2_000,
+			}),
+			messageRef({
+				id: "newer",
+				externalId: "newer-external",
+				receivedAtMs: 3_000,
+			}),
+			messageRef({
+				id: "newest",
+				externalId: "newest-external",
+				receivedAtMs: 4_000,
+			}),
+		]);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{ parameters: { limit: "2" } } as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({ total: 4, returned: 2 });
+		const limitedMessages = result.data?.messages;
+		expect(limitedMessages).toBeDefined();
+		if (!limitedMessages) {
+			throw new Error("Expected trimmed inbox messages");
+		}
+		expect(
+			(limitedMessages as Array<{ id: string }>).map((message) => message.id),
+		).toEqual(["newest", "newer"]);
+	});
+
+	it("summarizes the platform spread in the result text", async () => {
+		getDefaultMessageRefStore().saveMessages([
+			messageRef({
+				id: "gmail-spread",
+				externalId: "gmail-spread-external",
+				receivedAtMs: 3_000,
+			}),
+			messageRef({
+				id: "discord-spread",
+				source: "discord",
+				externalId: "discord-spread-external",
+				receivedAtMs: 2_000,
+			}),
+		]);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.text).toBe(
+			"2 unread message(s) across 2 platform(s); details in data.messages.",
+		);
+	});
+
+	it("filters read mail out of a live pull", async () => {
+		const adapter = new FixedListAdapter([
+			messageRef({
+				id: "live-read",
+				externalId: "live-read-external",
+				receivedAtMs: 9_000,
+				isRead: true,
+			}),
+			messageRef({
+				id: "live-unread-new",
+				externalId: "live-unread-new-external",
+				receivedAtMs: 8_000,
+			}),
+			messageRef({
+				id: "live-unread-old",
+				externalId: "live-unread-old-external",
+				receivedAtMs: 7_000,
+			}),
+		]);
+		await registerAdapter(adapter);
+
+		const result = await listInboxAction.handler(
+			createFakeRuntime(),
+			messageRef({ id: "turn" }) as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({ total: 2, returned: 2 });
+		const liveMessages = result.data?.messages;
+		expect(liveMessages).toBeDefined();
+		if (!liveMessages) {
+			throw new Error("Expected live-pull inbox messages");
+		}
+		expect(
+			(liveMessages as Array<{ id: string }>).map((message) => message.id),
+		).toEqual(["live-unread-new", "live-unread-old"]);
+	});
+
 	it("stringifies non-Error failures at the action boundary", async () => {
 		await registerAdapter(new FixedListAdapter([], "connector refused"));
 


### PR DESCRIPTION

## What

Extends unit coverage for `packages/core/src/features/messaging/triage/actions/listInbox.ts`.

The baseline suite for this action landed in #26347 (`list-inbox-action.test.ts`). This PR is **strictly additive**: +171/-0 on that single test file, no existing case touched, no production code changed.

## Why

The baseline leaves several real handler branches unexercised. The five new cases drive the actual handler end-to-end against the in-process default message-ref store / triage service (same harness as the existing cases — no new mocks) and pin consumer-visible behavior:

1. **Case-insensitive source matching** — `sources: ["GMAIL"]` still filters to gmail refs, because parameter parsing lowercases source names before the handler's filter runs.
2. **Unrecognized sources degrade to "no filter"**, not an empty inbox — a fully-unknown source list parses to `undefined`, so cached messages from every source are returned.
3. **Numeric-string `limit` coercion** — `limit: "2"` trims to the two newest unread while `data.total` keeps reporting the full unread count (4).
4. **Multi-platform summary text** — unread mail from two sources renders `"2 unread message(s) across 2 platform(s); details in data.messages."`.
5. **Read filtering on the live-pull path** — when the cache is empty and the adapter returns read+unread mail, read refs are excluded from both `total` and `messages` (the baseline only covered live pulls where everything was unread).

All expectations were written from observed behavior of the current code (each case passed unmodified on its first run); nothing aspirational is asserted.

## Evidence (test-only change; fork PR — hosted CI does not run on it)

Ran locally against `origin/develop` @ `de774b875774f478ef5b879dbdae8fd2997a3470`:

- `bunx vitest run packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts` → **Test Files 1 passed (1), Tests 12 passed (12)** — 7 baseline (unchanged) + 5 new, 0 failed, ~250ms
- `bunx biome check packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts` → clean ("Checked 1 file", no findings)
- `bunx tsc --noEmit` in `packages/core` → the new/changed test file appears nowhere in output (zero type errors introduced)
- `git diff --numstat origin/develop` → `171 0` on the single test file; no other path touched

No behavioral fix is claimed, so no origin reproduction or revert corpus applies.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8d922bcc323c0a526b038ec9c2e2a56a6f20d9f6 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
