### PR TITLE
test(core): cover send-policy

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/send-policy.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/send-policy.test.ts
@@ -37,3 +37,41 @@ describe("send-policy registry", () => {
 		expect(getSendPolicy(runtime)).toBeNull();
 	});
 });
+
+describe("send-policy registry lifecycle", () => {
+	const approvingPolicy = {
+		shouldRequireApproval: async () => true,
+		enqueueApproval: async () => ({ requestId: "r2", preview: "p2" }),
+	};
+
+	it("replaces an earlier policy when the same runtime registers twice", () => {
+		const runtime = {} as never;
+		registerSendPolicy(runtime, policy);
+		registerSendPolicy(runtime, approvingPolicy);
+		expect(getSendPolicy(runtime)).toBe(approvingPolicy);
+		expect(getSendPolicy(runtime)).not.toBe(policy);
+	});
+
+	it("resetting a runtime that never registered is a safe no-op", () => {
+		const runtime = {} as never;
+		expect(() => __resetSendPolicyForTests(runtime)).not.toThrow();
+		expect(getSendPolicy(runtime)).toBeNull();
+	});
+
+	it("accepts a fresh registration after reset", () => {
+		const runtime = {} as never;
+		registerSendPolicy(runtime, policy);
+		__resetSendPolicyForTests(runtime);
+		registerSendPolicy(runtime, approvingPolicy);
+		expect(getSendPolicy(runtime)).toBe(approvingPolicy);
+	});
+
+	it("keeps two runtimes' distinct policies independent", () => {
+		const a = {} as never;
+		const b = {} as never;
+		registerSendPolicy(a, policy);
+		registerSendPolicy(b, approvingPolicy);
+		expect(getSendPolicy(a)).toBe(policy);
+		expect(getSendPolicy(b)).toBe(approvingPolicy);
+	});
+});


### PR DESCRIPTION

## What

Adds four lifecycle cases to the existing `send-policy` registry suite in `packages/core/src/features/messaging/triage/__tests__/send-policy.test.ts`. The diff is **purely additive** (+38/-0) — no existing case was modified or removed.

The module backs `registerSendPolicy` / `getSendPolicy` with a module-scoped `WeakMap<IAgentRuntime, SendPolicy>`; real consumers (`actions/sendDraft.ts`, `actions/respondToMessage.ts`) call `getSendPolicy(runtime)` before dispatching sends. The new cases pin registry behaviors those consumers depend on but the base suite did not exercise:

- **Re-registration overwrites** — a second `registerSendPolicy` on the same runtime replaces the earlier policy (last-write-wins).
- **Reset of a never-registered runtime** — `__resetSendPolicyForTests` is a safe no-op and lookup stays `null`.
- **Re-register after reset** — the runtime accepts a fresh policy once cleared (hook lifetime tracks the runtime).
- **Distinct policies stay independent across two runtimes** — registering on runtime B neither evicts nor aliases runtime A's policy.

No production behavior is changed by this PR; assertions record observed behavior only.

## Evidence

Test-only change; counts below are from this exact branch head.

- `bunx vitest run src/features/messaging/triage/__tests__/send-policy.test.ts` (in `packages/core`): **1 file passed, 8 tests passed (8)** — 4 pre-existing cases plus these 4 new ones.
- `bunx biome check --write <file>`: clean ("Checked 1 file… No fixes applied"), against the repository `biome.json`.
- `bunx tsc --noEmit` in `packages/core`: the test filename appears nowhere in output (the package tsconfig excludes `src/**/*.test.ts`; no new type errors attributable to this diff).

## Notes

- This PR is filed from a fork; hosted CI does not run on it. The vitest/biome/tsc results above are quoted from a local run at the pushed head.
- The target acquired a same-named suite on `develop` shortly before this PR; per repository coverage policy this contribution only appends cases to it and deletes nothing.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:14ddf7c124991752be9995e1ae3786ff976a03da -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
