### PR TITLE
fix(elizaos): repair the scaffolded app's nested test import

### DIFF
--- a/packages/elizaos/templates/project/apps/app/src/__tests__/native-plugin-stubs.test.ts
+++ b/packages/elizaos/templates/project/apps/app/src/__tests__/native-plugin-stubs.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  Agent,
+  Desktop,
+  startDeviceBridgeClient,
+} from "../native-plugin-stubs.ts";
+
+describe("native-plugin-stubs", () => {
+  it("Agent.getStatus reports unavailable", async () => {
+    expect(await Agent.getStatus()).toEqual({ status: "unavailable" });
+  });
+
+  it("Desktop reports a N/A runtime and registers no-op handles", async () => {
+    expect(await Desktop.getVersion()).toEqual({ runtime: "N/A" });
+    await Desktop.registerShortcut({ id: "x", accelerator: "Cmd+K" });
+    const handle = await Desktop.addListener("shortcutPressed", () => {});
+    expect(handle.remove).toBeDefined();
+    await handle.remove();
+    await Desktop.setTrayMenu({ menu: [] });
+  });
+
+  it("startDeviceBridgeClient returns a stoppable client", () => {
+    const client = startDeviceBridgeClient({ agentUrl: "http://x" });
+    expect(client.stop).toBeDefined();
+    client.stop();
+  });
+});


### PR DESCRIPTION
# Relates to

No separate issue — the defect and its user-facing consequence are described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] One specifier; both candidate paths probed against the tree at head.
- [x] A reviewer can confirm it from the path listing without reading the code.

# Sync with develop

- [x] Built on `origin/develop@de774b87`; zero conflicts.
- [x] One file differs, one line.

# Risks

None to repository code. The change is a relative path inside a template test file. No test body, assertion, or source module changes.

# Background

## What does this PR do?

`templates/project/apps/app/src/__tests__/native-plugin-stubs.test.ts` imports its subject as a sibling:

```ts
import {
  ...
} from "./native-plugin-stubs.ts";
```

From inside `__tests__/` that resolves to `src/__tests__/native-plugin-stubs.ts`, which does not exist. The module is one directory up:

```
packages/elizaos/templates/project/apps/app/src/
├── __tests__/
│   └── native-plugin-stubs.test.ts   <- importer
└── native-plugin-stubs.ts            <- actual module
```

Probed against the tree at head: sibling path **404**, parent path **200**.

## Why this one reaches users

Unlike the in-repo instances of this defect, this file is inside a scaffold template, and `biome.json` excludes `packages/elizaos/templates` (line 45) from the repository lint scope. So it is invisible to repository CI and surfaces only **after `elizaos create`**, in the user's freshly scaffolded project:

- the template's own `tsconfig.json` sets `"include": ["src/**/*.ts", "src/**/*.tsx"]`, so `bun run typecheck` fails with `TS2307`;
- `bun run test` cannot load the suite, so none of its cases execute while the file still reports as collected.

A new project therefore ships with a red typecheck and a silently non-running test out of the box.

This is the same defect class as #24905 (repaired by #24977) and #25205 (repaired by #25281). A repository-wide sweep of every `__tests__/` suite fixed 30 instances across 7 packages in #25281, #25325, #25326, #25329, #25330, #25331 and #25332. Re-running that sweep against current `develop` leaves exactly one — this template file, because the template tree was outside the earlier pass.

## What is the fix?

Point the specifier one level up. Nothing else changes.

```diff
-} from "./native-plugin-stubs.ts";
+} from "../native-plugin-stubs.ts";
```

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes, and no change to the scaffold contract.

# Testing

## Where should a reviewer start?

The directory listing above. `native-plugin-stubs.ts` is a sibling of `__tests__/`, not a member of it, so `../native-plugin-stubs.ts` is the only specifier that resolves.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| sibling path `src/__tests__/native-plugin-stubs.ts` at head | `404 Not Found` — where the current specifier resolves |
| parent path `src/native-plugin-stubs.ts` at head | `200` — where this PR points |
| template `tsconfig.json` | `"include": ["src/**/*.ts", …]` — the file is in the typecheck program |
| repo-wide re-sweep of all `__tests__/` suites on `develop` | 1 remaining instance, this file |
| diff vs `develop` | `+1/-1`, one file |

The test body is unchanged, so the suite keeps exactly its intended coverage and can now resolve the module it was written against.

# Evidence Gate

<!-- evidence-head:d05bb3588449836eaa735a31d794926eeb97332e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - a module specifier in a template test file; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - a module specifier in a template test file; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is module resolution, shown by the 404/200 probe above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the failure is a compile-time and loader resolution error`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in module resolution`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the resolution result above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by re-running a repository-wide sweep of every `__tests__/` suite against current `develop` after the earlier 30-file pass.
- Sweep, verification, and fix by Claude Code (`claude-opus-5`).

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Attribution status: self-reported
