### PR TITLE
test(core): cover message-ref-store

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
@@ -4,8 +4,12 @@
  * capacities without replacing the system under test.
  */
 
-import { describe, expect, it } from "vitest";
-import { MessageRefStore } from "../message-ref-store.ts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	__resetDefaultMessageRefStoreForTests,
+	getDefaultMessageRefStore,
+	MessageRefStore,
+} from "../message-ref-store.ts";
 import type { DraftRecord, MessageRef } from "../types.ts";
 
 const MESSAGE_CAPACITY = 5000;
@@ -228,5 +232,150 @@ describe("MessageRefStore write-recency eviction", () => {
 			scheduleCommit,
 		});
 		expect(store.getDraft("draft-1")).toBeNull();
+	});
+});
+
+describe("MessageRefStore lookup and empty-store contracts", () => {
+	it("returns null reads and an empty list from an empty store", () => {
+		const store = new MessageRefStore();
+
+		expect(store.getMessage("message-0")).toBeNull();
+		expect(store.listMessages()).toEqual([]);
+		expect(store.findByExternalId("gmail", "external-0")).toBeNull();
+		expect(store.getDraft("draft-0")).toBeNull();
+	});
+
+	it("ignores an empty saveMessages batch", () => {
+		const store = new MessageRefStore();
+
+		store.saveMessages([]);
+
+		expect(store.listMessages()).toEqual([]);
+	});
+
+	it("keeps every message when the store holds exactly its capacity", () => {
+		const store = new MessageRefStore();
+		fillMessages(store);
+
+		const listed = store.listMessages();
+		expect(listed).toHaveLength(MESSAGE_CAPACITY);
+		expect(listed[0]?.id).toBe("message-0");
+		expect(listed[MESSAGE_CAPACITY - 1]?.id).toBe(
+			`message-${MESSAGE_CAPACITY - 1}`,
+		);
+	});
+
+	it("matches findByExternalId only when source and external id both agree", () => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0));
+		store.saveMessage(message(1, { source: "discord" }));
+
+		expect(store.findByExternalId("gmail", "external-0")?.id).toBe("message-0");
+		expect(store.findByExternalId("gmail", "external-1")).toBeNull();
+		expect(store.findByExternalId("discord", "external-0")).toBeNull();
+	});
+});
+
+describe("MessageRefStore tag contracts", () => {
+	it.each([
+		{
+			name: "addTag",
+			mutate: (store: MessageRefStore) => store.addTag("absent", "urgent"),
+		},
+		{
+			name: "removeTag",
+			mutate: (store: MessageRefStore) => store.removeTag("absent", "urgent"),
+		},
+	])("returns null when $name targets a missing message", ({ mutate }) => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0));
+
+		expect(mutate(store)).toBeNull();
+		expect(store.getMessage("message-0")).not.toBeNull();
+	});
+
+	it("creates a tag list when addTag runs on a message without tags", () => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0));
+
+		const updated = store.addTag("message-0", "urgent");
+
+		expect(updated?.tags).toEqual(["urgent"]);
+		expect(store.getMessage("message-0")?.tags).toEqual(["urgent"]);
+	});
+
+	it("leaves a message without tags unchanged when removeTag has nothing to remove", () => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0));
+
+		const result = store.removeTag("message-0", "urgent");
+
+		expect(result).not.toBeNull();
+		expect(result?.tags).toBeUndefined();
+		expect(store.getMessage("message-0")?.tags).toBeUndefined();
+	});
+});
+
+describe("MessageRefStore missing-draft contracts", () => {
+	it.each([
+		{
+			name: "markDraftSent",
+			act: (store: MessageRefStore) =>
+				store.markDraftSent("absent", "provider-message-x"),
+		},
+		{
+			name: "markDraftScheduled",
+			act: (store: MessageRefStore) =>
+				store.markDraftScheduled("absent", 1_786_569_000_000, "schedule-0", {
+					kind: "durable",
+					id: "task-0",
+					committedAt: "2026-08-12T21:00:00.000Z",
+					idempotencyKey: "schedule-absent",
+					replayed: false,
+				}),
+		},
+	])("returns null when $name targets a missing draft", ({ act }) => {
+		const store = new MessageRefStore();
+		store.saveDraft(draft(0));
+
+		expect(act(store)).toBeNull();
+		expect(store.getDraft("draft-0")?.sent).toBe(false);
+		expect(store.getDraft("draft-0")?.scheduledId).toBeUndefined();
+	});
+
+	it("clears both messages and drafts", () => {
+		const store = new MessageRefStore();
+		store.saveMessage(message(0));
+		store.saveDraft(draft(0));
+
+		store.clear();
+
+		expect(store.listMessages()).toEqual([]);
+		expect(store.getMessage("message-0")).toBeNull();
+		expect(store.getDraft("draft-0")).toBeNull();
+	});
+});
+
+describe("getDefaultMessageRefStore singleton lifecycle", () => {
+	beforeEach(() => {
+		__resetDefaultMessageRefStoreForTests();
+	});
+
+	afterEach(() => {
+		__resetDefaultMessageRefStoreForTests();
+	});
+
+	it("hands every caller the same live instance until it is reset", () => {
+		const first = getDefaultMessageRefStore();
+		first.saveMessage(message(42));
+
+		expect(getDefaultMessageRefStore().getMessage("message-42")).not.toBeNull();
+		expect(getDefaultMessageRefStore()).toBe(first);
+
+		__resetDefaultMessageRefStoreForTests();
+
+		const next = getDefaultMessageRefStore();
+		expect(next).not.toBe(first);
+		expect(next.getMessage("message-42")).toBeNull();
 	});
 });

--- a/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts
@@ -4,12 +4,8 @@
  * capacities without replacing the system under test.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-	__resetDefaultMessageRefStoreForTests,
-	getDefaultMessageRefStore,
-	MessageRefStore,
-} from "../message-ref-store.ts";
+import { describe, expect, it } from "vitest";
+import { MessageRefStore } from "../message-ref-store.ts";
 import type { DraftRecord, MessageRef } from "../types.ts";
 
 const MESSAGE_CAPACITY = 5000;
@@ -357,25 +353,24 @@ describe("MessageRefStore missing-draft contracts", () => {
 });
 
 describe("getDefaultMessageRefStore singleton lifecycle", () => {
-	beforeEach(() => {
-		__resetDefaultMessageRefStoreForTests();
-	});
+	it("hands every caller the same live instance until it is reset", async () => {
+		const storeModule = await import("../message-ref-store.ts");
+		storeModule.__resetDefaultMessageRefStoreForTests();
 
-	afterEach(() => {
-		__resetDefaultMessageRefStoreForTests();
-	});
-
-	it("hands every caller the same live instance until it is reset", () => {
-		const first = getDefaultMessageRefStore();
+		const first = storeModule.getDefaultMessageRefStore();
 		first.saveMessage(message(42));
 
-		expect(getDefaultMessageRefStore().getMessage("message-42")).not.toBeNull();
-		expect(getDefaultMessageRefStore()).toBe(first);
+		expect(
+			storeModule.getDefaultMessageRefStore().getMessage("message-42"),
+		).not.toBeNull();
+		expect(storeModule.getDefaultMessageRefStore()).toBe(first);
 
-		__resetDefaultMessageRefStoreForTests();
+		storeModule.__resetDefaultMessageRefStoreForTests();
 
-		const next = getDefaultMessageRefStore();
+		const next = storeModule.getDefaultMessageRefStore();
 		expect(next).not.toBe(first);
 		expect(next.getMessage("message-42")).toBeNull();
+
+		storeModule.__resetDefaultMessageRefStoreForTests();
 	});
 });


### PR DESCRIPTION

# test(core): cover message-ref-store lookup, tag, draft-null and singleton contracts

Additive-only coverage for `packages/core/src/features/messaging/triage/message-ref-store.ts`, appended to the existing suite at `packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts`. **This diff touches only that one test file** (+144/−0 — every line of the existing suite on `develop` is preserved verbatim; all 12 cases below are appended after the existing describe block).

## What is added (12 new cases)

- Empty-store contracts: `getMessage`, `listMessages`, `findByExternalId`, `getDraft` all return null/empty on a fresh store.
- `saveMessages([])` is a no-op.
- Exact-capacity boundary: filling to exactly 5000 messages evicts nothing (eviction is strictly `size > max`).
- `findByExternalId` requires BOTH source and externalId to match: same externalId under a different source returns null, and vice versa.
- `addTag`/`removeTag` return null when the message id does not exist (existing store entry untouched).
- `addTag` creates the tag list when the stored message has no `tags` field.
- `removeTag` on an untagged message returns the message unchanged (`tags` stays undefined).
- `markDraftSent`/`markDraftScheduled` return null for a missing draft id, leaving other drafts untouched.
- `clear()` empties both messages and drafts.
- `getDefaultMessageRefStore()` returns one live instance across calls; `__resetDefaultMessageRefStoreForTests()` produces a fresh empty instance (with before/after resets so no state leaks across suites).

## Evidence (test-only change; no production behavior touched)

All commands were run against current `origin/develop` immediately before filing:

1. `bunx vitest run packages/core/src/features/messaging/triage/__tests__/message-ref-store.test.ts`
   → **Test Files 1 passed (1), Tests 22 passed (22)** (10 pre-existing cases unchanged + 12 added). Duration ~150 ms.
2. `bunx biome check --write <file>` → clean (`Checked 1 file ... No fixes applied` on re-check).
3. `bunx tsc --noEmit` in `packages/core`, grep for `message-ref-store.test` → **no output** (zero type diagnostics reference the new code).
4. The diff contains only the single test file named above. No mocks are used — the real in-memory store is driven at its production capacities, consistent with the existing harness.

Note: this is a fork contribution, so hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a77ccf08cc9ee1a3506fa9fe883ac9efabbca207 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
