### PR TITLE
fix(cloud): serialize invalid dates as null without throwing in stableSerialize

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.test.ts
@@ -26,6 +26,11 @@ describe("stableSerialize", () => {
     );
   });
 
+  test("serializes invalid Date values as null without throwing", () => {
+    expect(stableSerialize(new Date(Number.NaN))).toBe("null");
+    expect(stableSerialize({ date: new Date(Number.NaN) })).toBe('{"date":null}');
+  });
+
   test("rejects non-plain objects that would otherwise collide", () => {
     expect(() => stableSerialize(new Map([["a", 1]]))).toThrow(TypeError);
     class Example {

--- a/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts
+++ b/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts
@@ -16,7 +16,7 @@ function serializeStableValue(value: unknown, seen: WeakSet<object>): string {
 
   if (value && typeof value === "object") {
     if (value instanceof Date) {
-      return JSON.stringify(value.toISOString());
+      return Number.isNaN(value.getTime()) ? "null" : JSON.stringify(value.toISOString());
     }
 
     const prototype = Object.getPrototypeOf(value);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Serializes invalid Date objects (such as `new Date(NaN)`) as `"null"` in `stableSerialize` matching standard JSON serialization behavior instead of throwing `RangeError: Invalid Date`.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts`, `serializeStableValue` encountered `value instanceof Date` and called `value.toISOString()`. For an invalid date (whose timestamp is `NaN`), `toISOString()` throws `RangeError: Invalid Date`. In standard JSON semantics, `JSON.stringify(new Date(NaN))` evaluates to `null`. Checking `Number.isNaN(value.getTime())` and returning `"null"` prevents unexpected runtime crashes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts` and `stable-serialize.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/eliza/runtime/stable-serialize.test.ts`.

# Evidence Gate

<!-- evidence-head:0f3024ab08844f3e357c5fb90525bd46c46822a2 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - stable serializer helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
RangeError: Invalid Date
      at serializeStableValue (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/cloud/shared/src/lib/eliza/runtime/stable-serialize.ts:19:35)
(fail) stableSerialize > serializes invalid Date values as null without throwing
6 pass, 1 fail
```

## Green (restored)
```
(pass) stableSerialize > serializes invalid Date values as null without throwing [0.01ms]
7 pass, 0 fail, 12 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

