### PR TITLE
fix(cloud): safely fallback methods array in addCorsHeaders

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/cors-apps.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/cors-apps.test.ts
@@ -22,4 +22,12 @@ describe("cors-apps", () => {
     const out = addCorsHeaders(res, "https://example.com");
     expect(out.headers.get("access-control-allow-origin")).toBeTruthy();
   });
+
+  it("safely falls back to default methods when methods is empty or non-array", () => {
+    const res = new Response("ok");
+    const out = addCorsHeaders(res, null, []);
+    expect(out.headers.get("access-control-allow-methods")).toBe(
+      "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+    );
+  });
 });

--- a/packages/cloud/shared/src/lib/middleware/cors-apps.ts
+++ b/packages/cloud/shared/src/lib/middleware/cors-apps.ts
@@ -39,9 +39,18 @@ export function addCorsHeaders(
   origin: string | null,
   methods: string[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 ): Response {
+  const effectiveMethods =
+    Array.isArray(methods) && methods.length > 0
+      ? methods.filter((m) => typeof m === "string" && m.trim().length > 0)
+      : [];
+  const methodsList =
+    effectiveMethods.length > 0
+      ? effectiveMethods
+      : ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+
   // Use wildcard for maximum compatibility - security is via auth tokens
   response.headers.set("Access-Control-Allow-Origin", "*");
-  response.headers.set("Access-Control-Allow-Methods", methods.join(", "));
+  response.headers.set("Access-Control-Allow-Methods", methodsList.join(", "));
   response.headers.set("Access-Control-Allow-Headers", CORS_ALLOW_HEADERS);
   // Note: credentials cannot be used with wildcard, but we use auth tokens instead
   response.headers.set("Access-Control-Max-Age", CORS_MAX_AGE);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely falls back to default HTTP methods (`["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]`) when `methods` is passed as an empty array or non-array in `addCorsHeaders`.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/middleware/cors-apps.ts`, `addCorsHeaders` set the `Access-Control-Allow-Methods` header to `methods.join(", ")`. If `methods` was passed as an empty array `[]` or non-array, it produced an empty header value `""`, causing browsers to reject CORS preflight requests. Filtering for non-empty string methods and falling back to canonical defaults prevents malformed headers.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/middleware/cors-apps.ts` and `cors-apps.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/middleware/cors-apps.test.ts`.

# Evidence Gate

<!-- evidence-head:8a1b0475abd05599db7b148c5d7650ee3b2235f4 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - CORS middleware header helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toBe(expected)
Expected: "GET, POST, PUT, PATCH, DELETE, OPTIONS"
Received: ""
(fail) cors-apps > safely falls back to default methods when methods is empty or non-array
2 pass, 1 fail
```

## Green (restored)
```
(pass) cors-apps > safely falls back to default methods when methods is empty or non-array
3 pass, 0 fail, 3 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

