### PR TITLE
test(ui): cover autonomy

### DIFF
--- a/packages/ui/src/state/autonomy.test.ts
+++ b/packages/ui/src/state/autonomy.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Verifies autonomy run-health tracking over real streamed envelopes: sequence
+ * gap detection, recovery, store hydration on reconnect, dedup, ledger
+ * trimming, watermark cursor movement, and gap-replay request building.
+ */
+import { describe, expect, it } from "vitest";
+import type { StreamEventEnvelope } from "../api/client";
+import type { AutonomyRunHealth, AutonomyRunHealthMap } from "./autonomy";
+import {
+  buildAutonomyGapReplayRequests,
+  hasPendingAutonomyGaps,
+  markPendingAutonomyGapsPartial,
+  mergeAutonomyEvents,
+} from "./autonomy";
+
+function evt(
+  eventId: string,
+  opts: { runId?: string; seq?: number; stream?: string; ts?: number } = {},
+): StreamEventEnvelope {
+  return {
+    type: "agent_event",
+    version: 1,
+    eventId,
+    ts: opts.ts ?? 1_000,
+    runId: opts.runId,
+    seq: opts.seq,
+    stream: opts.stream,
+    payload: null,
+  };
+}
+
+function healthOf(
+  runId: string,
+  missingSeqs: number[],
+  lastSeq: number | null,
+): AutonomyRunHealth {
+  return { runId, status: "ok", lastSeq, missingSeqs, gapCount: 0 };
+}
+
+describe("mergeAutonomyEvents", () => {
+  it("returns an empty ledger for a cold start with nothing to merge", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [],
+      runHealthByRunId: {},
+    });
+
+    expect(result.events).toEqual([]);
+    expect(result.latestEventId).toBeNull();
+    expect(result.insertedCount).toBe(0);
+    expect(result.duplicateCount).toBe(0);
+    expect(result.runsWithNewGaps).toEqual([]);
+    expect(result.runsRecovered).toEqual([]);
+    expect(result.hasUnresolvedGaps).toBe(false);
+    expect(result.store.eventOrder).toEqual([]);
+    expect(result.store.watermark).toBeNull();
+  });
+
+  it("tracks lastSeq across an initial batch without inventing cold-start gaps", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens", ts: 100 }),
+        evt("evt-2", { runId: "run-1", seq: 2, stream: "tokens", ts: 200 }),
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens", ts: 300 }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(result.insertedCount).toBe(3);
+    expect(result.events.map((e) => e.eventId)).toEqual([
+      "evt-1",
+      "evt-2",
+      "evt-3",
+    ]);
+    expect(result.latestEventId).toBe("evt-3");
+    expect(result.store.runIndex["run-1"]).toEqual({
+      1: "evt-1",
+      2: "evt-2",
+      3: "evt-3",
+    });
+    expect(result.runHealthByRunId["run-1"]).toMatchObject({
+      status: "ok",
+      lastSeq: 3,
+      missingSeqs: [],
+    });
+    expect(result.hasUnresolvedGaps).toBe(false);
+  });
+
+  it("flags a skipped seq as gap_detected with gap metadata", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens", ts: 100 }),
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens", ts: 300 }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    const health = result.runHealthByRunId["run-1"];
+    expect(health.status).toBe("gap_detected");
+    expect(health.missingSeqs).toEqual([2]);
+    expect(health.gapCount).toBe(1);
+    expect(health.lastGapAt).toBe(300);
+    expect(health.lastSeq).toBe(3);
+    expect(result.runsWithNewGaps).toEqual(["run-1"]);
+    expect(result.hasUnresolvedGaps).toBe(true);
+  });
+
+  it("recovers when the missing envelope arrives later in the same batch", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens", ts: 100 }),
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens", ts: 300 }),
+        evt("evt-2", { runId: "run-1", seq: 2, stream: "tokens", ts: 200 }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    const health = result.runHealthByRunId["run-1"];
+    expect(health.status).toBe("recovered");
+    expect(health.recoveredAt).toBe(200);
+    expect(health.missingSeqs).toEqual([]);
+    expect(health.lastSeq).toBe(3);
+    expect(result.runsRecovered).toEqual(["run-1"]);
+    expect(result.runsWithNewGaps).toEqual(["run-1"]);
+    expect(result.hasUnresolvedGaps).toBe(false);
+  });
+
+  it("keeps the run flagged while any missing seq is outstanding across calls", () => {
+    const first = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("evt-4", { runId: "run-1", seq: 4, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+    expect(first.runHealthByRunId["run-1"].missingSeqs).toEqual([2, 3]);
+
+    const second = mergeAutonomyEvents({
+      store: first.store,
+      incomingEvents: [
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens" }),
+      ],
+      runHealthByRunId: first.runHealthByRunId,
+    });
+    expect(second.runHealthByRunId["run-1"].status).toBe("gap_detected");
+    expect(second.runHealthByRunId["run-1"].missingSeqs).toEqual([2]);
+    expect(second.runsRecovered).toEqual([]);
+
+    const third = mergeAutonomyEvents({
+      store: second.store,
+      incomingEvents: [
+        evt("evt-2", { runId: "run-1", seq: 2, stream: "tokens" }),
+      ],
+      runHealthByRunId: second.runHealthByRunId,
+    });
+    expect(third.runHealthByRunId["run-1"].status).toBe("recovered");
+    expect(third.runsRecovered).toEqual(["run-1"]);
+    expect(third.hasUnresolvedGaps).toBe(false);
+  });
+
+  it("reconstructs gaps from a carried store on reconnect with a fresh health map", () => {
+    const connected = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    const reconnected = mergeAutonomyEvents({
+      store: connected.store,
+      incomingEvents: [],
+      runHealthByRunId: {},
+    });
+
+    const health = reconnected.runHealthByRunId["run-1"];
+    expect(health.status).toBe("gap_detected");
+    expect(health.missingSeqs).toEqual([2]);
+    expect(health.lastSeq).toBe(3);
+    expect(health.gapCount).toBe(1);
+    expect(reconnected.hasUnresolvedGaps).toBe(true);
+    expect(reconnected.events.map((e) => e.eventId)).toEqual([
+      "evt-1",
+      "evt-3",
+    ]);
+    expect(reconnected.latestEventId).toBe("evt-3");
+  });
+
+  it("does not mutate the caller's store or health map", () => {
+    const initial = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("evt-2", { runId: "run-1", seq: 2, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+    const healthBefore = structuredClone(initial.runHealthByRunId);
+    const orderBefore = [...initial.store.eventOrder];
+
+    mergeAutonomyEvents({
+      store: initial.store,
+      incomingEvents: [
+        evt("evt-9", { runId: "run-1", seq: 9, stream: "tokens" }),
+      ],
+      runHealthByRunId: initial.runHealthByRunId,
+    });
+
+    expect(initial.store.eventOrder).toEqual(orderBefore);
+    expect(initial.store.eventsById["evt-9"]).toBeUndefined();
+    expect(initial.runHealthByRunId).toEqual(healthBefore);
+  });
+
+  it("counts duplicates by eventId and by run/seq/stream fallback key", () => {
+    const first = evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" });
+    const sameEnvelopeDifferentId = evt("evt-1b", {
+      runId: "run-1",
+      seq: 1,
+      stream: "tokens",
+    });
+
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        first,
+        sameEnvelopeDifferentId,
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(result.insertedCount).toBe(1);
+    expect(result.duplicateCount).toBe(2);
+    expect(result.events.map((e) => e.eventId)).toEqual(["evt-1"]);
+  });
+
+  it("skips health tracking for envelopes lacking runId or seq", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-x"),
+        evt("evt-y", { runId: "run-noseq" }),
+        evt("evt-z", { runId: "run-1", seq: 1, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(result.insertedCount).toBe(3);
+    expect(Object.keys(result.runHealthByRunId)).toEqual(["run-1"]);
+    expect(Object.keys(result.store.eventsById).sort()).toEqual([
+      "evt-x",
+      "evt-y",
+      "evt-z",
+    ]);
+    expect(Object.keys(result.store.runIndex)).toEqual(["run-1"]);
+  });
+
+  it("never indexes prototype-dangerous runIds into the run index", () => {
+    const result = mergeAutonomyEvents({
+      existingEvents: [
+        evt("evt-p1", { runId: "constructor", seq: 1, stream: "tokens" }),
+        evt("evt-p2", { runId: "prototype", seq: 2, stream: "tokens" }),
+      ],
+      incomingEvents: [
+        evt("evt-p3", { runId: "prototype", seq: 3, stream: "tokens" }),
+        evt("evt-ok", { runId: "run-1", seq: 4, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(Object.hasOwn(result.store.runIndex, "constructor")).toBe(false);
+    expect(Object.hasOwn(result.store.runIndex, "prototype")).toBe(false);
+    expect(Object.keys(result.store.runIndex)).toEqual(["run-1"]);
+    expect(result.store.eventsById["evt-p1"]).toBeDefined();
+    expect(result.store.eventsById["evt-p2"]).toBeDefined();
+    expect(result.store.eventsById["evt-p3"]).toBeDefined();
+  });
+
+  it("marks unresolved runs partial on replay even with no incoming events", () => {
+    const connected = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("evt-3", { runId: "run-1", seq: 3, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+    const before = Date.now();
+
+    const replayed = mergeAutonomyEvents({
+      store: connected.store,
+      incomingEvents: [],
+      runHealthByRunId: connected.runHealthByRunId,
+      replay: true,
+    });
+
+    const health = replayed.runHealthByRunId["run-1"];
+    expect(health.status).toBe("partial");
+    expect(health.partialAt).toBeGreaterThanOrEqual(before);
+    expect(replayed.insertedCount).toBe(0);
+    expect(replayed.hasUnresolvedGaps).toBe(true);
+  });
+
+  it("trims the ledger to maxEvents and drops evicted seqs from the run index", () => {
+    const trimmed = mergeAutonomyEvents({
+      incomingEvents: [1, 2, 3, 4, 5].map((seq) =>
+        evt(`evt-${seq}`, { runId: "run-1", seq, stream: "tokens" }),
+      ),
+      runHealthByRunId: {},
+      maxEvents: 3,
+    });
+
+    expect(trimmed.events.map((e) => e.eventId)).toEqual([
+      "evt-3",
+      "evt-4",
+      "evt-5",
+    ]);
+    expect(trimmed.store.eventsById["evt-1"]).toBeUndefined();
+    expect(trimmed.store.eventsById["evt-2"]).toBeUndefined();
+    expect(trimmed.store.runIndex["run-1"]).toEqual({
+      3: "evt-3",
+      4: "evt-4",
+      5: "evt-5",
+    });
+    expect(trimmed.latestEventId).toBe("evt-5");
+
+    const rehydrated = mergeAutonomyEvents({
+      store: trimmed.store,
+      incomingEvents: [],
+      runHealthByRunId: {},
+    });
+    expect(rehydrated.runHealthByRunId["run-1"]).toMatchObject({
+      status: "ok",
+      lastSeq: 5,
+      missingSeqs: [],
+    });
+  });
+
+  it("does not move the watermark cursor backwards on late low-seq arrivals", () => {
+    const first = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-10", { runId: "run-1", seq: 10, stream: "tokens" }),
+        evt("evt-11", { runId: "run-1", seq: 11, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+    expect(first.latestEventId).toBe("evt-11");
+
+    const late = mergeAutonomyEvents({
+      store: first.store,
+      incomingEvents: [
+        evt("evt-9", { runId: "run-1", seq: 9, stream: "tokens" }),
+      ],
+      runHealthByRunId: first.runHealthByRunId,
+    });
+
+    expect(late.insertedCount).toBe(1);
+    expect(late.latestEventId).toBe("evt-11");
+  });
+
+  it("advances the cursor to a non-ordinal eventId when one arrives", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("snapshot-final"),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(result.latestEventId).toBe("snapshot-final");
+  });
+
+  it("truncates fractional seqs onto the integer run index", () => {
+    const result = mergeAutonomyEvents({
+      incomingEvents: [
+        evt("evt-1", { runId: "run-1", seq: 1, stream: "tokens" }),
+        evt("evt-2", { runId: "run-1", seq: 2.9, stream: "tokens" }),
+      ],
+      runHealthByRunId: {},
+    });
+
+    expect(result.store.runIndex["run-1"][2]).toBe("evt-2");
+    expect(result.runHealthByRunId["run-1"].lastSeq).toBe(2);
+    expect(result.runHealthByRunId["run-1"].missingSeqs).toEqual([]);
+    expect(result.runsWithNewGaps).toEqual([]);
+  });
+});
+
+describe("buildAutonomyGapReplayRequests", () => {
+  it("returns no requests when there is no tracked health", () => {
+    expect(
+      buildAutonomyGapReplayRequests(
+        {},
+        {
+          eventsById: {},
+          eventOrder: [],
+          runIndex: {},
+          watermark: null,
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it("requests only unresolved seqs and sorts by fromSeq", () => {
+    const runHealthByRunId = {
+      "run-a": {
+        ...healthOf("run-a", [2, 3, 5], 5),
+        status: "gap_detected" as const,
+      },
+      "run-b": {
+        ...healthOf("run-b", [1], 1),
+        status: "gap_detected" as const,
+      },
+      "run-c": {
+        ...healthOf("run-c", [4], 4),
+        status: "gap_detected" as const,
+      },
+    };
+    const store = {
+      eventsById: {},
+      eventOrder: [],
+      runIndex: {
+        "run-a": { 2: "evt-a2" },
+        "run-c": { 4: "evt-c4" },
+      },
+      watermark: null,
+    };
+
+    const requests = buildAutonomyGapReplayRequests(runHealthByRunId, store);
+
+    expect(requests).toEqual([
+      { runId: "run-b", fromSeq: 1, missingSeqs: [1] },
+      { runId: "run-a", fromSeq: 3, missingSeqs: [3, 5] },
+    ]);
+  });
+});
+
+describe("hasPendingAutonomyGaps", () => {
+  it("is false for an empty map and for fully healthy runs", () => {
+    expect(hasPendingAutonomyGaps({})).toBe(false);
+    expect(hasPendingAutonomyGaps({ "run-1": healthOf("run-1", [], 7) })).toBe(
+      false,
+    );
+  });
+
+  it("is true when any run still has missing seqs", () => {
+    expect(
+      hasPendingAutonomyGaps({
+        "run-1": healthOf("run-1", [], 7),
+        "run-2": healthOf("run-2", [4], 5),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("markPendingAutonomyGapsPartial", () => {
+  it("marks only gapped runs partial and never mutates its input", () => {
+    const input: AutonomyRunHealthMap = {
+      healthy: healthOf("healthy", [], 4),
+      gapped: {
+        runId: "gapped",
+        status: "gap_detected" as const,
+        lastSeq: 5,
+        missingSeqs: [2, 4],
+        gapCount: 1,
+      },
+    };
+
+    const marked = markPendingAutonomyGapsPartial(input, 12345);
+
+    expect(marked.gapped.status).toBe("partial");
+    expect(marked.gapped.partialAt).toBe(12345);
+    expect(marked.gapped.missingSeqs).toEqual([2, 4]);
+    expect(marked.healthy.status).toBe("ok");
+    expect(marked.healthy.partialAt).toBeUndefined();
+
+    expect(marked.gapped).not.toBe(input.gapped);
+    expect(marked.gapped.missingSeqs).not.toBe(input.gapped.missingSeqs);
+    marked.gapped.missingSeqs.push(99);
+    expect(input.gapped.missingSeqs).toEqual([2, 4]);
+    expect(input.gapped.status).toBe("gap_detected");
+    expect(input.gapped.partialAt).toBeUndefined();
+  });
+
+  it("defaults the partial timestamp to now", () => {
+    const before = Date.now();
+    const marked = markPendingAutonomyGapsPartial({
+      "run-1": healthOf("run-1", [3], 4),
+    });
+    const after = Date.now();
+
+    expect(marked["run-1"].partialAt).toBeGreaterThanOrEqual(before);
+    expect(marked["run-1"].partialAt).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION

Adds a first unit suite for `packages/ui/src/state/autonomy.ts` (client-side
autonomy run-health tracking: sequence-gap detection over streamed event
envelopes, recovery, reconnect hydration from the carried store, dedup,
ledger trimming, watermark cursor semantics, and gap-replay request
building). No production code is touched; the diff is one new co-located
vitest file (+490/−0) matching the sibling `*.test.ts` convention already
used throughout `packages/ui/src/state/`.

## Evidence

- `bunx vitest run packages/ui/src/state/autonomy.test.ts` → **Test Files 1 passed (1); Tests 21 passed (21)** against current `origin/develop` (`de774b8757`). Re-fetched immediately before filing; `origin/develop` had not moved since the branch point.
- `bunx biome check packages/ui/src/state/autonomy.test.ts` → clean ("Checked 1 file … No fixes applied"). Verified non-vacuous: `biome.json` exists at the repo root and the checkout is not sparse.
- `bunx tsc --noEmit -p .` in `packages/ui`: `autonomy.test.ts` appears **nowhere** in the output. The run reports 8 pre-existing errors in files this diff does not touch (`packages/core/src/cloud-routing.ts`, `src/cloud/mcps/lib/use-mcps.test.tsx`, `src/cloud/organization/data/use-credentials.test.tsx`).
- The diff touches only `packages/ui/src/state/autonomy.test.ts`. Every case drives the real module — no mocks, no `expectTypeOf`.

## Note for reviewers

While writing the suite I observed behavior that looks like a latent bug rather than intended contract, so I did **not** assert it as expected: an incoming envelope whose `runId` is literally `"__proto__"` or `"constructor"` makes `mergeAutonomyEvents` throw `TypeError: Cannot read properties of undefined (reading 'length')`, because `ensureRunHealth` reads the inherited property as a pre-existing truthy health object. This test-only diff covers the non-crashing guard branches instead (`constructor`/`prototype` runIds never enter `runIndex`); a production fix belongs in a separate, justified change.

## What the suite covers

- `mergeAutonomyEvents`: cold-start empty result; first-batch insertion with `lastSeq` and no invented gaps; gap detection metadata (`missingSeqs`, `gapCount`, `lastGapAt`, `runsWithNewGaps`); same-batch recovery (`recoveredAt`, `runsRecovered`); multi-gap partial fill across calls carrying the returned store forward; reconnect hydration from a carried store into a fresh health map; caller-input immutability (store and health map are cloned); duplicate counting by `eventId` and by the `runId:seq:stream` fallback key; envelopes without `runId`/`seq` stored but exempt from health tracking; prototype-dangerous runIds excluded from `runIndex`; `replay: true` marking unresolved runs `partial`; `maxEvents` trimming evicting seqs from `runIndex` with consistent rehydration; watermark cursor not moving backwards on late low-seq arrivals; non-ordinal `eventId` takeover of the cursor; fractional `seq` truncation onto the integer index.
- `buildAutonomyGapReplayRequests`: no requests without health; already-replayed seqs filtered out; requests sorted by `fromSeq`.
- `hasPendingAutonomyGaps`: false for empty/healthy maps, true when any run still misses seqs.
- `markPendingAutonomyGapsPartial`: only gapped runs become `partial`; explicit timestamp honored; default timestamp is now; deep-clone semantics with the input left untouched.

## CI note

This PR comes from a fork, so hosted CI does not run on it; all checks above were executed locally against the pushed head and their real outputs are quoted here.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:db7b199b608110634599de176deeb09f9e13ed07 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
