### PR TITLE
fix(cloud): reject negative points in usdFromPoints

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/earnings-units.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/earnings-units.test.ts
@@ -44,6 +44,11 @@ describe("usdFromPoints (API boundary -> canonical USD)", () => {
     }
   });
 
+  test("fails closed on negative points with a typed error", () => {
+    expect(() => usdFromPoints(-1)).toThrow(/non-negative/);
+    expect(() => usdFromPoints(-100)).toThrow(/non-negative/);
+  });
+
   test("large points stay exact where float math would drift", () => {
     // 0.07-style drift class: 12,345,678 points = $123,456.78 exactly.
     expect(usdFromPoints(12_345_678).toString()).toBe("123456.78");

--- a/packages/cloud/shared/src/lib/services/earnings-units.ts
+++ b/packages/cloud/shared/src/lib/services/earnings-units.ts
@@ -41,11 +41,14 @@ export type EarningsUsd = Decimal;
  * backstop).
  */
 export function usdFromPoints(points: number): Decimal {
-  if (!Number.isInteger(points)) {
-    throw new ElizaError(`pointsAmount must be an integer number of points, received: ${points}`, {
-      code: "INVALID_REDEMPTION_POINTS",
-      context: { received: String(points) },
-    });
+  if (!Number.isInteger(points) || points < 0) {
+    throw new ElizaError(
+      `pointsAmount must be a non-negative integer number of points, received: ${points}`,
+      {
+        code: "INVALID_REDEMPTION_POINTS",
+        context: { received: String(points) },
+      },
+    );
   }
   return new Decimal(points).div(REDEMPTION_POINTS_PER_USD);
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Throws typed `INVALID_REDEMPTION_POINTS` error when negative points are passed to `usdFromPoints`, preventing negative USD conversion.

# Background

## What does this PR do?

In `packages/cloud/shared/src/lib/services/earnings-units.ts`, `usdFromPoints` checked `!Number.isInteger(points)`. Because negative integers satisfy `Number.isInteger`, negative point inputs (e.g. `-100`) converted to negative USD (`-1.00`), violating the non-negative money-out invariant. Adding `points < 0` to the validation check ensures negative points fail closed.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/cloud/shared/src/lib/services/earnings-units.ts` and `earnings-units.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/cloud/shared src/lib/services/__tests__/earnings-units.test.ts`.

# Evidence Gate

<!-- evidence-head:7e9076b12418e8d36140f8d5931f46213f4b2c05 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - earnings units conversion helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
error: expect(received).toThrow(expected)
Expected pattern: /non-negative/
Received function did not throw
Received value: -0.01
(fail) usdFromPoints (API boundary -> canonical USD) > fails closed on negative points with a typed error
12 pass, 1 fail
```

## Green (restored)
```
(pass) usdFromPoints (API boundary -> canonical USD) > fails closed on negative points with a typed error
13 pass, 0 fail, 45 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

