### PR TITLE
test(core): cover types

### DIFF
--- a/packages/core/src/features/messaging/triage/types.test.ts
+++ b/packages/core/src/features/messaging/triage/types.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Covers the triage contract's runtime surface in types.ts: the two adapter
+ * registry lists that action parameter schemas enumerate and membership-check,
+ * and the NotYetImplementedError that optional adapter hooks throw instead of
+ * silently succeeding.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	ALL_MESSAGE_SOURCES,
+	MANAGE_OPERATION_KINDS,
+	NotYetImplementedError,
+} from "./types.ts";
+
+const throwFeature = (feature: string): unknown => {
+	try {
+		throw new NotYetImplementedError(feature);
+	} catch (error) {
+		return error;
+	}
+};
+
+describe("NotYetImplementedError", () => {
+	it("carries the feature name in its message", () => {
+		const error = new NotYetImplementedError("scheduleSend");
+
+		expect(error.message).toBe("NotYetImplemented: scheduleSend");
+	});
+
+	it("sets its own name for logs and serialization", () => {
+		const error = new NotYetImplementedError("readMessage");
+
+		expect(error.name).toBe("NotYetImplementedError");
+	});
+
+	it("stays on the Error prototype chain", () => {
+		const error = new NotYetImplementedError("searchMessages");
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(NotYetImplementedError);
+	});
+
+	it("is catchable as itself through a real throw site", () => {
+		const caught = throwFeature("manageMessage");
+
+		expect(caught).toBeInstanceOf(NotYetImplementedError);
+		expect((caught as NotYetImplementedError).message).toBe(
+			"NotYetImplemented: manageMessage",
+		);
+	});
+
+	it("preserves unusual feature identifiers losslessly", () => {
+		const error = new NotYetImplementedError(
+			"plugin-x/schedule_send (beta v2)",
+		);
+
+		expect(error.message).toBe(
+			"NotYetImplemented: plugin-x/schedule_send (beta v2)",
+		);
+	});
+
+	it("renders an empty feature as the bare prefix", () => {
+		const error = new NotYetImplementedError("");
+
+		expect(error.message).toBe("NotYetImplemented: ");
+	});
+});
+
+describe("ALL_MESSAGE_SOURCES", () => {
+	it("registers at least one connector", () => {
+		expect(ALL_MESSAGE_SOURCES.length).toBeGreaterThan(0);
+	});
+
+	it("has no duplicate sources, keeping action parameter enums valid", () => {
+		const spread = [...ALL_MESSAGE_SOURCES];
+
+		expect(spread.length).toBe(ALL_MESSAGE_SOURCES.length);
+		expect(new Set(spread).size).toBe(spread.length);
+	});
+
+	it("stores every source in canonical lowercase form", () => {
+		for (const source of ALL_MESSAGE_SOURCES) {
+			expect(source).toBe(source.trim().toLowerCase());
+		}
+	});
+});
+
+describe("MANAGE_OPERATION_KINDS", () => {
+	it("registers at least one manage operation", () => {
+		expect(MANAGE_OPERATION_KINDS.length).toBeGreaterThan(0);
+	});
+
+	it("has no duplicate operation kinds", () => {
+		const spread = [...MANAGE_OPERATION_KINDS];
+
+		expect(spread.length).toBe(MANAGE_OPERATION_KINDS.length);
+		expect(new Set(spread).size).toBe(spread.length);
+	});
+
+	it("uses snake_case tokens safe for action parameter enums", () => {
+		for (const kind of MANAGE_OPERATION_KINDS) {
+			expect(kind).toMatch(/^[a-z][a-z_]*$/);
+		}
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/messaging/triage/types.test.ts`, a new vitest suite covering the runtime surface of the messaging triage contract module (`types.ts`), which previously had no same-named suite anywhere on develop.

## Why

`types.ts` is mostly type declarations, but it ships three runtime exports that live code depends on:

- `NotYetImplementedError` - thrown by every optional `BaseMessageAdapter` hook (`adapters/base.ts`) and caught by `instanceof` in `actions/sendDraft.ts`;
- `ALL_MESSAGE_SOURCES` - spread into action parameter JSON-schema enums by `listInbox.ts`, `searchMessages.ts`, and the shared message-action params, and used as a membership gate via `.includes(input.toLowerCase())` in `actions/_shared.ts`;
- `MANAGE_OPERATION_KINDS` - spread into the manage operation enum by `manageMessage.ts`.

The suite asserts behavior at those boundaries rather than mirroring source literals:

- the error's message format (`NotYetImplemented: <feature>`), its own `name`, the intact `Error` prototype chain, catchability through a real throw site, lossless preservation of unusual feature identifiers, and the empty-feature edge;
- both registry lists are non-empty, duplicate-free (duplicates would emit invalid action parameter enums), spread-lossless, lowercase/snake_case-canonical so the existing `.includes(input.toLowerCase())` validation keeps matching user input.

No mocks stand between the suite and the module: everything drives the real exports.

## Evidence (test-only change)

- Diff is purely additive: one new file, +105/-0, no production code touched.
- `bunx vitest run src/features/messaging/triage/types.test.ts` (packages/core): **Test Files 1 passed (1) - Tests 12 passed (12)** - re-fetched and re-run immediately before filing against current `origin/develop` (`de774b875774f478ef5b879dbdae8fd2997a3470`); develop had not moved since the branch point.
- `bunx biome check --write` on the touched file: clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in packages/core: **0 errors** total; the new filename appears nowhere in output.
- No `expectTypeOf` and no type-only subject: every assertion executes real runtime values.
- Fork contributor: hosted CI does not run on this PR; all checks above were executed locally and are quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:edf8c590a9644d2cf997aae85504e47102341380 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
