### PR TITLE
fix(plugin-app-manager): gate /api/apps/relaunch behind OWNER/ADMIN role

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -293,6 +293,73 @@ describe("handleAppsRoutes", () => {
     },
   );
 
+  it.each([undefined, null, "USER", "GUEST"] as const)(
+    "denies %s actor at /api/apps/relaunch without stopping or launching",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/relaunch",
+        appManager,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App relaunch requires OWNER or ADMIN role",
+      });
+      expect(appManager.launch).not.toHaveBeenCalled();
+      expect(appManager.stop).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["OWNER", "ADMIN"] as const)(
+    "allows %s actor to relaunch apps",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/relaunch",
+        appManager,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.body).toEqual({
+        launch: { success: true },
+        verify: null,
+      });
+      expect(appManager.stop).toHaveBeenCalledTimes(1);
+      expect(appManager.launch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("denies the relaunch role gate before parsing the request body", async () => {
+    const appManager = createAppManager();
+
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/relaunch",
+      appManager,
+      actorRole: "USER",
+      body: { name: "", __proto__: { polluted: true } },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(403);
+    expect(result.res.body).toEqual({
+      error: "App relaunch requires OWNER or ADMIN role",
+    });
+    expect(appManager.stop).not.toHaveBeenCalled();
+    expect(appManager.launch).not.toHaveBeenCalled();
+  });
+
   it("rejects illegal percent-encoding in app path segments before service calls", async () => {
     const appManager = createAppManager();
     const refreshRegistry = vi.fn(async () => new Map());

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1441,6 +1441,15 @@ export async function handleAppsRoutes(
   // -------------------------------------------------------------------------
 
   if (method === "POST" && pathname === "/api/apps/relaunch") {
+    // Relaunch stops matching runs and launches the app again — the same
+    // privileged operation the /api/apps/launch branch gates. Enforce the
+    // identical OWNER/ADMIN check here so relaunch cannot be used to bypass
+    // the launch authorization control (a USER/GUEST/anonymous actor must
+    // not be able to stop or launch arbitrary apps through this endpoint).
+    if (!canLaunchApps(actorRole)) {
+      error(res, "App relaunch requires OWNER or ADMIN role", 403);
+      return true;
+    }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostRelaunchAppRequestSchema.safeParse(rawBody);


### PR DESCRIPTION
# Relates to

Closes #27591

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and the owning package's `test`/`typecheck`/`lint:check` were run after sync (see Known gaps for the repo-wide `bun run verify` note).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`HEAD..origin/develop` == 0).
- [x] Owning-package gates pass post-sync; repo-wide `bun run verify` blocker documented in **Known gaps / failures**.

# Risks

Low. The change adds one authorization guard on a single HTTP branch (`POST /api/apps/relaunch`) using the existing `canLaunchApps` helper and `actorRole` already present in the route context. It only *removes* an unauthorized capability; OWNER/ADMIN behavior is unchanged. No schema, storage, or wire-shape changes.

# Background

## What does this PR do?

`handleAppsRoutes` gates `POST /api/apps/launch` behind `canLaunchApps(actorRole)` — only `OWNER` or `ADMIN` may launch an app, returning `403` otherwise. `POST /api/apps/relaunch` performs the **same privileged operation** (it calls `appManager.stop()` then `appManager.launch()` to bring an app up), but the relaunch handler had **no role check**.

That meant a `USER`, `GUEST`, or unauthenticated actor (`undefined`/`null` role) could stop and launch arbitrary apps through `/api/apps/relaunch`, defeating the launch authorization control. This is a privilege-escalation / authorization-bypass on a real HTTP boundary: `packages/agent/src/api/server.ts` computes `appActorRole = resolveBoundaryRole(req)` and passes it straight through to `handleAppsRoutes`, and `/api/apps/relaunch` matches the `/api/apps` prefix — so the unguarded branch is reachable in production. The relaunch endpoint is a documented external surface that pairs with the in-process APP action so dashboard UIs and platform connectors can reach the same behaviour.

The fix adds the identical guard used by the launch branch, at the top of the relaunch branch (before body parsing / stop / launch):

```ts
if (!canLaunchApps(actorRole)) {
  error(res, "App relaunch requires OWNER or ADMIN role", 403);
  return true;
}
```

Scope is intentionally limited to relaunch parity with launch. `/api/apps/stop` and `/api/apps/install` are out of scope for this fix.

## What kind of change is this?

Bug fix (non-breaking change which fixes an authorization-bypass defect).

# Documentation changes needed?

My changes do not require a change to the project documentation. The endpoint's documented purpose is unchanged; only the missing authorization check on a privileged operation is added.

# Testing

## Where should a reviewer start?

`plugins/plugin-app-manager/src/api/apps-routes.test.ts`. Run the added relaunch-authz tests against `develop` (they fail) and against this branch (they pass):

```bash
bun install
bunx --cwd plugins/plugin-app-manager vitest run src/api/apps-routes.test.ts -t relaunch
```

## Detailed testing steps

The new parametrized tests mirror the existing launch-gate coverage exactly:

- `it.each([undefined, null, "USER", "GUEST"])` — asserts `POST /api/apps/relaunch` returns `403` with body `{ error: "App relaunch requires OWNER or ADMIN role" }` and that **neither** `appManager.stop` **nor** `appManager.launch` is invoked.
- `it.each(["OWNER", "ADMIN"])` — asserts the relaunch path proceeds: `200`, body `{ launch: { success: true }, verify: null }`, with `stop` and `launch` each called once.
- A dedicated test proving the gate fires **before** request-body parsing (a `USER` sending a malformed body still gets `403`, not `400`), confirming the guard is placed ahead of side effects.

# Evidence Gate

<!-- evidence-head:c8d32d7f1b9c161624ae77f891bab3f28b5d5a69 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend HTTP authorization change; no UI surface is rendered or modified by this PR.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend HTTP authorization change; no UI surface is rendered or modified by this PR.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-visual HTTP route guard; the reviewable flow is the failing-before/passing-after vitest run captured below.`
<!-- evidence-row:backend-logs -->
- [x] Failing-before and passing-after vitest output for the relaunch authz path is attached under **Backend + frontend logs**.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved; the boundary is the /api/apps/relaunch HTTP handler exercised directly in tests.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; this is a route authorization guard.`
<!-- evidence-row:domain-artifacts -->
- [x] Test artifacts (failing-before / passing-after / full-package run) are attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes.`

## Backend + frontend logs

**Failing BEFORE the fix** (relaunch source reverted to base, new tests present) — the unguarded relaunch returns `200`/`400` and invokes `appManager.launch`:

```text
     × denies undefined actor at /api/apps/relaunch without stopping or launching
     × denies null actor at /api/apps/relaunch without stopping or launching
     × denies USER actor at /api/apps/relaunch without stopping or launching
     × denies GUEST actor at /api/apps/relaunch without stopping or launching
     × denies the relaunch role gate before parsing the request body
AssertionError: expected 200 to be 403 // Object.is equality
- 403
+ 200
AssertionError: expected 400 to be 403 // Object.is equality
- 403
+ 400
 Test Files  1 failed (1)
      Tests  5 failed | 2 passed | 16 skipped (23)
```

**Passing AFTER the fix** (relaunch authz subset):

```text
 Test Files  1 passed (1)
      Tests  7 passed | 16 skipped (23)
```

**Full package run** (`bun run --cwd plugins/plugin-app-manager test`) — green including the pre-existing launch-gate tests:

```text
 Test Files  4 passed (4)
      Tests  44 passed (44)
```

`typecheck` (`tsc --noEmit --rootDir ../..`) and `lint:check` (`biome check .`) both pass clean for the package after building the `@elizaos/logger` and `@elizaos/cloud-routing` prebuild deps.

## Screenshots (before / after) + video walkthrough

`N/A - backend authorization change with no rendered UI surface.`

### Before

`N/A - no UI.`

### After

`N/A - no UI.`

### Walkthrough video

`N/A - no UI; the failing-before/passing-after vitest output is the reviewable proof.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this machine: `bun install` requires `--minimum-release-age=0` to bypass a local registry release-age policy, and the full `verify` gate builds every workspace which is disproportionate for this ~9-line guard. Instead the owning package's `test` (44 passed), `typecheck` (clean), and `lint:check` (clean) were run and are attached. This is not a blocker for a single-branch authorization guard reusing existing helpers.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@de774b875774f478ef5b879dbdae8fd2997a3470:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@de774b875774f478ef5b879dbdae8fd2997a3470:packages/skills/skills/contribute-to-eliza"} -->
