### PR TITLE
test(core): cover oauth feature barrel

### DIFF
--- a/packages/core/src/features/oauth/index.test.ts
+++ b/packages/core/src/features/oauth/index.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the features/oauth public barrel (index.ts) — the eager
+ * bundle-safety anchor that keeps the feature in mobile bundles, the
+ * composition of the five atomic actions into oauthPlugin, both init()
+ * branches (in-process bus registration vs. existing cloud bus), and the
+ * OAuth delivery-target ordering contract. Real modules only; the runtime is
+ * a minimal recording stub and there is no network or HTTP server.
+ */
+import { describe, expect, test, vi } from "vitest";
+import type { IAgentRuntime } from "../../types/index.ts";
+import * as OAuthFeature from "./index.ts";
+import {
+	awaitOAuthCallbackAction,
+	bindOAuthCredentialAction,
+	createOAuthIntentAction,
+	deliverOAuthLinkAction,
+	eligibleOAuthDeliveryTargets,
+	LocalOAuthCallbackBus,
+	oauthPlugin,
+	revokeOAuthCredentialAction,
+} from "./index.ts";
+
+const ATOMIC_ACTIONS = [
+	awaitOAuthCallbackAction,
+	bindOAuthCredentialAction,
+	createOAuthIntentAction,
+	deliverOAuthLinkAction,
+	revokeOAuthCredentialAction,
+];
+
+function makeRuntime(cloudBus?: unknown): IAgentRuntime & {
+	getService: ReturnType<typeof vi.fn>;
+	registerService: ReturnType<typeof vi.fn>;
+} {
+	return {
+		getService: vi.fn(() => cloudBus),
+		registerService: vi.fn(async () => {}),
+	} as unknown as IAgentRuntime & {
+		getService: ReturnType<typeof vi.fn>;
+		registerService: ReturnType<typeof vi.fn>;
+	};
+}
+
+describe("features/oauth barrel (index.ts)", () => {
+	test("eagerly anchors the composed plugin on globalThis for mobile-bundle retention", () => {
+		const anchored = (globalThis as Record<string, unknown>)
+			.__bundle_safety_FEATURES_OAUTH_INDEX__;
+		expect(Array.isArray(anchored)).toBe(true);
+		expect(anchored).toHaveLength(1);
+		expect((anchored as unknown[])[0]).toBe(oauthPlugin);
+	});
+
+	test("exposes all five atomic actions as live dispatchable handlers", () => {
+		for (const action of ATOMIC_ACTIONS) {
+			expect(action).toBeTypeOf("object");
+			expect(action.name).toBeTypeOf("string");
+			expect(action.name.length).toBeGreaterThan(0);
+			expect(action.validate).toBeTypeOf("function");
+			expect(action.handler).toBeTypeOf("function");
+		}
+	});
+
+	test("composes exactly the five exported action objects into the plugin", () => {
+		const exported = new Set(ATOMIC_ACTIONS);
+		expect(oauthPlugin.actions).toHaveLength(5);
+		for (const action of oauthPlugin.actions ?? []) {
+			expect(exported.has(action)).toBe(true);
+		}
+	});
+
+	test("default export is the same plugin object as the named export", () => {
+		expect(OAuthFeature.default).toBe(OAuthFeature.oauthPlugin);
+	});
+
+	test("ships the public local callback route", () => {
+		const routes = oauthPlugin.routes ?? [];
+		expect(routes).toHaveLength(1);
+		expect(routes[0].type).toBe("POST");
+		expect(routes[0].path).toBe("/api/oauth/callback");
+		expect(routes[0].public).toBe(true);
+	});
+
+	test("init registers LocalOAuthCallbackBus when no cloud bus client is present", async () => {
+		const runtime = makeRuntime(undefined);
+		await oauthPlugin.init({}, runtime);
+		expect(runtime.getService).toHaveBeenCalledWith("OAuthCallbackBusClient");
+		expect(runtime.registerService).toHaveBeenCalledTimes(1);
+		expect(runtime.registerService).toHaveBeenCalledWith(LocalOAuthCallbackBus);
+	});
+
+	test("init keeps an existing cloud bus client and skips local registration", async () => {
+		const runtime = makeRuntime({ waitFor: async () => ({}) });
+		await oauthPlugin.init({}, runtime);
+		expect(runtime.registerService).not.toHaveBeenCalled();
+	});
+
+	test("eligibleOAuthDeliveryTargets prefers direct/authenticated channels before public_link", () => {
+		expect(eligibleOAuthDeliveryTargets()).toEqual([
+			"dm",
+			"owner_app_inline",
+			"cloud_authenticated_link",
+			"tunnel_authenticated_link",
+			"public_link",
+		]);
+	});
+
+	test("returns a fresh array so callers can mutate their copy safely", () => {
+		const first = eligibleOAuthDeliveryTargets();
+		const second = eligibleOAuthDeliveryTargets();
+		expect(first).not.toBe(second);
+		first.reverse();
+		expect(second[0]).toBe("dm");
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the OAuth feature's public barrel,
`packages/core/src/features/oauth/index.ts` — previously untested at that
path. Test-only change: one new file, +114/−0, no production behaviour is
modified.

## Coverage (all driven through `./index.ts`, real modules, no mocks of the subject)

1. **Bundle-safety anchor** — importing the barrel must eagerly stash the
   composed plugin on `globalThis.__bundle_safety_FEATURES_OAUTH_INDEX__`
   (array of 1, identity-equal to the exported `oauthPlugin`). This is the
   retention contract the barrel exists for (Bun.build drops re-export-only
   barrels from the mobile bundle — incidents #10727/#11030/#11248/#11276).
2. **Live action surface** — all five atomic actions resolve as dispatchable
   handlers (non-empty `name`, callable `validate`/`handler`) consumed by the
   runtime action catalog.
3. **Plugin composition** — `oauthPlugin.actions` contains exactly those five
   exported action references; default export is the same object as the named
   export; the plugin ships exactly the public POST `/api/oauth/callback`
   route.
4. **Both `init()` branches** — with no cloud bus client present the plugin
   registers `LocalOAuthCallbackBus`; with an existing cloud bus client it
   skips local registration (observed via a recording stub runtime).
5. **Delivery targets** — `eligibleOAuthDeliveryTargets()` returns the
   authenticated-channels-first ordering ending in `public_link`, and a fresh
   array per call so callers can mutate their copy safely.

## Verification (observed counts)

- `bunx vitest run src/features/oauth/index.test.ts` (in `packages/core`):
  **Test Files 1 passed (1), Tests 9 passed (9)** — re-fetched and re-run
  against current `origin/develop` immediately before filing; zero drift in
  every module the suite imports.
- `bunx biome check --write src/features/oauth/index.test.ts`: clean,
  "No fixes applied", exit 0.
- `bunx tsc --noEmit` in `packages/core`: exit 0, zero output; the new file
  appears nowhere in diagnostics.
- Diff touches only the single new test file (+114/−0).

**Note:** this PR comes from a fork, so hosted CI does not run on it — the
counts above are from local runs of the pinned toolchain against current
develop.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:84cbc94e345bf6d17bb9ee76ad198ee0f1e7353b -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
