### PR TITLE
test(app-core): cover windows cef profile version resolution

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/windows-cef-profile.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/windows-cef-profile.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDesktopBundleVersion,
+  shouldResetWindowsCefProfile,
+  shouldWriteWindowsCefProfileMarker,
+} from "./windows-cef-profile.ts";
+
+describe("resolveDesktopBundleVersion", () => {
+  it("resolves version from the macOS app bundle resources", () => {
+    const fsMock = {
+      existsSync: (p: string) => p.includes("Resources/version.json"),
+      readFileSync: () => '{"version": "1.2.3"}',
+    };
+    const version = resolveDesktopBundleVersion(
+      "/opt/app",
+      "/Applications/Test.app/Contents/MacOS/Test",
+      "darwin",
+      fsMock as never,
+    );
+    expect(version).toBe("1.2.3");
+  });
+
+  it("falls back to the module package.json", () => {
+    const fsMock = {
+      existsSync: (p: string) => p.endsWith("package.json"),
+      readFileSync: () => '{"version": "9.9.9"}',
+    };
+    const version = resolveDesktopBundleVersion(
+      "/opt/app/packages/app",
+      "/usr/bin/node",
+      "linux",
+      fsMock as never,
+    );
+    expect(version).toBe("9.9.9");
+  });
+
+  it("returns null on invalid version json", () => {
+    const fsMock = {
+      existsSync: () => true,
+      readFileSync: () => "not-json",
+    };
+    expect(
+      resolveDesktopBundleVersion(
+        "/opt/app",
+        "/usr/bin/node",
+        "linux",
+        fsMock as never,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("shouldResetWindowsCefProfile", () => {
+  it("resets when version changed", () => {
+    expect(
+      shouldResetWindowsCefProfile({
+        currentVersion: "2.0.0",
+        previousVersion: "1.0.0",
+        cefDirExists: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reset when version is same or unknown", () => {
+    expect(
+      shouldResetWindowsCefProfile({
+        currentVersion: "1.0.0",
+        previousVersion: "1.0.0",
+        cefDirExists: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldResetWindowsCefProfile({
+        currentVersion: "unknown",
+        previousVersion: "1.0.0",
+        cefDirExists: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reset when cef dir is missing", () => {
+    expect(
+      shouldResetWindowsCefProfile({
+        currentVersion: "2.0.0",
+        previousVersion: "1.0.0",
+        cefDirExists: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldWriteWindowsCefProfileMarker", () => {
+  it("writes marker for a known version", () => {
+    expect(shouldWriteWindowsCefProfileMarker("1.0.0")).toBe(true);
+  });
+
+  it("does not write for unknown or missing versions", () => {
+    expect(shouldWriteWindowsCefProfileMarker("unknown")).toBe(false);
+    expect(shouldWriteWindowsCefProfileMarker(null)).toBe(false);
+    expect(shouldWriteWindowsCefProfileMarker("  ")).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 8 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
