### PR TITLE
test(core): cover types

### DIFF
--- a/packages/core/src/features/payments/types.test.ts
+++ b/packages/core/src/features/payments/types.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Behavioural coverage for the payments feature's runtime surface:
+ * `eligibleDeliveryTargetsFor`, the public-link eligibility gate the PAYMENT
+ * action applies before dispatching a hosted link, plus the service-name
+ * registry keys the actions resolve cloud clients through and the context-kind
+ * enumeration fed into the action parameter schema. Drives the real module
+ * directly; no mocks and no runtime harness.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+	eligibleDeliveryTargetsFor,
+	PAYMENT_BUS_CLIENT_SERVICE,
+	PAYMENT_CONTEXT_KINDS,
+	PAYMENT_REQUESTS_CLIENT_SERVICE,
+	PAYMENT_SETTLER_SERVICE,
+} from "./types";
+
+describe("eligibleDeliveryTargetsFor", () => {
+	test("any_payer is the only context eligible for public_link delivery", () => {
+		expect(eligibleDeliveryTargetsFor("any_payer")).toEqual([
+			"public_link",
+			"dm",
+			"owner_app_inline",
+			"cloud_authenticated_link",
+			"tunnel_authenticated_link",
+		]);
+	});
+
+	test.each(["verified_payer", "specific_payer"] as const)(
+		"%s falls back to authenticated routes only",
+		(kind) => {
+			const targets = eligibleDeliveryTargetsFor(kind);
+			expect(targets).not.toContain("public_link");
+			expect(targets).toEqual([
+				"dm",
+				"owner_app_inline",
+				"cloud_authenticated_link",
+				"tunnel_authenticated_link",
+			]);
+		},
+	);
+
+	test("every registered context kind resolves to a non-empty target list", () => {
+		for (const kind of PAYMENT_CONTEXT_KINDS) {
+			const targets = eligibleDeliveryTargetsFor(kind);
+			expect(targets.length).toBeGreaterThan(0);
+			if (kind !== "any_payer") {
+				expect(targets).not.toContain("public_link");
+			}
+		}
+	});
+
+	test("each call returns a fresh array so caller mutation cannot leak into later lookups", () => {
+		const first = eligibleDeliveryTargetsFor("any_payer");
+		const second = eligibleDeliveryTargetsFor("any_payer");
+		expect(first).not.toBe(second);
+		first.pop();
+		expect(second).toContain("tunnel_authenticated_link");
+		expect(eligibleDeliveryTargetsFor("any_payer")).toHaveLength(5);
+	});
+});
+
+describe("payment service registry keys", () => {
+	test("registers the cloud adapters under their stable getService keys", () => {
+		expect(PAYMENT_REQUESTS_CLIENT_SERVICE).toBe("PaymentRequestsClient");
+		expect(PAYMENT_BUS_CLIENT_SERVICE).toBe("PaymentBusClient");
+		expect(PAYMENT_SETTLER_SERVICE).toBe("PaymentSettler");
+	});
+
+	test("registry keys are pairwise distinct", () => {
+		const keys = [
+			PAYMENT_REQUESTS_CLIENT_SERVICE,
+			PAYMENT_BUS_CLIENT_SERVICE,
+			PAYMENT_SETTLER_SERVICE,
+		];
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});
+
+describe("PAYMENT_CONTEXT_KINDS", () => {
+	test("carries no duplicates into the action parameter schema enum", () => {
+		expect(new Set(PAYMENT_CONTEXT_KINDS).size).toBe(
+			PAYMENT_CONTEXT_KINDS.length,
+		);
+		expect(PAYMENT_CONTEXT_KINDS).toContain("any_payer");
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit suite for the runtime surface of `packages/core/src/features/payments/types.ts`, which previously had no same-named test file anywhere in the repository. This is a **test-only change**: one new file, `packages/core/src/features/payments/types.test.ts` (+88/-0). No production code is modified.

## What is covered

The assertions mirror what real consumers do with this module, not its shape:

- `eligibleDeliveryTargetsFor` — the public-link eligibility gate that the PAYMENT action applies before dispatch (`handleDeliverLink` gates on `eligible.includes(target)`; `handleCreateRequest` reports the list as `data.eligibleDeliveryTargets`):
  - `"any_payer"` is the only context kind whose target list contains `public_link` (exact ordered list asserted);
  - `"verified_payer"` and `"specific_payer"` fall back to the authenticated-route list only;
  - every entry of `PAYMENT_CONTEXT_KINDS` resolves to a non-empty list, with `public_link` excluded outside `any_payer`;
  - each call returns a fresh array, so caller-side mutation cannot leak into later lookups.
- Service registry keys `PAYMENT_REQUESTS_CLIENT_SERVICE` / `PAYMENT_BUS_CLIENT_SERVICE` / `PAYMENT_SETTLER_SERVICE` pin the stable keys behind every action's `runtime.getService(...)` resolution (consumed by `packages/core/src/features/payments/actions/payment.ts`) and are pairwise distinct.
- `PAYMENT_CONTEXT_KINDS` carries no duplicates before being spread into the action parameter schema enum (`enum: [...PAYMENT_CONTEXT_KINDS]`).

## Evidence (all observed locally on this branch)

- `bunx vitest run packages/core/src/features/payments/types.test.ts`: **Test Files 1 passed (1), Tests 8 passed (8)** — re-run against current `origin/develop` immediately before filing; develop had not moved (`de774b87`) and the module under test is byte-identical to it.
- `bunx biome check --write packages/core/src/features/payments/types.test.ts`: fixed once on first pass; subsequent check clean ("No fixes applied").
- `bunx tsc --noEmit` in `packages/core`: exit 0, empty output — the new test file appears nowhere in it.
- Diff touches exactly one new file; no existing lines removed or modified.

Note: this is a fork contribution, so hosted CI does not run on this pull request. All checks above were executed locally against current `origin/develop`.

Reproduce with:

```sh
bunx vitest run packages/core/src/features/payments/types.test.ts
```

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f7e1daf9ad614de884cb26b423a909e44a03b21 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
