### PR TITLE
test(shared): cover gpu tier detection

### DIFF
--- a/packages/shared/src/local-inference-gpu/__tests__/gpu-tier-detect.test.ts
+++ b/packages/shared/src/local-inference-gpu/__tests__/gpu-tier-detect.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execSync: mocks.execSync }));
+vi.mock("./gpu-tier-profiles.js", () => ({
+  getGpuProfile: () => null,
+  selectBestProfile: () => null,
+}));
+
+import { detectNvidiaGpu } from "./gpu-tier-detect.ts";
+
+describe("detectNvidiaGpu", () => {
+  it("parses nvidia-smi output", () => {
+    mocks.execSync.mockReturnValue("NVIDIA GeForce RTX 4090, 24564, 8.9\n");
+    const gpu = detectNvidiaGpu();
+    expect(gpu?.name).toContain("RTX 4090");
+    expect(gpu?.vram_mb).toBe(24564);
+    expect(gpu?.cuda_compute).toBe("8.9");
+  });
+
+  it("handles missing compute capability", () => {
+    mocks.execSync.mockReturnValue("Tesla T4, 15360, N/A\n");
+    const gpu = detectNvidiaGpu();
+    expect(gpu?.name).toContain("T4");
+    expect(gpu?.cuda_compute).toBeNull();
+  });
+
+  it("returns null when nvidia-smi fails (fail-closed)", () => {
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("command not found");
+    });
+    expect(detectNvidiaGpu()).toBeNull();
+  });
+
+  it("returns null on empty output", () => {
+    mocks.execSync.mockReturnValue("\n\n");
+    expect(detectNvidiaGpu()).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
