### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/plugin-config/index.test.ts
+++ b/packages/core/src/features/plugin-config/index.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Coverage for the plugin-config feature barrel: importing the module must
+ * eagerly anchor the assembled plugin under its unique bundle-safety key on
+ * globalThis (the Bun.build tree-shaking workaround), alias the default export
+ * to the same plugin object, and forward every action and runtime constant as
+ * the identical reference from its defining module. Real module under test;
+ * no mocks.
+ */
+import { describe, expect, test } from "vitest";
+import { activatePluginIfReadyAction } from "./actions/activate-plugin-if-ready";
+import { deliverPluginConfigFormAction } from "./actions/deliver-plugin-config-form";
+import { pollPluginConfigStatusAction } from "./actions/poll-plugin-config-status";
+import { probePluginConfigRequirementsAction } from "./actions/probe-plugin-config-requirements";
+import * as pluginConfigIndex from "./index";
+import { pluginConfigPlugin } from "./plugin";
+import { PLUGIN_ACTIVATED_EVENT, PLUGIN_CONFIG_CLIENT_SERVICE } from "./types";
+
+describe("features/plugin-config/index", () => {
+	test("anchors the assembled plugin on globalThis for bundle retention", () => {
+		const source = globalThis as Record<string, unknown>;
+		const anchored = source.__bundle_safety_FEATURES_PLUGIN_CONFIG_INDEX__;
+		expect(Array.isArray(anchored)).toBe(true);
+		const values = anchored as readonly unknown[];
+		expect(values).toHaveLength(1);
+		expect(values[0]).toBe(pluginConfigPlugin);
+	});
+
+	test("aliases the default export to the named pluginConfigPlugin", () => {
+		expect(pluginConfigIndex.pluginConfigPlugin).toBe(pluginConfigPlugin);
+		expect(pluginConfigIndex.default).toBe(pluginConfigPlugin);
+	});
+
+	test("forwards each atomic action by reference from its defining module", () => {
+		expect(pluginConfigIndex.activatePluginIfReadyAction).toBe(
+			activatePluginIfReadyAction,
+		);
+		expect(pluginConfigIndex.deliverPluginConfigFormAction).toBe(
+			deliverPluginConfigFormAction,
+		);
+		expect(pluginConfigIndex.pollPluginConfigStatusAction).toBe(
+			pollPluginConfigStatusAction,
+		);
+		expect(pluginConfigIndex.probePluginConfigRequirementsAction).toBe(
+			probePluginConfigRequirementsAction,
+		);
+	});
+
+	test("forwards the runtime event and service constants from types", () => {
+		expect(pluginConfigIndex.PLUGIN_ACTIVATED_EVENT).toBe(
+			PLUGIN_ACTIVATED_EVENT,
+		);
+		expect(pluginConfigIndex.PLUGIN_CONFIG_CLIENT_SERVICE).toBe(
+			PLUGIN_CONFIG_CLIENT_SERVICE,
+		);
+	});
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/core/src/features/plugin-config/index.ts`, which previously had no same-named test file anywhere on develop.

The module is the plugin-config feature barrel: four atomic action re-exports, the assembled plugin (named plus default alias), two runtime constants, and an eager bundle-safety anchor. The suite drives the real module (no mocks) and asserts observable runtime behaviour:

- Importing the barrel eagerly writes `__bundle_safety_FEATURES_PLUGIN_CONFIG_INDEX__` on `globalThis` as an array containing exactly one entry that is reference-identical to `pluginConfigPlugin` from `./plugin` — the anchor whose absence historically let Bun.build tree-shake the whole feature out of the mobile agent bundle (#10727, #11030, #11248, #11276).
- The default export is the identical object as the named `pluginConfigPlugin`.
- Each of the four exported actions is the identical reference from its defining module (`activate-plugin-if-ready`, `deliver-plugin-config-form`, `poll-plugin-config-status`, `probe-plugin-config-requirements`), so the barrel forwards real implementations rather than wrappers or copies.
- `PLUGIN_ACTIVATED_EVENT` and `PLUGIN_CONFIG_CLIENT_SERVICE` are forwarded from `./types` by live-reference comparison (no literals duplicated in the test, so intentional copy/value edits upstream cannot break this suite).

Branch note: the prescribed name `test/core-index-coverage` was occupied locally by another lane's unfiled credential-proxy work in the shared checkout, so this PR uses the non-colliding head branch `test/core-pluginconfig-index-coverage`.

## Test plan

Test-only change; no production behaviour modified. The diff is one new file, +56/-0.

- [x] `bunx vitest run packages/core/src/features/plugin-config/index.test.ts` — 1 file passed, 4 tests passed (4/4), re-run immediately before filing against current origin/develop (`de774b875774f478ef5b879dbdae8fd2997a3470`).
- [x] `bunx biome check packages/core/src/features/plugin-config/index.test.ts` — clean, exit 0, config verified present.
- [x] `bunx tsc --noEmit` in `packages/core` — the new test file appears nowhere in the output.
- [x] Diff touches only `packages/core/src/features/plugin-config/index.test.ts`.

Note: this PR comes from a fork, so hosted CI does not run on it; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cf38bd830b3509463bd1cd6ee8530c94dc5a94b9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
