### PR TITLE
test(ui): cover useAppLifecycleEvents

### DIFF
--- a/packages/ui/src/state/useAppLifecycleEvents.test.tsx
+++ b/packages/ui/src/state/useAppLifecycleEvents.test.tsx
@@ -364,4 +364,109 @@ describe("useAppLifecycleEvents", () => {
       "conv-persist",
     );
   });
+
+  it("on pause with no active conversation removes any persisted conversation id", () => {
+    window.localStorage.setItem(
+      "eliza:chat:activeConversationId",
+      "conv-stale",
+    );
+    const { chatAbortRef } = setup({ activeId: null });
+
+    dispatchPause();
+
+    expect(chatAbortRef.current).toBeNull();
+    expect(
+      window.localStorage.getItem("eliza:chat:activeConversationId"),
+    ).toBeNull();
+  });
+
+  it("on pause clears chatAbortRef after aborting a live controller", () => {
+    const controller = new AbortController();
+    const { chatAbortRef } = setup({ activeId: "conv-abort-clear" });
+    chatAbortRef.current = controller;
+
+    dispatchPause();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortRef.current).toBeNull();
+  });
+
+  it("on pause clears chatAbortRef without re-aborting an already-aborted controller", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { chatAbortRef } = setup();
+    chatAbortRef.current = controller;
+
+    dispatchPause();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortRef.current).toBeNull();
+  });
+
+  it("on resume leaves conversation state untouched when the transcript is empty", () => {
+    const { setConversationMessages } = setup({ messages: [] });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(setConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("sweeps only the trailing empty assistant placeholder, leaving earlier assistant turns alone", () => {
+    const stored = makeMessages(
+      { id: "m0", role: "assistant", text: "" } as ConversationMessage,
+      { id: "m1", role: "user", text: "hi" } as ConversationMessage,
+      { id: "m2", role: "assistant", text: "" } as ConversationMessage,
+    );
+    const { setConversationMessages } = setup({ messages: stored });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(setConversationMessages).toHaveBeenCalledTimes(1);
+    const updater = setConversationMessages.mock.calls[0][0] as (
+      prev: ConversationMessage[],
+    ) => ConversationMessage[];
+    const next = updater(stored);
+    expect(next).toHaveLength(3);
+    expect(next[0].interrupted).toBeUndefined();
+    expect(next[1].interrupted).toBeUndefined();
+    expect(next[2].interrupted).toBe(true);
+  });
+
+  it("runs a second resume burst after the first completed (debounce re-arms)", () => {
+    const { loadConversationMessages } = setup({ activeId: "conv-rearm" });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(2);
+    expect(loadConversationMessages).toHaveBeenCalledTimes(2);
+    expect(loadConversationMessages).toHaveBeenLastCalledWith("conv-rearm");
+  });
+
+  it("probes /api/health with the non-fatal request contract on a normal base", () => {
+    setup({ activeId: "conv-probe" });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.fetch).toHaveBeenCalledWith("/api/health", undefined, {
+      allowNonOk: true,
+      timeoutMs: 5_000,
+    });
+  });
+
+  it("a rejected health probe does not derail the rest of the resume sequence", async () => {
+    mocks.client.fetch.mockRejectedValueOnce(new Error("probe unreachable"));
+    const { loadConversationMessages } = setup({ activeId: "conv-degraded" });
+
+    dispatchResume();
+    await vi.advanceTimersByTimeAsync(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-degraded");
+  });
 });


### PR DESCRIPTION

Adds unit coverage for `packages/ui/src/state/useAppLifecycleEvents.ts`, the hook that wires APP_PAUSE/APP_RESUME (and bfcache `pageshow`) events to chat runtime state.

A colocated suite already exists on develop (14 cases), so this change is **strictly additive**: it appends eight cases inside the existing describe block and deletes nothing (`+105/-0`, one test file). The new cases pin branches the existing suite did not exercise:

- pause with **no** active conversation removes any persisted conversation id from storage (`removeItem` path)
- pause clears `chatAbortRef` after aborting a live controller
- pause clears `chatAbortRef` without re-aborting an already-aborted controller
- resume leaves conversation state untouched when the transcript is empty
- the stale-placeholder sweep marks only the *trailing* empty assistant turn interrupted, leaving earlier assistant turns alone (id-scoped, length-preserving)
- the debounce re-arms: a second resume burst after the first completed runs again (not a one-shot latch)
- on a normal base, resume probes `/api/health` with the non-fatal request contract (`allowNonOk: true`, 5s timeout)
- a rejected health probe does not derail the reconnect or the active-conversation tail refetch

## Evidence (test-only diff; no production behavior changed)

- `vitest run src/state/useAppLifecycleEvents.test.tsx` (packages/ui lane, jsdom, package config): **Test Files 1 passed (1), Tests 22 passed (22)** — 14 pre-existing + 8 new.
- `biome check src/state/useAppLifecycleEvents.test.tsx`: clean ("No fixes applied", zero diagnostics).
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output.
- `git diff --numstat` vs base: `105 0` on `packages/ui/src/state/useAppLifecycleEvents.test.tsx` only — additions only, no other file touched.

Runs were executed in an elizaOS/eliza working tree whose copies of both `useAppLifecycleEvents.ts` and its test file are byte-identical to this branch's head `66082ce060` (verified against `origin/develop` immediately before filing). As a fork contribution, hosted CI does not run on this pull request; all counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:66082ce0609cfe5c7cbfdb9018427e6386444cf6 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
