### PR TITLE
fix(core): safely handle non-string inputs in channel-utils

### DIFF
--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -27,6 +27,15 @@ describe("normalizeChatType", () => {
 		expect(normalizeChatType(undefined)).toBe("direct");
 		expect(normalizeChatType("weird")).toBe("direct");
 	});
+
+	it("returns direct for non-string inputs without throwing", () => {
+		expect(normalizeChatType(null as unknown as string)).toBe("direct");
+		expect(normalizeChatType(123 as unknown as string)).toBe("direct");
+		expect(normalizeChatType(0 as unknown as string)).toBe("direct");
+		expect(normalizeChatType(true as unknown as string)).toBe("direct");
+		expect(normalizeChatType({} as unknown as string)).toBe("direct");
+		expect(normalizeChatType([] as unknown as string)).toBe("direct");
+	});
 });
 
 describe("resolveMentionGating", () => {
@@ -302,5 +311,14 @@ describe("resolveSenderLabel and listSenderLabelCandidates", () => {
 		expect(candidates).toContain("alice_w");
 		expect(candidates).toContain("u123");
 		expect(candidates).toContain("Alice (u123)");
+	});
+
+	it("returns null/empty for non-string sender inputs without throwing", () => {
+		expect(resolveSenderLabel({ name: 123 as unknown as string })).toBeNull();
+		expect(resolveSenderLabel({ username: {} as unknown as string })).toBeNull();
+		expect(resolveSenderLabel({ tag: true as unknown as string })).toBeNull();
+		expect(listSenderLabelCandidates({ name: 123 as unknown as string })).toEqual([]);
+		expect(listSenderLabelCandidates({ id: 123 as unknown as string })).toEqual([]);
+		expect(listSenderLabelCandidates({ name: null as unknown as string, id: undefined })).toEqual([]);
 	});
 });

--- a/packages/core/src/utils/channel-utils.ts
+++ b/packages/core/src/utils/channel-utils.ts
@@ -17,7 +17,8 @@ export type NormalizedChatType = "direct" | "group" | "channel";
  * @returns Normalized chat type
  */
 export function normalizeChatType(raw?: string): NormalizedChatType {
-	const lower = raw?.toLowerCase().trim();
+	if (typeof raw !== "string") return "direct";
+	const lower = raw.toLowerCase().trim();
 	if (!lower) {
 		return "direct";
 	}
@@ -353,7 +354,8 @@ export type SenderLabelParams = {
 };
 
 function normalizeLabel(value?: string): string | undefined {
-	const trimmed = value?.trim();
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
 	return trimmed ? trimmed : undefined;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - small bug fix, no linked issue

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Isolated guards in channel-utils string normalization; non-string inputs return safe defaults (direct/undefined). No change for valid string inputs.

# Background

## What does this PR do?

In `packages/core/src/utils/channel-utils.ts` `normalizeChatType` assumed `raw` was string-or-undefined and called `raw?.toLowerCase().trim()` directly, and `normalizeLabel` assumed `value` was string and called `value?.trim()` directly. Passing `number`/`object`/`boolean` (e.g. malformed platform payload or caller bug) threw `TypeError: raw?.toLowerCase is not a function` / `value?.trim is not a function`. Adds `typeof raw !== "string"` guard returning `"direct"` fail-closed and `typeof value !== "string"` guard returning `undefined` fail-closed, consistent with recent string-guard fixes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/core/src/utils/channel-utils.ts` and `channel-utils.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/channel-utils.test.ts`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:410e7c8e7273267654396ce943671df997023998 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - pure channel utility, no LLM`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Real LLM-call trajectory

N/A - pure channel utility, no LLM

## Backend + frontend logs

N/A - unit test verified

## Screenshots (before / after) + video walkthrough

N/A - backend logic change only

### Before

N/A - backend logic change only

### After

N/A - backend logic change only

### Walkthrough video

N/A - backend logic change only

## Audio / voice walkthrough

N/A - no voice changes

## Known gaps / failures

None. `bun test packages/core/src/utils/channel-utils.test.ts` and `bun run --cwd packages/core typecheck` pass, `bunx biome check` clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


## Red (reverted) → Green (restored)

**Red (production reverted, 19 pass 2 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/channel-utils.test.ts:
(pass) normalizeChatType > folds platform synonyms into direct/group/channel
20 | export function normalizeChatType(raw?: string): NormalizedChatType {
21 | 	const lower = raw?.toLowerCase().trim();
                              ^
TypeError: raw?.toLowerCase is not a function. (In 'raw?.toLowerCase()', 'raw?.toLowerCase' is undefined)
      at normalizeChatType (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.ts:20:21)
      at <anonymous> (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.test.ts:33:10)
(fail) normalizeChatType > returns direct for non-string inputs without throwing [0.47ms]
(pass) resolveMentionGating > skips only when a mention is required, detectable, and absent
(pass) resolveMentionGating > treats an implicit mention (reply) or bypass as mentioned
(pass) resolveMentionGating > never skips when mention is not required or not detectable
(pass) resolveMentionGatingWithBypass > lets an authorized control command bypass the mention gate in a group
(pass) resolveMentionGatingWithBypass > does not bypass for an unauthorized command
(pass) shouldAckReaction > honors scope: off/all/direct/group-all
(pass) shouldAckReaction > group-mentions only acks a detectable mention in a mentionable group
(pass) formatLocationText > formats basic pin location with coordinates and positive accuracy
(pass) formatLocationText > sanitizes negative or non-finite accuracy values by omitting accuracy
(pass) formatLocationText > preserves zero accuracy as a valid non-negative measurement
(pass) formatLocationText > formats named place location with label and coordinates
(pass) formatLocationText > formats live location indicator and includes caption when present
(pass) toLocationContext > converts normalized location and sanitizes negative accuracy to undefined
(pass) toLocationContext > preserves valid positive accuracy in location context
(pass) toLocationContext > omits non-finite accuracy without fabricating a measurement
(pass) resolveSenderLabel and listSenderLabelCandidates > resolves display with id when both differ
(pass) resolveSenderLabel and listSenderLabelCandidates > falls back gracefully when only id or only name is provided
(pass) resolveSenderLabel and listSenderLabelCandidates > lists all distinct sender label candidates
355 | function normalizeLabel(value?: string): string | undefined {
356 | 	const trimmed = value?.trim();
                              ^
TypeError: value?.trim is not a function. (In 'value?.trim()', 'value?.trim' is undefined)
      at normalizeLabel (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.ts:356:25)
      at getNormalizedSenderParts (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.ts:373:15)
      at resolveSenderLabel (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.ts:400:30)
      at <anonymous> (/private/tmp/wt-channel-utils/packages/core/src/utils/channel-utils.test.ts:317:10)
(fail) resolveSenderLabel and listSenderLabelCandidates > returns null/empty for non-string sender inputs without throwing
------------------------------------------|---------|---------|-------------------
File                                      | % Funcs | % Lines | Uncovered Line #s
------------------------------------------|---------|---------|-------------------
All files                                 |   65.00 |   62.50 |
 packages/core/src/utils/channel-utils.ts |   65.00 |   62.50 | 169-190,253,256,266-298,318-336,424,427,568,577-584,593-602,611-618
------------------------------------------|---------|---------|-------------------

 19 pass
 2 fail
 44 expect() calls
Ran 21 tests across 1 file. [94.00ms]
```

**Green (restored, 21 pass 0 fail):**
```
bun test v1.3.11 (af24e281)

packages/core/src/utils/channel-utils.test.ts:
(pass) normalizeChatType > folds platform synonyms into direct/group/channel
(pass) normalizeChatType > returns direct for non-string inputs without throwing [0.42ms]
(pass) resolveMentionGating > skips only when a mention is required, detectable, and absent
(pass) resolveMentionGating > treats an implicit mention (reply) or bypass as mentioned
(pass) resolveMentionGating > never skips when mention is not required or not detectable
(pass) resolveMentionGatingWithBypass > lets an authorized control command bypass the mention gate in a group
(pass) resolveMentionGatingWithBypass > does not bypass for an unauthorized command
(pass) shouldAckReaction > honors scope: off/all/direct/group-all
(pass) shouldAckReaction > group-mentions only acks a detectable mention in a mentionable group
(pass) formatLocationText > formats basic pin location with coordinates and positive accuracy
(pass) formatLocationText > sanitizes negative or non-finite accuracy values by omitting accuracy
(pass) formatLocationText > preserves zero accuracy as a valid non-negative measurement
(pass) formatLocationText > formats named place location with label and coordinates
(pass) formatLocationText > formats live location indicator and includes caption when present
(pass) toLocationContext > converts normalized location and sanitizes negative accuracy to undefined
(pass) toLocationContext > preserves valid positive accuracy in location context
(pass) toLocationContext > omits non-finite accuracy without fabricating a measurement
(pass) resolveSenderLabel and listSenderLabelCandidates > resolves display with id when both differ
(pass) resolveSenderLabel and listSenderLabelCandidates > falls back gracefully when only id or only name is provided
(pass) resolveSenderLabel and listSenderLabelCandidates > lists all distinct sender label candidates
(pass) resolveSenderLabel and listSenderLabelCandidates > returns null/empty for non-string sender inputs without throwing [0.99ms]
------------------------------------------|---------|---------|-------------------
File                                      | % Funcs | % Lines | Uncovered Line #s
------------------------------------------|---------|---------|-------------------
All files                                 |   65.00 |   62.41 |
 packages/core/src/utils/channel-utils.ts |   65.00 |   62.41 | 23,170-191,254,257,267-299,319-337,426,429,570,579-586,595-604,613-620
------------------------------------------|---------|---------|-------------------

 21 pass
 0 fail
 55 expect() calls
Ran 21 tests across 1 file. [92.00ms]
```

**Package checks:**
- `bun test packages/core/src/utils/channel-utils.test.ts` → Green 21 pass
- `bun run --cwd packages/core typecheck` → pass
- `bunx biome check` → clean
