### PR TITLE
test(core): cover types

### DIFF
--- a/packages/core/src/features/plugin-manager/types.test.ts
+++ b/packages/core/src/features/plugin-manager/types.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the runtime half of the plugin-manager shared type surface:
+ * the `PluginManagerServiceType` service-name constants and the `PluginStatus`
+ * lifecycle enum. Fully deterministic — no runtime, database, or live model in
+ * play. The suites drive the real exported objects and reproduce the
+ * equality-partition counting pattern that
+ * `actions/plugin-handlers/runtime-state.ts` performs over tracked plugin
+ * states, so the invariants asserted here are ones consumers actually rely on.
+ */
+import { describe, expect, it } from "vitest";
+import { PluginManagerServiceType, PluginStatus } from "./types.ts";
+
+const ALL_STATUSES = [
+	PluginStatus.READY,
+	PluginStatus.LOADED,
+	PluginStatus.ERROR,
+	PluginStatus.UNLOADED,
+] as const;
+
+describe("plugin-manager types → PluginStatus lifecycle enum", () => {
+	it("closes the lifecycle over exactly four distinct non-empty states", () => {
+		const entries = Object.entries(PluginStatus);
+		expect(entries.map(([name]) => name).sort()).toEqual([
+			"ERROR",
+			"LOADED",
+			"READY",
+			"UNLOADED",
+		]);
+		for (const [name, value] of entries) {
+			expect(typeof value).toBe("string");
+			expect(
+				value.length,
+				`${name} must map to a non-empty string`,
+			).toBeGreaterThan(0);
+		}
+		expect(new Set(entries.map(([, value]) => value)).size).toBe(
+			ALL_STATUSES.length,
+		);
+	});
+
+	it("keeps the runtime-state four-bucket count exhaustive and disjoint", () => {
+		// Mirrors the counting loop in actions/plugin-handlers/runtime-state.ts:
+		// every tracked plugin must land in exactly one of the four === buckets,
+		// so reported loaded/ready/unloaded/error counts always sum to the total.
+		const tracked: PluginStatus[] = [
+			PluginStatus.LOADED,
+			PluginStatus.READY,
+			PluginStatus.LOADED,
+			PluginStatus.ERROR,
+			PluginStatus.UNLOADED,
+			PluginStatus.READY,
+			PluginStatus.LOADED,
+		];
+
+		const counted = ALL_STATUSES.reduce(
+			(sum, status) =>
+				sum + tracked.filter((candidate) => candidate === status).length,
+			0,
+		);
+		expect(counted).toBe(tracked.length);
+
+		const byStatus = new Map(
+			ALL_STATUSES.map((status) => [
+				status,
+				tracked.filter((candidate) => candidate === status).length,
+			]),
+		);
+		expect(byStatus.get(PluginStatus.LOADED)).toBe(3);
+		expect(byStatus.get(PluginStatus.READY)).toBe(2);
+		expect(byStatus.get(PluginStatus.ERROR)).toBe(1);
+		expect(byStatus.get(PluginStatus.UNLOADED)).toBe(1);
+	});
+
+	it("survives a JSON persistence round-trip with discrimination intact", () => {
+		const stored = JSON.parse(
+			JSON.stringify({
+				id: "00000000-0000-0000-0000-00000000c0de",
+				name: "plugin-sql",
+				status: PluginStatus.LOADED,
+			}),
+		) as { id: string; name: string; status: PluginStatus };
+
+		expect(stored.status).toBe(PluginStatus.LOADED);
+		expect(stored.status === PluginStatus.ERROR).toBe(false);
+	});
+
+	it("deduplicates as a plain string inside consumer tracking sets", () => {
+		const seen = new Set<string>([
+			PluginStatus.READY,
+			PluginStatus.READY,
+			PluginStatus.LOADED,
+		]);
+		expect(seen.size).toBe(2);
+		expect(seen.has(PluginStatus.READY)).toBe(true);
+		expect(seen.has(PluginStatus.UNLOADED)).toBe(false);
+	});
+});
+
+describe("plugin-manager types → PluginManagerServiceType constants", () => {
+	it("names exactly the four plugin-manager services without collisions", () => {
+		const entries = Object.entries(PluginManagerServiceType);
+		expect(entries.map(([key]) => key).sort()).toEqual([
+			"CORE_MANAGER",
+			"PLUGIN_CONFIGURATION",
+			"PLUGIN_MANAGER",
+			"REGISTRY",
+		]);
+		const names = entries.map(([, value]) => value);
+		for (const name of names) {
+			expect(
+				name.length,
+				`${name} must be a non-empty service name`,
+			).toBeGreaterThan(0);
+		}
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	it("keeps service lookups unambiguous across the four namespaces", () => {
+		// The registration/lookup seam every consumer relies on: services are
+		// stored under these constants and retrieved with the same constant.
+		// A collision between any two constants would silently overwrite the
+		// earlier registration, so the map must hold all four at once.
+		const services = new Map<string, string>();
+		services.set(PluginManagerServiceType.PLUGIN_MANAGER, "manager");
+		services.set(
+			PluginManagerServiceType.PLUGIN_CONFIGURATION,
+			"configuration",
+		);
+		services.set(PluginManagerServiceType.REGISTRY, "registry");
+		services.set(PluginManagerServiceType.CORE_MANAGER, "core");
+
+		expect(services.size).toBe(4);
+		expect(services.get(PluginManagerServiceType.PLUGIN_MANAGER)).toBe(
+			"manager",
+		);
+		expect(services.get(PluginManagerServiceType.PLUGIN_CONFIGURATION)).toBe(
+			"configuration",
+		);
+		expect(services.get(PluginManagerServiceType.REGISTRY)).toBe("registry");
+		expect(services.get(PluginManagerServiceType.CORE_MANAGER)).toBe("core");
+	});
+});


### PR DESCRIPTION

## Summary

Adds a deterministic vitest suite for the runtime half of `packages/core/src/features/plugin-manager/types.ts`, which previously had no same-named test file anywhere in the repo.

The module's runtime surface is two exported values: the `PluginManagerServiceType` service-name constants and the `PluginStatus` lifecycle enum (the remaining exports are interfaces/type unions and are deliberately not restated). The suite drives those real objects and exercises the invariants downstream consumers actually rely on:

- **Exhaustive, disjoint lifecycle partition** — reproduces the exact equality-filter counting loop that `actions/plugin-handlers/runtime-state.ts` performs over tracked plugin states (`loaded/ready/unloaded/error` buckets); asserts the bucket counts sum to the total and match per-status expectations, so a duplicate or missing enum member would fail.
- **Closed value space** — `PluginStatus` exposes exactly its four members as distinct non-empty strings.
- **Persistence boundary** — a JSON round-trip of a plugin state still discriminates to the same status via `===`, matching how statuses are stored and compared as plain strings.
- **String-set interop** — statuses dedupe correctly inside the tracking sets consumers build.
- **Service-name registry integrity** — `PluginManagerServiceType` names exactly four services with no collisions; registering under each constant and looking back up through a `getService`-style map resolves unambiguously (a collision would silently overwrite an earlier registration).

## Test plan

- [x] `bunx vitest run src/features/plugin-manager/types.test.ts` (in `packages/core`) — **1 file passed, 6 tests passed / 0 failed**, verified against current `origin/develop` immediately before filing.
- [x] `bunx biome check --write packages/core/src/features/plugin-manager/types.test.ts` — clean.
- [x] `bunx tsc --noEmit` in `packages/core` — zero diagnostics mention the new test file.
- [x] Diff is purely additive: one new test file, +142/-0; no production behavior changes.

Note: this is a fork contribution, so hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9fad351675d957a1015178533b06469d50cfc2e7 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
