### PR TITLE
test(core): cover payments feature barrel entry point

### DIFF
--- a/packages/core/src/features/payments/index.test.ts
+++ b/packages/core/src/features/payments/index.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Public entry-point contract of the payments feature barrel: the eager
+ * FEATURES_PAYMENTS_INDEX bundle-safety anchor, the delivery-target
+ * eligibility policy, and live PAYMENT validate/handler behavior reached
+ * through the re-exports. Deterministic: service lookups run against a stub
+ * runtime; no model, database, or payment provider.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+	eligibleDeliveryTargetsFor,
+	PAYMENT_REQUESTS_CLIENT_SERVICE,
+	paymentAction,
+	paymentsPlugin,
+} from "./index";
+
+function createRuntime(services: Record<string, unknown | null>) {
+	return {
+		agentId: "agent-1",
+		getService: (name: string) => services[name] ?? null,
+	};
+}
+
+function message() {
+	return { entityId: "u1", roomId: "r1", content: { text: "" } };
+}
+
+function requestsClient() {
+	return { create: () => {}, get: () => {}, cancel: () => {} };
+}
+
+describe("payments feature index", () => {
+	test("anchors exactly the exported paymentAction and paymentsPlugin under FEATURES_PAYMENTS_INDEX", () => {
+		const stashed = (globalThis as Record<string, unknown>)
+			.__bundle_safety_FEATURES_PAYMENTS_INDEX__;
+		expect(Array.isArray(stashed)).toBe(true);
+		expect(stashed).toEqual([paymentAction, paymentsPlugin]);
+	});
+
+	test("registers the same PAYMENT action instance the plugin carries", () => {
+		expect(paymentsPlugin.actions?.[0]).toBe(paymentAction);
+	});
+
+	test("keeps public_link eligible only for any_payer contexts", () => {
+		expect(eligibleDeliveryTargetsFor("any_payer")).toEqual([
+			"public_link",
+			"dm",
+			"owner_app_inline",
+			"cloud_authenticated_link",
+			"tunnel_authenticated_link",
+		]);
+	});
+
+	test("restricts verified_payer and specific_payer to authenticated targets", () => {
+		const authenticatedOnly = [
+			"dm",
+			"owner_app_inline",
+			"cloud_authenticated_link",
+			"tunnel_authenticated_link",
+		];
+		for (const kind of ["verified_payer", "specific_payer"] as const) {
+			expect(eligibleDeliveryTargetsFor(kind)).toEqual(authenticatedOnly);
+		}
+	});
+
+	test("falls back to authenticated-only targets for unrecognized kinds", () => {
+		expect(eligibleDeliveryTargetsFor("not_a_kind" as never)).toEqual([
+			"dm",
+			"owner_app_inline",
+			"cloud_authenticated_link",
+			"tunnel_authenticated_link",
+		]);
+	});
+
+	test("handler rejects an unrecognized discriminator without touching payment services", async () => {
+		const result = await paymentAction.handler(
+			createRuntime({}) as never,
+			message() as never,
+			undefined,
+			{ parameters: { action: "issue_refund" } } as never,
+		);
+		expect(result.success).toBe(false);
+		expect(result.text).toContain("PAYMENT requires action");
+	});
+
+	test("handler rejects missing handler options with planner guidance", async () => {
+		const result = await paymentAction.handler(
+			createRuntime({}) as never,
+			message() as never,
+			undefined,
+			undefined,
+		);
+		expect(result.success).toBe(false);
+		expect(result.text).toContain("PAYMENT requires action");
+	});
+
+	test("validate accepts a well-formed create_request under the re-exported service key", async () => {
+		const ok = await paymentAction.validate?.(
+			createRuntime({
+				[PAYMENT_REQUESTS_CLIENT_SERVICE]: requestsClient(),
+			}) as never,
+			message() as never,
+			undefined,
+			{
+				parameters: {
+					action: "create_request",
+					provider: "stripe",
+					amountCents: 2500,
+					paymentContext: { kind: "any_payer" },
+				},
+			} as never,
+		);
+		expect(ok).toBe(true);
+	});
+
+	test("validate reads parameters given flat at the options root", async () => {
+		const ok = await paymentAction.validate?.(
+			createRuntime({
+				[PAYMENT_REQUESTS_CLIENT_SERVICE]: requestsClient(),
+			}) as never,
+			message() as never,
+			undefined,
+			{
+				action: "create_request",
+				provider: "x402",
+				amountCents: 100,
+				paymentContext: { kind: "specific_payer", payerIdentityId: "payer-1" },
+			} as never,
+		);
+		expect(ok).toBe(true);
+	});
+
+	test("validate rejects an unrecognized discriminator even with every service present", async () => {
+		const ok = await paymentAction.validate?.(
+			createRuntime({
+				[PAYMENT_REQUESTS_CLIENT_SERVICE]: requestsClient(),
+				PaymentBusClient: { waitFor: () => {}, verifyProof: () => {} },
+				PaymentSettler: { settle: () => {} },
+			}) as never,
+			message() as never,
+			undefined,
+			{ parameters: { action: "refund_everything" } } as never,
+		);
+		expect(ok).toBe(false);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/payments/index.test.ts` — a new deterministic vitest suite for the payments feature barrel (`packages/core/src/features/payments/index.ts`), which had no same-named test file anywhere in the repo. The diff is one new file, +146/−0; no production code changes.

## Coverage

The suite imports only from the public entry point (`./index`) and asserts behavior, not shape:

- **Bundle-safety anchor**: importing the barrel registers `__bundle_safety_FEATURES_PAYMENTS_INDEX__` containing exactly the exported `paymentAction` and `paymentsPlugin` references — the eager-anchor contract that keeps this feature in the mobile bundle (incident class elizaOS/eliza #10727 et al.). Also pins that the plugin registers the same action instance the barrel exports.
- **Delivery-target eligibility policy** (`eligibleDeliveryTargetsFor`, previously untested directly): `any_payer` keeps the ordered five-target list including `public_link`; `verified_payer`/`specific_payer` are restricted to the four authenticated targets; unrecognized kinds fall back to authenticated-only.
- **Entry-point validate/handler edges not covered by the existing `actions/payment.test.ts`**: handler rejects an unrecognized discriminator and missing handler options with planner-guidance text before any service lookup; `validate` accepts a well-formed `create_request` under the re-exported `PAYMENT_REQUESTS_CLIENT_SERVICE` key, accepts flat (non-`parameters`) options shapes via the `readParams` fallback, and rejects an unknown discriminator even when every payment service is present.

Service collaborators are plain stubs behind the documented `runtime.getService(...)` seam; no model, database, or payment provider is involved.

## Verification

Fork contributor: hosted CI does not run on this PR. All checks were executed locally against current `develop` (`de774b875774`):

- `bunx vitest run src/features/payments/index.test.ts` (in `packages/core`) — **1 test file passed, 10 tests passed**.
- `bunx biome check src/features/payments/index.test.ts` — clean (exit 0, no fixes remaining).
- `bunx tsc --noEmit` in `packages/core` — zero occurrences of `index.test.ts` in output (the package's TypeScript program excludes test files; no new type errors attributable to this diff).

Test-only change: no production behavior is modified.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f79c826c424e66be6eeee3f9c8b844f3c8dfd119 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
