### PR TITLE
test(core): cover plugin

### DIFF
--- a/packages/core/src/features/secrets/plugin.test.ts
+++ b/packages/core/src/features/secrets/plugin.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Exercises the `secrets` plugin assembly itself: the planner- and
+ * runtime-facing registration contract (actions, providers, services) and the
+ * init/dispose lifecycle orchestration against a deterministic runtime stub.
+ * Every binding asserted is the real imported symbol; no handler, service,
+ * provider, database, or secret store is mocked.
+ */
+
+import { describe, expect, test } from "vitest";
+import { secretsAction } from "./actions/manage-secret";
+import defaultExport, { secretsManagerPlugin } from "./plugin";
+import {
+	secretsInfoProvider,
+	secretsStatusProvider,
+} from "./providers/secrets-status";
+import {
+	PLUGIN_ACTIVATOR_SERVICE_TYPE,
+	PluginActivatorService,
+} from "./services/plugin-activator";
+import { SECRETS_SERVICE_TYPE, SecretsService } from "./services/secrets";
+import { updateSettingsAction } from "./setup/action";
+import {
+	missingSecretsProvider,
+	setupSettingsProvider,
+} from "./setup/provider";
+import { SETUP_SERVICE_TYPE, SetupService } from "./setup/service";
+
+describe("secrets plugin assembly", () => {
+	test("publishes the runtime-facing registration contract", () => {
+		expect(secretsManagerPlugin.name).toBe("secrets");
+		expect(secretsManagerPlugin.description).toBeTruthy();
+		expect(secretsManagerPlugin.actions?.[0]).toBe(secretsAction);
+		expect(secretsManagerPlugin.actions?.[1]).toBe(updateSettingsAction);
+		expect(secretsManagerPlugin.providers?.[0]).toBe(secretsStatusProvider);
+		expect(secretsManagerPlugin.providers?.[1]).toBe(secretsInfoProvider);
+		expect(secretsManagerPlugin.providers?.[2]).toBe(setupSettingsProvider);
+		expect(secretsManagerPlugin.providers?.[3]).toBe(missingSecretsProvider);
+	});
+
+	test("registers exactly the two planner-visible actions", () => {
+		expect(secretsManagerPlugin.actions?.map((action) => action.name)).toEqual([
+			"SECRETS",
+			"SECRETS_UPDATE_SETTINGS",
+		]);
+	});
+
+	test("registers the four context-injection providers in order", () => {
+		expect(
+			secretsManagerPlugin.providers?.map((provider) => provider.name),
+		).toEqual([
+			"SECRETS_STATUS",
+			"SECRETS_INFO",
+			"SETUP_SETTINGS",
+			"MISSING_SECRETS",
+		]);
+	});
+
+	test("declares its three owning services", () => {
+		expect(secretsManagerPlugin.services).toEqual([
+			SecretsService,
+			PluginActivatorService,
+			SetupService,
+		]);
+	});
+
+	test("exposes the same plugin through the default export", () => {
+		expect(defaultExport).toBe(secretsManagerPlugin);
+	});
+});
+
+describe("secrets plugin lifecycle", () => {
+	test("init resolves with a full configuration object", async () => {
+		await expect(
+			secretsManagerPlugin.init?.(
+				{
+					enableEncryption: true,
+					encryptionSalt: "unit-test-salt",
+					enableAccessLogging: false,
+					enableAutoActivation: false,
+					activationPollingMs: 1000,
+				} as never,
+				{} as never,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	function createRecordingRuntime(events: string[]) {
+		return {
+			getService(type: string) {
+				events.push(`lookup:${type}`);
+				return {
+					stop: async () => {
+						events.push(`stopped:${type}`);
+					},
+				};
+			},
+		};
+	}
+
+	test("dispose stops every owned service once, keyed by its service type", async () => {
+		const events: string[] = [];
+		await secretsManagerPlugin.dispose(createRecordingRuntime(events) as never);
+		expect(events).toEqual([
+			`lookup:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`stopped:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`lookup:${SECRETS_SERVICE_TYPE}`,
+			`stopped:${SECRETS_SERVICE_TYPE}`,
+			`lookup:${SETUP_SERVICE_TYPE}`,
+			`stopped:${SETUP_SERVICE_TYPE}`,
+		]);
+	});
+
+	test("dispose resolves when no services are registered", async () => {
+		await expect(
+			secretsManagerPlugin.dispose({
+				getService: () => null,
+			} as never),
+		).resolves.toBeUndefined();
+	});
+
+	test("dispose skips only the services that are absent", async () => {
+		const events: string[] = [];
+		await secretsManagerPlugin.dispose({
+			getService: (type: string) => {
+				events.push(`lookup:${type}`);
+				return type === PLUGIN_ACTIVATOR_SERVICE_TYPE
+					? {
+							stop: async () => {
+								events.push(`stopped:${type}`);
+							},
+						}
+					: null;
+			},
+		} as never);
+		expect(events).toEqual([
+			`lookup:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`stopped:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`lookup:${SECRETS_SERVICE_TYPE}`,
+			`lookup:${SETUP_SERVICE_TYPE}`,
+		]);
+	});
+
+	test("dispose awaits each stop before proceeding to the next service", async () => {
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const events: string[] = [];
+		const runtime = {
+			getService(type: string) {
+				events.push(`lookup:${type}`);
+				return {
+					stop: async () => {
+						if (type === PLUGIN_ACTIVATOR_SERVICE_TYPE) {
+							await blocked;
+						}
+						events.push(`stopped:${type}`);
+					},
+				};
+			},
+		};
+		const disposal = secretsManagerPlugin.dispose(runtime as never);
+
+		for (let i = 0; i < 10; i++) {
+			await Promise.resolve();
+		}
+		expect(events).toEqual([`lookup:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`]);
+
+		release();
+		await disposal;
+		expect(events).toEqual([
+			`lookup:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`stopped:${PLUGIN_ACTIVATOR_SERVICE_TYPE}`,
+			`lookup:${SECRETS_SERVICE_TYPE}`,
+			`stopped:${SECRETS_SERVICE_TYPE}`,
+			`lookup:${SETUP_SERVICE_TYPE}`,
+			`stopped:${SETUP_SERVICE_TYPE}`,
+		]);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/secrets/plugin.test.ts`, a new vitest suite for the secrets capability plugin assembly (`packages/core/src/features/secrets/plugin.ts`), which previously had no same-named test file on `develop`.

## Coverage

The suite drives the real module (no handler/service/provider/database mocks) and covers:

- **Runtime-facing registration contract** — plugin name/description, and identity checks that the plugin's `actions`, `providers`, and `services` arrays carry exactly the real imported bindings (`secretsAction`, `updateSettingsAction`; the four providers in order; `SecretsService`, `PluginActivatorService`, `SetupService`), plus the planner-visible action names (`SECRETS`, `SECRETS_UPDATE_SETTINGS`) and provider names.
- **Default export parity** — the default export is the same object as the named export.
- **init lifecycle** — resolves cleanly with a fully populated `SecretsManagerPluginConfig`.
- **dispose orchestration** — stops every owned service exactly once, keyed by the correct service-type constants (`PLUGIN_ACTIVATOR_SERVICE_TYPE`, `SECRETS_SERVICE_TYPE`, `SETUP_SERVICE_TYPE`); resolves when no services are registered; skips only absent services when some are present; and deterministically awaits each `stop()` before looking up the next service (proven with a gated promise, not timers).

## Evidence

- `bunx vitest run packages/core/src/features/secrets/plugin.test.ts`: **1 file passed, 10/10 tests passed**, re-run immediately before filing against current `origin/develop`.
- `bunx biome check packages/core/src/features/secrets/plugin.test.ts`: clean (no diagnostics).
- `bunx tsc --noEmit` in `packages/core`: **exit 0, zero errors package-wide**, so zero new errors introduced by this file.
- Diff is a single new test file: +180/−0. No production behavior is changed.

Note: this PR comes from a fork, so hosted CI does not run on it — the counts above are from local runs of the pinned toolchain against `origin/develop`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fbcb217191e59eac2d94c9835e2aa38aa90c4904 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
