### PR TITLE
test(app): cover side-effect app module discovery

### DIFF
--- a/packages/app/vite/__tests__/app-side-effect.test.ts
+++ b/packages/app/vite/__tests__/app-side-effect.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  default: mocks,
+  existsSync: mocks.existsSync,
+  readFileSync: mocks.readFileSync,
+  readdirSync: mocks.readdirSync,
+}));
+
+import { discoverSideEffectAppModules } from "./app-side-effect-modules.ts";
+
+describe("discoverSideEffectAppModules", () => {
+  it("discovers register-mode plugins", () => {
+    mocks.readdirSync.mockReturnValue([
+      { name: "plugin-a", isDirectory: () => true },
+    ]);
+    mocks.readFileSync.mockReturnValue(
+      JSON.stringify({
+        name: "@scope/plugin-a",
+        elizaos: { appRegister: "register" },
+      }),
+    );
+    mocks.existsSync.mockImplementation(
+      (p: string) =>
+        p === "/repo/plugins" ||
+        p.endsWith("package.json") ||
+        p.endsWith("src/register.ts"),
+    );
+
+    const modules = discoverSideEffectAppModules(["/repo/plugins"]);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].mode).toBe("register");
+    expect(modules[0].key).toContain("#register");
+    expect(modules[0].entry).toContain("src/register.ts");
+  });
+
+  it("discovers ui-mode plugins with fallback entry candidates", () => {
+    mocks.readdirSync.mockReturnValue([
+      { name: "plugin-b", isDirectory: () => true },
+    ]);
+    mocks.readFileSync.mockReturnValue(
+      JSON.stringify({
+        name: "@scope/plugin-b",
+        elizaos: { appRegister: "ui" },
+      }),
+    );
+    mocks.existsSync.mockImplementation(
+      (p: string) =>
+        p === "/repo/plugins" ||
+        p.endsWith("package.json") ||
+        p.endsWith("src/ui/index.ts"),
+    );
+
+    const modules = discoverSideEffectAppModules(["/repo/plugins"]);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].mode).toBe("ui");
+    expect(modules[0].entry).toContain("src/ui/index.ts");
+  });
+
+  it("skips plugins without the appRegister marker", () => {
+    mocks.readdirSync.mockReturnValue([
+      { name: "plugin-c", isDirectory: () => true },
+    ]);
+    mocks.readFileSync.mockReturnValue(JSON.stringify({ name: "plugin-c" }));
+    const modules = discoverSideEffectAppModules(["/repo/plugins"]);
+    expect(modules).toHaveLength(0);
+  });
+
+  it("skips plugins whose declared entry is missing", () => {
+    mocks.readdirSync.mockReturnValue([
+      { name: "plugin-d", isDirectory: () => true },
+    ]);
+    mocks.readFileSync.mockReturnValue(
+      JSON.stringify({
+        name: "plugin-d",
+        elizaos: { appRegister: "register" },
+      }),
+    );
+    mocks.existsSync.mockReturnValue(false);
+    const modules = discoverSideEffectAppModules(["/repo/plugins"]);
+    expect(modules).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
