### PR TITLE
test(ui): cover useViewLifecycle

### DIFF
--- a/packages/ui/src/state/useViewLifecycle.test.tsx
+++ b/packages/ui/src/state/useViewLifecycle.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * Verifies the view-author hooks (`useViewLifecycle`, `usePauseAware`,
+ * `usePausableInterval`) against the REAL ViewLifecycleController through a
+ * live `ViewLifecycleSlot`: transitions are driven by controller commands
+ * (`setActive`, `markPaused`, `markResumed`, `markCrashed`,
+ * `markRecovering`), never by mocked subscriptions, and timer bookkeeping is
+ * asserted through the real resource-counter registry. jsdom environment;
+ * fake timers only for the interval cases.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetResourceCountersForTests,
+  snapshotResourceCounters,
+} from "../perf/resource-counters";
+import {
+  usePausableInterval,
+  usePauseAware,
+  useViewLifecycle,
+} from "./useViewLifecycle";
+import {
+  __resetViewLifecycleForTests,
+  viewLifecycleController as ctrl,
+  registerViewPolicy,
+} from "./view-lifecycle";
+import { ViewLifecycleSlot } from "./view-lifecycle-context";
+
+const VIEW_ID = "lifecycle-probe-view";
+const OTHER_VIEW_ID = "lifecycle-other-view";
+
+function slotWrapper(
+  viewId: string = VIEW_ID,
+): ({ children }: { children: ReactNode }) => React.JSX.Element {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ViewLifecycleSlot viewId={viewId} hidden={false}>
+        {children}
+      </ViewLifecycleSlot>
+    );
+  };
+}
+
+beforeEach(() => {
+  __resetViewLifecycleForTests();
+  __resetResourceCountersForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  __resetViewLifecycleForTests();
+  __resetResourceCountersForTests();
+});
+
+describe("useViewLifecycle", () => {
+  it("falls back to the active state and fires no handlers outside a slot", () => {
+    const handlers = {
+      onMount: vi.fn(),
+      onShow: vi.fn(),
+      onHide: vi.fn(),
+      onPause: vi.fn(),
+      onResume: vi.fn(),
+      onEvict: vi.fn(),
+      onRestore: vi.fn(),
+    };
+    const { result } = renderHook(() => useViewLifecycle(handlers));
+
+    expect(result.current).toEqual({
+      phase: "active",
+      isActive: true,
+      isPaused: false,
+      isHidden: false,
+    });
+    for (const handler of Object.values(handlers)) {
+      expect(handler).not.toHaveBeenCalled();
+    }
+
+    const pauseAware = renderHook(() => usePauseAware());
+    expect(pauseAware.result.current).toEqual({ paused: false, active: true });
+  });
+
+  it("fires onMount once inside a slot and seeds state from the controller's current phase", () => {
+    registerViewPolicy(VIEW_ID, { keepAlive: true, pausable: true });
+    ctrl.setActive(VIEW_ID);
+    // Hide behind another active view: the retained view is now paused.
+    ctrl.setActive(OTHER_VIEW_ID);
+    expect(ctrl.getPhase(VIEW_ID)).toBe("paused");
+
+    const onMount = vi.fn();
+    const { result } = renderHook(() => useViewLifecycle({ onMount }), {
+      wrapper: slotWrapper(),
+    });
+
+    expect(onMount).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      phase: "paused",
+      isActive: false,
+      isPaused: true,
+      isHidden: true,
+    });
+  });
+
+  it("dispatches onShow and reports active when the view becomes visible", () => {
+    const events: string[] = [];
+    const { result } = renderHook(
+      () =>
+        useViewLifecycle({
+          onShow: () => events.push("show"),
+          onHide: () => events.push("hide"),
+          onPause: (reason) => events.push(`pause:${reason}`),
+          onResume: () => events.push("resume"),
+          onEvict: (reason) => events.push(`evict:${reason}`),
+          onRestore: () => events.push("restore"),
+        }),
+      { wrapper: slotWrapper() },
+    );
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+
+    expect(events).toEqual(["show"]);
+    expect(result.current).toEqual({
+      phase: "active",
+      isActive: true,
+      isPaused: false,
+      isHidden: false,
+    });
+  });
+
+  it("pauses a retained view on hide (onHide before onPause) and resumes to inactive", () => {
+    registerViewPolicy(VIEW_ID, { keepAlive: true, pausable: true });
+    const events: string[] = [];
+    const { result } = renderHook(
+      () =>
+        useViewLifecycle({
+          onShow: () => events.push("show"),
+          onHide: () => events.push("hide"),
+          onPause: (reason) => events.push(`pause:${reason}`),
+          onResume: () => events.push("resume"),
+        }),
+      { wrapper: slotWrapper() },
+    );
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    act(() => {
+      ctrl.setActive(OTHER_VIEW_ID);
+    });
+
+    // Hide of a pausable keep-alive view stops resources (hide) AND pauses.
+    expect(events).toEqual(["show", "hide", "pause:hide"]);
+    expect(result.current).toEqual({
+      phase: "paused",
+      isActive: false,
+      isPaused: true,
+      isHidden: true,
+    });
+
+    // Resuming while hidden restores to inactive, routed to onResume.
+    act(() => {
+      ctrl.markResumed(VIEW_ID);
+    });
+    expect(events).toEqual(["show", "hide", "pause:hide", "resume"]);
+    expect(result.current).toEqual({
+      phase: "inactive",
+      isActive: false,
+      isPaused: false,
+      isHidden: true,
+    });
+  });
+
+  it("defaults the pause reason to app-pause and routes resume to onResume, not onShow", () => {
+    const events: string[] = [];
+    const { result } = renderHook(
+      () =>
+        useViewLifecycle({
+          onShow: () => events.push("show"),
+          onHide: () => events.push("hide"),
+          onPause: (reason) => events.push(`pause:${reason}`),
+          onResume: () => events.push("resume"),
+        }),
+      { wrapper: slotWrapper() },
+    );
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    act(() => {
+      ctrl.markPaused(VIEW_ID);
+    });
+    act(() => {
+      ctrl.markResumed(VIEW_ID);
+    });
+
+    // Entering "paused" always stops resources first: onHide then onPause,
+    // with markPaused's default reason.
+    expect(events).toEqual(["show", "hide", "pause:app-pause", "resume"]);
+    expect(result.current).toEqual({
+      phase: "active",
+      isActive: true,
+      isPaused: false,
+      isHidden: false,
+    });
+  });
+
+  it("reports crashed phases without a handler and dispatches onRestore while recovering", () => {
+    const events: string[] = [];
+    const { result } = renderHook(
+      () =>
+        useViewLifecycle({
+          onShow: () => events.push("show"),
+          onHide: () => events.push("hide"),
+          onPause: (reason) => events.push(`pause:${reason}`),
+          onResume: () => events.push("resume"),
+          onEvict: (reason) => events.push(`evict:${reason}`),
+          onRestore: () => events.push("restore"),
+        }),
+      { wrapper: slotWrapper() },
+    );
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    act(() => {
+      ctrl.markCrashed(VIEW_ID);
+    });
+
+    // Crashing has no dedicated handler branch: state updates, handlers don't.
+    expect(events).toEqual(["show"]);
+    expect(result.current).toEqual({
+      phase: "crashed",
+      isActive: false,
+      isPaused: false,
+      isHidden: false,
+    });
+
+    act(() => {
+      ctrl.markRecovering(VIEW_ID);
+    });
+
+    expect(events).toEqual(["show", "restore", "resume"]);
+    expect(result.current).toEqual({
+      phase: "active",
+      isActive: true,
+      isPaused: false,
+      isHidden: false,
+    });
+  });
+
+  it("delivers onEvict when a default-policy view is hidden by another view", () => {
+    const events: string[] = [];
+    const { result } = renderHook(
+      () =>
+        useViewLifecycle({
+          onEvict: (reason) => events.push(`evict:${reason}`),
+        }),
+      { wrapper: slotWrapper() },
+    );
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    act(() => {
+      ctrl.setActive(OTHER_VIEW_ID);
+    });
+
+    // Default policy unmounts on hide: the hook observes the eviction.
+    expect(events).toEqual([`evict:inactive`]);
+    expect(result.current).toEqual({
+      phase: "evicted",
+      isActive: false,
+      isPaused: false,
+      isHidden: false,
+    });
+    expect(ctrl.getPhase(VIEW_ID)).toBeNull();
+  });
+
+  it("routes transitions to the latest handlers across rerenders without remounting", () => {
+    const firstHandlers = { onMount: vi.fn(), onShow: vi.fn() };
+    const secondHandlers = { onMount: vi.fn(), onShow: vi.fn() };
+    const { rerender } = renderHook(
+      ({
+        handlers,
+      }: {
+        handlers: { onMount: () => void; onShow: () => void };
+      }) => useViewLifecycle(handlers),
+      { wrapper: slotWrapper(), initialProps: { handlers: firstHandlers } },
+    );
+
+    rerender({ handlers: secondHandlers });
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+
+    expect(firstHandlers.onMount).toHaveBeenCalledTimes(1);
+    expect(secondHandlers.onMount).not.toHaveBeenCalled();
+    expect(firstHandlers.onShow).not.toHaveBeenCalled();
+    expect(secondHandlers.onShow).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops delivering transitions after unmount", () => {
+    const onShow = vi.fn();
+    const { unmount } = renderHook(() => useViewLifecycle({ onShow }), {
+      wrapper: slotWrapper(),
+    });
+
+    unmount();
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    expect(onShow).not.toHaveBeenCalled();
+  });
+});
+
+describe("usePauseAware", () => {
+  it("mirrors pause and resume into the paused/active booleans", () => {
+    const { result } = renderHook(() => usePauseAware(), {
+      wrapper: slotWrapper(),
+    });
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    expect(result.current).toEqual({ paused: false, active: true });
+
+    act(() => {
+      ctrl.markPaused(VIEW_ID);
+    });
+    expect(result.current).toEqual({ paused: true, active: false });
+
+    act(() => {
+      ctrl.markResumed(VIEW_ID);
+    });
+    expect(result.current).toEqual({ paused: false, active: true });
+  });
+});
+
+describe("usePausableInterval", () => {
+  it("runs while active and registers exactly one pending timer for the scoped view", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    renderHook(() => usePausableInterval(callback, 10), {
+      wrapper: slotWrapper(),
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(35);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(1);
+  });
+
+  it("tracks the timer under the unscoped id outside a slot", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    renderHook(() => usePausableInterval(callback, 10));
+
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(snapshotResourceCounters("unscoped").pendingTimers).toBe(1);
+  });
+
+  it("stops and untracks the timer while paused and restarts it on resume", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    renderHook(() => usePausableInterval(callback, 10), {
+      wrapper: slotWrapper(),
+    });
+
+    act(() => {
+      ctrl.setActive(VIEW_ID);
+    });
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+    const beforePause = callback.mock.calls.length;
+    expect(beforePause).toBeGreaterThanOrEqual(1);
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(1);
+
+    act(() => {
+      ctrl.markPaused(VIEW_ID);
+    });
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(callback).toHaveBeenCalledTimes(beforePause);
+
+    act(() => {
+      ctrl.markResumed(VIEW_ID);
+    });
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(1);
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+    expect(callback.mock.calls.length).toBeGreaterThan(beforePause);
+  });
+
+  it("clears the interval and releases the timer on unmount", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => usePausableInterval(callback, 10), {
+      wrapper: slotWrapper(),
+    });
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(1);
+
+    unmount();
+
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("never starts for non-positive delays and tracks no timer", () => {
+    vi.useFakeTimers();
+    const zeroDelay = vi.fn();
+    const zero = renderHook(() => usePausableInterval(zeroDelay, 0), {
+      wrapper: slotWrapper(),
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(zeroDelay).not.toHaveBeenCalled();
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(0);
+    zero.unmount();
+
+    const negativeDelay = vi.fn();
+    renderHook(() => usePausableInterval(negativeDelay, -5), {
+      wrapper: slotWrapper(),
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(negativeDelay).not.toHaveBeenCalled();
+    expect(snapshotResourceCounters(VIEW_ID).pendingTimers).toBe(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located unit suite for `packages/ui/src/state/useViewLifecycle.ts` — the view-author hooks (`useViewLifecycle`, `usePauseAware`, `usePausableInterval`) that previously had no same-named test file anywhere in the repo. Test-only change: 448 added lines, zero production lines touched.

## How it tests

The suite drives the REAL system, not mocks: transitions are produced by issuing commands to the actual `ViewLifecycleController` singleton (`setActive`, `markPaused`, `markResumed`, `markCrashed`, `markRecovering`) while the hook is mounted inside a live `ViewLifecycleSlot` provider, and timer bookkeeping is asserted through the real `resource-counters` registry (`snapshotResourceCounters`). No module is mocked and no assertion restates a mock's return value.

Coverage per export:

- `useViewLifecycle`: active-fallback degradation outside a slot (no handlers fire); `onMount` once with initial state seeded from the controller's current phase; handler dispatch on every phase branch reachable through the public API — show → `onShow`; hide of a retained view → `onHide` then `onPause("hide")` in order; app-pause default reason `onPause("app-pause")`; resume routing to `onResume` (both active and hidden-to-inactive paths); crash reported silently; recovering → `onRestore`; eviction of a default-policy view → `onEvict` with the observed `"inactive"` reason; latest-handler routing across rerenders without remount; no deliveries after unmount.
- `usePauseAware`: paused/active booleans mirror the pause/resume cycle.
- `usePausableInterval`: runs while active and registers exactly one pending timer under the scoped view id; tracks under `"unscoped"` outside a slot; stops and untracks while paused and restarts on resume; clears interval and releases the counter on unmount; never starts for non-positive delays.

One expectation is worth flagging: entering the `paused` phase always dispatches `onHide` before `onPause` (the hook's `case "paused"` does both regardless of entry path) — the suite asserts the observed behavior rather than an assumed one.

## Evidence

- `bunx vitest run src/state/useViewLifecycle.test.tsx` (packages/ui): **1 file, 15 tests, 15 passed** against current `origin/develop` (`d77eb55bc0`).
- `bunx biome check src/state/useViewLifecycle.test.tsx`: clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output (zero type errors introduced).
- Diff contains only the new test file (+448/−0).

This is a fork contribution, so hosted CI does not run on this PR; the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e5eb3e1df00d266b8708234941fbba76ee8f9d39 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
