### PR TITLE
test(ui): cover useTabSync

### DIFF
--- a/packages/ui/src/state/useTabSync.test.ts
+++ b/packages/ui/src/state/useTabSync.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Verifies the cross-window tab-sync hook through renderHook against a
+ * scripted BroadcastChannel transport: the inert fallback when the API is
+ * absent, payload shapes published to peer windows, guarded routing of
+ * inbound frames to the latest handler identities, and channel teardown on
+ * unmount. Only the platform transport is doubled; all hook logic is real.
+ */
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type UseTabSyncOptions, useTabSync } from "./useTabSync";
+
+class FakeBroadcastChannel {
+  private static readonly opened: FakeBroadcastChannel[] = [];
+
+  readonly name: string;
+  closed = false;
+  readonly posted: unknown[] = [];
+  private readonly listeners: Array<{
+    type: string;
+    callback: EventListenerOrEventListenerObject;
+  }> = [];
+
+  constructor(name: string) {
+    this.name = name;
+    FakeBroadcastChannel.opened.push(this);
+  }
+
+  static get openedChannels(): readonly FakeBroadcastChannel[] {
+    return FakeBroadcastChannel.opened;
+  }
+
+  static reset(): void {
+    FakeBroadcastChannel.opened.length = 0;
+  }
+
+  addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+  ): void {
+    if (callback) this.listeners.push({ type, callback });
+  }
+
+  removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+  ): void {
+    if (!callback) return;
+    const index = this.listeners.findIndex(
+      (entry) => entry.type === type && entry.callback === callback,
+    );
+    if (index !== -1) this.listeners.splice(index, 1);
+  }
+
+  postMessage(message: unknown): void {
+    this.posted.push(message);
+    for (const peer of FakeBroadcastChannel.opened) {
+      if (peer === this || peer.closed || peer.name !== this.name) continue;
+      peer.deliver(message);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    this.listeners.length = 0;
+  }
+
+  private deliver(data: unknown): void {
+    const event = new MessageEvent("message", { data });
+    for (const { type, callback } of [...this.listeners]) {
+      if (type !== "message") continue;
+      if (typeof callback === "function") callback(event);
+      else callback.handleEvent(event);
+    }
+  }
+}
+
+function requireOpenedChannel(): FakeBroadcastChannel {
+  const [channel] = FakeBroadcastChannel.openedChannels;
+  if (!channel) throw new Error("expected a hook-opened channel");
+  return channel;
+}
+
+function remoteWindow(): FakeBroadcastChannel {
+  return new FakeBroadcastChannel(requireOpenedChannel().name);
+}
+
+const globalWithChannel = globalThis as { BroadcastChannel?: unknown };
+let originalBroadcastChannel: unknown;
+
+describe("useTabSync", () => {
+  beforeEach(() => {
+    originalBroadcastChannel = globalWithChannel.BroadcastChannel;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalWithChannel.BroadcastChannel = originalBroadcastChannel;
+    FakeBroadcastChannel.reset();
+  });
+
+  describe("without BroadcastChannel", () => {
+    beforeEach(() => {
+      globalWithChannel.BroadcastChannel = undefined;
+    });
+
+    it("reports disabled and never opens a channel", () => {
+      const { result } = renderHook(() => useTabSync());
+      expect(result.current.enabled).toBe(false);
+      expect(FakeBroadcastChannel.openedChannels).toHaveLength(0);
+    });
+
+    it("publishing is an inert no-op instead of a crash", () => {
+      const { result } = renderHook(() => useTabSync());
+      expect(() =>
+        act(() => {
+          result.current.publishActiveConversation("conv-1");
+          result.current.publishPrefs({ language: "de" });
+        }),
+      ).not.toThrow();
+      expect(FakeBroadcastChannel.openedChannels).toHaveLength(0);
+    });
+
+    it("hands every consumer the same stable noop api object", () => {
+      const first = renderHook(() => useTabSync());
+      const second = renderHook(() => useTabSync());
+      first.rerender();
+      expect(first.result.current).toBe(second.result.current);
+      first.unmount();
+      second.unmount();
+    });
+  });
+
+  describe("with BroadcastChannel available", () => {
+    beforeEach(() => {
+      globalWithChannel.BroadcastChannel =
+        FakeBroadcastChannel as unknown as typeof BroadcastChannel;
+    });
+
+    it("reports enabled and keeps exactly one channel across re-renders", () => {
+      const view = renderHook(() => useTabSync());
+      view.rerender();
+      view.rerender();
+      expect(view.result.current.enabled).toBe(true);
+      expect(FakeBroadcastChannel.openedChannels).toHaveLength(1);
+    });
+
+    it("broadcasts the active-conversation payload peers consume", () => {
+      const { result } = renderHook(() => useTabSync());
+      act(() => result.current.publishActiveConversation("conv-42"));
+      expect(requireOpenedChannel().posted).toEqual([
+        { kind: "active-conversation", conversationId: "conv-42" },
+      ]);
+    });
+
+    it("broadcasts null to clear the active conversation everywhere", () => {
+      const { result } = renderHook(() => useTabSync());
+      act(() => result.current.publishActiveConversation(null));
+      expect(requireOpenedChannel().posted).toEqual([
+        { kind: "active-conversation", conversationId: null },
+      ]);
+    });
+
+    it("broadcasts prefs updates with their payload intact", () => {
+      const { result } = renderHook(() => useTabSync());
+      act(() => result.current.publishPrefs({ language: "de" }));
+      expect(requireOpenedChannel().posted).toEqual([
+        { kind: "prefs", prefs: { language: "de" } },
+      ]);
+    });
+
+    it("mirrors another window's conversation switch into onActiveConversation", () => {
+      const received: Array<string | null> = [];
+      renderHook(() =>
+        useTabSync({ onActiveConversation: (id) => received.push(id) }),
+      );
+      remoteWindow().postMessage({
+        kind: "active-conversation",
+        conversationId: "conv-7",
+      });
+      expect(received).toEqual(["conv-7"]);
+    });
+
+    it("passes a null conversation id through to the handler untouched", () => {
+      const onActiveConversation = vi.fn();
+      renderHook(() => useTabSync({ onActiveConversation }));
+      remoteWindow().postMessage({
+        kind: "active-conversation",
+        conversationId: null,
+      });
+      expect(onActiveConversation).toHaveBeenCalledTimes(1);
+      expect(onActiveConversation).toHaveBeenCalledWith(null);
+    });
+
+    it("mirrors another window's prefs into onPrefs", () => {
+      const onPrefs = vi.fn();
+      renderHook(() => useTabSync({ onPrefs }));
+      remoteWindow().postMessage({
+        kind: "prefs",
+        prefs: { language: "fr" },
+      });
+      expect(onPrefs).toHaveBeenCalledTimes(1);
+      expect(onPrefs).toHaveBeenCalledWith({ language: "fr" });
+    });
+
+    it("drops malformed frames without touching either handler", () => {
+      const onActiveConversation = vi.fn();
+      const onPrefs = vi.fn();
+      renderHook(() => useTabSync({ onActiveConversation, onPrefs }));
+      const remote = remoteWindow();
+      const malformedFrames: unknown[] = [
+        42,
+        null,
+        "active-conversation",
+        {},
+        { kind: "unknown" },
+        { kind: "active-conversation", conversationId: 7 },
+        { kind: "active-conversation" },
+        { kind: "prefs", prefs: null },
+        { kind: "prefs", prefs: 3 },
+      ];
+      for (const frame of malformedFrames) remote.postMessage(frame);
+      expect(onActiveConversation).not.toHaveBeenCalled();
+      expect(onPrefs).not.toHaveBeenCalled();
+    });
+
+    it("routes frames to the newest handler identity without resubscribing", () => {
+      const firstHandler = vi.fn();
+      const secondHandler = vi.fn();
+      const view = renderHook((props: UseTabSyncOptions) => useTabSync(props), {
+        initialProps: { onActiveConversation: firstHandler },
+      });
+      view.rerender({ onActiveConversation: secondHandler });
+      expect(FakeBroadcastChannel.openedChannels).toHaveLength(1);
+      remoteWindow().postMessage({
+        kind: "active-conversation",
+        conversationId: "conv-8",
+      });
+      expect(firstHandler).not.toHaveBeenCalled();
+      expect(secondHandler).toHaveBeenCalledWith("conv-8");
+    });
+
+    it("closes its channel on unmount and goes quiet afterwards", () => {
+      const onActiveConversation = vi.fn();
+      const view = renderHook(() => useTabSync({ onActiveConversation }));
+      const mine = requireOpenedChannel();
+      view.unmount();
+      expect(mine.closed).toBe(true);
+      const remote = new FakeBroadcastChannel(mine.name);
+      remote.postMessage({
+        kind: "active-conversation",
+        conversationId: "late",
+      });
+      expect(onActiveConversation).not.toHaveBeenCalled();
+      expect(() =>
+        act(() => view.result.current.publishActiveConversation("stray")),
+      ).not.toThrow();
+      expect(remote.posted).toEqual([
+        { kind: "active-conversation", conversationId: "late" },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION

Adds a co-located unit suite for `packages/ui/src/state/useTabSync.ts`, which had no same-named test file anywhere in the repository. Test-only change: no production behaviour is modified, and the diff touches exactly one new file.

The hook keeps same-origin browser windows in sync over BroadcastChannel. The suite drives the real hook through `renderHook` (`@testing-library/react`) and doubles only the platform transport (a scripted `BroadcastChannel`), since jsdom's support for it is incidental:

- inert fallback when `BroadcastChannel` is absent: `enabled === false`, publishing never throws or opens a channel, and every consumer receives the same stable noop api object
- single channel opened on mount and preserved across re-renders
- publish payload shapes for `publishActiveConversation` (including `null` to clear) and `publishPrefs`
- cross-window delivery of `active-conversation` and `prefs` frames into `onActiveConversation` / `onPrefs`, with `null` conversation ids passed through untouched
- malformed frames dropped by the message guard without touching either handler (non-objects, missing/unknown `kind`, non-string ids, null/non-object prefs)
- handler identities refresh on re-render while the subscription stays put
- unmount closes the channel, stops delivery, and leaves late publishes a safe no-op

Evidence (run against current `origin/develop` immediately before filing):

- `bunx vitest run src/state/useTabSync.test.ts` in `packages/ui`: **1 file passed (1), 13 tests passed (13)**
- `bunx biome check src/state/useTabSync.test.ts`: clean ("Checked 1 file... No fixes applied")
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output; remaining diagnostics are pre-existing/environmental (missing untracked `i18n/generated` artifacts, cross-package module resolution) and reproduce identically without this diff

As a fork contributor, hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:de774b875774f478ef5b879dbdae8fd2997a3470 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
