### PR TITLE
test(ui): cover useDataLoaders

### DIFF
--- a/packages/ui/src/state/useDataLoaders.load-resilience.test.tsx
+++ b/packages/ui/src/state/useDataLoaders.load-resilience.test.tsx
@@ -1,0 +1,482 @@
+/** Verifies useDataLoaders — load resilience contracts through the package's configured test harness. */
+// @vitest-environment jsdom
+//
+// Coverage for the failure-mode and capacity branches of the data loaders that
+// the sibling suites do not touch: transient (non-404) fetch failures keep the
+// painted thread and report softly when a cache paint exists but fail loudly
+// without one; the prefetch cache evicts oldest-first at its 16-entry cap with
+// re-insertion refreshing recency; the around-window jump loader abandons
+// results after navigation; extension-status checks install a documented
+// offline fallback; update-channel changes no-op on the same channel.
+
+import { logger } from "@elizaos/logger";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ConversationMessage,
+  ExtensionStatus,
+  UpdateStatus,
+} from "../api";
+import { client } from "../api";
+import type { LoadConversationMessagesResult } from "./internal";
+import { type DataLoadersDeps, useDataLoaders } from "./useDataLoaders";
+
+vi.mock("../api", () => ({
+  client: {
+    getConversationMessages: vi.fn(),
+    listConversations: vi.fn(async () => ({ conversations: [] })),
+    getConfig: vi.fn(async () => ({ ui: {} })),
+    getUpdateStatus: vi.fn(),
+    setUpdateChannel: vi.fn(),
+    getExtensionStatus: vi.fn(),
+  },
+}));
+
+const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+function userMsg(id: string): ConversationMessage {
+  return {
+    id,
+    role: "user",
+    text: `msg-${id}`,
+    timestamp: 0,
+  } as ConversationMessage;
+}
+
+function makeDeps(overrides: Partial<DataLoadersDeps> = {}) {
+  const conversationMessagesRef = { current: [] as ConversationMessage[] };
+  const activeConversationIdRef = { current: null as string | null };
+  const greetingFiredRef = { current: false };
+  const noop = () => {};
+  const deps = {
+    autonomousStoreRef: { current: {} },
+    autonomousEventsRef: { current: [] },
+    autonomousLatestEventIdRef: { current: null },
+    autonomousRunHealthByRunIdRef: { current: {} },
+    autonomousReplayInFlightRef: { current: false },
+    setAutonomousEvents: noop,
+    setAutonomousLatestEventId: noop,
+    setAutonomousRunHealthByRunId: noop,
+    activeConversationIdRef,
+    conversationMessagesRef,
+    greetingFiredRef,
+    setConversations: vi.fn(),
+    setActiveConversationId: vi.fn(),
+    setConversationMessages: vi.fn(),
+    loadWalletConfig: async () => {},
+    agentStatus: null,
+    characterData: null,
+    characterDraft: null,
+    loadCharacter: async () => {},
+    selectedVrmIndex: 0,
+    firstRunComplete: false,
+    uiLanguage: "en",
+    setOwnerNameState: noop,
+    ...overrides,
+  } as unknown as DataLoadersDeps;
+  return {
+    deps,
+    conversationMessagesRef,
+    activeConversationIdRef,
+    greetingFiredRef,
+  };
+}
+
+const stableStatus: UpdateStatus = {
+  currentVersion: "1.2.3",
+  channel: "stable",
+  installMethod: "package-manager",
+  updateAvailable: false,
+  latestVersion: null,
+  channels: { stable: "1.2.3", beta: null, nightly: null },
+  distTags: { stable: "latest", beta: "beta", nightly: "nightly" },
+  lastCheckAt: null,
+  error: null,
+};
+
+beforeEach(() => {
+  vi.mocked(client.getConversationMessages).mockReset();
+  vi.mocked(client.getUpdateStatus).mockReset();
+  vi.mocked(client.setUpdateChannel).mockReset();
+  vi.mocked(client.getExtensionStatus).mockReset();
+  debugSpy.mockClear();
+  window.localStorage.clear();
+});
+
+describe("useDataLoaders — transient load failures", () => {
+  it("reports soft success and keeps the painted thread when revalidation fails after a cache paint", async () => {
+    vi.mocked(client.getConversationMessages)
+      .mockResolvedValueOnce({ messages: [userMsg("conv-a")] })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("upstream exploded"), { status: 500 }),
+      );
+    const { deps, conversationMessagesRef } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      result.current.prefetchConversationMessages(["conv-a"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    let outcome: LoadConversationMessagesResult | undefined;
+    await act(async () => {
+      outcome = await result.current.loadConversationMessages("conv-a");
+    });
+
+    // The user is looking at usable cached content — the failed revalidation
+    // must not blank it or surface an error over it.
+    expect(outcome).toEqual({ ok: true });
+    expect(conversationMessagesRef.current).toEqual([userMsg("conv-a")]);
+  });
+
+  it("reports ok:false with status and message for a transient failure without a cache paint", async () => {
+    vi.mocked(client.getConversationMessages).mockRejectedValue(
+      Object.assign(new Error("upstream exploded"), { status: 503 }),
+    );
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let outcome: LoadConversationMessagesResult | undefined;
+    await act(async () => {
+      outcome = await result.current.loadConversationMessages("conv-a");
+    });
+
+    if (!outcome || outcome.ok) {
+      throw new Error("expected a failure result");
+    }
+    expect(outcome.status).toBe(503);
+    expect(outcome.message).toBe("upstream exploded");
+  });
+
+  it("falls back to a generic message for rejections that are not Errors", async () => {
+    vi.mocked(client.getConversationMessages).mockRejectedValue({
+      bodyText: "not an Error instance",
+    });
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let outcome: LoadConversationMessagesResult | undefined;
+    await act(async () => {
+      outcome = await result.current.loadConversationMessages("conv-a");
+    });
+
+    if (!outcome || outcome.ok) {
+      throw new Error("expected a failure result");
+    }
+    expect(outcome.status).toBeUndefined();
+    expect(outcome.message).toBe("Failed to load conversation messages");
+  });
+});
+
+describe("useDataLoaders — prefetch cache capacity and recency", () => {
+  it("ignores empty ids in a prefetch batch", async () => {
+    vi.mocked(client.getConversationMessages).mockImplementation(
+      async (id: string) => ({ messages: [userMsg(id)] }),
+    );
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      result.current.prefetchConversationMessages([""]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c1"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest cached conversation once the 16-entry cap is exceeded", async () => {
+    vi.mocked(client.getConversationMessages).mockImplementation(
+      async (id: string) => ({ messages: [userMsg(id)] }),
+    );
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      result.current.prefetchConversationMessages([
+        "c0",
+        "c1",
+        "c2",
+        "c3",
+        "c4",
+        "c5",
+        "c6",
+        "c7",
+        "c8",
+        "c9",
+        "c10",
+        "c11",
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+      ]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(16);
+
+    // A 17th neighbor fits (evicting c0)…
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c16"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(17);
+
+    // …so c0 is gone from the cache and prefetches again…
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c0"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(18);
+
+    // Caching the c0 refill itself pushes the map back to 17 entries, so the
+    // cap evicted the then-oldest survivor c1 on insert. Untouched c2 survived
+    // both evictions and issues no fetch…
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c2"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(18);
+
+    // …while c1 is gone from the cache and prefetches again.
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c1"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(19);
+  });
+
+  it("refreshes recency on re-insert so a touched entry survives the next eviction", async () => {
+    vi.mocked(client.getConversationMessages).mockImplementation(
+      async (id: string) => ({ messages: [userMsg(id)] }),
+    );
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      result.current.prefetchConversationMessages([
+        "c0",
+        "c1",
+        "c2",
+        "c3",
+        "c4",
+        "c5",
+        "c6",
+        "c7",
+        "c8",
+        "c9",
+        "c10",
+        "c11",
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+      ]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(16);
+
+    // Loading c0 re-inserts it as most-recently used.
+    await act(async () => {
+      await result.current.loadConversationMessages("c0");
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(17);
+
+    // The next eviction therefore takes untouched c1, not touched c0.
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c16"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(18);
+
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c0"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(18);
+
+    await act(async () => {
+      result.current.prefetchConversationMessages(["c1"]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledTimes(19);
+  });
+});
+
+describe("useDataLoaders — around-window jump loader (#9955)", () => {
+  it("commits the centered window when the conversation is still active", async () => {
+    vi.mocked(client.getConversationMessages).mockResolvedValue({
+      messages: [userMsg("w1"), userMsg("w2")],
+    });
+    const { deps, conversationMessagesRef, activeConversationIdRef } =
+      makeDeps();
+    activeConversationIdRef.current = "conv-a";
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let landed: boolean | undefined;
+    await act(async () => {
+      landed = await result.current.loadConversationMessagesAround(
+        "conv-a",
+        "m42",
+      );
+    });
+
+    expect(landed).toBe(true);
+    expect(vi.mocked(client.getConversationMessages)).toHaveBeenCalledWith(
+      "conv-a",
+      { around: "m42" },
+    );
+    expect(conversationMessagesRef.current.map((m) => m.id)).toEqual([
+      "w1",
+      "w2",
+    ]);
+    expect(result.current.loadedConversationIdRef.current).toBe("conv-a");
+  });
+
+  it("abandons the window after the user navigates away before it lands", async () => {
+    let resolveWindow: ((messages: ConversationMessage[]) => void) | undefined;
+    vi.mocked(client.getConversationMessages).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveWindow = (messages) => resolve({ messages });
+        }),
+    );
+    const { deps, conversationMessagesRef, activeConversationIdRef } =
+      makeDeps();
+    activeConversationIdRef.current = "conv-a";
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let jumped: Promise<boolean> | undefined;
+    act(() => {
+      jumped = result.current.loadConversationMessagesAround("conv-a", "m42");
+    });
+    if (!jumped) throw new Error("around-window load did not start");
+
+    // The user swipes to another conversation while the jump is in flight.
+    activeConversationIdRef.current = "conv-b";
+
+    let landed: boolean | undefined;
+    await act(async () => {
+      resolveWindow?.([userMsg("w1")]);
+      landed = await jumped;
+    });
+
+    expect(landed).toBe(false);
+    // The stale window never reaches the thread of the now-active conversation.
+    expect(conversationMessagesRef.current).toEqual([]);
+  });
+
+  it("returns false and logs at debug when the around-window fetch fails", async () => {
+    vi.mocked(client.getConversationMessages).mockRejectedValue(
+      new Error("search index down"),
+    );
+    const { deps, conversationMessagesRef, activeConversationIdRef } =
+      makeDeps();
+    activeConversationIdRef.current = "conv-a";
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let landed: boolean | undefined;
+    await act(async () => {
+      landed = await result.current.loadConversationMessagesAround(
+        "conv-a",
+        "m42",
+      );
+    });
+
+    expect(landed).toBe(false);
+    expect(conversationMessagesRef.current).toEqual([]);
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0]?.[1]).toContain(
+      "around-window load failed for conv-a",
+    );
+  });
+});
+
+describe("useDataLoaders — extension status check", () => {
+  it("propagates a healthy relay payload and settles the checking flag", async () => {
+    const liveExtension: ExtensionStatus = {
+      relayReachable: true,
+      relayPort: 19999,
+      extensionPath: "/tmp/eliza-extension",
+    };
+    vi.mocked(client.getExtensionStatus).mockResolvedValue(liveExtension);
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.checkExtensionStatus();
+    });
+
+    expect(result.current.extensionStatus).toEqual(liveExtension);
+    expect(result.current.extensionChecking).toBe(false);
+  });
+
+  it("installs the documented offline fallback when the probe fails", async () => {
+    vi.mocked(client.getExtensionStatus).mockRejectedValue(
+      new Error("relay down"),
+    );
+    const { deps } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.checkExtensionStatus();
+    });
+
+    expect(result.current.extensionStatus).toEqual({
+      relayReachable: false,
+      relayPort: 18792,
+      extensionPath: null,
+      chromeBuildPath: null,
+      chromePackagePath: null,
+      safariWebExtensionPath: null,
+      safariAppPath: null,
+      safariPackagePath: null,
+    });
+    expect(result.current.extensionChecking).toBe(false);
+  });
+});
+
+describe("useDataLoaders — update channel change guard", () => {
+  it("no-ops when the requested channel is already active and force-reloads after a real switch", async () => {
+    vi.mocked(client.getUpdateStatus).mockResolvedValue(stableStatus);
+    vi.mocked(client.setUpdateChannel).mockResolvedValue({ channel: "beta" });
+    const { deps } = makeDeps();
+    const { result, rerender } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.loadUpdateStatus();
+    });
+    rerender();
+    expect(result.current.updateStatus?.channel).toBe("stable");
+
+    await act(async () => {
+      await result.current.handleChannelChange("stable");
+    });
+    expect(vi.mocked(client.setUpdateChannel)).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.handleChannelChange("beta");
+    });
+    expect(vi.mocked(client.setUpdateChannel)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(client.setUpdateChannel)).toHaveBeenCalledWith("beta");
+    // The post-switch reload forces a fresh status check.
+    expect(vi.mocked(client.getUpdateStatus)).toHaveBeenLastCalledWith(true);
+    expect(result.current.updateChannelSaving).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/ui/src/state/useDataLoaders.ts`: `useDataLoaders.load-resilience.test.tsx` (12 cases). Test-only diff: **+482/-0**, one new file. The three existing suites for this module (`useDataLoaders.auth-gate.test.tsx`, `useDataLoaders.conversation-cache.test.tsx`, `useDataLoaders.refresh-404-error.test.tsx`) are untouched; this suite covers branches none of them exercise:

- **Transient load failures** — a non-404 revalidation failure after a prefetch-cache paint returns soft success (`{ok:true}`) and keeps the painted thread; without a cache paint it returns `{ok:false}` carrying the error `status` and `message`; a rejection that is not an `Error` falls back to the generic message with no `status`.
- **Prefetch cache capacity** — eviction of the oldest entry once the 16-entry cap is exceeded, including the cascade where caching a refill itself evicts the then-oldest survivor, and recency refresh via re-insertion so a touched entry survives the next eviction.
- **Around-window jump loader (#9955)** — commits a centered window while the conversation is still active, abandons the result (returns `false`, thread untouched) if the user navigated away before it lands, and returns `false` with a debug log when the fetch fails.
- **Extension status probe** — propagates a healthy relay payload and installs the documented offline fallback (`relayReachable:false`, port 18792) on failure, clearing the checking flag both ways.
- **Update channel guard** — selecting the already-active channel issues no request; a real switch calls `setUpdateChannel` and force-reloads update status, resetting the saving flag.

Expectations were written against observed behavior of the current implementation on `origin/develop` (the eviction-cascade assertions record how the cap actually behaves on insert).

## Evidence (test-only PR)

- `bunx vitest run src/state/useDataLoaders.load-resilience.test.tsx` — **1 file passed, 12 tests passed / 12 total** at head `3a2199f899` based on current `origin/develop` (`d77eb55bc0`), re-run immediately before filing after the latest develop fetch.
- `bunx biome check --write packages/ui/src/state/useDataLoaders.load-resilience.test.tsx` — clean ("Checked 1 file … No fixes applied"); config proven present (`biome.json`, `tsconfig.json` at repo root, worktree not sparse).
- `bunx tsc --noEmit` in `packages/ui` — zero occurrences of `useDataLoaders.load-resilience` in output.
- Diff touches only the new test file (+482/-0); no deletions, no changes to any existing test or source file.

## Notes for reviewers

- This is a fork contribution: hosted CI does not run on this pull request. All checks above were executed locally and their counts quoted verbatim.
- No production behavior is changed by this diff, so the bug-fix evidence procedure does not apply; the four-item test-only evidence bar above is the complete set.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3a2199f899ee1155668e5f6b99cec876b4c42dd6 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
