### PR TITLE
test(ui): cover useTriggersState

### DIFF
--- a/packages/ui/src/state/useTriggersState.test.ts
+++ b/packages/ui/src/state/useTriggersState.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Verifies useTriggersState — trigger CRUD, run history, and health polling —
+ * against a controlled ../api transport double: queue ordering, loud/silent
+ * load semantics, upsert/prune merges, and error surfacing.
+ */
+// @vitest-environment jsdom
+
+// Drives the real hook through renderHook and asserts observable state
+// transitions. Only the transport boundary (../api client) is doubled, so the
+// sorting, merging, flag lifecycle, and error mapping under test run for real.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  TriggerHealthSnapshot,
+  TriggerRunRecord,
+  TriggerSummary,
+} from "../api";
+
+const getTriggers = vi.fn();
+const getTriggerRuns = vi.fn();
+const createTriggerFn = vi.fn();
+const updateTriggerFn = vi.fn();
+const deleteTriggerFn = vi.fn();
+const runTriggerNowFn = vi.fn();
+const getTriggerHealth = vi.fn();
+
+vi.mock("../api", () => ({
+  client: {
+    getTriggers: (...args: unknown[]) => getTriggers(...args),
+    getTriggerRuns: (...args: unknown[]) => getTriggerRuns(...args),
+    createTrigger: (...args: unknown[]) => createTriggerFn(...args),
+    updateTrigger: (...args: unknown[]) => updateTriggerFn(...args),
+    deleteTrigger: (...args: unknown[]) => deleteTriggerFn(...args),
+    runTriggerNow: (...args: unknown[]) => runTriggerNowFn(...args),
+    getTriggerHealth: (...args: unknown[]) => getTriggerHealth(...args),
+  },
+}));
+
+import { useTriggersState } from "./useTriggersState";
+
+function triggerFixture(
+  id: string,
+  overrides: Partial<TriggerSummary> = {},
+): TriggerSummary {
+  return {
+    id,
+    taskId: `task-${id}`,
+    displayName: `Trigger ${id}`,
+    instructions: "Do the scheduled thing",
+    triggerType: "interval",
+    enabled: true,
+    wakeMode: "inject_now",
+    createdBy: "user-1",
+    runCount: 0,
+    ...overrides,
+  };
+}
+
+function runRecordFixture(triggerId: string): TriggerRunRecord {
+  return {
+    triggerRunId: `${triggerId}-run-1`,
+    triggerId,
+    taskId: `task-${triggerId}`,
+    startedAt: 1000,
+    finishedAt: 1500,
+    status: "success",
+    latencyMs: 500,
+    source: "scheduler",
+  };
+}
+
+function healthSnapshot(): TriggerHealthSnapshot {
+  return {
+    triggersEnabled: true,
+    activeTriggers: 1,
+    disabledTriggers: 0,
+    totalExecutions: 3,
+    totalFailures: 0,
+    totalSkipped: 0,
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function loadTriggersOnce(
+  result: { current: ReturnType<typeof useTriggersState> },
+  payload: { triggers: TriggerSummary[] },
+): Promise<void> {
+  getTriggers.mockResolvedValueOnce(payload);
+  await act(async () => {
+    await result.current.loadTriggers();
+  });
+}
+
+describe("useTriggersState", () => {
+  beforeEach(() => {
+    for (const mock of [
+      getTriggers,
+      getTriggerRuns,
+      createTriggerFn,
+      updateTriggerFn,
+      deleteTriggerFn,
+      runTriggerNowFn,
+      getTriggerHealth,
+    ]) {
+      mock.mockReset();
+    }
+    // Defaults so fire-and-forget health refreshes and run-history loads in
+    // CRUD flows never reject; individual tests override with Once variants.
+    getTriggerHealth.mockResolvedValue(healthSnapshot());
+    getTriggerRuns.mockResolvedValue({ runs: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("initial state", () => {
+    it("starts idle with an empty queue, no history, and no errors", () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      expect(result.current.state.triggers).toEqual([]);
+      expect(result.current.state.triggersLoaded).toBe(false);
+      expect(result.current.state.triggersLoading).toBe(false);
+      expect(result.current.state.triggersSaving).toBe(false);
+      expect(result.current.state.triggerRunsById).toEqual({});
+      expect(result.current.state.triggerHealth).toBeNull();
+      expect(result.current.state.triggerError).toBeNull();
+    });
+  });
+
+  describe("loadTriggers ordering", () => {
+    it("sorts ascending by nextRunAtMs and places never-scheduled triggers last", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("unscheduled-a"),
+          triggerFixture("late", { nextRunAtMs: 300 }),
+          triggerFixture("early", { nextRunAtMs: 100 }),
+          triggerFixture("unscheduled-b"),
+        ],
+      });
+
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "early",
+        "late",
+        "unscheduled-a",
+        "unscheduled-b",
+      ]);
+      expect(result.current.state.triggerError).toBeNull();
+      expect(result.current.state.triggersLoaded).toBe(true);
+    });
+
+    it("breaks ties on nextRunAtMs by displayName", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("c", { displayName: "gamma", nextRunAtMs: 100 }),
+          triggerFixture("a", { displayName: "alpha", nextRunAtMs: 100 }),
+          triggerFixture("b", { displayName: "beta", nextRunAtMs: 100 }),
+        ],
+      });
+
+      expect(
+        result.current.state.triggers.map((item) => item.displayName),
+      ).toEqual(["alpha", "beta", "gamma"]);
+    });
+
+    it("sorts into a copy and leaves the server-supplied array untouched", async () => {
+      const serverPayload = [
+        triggerFixture("unscheduled"),
+        triggerFixture("later", { nextRunAtMs: 900 }),
+      ];
+      const { result } = renderHook(() => useTriggersState());
+
+      await loadTriggersOnce(result, { triggers: serverPayload });
+
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "later",
+        "unscheduled",
+      ]);
+      expect(serverPayload.map((item) => item.id)).toEqual([
+        "unscheduled",
+        "later",
+      ]);
+    });
+
+    it("accepts an empty queue as a successful load", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      await loadTriggersOnce(result, { triggers: [] });
+
+      expect(result.current.state.triggers).toEqual([]);
+      expect(result.current.state.triggersLoaded).toBe(true);
+      expect(result.current.state.triggersLoading).toBe(false);
+      expect(result.current.state.triggerError).toBeNull();
+    });
+
+    it("toggles the loading flag around a loud reload and swaps in fresh data", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("stale", { nextRunAtMs: 100 })],
+      });
+
+      const gate = deferred<{ triggers: TriggerSummary[] }>();
+      getTriggers.mockImplementationOnce(() => gate.promise);
+      let flight: Promise<void>;
+      act(() => {
+        flight = result.current.loadTriggers();
+      });
+      expect(result.current.state.triggersLoading).toBe(true);
+
+      await act(async () => {
+        gate.resolve({
+          triggers: [triggerFixture("fresh", { nextRunAtMs: 50 })],
+        });
+        await flight;
+      });
+
+      expect(result.current.state.triggersLoading).toBe(false);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "fresh",
+      ]);
+      expect(result.current.state.triggerError).toBeNull();
+    });
+
+    it("drops stale triggers on a loud failure and falls back for non-Error rejections", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("old", { nextRunAtMs: 100 })],
+      });
+
+      getTriggers.mockRejectedValueOnce("socket hang up");
+      await act(async () => {
+        await result.current.loadTriggers();
+      });
+
+      expect(result.current.state.triggers).toEqual([]);
+      expect(result.current.state.triggerError).toBe("Failed to load triggers");
+      expect(result.current.state.triggersLoaded).toBe(true);
+      expect(result.current.state.triggersLoading).toBe(false);
+    });
+
+    it("keeps previously loaded triggers on a silent failure and surfaces the Error message", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("kept", { nextRunAtMs: 100 })],
+      });
+
+      getTriggers.mockRejectedValueOnce(new Error("server 500"));
+      await act(async () => {
+        await result.current.loadTriggers({ silent: true });
+      });
+
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "kept",
+      ]);
+      expect(result.current.state.triggerError).toBe("server 500");
+      expect(result.current.state.triggersLoading).toBe(false);
+    });
+  });
+
+  describe("ensureTriggersLoaded", () => {
+    it("loads loudly the first time and silently once triggers are loaded", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      // First call: nothing loaded yet, so the loud path shows loading=true.
+      const firstGate = deferred<{ triggers: TriggerSummary[] }>();
+      getTriggers.mockImplementationOnce(() => firstGate.promise);
+      let firstFlight: Promise<void>;
+      act(() => {
+        firstFlight = result.current.ensureTriggersLoaded();
+      });
+      expect(result.current.state.triggersLoading).toBe(true);
+      await act(async () => {
+        firstGate.resolve({
+          triggers: [triggerFixture("boot", { nextRunAtMs: 10 })],
+        });
+        await firstFlight;
+      });
+      expect(result.current.state.triggersLoaded).toBe(true);
+
+      // Second call: already loaded, routed through the silent path.
+      const secondGate = deferred<{ triggers: TriggerSummary[] }>();
+      getTriggers.mockImplementationOnce(() => secondGate.promise);
+      let secondFlight: Promise<void>;
+      act(() => {
+        secondFlight = result.current.ensureTriggersLoaded();
+      });
+      expect(result.current.state.triggersLoading).toBe(false);
+
+      await act(async () => {
+        secondGate.resolve({
+          triggers: [triggerFixture("refreshed", { nextRunAtMs: 5 })],
+        });
+        await secondFlight;
+      });
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "refreshed",
+      ]);
+    });
+  });
+
+  describe("loadTriggerRuns", () => {
+    it("stores run history per trigger without clobbering other entries", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      const runsForT1 = [runRecordFixture("t1")];
+      const runsForT2 = [runRecordFixture("t2")];
+
+      getTriggerRuns.mockResolvedValueOnce({ runs: runsForT1 });
+      await act(async () => {
+        await result.current.loadTriggerRuns("t1");
+      });
+      getTriggerRuns.mockResolvedValueOnce({ runs: runsForT2 });
+      await act(async () => {
+        await result.current.loadTriggerRuns("t2");
+      });
+
+      expect(Object.keys(result.current.state.triggerRunsById)).toEqual([
+        "t1",
+        "t2",
+      ]);
+      expect(result.current.state.triggerRunsById.t1).toEqual(runsForT1);
+      expect(result.current.state.triggerRunsById.t2).toEqual(runsForT2);
+      expect(result.current.state.triggerError).toBeNull();
+    });
+
+    it("surfaces Error messages verbatim", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      getTriggerRuns.mockRejectedValueOnce(new Error("runs offline"));
+      await act(async () => {
+        await result.current.loadTriggerRuns("t1");
+      });
+
+      expect(result.current.state.triggerError).toBe("runs offline");
+      expect(result.current.state.triggerRunsById).toEqual({});
+    });
+
+    it("falls back to a generic message for non-Error rejections", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      getTriggerRuns.mockRejectedValueOnce(42);
+      await act(async () => {
+        await result.current.loadTriggerRuns("t1");
+      });
+
+      expect(result.current.state.triggerError).toBe(
+        "Failed to load trigger runs",
+      );
+    });
+  });
+
+  describe("createTrigger", () => {
+    it("inserts the created trigger in sorted position and refreshes health", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("existing", { nextRunAtMs: 100 })],
+      });
+      getTriggerHealth.mockClear();
+
+      const created = triggerFixture("sooner", {
+        displayName: "Sooner",
+        nextRunAtMs: 50,
+      });
+      createTriggerFn.mockResolvedValueOnce({ trigger: created });
+
+      let returned: TriggerSummary | null = null;
+      await act(async () => {
+        returned = await result.current.createTrigger({ intervalMs: 60000 });
+      });
+
+      expect(returned).toEqual(created);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "sooner",
+        "existing",
+      ]);
+      expect(result.current.state.triggersSaving).toBe(false);
+      expect(getTriggerHealth).toHaveBeenCalledTimes(1);
+      expect(result.current.state.triggerError).toBeNull();
+    });
+
+    it("replaces a stale entry carrying the same id instead of duplicating it", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("other", { nextRunAtMs: 100 }),
+          triggerFixture("dup", { nextRunAtMs: 999 }),
+        ],
+      });
+
+      const replacement = triggerFixture("dup", { nextRunAtMs: 10 });
+      createTriggerFn.mockResolvedValueOnce({ trigger: replacement });
+
+      await act(async () => {
+        await result.current.createTrigger({});
+      });
+
+      const duplicates = result.current.state.triggers.filter(
+        (item) => item.id === "dup",
+      );
+      expect(duplicates).toHaveLength(1);
+      expect(duplicates[0].nextRunAtMs).toBe(10);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "dup",
+        "other",
+      ]);
+    });
+
+    it("returns null and records the Error message on failure", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      createTriggerFn.mockRejectedValueOnce(new Error("quota exceeded"));
+      let returned: TriggerSummary | null = null;
+      await act(async () => {
+        returned = await result.current.createTrigger({});
+      });
+
+      expect(returned).toBeNull();
+      expect(result.current.state.triggerError).toBe("quota exceeded");
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+
+    it("falls back to a generic message for non-Error rejections", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      createTriggerFn.mockRejectedValueOnce("nope");
+      let returned: TriggerSummary | null = null;
+      await act(async () => {
+        returned = await result.current.createTrigger({});
+      });
+
+      expect(returned).toBeNull();
+      expect(result.current.state.triggerError).toBe(
+        "Failed to create trigger",
+      );
+    });
+  });
+
+  describe("updateTrigger", () => {
+    it("swaps the updated record in place and re-sorts the queue", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("a", { nextRunAtMs: 100 }),
+          triggerFixture("b", { nextRunAtMs: 200 }),
+        ],
+      });
+
+      const updated = triggerFixture("b", {
+        displayName: "B moved up",
+        nextRunAtMs: 10,
+      });
+      updateTriggerFn.mockResolvedValueOnce({ trigger: updated });
+
+      let returned: TriggerSummary | null = null;
+      await act(async () => {
+        returned = await result.current.updateTrigger("b", {
+          intervalMs: 120000,
+        });
+      });
+
+      expect(returned).toEqual(updated);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "b",
+        "a",
+      ]);
+      expect(result.current.state.triggersSaving).toBe(false);
+      expect(result.current.state.triggerError).toBeNull();
+    });
+
+    it("returns null and records the Error message on failure", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      updateTriggerFn.mockRejectedValueOnce(new Error("read-only"));
+      let returned: TriggerSummary | null = null;
+      await act(async () => {
+        returned = await result.current.updateTrigger("b", {});
+      });
+
+      expect(returned).toBeNull();
+      expect(result.current.state.triggerError).toBe("read-only");
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+  });
+
+  describe("deleteTrigger", () => {
+    it("removes the trigger and prunes only its own run history", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("t1", { nextRunAtMs: 100 }),
+          triggerFixture("t2", { nextRunAtMs: 200 }),
+        ],
+      });
+      getTriggerRuns.mockResolvedValueOnce({ runs: [runRecordFixture("t1")] });
+      await act(async () => {
+        await result.current.loadTriggerRuns("t1");
+      });
+      getTriggerRuns.mockResolvedValueOnce({ runs: [runRecordFixture("t2")] });
+      await act(async () => {
+        await result.current.loadTriggerRuns("t2");
+      });
+      getTriggerHealth.mockClear();
+
+      deleteTriggerFn.mockResolvedValueOnce({ ok: true });
+      let returned = false;
+      await act(async () => {
+        returned = await result.current.deleteTrigger("t1");
+      });
+
+      expect(returned).toBe(true);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "t2",
+      ]);
+      expect(Object.keys(result.current.state.triggerRunsById)).toEqual(["t2"]);
+      expect(getTriggerHealth).toHaveBeenCalledTimes(1);
+      expect(result.current.state.triggerError).toBeNull();
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+
+    it("keeps local data intact, reports the error, and returns false on failure", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("survivor", { nextRunAtMs: 100 })],
+      });
+
+      deleteTriggerFn.mockRejectedValueOnce("denied");
+      let returned = false;
+      await act(async () => {
+        returned = await result.current.deleteTrigger("survivor");
+      });
+
+      expect(returned).toBe(false);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "survivor",
+      ]);
+      expect(result.current.state.triggerError).toBe(
+        "Failed to delete trigger",
+      );
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+  });
+
+  describe("runTriggerNow", () => {
+    it("replaces an existing entry in place and re-sorts after a manual run", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [
+          triggerFixture("a", { nextRunAtMs: 100 }),
+          triggerFixture("b", { nextRunAtMs: 200 }),
+        ],
+      });
+      getTriggerHealth.mockClear();
+
+      const ranAgain = triggerFixture("b", {
+        displayName: "B ran now",
+        nextRunAtMs: 40,
+        runCount: 1,
+      });
+      runTriggerNowFn.mockResolvedValueOnce({
+        ok: true,
+        result: { status: "success", taskDeleted: false },
+        trigger: ranAgain,
+      });
+
+      let returned = false;
+      await act(async () => {
+        returned = await result.current.runTriggerNow("b");
+      });
+
+      expect(returned).toBe(true);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "b",
+        "a",
+      ]);
+      expect(result.current.state.triggers[0].displayName).toBe("B ran now");
+      expect(getTriggerHealth).toHaveBeenCalledTimes(1);
+      expect(result.current.state.triggerError).toBeNull();
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+
+    it("appends a trigger unknown to the local list from the run response", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("known", { nextRunAtMs: 100 })],
+      });
+
+      const appended = triggerFixture("brand-new", { nextRunAtMs: 20 });
+      runTriggerNowFn.mockResolvedValueOnce({
+        ok: true,
+        result: { status: "success", taskDeleted: false },
+        trigger: appended,
+      });
+
+      await act(async () => {
+        await result.current.runTriggerNow("brand-new");
+      });
+
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "brand-new",
+        "known",
+      ]);
+    });
+
+    it("refetches the whole list when the run response carries no trigger", async () => {
+      const { result } = renderHook(() => useTriggersState());
+      await loadTriggersOnce(result, {
+        triggers: [triggerFixture("doomed", { nextRunAtMs: 100 })],
+      });
+
+      runTriggerNowFn.mockResolvedValueOnce({
+        ok: true,
+        result: { status: "skipped", taskDeleted: true },
+      });
+      getTriggers.mockResolvedValueOnce({
+        triggers: [triggerFixture("remaining", { nextRunAtMs: 70 })],
+      });
+
+      let returned = false;
+      await act(async () => {
+        returned = await result.current.runTriggerNow("doomed");
+      });
+
+      expect(returned).toBe(true);
+      expect(getTriggers).toHaveBeenCalledTimes(2);
+      expect(result.current.state.triggers.map((item) => item.id)).toEqual([
+        "remaining",
+      ]);
+    });
+
+    it("returns false and records the Error message when the run request fails", async () => {
+      const { result } = renderHook(() => useTriggersState());
+
+      runTriggerNowFn.mockRejectedValueOnce(new Error("runner offline"));
+      let returned = false;
+      await act(async () => {
+        returned = await result.current.runTriggerNow("t1");
+      });
+
+      expect(returned).toBe(false);
+      expect(result.current.state.triggerError).toBe("runner offline");
+      expect(result.current.state.triggersSaving).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/state/useTriggersState.test.ts` — a new co-located vitest suite (24 cases) for the trigger-state domain hook that AppContext composes. **Test-only change: the diff is one new test file, +655/−0; no production code is touched.**

## Why

`useTriggersState.ts` had no same-named suite anywhere on develop. The hook owns non-trivial client-side behaviour worth pinning: queue ordering with a never-scheduled-last sentinel, loud-vs-silent reload semantics, upsert/prune merges across CRUD, and error surfacing including fallbacks for non-`Error` rejections.

## Coverage

- **Ordering** — ascending by `nextRunAtMs`; triggers without a schedule sort last; ties break by `displayName`; sorting writes into a copy so the server-supplied array is left untouched; empty queue loads successfully.
- **load semantics** — loud loads toggle `triggersLoading` true→false and drop a stale list on failure; silent loads never raise the flag and retain previously loaded triggers; `ensureTriggersLoaded` routes loudly before the first load and silently afterwards.
- **Run history** — `loadTriggerRuns` stores history per trigger id without clobbering other entries; failures surface `Error.message` verbatim or the operation-specific fallback for non-`Error` rejections.
- **CRUD merges** — `createTrigger` inserts in sorted position and replaces any stale entry carrying the same id instead of duplicating it; `updateTrigger` swaps the record in place and re-sorts; `deleteTrigger` removes only its own run-history entry.
- **runTriggerNow** — replaces an existing entry or appends an unknown one from the run response; refetches the whole list when the response omits the trigger; returns the response's `ok` and records failures.
- **Flags & errors** — every mutation toggles `triggersSaving`, clears `triggerError` on success, sets the observed message on failure; health refresh fires after successful mutations.

The suite drives the real hook through `renderHook` (`@testing-library/react`) against a controlled `../api` transport double — the established pattern of sibling tests in `src/state/`. Assertions cover observable state transitions of the real module; no mock echoes its own stub.

## Evidence

Validated locally on current `origin/develop@d77eb55bc0` and re-run inside the pushed head `7413818e9611d53b3cea7ab413ed6c4a5e1321e5`:

- `bunx vitest run src/state/useTriggersState.test.ts` → **Test Files 1 passed (1), Tests 24 passed (24)**
- `bunx biome check packages/ui/src/state/useTriggersState.test.ts` → **Checked 1 file, no fixes applied** (clean)
- `bunx tsc --noEmit` in `packages/ui` → **zero diagnostics mention the new test file** (pre-existing unrelated package errors unchanged)

As a fork contribution, hosted CI does not run on this pull request; the counts above are the validation record.

## Risk

None — additive test coverage only; no runtime behaviour is modified.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7413818e9611d53b3cea7ab413ed6c4a5e1321e5 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
