### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/features/sub-agent-credentials/index.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/index.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Covers the public entry barrel of the sub-agent-credentials feature as
+ * consumers see it through `@elizaos/core`: the default export aliases the
+ * named plugin, each re-exported atomic action is the exact instance the
+ * plugin registers, every action resolves its collaborator under the service
+ * name this module exports for it, and the exported service-name constants
+ * stay registry-safe (non-empty, pairwise distinct). Handlers run against a
+ * recording runtime stub that serves no services, so the lookup contract is
+ * observed deterministically — no real bridge, bus, or child process.
+ */
+import { describe, expect, test } from "vitest";
+import * as entry from "./index";
+
+function message() {
+	return { entityId: "u1", roomId: "r1", content: { text: "" } };
+}
+
+describe("features/sub-agent-credentials public entry", () => {
+	test("default export aliases the named subAgentCredentialsPlugin", () => {
+		expect(entry.default).toBe(entry.subAgentCredentialsPlugin);
+	});
+
+	test("re-exported atomic actions are the instances the plugin registers", () => {
+		const registered = new Map(
+			(entry.subAgentCredentialsPlugin.actions ?? []).map((a) => [a.name, a]),
+		);
+		const reexported = [
+			entry.declareSubAgentCredentialScopeAction,
+			entry.tunnelCredentialToChildSessionAction,
+			entry.awaitChildAgentDecisionAction,
+			entry.retrieveChildAgentResultsAction,
+		];
+		expect(registered.size).toBe(reexported.length);
+		for (const action of reexported) {
+			expect(registered.get(action.name)).toBe(action);
+		}
+	});
+
+	test("every action resolves its collaborator under the constant this module exports", async () => {
+		const cases = [
+			{
+				action: entry.declareSubAgentCredentialScopeAction,
+				service: entry.SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,
+			},
+			{
+				action: entry.tunnelCredentialToChildSessionAction,
+				service: entry.SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,
+			},
+			{
+				action: entry.awaitChildAgentDecisionAction,
+				service: entry.SUB_AGENT_CHILD_DECISION_BUS_SERVICE,
+			},
+			{
+				action: entry.retrieveChildAgentResultsAction,
+				service: entry.SUB_AGENT_CHILD_RESULTS_CLIENT_SERVICE,
+			},
+		];
+		for (const { action, service } of cases) {
+			const asked: string[] = [];
+			const runtime = {
+				getService: (name: string) => {
+					asked.push(name);
+					return null;
+				},
+			};
+			const result = await action.handler(
+				runtime as never,
+				message() as never,
+				undefined,
+				undefined,
+			);
+			expect(result.success).toBe(false);
+			expect(asked).toEqual([service]);
+		}
+	});
+
+	test("service-name constants are non-empty and pairwise distinct", () => {
+		const names = [
+			entry.SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,
+			entry.SUB_AGENT_CREDENTIAL_BRIDGE_ADAPTER_SERVICE,
+			entry.SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
+			entry.SUB_AGENT_CHILD_DECISION_BUS_SERVICE,
+			entry.SUB_AGENT_CHILD_RESULTS_CLIENT_SERVICE,
+		];
+		expect(names.length).toBe(5);
+		for (const name of names) {
+			expect(name.length).toBeGreaterThan(0);
+		}
+		expect(new Set(names).size).toBe(names.length);
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/features/sub-agent-credentials/index.test.ts` — a new unit suite for the feature's public entry barrel (`packages/core/src/features/sub-agent-credentials/index.ts`), which had no same-named test file anywhere in the repo. The diff is a single new test file, +91/−0; no production code changes.

## What it covers

- **Default-export alias:** `export { subAgentCredentialsPlugin as default }` must alias the identical plugin object consumers get via the named import (`index.node.ts` and `index.browser.ts` re-export this barrel, so this is the real `@elizaos/core` surface).
- **Re-export wiring by reference:** each of the four atomic actions re-exported by the barrel is the exact object instance registered inside `subAgentCredentialsPlugin.actions` — the existing `plugin.test.ts` pins names and order; this pins instance identity so the exports and the plugin wiring cannot drift apart.
- **Service-name lookup contract:** each action handler resolves its collaborator under exactly the service-name constant this module exports for it, observed by invoking the real handlers against a recording runtime stub that serves no services (`SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE`, `SUB_AGENT_CHILD_DECISION_BUS_SERVICE`, `SUB_AGENT_CHILD_RESULTS_CLIENT_SERVICE`). This is the registry contract app-core's bridge wiring depends on.
- **Registry safety of the constants:** the five exported `SUB_AGENT_*` service names are non-empty and pairwise distinct, so registering them cannot collide in a service registry.

No `vi.hoisted`, no type-level assertions, no mocks asserted against themselves — collaborators are observed through recorded lookups, and every expectation records what the code actually does.

## Verification

- `bunx vitest run src/features/sub-agent-credentials/index.test.ts` (in `packages/core`): **1 file passed, 4 tests passed**, re-run fresh against current `origin/develop` immediately before filing (the target directory is unchanged between the branch base and current `develop`).
- `bunx biome check --write` on the new file: **clean** ("Checked 1 file ... No fixes applied", with the repo-root `biome.json` present).
- `bunx tsc --noEmit` in `packages/core`: **zero occurrences** of `sub-agent-credentials/index.test.ts` in the output.
- The diff touches **only** the new test file (+91/−0).

## CI note

This PR comes from a fork, so hosted CI does not run on it; the checks above were executed locally and their real counts are quoted here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6a7274501a1ffa9f8a5d627dfff2256be906284a -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
