### PR TITLE
test(ui): cover widget-cert

### DIFF
--- a/packages/ui/src/testing/widget-cert.test.tsx
+++ b/packages/ui/src/testing/widget-cert.test.tsx
@@ -5,6 +5,8 @@
 // biome-ignore-all lint/a11y/useSemanticElements: test fixtures deliberately use role=button spans to exercise the sweep selector
 // biome-ignore-all lint/a11y/useFocusableInteractive: intentional non-focusable role=button edge case for the sweep
 // biome-ignore-all lint/a11y/noNoninteractiveTabindex: intentional tabindex div edge case for the sweep
+// biome-ignore-all lint/a11y/useAriaPropsForRole: fixtures deliberately build bare ARIA roles to exercise the sweep selector
+// biome-ignore-all lint/a11y/useValidAnchor: an href-less anchor is precisely the edge case the sweep must exclude
 //
 // Certifies the WIDGET-CERT harness (#14380) end-to-end against real rendered
 // DOM: the sweep finds the interactive controls + scrollers, reads geometry
@@ -24,6 +26,7 @@ import {
   certifyWidget,
   collectInteractive,
   collectScrollers,
+  liveGeometryProvider,
   locate,
   mapGeometryProvider,
 } from "./widget-cert";
@@ -324,5 +327,334 @@ describe("certifyWidget — list view (safe-area)", () => {
       (x) => x.code === "safe-area/under-bottom-inset",
     );
     expect(v?.target).toBe('[data-testid="row-last"]');
+  });
+});
+
+/* ── sweep selector coverage beyond the first-pass cases ────────────────── */
+
+describe("collectInteractive — remaining selector branches", () => {
+  it("includes ARIA-role variants and explicit data-tap-target opt-ins; excludes hidden inputs and href-less anchors", () => {
+    const { container } = render(
+      <div>
+        <span role="tab" data-testid="tab" />
+        <span role="checkbox" data-testid="checkbox" />
+        <span role="menuitem" data-testid="menuitem" />
+        <span data-tap-target="swipe-back" data-testid="optin" />
+        <input type="hidden" data-testid="hidden-input" />
+        <a data-testid="no-href">anchor without href</a>
+        <select data-testid="select" />
+        <textarea data-testid="textarea" />
+      </div>,
+    );
+    const found = collectInteractive(container).map((el) =>
+      el.getAttribute("data-testid"),
+    );
+    expect(found).toEqual([
+      "tab",
+      "checkbox",
+      "menuitem",
+      "optin",
+      "select",
+      "textarea",
+    ]);
+  });
+});
+
+describe("collectScrollers — root opt-in + chat-thread alias", () => {
+  it("prepends the root itself when it carries the opt-in attribute, and finds [data-testid=chat-thread]", () => {
+    const { container } = render(
+      <section data-scroll-cert-scroller data-testid="root-s">
+        <div data-testid="chat-thread">messages</div>
+      </section>,
+    );
+    const root = container.firstElementChild as Element;
+    const found = collectScrollers(root);
+    expect(found[0]).toBe(root);
+    expect(found).toHaveLength(2);
+    expect(found[1].getAttribute("data-testid")).toBe("chat-thread");
+  });
+});
+
+describe("locate — tap-target precedence + bare fallback", () => {
+  const mk = (html: string) => {
+    const d = document.createElement("div");
+    d.innerHTML = html;
+    return d.firstElementChild as Element;
+  };
+  it("uses data-tap-target when no testid, falls through ignore to aria-label, names bare elements by tag", () => {
+    expect(locate(mk('<button data-tap-target="send">x</button>'))).toBe(
+      '[data-tap-target="send"]',
+    );
+    expect(
+      locate(
+        mk('<button data-tap-target="ignore" aria-label="Menu">x</button>'),
+      ),
+    ).toBe('button[aria-label="Menu"]');
+    expect(locate(mk("<span></span>"))).toBe("span");
+  });
+});
+
+/* ── safe-area: the top (notch) inset ───────────────────────────────────── */
+
+describe("certifyWidget — safe-area top inset", () => {
+  it("flags a control tucked under the notch while its clear sibling passes", () => {
+    const { container } = render(
+      <div>
+        <button type="button" data-testid="under-notch">
+          n
+        </button>
+        <button type="button" data-testid="clear">
+          c
+        </button>
+      </div>,
+    );
+    const controls = collectInteractive(container);
+    const provider = mapGeometryProvider([
+      [controls[0], { box: box(20, 0, 200, 44) }],
+      [controls[1], { box: box(100, 0, 200, 44) }],
+    ]);
+    const report = certifyWidget("header", container, provider, {
+      dimensions: ["safe-area"],
+      safeArea: { insetTop: 59, insetBottom: 34, viewportHeight: 874 },
+    });
+    expect(report.passed).toBe(false);
+    const topHits = report.violations.filter(
+      (v) => v.code === "safe-area/under-top-inset",
+    );
+    expect(topHits).toHaveLength(1);
+    expect(topHits[0].dimension).toBe("safe-area");
+    expect(topHits[0].target).toBe('[data-testid="under-notch"]');
+  });
+});
+
+/* ── scroll: horizontal overflow + nested overscroll chaining ───────────── */
+
+describe("certifyWidget — unintended horizontal overflow", () => {
+  it("flags scrollWidth past clientWidth without an explicit x opt-in; passes the auto opt-in", () => {
+    const { container } = render(<div id="continuous-thread">messages</div>);
+    const scroller = container.querySelector(
+      "#continuous-thread",
+    ) as Element & {
+      scrollHeight: number;
+      scrollWidth: number;
+    };
+    Object.defineProperty(scroller, "scrollHeight", {
+      value: 2400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 900,
+      configurable: true,
+    });
+
+    const badProvider = mapGeometryProvider([
+      [
+        scroller,
+        {
+          box: box(0, 0, 402, 700),
+          overflowY: "auto",
+          overflowX: "hidden",
+          midScrollTopSettled: 850,
+        },
+      ],
+    ]);
+    const bad = certifyWidget("wide-widget", scroller, badProvider, {
+      dimensions: ["scroll"],
+    });
+    expect(bad.violations.map((v) => v.code)).toEqual([
+      "scroll/horizontal-overflow",
+    ]);
+
+    const okProvider = mapGeometryProvider([
+      [
+        scroller,
+        {
+          box: box(0, 0, 402, 700),
+          overflowY: "auto",
+          overflowX: "auto",
+          midScrollTopSettled: 850,
+        },
+      ],
+    ]);
+    const ok = certifyWidget("wide-widget", scroller, okProvider, {
+      dimensions: ["scroll"],
+    });
+    expect(ok.passed).toBe(true);
+  });
+});
+
+describe("certifyWidget — nested overscroll containment", () => {
+  it("fails a nested scroller left on the default auto overscroll-behavior-y", () => {
+    const { container } = render(<div id="continuous-thread">messages</div>);
+    const scroller = container.querySelector(
+      "#continuous-thread",
+    ) as Element & {
+      scrollHeight: number;
+      scrollWidth: number;
+    };
+    Object.defineProperty(scroller, "scrollHeight", {
+      value: 2400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 402,
+      configurable: true,
+    });
+    const provider = mapGeometryProvider([
+      [
+        scroller,
+        {
+          box: box(0, 0, 402, 700),
+          overflowY: "auto",
+          overflowX: "hidden",
+          midScrollTopSettled: 850,
+        },
+      ],
+    ]);
+    const report = certifyWidget("sheet-list", scroller, provider, {
+      dimensions: ["scroll"],
+      nestedScrollers: { "#continuous-thread": true },
+    });
+    expect(report.passed).toBe(false);
+    expect(report.violations.map((v) => v.code)).toEqual([
+      "scroll/overscroll-chains",
+    ]);
+    expect(report.violations[0].target).toBe("#continuous-thread");
+  });
+});
+
+/* ── keyboard dimension (never exercised above) ─────────────────────────── */
+
+describe("certifyWidget — keyboard clearance", () => {
+  const KEYBOARD = { layoutViewportHeight: 800 };
+  const emptyRoot = () => document.createElement("div");
+
+  it("reports a region fully hidden behind the keyboard fold", () => {
+    const report = certifyWidget(
+      "composer",
+      emptyRoot(),
+      mapGeometryProvider([]),
+      {
+        dimensions: ["keyboard"],
+        keyboard: {
+          ...KEYBOARD,
+          visualViewportHeight: 400,
+          interactiveTop: 500,
+          interactiveBottom: 560,
+        },
+      },
+    );
+    expect(report.passed).toBe(false);
+    expect(report.violations.map((v) => v.code)).toEqual([
+      "keyboard/region-fully-hidden",
+    ]);
+  });
+
+  it("reports partial clipping when only the region bottom passes the fold", () => {
+    const report = certifyWidget(
+      "composer",
+      emptyRoot(),
+      mapGeometryProvider([]),
+      {
+        dimensions: ["keyboard"],
+        keyboard: {
+          ...KEYBOARD,
+          visualViewportHeight: 400,
+          interactiveTop: 380,
+          interactiveBottom: 460,
+        },
+      },
+    );
+    expect(report.passed).toBe(false);
+    expect(report.violations.map((v) => v.code)).toEqual([
+      "keyboard/region-clipped",
+    ]);
+  });
+
+  it("stays quiet with the keyboard down and forwards evidence artifacts", () => {
+    const report = certifyWidget(
+      "composer",
+      emptyRoot(),
+      mapGeometryProvider([]),
+      {
+        dimensions: ["keyboard"],
+        keyboard: {
+          ...KEYBOARD,
+          visualViewportHeight: 800,
+          interactiveTop: 500,
+          interactiveBottom: 560,
+        },
+        artifacts: ["output-widget-cert/composer.png"],
+      },
+    );
+    expect(report.passed).toBe(true);
+    expect(report.artifacts).toEqual(["output-widget-cert/composer.png"]);
+  });
+});
+
+/* ── default dimension set + report assembly ────────────────────────────── */
+
+describe("certifyWidget — default dimensions", () => {
+  it("runs scroll + tap-target + safe-area when no list is given, skipping insets quietly when none are supplied", () => {
+    const { container } = render(
+      <div>
+        <button type="button" data-testid="only">
+          ok
+        </button>
+      </div>,
+    );
+    const controls = collectInteractive(container);
+    const provider = mapGeometryProvider([
+      [controls[0], { box: box(100, 0, 200, 44) }],
+    ]);
+    const report = certifyWidget("clean-card", container, provider);
+    expect(report.widget).toBe("clean-card");
+    expect(report.dimensions).toEqual(["scroll", "tap-target", "safe-area"]);
+    expect(report.passed).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
+});
+
+/* ── provider defaults for unmeasured elements ──────────────────────────── */
+
+describe("mapGeometryProvider — unmeasured elements fail loud", () => {
+  it("reports a zero box, visible overflow, and settled scrollTop 0 outside the map", () => {
+    const { container } = render(<div id="unmeasured">x</div>);
+    const el = container.querySelector("#unmeasured") as Element;
+    const provider = mapGeometryProvider([]);
+    expect(provider.box(el)).toEqual({ top: 0, left: 0, width: 0, height: 0 });
+    expect(provider.computed(el)).toEqual({
+      overflowY: "visible",
+      overflowX: "visible",
+      overscrollBehaviorY: undefined,
+    });
+    expect(provider.probeMidScrollTop?.(el)).toBe(0);
+  });
+});
+
+/* ── live provider plumbing against real DOM nodes ──────────────────────── */
+
+describe("liveGeometryProvider — jsdom-backed checks", () => {
+  it("maps getBoundingClientRect into a Box, reads computed style through the window, probes mid-scroll by mutating the node", () => {
+    const provider = liveGeometryProvider(window);
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    expect(provider.box(el)).toEqual({ top: 0, left: 0, width: 0, height: 0 });
+
+    const cs = provider.computed(el);
+    expect(typeof cs.overflowY).toBe("string");
+    // jsdom reports the initial computed value "auto"; liveGeometryProvider
+    // passes it through verbatim (no `|| undefined` coercion here).
+    expect(cs.overscrollBehaviorY).toBe("auto");
+
+    Object.defineProperty(el, "scrollHeight", {
+      value: 2400,
+      configurable: true,
+    });
+    expect(provider.probeMidScrollTop?.(el)).toBe(1200);
+    expect(el.scrollTop).toBe(1200);
+
+    el.remove();
   });
 });


### PR DESCRIPTION

## What

Additive test-only coverage for `packages/ui/src/testing/widget-cert.ts`, the DOM-walking half of the #14380 widget certification harness. **+332/−0, a single test file** — no production code is touched and every pre-existing case passes unchanged.

Develop gained a same-named suite (`widget-cert.test.tsx`) after the original coverage gap was identified, so this PR extends that suite additively rather than creating a duplicate file or rewriting existing cases.

## New cases (12)

- **collectInteractive selector branches** — `[role=tab|checkbox|menuitem]` inclusion, explicit `data-tap-target` opt-in on a plain span, `input[type=hidden]` exclusion, href-less `<a>` exclusion.
- **collectScrollers root opt-in** — the sweep prepends the root itself when it carries `data-scroll-cert-scroller` (line 137 branch), plus the `[data-testid="chat-thread"]` alias selector.
- **locate precedence** — the `data-tap-target` locator branch, the `data-tap-target="ignore"` fall-through to `aria-label`, and the bare tag-name fallback for attribute-less elements.
- **safe-area top inset** — `safe-area/under-top-inset` flags a control tucked under the notch while a clear sibling passes (only the bottom inset was covered before).
- **scroll/horizontal-overflow** — fires when `scrollWidth > clientWidth` without an explicit x opt-in; an explicit `auto` opt-in passes cleanly.
- **scroll/overscroll-chains** — a nested scroller left on default `overscroll-behavior-y: auto` fails with exactly that code; asserts the violation targets `#continuous-thread`.
- **keyboard dimension** — first coverage of `dimensions: ["keyboard"]`: `keyboard/region-fully-hidden`, `keyboard/region-clipped`, quiet when the keyboard is down, and `artifacts` passthrough into `buildWidgetReport`.
- **default dimensions** — no `opts.dimensions` records `["scroll", "tap-target", "safe-area"]`; requesting safe-area with no insets skips quietly instead of fabricating violations.
- **mapGeometryProvider defaults** — unmeasured elements report the documented loud-failure shape: zero box, `visible` overflow, settled scrollTop 0.
- **liveGeometryProvider** — previously zero coverage: `box()` maps `getBoundingClientRect` into a Box, `computed()` plumbs through the window's `getComputedStyle`, and `probeMidScrollTop` actually mutates the node (`scrollTop = round(scrollHeight/2)` settles at 1200).

All expectations record observed behavior of the module as it exists on develop.

## Evidence

Environment: fork contributor checkout at current `origin/develop` (`d77eb55b`); hosted CI does not run on fork pull requests, so counts are quoted from local runs.

1. `bunx vitest run src/testing/widget-cert.test.tsx` (packages/ui, vitest 4.1.10): **1 file passed, 20/20 tests passed** — the 8 pre-existing cases untouched, 12 new cases green.
2. `bunx biome check --write src/testing/widget-cert.test.tsx`: clean ("Checked 1 file"). Two fixture-driven a11y rules joined the file's existing `biome-ignore-all` header block with reasons.
3. `bunx tsc --noEmit -p tsconfig.json` in packages/ui: **zero diagnostics reference `widget-cert.test.tsx`** (the package has 14 pre-existing errors, all in four files this diff does not touch).
4. This diff touches only `packages/ui/src/testing/widget-cert.test.tsx` (+332/−0).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c842920c934537b8df75921c0f92c2d1aae094b7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
