### PR TITLE
test(core): cover database adapter pagination validators and comparators

### DIFF
--- a/packages/core/src/database.test.ts
+++ b/packages/core/src/database.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Exercises the shared helpers on the adapter base module: the two pagination
+ * validators' accept/reject matrix, the PostgreSQL-order UUID comparators, and
+ * `DatabaseAdapter`'s fail-closed defaults (`updatePendingTask` and the
+ * optional connector-account/OAuth domains). Deterministic — pure functions
+ * plus prototype defaults, no database, model, or filesystem involved.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	compareMemoryIds,
+	compareTasksForQuery,
+	DatabaseAdapter,
+	validateQueryEntitiesPagination,
+	validateTaskQueryPagination,
+} from "./database.ts";
+import type { Task } from "./types.ts";
+
+const LOWER_A = "9f1c3e22-8f0e-4c1d-9b2a-111111111111";
+const UPPER_A = "9F1C3E22-8F0E-4C1D-9B2A-111111111111";
+const LOWER_B = "a0c4d526-91af-4d22-8c31-222222222222";
+
+function task(id: string | undefined, createdAt?: number | bigint): Task {
+	return { id, name: "task", createdAt };
+}
+
+describe("validateQueryEntitiesPagination", () => {
+	it("accepts unset, zero, and largest-safe values", () => {
+		expect(() => validateQueryEntitiesPagination({})).not.toThrow();
+		expect(() =>
+			validateQueryEntitiesPagination({ limit: 0, offset: 0 }),
+		).not.toThrow();
+		expect(() =>
+			validateQueryEntitiesPagination({
+				limit: Number.MAX_SAFE_INTEGER,
+				offset: Number.MAX_SAFE_INTEGER,
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects negative values naming the offending field", () => {
+		expect(() => validateQueryEntitiesPagination({ limit: -1 })).toThrow(
+			new RangeError("queryEntities limit must be a non-negative safe integer"),
+		);
+		expect(() => validateQueryEntitiesPagination({ offset: -5 })).toThrow(
+			new RangeError(
+				"queryEntities offset must be a non-negative safe integer",
+			),
+		);
+	});
+
+	it("rejects fractional and beyond-safe values", () => {
+		expect(() => validateQueryEntitiesPagination({ limit: 1.5 })).toThrow(
+			RangeError,
+		);
+		expect(() => validateQueryEntitiesPagination({ offset: 2 ** 53 })).toThrow(
+			RangeError,
+		);
+	});
+});
+
+describe("validateTaskQueryPagination", () => {
+	it("accepts unset and valid values", () => {
+		expect(() => validateTaskQueryPagination({})).not.toThrow();
+		expect(() =>
+			validateTaskQueryPagination({ limit: 10, offset: 20 }),
+		).not.toThrow();
+	});
+
+	it("rejects invalid values with the getTasks boundary prefix", () => {
+		expect(() => validateTaskQueryPagination({ limit: -1 })).toThrow(
+			new RangeError("getTasks limit must be a non-negative safe integer"),
+		);
+		expect(() => validateTaskQueryPagination({ offset: 0.25 })).toThrow(
+			new RangeError("getTasks offset must be a non-negative safe integer"),
+		);
+	});
+});
+
+describe("compareMemoryIds", () => {
+	it("treats hexadecimal case as insignificant for equality", () => {
+		expect(compareMemoryIds(LOWER_A, LOWER_A)).toBe(0);
+		expect(compareMemoryIds(LOWER_A, UPPER_A)).toBe(0);
+		expect(compareMemoryIds(UPPER_A, LOWER_A)).toBe(0);
+	});
+
+	it("orders distinct ids by their normalized bytes", () => {
+		expect(compareMemoryIds(LOWER_A, LOWER_B)).toBe(-1);
+		expect(compareMemoryIds(LOWER_B, UPPER_A)).toBe(1);
+	});
+});
+
+describe("compareTasksForQuery", () => {
+	it("orders by createdAt ascending in either argument order", () => {
+		const earlier = task("id-earlier", 1_000);
+		const later = task("id-later", 2_000);
+		expect(compareTasksForQuery(earlier, later)).toBe(-1);
+		expect(compareTasksForQuery(later, earlier)).toBe(1);
+	});
+
+	it("compares bigint and numeric createdAt on the same scale", () => {
+		const bigintCreated = task("id-bigint", 1_000n);
+		const numericCreated = task("id-numeric", 2_000);
+		expect(compareTasksForQuery(bigintCreated, numericCreated)).toBe(-1);
+		expect(compareTasksForQuery(numericCreated, bigintCreated)).toBe(1);
+	});
+
+	it("breaks createdAt ties through case-insensitive id order", () => {
+		expect(compareTasksForQuery(task(UPPER_A, 5), task(LOWER_B, 5))).toBe(-1);
+		expect(compareTasksForQuery(task(LOWER_B, 5), task(LOWER_A, 5))).toBe(1);
+		expect(compareTasksForQuery(task(LOWER_A, 5), task(UPPER_A, 5))).toBe(0);
+	});
+
+	it("sorts tasks without createdAt after dated tasks", () => {
+		const dated = task("id-dated", 1);
+		const undated = task("id-undated");
+		expect(compareTasksForQuery(dated, undated)).toBe(-1);
+		expect(compareTasksForQuery(undated, dated)).toBe(1);
+	});
+
+	it("falls back to id order when neither task is dated", () => {
+		expect(compareTasksForQuery(task(UPPER_A), task(LOWER_B))).toBe(-1);
+		expect(compareTasksForQuery(task(undefined), task(LOWER_B))).toBe(-1);
+		expect(compareTasksForQuery(task(undefined), task(undefined))).toBe(0);
+	});
+});
+
+describe("DatabaseAdapter fail-closed defaults", () => {
+	const adapter = Object.create(DatabaseAdapter.prototype) as DatabaseAdapter;
+
+	it("fails closed on the optional pending-task transition", async () => {
+		await expect(adapter.updatePendingTask(LOWER_A, {})).resolves.toBe(false);
+	});
+
+	it("rejects optional connector-account domains at the adapter level", () => {
+		expect(() => adapter.listConnectorAccounts()).toThrow(
+			"Database adapter does not support connector account storage",
+		);
+		expect(() => adapter.getConnectorAccount({})).toThrow(
+			"connector account storage",
+		);
+	});
+
+	it("rejects optional OAuth flow-state domains at the adapter level", () => {
+		expect(() => adapter.getOAuthFlowState({})).toThrow(
+			"Database adapter does not support connector account storage",
+		);
+		expect(() => adapter.deleteOAuthFlowState({})).toThrow(
+			"connector account storage",
+		);
+	});
+});


### PR DESCRIPTION

## What

Adds one new test file, `packages/core/src/database.test.ts`, covering the shared runtime surface of `@elizaos/core`'s adapter base module (`packages/core/src/database.ts`). No production file is touched (+151/-0, single new file).

## Why

`packages/core/src/database.ts` had no same-named suite anywhere in the repo, while its exported helpers are load-bearing contracts that concrete adapters and cross-table merges rely on:

- `validateQueryEntitiesPagination` / `validateTaskQueryPagination` — the accept/reject matrix at two distinct query boundaries (`queryEntities` vs `getTasks` error prefixes), including negative, fractional, zero, `Number.MAX_SAFE_INTEGER`, and beyond-safe (`2**53`) values.
- `compareMemoryIds` — PostgreSQL-compatible UUID ordering: hexadecimal case insensitivity for equality and normalized-byte ordering for distinct ids.
- `compareTasksForQuery` — ascending `(createdAt, id)` task order: tie-breaking through case-insensitive id comparison, undated tasks sorting after dated ones in both argument orders, mixed `number`/`bigint` timestamps (the declared `Task.createdAt` domain), and the absent-id fallback.
- `DatabaseAdapter` fail-closed defaults — `updatePendingTask` resolves `false`, and the optional connector-account / OAuth flow-state domains throw the adapter-level "does not support connector account storage" error synchronously, exactly as a minimal adapter author experiences them.

Assertions drive the real module directly — no mocks, no stubbed return values, no type-level assertions.

## Verification (quoted from this exact head)

Fork-contributor note: hosted CI does **not** run on this pull request; the numbers below were produced locally against current `develop` (`dea8d697df9d`) immediately before filing.

- `bunx vitest run src/database.test.ts` (in `packages/core`) — **Test Files 1 passed (1), Tests 15 passed (15)**, ~128 ms.
- `bunx biome check packages/core/src/database.test.ts` — clean ("No fixes applied"), repository `biome.json` config confirmed present.
- `bunx tsc --noEmit` (in `packages/core`) — **0 errors package-wide**; the new test filename appears nowhere in the output.
- Diff scope: exactly one new file, `packages/core/src/database.test.ts`; no deletions, no production changes.

This is a test-only change; behavior of shipped code is unchanged.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8251590c3da30f05de05bf9a596841d87099069e -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
