### PR TITLE
test(plugin-sql): cover sslmode normalization

### DIFF
--- a/plugins/plugin-sql/src/pg/__tests__/sslmode.test.ts
+++ b/plugins/plugin-sql/src/pg/__tests__/sslmode.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizePgSslMode } from "./sslmode.ts";
+
+describe("normalizePgSslMode", () => {
+  it("rewrites prefer/require/verify-ca to verify-full in query strings", () => {
+    expect(normalizePgSslMode("postgres://db?sslmode=prefer")).toBe(
+      "postgres://db?sslmode=verify-full"
+    );
+    expect(normalizePgSslMode("postgres://db?sslmode=require")).toBe(
+      "postgres://db?sslmode=verify-full"
+    );
+    expect(normalizePgSslMode("postgres://db?sslmode=verify-ca")).toBe(
+      "postgres://db?sslmode=verify-full"
+    );
+  });
+
+  it("leaves verify-full and disable untouched", () => {
+    expect(normalizePgSslMode("postgres://db?sslmode=verify-full")).toBe(
+      "postgres://db?sslmode=verify-full"
+    );
+    expect(normalizePgSslMode("postgres://db?sslmode=disable")).toBe(
+      "postgres://db?sslmode=disable"
+    );
+  });
+
+  it("honors uselibpqcompat=true escape hatch", () => {
+    expect(normalizePgSslMode("postgres://db?sslmode=prefer&uselibpqcompat=true")).toBe(
+      "postgres://db?sslmode=prefer&uselibpqcompat=true"
+    );
+  });
+
+  it("handles empty input", () => {
+    expect(normalizePgSslMode("")).toBe("");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
