### PR TITLE
test(agent): cover imessage contact path parsing

### DIFF
--- a/plugins/plugin-imessage/src/contact-path.test.ts
+++ b/plugins/plugin-imessage/src/contact-path.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Exercises every branch of iMessage contact identifier parsing against the
+ * real parser; both HTTP route adapters gate contact access on these results.
+ */
+import { describe, expect, it } from "vitest";
+import { parseIMessageContactId } from "./contact-path";
+
+describe("parseIMessageContactId", () => {
+  it("reports missing for paths outside the contacts prefix", () => {
+    expect(parseIMessageContactId("/api/imessage/chats")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+    expect(parseIMessageContactId("/imessage/contacts/+14155550123")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+    expect(parseIMessageContactId("")).toEqual({ ok: false, reason: "missing" });
+  });
+
+  it("reports missing when the prefix carries no identifier", () => {
+    expect(parseIMessageContactId("/api/imessage/contacts/")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+  });
+
+  it("returns the raw identifier untouched", () => {
+    const parsed = parseIMessageContactId("/api/imessage/contacts/+14155550123");
+    expect(parsed).toEqual({ ok: true, id: "+14155550123" });
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("percent-decodes an encoded identifier", () => {
+    expect(parseIMessageContactId("/api/imessage/contacts/John%20Doe")).toEqual({
+      ok: true,
+      id: "John Doe",
+    });
+    expect(parseIMessageContactId("/api/imessage/contacts/email%40example.com")).toEqual({
+      ok: true,
+      id: "email@example.com",
+    });
+  });
+
+  it("decodes an encoded slash instead of treating it as a path separator", () => {
+    expect(parseIMessageContactId("/api/imessage/contacts/team%2Fops")).toEqual({
+      ok: true,
+      id: "team/ops",
+    });
+  });
+
+  it("decodes multibyte UTF-8 identifiers", () => {
+    expect(parseIMessageContactId("/api/imessage/contacts/ren%C3%A9e")).toEqual({
+      ok: true,
+      id: "renée",
+    });
+  });
+
+  it("fails closed with malformed instead of throwing on invalid escapes", () => {
+    expect(parseIMessageContactId("/api/imessage/contacts/%zz")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+    expect(parseIMessageContactId("/api/imessage/contacts/%")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+    expect(parseIMessageContactId("/api/imessage/contacts/ok%2Gtruncated")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("never reports malformed for well-formed identifiers", () => {
+    const parsed = parseIMessageContactId("/api/imessage/contacts/alice");
+    if (!parsed.ok) {
+      throw new Error("well-formed identifier parsed as malformed");
+    }
+    expect(parsed.id).toBe("alice");
+  });
+});


### PR DESCRIPTION

Adds `packages/plugin-imessage/src/contact-path.test.ts` (+81/-0), a new unit suite for `parseIMessageContactId` in `plugins/plugin-imessage/src/contact-path.ts`. Both iMessage HTTP adapters (`src/api/imessage-routes.ts` and `src/data-routes.ts`) gate contact access on this parser's discriminated result, but the module had no same-named suite anywhere in the repository.

The suite drives the real module with no mocks and covers every observable branch:

- paths outside the contacts prefix, including a near-miss prefix, report `{ ok: false, reason: "missing" }`;
- the bare prefix with no identifier reports missing;
- plain identifiers pass through untouched;
- percent-encoded identifiers decode (`%20` space, `%40` @, `%2F` slash stays inside one identifier rather than splitting the path, multibyte UTF-8);
- invalid escapes (`%zz`, bare `%`, truncated escape) fail closed with `{ ok: false, reason: "malformed" }` instead of throwing into the route handler;
- a guard case proves well-formed identifiers can never be classified malformed.

Test-only change: no production file is touched.

Evidence (all commands run against current `origin/develop` immediately before filing):

- `bunx vitest run src/contact-path.test.ts` (in `plugins/plugin-imessage`) → Test Files 1 passed (1), Tests 8 passed (8).
- `bunx biome check --write src/contact-path.test.ts` → fixed formatting once; immediate re-check → `Checked 1 file in 14ms. No fixes applied.` (root `biome.json` present; worktree is not sparse).
- `bunx tsc --noEmit -p tsconfig.json` in `plugins/plugin-imessage` → exits 0 with zero output; the new file appears nowhere in type-check output (and is excluded from the package project as tests are by convention).

This is a fork contribution, so hosted CI does not run on this pull request; the counts above are quoted from local runs of the exact head commit.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:be762b4e52841e1a32cc72850cab0788373d8423 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
