### PR TITLE
fix(plugin-calendar): reject out-of-range local time-of-day as CalendarServiceError(400)

### DIFF
--- a/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.test.ts
@@ -1,8 +1,11 @@
 /**
- * Unit tests for the Z/offset path of `normalizeCalendarDateTimeInTimeZone`.
- * JavaScript's `Date.parse` silently rolls over impossible dates like
- * 2026-02-30 to March 2; the helper must reject those before they reach the
- * pipeline (#19222).
+ * Unit tests for `normalizeCalendarDateTimeInTimeZone`. Two invalid-input
+ * grammars must both surface as a translatable `CalendarServiceError(400)`
+ * rather than leaking a raw error past the CALENDAR action boundary: the
+ * Z/offset path, where `Date.parse` silently rolls over impossible dates like
+ * 2026-02-30 (#19222); and the offset-less local path, where an out-of-range
+ * time-of-day (hour >= 24, minute >= 60, second >= 60) previously fell through
+ * to `buildUtcDateFromLocalParts` and threw a bare `RangeError` (#27640).
  */
 import { describe, expect, it } from "vitest";
 import { normalizeCalendarDateTimeInTimeZone } from "./calendar-normalize.js";
@@ -11,11 +14,13 @@ import { CalendarServiceError } from "./errors.js";
 const expectInvalidDate = (
   text: string,
   field: string,
+  timeZone = "UTC",
 ): CalendarServiceError => {
   try {
-    normalizeCalendarDateTimeInTimeZone(text, field, "UTC");
+    normalizeCalendarDateTimeInTimeZone(text, field, timeZone);
   } catch (error) {
     expect(error).toBeInstanceOf(CalendarServiceError);
+    expect(error).not.toBeInstanceOf(RangeError);
     expect((error as CalendarServiceError).status).toBe(400);
     return error as CalendarServiceError;
   }
@@ -105,5 +110,107 @@ describe("normalizeCalendarDateTimeInTimeZone — Z/offset path", () => {
 
   it("rejects an impossible day-of-month (day 32)", () => {
     expectInvalidDate("2026-01-32T09:00:00Z", "startAt");
+  });
+});
+
+describe("normalizeCalendarDateTimeInTimeZone — offset-less time-of-day (#27640)", () => {
+  // Before this fix an out-of-range local time-of-day fell through to
+  // buildUtcDateFromLocalParts, which threw a bare RangeError blaming the
+  // timezone. Only CalendarServiceError is translated at the action boundary,
+  // so the RangeError escaped as an uncaught 500-class failure. Every
+  // out-of-range field must now fail as a clean 400 like an impossible date.
+  it("rejects hour 24 (ISO end-of-day is not accepted here)", () => {
+    const error = expectInvalidDate("2024-06-05T24:00", "startAt");
+    expect(error.message).toBe("startAt must be a valid ISO datetime");
+  });
+
+  it("rejects hour 25", () => {
+    expectInvalidDate("2024-06-05T25:00", "startAt");
+  });
+
+  it("rejects hour 31", () => {
+    expectInvalidDate("2024-06-05T31:00", "endAt");
+  });
+
+  it("rejects minute 60", () => {
+    expectInvalidDate("2024-06-05T10:60", "startAt");
+  });
+
+  it("rejects minute 75", () => {
+    expectInvalidDate("2024-06-05T10:75", "startAt");
+  });
+
+  it("rejects second 60", () => {
+    expectInvalidDate("2024-06-05T10:00:60", "startAt");
+  });
+
+  it("rejects second 99", () => {
+    expectInvalidDate("2024-06-05T10:00:99", "endAt");
+  });
+
+  it("rejects an out-of-range hour in a DST zone (America/New_York)", () => {
+    expectInvalidDate("2024-06-05T25:00", "startAt", "America/New_York");
+  });
+
+  it("rejects an out-of-range minute in a DST zone (America/New_York)", () => {
+    expectInvalidDate("2024-06-05T10:75", "startAt", "America/New_York");
+  });
+
+  it("rejects an out-of-range second in a DST zone (America/New_York)", () => {
+    expectInvalidDate("2024-06-05T10:00:99", "endAt", "America/New_York");
+  });
+
+  it("still accepts the last valid wall time 23:59:59 in UTC", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-06-05T23:59:59",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2024-06-05T23:59:59.000Z");
+  });
+
+  it("still accepts midnight 00:00:00 in UTC", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-06-05T00:00:00",
+        "startAt",
+        "UTC",
+      ),
+    ).toBe("2024-06-05T00:00:00.000Z");
+  });
+
+  it("still resolves the last valid wall time in a DST zone", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-06-05T23:59:59",
+        "startAt",
+        "America/New_York",
+      ),
+    ).toBe("2024-06-06T03:59:59.000Z");
+  });
+
+  it("still resolves midnight in a standard-time DST zone offset", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-01-15T00:00:00",
+        "startAt",
+        "America/New_York",
+      ),
+    ).toBe("2024-01-15T05:00:00.000Z");
+  });
+
+  it("still resolves a leap-day local datetime without time-of-day", () => {
+    expect(
+      normalizeCalendarDateTimeInTimeZone(
+        "2024-02-29T10:00",
+        "startAt",
+        "America/New_York",
+      ),
+    ).toBe("2024-02-29T15:00:00.000Z");
+  });
+
+  it("still rejects an out-of-range hour carrying a Z suffix as a clean 400", () => {
+    expectInvalidDate("2024-06-05T25:00:00Z", "startAt");
   });
 });

--- a/plugins/plugin-calendar/src/internal/calendar-normalize.ts
+++ b/plugins/plugin-calendar/src/internal/calendar-normalize.ts
@@ -46,9 +46,10 @@ export function normalizeCalendarTimeZone(value: unknown): string {
 }
 
 function validateIsoCalendarDatePrefix(text: string, field: string): void {
-  const match = /^(?<year>[+-]?\d{4,6})-(?<month>\d{1,2})-(?<day>\d{1,2})/.exec(
-    text,
-  );
+  const match =
+    /^(?<year>[+-]?\d{4,6})-(?<month>\d{1,2})-(?<day>\d{1,2})(?:[T ](?<hour>\d{1,2}):(?<minute>\d{2})(?::(?<second>\d{2})(?:\.\d{1,3})?)?)?/.exec(
+      text,
+    );
   // Non-ISO compatibility inputs remain the generic parser's responsibility.
   // Every ISO-like input, however, must prove its civil date before any route
   // reaches Date.parse, whose permissive legacy grammar normalizes Feb 30.
@@ -80,6 +81,20 @@ function validateIsoCalendarDatePrefix(text: string, field: string): void {
     day > (daysInMonth[month - 1] ?? 0)
   ) {
     fail(400, `${field} must be a valid ISO datetime`);
+  }
+
+  // The date fix (#19222) only bounded the civil date. An offset-less local
+  // time-of-day that is out of range (hour >= 24, minute >= 60, second >= 60)
+  // otherwise falls through to `buildUtcDateFromLocalParts`, which throws a
+  // bare RangeError blaming the timezone; the action boundary only translates
+  // CalendarServiceError, so that leaks. Reject it here as the same clean 400.
+  if (match.groups.hour !== undefined) {
+    const hour = Number(match.groups.hour);
+    const minute = Number(match.groups.minute);
+    const second = Number(match.groups.second ?? "0");
+    if (hour > 23 || minute > 59 || second > 59) {
+      fail(400, `${field} must be a valid ISO datetime`);
+    }
   }
 }
 


### PR DESCRIPTION
# Relates to

Closes #27640

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning-package checks were run after sync; failures
      recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (before = uncaught `RangeError`, after = clean 400).

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`dea8d697df`); zero conflicts.
- [x] Owning-package `test`, `typecheck`, and `lint` pass post-sync. Full repo
      `bun run verify` is not run here — see **Known gaps / failures**.

# Risks

Low. The change is a bounded validation extension in one helper
(`validateIsoCalendarDatePrefix`). It only turns inputs that previously threw an
uncaught `RangeError` into the already-handled `CalendarServiceError(400)`. All
valid UTC / offset / leap-day / local datetimes normalize to the same result as
before (proven by the retained + new acceptance tests).

# Background

## What does this PR do?

`normalizeCalendarDateTimeInTimeZone` (`plugins/plugin-calendar/src/internal/calendar-normalize.ts`)
is documented to fail "with `CalendarServiceError` on invalid input" and is the
shared normalization helper behind `create_event` / `update_event`.

A recent fix (#19222 / #19611) added `validateIsoCalendarDatePrefix`, which
range-checks the civil `YEAR-MONTH-DAY` prefix so impossible dates like Feb 30
correctly throw `CalendarServiceError(400)`. But that validation covered only
the **date** prefix. For an offset-less ("local") datetime string, an
out-of-range **time-of-day** (`hour >= 24`, `minute >= 60`, `second >= 60`) was
not validated: it fell through to `buildUtcDateFromLocalParts`, which throws a
bare `RangeError("Local date-time cannot be resolved in timezone <tz>")` — the
wrong error class and a misleading message that blames the timezone, not the
invalid time.

The CALENDAR action boundary (`src/actions/calendar-handler.ts:5448`) only
translates `CalendarServiceError` into a clean user-facing failure and rethrows
everything else (`:5509 throw error`). So a bad `startAt`/`endAt` on
create/update escaped the designed 400-validation boundary as an uncaught
`RangeError` instead of a clean "invalid time" rejection. The offset/`Z` branch
was already safe (`Date.parse` rejects hour 25), so this was a consistency gap
left by the incomplete half of the shipped date fix.

**Fix:** extend `validateIsoCalendarDatePrefix` to also match the optional
`T`/space `HH:MM(:SS(.fff)?)?` suffix and `fail(400, …)` when hour > 23,
minute > 59, or second > 59. Genuinely non-ISO inputs are still left to the
generic parser. `"2024-06-05T25:00"` now throws the same
`CalendarServiceError(400)` as an impossible date, so the action boundary
renders a clean, translatable validation reply instead of leaking a `RangeError`.

Diff is limited to the normalization helper (+13 lines) and its test file; no
restructure.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. The helper's file header already documents "failing with
`CalendarServiceError` on invalid input"; this change makes that contract true
for the local time-of-day path. No user-facing docs describe the old behavior.

# Testing

## Where should a reviewer start?

`plugins/plugin-calendar/src/internal/calendar-normalize.test.ts` — a new
`describe("… offset-less time-of-day (#27640)")` block covers the reproduction.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-calendar vitest run --config vitest.config.ts \
  src/internal/calendar-normalize.test.ts
```

New assertions:
- `normalizeCalendarDateTimeInTimeZone` throws `CalendarServiceError(400)` (and
  explicitly **not** `RangeError`) for hour 24/25/31, minute 60/75, second 60/99
  across `UTC` and the DST zone `America/New_York`.
- It still returns the correct ISO for boundary-valid `T23:59:59`, `T00:00:00`,
  leap-day `2024-02-29T10:00`, and a `Z`-suffixed out-of-range hour still fails
  as a clean 400.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:31f315b89f6d5bee4a9d7874c5d0a11e815195bf -->

<!-- evidence-row:before-screenshots -->
- [ ] `N/A - no UI surface; this is a pure domain-validation helper in plugin-calendar/src/internal.`
<!-- evidence-row:after-screenshots -->
- [ ] `N/A - no UI surface; this is a pure domain-validation helper in plugin-calendar/src/internal.`
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - no user-facing flow rendered; the change is exercised by unit tests over the helper contract.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - hosted artifact link unavailable: GitHub release-asset upload is not permitted for fork contributors on this machine (upload 404s). The focused before/after vitest output is pasted inline in Evidence Details as collapsible code blocks (before = uncaught RangeError; after = CalendarServiceError 400, 29 passed).
<!-- evidence-row:frontend-logs -->
- [ ] `N/A - no frontend request/response; the helper is invoked server-side by CalendarService on create/update.`
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/prompt/model change; this is deterministic input validation with no model call.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - same hosting limitation as backend-logs. The failing-then-passing reproduction (the out-of-range time-of-day case table) is inline in Evidence Details: 10 rejection cases fail with RangeError before the fix and pass as CalendarServiceError(400) after.
<!-- evidence-row:ocr-review -->
- [ ] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic input validation; no model call on this path.`

## Backend + frontend logs

Backend: focused vitest run over the changed contract.

**Before the fix** (source reverted to `HEAD~1`, new tests run) — the 10
rejection cases fail because the helper leaks a raw `RangeError` instead of a
`CalendarServiceError`:

<details><summary>before-calendar-normalize-tests.txt</summary>

```
     × rejects hour 24 (ISO end-of-day is not accepted here) 37ms
     × rejects hour 25 2ms
     × rejects hour 31 2ms
     × rejects minute 60 1ms
     × rejects minute 75 1ms
     × rejects second 60 2ms
     × rejects second 99 1ms
     × rejects an out-of-range hour in a DST zone (America/New_York) 2ms
     × rejects an out-of-range minute in a DST zone (America/New_York) 2ms
     × rejects an out-of-range second in a DST zone (America/New_York) 1ms
AssertionError: expected RangeError: Local date-time cannot be res… to be an instance of CalendarServiceError
 Test Files  1 failed (1)
      Tests  10 failed | 19 passed (29)
```

Full log excerpt inline above. (GitHub release-asset upload is unavailable to fork contributors on this machine; see Known gaps / failures.)

</details>

**After the fix** — all 29 pass:

<details><summary>after-calendar-normalize-tests.txt</summary>

```
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Full log excerpt inline above. (GitHub release-asset upload is unavailable to fork contributors on this machine; see Known gaps / failures.)

</details>

Frontend: `N/A - server-side helper; no frontend request/response.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full-repo `bun run verify` was not executed on this machine; it drives the
  entire workspace build/lint/typecheck matrix, which is out of scope and time
  for a two-file domain fix. The owning package's `test` (29 passed),
  `typecheck` (exit 0), and `biome check` (no fixes) all pass. This is not a
  blocker: the diff is confined to `plugins/plugin-calendar/src/internal` and
  introduces no new exports or cross-package surface.
- `bun install` required `--minimum-release-age=0` because a transitive
  dev-dependency was published inside the machine's default install-age window;
  unrelated to this change.

## Maintainer CI exception record

`N/A - no exception requested`

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@31f315b89f6d5bee4a9d7874c5d0a11e815195bf:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@31f315b89f6d5bee4a9d7874c5d0a11e815195bf:packages/skills/skills/contribute-to-eliza"} -->
