### PR TITLE
test(agent): cover server-helpers-auth

### DIFF
--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -6,11 +6,20 @@ import {
   __resetPendingWebSocketsForTests,
   applyCors,
   CORS_ALLOWED_HEADERS,
+  extractAuthToken,
+  isAllowedHost,
   isAuthorized,
+  isBoundaryRoleAuthorized,
   isServerTokenAuthorized,
+  isSharedTerminalClientId,
   MAX_PENDING_WEBSOCKETS_PER_PEER,
+  normalizeWsClientId,
   pendingWebSocketCount,
   releasePendingWebSocket,
+  resolveBoundaryRole,
+  resolveTerminalRunClientId,
+  resolveTerminalRunRejection,
+  resolveWebSocketUpgradeRejection,
   tryAcquirePendingWebSocket,
 } from "../../src/api/server-helpers-auth";
 
@@ -425,5 +434,408 @@ describe("unauthenticated WebSocket pending-socket bounds (W5-015)", () => {
     expect(pendingWebSocketCount(null)).toBe(1);
     releasePendingWebSocket(undefined);
     expect(pendingWebSocketCount(undefined)).toBe(0);
+  });
+});
+
+/**
+ * Minimal request builder for helpers that only inspect headers and the peer
+ * address. The optional remoteAddress is installed on the socket exactly like
+ * RemoteForwardRequest does, so loopback-trust decisions see a real peer IP.
+ */
+class HeaderOnlyRequest extends http.IncomingMessage {
+  constructor(headers: Record<string, string>, remoteAddress?: string) {
+    const socket = new Socket();
+    if (remoteAddress) {
+      Object.defineProperty(socket, "remoteAddress", {
+        value: remoteAddress,
+        configurable: true,
+      });
+    }
+    super(socket);
+    this.headers = {};
+    for (const [key, value] of Object.entries(headers)) {
+      this.headers[key.toLowerCase()] = value;
+    }
+  }
+}
+
+function requestWithHeaders(
+  headers: Record<string, string>,
+  remoteAddress?: string,
+): http.IncomingMessage {
+  return new HeaderOnlyRequest(headers, remoteAddress);
+}
+
+describe("isAllowedHost (DNS rebinding protection)", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_API_BIND;
+    delete process.env.ELIZA_ALLOWED_HOSTS;
+  });
+
+  it("admits requests without a Host header (non-browser clients)", () => {
+    expect(isAllowedHost(requestWithHeaders({}))).toBe(true);
+  });
+
+  it("admits a whitespace-only Host header", () => {
+    expect(isAllowedHost(requestWithHeaders({ Host: "   " }))).toBe(true);
+  });
+
+  it("admits loopback hosts with an explicit port", () => {
+    expect(isAllowedHost(requestWithHeaders({ Host: "localhost:31337" }))).toBe(
+      true,
+    );
+    expect(isAllowedHost(requestWithHeaders({ Host: "[::1]:31337" }))).toBe(
+      true,
+    );
+  });
+
+  it("rejects a DNS-rebound non-loopback hostname", () => {
+    expect(isAllowedHost(requestWithHeaders({ Host: "evil.example" }))).toBe(
+      false,
+    );
+  });
+
+  it("does not treat a loopback-prefixed subdomain as local", () => {
+    expect(
+      isAllowedHost(requestWithHeaders({ Host: "127.0.0.1.evil.com" })),
+    ).toBe(false);
+  });
+
+  it("allows any Host while bound to a wildcard address", () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    expect(isAllowedHost(requestWithHeaders({ Host: "evil.example" }))).toBe(
+      true,
+    );
+  });
+
+  it("accepts an operator-allowlisted host after port stripping and case folding", () => {
+    process.env.ELIZA_ALLOWED_HOSTS = "Dashboard.Example";
+    expect(
+      isAllowedHost(requestWithHeaders({ Host: "dashboard.example:8080" })),
+    ).toBe(true);
+  });
+
+  it("accepts the exact configured bind hostname and still rejects others", () => {
+    process.env.ELIZA_API_BIND = "agent.internal";
+    expect(
+      isAllowedHost(requestWithHeaders({ Host: "agent.internal:19687" })),
+    ).toBe(true);
+    expect(isAllowedHost(requestWithHeaders({ Host: "other.internal" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("extractAuthToken credential extraction", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_ALLOW_WS_QUERY_TOKEN;
+  });
+
+  it("parses the Bearer scheme case-insensitively", () => {
+    const req = requestWithHeaders({ Authorization: "bearer tok-1" });
+    expect(extractAuthToken(req)).toBe("tok-1");
+  });
+
+  it("trims whitespace around the bearer credentials", () => {
+    const req = requestWithHeaders({ Authorization: "Bearer   tok-2   " });
+    expect(extractAuthToken(req)).toBe("tok-2");
+  });
+
+  it("returns null when the header carries a bare scheme without credentials", () => {
+    const req = requestWithHeaders({ Authorization: "Bearer " });
+    expect(extractAuthToken(req)).toBe(null);
+  });
+
+  it("reads X-Eliza-Token when no Authorization header is present", () => {
+    const req = requestWithHeaders({ "X-Eliza-Token": "tok-3" });
+    expect(extractAuthToken(req)).toBe("tok-3");
+  });
+
+  it("falls back to X-Api-Key and prefers the eliza token header over it", () => {
+    expect(extractAuthToken(requestWithHeaders({ "X-Api-Key": "key-1" }))).toBe(
+      "key-1",
+    );
+    expect(
+      extractAuthToken(
+        requestWithHeaders({
+          "X-Eliza-Token": "eliza-1",
+          "X-Api-Key": "key-1",
+        }),
+      ),
+    ).toBe("eliza-1");
+  });
+
+  it("a blank X-Eliza-Token shadows a valid X-Api-Key rather than falling through", () => {
+    expect(
+      extractAuthToken(
+        requestWithHeaders({
+          "X-Eliza-Token": "   ",
+          "X-Api-Key": "key-2",
+        }),
+      ),
+    ).toBe(null);
+  });
+
+  it("ignores a duplicated (array-form) Authorization header", () => {
+    const req = requestWithHeaders({});
+    req.headers.authorization = ["Bearer tok-array"];
+    expect(extractAuthToken(req)).toBe(null);
+  });
+
+  it("caps oversized Authorization headers at 8192 characters", () => {
+    const req = requestWithHeaders({
+      Authorization: `Bearer ${"x".repeat(9000)}`,
+    });
+    expect(extractAuthToken(req)).toBe("x".repeat(8185));
+  });
+});
+
+describe("resolveTerminalRunRejection", () => {
+  const TERMINAL_TOKEN = "terminal-secret";
+
+  beforeEach(() => {
+    delete process.env.ELIZA_TERMINAL_RUN_TOKEN;
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.AGENT_SERVER_SHARED_SECRET;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.STEWARD_AGENT_TOKEN;
+    delete process.env.ELIZAOS_CLOUD_ENABLED;
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZA_TERMINAL_RUN_TOKEN;
+    delete process.env.ELIZA_API_TOKEN;
+  });
+
+  it("keeps legacy compatibility open when neither token is configured", () => {
+    expect(resolveTerminalRunRejection(gatewayForward({}), {})).toBe(null);
+  });
+
+  it("disables command execution for token-authenticated sessions without a terminal token", () => {
+    process.env.ELIZA_API_TOKEN = "api-tok";
+    const rejection = resolveTerminalRunRejection(gatewayForward({}), {});
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.reason).toContain("ELIZA_TERMINAL_RUN_TOKEN");
+  });
+
+  it("demands a credential when a terminal token is configured", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_TOKEN;
+    const rejection = resolveTerminalRunRejection(gatewayForward({}), {});
+    expect(rejection?.status).toBe(401);
+    expect(rejection?.reason).toContain("Missing terminal token");
+  });
+
+  it("rejects a wrong header token", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_TOKEN;
+    const rejection = resolveTerminalRunRejection(
+      gatewayForward({ "X-Eliza-Terminal-Token": "wrong" }),
+      {},
+    );
+    expect(rejection?.status).toBe(401);
+    expect(rejection?.reason).toContain("Invalid terminal token");
+  });
+
+  it("accepts the correct token from either the header or the body", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_TOKEN;
+    expect(
+      resolveTerminalRunRejection(
+        gatewayForward({ "X-Eliza-Terminal-Token": TERMINAL_TOKEN }),
+        {},
+      ),
+    ).toBe(null);
+    expect(
+      resolveTerminalRunRejection(gatewayForward({}), {
+        terminalToken: TERMINAL_TOKEN,
+      }),
+    ).toBe(null);
+  });
+
+  it("trims the body credential before comparing", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_TOKEN;
+    expect(
+      resolveTerminalRunRejection(gatewayForward({}), {
+        terminalToken: `  ${TERMINAL_TOKEN}  `,
+      }),
+    ).toBe(null);
+  });
+
+  it("prefers a valid header token over an invalid body token", () => {
+    process.env.ELIZA_TERMINAL_RUN_TOKEN = TERMINAL_TOKEN;
+    expect(
+      resolveTerminalRunRejection(
+        gatewayForward({ "X-Eliza-Terminal-Token": TERMINAL_TOKEN }),
+        { terminalToken: "wrong" },
+      ),
+    ).toBe(null);
+  });
+});
+
+describe("terminal client id normalization and routing", () => {
+  it("normalizes valid ids and trims surrounding whitespace", () => {
+    expect(normalizeWsClientId("ui-terminal-1")).toBe("ui-terminal-1");
+    expect(normalizeWsClientId("  ui-2  ")).toBe("ui-2");
+  });
+
+  it("rejects non-string, empty, and whitespace-only values", () => {
+    expect(normalizeWsClientId(42)).toBe(null);
+    expect(normalizeWsClientId(null)).toBe(null);
+    expect(normalizeWsClientId("")).toBe(null);
+    expect(normalizeWsClientId("    ")).toBe(null);
+  });
+
+  it("enforces the [A-Za-z0-9._-]{1,128} shape", () => {
+    expect(normalizeWsClientId("bad id!")).toBe(null);
+    expect(normalizeWsClientId("a".repeat(128))).toBe("a".repeat(128));
+    expect(normalizeWsClientId("a".repeat(129))).toBe(null);
+  });
+
+  it("resolves the terminal client id from the header first, then the body", () => {
+    expect(
+      resolveTerminalRunClientId(
+        gatewayForward({ "X-Eliza-Client-Id": "hdr-client" }),
+        { clientId: "body-client" },
+      ),
+    ).toBe("hdr-client");
+    expect(
+      resolveTerminalRunClientId(gatewayForward({}), {
+        clientId: "body-client",
+      }),
+    ).toBe("body-client");
+  });
+
+  it("returns null when neither the header nor the body carries a usable id", () => {
+    expect(resolveTerminalRunClientId(gatewayForward({}), {})).toBe(null);
+    expect(
+      resolveTerminalRunClientId(gatewayForward({}), { clientId: "!!" }),
+    ).toBe(null);
+  });
+
+  it("recognizes the shared runtime terminal client ids only", () => {
+    expect(isSharedTerminalClientId("runtime-terminal-action")).toBe(true);
+    expect(isSharedTerminalClientId("runtime-shell-action")).toBe(true);
+    expect(isSharedTerminalClientId("some-private-session")).toBe(false);
+  });
+});
+
+describe("resolveWebSocketUpgradeRejection", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.AGENT_SERVER_SHARED_SECRET;
+    delete process.env.ELIZA_ALLOW_WS_QUERY_TOKEN;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.STEWARD_AGENT_TOKEN;
+    delete process.env.ELIZAOS_CLOUD_ENABLED;
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZA_ALLOW_WS_QUERY_TOKEN;
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.STEWARD_AGENT_TOKEN;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+  });
+
+  it("404s upgrades off the /ws pathname before any auth work", () => {
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "127.0.0.1:31337" }, "127.0.0.1"),
+      new URL("http://127.0.0.1:31337/not-ws"),
+    );
+    expect(rejection?.status).toBe(404);
+  });
+
+  it("403s a browser origin that CORS would never reflect", () => {
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders(
+        { Host: "203.0.113.7:19687", Origin: "https://evil.example" },
+        "203.0.113.7",
+      ),
+      new URL("http://203.0.113.7:19687/ws"),
+    );
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.reason).toContain("Origin");
+  });
+
+  it("admits a credential-less upgrade from a trusted loopback peer when no API token is configured", () => {
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "127.0.0.1:31337" }, "127.0.0.1"),
+      new URL("http://127.0.0.1:31337/ws"),
+    );
+    expect(rejection).toBe(null);
+  });
+
+  it("rejects a credential-less upgrade from a non-loopback peer when no API token is configured", () => {
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "203.0.113.7:19687" }, "203.0.113.7"),
+      new URL("http://203.0.113.7:19687/ws"),
+    );
+    expect(rejection?.status).toBe(401);
+  });
+
+  it("rejects a mismatching Bearer credential during the handshake", () => {
+    process.env.ELIZA_API_TOKEN = "api-tok";
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders(
+        { Host: "203.0.113.7:19687", Authorization: "Bearer wrong" },
+        "203.0.113.7",
+      ),
+      new URL("http://203.0.113.7:19687/ws"),
+    );
+    expect(rejection?.status).toBe(401);
+  });
+
+  it("accepts the query-string token for browser handshakes when the flag is enabled", () => {
+    process.env.ELIZA_API_TOKEN = "api-tok";
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const rejection = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "203.0.113.7:19687" }, "203.0.113.7"),
+      new URL("http://203.0.113.7:19687/ws?token=api-tok"),
+    );
+    expect(rejection).toBe(null);
+  });
+
+  it("admits a credential-less non-cloud upgrade for post-open auth but rejects cloud containers", () => {
+    process.env.ELIZA_API_TOKEN = "api-tok";
+    const admitted = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "203.0.113.7:19687" }, "203.0.113.7"),
+      new URL("http://203.0.113.7:19687/ws"),
+    );
+    expect(admitted).toBe(null);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward";
+    const rejected = resolveWebSocketUpgradeRejection(
+      requestWithHeaders({ Host: "203.0.113.7:19687" }, "203.0.113.7"),
+      new URL("http://203.0.113.7:19687/ws"),
+    );
+    expect(rejected?.status).toBe(401);
+  });
+});
+
+describe("boundary role resolution at the HTTP edge", () => {
+  beforeEach(() => {
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.AGENT_SERVER_SHARED_SECRET;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZA_API_TOKEN;
+  });
+
+  it("collapses an authorized caller to OWNER and everyone else to GUEST", () => {
+    process.env.ELIZA_API_TOKEN = "role-tok";
+    expect(
+      resolveBoundaryRole(gatewayForward({ Authorization: "Bearer role-tok" })),
+    ).toBe("OWNER");
+    expect(resolveBoundaryRole(gatewayForward({}))).toBe("GUEST");
+  });
+
+  it("falls through to trunk auth when no product boundary-role resolver claims the request", () => {
+    expect(
+      isBoundaryRoleAuthorized(gatewayForward({}), "POST", "/api/agents"),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION

## Summary

Test-only coverage PR for `packages/agent/src/api/server-helpers-auth.ts`. A suite already existed at `packages/agent/test/api/server-helpers-auth.test.ts` on `origin/develop`, so this change is **strictly additive**: it appends 38 cases (+412/-0, no deleted lines) for exported surfaces the existing file did not reach. No production code is touched.

## Newly covered behavior (all driven through the real module, no mocks)

- **`isAllowedHost`** (DNS-rebinding Host gate): missing/blank Host admitted; loopback hosts with ports (`localhost:31337`, `[::1]:31337`) admitted; DNS-rebound hostname and loopback-prefixed subdomain (`127.0.0.1.evil.com`) rejected; wildcard bind (`ELIZA_API_BIND=0.0.0.0`) admits any Host; operator allowlist matches after port strip + case fold; exact configured bind host accepted while others stay rejected.
- **`extractAuthToken`**: case-insensitive Bearer scheme, credential trimming, bare-scheme fallthrough to `null`, `X-Eliza-Token` and `X-Api-Key` fallbacks with header precedence, array-form `Authorization` ignored, blank `X-Eliza-Token` shadowing a valid `X-Api-Key`, and the observed 8192-character cap on oversized Authorization headers.
- **`resolveTerminalRunRejection`**: legacy compatibility when no tokens are configured, 403 disablement for token-authenticated sessions without `ELIZA_TERMINAL_RUN_TOKEN`, 401 challenge/wrong-token paths, header-or-body acceptance, credential trimming, header-over-body precedence.
- **Terminal client ids**: `normalizeWsClientId` shape enforcement (`[A-Za-z0-9._-]{1,128}`, trimming, non-string/empty rejection), `resolveTerminalRunClientId` header-then-body resolution, `isSharedTerminalClientId` allowlist.
- **`resolveWebSocketUpgradeRejection`**: 404 off `/ws` before auth work, 403 for unreflectable browser origins, credential-less admission for trusted-loopback peers vs 401 for non-loopback peers when no API token is configured, mismatching Bearer 401, query-string token under `ELIZA_ALLOW_WS_QUERY_TOKEN=1`, and the cloud-container handshake-auth requirement.
- **Boundary roles**: `resolveBoundaryRole` OWNER/GUEST collapse and the trunk-default fallthrough of `isBoundaryRoleAuthorized` when no product resolver claims the request.

## Verification (fork contributor: hosted CI does not run on this PR; counts below are from local runs at head `6bdeca30ef6628b9339bbf63a917c4973ee20655`, re-fetched and re-run against current `origin/develop` immediately before filing)

- `bunx vitest run test/api/server-helpers-auth.test.ts` (in `packages/agent`): **Test Files 1 passed (1), Tests 63 passed (63)** — 25 pre-existing cases still green plus 38 new; baseline before the change was 25 passed (25).
- `bunx biome check packages/agent/test/api/server-helpers-auth.test.ts`: clean ("Checked 1 file... No fixes applied") after a single `--write` pass.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent`, grepped for `server-helpers-auth`: **no output mentioning the touched file** (zero new errors attributable to this diff).
- Diff shape: single file, `+412/-0` against `dea8d697df9d0c1e1b2f70639e22ecfc9e4dcd46` — purely additive, no existing case removed or rewritten.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6bdeca30ef6628b9339bbf63a917c4973ee20655 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
