### PR TITLE
fix(cloud): cap route timeout at the platform budget

### DIFF
--- a/packages/cloud/shared/src/lib/utils/request-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/utils/request-timeout.test.ts
@@ -14,4 +14,8 @@ describe("request-timeout", () => {
   it("custom buffer", () => {
     expect(getRouteTimeoutMs(10, 5000)).toBe(5000);
   });
+  it("never exceeds the platform budget", () => {
+    expect(getRouteTimeoutMs(0.5)).toBe(500);
+    expect(getRouteTimeoutMs(1, 30000)).toBe(1000);
+  });
 });

--- a/packages/cloud/shared/src/lib/utils/request-timeout.ts
+++ b/packages/cloud/shared/src/lib/utils/request-timeout.ts
@@ -10,5 +10,8 @@ export function getRouteTimeoutMs(
   maxDurationSeconds: number,
   bufferMs: number = ROUTE_TIMEOUT_BUFFER_MS,
 ): number {
-  return Math.max(MIN_ROUTE_TIMEOUT_MS, maxDurationSeconds * 1000 - bufferMs);
+  const budgetMs = maxDurationSeconds * 1000;
+  // Cap at the platform budget: for budgets smaller than MIN + buffer, aborting
+  // at the budget itself is the best we can do (never exceed the platform limit).
+  return Math.min(budgetMs, Math.max(MIN_ROUTE_TIMEOUT_MS, budgetMs - bufferMs));
 }


### PR DESCRIPTION
## Problem

`getRouteTimeoutMs` returns `max(1000, budget - buffer)`: for a platform budget under 10.5s the result is the 1s floor — e.g. a 0.5s budget yields a 1s timeout, so the internal abort fires *after* the platform has already terminated the request, defeating the helper's stated purpose ("abort shortly before the platform request budget elapses").

## Change

Cap the result at the platform budget: `min(budgetMs, max(MIN, budgetMs - buffer))`. Small budgets now abort at (or before) the platform limit instead of after it.

## Evidence

- `bun test packages/cloud/shared/src/lib/utils/request-timeout.test.ts` — 4 pass, including new `getRouteTimeoutMs(0.5) === 500` and oversized-buffer cases; existing `(30) -> 20000` / `(1) -> 1000` / `(10,5000) -> 5000` unchanged.

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
