### PR TITLE
fix(cloud): reclaim expired idempotency claims on conflict

### DIFF
--- a/packages/cloud/shared/src/lib/utils/idempotency.ts
+++ b/packages/cloud/shared/src/lib/utils/idempotency.ts
@@ -5,7 +5,7 @@
  * TTL matches the 2-minute webhook signature validity window.
  */
 
-import { count, eq, gt, lt } from "drizzle-orm";
+import { count, eq, gt, lt, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import { idempotencyKeys } from "../../db/schemas/idempotency-keys";
 import { logger } from "./logger";
@@ -53,7 +53,13 @@ export async function tryClaimForProcessing(key: string, source = "unknown"): Pr
     const rows = await dbWrite
       .insert(idempotencyKeys)
       .values({ key, source, expires_at })
-      .onConflictDoNothing({ target: idempotencyKeys.key })
+      .onConflictDoUpdate({
+        target: idempotencyKeys.key,
+        set: { source, expires_at },
+        // Reclaim keys whose TTL has passed: a crashed claimer must not block
+        // retries until the cleanup cron runs. Live keys stay claimed.
+        where: sql`${idempotencyKeys.expires_at} < now()`,
+      })
       .returning({ key: idempotencyKeys.key });
 
     // length === 1 means we inserted (claimed), 0 means key already exists (conflict)


### PR DESCRIPTION
## Problem

`tryClaimForProcessing` uses `ON CONFLICT DO NOTHING`, so a key whose 2-minute TTL has passed still conflicts (the row remains until the cleanup cron runs). A webhook whose claimer crashed is then rejected as "already claimed" on every retry — the documented TTL is defeated on the claim path, while the sibling `isAlreadyProcessed` explicitly deletes expired rows.

## Change

Switch to `ON CONFLICT DO UPDATE ... WHERE expires_at < now()`: a conflict only reclaims the key when the existing row has expired, so live claims stay exclusive while crashed-claim retries succeed after the TTL.

## Evidence

- `bun test packages/cloud/shared/src/lib/utils/idempotency.logging.test.ts` — passes (unchanged behavior for the fail-open/logging paths).

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
