### PR TITLE
fix(cloud): bound username collision suffix to the reserved width

### DIFF
--- a/packages/cloud/shared/src/lib/utils/agent-username.ts
+++ b/packages/cloud/shared/src/lib/utils/agent-username.ts
@@ -222,7 +222,7 @@ export function generateUniqueUsername(
   let suffix = 2;
   let candidate = `${truncatedBase}-${suffix}`;
 
-  while (existingUsernames.has(candidate) && suffix < 10000) {
+  while (existingUsernames.has(candidate) && suffix < 1000) {
     suffix++;
     candidate = `${truncatedBase}-${suffix}`;
   }


### PR DESCRIPTION
## Problem

`generateUniqueUsername` reserves 4 chars for the suffix ("-999") but the collision loop runs to `suffix < 10000`, so a 26-char base with ≥1000 collisions produces `26 + "-" + 4 digits = 31` chars — longer than `USERNAME_MAX_LENGTH` (30) and failing the function's own `validateUsername` contract.

## Change

Bound the loop at `suffix < 1000` (3 digits), matching the reserved width. On exhausting 999 collisions the existing throw path fires instead of emitting an invalid username.

## Evidence

- `bun test packages/cloud/shared/src/lib/utils/agent-username.test.ts` — passes.

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
