### PR TITLE
fix(cloud): remove tautological conditional in phrase aggregator take

### DIFF
--- a/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
+++ b/packages/cloud/shared/src/lib/voice-session/phrase-aggregator.ts
@@ -107,7 +107,7 @@ export class PhraseAggregator {
     const trimmed = this.buffer.trim();
     this.buffer = "";
     if (trimmed.length < this.minEmitChars) {
-      return trimmed.length > 0 ? null : null;
+      return null;
     }
     this.emittedCount += 1;
     return trimmed;


### PR DESCRIPTION
## Problem

`take()` in `PhraseAggregator` contains a tautological conditional — `trimmed.length > 0 ? null : null` — both branches identical (dead code).

## Change

Replace with a plain `return null;`. No behavior change; the short-fragment discard path is intentional.

## Evidence

- `bun test packages/cloud/shared/src/lib/voice-session/phrase-aggregator.test.ts` — passes.

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
