### PR TITLE
fix(cloud): unref the connection-cache cleanup timer

### DIFF
--- a/packages/cloud/shared/src/lib/cache/connection-cache.ts
+++ b/packages/cloud/shared/src/lib/cache/connection-cache.ts
@@ -21,12 +21,14 @@ export class ConnectionCache {
 
   private constructor() {
     // Cleanup memory cache every 10 minutes to prevent unbounded growth
-    setInterval(() => {
+    const timer = setInterval(() => {
       if (this.memoryCache.size > 10000) {
         logger.warn("[Connection Cache] Memory cache exceeded 10k entries, clearing...");
         this.memoryCache.clear();
       }
     }, 600000);
+    // Don't keep the process alive solely for the cleanup timer (Node).
+    timer.unref?.();
   }
 
   public static getInstance(): ConnectionCache {


### PR DESCRIPTION
## Problem

`ConnectionCache`'s singleton constructor installs a 10-minute `setInterval` that is never cleared or unreferenced — every process importing the module holds a live timer for its entire lifetime (and keeps the Node event loop alive), a genuine resource leak in long-lived runtimes and a nuisance in test suites.

## Change

Keep a handle to the timer and call `timer.unref?.()` so the cleanup interval no longer keeps the process alive; the timer still runs while the process is otherwise alive.

## Evidence

- No behavioral change to cache clearing; typecheck-clean.

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
