### PR TITLE
test(agent): cover misc-routes agent-event envelope contract

### DIFF
--- a/packages/agent/src/api/misc-routes.agent-event-envelope.test.ts
+++ b/packages/agent/src/api/misc-routes.agent-event-envelope.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Covers the agent-event ingestion envelope contract in `handleMiscRoutes`:
+ * the per-agent gateway variant's normalization into a system-stream
+ * envelope, runtime-identity admission before buffering, the 1500-envelope
+ * replay-buffer cap, broadcast copy isolation, and event-id sequencing.
+ * Deterministic unit harness: the HTTP transport boundary (json/error/
+ * readJsonBody) is a spy seam and the route module under test is real.
+ */
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleMiscRoutes, type MiscRouteContext } from "./misc-routes";
+import { AGENT_EVENT_ALLOWED_STREAMS } from "./plugin-discovery-helpers";
+
+const RUNTIME_AGENT_ID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d";
+const FOREIGN_AGENT_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+
+function makeAgentEventContext(pathname: string): {
+  ctx: MiscRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  readJsonBody: ReturnType<typeof vi.fn>;
+  broadcastWs: ReturnType<typeof vi.fn>;
+} {
+  const req = { url: pathname } as http.IncomingMessage;
+  const res = {
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  const broadcastWs = vi.fn();
+
+  return {
+    ctx: {
+      req,
+      res,
+      method: "POST",
+      pathname,
+      url: new URL(`http://localhost${pathname}`),
+      state: {
+        config: {} as MiscRouteContext["state"]["config"],
+        runtime: { agentId: RUNTIME_AGENT_ID } as AgentRuntime,
+        agentState: "running",
+        agentName: "Eliza",
+        shellEnabled: true,
+        broadcastWs,
+        broadcastWsToClientId: vi.fn(),
+        nextEventId: 1,
+        eventBuffer: [],
+        shareIngestQueue: [],
+        startup: { phase: "running", attempt: 0 },
+        broadcastStatus: vi.fn(),
+        pendingRestartReasons: [],
+      },
+      json,
+      error,
+      readJsonBody,
+      AGENT_EVENT_ALLOWED_STREAMS,
+      resolveTerminalRunRejection: vi.fn().mockReturnValue(null),
+      resolveTerminalRunClientId: vi.fn().mockReturnValue(null),
+      isSharedTerminalClientId: vi.fn().mockReturnValue(false),
+      activeTerminalRunCount: 0,
+      setActiveTerminalRunCount: vi.fn(),
+    },
+    json,
+    error,
+    readJsonBody,
+    broadcastWs,
+  };
+}
+
+describe("handleMiscRoutes agent event envelope", () => {
+  it("normalizes a per-agent gateway event into a system-stream envelope", async () => {
+    const gatewayPayload = { kind: "ping" };
+    const { ctx, json, error, readJsonBody } = makeAgentEventContext(
+      `/api/agents/${RUNTIME_AGENT_ID}/event`,
+    );
+    readJsonBody.mockResolvedValue({
+      type: "ping",
+      userId: "user-9",
+      payload: gatewayPayload,
+    });
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(ctx.res, { ok: true });
+    expect(ctx.state.eventBuffer).toHaveLength(1);
+    expect(ctx.state.eventBuffer[0]).toMatchObject({
+      type: "agent_event",
+      version: 1,
+      eventId: "evt-1",
+      stream: "system",
+      agentId: RUNTIME_AGENT_ID,
+      payload: {
+        gatewayType: "ping",
+        userId: "user-9",
+        payload: gatewayPayload,
+      },
+    });
+    expect(readJsonBody).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a valid but foreign agent id with 404 before buffering or broadcasting", async () => {
+    const { ctx, json, error, broadcastWs, readJsonBody } =
+      makeAgentEventContext(`/api/agents/${FOREIGN_AGENT_ID}/event`);
+    readJsonBody.mockResolvedValue({ type: "ping", payload: {} });
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      { error: "Agent not found" },
+      404,
+    );
+    expect(ctx.state.eventBuffer).toHaveLength(0);
+    expect(broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("caps the replay buffer at 1500 envelopes by dropping the oldest", async () => {
+    const { ctx, json, error, readJsonBody } =
+      makeAgentEventContext("/api/agent/event");
+    for (let i = 0; i < 1500; i++) {
+      ctx.state.eventBuffer.push({
+        type: "agent_event",
+        version: 1,
+        eventId: `seed-${i}`,
+        ts: i,
+        stream: "chat",
+        payload: { i },
+      });
+    }
+    ctx.state.nextEventId = 1500;
+    readJsonBody.mockResolvedValue({ stream: "chat", data: { n: 1 } });
+
+    const handled = await handleMiscRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    expect(ctx.state.eventBuffer).toHaveLength(1500);
+    expect(ctx.state.eventBuffer[0]?.eventId).toBe("seed-1");
+    expect(ctx.state.eventBuffer[1499]).toMatchObject({
+      eventId: "evt-1500",
+      stream: "chat",
+      payload: { n: 1 },
+    });
+    expect(ctx.state.nextEventId).toBe(1501);
+    expect(json).toHaveBeenCalledWith(ctx.res, { ok: true });
+  });
+
+  it("broadcasts a copy that never aliases the buffered envelope", async () => {
+    const { ctx, broadcastWs, readJsonBody } =
+      makeAgentEventContext("/api/agent/event");
+    readJsonBody.mockResolvedValue({
+      stream: "notification",
+      data: { hello: "world" },
+    });
+
+    await handleMiscRoutes(ctx);
+
+    expect(broadcastWs).toHaveBeenCalledOnce();
+    const buffered = ctx.state.eventBuffer[0];
+    const broadcastPayload = broadcastWs.mock.calls[0]?.[0];
+    expect(buffered).toBeDefined();
+    expect(broadcastPayload).toEqual(buffered);
+    expect(broadcastPayload).not.toBe(buffered);
+  });
+
+  it("passes roomId through, defaults missing data to an empty payload, and increments event ids", async () => {
+    const { ctx, error, readJsonBody } =
+      makeAgentEventContext("/api/agent/event");
+    readJsonBody.mockResolvedValueOnce({ stream: "chat", roomId: "room-7" });
+    readJsonBody.mockResolvedValueOnce({ stream: "chat" });
+
+    expect(await handleMiscRoutes(ctx)).toBe(true);
+    expect(await handleMiscRoutes(ctx)).toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(ctx.state.eventBuffer).toHaveLength(2);
+    expect(ctx.state.eventBuffer[0]).toMatchObject({
+      eventId: "evt-1",
+      roomId: "room-7",
+      payload: {},
+    });
+    expect(ctx.state.eventBuffer[1]).toMatchObject({
+      eventId: "evt-2",
+      roomId: undefined,
+      payload: {},
+    });
+    expect(ctx.state.nextEventId).toBe(3);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/agent/src/api/misc-routes.agent-event-envelope.test.ts`, a deterministic Vitest unit suite for the agent-event ingestion envelope contract in `handleMiscRoutes` (`packages/agent/src/api/misc-routes.ts`). It follows the existing `misc-routes.<aspect>.test.ts` convention and drives the real handler with only the HTTP transport boundary (`json`/`error`/`readJsonBody`) spied, matching the harness pattern of the sibling suites on develop.

## Coverage added (all net-new on current develop)

- **Per-agent gateway normalization success path** (`POST /api/agents/:id/event`): `{type, userId, payload}` bodies become a `system`-stream envelope with `payload = {gatewayType, userId, payload}` and the route's runtime agent id attached. Only the two rejection branches of this variant were previously covered.
- **Runtime-identity admission**: a valid but foreign agent id is rejected with `404 {"error":"Agent not found"}` before anything is buffered or broadcast.
- **Replay-buffer cap**: pushing past 1500 envelopes drops exactly the oldest entry, keeps length at 1500, appends the new envelope with its sequenced event id, and increments `nextEventId`.
- **Broadcast copy isolation**: WS subscribers receive an object deep-equal to but never aliasing the buffered envelope (`{...envelope}` spread contract).
- **Field semantics across sequential events**: `roomId` passthrough, missing `data` defaulting to an empty payload, and monotonic `evt-N` id sequencing.

## Verification (fork PR — hosted CI does not run on our pull requests)

- `bunx vitest run packages/agent/src/api/misc-routes.agent-event-envelope.test.ts` → **Test Files 1 passed (1), Tests 5 passed (5)** — re-run immediately before filing against current origin/develop (`dea8d697df9d`); `misc-routes.ts` is byte-identical between the branch base and current develop.
- `bunx biome check --write packages/agent/src/api/misc-routes.agent-event-envelope.test.ts` → `Checked 1 file in 17ms. Fixed 1 file.` (formatting normalization only; config verified present, worktree not sparse).
- `bunx tsc --noEmit` in `packages/agent` → zero occurrences of `misc-routes.agent-event-envelope` in output (the package's pre-existing errors are all in unrelated files).
- The diff adds one test file only: +197/−0. No production code, no existing tests modified or deleted.

## Notes

- No `expectTypeOf`, no `vi.hoisted`; assertions are behavioral against the real module.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d2f8c286182b72fd697debd26fa957483491ed9c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
