### PR TITLE
test(ui): cover client

### DIFF
--- a/packages/ui/src/api/client.test.ts
+++ b/packages/ui/src/api/client.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Composition-root contract for client.ts: the singleton `client` must carry
+ * every domain method installed on ElizaClient.prototype by its side-effect
+ * augmentation imports, and the public entry point must serve working runtime
+ * values. Deterministic unit harness — the HTTP boundary is a recording
+ * request transport; the module graph itself is real and unmocked.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  client,
+  ElizaClient,
+  parseMeetingStatusEvent,
+  parseMeetingTranscriptEvent,
+} from "./client";
+
+/** One representative prototype method per augmentation import in client.ts. */
+const AUGMENTED_METHODS = {
+  "client-agent": "startAgent",
+  "client-approvals": "listPendingActions",
+  "client-automations": "listAutomations",
+  "client-background": "uploadBackgroundImage",
+  "client-browser-bridge": "listBrowserBridgeSessions",
+  "client-browser-workspace": "getBrowserWorkspace",
+  "client-chat": "listConversations",
+  "client-cloud": "getCloudStatus",
+  "client-computeruse": "getComputerUseApprovals",
+  "client-files": "listFiles",
+  "client-imessage": "sendIMessage",
+  "client-local-inference": "getLocalInferenceHub",
+  "client-meetings": "listMeetings",
+  "client-notifications": "listNotifications",
+  "client-scheduled-tasks": "listScheduledTasks",
+  "client-skills": "getSkills",
+  "client-transcripts": "listTranscripts",
+  "client-vault": "listSavedLogins",
+  "client-voice-models": "listVoiceModels",
+  "client-wallet": "getWalletBalances",
+  "client-workflow": "listWorkflowDefinitions",
+} as const;
+
+const AUGMENTATION_ENTRIES = Object.entries(AUGMENTED_METHODS) as Array<
+  [keyof typeof AUGMENTED_METHODS, keyof ElizaClient]
+>;
+
+interface RecordedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+/** The singleton resolves no base outside a browser; give it one explicitly. */
+const SINGLETON_BASE = "http://agent.example:31337";
+
+function recordSingletonRequests(
+  body: unknown = { ok: true },
+): RecordedRequest[] {
+  const calls: RecordedRequest[] = [];
+  client.setBaseUrl(SINGLETON_BASE, { persist: false });
+  client.setRequestTransport({
+    request: async (url, init) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  });
+  return calls;
+}
+
+/** Narrows the single recorded request or fails the test loudly. */
+function firstCall(calls: RecordedRequest[]): RecordedRequest {
+  const call = calls.at(0);
+  if (!call) throw new Error("expected one recorded request");
+  return call;
+}
+
+describe("client.ts composition root", () => {
+  it("exports the ElizaClient class and a singleton instance of exactly that class", () => {
+    expect(client).toBeInstanceOf(ElizaClient);
+    expect(client.constructor).toBe(ElizaClient);
+  });
+
+  it("installs every augmentation module's methods on the singleton prototype", () => {
+    for (const [augmentation, representative] of AUGMENTATION_ENTRIES) {
+      expect(
+        typeof client[representative],
+        `${augmentation} must install ${String(representative)}()`,
+      ).toBe("function");
+    }
+  });
+});
+
+describe("singleton request path (LifeOps scheduled-task verbs)", () => {
+  it("listScheduledTasks GETs /api/lifeops/scheduled-tasks and passes the envelope through", async () => {
+    const tasks = [{ id: "task-1", kind: "reminder", status: "pending" }];
+    const calls = recordSingletonRequests({ tasks });
+
+    await expect(client.listScheduledTasks()).resolves.toEqual({ tasks });
+
+    const req = firstCall(calls);
+    expect(req.url).toBe(`${SINGLETON_BASE}/api/lifeops/scheduled-tasks`);
+    expect(req.init?.method).toBeUndefined();
+  });
+
+  it("listScheduledTasks serialises the filter into the query string", async () => {
+    const calls = recordSingletonRequests({ tasks: [] });
+
+    await client.listScheduledTasks({
+      kind: "reminder",
+      ownerVisibleOnly: true,
+    });
+
+    expect(firstCall(calls).url).toBe(
+      `${SINGLETON_BASE}/api/lifeops/scheduled-tasks?kind=reminder&ownerVisibleOnly=1`,
+    );
+  });
+
+  it("listScheduledTasks normalises a missing or non-array tasks field to an empty list", async () => {
+    recordSingletonRequests({});
+    await expect(client.listScheduledTasks()).resolves.toEqual({ tasks: [] });
+
+    const broken = recordSingletonRequests({ tasks: "nope" });
+    await expect(client.listScheduledTasks()).resolves.toEqual({ tasks: [] });
+    expect(firstCall(broken).url).toBe(
+      `${SINGLETON_BASE}/api/lifeops/scheduled-tasks`,
+    );
+  });
+
+  it("applyScheduledTask POSTs the JSON payload to /<encoded-id>/<verb>", async () => {
+    const task = { id: "t 1" };
+    const calls = recordSingletonRequests({ task });
+
+    await expect(
+      client.applyScheduledTask("t 1", "snooze", { minutes: 5 }),
+    ).resolves.toEqual({ task });
+
+    const req = firstCall(calls);
+    expect(req.url).toBe(
+      `${SINGLETON_BASE}/api/lifeops/scheduled-tasks/t%201/snooze`,
+    );
+    expect(req.init?.method).toBe("POST");
+    expect(req.init?.body).toBe(JSON.stringify({ minutes: 5 }));
+  });
+
+  it("applyScheduledTask sends an empty JSON object when no payload is given", async () => {
+    const calls = recordSingletonRequests({ task: { id: "t-2" } });
+
+    await client.applyScheduledTask("t-2", "complete");
+
+    expect(firstCall(calls).init?.body).toBe("{}");
+  });
+
+  it("fireScheduledTask POSTs to /<encoded-id>/fire with an empty body and returns the fire outcome", async () => {
+    const fire = { kind: "fired", task: { id: "t-3" } };
+    const calls = recordSingletonRequests({ fire });
+
+    await expect(client.fireScheduledTask("weird/id")).resolves.toEqual({
+      fire,
+    });
+
+    const req = firstCall(calls);
+    expect(req.url).toBe(
+      `${SINGLETON_BASE}/api/lifeops/scheduled-tasks/${encodeURIComponent("weird/id")}/fire`,
+    );
+    expect(req.init?.method).toBe("POST");
+    expect(req.init?.body).toBe("{}");
+  });
+
+  it("runLifeOpsTestProbe POSTs /test-probe, defaulting the body to {}", async () => {
+    const calls = recordSingletonRequests({
+      task: { id: "probe-1" },
+      fire: { kind: "raced", task: null },
+    });
+
+    await client.runLifeOpsTestProbe();
+
+    expect(firstCall(calls).url).toBe(
+      `${SINGLETON_BASE}/api/lifeops/scheduled-tasks/test-probe`,
+    );
+    expect(firstCall(calls).init?.body).toBe("{}");
+  });
+
+  it("runLifeOpsTestProbe forwards the requested probe kind", async () => {
+    const calls = recordSingletonRequests({
+      task: { id: "probe-2" },
+      fire: { kind: "skipped", reason: "gate" },
+    });
+
+    await expect(client.runLifeOpsTestProbe("checkin")).resolves.toEqual({
+      task: { id: "probe-2" },
+      fire: { kind: "skipped", reason: "gate" },
+    });
+
+    expect(firstCall(calls).init?.body).toBe(
+      JSON.stringify({ kind: "checkin" }),
+    );
+  });
+});
+
+describe("re-exported meeting WebSocket guards via the public entry point", () => {
+  it("narrows well-formed envelopes and rejects malformed ones through ./client", () => {
+    const confirmed = [{ id: "seg-1", text: "hello" }];
+
+    expect(
+      parseMeetingTranscriptEvent({
+        type: "meeting-transcript",
+        sessionId: "s-1",
+        transcriptId: "tr-1",
+        confirmed,
+        pending: [],
+      }),
+    ).toEqual({
+      type: "meeting-transcript",
+      sessionId: "s-1",
+      transcriptId: "tr-1",
+      confirmed,
+      pending: [],
+    });
+    expect(parseMeetingTranscriptEvent({ type: "other" })).toBeNull();
+
+    expect(
+      parseMeetingStatusEvent({
+        type: "meeting-status",
+        session: { id: "sess-9" },
+      }),
+    ).toEqual({ type: "meeting-status", session: { id: "sess-9" } });
+    expect(parseMeetingStatusEvent({ type: "meeting-status" })).toBeNull();
+    expect(
+      parseMeetingStatusEvent({ type: "meeting-status", session: null }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

Adds a unit suite for `packages/ui/src/api/client.ts` — the API composition root — which has no same-named test file anywhere in the repo (verified against current `origin/develop` via `git ls-tree`). The module's documented contract is runtime composition: a singleton `ElizaClient` whose domain methods exist only because of side-effect augmentation imports. That contract is invisible to `tsc` if an augmentation import stops applying at runtime, which is exactly what this suite pins.

## What is covered

- **Composition root:** importing `./client` exports the shared `ElizaClient` class and a singleton instance of exactly that class (`constructor` identity), and every side-effect augmentation import installs its domain methods on the singleton prototype — one representative method asserted per module across all 21 augmentation modules that install prototype methods (`client-accounts` intentionally excluded: it contributes interface merging only, no runtime surface).
- **Singleton request path:** the LifeOps scheduled-task verbs are driven end-to-end through the singleton against a recording request transport (real module graph, nothing mocked): list path + filter query serialisation (`?kind=reminder&ownerVisibleOnly=1`), missing/non-array `tasks` field normalised to `{ tasks: [] }`, verb POST to `/<encoded-id>/<verb>` with JSON payload and `{}` default, fire body `"{}"` with id encoding, and test-probe kind forwarding.
- **Public entry point:** the meeting WebSocket guards re-exported through `./client` narrow well-formed envelopes and reject malformed ones at the same entry consumers import from.

## Evidence (test-only change; vitest, biome and tsc counts quoted in the PR body)

- `bunx vitest run src/api/client.test.ts` in `packages/ui`: **Test Files 1 passed (1); Tests 11 passed (11)** — re-fetched `origin/develop` and re-run immediately before filing; same result.
- `bunx biome check packages/ui/src/api/client.test.ts`: clean, no fixes applied (config presence verified: `biome.json` materialised, worktree not sparse).
- `bunx tsc --noEmit` in `packages/ui`: no diagnostic references `src/api/client.test.ts`.
- Diff is a single new test file, +232/−0. No production behaviour is changed by this PR.

Note: this is a fork contribution, so hosted CI does not run on this PR; the counts above are from local runs of the real toolchain.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0f8e984e01631de7a5fefc90d6454abda8570c54 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
