### PR TITLE
test(shared): cover view-command-matcher

### DIFF
--- a/packages/shared/src/views/view-command-matcher.test.ts
+++ b/packages/shared/src/views/view-command-matcher.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Behavioural coverage for the deterministic view-command matcher: which
+ * explicit navigation phrasings resolve to which view id, and which inputs are
+ * deliberately rejected (bare nouns in prose, negated commands, companion
+ * action requests, over-length input, cloud-apps mentions). Real module, no
+ * mocks — the matcher is a pure string decision consumed by the EARLY hook,
+ * the VIEWS action, the contextual evaluator gate, and the shared runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { matchViewCommand } from "./view-command-matcher.js";
+
+describe("matchViewCommand", () => {
+  it("returns null for missing and empty input", () => {
+    expect(matchViewCommand(undefined)).toBeNull();
+    expect(matchViewCommand("")).toBeNull();
+    expect(matchViewCommand("   ")).toBeNull();
+    expect(matchViewCommand("\n\t")).toBeNull();
+  });
+
+  it("resolves explicit verb commands to their views", () => {
+    expect(matchViewCommand("open settings")).toBe("settings");
+    expect(matchViewCommand("Open Settings")).toBe("settings");
+    expect(matchViewCommand("show me my calendar")).toBe("calendar");
+    expect(matchViewCommand("go to the vault")).toBe("vault");
+  });
+
+  it("matches a bare noun only when it is the whole message", () => {
+    expect(matchViewCommand("settings")).toBe("settings");
+    expect(matchViewCommand("the settings are wrong")).toBeNull();
+  });
+
+  it("matches possessive and noun+view-word signals", () => {
+    expect(matchViewCommand("my wallet")).toBe("wallet");
+    expect(matchViewCommand("mis ajustes")).toBe("settings");
+    expect(matchViewCommand("settings page")).toBe("settings");
+  });
+
+  it("resolves non-English commands including SOV order", () => {
+    expect(matchViewCommand("abre ajustes")).toBe("settings");
+    expect(matchViewCommand("abre la configuración")).toBe("settings");
+    expect(matchViewCommand("打开设置")).toBe("settings");
+    expect(matchViewCommand("設定を開いて")).toBe("settings");
+    expect(matchViewCommand("설정 열어줘")).toBe("settings");
+  });
+
+  it("sends bare 'go back' home to chat", () => {
+    expect(matchViewCommand("go back")).toBe("chat");
+    expect(matchViewCommand("  Go back. ")).toBe("chat");
+  });
+
+  it("rejects navigation inside a negated clause", () => {
+    expect(matchViewCommand("don't open settings")).toBeNull();
+    expect(matchViewCommand("do not open settings")).toBeNull();
+    expect(matchViewCommand("never open my wallet")).toBeNull();
+  });
+
+  it("rejects companion action requests even with view-like nouns", () => {
+    expect(matchViewCommand("please render a dance emote")).toBeNull();
+  });
+
+  it("rejects input beyond the 160-character command cap", () => {
+    const filler = (n: number) => "a".repeat(n);
+    expect(matchViewCommand(`open settings ${filler(146)}`)).toBe("settings");
+    expect(matchViewCommand(`open settings ${filler(147)}`)).toBeNull();
+  });
+
+  it("opens the cloud apps studio on strict commands", () => {
+    expect(matchViewCommand("open the cloud apps")).toBe("cloud-apps");
+    expect(matchViewCommand("launch app studio")).toBe("cloud-apps");
+  });
+
+  it("never treats a named singular cloud app as the studio", () => {
+    expect(matchViewCommand("open the cloud app Acme")).toBeNull();
+  });
+
+  it("does not let another noun hijack a sentence mentioning cloud apps", () => {
+    expect(matchViewCommand("open help for the cloud apps studio")).toBeNull();
+  });
+
+  it("prefers higher-priority views when several nouns appear", () => {
+    expect(matchViewCommand("open memories and notes")).toBe("memories");
+    expect(matchViewCommand("open cockpit and wallet")).toBe("cockpit");
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/shared/src/views/view-command-matcher.test.ts`, a behavioural unit suite for `matchViewCommand` — the deterministic zero-model view-navigation matcher consumed by the EARLY hook, the VIEWS action, the contextual evaluator's gate, and the shared-runtime turn. The module had no test coverage on develop.

The suite pins the observable decision contract of the real module (no mocks):

- missing / empty / whitespace-only input resolves to `null`
- explicit verb commands resolve case-insensitively (`open settings` -> settings, `show me my calendar` -> calendar)
- a bare noun matches only when it is the whole message (`settings` matches; `the settings are wrong` does not)
- possessive and noun+view-word signals (`my wallet`, `mis ajustes`, `settings page`)
- non-English commands including SOV order (`abre ajustes`, `abre la configuración`, `打开设置`, `設定を開いて`, `설정 열어줘`)
- bare `go back` routes home to chat, including punctuation-padded forms
- negated clauses veto navigation (`don't open settings`, `do not open settings`, `never open my wallet`)
- companion action requests are vetoed even with view-like nouns (`please render a dance emote`)
- the 160-character command cap holds exactly at the boundary (160 chars match, 161 do not)
- the cloud-apps studio opens only on strict commands (`open the cloud apps`, `launch app studio`); a named singular cloud app (`open the cloud app Acme`) deliberately stays unclaimed, and another noun (`help`) cannot hijack a sentence that mentions cloud apps
- priority order decides when several nouns appear (`memories` before `notes`; `cockpit` first)

## Evidence (test-only change)

- The diff adds exactly one new test file and touches no production code (+84/-0).
- `bunx vitest run src/views/view-command-matcher.test.ts` from `packages/shared`: **Test Files 1 passed (1), Tests 13 passed (13)**.
- `bunx biome check src/views/view-command-matcher.test.ts`: clean, no fixes applied (after an initial formatting pass by `--write`).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/shared`: the new test file appears nowhere in the output.
- Immediately before filing, re-fetched `origin/develop`, confirmed `view-command-matcher.ts` is byte-identical to the base this suite ran against, confirmed no suite or competing open PR exists for the module, and re-ran the suite: **13 passed (13)** on current develop.
- We are a fork contributor: hosted CI does not run on this pull request. The counts above are the real local runs against the pushed tree (`test/shared-view-command-matcher-coverage` @ `1f236fd1f58f`).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
