### PR TITLE
test(plugin-google-genai): cover image url fetcher guards

### DIFF
--- a/plugins/plugin-google-genai/models/__tests__/image-url.test.ts
+++ b/plugins/plugin-google-genai/models/__tests__/image-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  fetchImageFromUrl,
+  IMAGE_DESCRIPTION_MAX_BYTES,
+  installImageUrlFetcher,
+} from "./image-url.ts";
+
+describe("fetchImageFromUrl", () => {
+  it("fails closed without an installed fetcher", async () => {
+    await expect(fetchImageFromUrl("https://x.com/a.png")).rejects.toThrow(
+      /platform build entrypoint/,
+    );
+  });
+
+  it("delegates to the installed fetcher", async () => {
+    installImageUrlFetcher(async (url) => ({
+      base64: "aGVsbG8=",
+      contentType: "image/png",
+    }));
+    const result = await fetchImageFromUrl("https://x.com/a.png");
+    expect(result.base64).toBe("aGVsbG8=");
+    expect(result.contentType).toBe("image/png");
+  });
+
+  it("exposes the memory cap constant", () => {
+    expect(IMAGE_DESCRIPTION_MAX_BYTES).toBe(20 * 1024 * 1024);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
