### PR TITLE
test(shared): cover app-config

### DIFF
--- a/packages/shared/src/config/app-config.test.ts
+++ b/packages/shared/src/config/app-config.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit coverage for the white-label application configuration surface in
+ * app-config.ts: the framework default AppConfig and the three-layer
+ * resolveAppBranding merge (framework branding defaults, app identity
+ * fields, app branding overrides) that every white-label consumer relies
+ * on for naming, links, and distribution tokens.
+ *
+ * Deterministic suite over the real module — no mocks, no network.
+ */
+import { describe, expect, it } from "vitest";
+import type { AppConfig } from "./app-config.ts";
+import { DEFAULT_APP_CONFIG, resolveAppBranding } from "./app-config.ts";
+import { DEFAULT_BRANDING } from "./branding.ts";
+
+function acmeConfig(overrides?: Partial<AppConfig>): AppConfig {
+  return {
+    appName: "Acme",
+    appId: "com.acme.acme",
+    orgName: "acme",
+    repoName: "acme-app",
+    cliName: "acme",
+    description: "Agents for the Acme org",
+    branding: {},
+    ...overrides,
+  };
+}
+
+describe("resolveAppBranding", () => {
+  it("fills every required branding token from framework defaults when the app declares none", () => {
+    const branding = resolveAppBranding(acmeConfig());
+
+    expect(branding.docsUrl).toBe(DEFAULT_BRANDING.docsUrl);
+    expect(branding.appUrl).toBe(DEFAULT_BRANDING.appUrl);
+    expect(branding.bugReportUrl).toBe(DEFAULT_BRANDING.bugReportUrl);
+    expect(branding.hashtag).toBe(DEFAULT_BRANDING.hashtag);
+    expect(branding.fileExtension).toBe(DEFAULT_BRANDING.fileExtension);
+    expect(branding.packageScope).toBe(DEFAULT_BRANDING.packageScope);
+  });
+
+  it("keeps the framework link defaults live and absolute", () => {
+    const branding = resolveAppBranding(acmeConfig());
+
+    expect(typeof branding.docsUrl).toBe("string");
+    expect(typeof branding.appUrl).toBe("string");
+    expect(branding.docsUrl.startsWith("https://")).toBe(true);
+    expect(branding.appUrl.startsWith("https://")).toBe(true);
+  });
+
+  it("projects the app identity fields onto the resolved branding", () => {
+    const branding = resolveAppBranding(acmeConfig());
+
+    expect(branding.appName).toBe("Acme");
+    expect(branding.orgName).toBe("acme");
+    expect(branding.repoName).toBe("acme-app");
+  });
+
+  it("lets the branding block win over the app identity fields", () => {
+    const branding = resolveAppBranding(
+      acmeConfig({
+        appName: "Acme",
+        orgName: "acme",
+        repoName: "acme-app",
+        branding: {
+          appName: "AcmeOS",
+          orgName: "acme-industries",
+          repoName: "acme-monorepo",
+        },
+      }),
+    );
+
+    expect(branding.appName).toBe("AcmeOS");
+    expect(branding.orgName).toBe("acme-industries");
+    expect(branding.repoName).toBe("acme-monorepo");
+  });
+
+  it("preserves untouched defaults alongside a partial branding override", () => {
+    const branding = resolveAppBranding(
+      acmeConfig({ branding: { cloudOnly: true } }),
+    );
+
+    expect(branding.cloudOnly).toBe(true);
+    expect(branding.docsUrl).toBe(DEFAULT_BRANDING.docsUrl);
+    expect(branding.appUrl).toBe(DEFAULT_BRANDING.appUrl);
+    expect(branding.hashtag).toBe(DEFAULT_BRANDING.hashtag);
+    expect(branding.fileExtension).toBe(DEFAULT_BRANDING.fileExtension);
+  });
+
+  it("replaces individual link defaults without disturbing siblings", () => {
+    const branding = resolveAppBranding(
+      acmeConfig({
+        branding: {
+          docsUrl: "https://docs.acme.dev",
+          bugReportUrl: "https://github.com/acme/acme-app/issues/new",
+        },
+      }),
+    );
+
+    expect(branding.docsUrl).toBe("https://docs.acme.dev");
+    expect(branding.bugReportUrl).toBe(
+      "https://github.com/acme/acme-app/issues/new",
+    );
+    expect(branding.appUrl).toBe(DEFAULT_BRANDING.appUrl);
+  });
+
+  it("passes custom provider options through to the resolved branding", () => {
+    const providers = [
+      {
+        id: "acme-cloud",
+        name: "Acme Cloud",
+        envKey: "ACME_API_KEY",
+        pluginName: "@acme/plugin-acme-cloud",
+        keyPrefix: null,
+        description: "Acme hosted models",
+        family: "openai",
+        authMode: "api-key" as const,
+        group: "cloud" as const,
+        order: 1,
+      },
+    ];
+
+    const branding = resolveAppBranding(
+      acmeConfig({ branding: { customProviders: providers } }),
+    );
+
+    expect(branding.customProviders).toStrictEqual(providers);
+  });
+
+  it("does not mutate the supplied configuration or branding block", () => {
+    const config = acmeConfig();
+    const frozenBranding = Object.freeze({
+      ...config.branding,
+      hashtag: "#FrozenAcme",
+    }) as Partial<AppConfig["branding"]>;
+    const subject = { ...config, branding: frozenBranding };
+
+    const branding = resolveAppBranding(subject);
+
+    expect(branding.hashtag).toBe("#FrozenAcme");
+    expect(subject.branding).toStrictEqual(frozenBranding);
+  });
+});
+
+describe("DEFAULT_APP_CONFIG", () => {
+  it("resolves to a complete branding whose identity matches the default app", () => {
+    const branding = resolveAppBranding(DEFAULT_APP_CONFIG);
+
+    expect(branding.appName).toBe(DEFAULT_APP_CONFIG.appName);
+    expect(branding.orgName).toBe(DEFAULT_APP_CONFIG.orgName);
+    expect(branding.repoName).toBe(DEFAULT_APP_CONFIG.repoName);
+    expect(branding.customProviders).toBeUndefined();
+    expect(branding.cloudOnly).toBeUndefined();
+  });
+
+  it("applies the default branding block over the framework tokens", () => {
+    const branding = resolveAppBranding(DEFAULT_APP_CONFIG);
+
+    expect(branding.bugReportUrl).toBe(
+      "https://github.com/elizaOS/eliza/issues/new",
+    );
+    expect(branding.bugReportUrl).not.toBe(DEFAULT_BRANDING.bugReportUrl);
+    expect(branding.hashtag).toBe("#elizaOS");
+    expect(branding.hashtag).not.toBe(DEFAULT_BRANDING.hashtag);
+  });
+
+  it("keeps the framework documentation and app origins for the default app", () => {
+    const branding = resolveAppBranding(DEFAULT_APP_CONFIG);
+
+    expect(branding.docsUrl).toBe(DEFAULT_BRANDING.docsUrl);
+    expect(branding.appUrl).toBe(DEFAULT_BRANDING.appUrl);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/shared/src/config/app-config.test.ts` — a new, additive-only
vitest suite (11 cases) for `packages/shared/src/config/app-config.ts`, which
had no same-named test file anywhere on `develop`.

## Why this surface matters

`resolveAppBranding()` implements the three-layer branding merge every
white-label app depends on — framework `DEFAULT_BRANDING`, then the app's
top-level identity fields (`appName` / `orgName` / `repoName`), then the
app's `branding` block as final override. That precedence order is
consumer-visible behavior and was previously untested in this package.
`DEFAULT_APP_CONFIG` is the framework default app config that flows through
the same resolver.

The suite drives only the real module — no mocks — and pins observed
behavior:

- untouched defaults flow through for links/tokens (`docsUrl`, `appUrl`,
  `bugReportUrl`, `hashtag`, `fileExtension`, `packageScope`);
- identity fields project onto the resolved branding;
- the `branding` block wins over the identity fields;
- partial overrides preserve sibling defaults; individual link overrides
  leave siblings untouched;
- custom provider options pass through by value-shape;
- inputs are never mutated;
- the shipped `DEFAULT_APP_CONFIG.branding` deliberately overrides the
  framework bug-report URL (`…/issues/new` vs the templated variant) and
  hashtag (`#elizaOS` vs `#ElizaAgent`) while keeping the framework docs
  and app origins.

## Evidence (test-only change; no production behavior touched)

- `bunx vitest run src/config/app-config.test.ts --config ./vitest.config.ts`
  in `packages/shared` (v4.1.10): **Test Files 1 passed (1), Tests 11 passed
  (11)**. Identical result through the package lane
  (`node ../scripts/run-vitest.mjs run …`). Re-run against current
  `origin/develop` immediately before filing.
- `bunx @biomejs/biome check --write packages/shared/src/config/app-config.test.ts`
  from the repo root: **clean** ("Checked 1 file", no fixes applied);
  `biome.json` present and the worktree is not sparse, so the check is not
  vacuous.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/shared`: the new test
  file appears **nowhere** in the output (zero errors introduced by this
  diff).
- Diff shape: exactly one NEW file, +171/−0. No existing test file is
  modified or removed.

Note: we are a fork contributor, so hosted CI does not run on this pull
request; the counts above are quoted from local runs of the package's own
test lane.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6a7d1aa6c9e1789cccd3c7bf6965c50301bdee78 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
