### PR TITLE
test(ui): cover vault saved-login client

### DIFF
--- a/packages/ui/src/api/client-vault.test.ts
+++ b/packages/ui/src/api/client-vault.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit coverage for the vault saved-login client contracts: request-path and
+ * query construction, percent-encoding of user-controlled domain/username/
+ * identifier values, HTTP verb + JSON-body selection, and response-field
+ * projection. Transport stubbed; no live agent.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+import "./client-vault";
+
+function stubbedClient<T>(response: T) {
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  const fetch = vi.fn(async () => response);
+  client.fetch = fetch as typeof client.fetch;
+  return { client, fetch };
+}
+
+const savedLogin = {
+  source: "in-house" as const,
+  identifier: "login-1",
+  domain: "example.com",
+  username: "alice",
+  title: "Example",
+  updatedAt: 1735689600000,
+};
+
+describe("ElizaClient saved-login vault methods", () => {
+  describe("listSavedLogins", () => {
+    it("GETs /api/secrets/logins without a query string when no domain filter is given", async () => {
+      const { client, fetch } = stubbedClient({
+        ok: true,
+        logins: [savedLogin],
+        failures: [],
+      });
+
+      await expect(client.listSavedLogins()).resolves.toEqual({
+        logins: [savedLogin],
+        failures: [],
+      });
+      expect(fetch).toHaveBeenCalledWith("/api/secrets/logins");
+    });
+
+    it("appends the domain filter percent-encoded so reserved characters stay inside the query value", async () => {
+      const { client, fetch } = stubbedClient({
+        ok: true,
+        logins: [],
+        failures: [],
+      });
+
+      await client.listSavedLogins("example.com/path?q=1");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins?domain=example.com%2Fpath%3Fq%3D1",
+      );
+    });
+
+    it("projects only logins and failures out of the response envelope", async () => {
+      const { client } = stubbedClient({
+        ok: true,
+        logins: [savedLogin],
+        failures: [{ source: "bitwarden", message: "locked" }],
+        unexpectedExtra: "dropped",
+      });
+
+      await expect(client.listSavedLogins()).resolves.toEqual({
+        logins: [savedLogin],
+        failures: [{ source: "bitwarden", message: "locked" }],
+      });
+    });
+  });
+
+  describe("revealSavedLogin", () => {
+    it("serializes source + identifier through URLSearchParams and returns the revealed login", async () => {
+      const revealed = {
+        source: "bitwarden" as const,
+        identifier: "op://Vault/Item/Cred",
+        username: "alice",
+        password: "hunter2",
+        domain: null,
+      };
+      const { client, fetch } = stubbedClient({
+        ok: true,
+        login: revealed,
+      });
+
+      await expect(
+        client.revealSavedLogin("bitwarden", "op://Vault/Item/Cred"),
+      ).resolves.toBe(revealed);
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/reveal?source=bitwarden&identifier=op%3A%2F%2FVault%2FItem%2FCred",
+      );
+    });
+
+    it("form-encodes identifiers containing separators so they cannot split the query", async () => {
+      const { client, fetch } = stubbedClient({
+        ok: true,
+        login: {
+          source: "in-house",
+          identifier: "a b&c=d",
+          username: "alice",
+          password: "hunter2",
+          domain: null,
+        },
+      });
+
+      await client.revealSavedLogin("in-house", "a b&c=d");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/reveal?source=in-house&identifier=a+b%26c%3Dd",
+      );
+    });
+  });
+
+  describe("saveSavedLogin", () => {
+    it("POSTs the login as a JSON body to /api/secrets/logins", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+      const input = {
+        domain: "example.com",
+        username: "alice",
+        password: "hunter2",
+      };
+
+      await expect(client.saveSavedLogin(input)).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledWith("/api/secrets/logins", {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+    });
+
+    it("forwards optional otpSeed and notes in the saved payload", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+      const input = {
+        domain: "example.com",
+        username: "alice",
+        password: "hunter2",
+        otpSeed: "JBSWY3DPEHPK3PXP",
+        notes: "work account",
+      };
+
+      await client.saveSavedLogin(input);
+
+      expect(fetch).toHaveBeenCalledWith("/api/secrets/logins", {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+    });
+  });
+
+  describe("deleteSavedLogin", () => {
+    it("DELETEs the domain/username pair with each segment percent-encoded", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+
+      await expect(
+        client.deleteSavedLogin("example.com", "alice@example.com"),
+      ).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/example.com/alice%40example.com",
+        { method: "DELETE" },
+      );
+    });
+
+    it("keeps a username containing a slash inside one path segment", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+
+      await client.deleteSavedLogin("example.com", "org/alice");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/example.com/org%2Falice",
+        { method: "DELETE" },
+      );
+    });
+  });
+
+  describe("autofill allowance", () => {
+    it("GETs the autoallow endpoint and projects the allowed flag (true)", async () => {
+      const { client, fetch } = stubbedClient({ ok: true, allowed: true });
+
+      await expect(client.getAutofillAllowed("app.example.com")).resolves.toBe(
+        true,
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/app.example.com/autoallow",
+      );
+    });
+
+    it("projects the allowed flag through unchanged when the server says false", async () => {
+      const { client } = stubbedClient({ ok: true, allowed: false });
+
+      await expect(client.getAutofillAllowed("app.example.com")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("PUTs allowed=true as a JSON body", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+
+      await client.setAutofillAllowed("app.example.com", true);
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/app.example.com/autoallow",
+        { method: "PUT", body: JSON.stringify({ allowed: true }) },
+      );
+    });
+
+    it("PUTs allowed=false rather than hardcoding an enable", async () => {
+      const { client, fetch } = stubbedClient({ ok: true });
+
+      await client.setAutofillAllowed("app.example.com", false);
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/secrets/logins/app.example.com/autoallow",
+        { method: "PUT", body: JSON.stringify({ allowed: false }) },
+      );
+    });
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated vitest suite for the vault saved-login client contracts in
`packages/ui/src/api/client-vault.ts`, which had no same-named suite anywhere
on `develop`. **Test-only diff: one new file, +216/-0 — no production behavior
changes.**

Note on target selection: the originally assigned module,
`packages/ui/src/api/auth/sessions.ts`, turned out to be three exported string
constants with no runtime logic — a lockstep-mirror shape this lane's rules
reject ("pinning the literals themselves... prevents no user-visible
regression"). Per the same rules' fallback clause, coverage moved to the
neighboring untested `client-vault.ts`, whose six prototype methods have real
request-construction behavior to pin.

## What the suite covers

All six exported `ElizaClient` prototype methods, driving the real module with
only the transport stubbed (same pattern as `client-notifications.test.ts`):

- `listSavedLogins` — bare `/api/secrets/logins` when no domain filter is
  given; domain filter appended percent-encoded (`%2F/%3F/%3D`); response
  envelope projected down to `{ logins, failures }`.
- `revealSavedLogin` — source + identifier serialized through
  `URLSearchParams`; identifiers containing separators (`&`, `=`, space,
  `:`/`/`) cannot split the query; revealed record returned unchanged.
- `saveSavedLogin` — POST JSON body at `/api/secrets/logins`, with and without
  optional `otpSeed`/`notes`.
- `deleteSavedLogin` — DELETE with each of the two path segments independently
  percent-encoded (`@`→`%40`, `/`→`%2F` stays inside one segment).
- `getAutofillAllowed` / `setAutofillAllowed` — GET projects the `allowed`
  boolean through unchanged in both directions; PUT bodies carry
  `{"allowed":false}` as well as `true` (guards against a hardcoded enable).

## Verification

Run against current `origin/develop` (`dea8d697df`; `client-vault.ts` blob
`b4847db0` unchanged since the runs below):

- `bunx vitest run src/api/client-vault.test.ts` (packages/ui): **Test Files
  1 passed (1); Tests 13 passed (13)** — re-run after the final formatting
  pass, immediately before filing.
- `bunx biome check --write packages/ui/src/api/client-vault.test.ts`: clean
  (one formatting fix applied by the tool itself, then re-verified green).
- `bunx tsc --noEmit` (packages/ui): zero diagnostics reference
  `client-vault.test.ts`. Remaining package diagnostics are pre-existing and
  belong to other in-progress files not touched by this diff.
- `git diff --stat origin/develop..test/ui-vault-client-coverage`: exactly one
  file changed, 216 insertions(+), 0 deletions(-).

## CI note

This pull request comes from a fork, so hosted CI does not run on it; the
counts above are local runs quoted verbatim from the commands shown.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:65f17092f455c7137eb63bc0d2a41e3891d5face -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
