### PR TITLE
test(agent): cover workbench-routes

### DIFF
--- a/packages/agent/src/api/workbench-routes.test.ts
+++ b/packages/agent/src/api/workbench-routes.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Exercises `handleWorkbenchRoutes` routing decisions through the real helper
+ * implementations the production context binds: VFS delegation precedence, the
+ * GET-only overview guard, todo/trigger source-failure isolation, availability
+ * flags, and backward-compatible summary fields. Deterministic harness — the
+ * runtime boundary is a scripted `getTasks`, no live HTTP server.
+ */
+
+import type http from "node:http";
+import type { AgentRuntime, Task } from "@elizaos/core";
+import { stringToUuid } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { listTriggerTasks, taskToTriggerSummary } from "../triggers/runtime.ts";
+import { decodePathComponent } from "./server-helpers.ts";
+import type {
+  WorkbenchRouteContext,
+  WorkbenchTodoView,
+} from "./workbench-context.ts";
+import {
+  asObject,
+  normalizeTags,
+  parseNullableNumber,
+  readTaskCompleted,
+  readTaskMetadata,
+  toWorkbenchTodo,
+} from "./workbench-helpers.ts";
+import { handleWorkbenchRoutes } from "./workbench-routes.ts";
+
+type OverviewBody = {
+  tasks: unknown[];
+  triggers: Array<{ displayName: string; enabled: boolean }>;
+  todos: WorkbenchTodoView[];
+  summary: {
+    totalTasks: number;
+    completedTasks: number;
+    totalTriggers: number;
+    activeTriggers: number;
+    totalTodos: number;
+    completedTodos: number;
+  };
+  tasksAvailable: boolean;
+  triggersAvailable: boolean;
+  todosAvailable: boolean;
+};
+
+const AGENT_ID = stringToUuid("workbench-routes-test-agent");
+
+type GetTasks = (query?: { tags?: string[] }) => Promise<Task[]>;
+
+function runtimeWithGetTasks(getTasks: GetTasks): AgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getSetting: () => undefined,
+    getTasks,
+  } as unknown as AgentRuntime;
+}
+
+function todoTask(id: string, name: string, isCompleted = false): Task {
+  return {
+    id,
+    name,
+    description: "",
+    tags: ["todo"],
+    metadata: { isCompleted },
+  } as Task;
+}
+
+function configuredTriggerTask(
+  id: string,
+  displayName: string,
+  enabled: boolean,
+): Task {
+  return {
+    id,
+    name: "WORKFLOW_TRIGGER",
+    description: "",
+    tags: ["repeat", "trigger"],
+    metadata: {
+      trigger: {
+        triggerId: id,
+        displayName,
+        instructions: "",
+        triggerType: "cron",
+        enabled,
+      },
+    },
+  } as Task;
+}
+
+function unmappableTriggerTask(id: string, name: string): Task {
+  return {
+    id,
+    name,
+    description: "",
+    tags: ["repeat", "trigger"],
+    metadata: {},
+  } as Task;
+}
+
+function makeContext(options: {
+  method?: string;
+  pathname?: string;
+  runtime?: AgentRuntime | null;
+}): {
+  ctx: WorkbenchRouteContext;
+  response: { body?: unknown; status?: number };
+} {
+  const method = options.method ?? "GET";
+  const pathname = options.pathname ?? "/api/workbench/overview";
+  const url = new URL(pathname, "http://localhost");
+  const response: { body?: unknown; status?: number } = {};
+  const ctx: WorkbenchRouteContext = {
+    req: { method, url: pathname } as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method,
+    pathname: url.pathname,
+    url,
+    state: { runtime: options.runtime ?? null, adminEntityId: null },
+    json: (_res, data, status = 200) => {
+      response.body = data;
+      response.status = status;
+    },
+    error: (_res, message, status = 500) => {
+      response.body = { error: message };
+      response.status = status;
+    },
+    readJsonBody: async <T extends object>() => null as T | null,
+    toWorkbenchTodo,
+    normalizeTags,
+    readTaskMetadata,
+    readTaskCompleted,
+    parseNullableNumber,
+    asObject,
+    decodePathComponent,
+    taskToTriggerSummary,
+    listTriggerTasks,
+  };
+  return { ctx, response };
+}
+
+function overview(response: { body?: unknown; status?: number }): OverviewBody {
+  expect(response.status).toBe(200);
+  return response.body as OverviewBody;
+}
+
+describe("handleWorkbenchRoutes", () => {
+  it("claims nothing for a path outside the workbench surfaces", async () => {
+    const { ctx, response } = makeContext({
+      pathname: "/api/other",
+      runtime: runtimeWithGetTasks(async () => {
+        throw new Error("must not be queried");
+      }),
+    });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(false);
+    expect(response).toEqual({});
+  });
+
+  it("does not claim the overview route for POST requests", async () => {
+    const { ctx, response } = makeContext({
+      method: "POST",
+      runtime: runtimeWithGetTasks(async () => {
+        throw new Error("must not be queried");
+      }),
+    });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(false);
+    expect(response).toEqual({});
+  });
+
+  it("hands VFS-owned requests to the real VFS handler before considering the overview", async () => {
+    const { ctx, response } = makeContext({
+      pathname: "/api/workbench/vfs/plugins",
+      runtime: runtimeWithGetTasks(async () => {
+        throw new Error("must not be queried");
+      }),
+    });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    expect(response.status).toBe(200);
+    const body = response.body as { plugins?: unknown };
+    expect(Array.isArray(body.plugins)).toBe(true);
+    expect("summary" in body && body.summary !== undefined).toBe(false);
+  });
+
+  it("serves an all-zero overview when no runtime is attached", async () => {
+    const { ctx, response } = makeContext({ runtime: null });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    expect(overview(response)).toEqual({
+      tasks: [],
+      triggers: [],
+      todos: [],
+      summary: {
+        totalTasks: 0,
+        completedTasks: 0,
+        totalTriggers: 0,
+        activeTriggers: 0,
+        totalTodos: 0,
+        completedTodos: 0,
+      },
+      tasksAvailable: false,
+      triggersAvailable: false,
+      todosAvailable: false,
+    });
+  });
+
+  it("keeps backward-compat task fields empty while todos and triggers load", async () => {
+    const runtime = runtimeWithGetTasks(async (query) => {
+      const tags = query?.tags ?? [];
+      if (tags.includes("trigger")) {
+        return [
+          configuredTriggerTask("t-enabled", "Zulu Trigger", true),
+          configuredTriggerTask("t-disabled", "Yankee Trigger", false),
+          unmappableTriggerTask("t-bare", "NO_CONFIG"),
+        ];
+      }
+      if (tags.includes("heartbeat")) return [];
+      return [todoTask("open", "Bravo"), todoTask("done", "Alpha", true)];
+    });
+    const { ctx, response } = makeContext({ runtime });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    const body = overview(response);
+    expect(body.tasks).toEqual([]);
+    expect(body.tasksAvailable).toBe(false);
+    expect(body.summary.totalTasks).toBe(0);
+    expect(body.summary.completedTasks).toBe(0);
+    expect(body.todos.map((todo) => todo.name)).toEqual(["Alpha", "Bravo"]);
+    expect(body.summary.totalTodos).toBe(2);
+    expect(body.summary.completedTodos).toBe(1);
+    expect(body.todosAvailable).toBe(true);
+    expect(body.triggers.map((trigger) => trigger.displayName)).toEqual([
+      "Yankee Trigger",
+      "Zulu Trigger",
+    ]);
+    expect(body.summary.totalTriggers).toBe(2);
+    expect(body.summary.activeTriggers).toBe(1);
+    expect(body.triggersAvailable).toBe(true);
+  });
+
+  it("keeps trigger data available when loading todos fails", async () => {
+    const runtime = runtimeWithGetTasks(async (query) => {
+      const tags = query?.tags ?? [];
+      if (tags.includes("trigger")) {
+        return [configuredTriggerTask("t1", "Solo Trigger", true)];
+      }
+      if (tags.includes("heartbeat")) return [];
+      throw new Error("todo store unavailable");
+    });
+    const { ctx, response } = makeContext({ runtime });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    const body = overview(response);
+    expect(body.todos).toEqual([]);
+    expect(body.todosAvailable).toBe(false);
+    expect(body.triggersAvailable).toBe(true);
+    expect(body.triggers.map((trigger) => trigger.displayName)).toEqual([
+      "Solo Trigger",
+    ]);
+    expect(body.summary.totalTodos).toBe(0);
+    expect(body.summary.totalTriggers).toBe(1);
+  });
+
+  it("keeps todo data available when listing triggers fails", async () => {
+    const runtime = runtimeWithGetTasks(async (query) => {
+      const tags = query?.tags ?? [];
+      if (tags.includes("trigger") || tags.includes("heartbeat")) {
+        throw new Error("trigger listing unavailable");
+      }
+      return [todoTask("done", "Done", true)];
+    });
+    const { ctx, response } = makeContext({ runtime });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    const body = overview(response);
+    expect(body.triggers).toEqual([]);
+    expect(body.triggersAvailable).toBe(false);
+    expect(body.todosAvailable).toBe(true);
+    expect(body.todos.map((todo) => todo.id)).toEqual(["done"]);
+    expect(body.summary.totalTodos).toBe(1);
+    expect(body.summary.completedTodos).toBe(1);
+    expect(body.summary.totalTriggers).toBe(0);
+  });
+
+  it("still answers the overview when both sources fail", async () => {
+    const runtime = runtimeWithGetTasks(async () => {
+      throw new Error("storage unavailable");
+    });
+    const { ctx, response } = makeContext({ runtime });
+
+    await expect(handleWorkbenchRoutes(ctx)).resolves.toBe(true);
+    expect(overview(response)).toMatchObject({
+      tasks: [],
+      triggers: [],
+      todos: [],
+      tasksAvailable: false,
+      triggersAvailable: false,
+      todosAvailable: false,
+    });
+    expect(response.body).toMatchObject({
+      summary: {
+        totalTriggers: 0,
+        activeTriggers: 0,
+        totalTodos: 0,
+        completedTodos: 0,
+      },
+    });
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/agent/src/api/workbench-routes.test.ts`, a new unit suite for `handleWorkbenchRoutes` in `packages/agent/src/api/workbench-routes.ts`, which previously had no same-named suite anywhere in the repository.

The suite drives the real handler with the real production helper implementations (`toWorkbenchTodo` and friends from `workbench-helpers.ts`, `listTriggerTasks` / `taskToTriggerSummary` from `triggers/runtime.ts`) and the real VFS delegate. It covers behavior not pinned elsewhere:

- VFS delegation precedence: a `/api/workbench/vfs/plugins` request resolves through the real `handleWorkbenchVfsRoutes` before the overview is considered, and the runtime is never queried.
- The overview route is GET-only: a POST to `/api/workbench/overview` returns `false` and never touches storage.
- Unrelated paths return `false`.
- No-runtime overview serves the complete all-zero response shape with both availability flags false.
- Backward compatibility fields stay empty (`tasks: []`, `tasksAvailable: false`, `summary.totalTasks`/`completedTasks` at 0) while live todos and triggers load.
- Source-failure isolation: a failing todo store flips only `todosAvailable` to false while triggers still load and sort; a failing trigger listing flips only `triggersAvailable`; both failing still answers the route.
- Trigger summary mapping through real metadata: unmappable trigger tasks are skipped, disabled triggers are excluded from `activeTriggers` but counted in `totalTriggers`, and summaries sort by `displayName`.

## Evidence

Test-only change; vitest, biome and tsc counts are quoted here.

- `bunx vitest run packages/agent/src/api/workbench-routes.test.ts` against current `develop`: **1 test file passed, 8/8 tests passed** (re-run after formatting).
- `bunx biome check --write packages/agent/src/api/workbench-routes.test.ts`: clean ("Checked 1 file … Fixed 1 file" for import ordering, suite re-verified green afterward).
- `bunx tsc --noEmit` in `packages/agent`: the new file appears nowhere in the output (the package's pre-existing errors are unchanged and untouched by this diff).
- The diff touches exactly one new test file (+310/−0); no production code changes.

## CI note

This contribution comes from a fork, so hosted CI does not run on this pull request; the checks above were executed locally against current `develop` and their real output is quoted in this body.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:337e6e0ef71eaaef8b982c53b08d6e8ea7e4dbea -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
