### PR TITLE
test(plugin-personal-assistant): cover owner profile hint normalization

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/owner/__tests__/profile-hints.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/__tests__/profile-hints.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanHandle,
+  cleanName,
+  normalizePlatform,
+  relationTypeForRole,
+} from "./profile-hints.ts";
+
+describe("cleanName", () => {
+  it("strips quotes and collapses whitespace", () => {
+    expect(cleanName(`  "John"  Doe  `)).toBe("John Doe");
+  });
+
+  it("rejects short, long, and placeholder names", () => {
+    expect(cleanName("a")).toBeNull();
+    expect(cleanName("x".repeat(81))).toBeNull();
+    expect(cleanName("me")).toBeNull();
+    expect(cleanName("someone")).toBeNull();
+  });
+});
+
+describe("cleanHandle", () => {
+  it("trims trailing punctuation", () => {
+    expect(cleanHandle("@johndoe,")).toBe("@johndoe");
+    expect(cleanHandle("johndoe!")).toBe("johndoe");
+  });
+
+  it("rejects empty or short handles", () => {
+    expect(cleanHandle("")).toBeNull();
+    expect(cleanHandle("a")).toBeNull();
+  });
+});
+
+describe("normalizePlatform", () => {
+  it("maps twitter to x and lowercases", () => {
+    expect(normalizePlatform("Twitter")).toBe("x");
+    expect(normalizePlatform("DISCORD")).toBe("discord");
+  });
+});
+
+describe("relationTypeForRole", () => {
+  it("maps known roles", () => {
+    expect(relationTypeForRole("boss")).toBe("managed_by");
+    expect(relationTypeForRole("spouse")).toBe("partner_of");
+    expect(relationTypeForRole("Friend")).toBe("knows");
+  });
+
+  it("falls back to the lowercased role", () => {
+    expect(relationTypeForRole("Accountant")).toBe("accountant");
+  });
+
+  it("handles null", () => {
+    expect(relationTypeForRole(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 8 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
