### PR TITLE
test(plugin-personal-assistant): cover signal runtime config upsert

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/__tests__/signal-runtime-config.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/__tests__/signal-runtime-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { upsertSignalConnectorConfig } from "./signal-runtime-config.ts";
+
+describe("upsertSignalConnectorConfig", () => {
+  it("creates the connector config when absent", () => {
+    const config: Record<string, unknown> = {};
+    const changed = upsertSignalConnectorConfig(config, {
+      authDir: "/tmp/signal",
+      account: "+123",
+    });
+    expect(changed).toBe(true);
+    const signal = config.connectors?.signal as Record<string, unknown>;
+    expect(signal.authDir).toBe("/tmp/signal");
+    expect(signal.account).toBe("+123");
+    expect(signal.enabled).toBe(true);
+  });
+
+  it("updates when values differ", () => {
+    const config = {
+      connectors: { signal: { authDir: "/old", account: "+1", enabled: true } },
+    };
+    const changed = upsertSignalConnectorConfig(config, {
+      authDir: "/new",
+      account: "+2",
+    });
+    expect(changed).toBe(true);
+    expect(config.connectors.signal.authDir).toBe("/new");
+  });
+
+  it("returns false when nothing changed", () => {
+    const config = {
+      connectors: { signal: { authDir: "/s", account: "+1", enabled: true } },
+    };
+    const changed = upsertSignalConnectorConfig(config, {
+      authDir: "/s",
+      account: "+1",
+    });
+    expect(changed).toBe(false);
+  });
+
+  it("ignores malformed existing connector config", () => {
+    const config = { connectors: { signal: "not-an-object" } };
+    const changed = upsertSignalConnectorConfig(config, {
+      authDir: "/s",
+      account: "+1",
+    });
+    expect(changed).toBe(true);
+    expect(config.connectors.signal).toEqual({
+      authDir: "/s",
+      account: "+1",
+      enabled: true,
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
