### PR TITLE
test(agent): cover blocking-core-boot

### DIFF
--- a/packages/agent/src/runtime/__tests__/blocking-core-boot.test.ts
+++ b/packages/agent/src/runtime/__tests__/blocking-core-boot.test.ts
@@ -227,3 +227,167 @@ describe("initializeBlockingCoreRuntimeForBoot", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("preregisterCorePluginsInDependencyWaves dependency liveness", () => {
+  it("orders via the static boot-dependency map even with no declared dependencies", async () => {
+    const runtime = makeRuntime();
+    const resolved = [
+      // dependent listed first with an empty declared dependency list, so only
+      // the built-in CORE_PLUGIN_BOOT_DEPENDENCIES map can impose this order
+      makeResolved("@elizaos/plugin-agent-skills"),
+      makeResolved("@elizaos/plugin-coding-tools"),
+    ];
+    await preregisterCorePluginsInDependencyWaves({
+      runtime: runtime as never,
+      resolvedPlugins: resolved as never,
+      alreadyPreRegistered: new Set(),
+    });
+    const toolsIdx = runtime.registerOrder.indexOf(
+      "@elizaos/plugin-coding-tools",
+    );
+    const skillsIdx = runtime.registerOrder.indexOf(
+      "@elizaos/plugin-agent-skills",
+    );
+    expect(toolsIdx).toBeGreaterThanOrEqual(0);
+    expect(skillsIdx).toBeGreaterThan(toolsIdx);
+  });
+
+  it("marks a failed non-required plugin registered so its dependent is not stranded", async () => {
+    const runtime = makeRuntime();
+    runtime.registerPlugin.mockRejectedValueOnce(new Error("boom"));
+    await preregisterCorePluginsInDependencyWaves({
+      runtime: runtime as never,
+      resolvedPlugins: [
+        makeResolved("@elizaos/plugin-native-filesystem"),
+        makeResolved("@elizaos/plugin-agent-skills", [
+          "@elizaos/plugin-native-filesystem",
+        ]),
+      ] as never,
+      alreadyPreRegistered: new Set(),
+    });
+    expect(runtime.registerOrder).toEqual(["@elizaos/plugin-agent-skills"]);
+  });
+
+  it("breaks a dependency cycle by registering the whole pending set", async () => {
+    const runtime = makeRuntime();
+    await preregisterCorePluginsInDependencyWaves({
+      runtime: runtime as never,
+      resolvedPlugins: [
+        makeResolved("@elizaos/plugin-coding-tools", [
+          "@elizaos/plugin-agent-skills",
+        ]),
+        makeResolved("@elizaos/plugin-agent-skills", [
+          "@elizaos/plugin-coding-tools",
+        ]),
+      ] as never,
+      alreadyPreRegistered: new Set(),
+    });
+    expect(runtime.registerOrder).toHaveLength(2);
+    expect([...runtime.registerOrder].sort()).toEqual([
+      "@elizaos/plugin-agent-skills",
+      "@elizaos/plugin-coding-tools",
+    ]);
+  });
+
+  it("rethrows the original error when a required plugin fails during an active abort", async () => {
+    const abort = new AbortController();
+    const registerOrder: string[] = [];
+    const runtime = {
+      plugins: [],
+      registerOrder,
+      registerPlugin: vi.fn(async (plugin: { name: string }) => {
+        abort.abort();
+        throw new Error(`boom ${plugin.name}`);
+      }),
+    };
+    let caught: unknown;
+    try {
+      await preregisterCorePluginsInDependencyWaves({
+        runtime: runtime as never,
+        resolvedPlugins: [
+          makeResolved("@elizaos/plugin-native-filesystem"),
+        ] as never,
+        alreadyPreRegistered: new Set(),
+        requiredPluginNames: new Set(["@elizaos/plugin-native-filesystem"]),
+        abortSignal: abort.signal,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error).message).toBe(
+      "boom @elizaos/plugin-native-filesystem",
+    );
+    // the active abort must surface the raw cause, not the REQUIRED_CORE_
+    // PLUGIN_REGISTRATION_FAILED wrapper (which always carries .code)
+    expect((caught as { code?: string }).code).toBeUndefined();
+  });
+
+  it("tolerates a runtime whose plugins list is missing", async () => {
+    const registerOrder: string[] = [];
+    const runtime = {
+      registerPlugin: vi.fn(async (plugin: { name: string }) => {
+        registerOrder.push(plugin.name);
+      }),
+      registerOrder,
+    };
+    await preregisterCorePluginsInDependencyWaves({
+      runtime: runtime as never,
+      resolvedPlugins: [
+        makeResolved("@elizaos/plugin-native-filesystem"),
+      ] as never,
+      alreadyPreRegistered: new Set(),
+    });
+    expect(runtime.registerOrder).toEqual([
+      "@elizaos/plugin-native-filesystem",
+    ]);
+  });
+});
+
+describe("initializeBlockingCoreRuntimeForBoot seeding and late abort", () => {
+  it("treats plugin-sql and plugin-local-inference as already pre-registered", async () => {
+    const initializeCoreRuntime = vi.fn(async () => {});
+    const runtime = makeRuntime();
+    await initializeBlockingCoreRuntimeForBoot({
+      blockDeferredPluginImports: false,
+      runtime: runtime as never,
+      resolvedPlugins: [
+        makeResolved("@elizaos/plugin-sql"),
+        makeResolved("@elizaos/plugin-local-inference"),
+      ] as never,
+      requiredPluginNames: new Set(),
+      waitForBlockingEnvironment: async () => {},
+      initializeCoreRuntime,
+    });
+    expect(runtime.registerOrder).toEqual([]);
+    expect(initializeCoreRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts after successful pre-registration and before core initialization", async () => {
+    const abort = new AbortController();
+    const registerOrder: string[] = [];
+    const runtime = {
+      plugins: [],
+      registerOrder,
+      registerPlugin: vi.fn(async (plugin: { name: string }) => {
+        abort.abort();
+        registerOrder.push(plugin.name);
+      }),
+    };
+    const initializeCoreRuntime = vi.fn(async () => {});
+    await expect(
+      initializeBlockingCoreRuntimeForBoot({
+        blockDeferredPluginImports: false,
+        runtime: runtime as never,
+        resolvedPlugins: [
+          makeResolved("@elizaos/plugin-native-filesystem"),
+        ] as never,
+        requiredPluginNames: new Set(),
+        waitForBlockingEnvironment: async () => {},
+        initializeCoreRuntime,
+        abortSignal: abort.signal,
+      }),
+    ).rejects.toThrow();
+    expect(registerOrder).toEqual(["@elizaos/plugin-native-filesystem"]);
+    expect(initializeCoreRuntime).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

## What

Extends `packages/agent/src/runtime/__tests__/blocking-core-boot.test.ts` with seven new cases (+164/-0, test-only diff). No production behavior changes.

## New coverage

All cases drive the real `blocking-core-boot.ts` module through its documented seams and cover branches the existing suite did not:

- **Static boot-dependency map** (`CORE_PLUGIN_BOOT_DEPENDENCIES`): orders `@elizaos/plugin-agent-skills` after `@elizaos/plugin-coding-tools` even when the plugin declares an empty dependency list — the prior ordering case only exercised declared `plugin.dependencies`.
- **Failed non-required plugin unblocks its dependent**: a failing pre-registration still marks the plugin registered so a dependent is not stranded across waves.
- **Dependency-cycle fallback**: two core plugins depending on each other cannot produce a ready wave, so the whole pending set registers (liveness guarantee).
- **Catch-while-aborted**: when a required plugin fails during an active abort, the original error surfaces rather than the `REQUIRED_CORE_PLUGIN_REGISTRATION_FAILED` wrapper (asserted via `.code` being absent).
- **`runtime.plugins ?? []` nullish tolerance** for runtimes without a plugins list.
- **Seeded pre-registration** in `initializeBlockingCoreRuntimeForBoot`: resolved `plugin-sql` and `plugin-local-inference` are treated as already pre-registered and never re-registered.
- **Post-preregistration abort**: an abort after successful pre-registration rejects before `initializeCoreRuntime` runs.

## Verification (fork contributor — hosted CI does not run on this PR)

Run against current `origin/develop` at `1f236fd1f58f` immediately before filing:

- `bunx vitest run packages/agent/src/runtime/__tests__/blocking-core-boot.test.ts` — **Test Files 1 passed (1), Tests 19 passed (19)** (12 pre-existing + 7 new), quoted twice including after final formatting.
- `bunx biome check packages/agent/src/runtime/__tests__/blocking-core-boot.test.ts` — clean ("Checked 1 file ... No fixes applied") against the repo's pinned `biome.json`.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent` — zero occurrences of `blocking-core-boot.test` in output.
- `git diff --numstat origin/develop` on this branch: exactly one file, `+164/-0`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:439b1d4fcdc8fe28bfbc3db41b436d634a7514df -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
