### PR TITLE
test(ui): cover useSlashCommandController

### DIFF
--- a/packages/ui/src/chat/useSlashCommandController.side-effects.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.side-effects.test.ts
@@ -1,0 +1,459 @@
+/** Verifies useSlashCommandController — merged-catalog composition, app-level side effects, and telemetry reporting guards through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Complements the catalog/models suites with the parts they do not reach: the
+ * alias-merge precedence between the server catalog, saved commands
+ * (localStorage) and enabled custom actions; the navigation side effects the
+ * composer menu invokes (tab switch, settings/view/palette DOM events, chat
+ * clear); and the fire-and-forget telemetry guards (#8792) — no fetch without
+ * a configured API base or token, and a failed report POST degrades to a
+ * logger.warn instead of breaking navigation.
+ */
+
+import type { CustomActionDef } from "@elizaos/shared";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../api";
+import { SETTINGS_SECTION_SUGGESTIONS } from "../components/settings/settings-section-tokens";
+import { NAVIGATE_VIEW_EVENT } from "../events";
+
+vi.mock("../api", () => ({
+  client: {
+    getBaseUrl: () => "http://localhost:2138",
+    listCommands: vi
+      .fn<(surface?: string) => Promise<never[]>>()
+      .mockResolvedValue([]),
+    listCustomActions: vi.fn<() => Promise<never[]>>().mockResolvedValue([]),
+    getModelsCatalog: vi.fn(() =>
+      Promise.reject(new Error("getModelsCatalog not expected in this suite")),
+    ),
+  },
+}));
+vi.mock("../state", () => {
+  const setTab = vi.fn<(tab: string) => void>();
+  const handleChatClear = vi.fn<() => Promise<void>>();
+  function useAppSelectorShallow<T>(
+    selector: (s: {
+      setTab: typeof setTab;
+      handleChatClear: typeof handleChatClear;
+    }) => T,
+  ): T {
+    return selector({ setTab, handleChatClear });
+  }
+  return { useAppSelectorShallow, __spies: { setTab, handleChatClear } };
+});
+vi.mock("../hooks/useAvailableViews", () => {
+  let views: Array<{ id: string }> = [];
+  function useAvailableViews(): { views: Array<{ id: string }> } {
+    return { views };
+  }
+  return {
+    useAvailableViews,
+    __setViews(next: Array<{ id: string }>): void {
+      views = next;
+    },
+  };
+});
+vi.mock("../utils/eliza-globals", () => {
+  let base = "http://localhost:2138";
+  let token: string | null = "test-token";
+  let failBaseRead = false;
+  return {
+    getElizaApiBase: () => {
+      if (failBaseRead) throw new Error("base store unavailable");
+      return base;
+    },
+    getElizaApiToken: () => token,
+    setElizaApiBase: (next: string) => {
+      base = next;
+    },
+    setElizaApiToken: (next: string | null) => {
+      token = next;
+    },
+    clearElizaApiBase: () => {
+      base = "";
+    },
+    clearElizaApiToken: () => {
+      token = null;
+    },
+    __setGlobals(next: {
+      base?: string;
+      token?: string | null;
+      failBaseRead?: boolean;
+    }): void {
+      if (next.base !== undefined) base = next.base;
+      if (next.token !== undefined) token = next.token;
+      if (next.failBaseRead !== undefined) failBaseRead = next.failBaseRead;
+    },
+  };
+});
+
+import { CUSTOM_COMMANDS_STORAGE_KEY } from "./index";
+import { useSlashCommandController } from "./useSlashCommandController";
+
+const stateNs = (await import("../state")) as unknown as {
+  __spies: {
+    setTab: ReturnType<typeof vi.fn<(tab: string) => void>>;
+    handleChatClear: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  };
+};
+const viewsNs = (await import("../hooks/useAvailableViews")) as unknown as {
+  __setViews: (next: Array<{ id: string }>) => void;
+};
+const globalsNs = (await import("../utils/eliza-globals")) as unknown as {
+  __setGlobals: (next: {
+    base?: string;
+    token?: string | null;
+    failBaseRead?: boolean;
+  }) => void;
+};
+
+const listCommands = vi.mocked(client.listCommands);
+const listCustomActions = vi.mocked(client.listCustomActions);
+
+import { logger } from "@elizaos/logger";
+import type { SlashCommandCatalogItem } from "../api/client-types-commands";
+
+function cmd(
+  partial: Partial<SlashCommandCatalogItem> & { key: string },
+): SlashCommandCatalogItem {
+  return {
+    nativeName: partial.key,
+    description: "",
+    textAliases: [`/${partial.key}`],
+    scope: "both",
+    acceptsArgs: false,
+    args: [],
+    requiresAuth: false,
+    requiresElevated: false,
+    target: { kind: "agent" },
+    ...partial,
+    source: partial.source ?? "builtin",
+  };
+}
+
+function customAction(
+  partial: Partial<CustomActionDef> & { name: string },
+): CustomActionDef {
+  const { name, ...rest } = partial;
+  return {
+    id: `action-${name.toLowerCase()}`,
+    name,
+    description: "",
+    parameters: [],
+    handler: { type: "shell", command: "echo hi" },
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...rest,
+  };
+}
+
+function seedSavedCommands(
+  commands: Array<{ name: string; text: string }>,
+): void {
+  window.localStorage.setItem(
+    CUSTOM_COMMANDS_STORAGE_KEY,
+    JSON.stringify(
+      commands.map((c, i) => ({ ...c, createdAt: 1700000000000 + i })),
+    ),
+  );
+}
+
+async function renderLoadedController(
+  options?: Parameters<typeof useSlashCommandController>[0],
+) {
+  const harness = renderHook(() => useSlashCommandController(options));
+  await waitFor(() => expect(harness.result.current.loading).toBe(false));
+  return harness;
+}
+
+function lastFetchCall(): [string, RequestInit] {
+  expect(fetchMock).toHaveBeenCalled();
+  return fetchMock.mock.calls.at(-1) as unknown as [string, RequestInit];
+}
+
+const fetchMock =
+  vi.fn<
+    (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+  >();
+
+beforeEach(() => {
+  listCommands.mockReset().mockResolvedValue([]);
+  listCustomActions.mockReset().mockResolvedValue([]);
+  stateNs.__spies.setTab.mockClear();
+  stateNs.__spies.handleChatClear.mockReset().mockResolvedValue(undefined);
+  viewsNs.__setViews([]);
+  globalsNs.__setGlobals({
+    base: "http://localhost:2138",
+    token: "test-token",
+    failBaseRead: false,
+  });
+  window.localStorage.clear();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response("{}"));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useSlashCommandController — merged catalog composition", () => {
+  it("keeps the server definition on alias collisions and appends saved then custom commands in order", async () => {
+    listCommands.mockResolvedValue([
+      cmd({ key: "settings" }),
+      cmd({ key: "help", textAliases: ["/Help"] }),
+    ]);
+    seedSavedCommands([
+      { name: "/Deploy Prod", text: "deploy now" },
+      // Normalizes to the same alias as the server's /settings command.
+      { name: "settings", text: "open settings" },
+    ]);
+    listCustomActions.mockResolvedValue([
+      customAction({ name: "HELP" }),
+      customAction({ name: "Weather", enabled: true }),
+      customAction({ name: "Echo", enabled: false }),
+    ]);
+
+    const { result } = await renderLoadedController();
+
+    // Server first; colliding saved (/settings) and custom (/help) dropped;
+    // disabled custom action excluded; locally-derived survivors keep their
+    // group order (saved before custom actions).
+    expect(result.current.commands.map((c) => c.key)).toEqual([
+      "settings",
+      "help",
+      "saved:deploy prod",
+      "custom-action:weather",
+    ]);
+    expect(result.current.commands[2].source).toBe("saved");
+    expect(result.current.commands[3].source).toBe("custom-action");
+    expect(result.current.error).toBe(false);
+  });
+
+  it("renders locally-derived saved and custom commands when the server catalog is empty", async () => {
+    seedSavedCommands([{ name: "notes", text: "open notes" }]);
+    listCustomActions.mockResolvedValue([customAction({ name: "Status" })]);
+
+    const { result } = await renderLoadedController();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.commands.map((c) => c.key)).toEqual([
+      "saved:notes",
+      "custom-action:status",
+    ]);
+    // A healthy empty SERVER catalog is not a degraded load.
+    expect(result.current.error).toBe(false);
+  });
+});
+
+describe("useSlashCommandController — app-level side effects", () => {
+  it("navigateTab switches the shell tab and reports the surface without a path", async () => {
+    const { result } = await renderLoadedController();
+
+    act(() => result.current.navigateTab("inventory"));
+
+    expect(stateNs.__spies.setTab).toHaveBeenCalledWith("inventory");
+    const [url, init] = lastFetchCall();
+    expect(url).toBe("http://localhost:2138/api/views/inventory/navigate");
+    expect(init.method).toBe("POST");
+    // No optional path key when none was provided.
+    expect(JSON.parse(init.body as string)).toEqual({ source: "user" });
+  });
+
+  it("navigateSettings dispatches the settings event with the section and reports it as a settings view path", async () => {
+    const { NAVIGATE_SETTINGS_EVENT } = await import(
+      "./useSlashCommandController"
+    );
+    const seen: CustomEvent<{ section?: string }>[] = [];
+    const listener = (e: Event): void => {
+      seen.push(e as CustomEvent<{ section?: string }>);
+    };
+    window.addEventListener(NAVIGATE_SETTINGS_EVENT, listener);
+    const { result } = await renderLoadedController();
+
+    act(() => result.current.navigateSettings("appearance"));
+
+    window.removeEventListener(NAVIGATE_SETTINGS_EVENT, listener);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].detail.section).toBe("appearance");
+
+    const [url, init] = lastFetchCall();
+    expect(url).toBe("http://localhost:2138/api/views/settings/navigate");
+    expect(JSON.parse(init.body as string)).toEqual({
+      source: "user",
+      path: "appearance",
+    });
+  });
+
+  it("navigateView dispatches the view-navigation event and reports only when a viewId is present", async () => {
+    const seen: CustomEvent[] = [];
+    const listener = (e: Event): void => {
+      seen.push(e as CustomEvent);
+    };
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+    const { result } = await renderLoadedController();
+
+    act(() =>
+      result.current.navigateView({
+        viewId: "wallet-view",
+        viewPath: "/wallet",
+      }),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].detail).toMatchObject({
+      viewId: "wallet-view",
+      viewPath: "/wallet",
+    });
+    const [url, init] = lastFetchCall();
+    expect(url).toBe("http://localhost:2138/api/views/wallet-view/navigate");
+    expect(JSON.parse(init.body as string)).toEqual({
+      source: "user",
+      path: "/wallet",
+    });
+
+    // A bare deep-link (no viewId) still navigates but is never reported —
+    // the reporter keys off the viewId guard.
+    fetchMock.mockClear();
+    act(() => result.current.navigateView({ viewPath: "/deep/link" }));
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1].detail).toMatchObject({ viewPath: "/deep/link" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
+  it("clearChat delegates to the shell's chat-clear handler", async () => {
+    const { result } = await renderLoadedController();
+
+    act(() => result.current.clearChat());
+
+    expect(stateNs.__spies.handleChatClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("openCommandPalette dispatches the command palette event on the document", async () => {
+    const { COMMAND_PALETTE_EVENT } = await import("../events");
+    let fired = 0;
+    const listener = (): void => {
+      fired += 1;
+    };
+    document.addEventListener(COMMAND_PALETTE_EVENT, listener);
+    const { result } = await renderLoadedController();
+
+    act(() => result.current.openCommandPalette());
+
+    document.removeEventListener(COMMAND_PALETTE_EVENT, listener);
+    expect(fired).toBe(1);
+  });
+
+  it("keeps natural-language shortcuts disabled — slash protocol stays explicit", async () => {
+    const { result } = await renderLoadedController();
+    expect(result.current.naturalShortcutsEnabled).toBe(false);
+  });
+});
+
+describe("useSlashCommandController — telemetry reporting guards (#8792)", () => {
+  it("fires no report request when no API base is configured, without throwing", async () => {
+    globalsNs.__setGlobals({ base: "" });
+    const { result } = await renderLoadedController();
+
+    expect(() => {
+      act(() => result.current.navigateTab("inventory"));
+      result.current.navigateSettings("appearance");
+      act(() =>
+        result.current.navigateView({ viewId: "wallet-view", viewPath: "/" }),
+      );
+    }).not.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("omits the Authorization header when no API token is configured", async () => {
+    globalsNs.__setGlobals({ token: null });
+
+    const { reportShortcutFired } = await import("./useSlashCommandController");
+    reportShortcutFired("show-keyboard-shortcuts");
+
+    const [, init] = lastFetchCall();
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.Authorization).toBeUndefined();
+    expect(JSON.parse(init.body as string)).toEqual({
+      shortcutId: "show-keyboard-shortcuts",
+    });
+  });
+
+  it("degrades a non-ok report response to a logged warning for both reporters", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    fetchMock.mockResolvedValue(new Response("{}", { status: 500 }));
+
+    const { reportShortcutFired, reportUserViewSwitch } = await import(
+      "./useSlashCommandController"
+    );
+    expect(() => reportUserViewSwitch("wallet")).not.toThrow();
+    expect(() => reportShortcutFired("toggle-terminal")).not.toThrow();
+
+    await vi.waitFor(() => expect(warnSpy).toHaveBeenCalledTimes(2));
+    const messages = warnSpy.mock.calls.map((call) => String(call[0]));
+    expect(
+      messages.find((m) => m.includes("view-switch report failed")),
+    ).toBeTruthy();
+    expect(
+      messages.find((m) => m.includes("shortcut report failed")),
+    ).toBeTruthy();
+    expect(messages.join("\n")).toContain("500");
+  });
+
+  it("survives a synchronously failing API-base read without dispatching anything", async () => {
+    globalsNs.__setGlobals({ failBaseRead: true });
+
+    const { reportShortcutFired, reportUserViewSwitch } = await import(
+      "./useSlashCommandController"
+    );
+    expect(() => reportUserViewSwitch("wallet")).not.toThrow();
+    expect(() => reportShortcutFired("toggle-terminal")).not.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSlashCommandController — choice resolution sources", () => {
+  it("resolves view ids from the live registry and passes the settings suggestions through", async () => {
+    viewsNs.__setViews([{ id: "wallet-view" }, { id: "notes-view" }]);
+    const { result } = await renderLoadedController();
+
+    expect(result.current.resolveChoices("views")).toEqual([
+      "wallet-view",
+      "notes-view",
+    ]);
+    // The completion source IS the shared suggestion list, not a copy.
+    expect(result.current.resolveChoices("settings-sections")).toBe(
+      SETTINGS_SECTION_SUGGESTIONS,
+    );
+    expect(SETTINGS_SECTION_SUGGESTIONS.length).toBeGreaterThan(0);
+  });
+
+  it("answers no completions for sources this controller does not wire", async () => {
+    const { result } = await renderLoadedController();
+
+    // No models catalog was fetched (no loaded command declares a models arg).
+    expect(result.current.resolveChoices("models")).toEqual([]);
+    expect(result.current.resolveChoices("skills")).toEqual([]);
+    expect(result.current.resolveChoices("providers")).toEqual([]);
+  });
+
+  it("maps user-typed settings tokens to canonical section ids via resolveSection", async () => {
+    const { result } = await renderLoadedController();
+
+    expect(result.current.resolveSection("theme")).toBe("appearance");
+    expect(result.current.resolveSection("  MODEL ")).toBe("ai-model");
+    expect(
+      result.current.resolveSection("not-a-real-section-token"),
+    ).toBeUndefined();
+    expect(result.current.resolveSection("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/chat/useSlashCommandController.side-effects.test.ts` — a new, complementary vitest suite for `useSlashCommandController`. Test-only: **1 new file, +459/−0**, no production code touched.

## Why

Current develop already carries two suites for this hook (`useSlashCommandController.catalog.test.ts`, `useSlashCommandController.models.test.ts`). This suite covers the behavior they do not reach:

- **Merged-catalog composition** — server catalog wins alias collisions (case-insensitively) against saved commands and custom actions; locally-derived saved (localStorage-seeded through the real `loadSavedCustomCommands` path) and enabled custom-action commands still render when the server catalog is empty; disabled custom actions are excluded.
- **App-level side effects** — `navigateTab` switches the shell tab and reports `{ source: "user" }` with no path key; `navigateSettings` dispatches `NAVIGATE_SETTINGS_EVENT` with the section detail and reports it as a settings view path; `navigateView` dispatches the real `NAVIGATE_VIEW_EVENT` on window and reports only when a `viewId` is present (bare deep-links navigate unreported); `clearChat` delegates to the shell handler; `openCommandPalette` fires the palette event on document; `naturalShortcutsEnabled` stays `false`.
- **Telemetry guards (#8792)** — no report fetch without a configured API base; Authorization header omitted when no token; a synchronously failing base read never throws; a non-ok report response degrades to `logger.warn` for both reporters instead of breaking navigation.
- **Choice sources beyond "models"** — view ids from the live registry, the shared `SETTINGS_SECTION_SUGGESTIONS` passed through by reference, unwired sources answer empty, and `resolveSection` maps typed tokens to canonical section ids.

Assertions drive the real module (real events bus, real saved-command storage parsing, stubbed only at the network boundary), matching the house rule of asserting observed behavior rather than mock echoes.

## Evidence

- `bunx vitest run src/chat/useSlashCommandController.side-effects.test.ts` (packages/ui, vitest 4.1.10 jsdom): **1 file passed, 15 tests passed**, 0 failed.
- `bunx biome check src/chat/useSlashCommandController.side-effects.test.ts`: clean ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mention the new file; total package error count is unchanged versus an untouched control run (14 pre-existing errors elsewhere, none added).

## Notes for reviewers

- Fork contribution: hosted CI does **not** run on this PR — the counts above are from local runs against current `origin/develop`.
- The diff adds a brand-new file beside the existing suites; it deletes nothing and rewrites no existing coverage.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ae31dd0e4d37b63c6f6b35e282d4a59a3a4fa1b2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
