### PR TITLE
test(agent): cover ws-event-replay

### DIFF
--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -164,3 +164,121 @@ describe("selectReplayEvents — fail-closed on non-positive limit", () => {
     expect(selectReplayEvents(buffer, 5, 1.9)).toEqual([buffer.at(-1)]);
   });
 });
+
+describe("eventSequence — invalid bufferSeq falls back to eventId", () => {
+  it("ignores a negative bufferSeq and parses the eventId instead", () => {
+    expect(eventSequence({ eventId: "evt-9", bufferSeq: -1 })).toBe(9);
+  });
+
+  it("ignores a fractional bufferSeq", () => {
+    expect(eventSequence({ eventId: "evt-9", bufferSeq: 2.5 })).toBe(9);
+  });
+
+  it("ignores an unsafe bufferSeq above MAX_SAFE_INTEGER", () => {
+    expect(
+      eventSequence({
+        eventId: "evt-4",
+        bufferSeq: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).toBe(4);
+  });
+});
+
+describe("eventSequence — eventId parse edges", () => {
+  it("parses digits followed by trailing whitespace", () => {
+    expect(eventSequence({ eventId: "evt-7  " })).toBe(7);
+  });
+
+  it("uses the last digit run when the id has interleaved text", () => {
+    expect(eventSequence({ eventId: "batch12-run34" })).toBe(34);
+  });
+
+  it("returns null when the parsed sequence exceeds MAX_SAFE_INTEGER", () => {
+    expect(eventSequence({ eventId: "evt-99999999999999999999" })).toBeNull();
+  });
+
+  it("returns null for the bare prefix evt-", () => {
+    expect(eventSequence({ eventId: "evt-" })).toBeNull();
+  });
+});
+
+describe("parseEventCursor — numeric bounds", () => {
+  it("accepts exactly MAX_SAFE_INTEGER in both cursor forms", () => {
+    expect(parseEventCursor("9007199254740991")).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseEventCursor("evt-9007199254740991")).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("returns null for cursors beyond MAX_SAFE_INTEGER", () => {
+    expect(parseEventCursor("9007199254740992")).toBeNull();
+    expect(parseEventCursor("evt-99999999999999999999")).toBeNull();
+  });
+
+  it("parses zero-padded cursors as their integer value", () => {
+    expect(parseEventCursor("007")).toBe(7);
+  });
+});
+
+describe("selectReplayEvents — unsequenceable envelopes under a cursor", () => {
+  it("skips envelopes with no derivable sequence instead of failing or leaking them", () => {
+    const buffer: ReplayableEvent[] = [
+      { eventId: "evt-a" },
+      { eventId: "evt-2" },
+      { eventId: "no-sequence" },
+      { eventId: "evt-3" },
+    ];
+    const result = selectReplayEvents(buffer, 1);
+    expect(result.map((e) => e.eventId)).toEqual(["evt-2", "evt-3"]);
+  });
+});
+
+describe("selectReplayEvents — tied sequences", () => {
+  it("replays every envelope past the cursor, including duplicates, in buffer order", () => {
+    const buffer: ReplayableEvent[] = [
+      { eventId: "evt-1", bufferSeq: 1 },
+      { eventId: "evt-2a", bufferSeq: 2 },
+      { eventId: "evt-2b", bufferSeq: 2 },
+      { eventId: "evt-3", bufferSeq: 3 },
+    ];
+    const result = selectReplayEvents(buffer, 1);
+    expect(result.map((e) => e.eventId)).toEqual(["evt-2a", "evt-2b", "evt-3"]);
+  });
+});
+
+describe("selectReplayEvents — cap boundary under a cursor", () => {
+  it("returns all missing events unsliced when they exactly equal the cap", () => {
+    const buffer = makeBuffer(10); // seq 1..10
+    const result = selectReplayEvents(buffer, 4, 6); // missing 5..10 == cap
+    expect(result.map((e) => e.bufferSeq)).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("keeps only the newest cap events when missing exceeds the cap by one", () => {
+    const buffer = makeBuffer(10);
+    const result = selectReplayEvents(buffer, 3, 6); // missing 4..10 = 7 > 6
+    expect(result.map((e) => e.bufferSeq)).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("leaves the input buffer untouched after a capped replay", () => {
+    const buffer = makeBuffer(12);
+    const snapshot = [...buffer];
+    selectReplayEvents(buffer, 0, 5);
+    expect(buffer).toEqual(snapshot);
+    expect(buffer).toHaveLength(12);
+  });
+});
+
+describe("selectReplayEvents — explicit non-default limit without a cursor", () => {
+  it("returns tail slice(-limit) for an explicit limit below the buffer size", () => {
+    const buffer = makeBuffer(10);
+    const result = selectReplayEvents(buffer, null, 3);
+    expect(result.map((e) => e.bufferSeq)).toEqual([8, 9, 10]);
+  });
+
+  it("returns a full ordered copy when the limit covers the whole buffer", () => {
+    const buffer = makeBuffer(4);
+    const result = selectReplayEvents(buffer, null, 10);
+    expect(result).toEqual(buffer);
+    expect(result).not.toBe(buffer);
+  });
+});


### PR DESCRIPTION

## What

Appends real unit coverage for the pure WS event-buffer replay helpers in `packages/agent/src/api/ws-event-replay.ts`, extending the existing suite at `packages/agent/src/api/__tests__/ws-event-replay.test.ts`.

Test-only change: one file, +118/-0, no production code touched. A suite for this module landed on develop between target selection and filing, so per the additive-only policy this PR strictly APPENDS new cases — nothing removed, nothing rewritten, no existing assertion weakened.

## New cases (+17)

**`eventSequence` — invalid `bufferSeq` fallback**
- negative `bufferSeq` is ignored; the eventId suffix wins
- fractional `bufferSeq` is ignored
- unsafe `bufferSeq` above `Number.MAX_SAFE_INTEGER` is ignored

**`eventSequence` — eventId parse edges**
- digits followed by trailing whitespace parse (`"evt-7  "` → 7)
- last digit run wins when text is interleaved (`"batch12-run34"` → 34)
- parsed value beyond `MAX_SAFE_INTEGER` returns null
- bare `"evt-"` prefix returns null

**`parseEventCursor` — numeric bounds**
- exactly `MAX_SAFE_INTEGER` accepted in both `"N"` and `"evt-N"` forms
- one past `MAX_SAFE_INTEGER` rejected; far overflow rejected
- zero-padded `"007"` parses as 7

**`selectReplayEvents` under a cursor**
- envelopes with no derivable sequence are skipped (not leaked, not fatal)
- tied duplicate sequences all replay in buffer order
- exact-at-cap boundary returns the full missing set unsliced; cap+1 slices to the newest cap
- input buffer left untouched after a capped replay

**explicit non-default limit without a cursor**
- tail `slice(-limit)` behavior below the default limit
- full ordered copy (new array identity) when the limit covers the buffer

All assertions record observed behavior of the real module; the suite drives the actual functions with plain inputs — no mocks standing in for the subject.

## Evidence (test-only PR; no production behavior changed)

- `bunx vitest run src/api/__tests__/ws-event-replay.test.ts` (in `packages/agent`): **1 file passed, 36 passed / 0 failed** (19 pre-existing + 17 added), re-run against current `origin/develop` immediately before filing
- `bunx biome check --write packages/agent/src/api/__tests__/ws-event-replay.test.ts`: clean ("Checked 1 file", no fixes applied)
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent`: zero mentions of `ws-event-replay` — no new type errors introduced
- Diff is a single new-to-this-branch test-file addition, +118/-0

Hosted CI does not run on fork pull requests; the counts above are quoted verbatim from local runs on the pinned toolchain (Bun 1.3.14).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0fa0a883483ab21a692dd22c3d01083b995ebc89 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
