### PR TITLE
test(agent): cover memory-watchdog

### DIFF
--- a/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
+++ b/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
@@ -343,3 +343,86 @@ describe("createMemoryWatchdog start/stop (timer-driven)", () => {
     setIntervalSpy.mockRestore();
   });
 });
+
+// Kept as a separate import group below the suites it serves so this additive
+// extension never rewrites the pre-existing import block.
+import { startMemoryWatchdog, stopMemoryWatchdog } from "../memory-watchdog.ts";
+
+describe("resolveMemoryWatchdogConfig integer-parsing edges", () => {
+  it("clamps negative values up to their floors", () => {
+    expect(
+      resolveMemoryWatchdogConfig({
+        ELIZA_MEMORY_WATCHDOG_RSS_MB: "-512",
+        ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "-250",
+        ELIZA_MEMORY_WATCHDOG_SUSTAINED: "-2",
+      }),
+    ).toEqual({ rssThresholdMb: 128, intervalMs: 1_000, sustainedSamples: 1 });
+  });
+
+  it("falls back to defaults for empty-string values", () => {
+    expect(
+      resolveMemoryWatchdogConfig({
+        ELIZA_MEMORY_WATCHDOG_RSS_MB: "",
+        ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "",
+        ELIZA_MEMORY_WATCHDOG_SUSTAINED: "",
+      }),
+    ).toEqual({
+      rssThresholdMb: 1536,
+      intervalMs: 30_000,
+      sustainedSamples: 3,
+    });
+  });
+
+  it("parses the leading integer after trimming whitespace and ignores trailing units", () => {
+    expect(
+      resolveMemoryWatchdogConfig({
+        ELIZA_MEMORY_WATCHDOG_RSS_MB: " 2048 ",
+        ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "5000ms",
+        ELIZA_MEMORY_WATCHDOG_SUSTAINED: "2 samples",
+      }),
+    ).toEqual({ rssThresholdMb: 2048, intervalMs: 5_000, sustainedSamples: 2 });
+  });
+});
+
+describe("startMemoryWatchdog / stopMemoryWatchdog (process-wide singleton)", () => {
+  const enabledEnv: NodeJS.ProcessEnv = {
+    ELIZA_MEMORY_WATCHDOG: "1",
+    // 1 TiB expressed in MB — far above any real RSS, so the live sampler
+    // never reaches threshold and no restart request can fire in tests.
+    ELIZA_MEMORY_WATCHDOG_RSS_MB: "1048576",
+    ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "60000",
+    ELIZA_MEMORY_WATCHDOG_SUSTAINED: "2",
+  };
+
+  afterEach(() => {
+    stopMemoryWatchdog();
+  });
+
+  it("returns null while disabled, and stop() without a watchdog is a safe no-op", () => {
+    expect(startMemoryWatchdog({})).toBeNull();
+    expect(() => stopMemoryWatchdog()).not.toThrow();
+    expect(startMemoryWatchdog({ ELIZA_MEMORY_WATCHDOG: "0" })).toBeNull();
+  });
+
+  it("starts a live sampler wired to the real process RSS", () => {
+    const wd = startMemoryWatchdog(enabledEnv);
+    expect(wd).not.toBeNull();
+    if (!wd) return;
+    // The production readRssBytes seam feeds real process.memoryUsage().rss,
+    // which stays far below the 1 TiB threshold on a manual tick.
+    expect(wd.tick()).toBe(false);
+  });
+
+  it("returns the same watchdog while active and a fresh one after stop()", () => {
+    const first = startMemoryWatchdog(enabledEnv);
+    expect(first).not.toBeNull();
+    const second = startMemoryWatchdog(enabledEnv);
+    expect(second).toBe(first);
+
+    stopMemoryWatchdog();
+
+    const third = startMemoryWatchdog(enabledEnv);
+    expect(third).not.toBeNull();
+    expect(third).not.toBe(first);
+  });
+});


### PR DESCRIPTION

## Summary

Extends the **existing** unit suite for `packages/agent/src/runtime/memory-watchdog.ts` with six new cases: `+83 / -0`, additive only, not a single existing line rewritten.

Current `origin/develop` already ships `src/runtime/__tests__/memory-watchdog.test.ts` (18 cases covering env-flag parsing, config defaults/floors, the tick debounce/one-shot/re-arm state machine, and timer-driven start/stop). Per this repository's additive-only policy for existing suites, this PR appends to that suite rather than adding a duplicate file or reorganizing anything.

## New coverage

`resolveMemoryWatchdogConfig` integer-parsing edges (previously unpinned branches):

- negative values clamp up to their floors (`-512` → `128` MB, `-250` → `1000` ms, `-2` → `1` sample)
- empty-string values fall back to defaults (`""` parses to NaN → fallback)
- surrounding whitespace is trimmed and trailing units are ignored by the leading-integer parse (`" 2048 "`, `"5000ms"`, `"2 samples"`)

`startMemoryWatchdog` / `stopMemoryWatchdog` module-singleton lifecycle (two exported functions with no prior coverage):

- returns `null` while disabled, and `stop()` with no watchdog is a safe no-op
- starts a live sampler wired through the production seams — a manual `tick()` reads real `process.memoryUsage().rss` against an unreachable 1 TiB threshold and evaluates `false`; nothing about the RSS reader or restart seam is mocked
- hands back the same watchdog instance while active and constructs a fresh one after `stop()` (singleton reset)

## Verification

All runs against current `origin/develop` (`1f236fd1f58f`) immediately before filing, head `2e1fdaa04ecef9f352781bfb6909e7c734ea8b17`:

- `bunx vitest run packages/agent/src/runtime/__tests__/memory-watchdog.test.ts` → **Test Files 1 passed (1), Tests 24 passed (24)** (18 pre-existing + 6 new)
- `bunx biome check --write` on the touched file → clean; `git diff --numstat origin/develop..HEAD` → `83 0` (zero deletions)
- `tsc --noEmit -p tsconfig.json` in `packages/agent` → the new test code appears nowhere in the output (the package has 36 lines of pre-existing diagnostics elsewhere, unchanged by this diff)
- The diff touches only `packages/agent/src/runtime/__tests__/memory-watchdog.test.ts`. No production behavior change, no `expectTypeOf`, no `vi.hoisted`.

This comes from a fork contributor: hosted CI does not run on this pull request, so the local counts above are the verification record.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2e1fdaa04ecef9f352781bfb6909e7c734ea8b17 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
