### PR TITLE
test(agent-skills): cover binance compat-utils content extraction

### DIFF
--- a/plugins/plugin-agent-skills/src/binance/compat-utils.test.ts
+++ b/plugins/plugin-agent-skills/src/binance/compat-utils.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for {@link extractCompatTextContent} — the content-shape normalizer
+ * feeding the Binance direct-skill fast path. Drives the real pure function
+ * over every accepted message-content shape (plain string, text-part array,
+ * `{ text }` object) plus malformed inputs, asserting the exact concatenated
+ * output each shape produces. Deterministic; no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractCompatTextContent } from "./compat-utils";
+
+describe("extractCompatTextContent", () => {
+	describe("string content passes through verbatim", () => {
+		it("returns a plain string unchanged", () => {
+			expect(extractCompatTextContent("buy 0.5 BTC")).toBe("buy 0.5 BTC");
+		});
+
+		it("preserves an empty string instead of coercing it away", () => {
+			expect(extractCompatTextContent("")).toBe("");
+		});
+	});
+
+	describe("text-part arrays", () => {
+		it("joins text parts in order without separators", () => {
+			const content = [
+				{ type: "text", text: "hello, " },
+				{ type: "text", text: "world" },
+			];
+			expect(extractCompatTextContent(content)).toBe("hello, world");
+		});
+
+		it("includes parts that carry no explicit type field", () => {
+			const content = [{ text: "no type declared" }];
+			expect(extractCompatTextContent(content)).toBe("no type declared");
+		});
+
+		it("skips parts typed as something other than text", () => {
+			const content = [
+				{ type: "text", text: "keep " },
+				{ type: "image", text: "binary-prompt-leak" },
+				{ type: "tool_call", text: "ignored" },
+			];
+			expect(extractCompatTextContent(content)).toBe("keep ");
+		});
+
+		it("skips entries whose type field is not a string", () => {
+			const content = [{ type: 7, text: "untyped-by-type" }];
+			expect(extractCompatTextContent(content)).toBe("untyped-by-type");
+		});
+
+		it("skips non-object entries inside the array", () => {
+			const content = [
+				null,
+				42,
+				true,
+				"raw string part",
+				{ type: "text", text: "only this" },
+			];
+			expect(extractCompatTextContent(content)).toBe("only this");
+		});
+
+		it("drops empty-string text parts but keeps surrounding ones", () => {
+			const content = [
+				{ type: "text", text: "before" },
+				{ type: "text", text: "" },
+				{ type: "text", text: "after" },
+			];
+			expect(extractCompatTextContent(content)).toBe("beforeafter");
+		});
+
+		it("skips parts whose text field is not a string", () => {
+			const content = [
+				{ type: "text", text: 99 },
+				{ type: "text", text: null },
+				{ type: "text", text: "kept" },
+			];
+			expect(extractCompatTextContent(content)).toBe("kept");
+		});
+
+		it("returns an empty string when no entry contributes text", () => {
+			expect(
+				extractCompatTextContent([{ type: "image" }, null, "stray"]),
+			).toBe("");
+		});
+	});
+
+	describe("object content with a text field", () => {
+		it("returns a string text field verbatim", () => {
+			expect(extractCompatTextContent({ text: "solo body" })).toBe(
+				"solo body",
+			);
+		});
+
+		it("returns an empty string when text is not a string", () => {
+			expect(extractCompatTextContent({ text: 1234 })).toBe("");
+			expect(extractCompatTextContent({ text: null })).toBe("");
+		});
+
+		it("returns an empty string when the object has no text field", () => {
+			expect(extractCompatTextContent({ role: "user" })).toBe("");
+		});
+
+		it("does not recurse into nested objects", () => {
+			expect(
+				extractCompatTextContent({ text: { text: "nested" } }),
+			).toBe("");
+		});
+	});
+
+	describe("unsupported shapes normalize to empty string", () => {
+		it.each([null, undefined, 0, 7, false, true])(
+			"maps %p to an empty string",
+			(content) => {
+				expect(extractCompatTextContent(content)).toBe("");
+			},
+		);
+	});
+});


### PR DESCRIPTION

## What

Adds `plugins/plugin-agent-skills/src/binance/compat-utils.test.ts` — a colocated vitest suite for `extractCompatTextContent`, the content-shape normalizer that feeds the Binance direct-skill fast path. The diff is one new test file (+118/-0); no production behavior changes.

## Why this file

The lane was pointed at `packages/agent/src/config/types.ts`, which turns out to be a single-line type-only re-export barrel (`export * from "@elizaos/shared"`). It has no runtime surface a coverage lane can exercise without restating the source back at itself, so per this repository's test-integrity policy it was reported unusable and skipped rather than forcing a hollow suite onto it. `extractCompatTextContent` in the same owning area of work is real branching logic with zero existing coverage anywhere in the repo, no open PR touching it, and no other claimant.

## Coverage

The suite drives the real function (pure module, no mocks) across every accepted message-content shape:

- plain strings pass through verbatim, including the empty string;
- text-part arrays join their parts in order;
- array entries typed as something other than `text` are skipped, while entries with no type field (or a non-string type value) still contribute;
- non-object array entries (null, numbers, booleans, bare strings) are skipped;
- empty-string and non-string `text` fields contribute nothing but do not abort the join;
- `{ text }` object content passes strings through and maps missing/non-string/nested-object text to `""`;
- unsupported top-level shapes (null, undefined, numbers, booleans) map to `""`.

## Verification (fork contributor: hosted CI does not run on this PR)

- `bunx vitest run src/binance/compat-utils.test.ts` in `plugins/plugin-agent-skills`: **Test Files 1 passed (1), Tests 20 passed (20)** — run twice, including an immediate re-fetch/re-run against current `origin/develop` (`1f236fd1f58f`) before filing.
- `bunx biome check --write src/binance/compat-utils.test.ts`: clean ("Checked 1 file... No fixes applied"), against the repo's real root `biome.json` (worktree is not sparse).
- `bunx tsc --noEmit` in `plugins/plugin-agent-skills`: the new test file appears nowhere in the output. The package's tsconfig excludes `**/*.test.ts` by repository convention; the only emitted error is pre-existing in tracked source (`src/api/skills-routes.ts(20,3)`), untouched by this diff.
- `git diff --stat origin/develop..HEAD`: exactly one file changed, insertions only (+118/-0). No existing suite was modified or deleted.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a29bf9e916bf152c77ffb25343cec54ec8a575b9 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
