### PR TITLE
fix(tests): repair four merged test files that cannot import their subjects

### DIFF
--- a/packages/app-core/src/cli/program/__tests__/register-configure.test.ts
+++ b/packages/app-core/src/cli/program/__tests__/register-configure.test.ts
@@ -14,7 +14,7 @@ vi.mock("@elizaos/shared", () => ({
   theme: mocks.theme,
 }));
 
-import { registerConfigureCommand } from "./register.configure.ts";
+import { registerConfigureCommand } from "../register.configure.ts";
 
 function fakeProgram() {
   const cmd: {

--- a/packages/app-core/src/cli/program/__tests__/register-models.test.ts
+++ b/packages/app-core/src/cli/program/__tests__/register-models.test.ts
@@ -8,7 +8,7 @@ vi.mock("@elizaos/shared", () => ({
   getLogPrefix: (...a: unknown[]) => mocks.getLogPrefix(...a),
 }));
 
-import { registerModelsCli } from "./register.models.ts";
+import { registerModelsCli } from "../register.models.ts";
 
 function fakeProgram() {
   const cmd: {

--- a/packages/elizaos/src/commands/__tests__/cli-version.test.ts
+++ b/packages/elizaos/src/commands/__tests__/cli-version.test.ts
@@ -8,11 +8,11 @@ vi.mock("picocolors", () => ({
     green: (t: string) => `G:${t}`,
   },
 }));
-vi.mock("../package-info.js", () => ({
+vi.mock("../../package-info.js", () => ({
   readPackageJson: () => ({ name: "elizaos", version: "1.2.3" }),
 }));
 
-import { version } from "./version.ts";
+import { version } from "../version.ts";
 
 describe("version", () => {
   it("prints the package name and version", () => {

--- a/packages/elizaos/templates/project/apps/app/test/native-plugin-stubs.test.ts
+++ b/packages/elizaos/templates/project/apps/app/test/native-plugin-stubs.test.ts
@@ -3,7 +3,7 @@ import {
   Agent,
   Desktop,
   startDeviceBridgeClient,
-} from "./native-plugin-stubs.ts";
+} from "../src/native-plugin-stubs.ts";
 
 describe("native-plugin-stubs", () => {
   it("Agent.getStatus reports unavailable", async () => {


### PR DESCRIPTION
# Relates to

Repairs four merged instances of the `__tests__/` relative-import defect class that #25220 first repaired (five files) and that I have flagged in review on #25187, #27649, #27653, #27654, #27673–#27675, #27681–#27684, #27687, and #27688 — fourteen open-PR instances plus these four already on `develop`.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop` at `1f236fd1f5`; zero conflicts. Exact head `1645ae6fc4f088b6194f2656f512f1a2955c7e1b`.

# Risks

Minimal. Test-only: five changed lines across four test files (three import paths, one `vi.mock` path, one file move). No production source is touched.

# Background

## What does this PR do?

A full sweep of `origin/develop` for test files under `__tests__/` whose relative imports do not resolve found four merged files that import their subject as a sibling (`./X.ts`) when it lives one level up. Every one fails at collection with `Cannot find module` — zero tests run — so none of them has ever executed:

- `packages/app-core/src/cli/program/__tests__/register-configure.test.ts`
- `packages/app-core/src/cli/program/__tests__/register-models.test.ts`
- `packages/elizaos/src/commands/__tests__/cli-version.test.ts`
- `packages/elizaos/templates/project/apps/app/src/__tests__/native-plugin-stubs.test.ts`

Because they never ran, two latent defects hid behind the paths:

1. **`cli-version.test.ts`** mocked `"../package-info.js"` — which resolves from the *test* file to `src/commands/package-info.js` (nonexistent) — while the subject loads `src/package-info.ts`. The mock never attached; with only the import fixed, the suite still fails against the real package version. The mock path is corrected to `"../../package-info.js"`.
2. **`native-plugin-stubs.test.ts`** sat at `src/__tests__/` while the template's vitest include is `["test/**/*.test.ts", "test/**/*.test.tsx"]` — outside the glob, it could never run even with a correct import. It moves to `test/native-plugin-stubs.test.ts` with its import pointed at `../src/native-plugin-stubs.ts`, joining the template's existing suites (`scaffold-smoke.test.ts`, `viewport-zoom-a11y.test.ts`).

The sweep script resolved every `./` specifier in all 1,881 `__tests__/` test files on `develop` against the tree at `origin/develop`; the other candidate hits are string fixtures inside import-rewriter tests or ESM `.js → .ts` mappings that resolve fine. These four are the only real breakages.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

Run any of the four files at `origin/develop` — each dies at collection. Run them at this head — all green.

## Detailed testing steps

1. Check out exact head `1645ae6fc4f088b6194f2656f512f1a2955c7e1b`.
2. From `packages/app-core`: `bun x vitest run src/cli/program/__tests__/register-configure.test.ts src/cli/program/__tests__/register-models.test.ts` → **4/4** (2 files). At `origin/develop` the same command fails at collection: `Cannot find module './register.configure.ts'` / `'./register.models.ts'`, 0 tests.
3. From `packages/elizaos`: `bun x vitest run src/commands/__tests__/cli-version.test.ts` → **1/1**. At `origin/develop`: collection failure. With *only* the import fixed (mock path left broken): `AssertionError: expected "log" to be called with … "G:1.2.3"` — the latent mock-path defect, measured.
4. From `packages/elizaos/templates/project/apps/app`: `bun x vitest run test/native-plugin-stubs.test.ts` → **3/3**, now inside the template's `test/**` include.
5. Biome on all four files: exit 0, checked directly. `git diff --check`: clean.

<!-- evidence-head:1645ae6fc4f088b6194f2656f512f1a2955c7e1b -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — test-collection behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — test-collection behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the deterministic before/after collection runs below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>develop (broken) vs head (repaired) — vitest</summary>

```
# origin/develop 1f236fd1f5 — packages/app-core
$ bun x vitest run src/cli/program/__tests__/register-configure.test.ts src/cli/program/__tests__/register-models.test.ts
Error: Cannot find module '…/__tests__/register.configure.ts'
Error: Cannot find module '…/__tests__/register.models.ts'
 Test Files  2 failed (2)
      Tests  no tests

# head 1645ae6fc4 — packages/app-core
 Test Files  2 passed (2)
      Tests  4 passed (4)

# origin/develop — packages/elizaos
$ bun x vitest run src/commands/__tests__/cli-version.test.ts
Error: Cannot find module '…/__tests__/version.ts'   (0 tests)
# import fixed but the vi.mock specifier left as-is (latent defect measured):
AssertionError: expected "log" to be called with arguments: [ StringContaining "G:1.2.3" ]
# head — packages/elizaos
 Test Files  1 passed (1)
      Tests  1 passed (1)

# head — templates/project/apps/app
$ bun x vitest run test/native-plugin-stubs.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic module-resolution behavior, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates and sweep at exact head</summary>

```
$ node_modules/.bin/biome check \
    packages/app-core/src/cli/program/__tests__/register-configure.test.ts \
    packages/app-core/src/cli/program/__tests__/register-models.test.ts \
    packages/elizaos/src/commands/__tests__/cli-version.test.ts \
    packages/elizaos/templates/project/apps/app/test/native-plugin-stubs.test.ts
Checked 3 files in 65ms. No fixes applied.   (exit 0, captured directly)

$ git diff --check     (clean, exit 0)

$ git diff --stat origin/develop..HEAD
 .../app-core/src/cli/program/__tests__/register-configure.test.ts     | 2 +-
 packages/app-core/src/cli/program/__tests__/register-models.test.ts   | 2 +-
 packages/elizaos/src/commands/__tests__/cli-version.test.ts           | 4 ++--
 .../apps/app/{src/__tests__ => test}/native-plugin-stubs.test.ts      | 2 +-
 4 files changed, 5 insertions(+), 5 deletions(-)

Sweep: all 1,881 __tests__/ test files on origin/develop had every "./"
specifier resolved against the git tree; these four were the only real
unresolvable static imports (remaining hits: string literals inside
import-rewriter tests, and ESM .js→.ts mappings that resolve).
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused package runs and Biome above stand in.
- The scaffold generator that keeps emitting `./X.ts` under `__tests__/` lives outside this repository; fourteen open-PR instances are flagged in review with the same census. This PR only repairs what already merged.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
