### PR TITLE
test(agent): cover plugin-auto-enable

### DIFF
--- a/packages/agent/src/config/plugin-auto-enable.test.ts
+++ b/packages/agent/src/config/plugin-auto-enable.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Checks that the agent compat bridge behind the frozen
+ * `@elizaos/agent/config/plugin-auto-enable` subpath keeps forwarding the live
+ * shared surface by identity and that the forwarded connector map and
+ * configured-detection helper still behave the way boot-time auto-enable and
+ * host config sync consume them. Deterministic: drives the real modules with
+ * no mocks.
+ */
+import * as SHARED_SURFACE from "@elizaos/shared";
+import { describe, expect, test } from "vitest";
+
+import {
+  CONNECTOR_PLUGINS,
+  isConnectorConfigured,
+} from "./plugin-auto-enable.ts";
+
+describe("plugin-auto-enable compat bridge", () => {
+  test("forwards the live shared exports by identity", () => {
+    expect(typeof isConnectorConfigured).toBe("function");
+    expect(CONNECTOR_PLUGINS).toBe(SHARED_SURFACE.CONNECTOR_PLUGINS);
+    expect(isConnectorConfigured).toBe(SHARED_SURFACE.isConnectorConfigured);
+  });
+});
+
+describe("CONNECTOR_PLUGINS", () => {
+  test("is a populated record of connector keys to plugin package names", () => {
+    const entries = Object.entries(CONNECTOR_PLUGINS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [connectorKey, pluginName] of entries) {
+      expect(connectorKey.length).toBeGreaterThan(0);
+      expect(typeof pluginName).toBe("string");
+      expect(pluginName.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("detects every mapped connector once a universal credential is present", () => {
+    for (const connectorKey of Object.keys(CONNECTOR_PLUGINS)) {
+      expect(isConnectorConfigured(connectorKey, { apiKey: "secret" })).toBe(
+        true,
+      );
+    }
+  });
+
+  test("leaves every mapped connector unconfigured on an empty block", () => {
+    for (const connectorKey of Object.keys(CONNECTOR_PLUGINS)) {
+      expect(isConnectorConfigured(connectorKey, {})).toBe(false);
+    }
+  });
+});
+
+describe("isConnectorConfigured", () => {
+  test("rejects missing or non-object configuration blocks", () => {
+    expect(isConnectorConfigured("discord", undefined)).toBe(false);
+    expect(isConnectorConfigured("discord", null)).toBe(false);
+    expect(isConnectorConfigured("discord", "")).toBe(false);
+    expect(isConnectorConfigured("discord", 0)).toBe(false);
+    expect(isConnectorConfigured("discord", false)).toBe(false);
+    expect(isConnectorConfigured("discord", "botToken")).toBe(false);
+  });
+
+  test("an explicit enabled:false wins over present credentials", () => {
+    expect(
+      isConnectorConfigured("discord", { botToken: "t", enabled: false }),
+    ).toBe(false);
+  });
+
+  test("any truthy universal credential configures an otherwise unknown name", () => {
+    expect(isConnectorConfigured("discord", { botToken: "t" })).toBe(true);
+    expect(isConnectorConfigured("slack", { token: "t" })).toBe(true);
+    expect(isConnectorConfigured("not-a-connector", { apiKey: "k" })).toBe(
+      true,
+    );
+  });
+
+  test("falsy universal credential values do not configure anything", () => {
+    expect(isConnectorConfigured("discord", { token: "" })).toBe(false);
+    expect(isConnectorConfigured("slack", { token: 0 })).toBe(false);
+    expect(isConnectorConfigured("not-a-connector", { apiKey: false })).toBe(
+      false,
+    );
+  });
+
+  test("bluebubbles needs both serverUrl and password", () => {
+    expect(
+      isConnectorConfigured("bluebubbles", { serverUrl: "http://x" }),
+    ).toBe(false);
+    expect(isConnectorConfigured("bluebubbles", { password: "p" })).toBe(false);
+    expect(
+      isConnectorConfigured("bluebubbles", {
+        serverUrl: "http://x",
+        password: "p",
+      }),
+    ).toBe(true);
+  });
+
+  test("discordLocal needs both clientId and clientSecret", () => {
+    expect(isConnectorConfigured("discordLocal", { clientId: "id" })).toBe(
+      false,
+    );
+    expect(
+      isConnectorConfigured("discordLocal", {
+        clientId: "id",
+        clientSecret: "s",
+      }),
+    ).toBe(true);
+  });
+
+  test("imessage accepts enabled:true alone and ignores stringly truthy flags", () => {
+    expect(isConnectorConfigured("imessage", { enabled: true })).toBe(true);
+    expect(isConnectorConfigured("imessage", { cliPath: "/usr/bin/im" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("imessage", { dbPath: "/tmp/chat.db" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("imessage", { enabled: "true" })).toBe(false);
+    expect(isConnectorConfigured("imessage", {})).toBe(false);
+  });
+
+  test("whatsapp honors legacy fields and per-account auth directories", () => {
+    expect(isConnectorConfigured("whatsapp", { authState: "state" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("whatsapp", { sessionPath: "/tmp/s" })).toBe(
+      true,
+    );
+    expect(
+      isConnectorConfigured("whatsapp", {
+        accounts: { main: { authDir: "/a" } },
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("whatsapp", {
+        accounts: { main: { authDir: "/a", enabled: false } },
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("whatsapp", { accounts: { broken: null } }),
+    ).toBe(false);
+    expect(isConnectorConfigured("whatsapp", {})).toBe(false);
+  });
+
+  test("wechat detects credentials only on accounts that are not disabled", () => {
+    expect(
+      isConnectorConfigured("wechat", { accounts: { main: { apiKey: "k" } } }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("wechat", {
+        accounts: { main: { apiKey: "k", enabled: false } },
+      }),
+    ).toBe(false);
+    expect(isConnectorConfigured("wechat", { accounts: {} })).toBe(false);
+  });
+
+  test("googlechat requires service-account material and rejects array blocks", () => {
+    expect(
+      isConnectorConfigured("googlechat", { serviceAccount: "sa.json" }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("googlechat", {
+        serviceAccount: { clientEmail: "bot@project.iam" },
+      }),
+    ).toBe(true);
+    expect(isConnectorConfigured("googlechat", { projectId: "p" })).toBe(false);
+    expect(
+      isConnectorConfigured("googlechat", [{ serviceAccount: "sa.json" }]),
+    ).toBe(false);
+  });
+
+  test("unknown connector names without universal credentials stay unconfigured", () => {
+    expect(isConnectorConfigured("not-a-connector", { clientId: "id" })).toBe(
+      false,
+    );
+    expect(
+      isConnectorConfigured("", { serverUrl: "http://x", password: "p" }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/agent/src/config/plugin-auto-enable.test.ts` — a new colocated unit suite (178 lines, +N/-0) covering the agent-side compat bridge that re-exports `CONNECTOR_PLUGINS` and `isConnectorConfigured` from `@elizaos/shared` at the frozen `@elizaos/agent/config/plugin-auto-enable` subpath.

## Why

The published `@elizaos/app-core@2.0.0-alpha.537` bundle holds a frozen reference to this exact subpath, and the module header states it is what keeps Linux Electrobun (and any consumer of the packaged eliza-dist) booting. No same-named suite existed anywhere in the repo for this module on current `develop`; the only related coverage lives in `packages/shared/src/config/plugin-auto-enable.test.ts`, which exercises shared's own wrapper — not the agent subpath consumers actually import. If the bridge stops resolving or starts wrapping instead of forwarding, boot breaks with no test failing today.

## Scope

Test-only diff: one new file. No production behavior change. The suite drives the real modules end to end (agent barrel → `@elizaos/shared` barrel → engine → generated registry channel map → `@elizaos/core` detector) with no mocks:

- forwards the live shared exports by identity (`toBe` against the `@elizaos/shared` surface);
- `CONNECTOR_PLUGINS` structural contract consumed by host config sync (populated record of connector key → plugin package name), plus the cross-surface invariant that every mapped connector is detected once a universal credential is present and stays unconfigured on an empty block;
- `isConnectorConfigured` gate branches observed against the real implementation: non-object blocks, explicit `enabled:false` beating present credentials, truthy/falsy universal credentials (including unknown connector names), per-connector shapes (bluebubbles both-required, discordLocal both-required, imessage enabled-flag strictness, whatsapp legacy fields + per-account authDir with disabled-account exclusion, wechat multi-account credentials, googlechat service-account material incl. array rejection), and unknown names staying unconfigured.

## Verification

- `bunx vitest run packages/agent/src/config/plugin-auto-enable.test.ts` (repo root, vitest 4.1.10): **Test Files 1 passed (1), Tests 15 passed (15)** — re-fetched and re-run against current `origin/develop` immediately before filing; the subject's dependency closure (agent barrel, shared wrapper/engine, registry JSON, core detector) is byte-identical between the run tree and `origin/develop`.
- `bunx @biomejs/biome check packages/agent/src/config/plugin-auto-enable.test.ts`: clean ("No fixes applied" after one formatting pass).
- `bunx tsc --noEmit -p packages/agent/tsconfig.json` (`include: ["src"]`, so the test file is in-program): zero diagnostics mention the new file; full error output is byte-identical to a control program excluding the file (36 pre-existing, unrelated lines under `../cloud/*`).
- No `expectTypeOf`/type-level assertions, no mocks, no `vi.hoisted`; expectations record observed behavior only.
- Fork contributor: hosted CI does not run on this PR; all verification above is local and quoted.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:25ea0ab878499fb19dbbb0e2b2e5a595a0349695 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
