### PR TITLE
test(plugin-zerollama): cover ollama chat body rewrite

### DIFF
--- a/plugins/plugin-zerollama/utils/__tests__/ollama-compat.test.ts
+++ b/plugins/plugin-zerollama/utils/__tests__/ollama-compat.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { rewriteOllamaChatBody } from "./ollama-chat-compat-fetch.ts";
+
+describe("rewriteOllamaChatBody", () => {
+  it("moves sampling fields into options", () => {
+    const rewritten = rewriteOllamaChatBody({
+      model: "llama3",
+      messages: [{ role: "user", content: "hi" }],
+      temperature: 0.7,
+      top_p: 0.9,
+      max_output_tokens: 128,
+    });
+    expect(rewritten.options).toEqual({
+      temperature: 0.7,
+      top_p: 0.9,
+      num_predict: 128,
+    });
+    expect(rewritten.temperature).toBeUndefined();
+    expect(rewritten.top_p).toBeUndefined();
+    expect(rewritten.max_output_tokens).toBeUndefined();
+  });
+
+  it("drops tool_choice", () => {
+    const rewritten = rewriteOllamaChatBody({
+      model: "llama3",
+      messages: [],
+      tool_choice: "auto",
+    });
+    expect(rewritten.tool_choice).toBeUndefined();
+  });
+
+  it("keeps native options untouched", () => {
+    const rewritten = rewriteOllamaChatBody({
+      model: "llama3",
+      messages: [],
+      options: { temperature: 0.3, num_predict: 64 },
+    });
+    expect(rewritten.options).toEqual({ temperature: 0.3, num_predict: 64 });
+  });
+
+  it("returns the same object when nothing needs rewriting", () => {
+    const body = { model: "llama3", messages: [] };
+    const rewritten = rewriteOllamaChatBody(body);
+    expect(rewritten).toBe(body);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
