### PR TITLE
fix(cloud): scope Telegram delivery ledger by bot account

### DIFF
--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -159,6 +159,7 @@ async function run(
   runTurn: RunTurn,
   request = telegramRequest(),
   confirmIdentityLink?: TelegramEdgeDeps["confirmIdentityLink"],
+  botToken = "123:test-token",
 ): Promise<Response> {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
@@ -175,7 +176,7 @@ async function run(
   return app.fetch(
     request,
     {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
       ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
       ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
@@ -248,6 +249,81 @@ describe("Personal Shared Telegram edge", () => {
       providerMethods.filter((method) => method === "sendMessage"),
     ).toHaveLength(1);
     expect(providerMethods).not.toContain("webhook");
+  });
+
+  test("passes the stable Telegram bot id to the canonical turn across token rotation", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    const turn = mock(async (body: Record<string, unknown>) => {
+      bodies.push(body);
+      return Response.json({ data: { reply: "Account-scoped reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9011 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81609),
+          undefined,
+          "123:old-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "123:rotated-secret",
+        )
+      ).status,
+    ).toBe(200);
+
+    expect(bodies.map((body) => body.connectorAccountId)).toEqual([
+      "bot:123",
+      "bot:123",
+    ]);
+  });
+
+  test("fingerprints an opaque Telegram credential without forwarding the token", async () => {
+    const botToken = "opaque-test-credential";
+    let deliveryBody: Record<string, unknown> | undefined;
+    const turn = mock(async (body: Record<string, unknown>) => {
+      deliveryBody = body;
+      return Response.json({ data: { reply: "Opaque account reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9012 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81611),
+          undefined,
+          botToken,
+        )
+      ).status,
+    ).toBe(200);
+    expect(deliveryBody?.connectorAccountId).toBe(
+      "bot:d437b678c02873c49f7a3ffaaf947cc5ec289fb2676cd1a2063e84087750f9b4",
+    );
+    expect(JSON.stringify(deliveryBody)).not.toContain(botToken);
   });
 
   test("releases the processing claim after all pre-egress attempts fail", async () => {

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -217,6 +217,56 @@ describe("Personal Shared Telegram edge", () => {
     expect(sends).toBe(1);
   });
 
+  test("scopes reminder idempotency by stable bot account in one namespace", async () => {
+    const ledger = namespace();
+    let sends = 0;
+    globalThis.fetch = mock(async (input) => {
+      if (String(input).endsWith("/sendMessage")) sends += 1;
+      return Response.json({
+        ok: true,
+        result: { message_id: 9020 + sends },
+      });
+    }) as unknown as typeof fetch;
+    const env = (botToken: string) =>
+      ({
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
+        PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+      }) as AppEnv["Bindings"];
+    const input = {
+      project: "eliza-app",
+      chatId: "123456",
+      text: "time to stretch",
+      idempotencyKey: "reminder-rotation-1:2026-08-24T14:30:00.000Z",
+    };
+
+    const delivered = await dispatchPersonalTelegramReminder(
+      env("123:old-secret"),
+      input,
+    );
+    const rotatedDuplicate = await dispatchPersonalTelegramReminder(
+      env("123:rotated-secret"),
+      input,
+    );
+    const otherBot = await dispatchPersonalTelegramReminder(
+      env("456:other-secret"),
+      input,
+    );
+
+    expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9021"] });
+    expect(rotatedDuplicate).toEqual(delivered);
+    expect(otherBot).toMatchObject({
+      ok: true,
+      providerMessageIds: ["9022"],
+    });
+    expect(sends).toBe(2);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+  });
+
   test("runs the canonical turn and Telegram egress once without a Railway hop", async () => {
     const ledger = namespace();
     const turn = mock(async () =>
@@ -251,14 +301,17 @@ describe("Personal Shared Telegram edge", () => {
     expect(providerMethods).not.toContain("webhook");
   });
 
-  test("passes the stable Telegram bot id to the canonical turn across token rotation", async () => {
+  test("deduplicates a rotated secret for the same bot in one Durable Object namespace", async () => {
+    const ledger = namespace();
     const bodies: Record<string, unknown>[] = [];
+    let sends = 0;
     const turn = mock(async (body: Record<string, unknown>) => {
       bodies.push(body);
       return Response.json({ data: { reply: "Account-scoped reply" } });
     });
     globalThis.fetch = mock(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
       return Response.json({
         ok: true,
         result: body.text ? { message_id: 9011 } : true,
@@ -268,7 +321,7 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (
         await run(
-          namespace(),
+          ledger,
           turn,
           telegramRequest(81609),
           undefined,
@@ -279,19 +332,122 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (
         await run(
-          namespace(),
+          ledger,
           turn,
-          telegramRequest(81610),
+          telegramRequest(81609),
           undefined,
           "123:rotated-secret",
         )
       ).status,
     ).toBe(200);
 
-    expect(bodies.map((body) => body.connectorAccountId)).toEqual([
-      "bot:123",
-      "bot:123",
+    expect(turn).toHaveBeenCalledTimes(1);
+    expect(sends).toBe(1);
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        connectorAccountId: "bot:123",
+        messageId: "telegram:eliza-app:bot:123:81609",
+      }),
     ]);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:123:123456"]),
+    );
+  });
+
+  test("isolates different bots with the same sender and Telegram update id", async () => {
+    const ledger = namespace();
+    const bodies: Record<string, unknown>[] = [];
+    let sends = 0;
+    const turn = mock(async (body: Record<string, unknown>) => {
+      bodies.push(body);
+      return Response.json({ data: { reply: "Account-scoped reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9013 + sends } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "123:first-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "456:second-secret",
+        )
+      ).status,
+    ).toBe(200);
+
+    expect(turn).toHaveBeenCalledTimes(2);
+    expect(sends).toBe(2);
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        connectorAccountId: "bot:123",
+        messageId: "telegram:eliza-app:bot:123:81610",
+      }),
+      expect.objectContaining({
+        connectorAccountId: "bot:456",
+        messageId: "telegram:eliza-app:bot:456:81610",
+      }),
+    ]);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+  });
+
+  test("does not import an ambiguous account-independent tombstone into epoch 2", async () => {
+    const ledger = namespace();
+    ledger.values.set("telegram:eliza-app:personal-shared:123456:81612", {
+      delivery: "delivered",
+    });
+    const turn = mock(async () =>
+      Response.json({ data: { reply: "Fresh bot reply" } }),
+    );
+    let sends = 0;
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9015 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81612),
+          undefined,
+          "456:new-bot-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(1);
+    expect(sends).toBe(1);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:456:123456"]),
+    );
   });
 
   test("fingerprints an opaque Telegram credential without forwarding the token", async () => {
@@ -454,7 +610,7 @@ describe("Personal Shared Telegram edge", () => {
     );
   });
 
-  test("serves the authenticated Railway ledger from a token-independent Durable Object", async () => {
+  test("keeps epoch 1 reconciliation on its quarantined legacy namespace", async () => {
     const ledger = namespace();
     const app = new Hono<AppEnv>();
     app.route("/api/eliza-app/webhook/telegram", telegramRoute);
@@ -495,6 +651,98 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (await app.fetch(unauthorized, env, executionContext())).status,
     ).toBe(401);
+  });
+
+  test("validates epoch 2 reconciliation and writes its account-scoped boundary", async () => {
+    const ledger = namespace();
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    const request = (
+      connectorAccountId: string,
+      deliveryEpoch: number,
+      messageId = "81613",
+    ) =>
+      new Request(
+        "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/delivery",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Eliza-Webhook-Forwarder-Secret": "gateway-secret",
+          },
+          body: JSON.stringify({
+            deliveryEpoch,
+            project: "eliza-app",
+            connectorAccountId,
+            senderId: "123456",
+            messageId,
+            operation: "mark_delivered",
+          }),
+        },
+      );
+    const env = {
+      ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+    } as AppEnv["Bindings"];
+
+    expect(
+      (await app.fetch(request("bot:123", 2), env, executionContext())).status,
+    ).toBe(200);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:123:123456"]),
+    );
+    expect(
+      ledger.values.get(
+        "telegram:eliza-app:personal-shared:bot:123:123456:telegram:eliza-app:bot:123:81613",
+      )?.delivery,
+    ).toBe("delivered");
+    expect(
+      (await app.fetch(request("bot:456", 2), env, executionContext())).status,
+    ).toBe(200);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+    expect(
+      ledger.values.get(
+        "telegram:eliza-app:personal-shared:bot:456:123456:telegram:eliza-app:bot:456:81613",
+      )?.delivery,
+    ).toBe("delivered");
+
+    expect(
+      (
+        await app.fetch(
+          request("bot:123", 2, "x".repeat(160)),
+          env,
+          executionContext(),
+        )
+      ).status,
+    ).toBe(200);
+    const scopedName = "telegram:eliza-app:personal-shared:bot:123:123456";
+    const hashedKey = Array.from(ledger.values.keys()).find((key) =>
+      key.startsWith(`${scopedName}:telegram:v2:bot:123:`),
+    );
+    expect(hashedKey).toBeDefined();
+    expect(hashedKey?.slice(scopedName.length + 1).length).toBeLessThanOrEqual(
+      160,
+    );
+
+    const allocatedNames = ledger.names.length;
+    expect(
+      (
+        await app.fetch(
+          request("bot:not-a-valid-account", 2),
+          env,
+          executionContext(),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (await app.fetch(request("bot:456", 1), env, executionContext())).status,
+    ).toBe(400);
+    expect(ledger.names).toHaveLength(allocatedNames);
   });
 
   test("accepts the gateway edge handoff while public cutover is false and rechecks provider auth", async () => {

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -280,6 +280,7 @@ describe("Personal Shared Telegram edge", () => {
       await expect(
         dispatchPersonalTelegramReminder(env, {
           project: "eliza-app",
+          connectorAccountId: "bot:123",
           chatId: "-100123456789",
           providerThreadId,
           text: "time to stretch",

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -244,6 +244,7 @@ describe("Personal Shared Telegram edge", () => {
     } as AppEnv["Bindings"];
     const input = {
       project: "eliza-app",
+      connectorAccountId: "bot:123",
       chatId: "-100123456789",
       providerThreadId: "909",
       text: "time to stretch",

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -159,6 +159,7 @@ async function run(
   runTurn: RunTurn,
   request = telegramRequest(),
   confirmIdentityLink?: TelegramEdgeDeps["confirmIdentityLink"],
+  botToken = "123:test-token",
 ): Promise<Response> {
   const app = new Hono<AppEnv>();
   app.use("*", async (c, next) => {
@@ -175,7 +176,7 @@ async function run(
   return app.fetch(
     request,
     {
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
       ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
       ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
@@ -324,6 +325,81 @@ describe("Personal Shared Telegram edge", () => {
       providerMethods.filter((method) => method === "sendMessage"),
     ).toHaveLength(1);
     expect(providerMethods).not.toContain("webhook");
+  });
+
+  test("passes the stable Telegram bot id to the canonical turn across token rotation", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    const turn = mock(async (body: Record<string, unknown>) => {
+      bodies.push(body);
+      return Response.json({ data: { reply: "Account-scoped reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9011 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81609),
+          undefined,
+          "123:old-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "123:rotated-secret",
+        )
+      ).status,
+    ).toBe(200);
+
+    expect(bodies.map((body) => body.connectorAccountId)).toEqual([
+      "bot:123",
+      "bot:123",
+    ]);
+  });
+
+  test("fingerprints an opaque Telegram credential without forwarding the token", async () => {
+    const botToken = "opaque-test-credential";
+    let deliveryBody: Record<string, unknown> | undefined;
+    const turn = mock(async (body: Record<string, unknown>) => {
+      deliveryBody = body;
+      return Response.json({ data: { reply: "Opaque account reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9012 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          namespace(),
+          turn,
+          telegramRequest(81611),
+          undefined,
+          botToken,
+        )
+      ).status,
+    ).toBe(200);
+    expect(deliveryBody?.connectorAccountId).toBe(
+      "bot:d437b678c02873c49f7a3ffaaf947cc5ec289fb2676cd1a2063e84087750f9b4",
+    );
+    expect(JSON.stringify(deliveryBody)).not.toContain(botToken);
   });
 
   test("releases the processing claim after all pre-egress attempts fail", async () => {

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -293,6 +293,56 @@ describe("Personal Shared Telegram edge", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("scopes reminder idempotency by stable bot account in one namespace", async () => {
+    const ledger = namespace();
+    let sends = 0;
+    globalThis.fetch = mock(async (input) => {
+      if (String(input).endsWith("/sendMessage")) sends += 1;
+      return Response.json({
+        ok: true,
+        result: { message_id: 9020 + sends },
+      });
+    }) as unknown as typeof fetch;
+    const env = (botToken: string) =>
+      ({
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: botToken,
+        PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+      }) as AppEnv["Bindings"];
+    const input = {
+      project: "eliza-app",
+      chatId: "123456",
+      text: "time to stretch",
+      idempotencyKey: "reminder-rotation-1:2026-08-24T14:30:00.000Z",
+    };
+
+    const delivered = await dispatchPersonalTelegramReminder(
+      env("123:old-secret"),
+      input,
+    );
+    const rotatedDuplicate = await dispatchPersonalTelegramReminder(
+      env("123:rotated-secret"),
+      input,
+    );
+    const otherBot = await dispatchPersonalTelegramReminder(
+      env("456:other-secret"),
+      input,
+    );
+
+    expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9021"] });
+    expect(rotatedDuplicate).toEqual(delivered);
+    expect(otherBot).toMatchObject({
+      ok: true,
+      providerMessageIds: ["9022"],
+    });
+    expect(sends).toBe(2);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+  });
+
   test("runs the canonical turn and Telegram egress once without a Railway hop", async () => {
     const ledger = namespace();
     const turn = mock(async () =>
@@ -327,14 +377,17 @@ describe("Personal Shared Telegram edge", () => {
     expect(providerMethods).not.toContain("webhook");
   });
 
-  test("passes the stable Telegram bot id to the canonical turn across token rotation", async () => {
+  test("deduplicates a rotated secret for the same bot in one Durable Object namespace", async () => {
+    const ledger = namespace();
     const bodies: Record<string, unknown>[] = [];
+    let sends = 0;
     const turn = mock(async (body: Record<string, unknown>) => {
       bodies.push(body);
       return Response.json({ data: { reply: "Account-scoped reply" } });
     });
     globalThis.fetch = mock(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
       return Response.json({
         ok: true,
         result: body.text ? { message_id: 9011 } : true,
@@ -344,7 +397,7 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (
         await run(
-          namespace(),
+          ledger,
           turn,
           telegramRequest(81609),
           undefined,
@@ -355,19 +408,122 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (
         await run(
-          namespace(),
+          ledger,
           turn,
-          telegramRequest(81610),
+          telegramRequest(81609),
           undefined,
           "123:rotated-secret",
         )
       ).status,
     ).toBe(200);
 
-    expect(bodies.map((body) => body.connectorAccountId)).toEqual([
-      "bot:123",
-      "bot:123",
+    expect(turn).toHaveBeenCalledTimes(1);
+    expect(sends).toBe(1);
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        connectorAccountId: "bot:123",
+        messageId: "telegram:eliza-app:bot:123:81609",
+      }),
     ]);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:123:123456"]),
+    );
+  });
+
+  test("isolates different bots with the same sender and Telegram update id", async () => {
+    const ledger = namespace();
+    const bodies: Record<string, unknown>[] = [];
+    let sends = 0;
+    const turn = mock(async (body: Record<string, unknown>) => {
+      bodies.push(body);
+      return Response.json({ data: { reply: "Account-scoped reply" } });
+    });
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9013 + sends } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "123:first-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81610),
+          undefined,
+          "456:second-secret",
+        )
+      ).status,
+    ).toBe(200);
+
+    expect(turn).toHaveBeenCalledTimes(2);
+    expect(sends).toBe(2);
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        connectorAccountId: "bot:123",
+        messageId: "telegram:eliza-app:bot:123:81610",
+      }),
+      expect.objectContaining({
+        connectorAccountId: "bot:456",
+        messageId: "telegram:eliza-app:bot:456:81610",
+      }),
+    ]);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+  });
+
+  test("does not import an ambiguous account-independent tombstone into epoch 2", async () => {
+    const ledger = namespace();
+    ledger.values.set("telegram:eliza-app:personal-shared:123456:81612", {
+      delivery: "delivered",
+    });
+    const turn = mock(async () =>
+      Response.json({ data: { reply: "Fresh bot reply" } }),
+    );
+    let sends = 0;
+    globalThis.fetch = mock(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+      if (body.text) sends += 1;
+      return Response.json({
+        ok: true,
+        result: body.text ? { message_id: 9015 } : true,
+      });
+    }) as unknown as typeof fetch;
+
+    expect(
+      (
+        await run(
+          ledger,
+          turn,
+          telegramRequest(81612),
+          undefined,
+          "456:new-bot-secret",
+        )
+      ).status,
+    ).toBe(200);
+    expect(turn).toHaveBeenCalledTimes(1);
+    expect(sends).toBe(1);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:456:123456"]),
+    );
   });
 
   test("fingerprints an opaque Telegram credential without forwarding the token", async () => {
@@ -530,7 +686,7 @@ describe("Personal Shared Telegram edge", () => {
     );
   });
 
-  test("serves the authenticated Railway ledger from a token-independent Durable Object", async () => {
+  test("keeps epoch 1 reconciliation on its quarantined legacy namespace", async () => {
     const ledger = namespace();
     const app = new Hono<AppEnv>();
     app.route("/api/eliza-app/webhook/telegram", telegramRoute);
@@ -571,6 +727,98 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (await app.fetch(unauthorized, env, executionContext())).status,
     ).toBe(401);
+  });
+
+  test("validates epoch 2 reconciliation and writes its account-scoped boundary", async () => {
+    const ledger = namespace();
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    const request = (
+      connectorAccountId: string,
+      deliveryEpoch: number,
+      messageId = "81613",
+    ) =>
+      new Request(
+        "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/delivery",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Eliza-Webhook-Forwarder-Secret": "gateway-secret",
+          },
+          body: JSON.stringify({
+            deliveryEpoch,
+            project: "eliza-app",
+            connectorAccountId,
+            senderId: "123456",
+            messageId,
+            operation: "mark_delivered",
+          }),
+        },
+      );
+    const env = {
+      ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+    } as AppEnv["Bindings"];
+
+    expect(
+      (await app.fetch(request("bot:123", 2), env, executionContext())).status,
+    ).toBe(200);
+    expect(new Set(ledger.names)).toEqual(
+      new Set(["telegram:eliza-app:personal-shared:bot:123:123456"]),
+    );
+    expect(
+      ledger.values.get(
+        "telegram:eliza-app:personal-shared:bot:123:123456:telegram:eliza-app:bot:123:81613",
+      )?.delivery,
+    ).toBe("delivered");
+    expect(
+      (await app.fetch(request("bot:456", 2), env, executionContext())).status,
+    ).toBe(200);
+    expect(new Set(ledger.names)).toEqual(
+      new Set([
+        "telegram:eliza-app:personal-shared:bot:123:123456",
+        "telegram:eliza-app:personal-shared:bot:456:123456",
+      ]),
+    );
+    expect(
+      ledger.values.get(
+        "telegram:eliza-app:personal-shared:bot:456:123456:telegram:eliza-app:bot:456:81613",
+      )?.delivery,
+    ).toBe("delivered");
+
+    expect(
+      (
+        await app.fetch(
+          request("bot:123", 2, "x".repeat(160)),
+          env,
+          executionContext(),
+        )
+      ).status,
+    ).toBe(200);
+    const scopedName = "telegram:eliza-app:personal-shared:bot:123:123456";
+    const hashedKey = Array.from(ledger.values.keys()).find((key) =>
+      key.startsWith(`${scopedName}:telegram:v2:bot:123:`),
+    );
+    expect(hashedKey).toBeDefined();
+    expect(hashedKey?.slice(scopedName.length + 1).length).toBeLessThanOrEqual(
+      160,
+    );
+
+    const allocatedNames = ledger.names.length;
+    expect(
+      (
+        await app.fetch(
+          request("bot:not-a-valid-account", 2),
+          env,
+          executionContext(),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (await app.fetch(request("bot:456", 1), env, executionContext())).status,
+    ).toBe(400);
+    expect(ledger.names).toHaveLength(allocatedNames);
   });
 
   test("accepts the gateway edge handoff while public cutover is false and rechecks provider auth", async () => {

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -208,6 +208,7 @@ describe("Personal Shared Telegram edge", () => {
     } as AppEnv["Bindings"];
     const input = {
       project: "eliza-app",
+      connectorAccountId: "bot:123",
       chatId: "123456",
       text: "time to stretch",
       idempotencyKey: "reminder-1:2026-08-20T19:30:00.000Z",
@@ -293,7 +294,7 @@ describe("Personal Shared Telegram edge", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  test("scopes reminder idempotency by stable bot account in one namespace", async () => {
+  test("pins reminder delivery to its originating stable bot account", async () => {
     const ledger = namespace();
     let sends = 0;
     globalThis.fetch = mock(async (input) => {
@@ -310,6 +311,7 @@ describe("Personal Shared Telegram edge", () => {
       }) as AppEnv["Bindings"];
     const input = {
       project: "eliza-app",
+      connectorAccountId: "bot:123",
       chatId: "123456",
       text: "time to stretch",
       idempotencyKey: "reminder-rotation-1:2026-08-24T14:30:00.000Z",
@@ -331,15 +333,12 @@ describe("Personal Shared Telegram edge", () => {
     expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9021"] });
     expect(rotatedDuplicate).toEqual(delivered);
     expect(otherBot).toMatchObject({
-      ok: true,
-      providerMessageIds: ["9022"],
+      ok: false,
+      acceptance: "not_accepted",
     });
-    expect(sends).toBe(2);
+    expect(sends).toBe(1);
     expect(new Set(ledger.names)).toEqual(
-      new Set([
-        "telegram:eliza-app:personal-shared:bot:123:123456",
-        "telegram:eliza-app:personal-shared:bot:456:123456",
-      ]),
+      new Set(["telegram:eliza-app:personal-shared:bot:123:123456"]),
     );
   });
 
@@ -375,6 +374,48 @@ describe("Personal Shared Telegram edge", () => {
       providerMethods.filter((method) => method === "sendMessage"),
     ).toHaveLength(1);
     expect(providerMethods).not.toContain("webhook");
+  });
+
+  test("retries only the rejected chunk for a multi-chunk reply containing newlines", async () => {
+    const ledger = namespace();
+    const firstChunk = `${"a".repeat(4094)}\n\n`;
+    const secondChunk = "retry tail";
+    const reply = `${firstChunk}${secondChunk}`;
+    const turn = mock(async () => Response.json({ data: { reply } }));
+    const sentTexts: string[] = [];
+    let rejectedTail = false;
+    globalThis.fetch = mock(async (input, init) => {
+      if (!String(input).endsWith("/sendMessage")) {
+        return Response.json({ ok: true, result: true });
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        text?: string;
+      };
+      const text = body.text ?? "";
+      sentTexts.push(text);
+      if (text === secondChunk && !rejectedTail) {
+        rejectedTail = true;
+        return Response.json(
+          {
+            ok: false,
+            error_code: 400,
+            description: "Bad Request: chat not found",
+          },
+          { status: 400 },
+        );
+      }
+      return Response.json({
+        ok: true,
+        result: { message_id: 9100 + sentTexts.length },
+      });
+    }) as unknown as typeof fetch;
+
+    expect((await run(ledger, turn, telegramRequest(81613))).status).toBe(500);
+    expect((await run(ledger, turn, telegramRequest(81613))).status).toBe(200);
+
+    expect(turn).toHaveBeenCalledTimes(2);
+    expect(sentTexts).toEqual([firstChunk, secondChunk, secondChunk]);
+    expect(firstChunk).toHaveLength(4096);
   });
 
   test("deduplicates a rotated secret for the same bot in one Durable Object namespace", async () => {
@@ -686,7 +727,7 @@ describe("Personal Shared Telegram edge", () => {
     );
   });
 
-  test("keeps epoch 1 reconciliation on its quarantined legacy namespace", async () => {
+  test("keeps explicitly enabled epoch 1 reconciliation on its quarantined legacy namespace", async () => {
     const ledger = namespace();
     const app = new Hono<AppEnv>();
     app.route("/api/eliza-app/webhook/telegram", telegramRoute);
@@ -703,13 +744,15 @@ describe("Personal Shared Telegram edge", () => {
             project: "eliza-app",
             senderId: "123456",
             messageId: "81607",
-            operation: "prepare_plan",
-            chunkDigests: ["a".repeat(64)],
+            operation: "mark_uncertain",
           }),
         },
       );
     const env = {
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+      ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
 
@@ -722,11 +765,59 @@ describe("Personal Shared Telegram edge", () => {
     expect(new Set(ledger.names)).toEqual(
       new Set(["telegram:eliza-app:personal-shared:123456"]),
     );
+    expect(
+      ledger.values.get("telegram:eliza-app:personal-shared:123456:81607")
+        ?.delivery,
+    ).toBe("uncertain");
     const unauthorized = request();
     unauthorized.headers.set("X-Eliza-Webhook-Forwarder-Secret", "wrong");
     expect(
       (await app.fetch(unauthorized, env, executionContext())).status,
     ).toBe(401);
+  });
+
+  test("rejects epoch 1 reconciliation unless the temporary compatibility gate is exact true", async () => {
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    for (const legacyGate of [undefined, "false", "1", " true "]) {
+      const ledger = namespace();
+      const response = await app.fetch(
+        new Request(
+          "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/delivery",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Eliza-Webhook-Forwarder-Secret": "gateway-secret",
+            },
+            body: JSON.stringify({
+              project: "eliza-app",
+              senderId: "123456",
+              messageId: "81607",
+              operation: "mark_uncertain",
+            }),
+          },
+        ),
+        {
+          ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+          ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+          ...(legacyGate === undefined
+            ? {}
+            : {
+                PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: legacyGate,
+              }),
+          PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+        } as AppEnv["Bindings"],
+        executionContext(),
+      );
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        code: "LEGACY_DELIVERY_EPOCH_DISABLED",
+      });
+      expect(ledger.names).toHaveLength(0);
+    }
   });
 
   test("validates epoch 2 reconciliation and writes its account-scoped boundary", async () => {
@@ -758,6 +849,8 @@ describe("Personal Shared Telegram edge", () => {
       );
     const env = {
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+      ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
       PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
     } as AppEnv["Bindings"];
 
@@ -772,20 +865,11 @@ describe("Personal Shared Telegram edge", () => {
         "telegram:eliza-app:personal-shared:bot:123:123456:telegram:eliza-app:bot:123:81613",
       )?.delivery,
     ).toBe("delivered");
+    const allocatedNames = ledger.names.length;
     expect(
       (await app.fetch(request("bot:456", 2), env, executionContext())).status,
-    ).toBe(200);
-    expect(new Set(ledger.names)).toEqual(
-      new Set([
-        "telegram:eliza-app:personal-shared:bot:123:123456",
-        "telegram:eliza-app:personal-shared:bot:456:123456",
-      ]),
-    );
-    expect(
-      ledger.values.get(
-        "telegram:eliza-app:personal-shared:bot:456:123456:telegram:eliza-app:bot:456:81613",
-      )?.delivery,
-    ).toBe("delivered");
+    ).toBe(403);
+    expect(ledger.names).toHaveLength(allocatedNames);
 
     expect(
       (
@@ -804,8 +888,8 @@ describe("Personal Shared Telegram edge", () => {
     expect(hashedKey?.slice(scopedName.length + 1).length).toBeLessThanOrEqual(
       160,
     );
+    const allocatedNamesAfterValidRequests = ledger.names.length;
 
-    const allocatedNames = ledger.names.length;
     expect(
       (
         await app.fetch(
@@ -818,7 +902,78 @@ describe("Personal Shared Telegram edge", () => {
     expect(
       (await app.fetch(request("bot:456", 1), env, executionContext())).status,
     ).toBe(400);
-    expect(ledger.names).toHaveLength(allocatedNames);
+    expect(ledger.names).toHaveLength(allocatedNamesAfterValidRequests);
+
+    const wrongProjectRequest = request("bot:123", 2);
+    const wrongProjectBody = (await wrongProjectRequest.json()) as Record<
+      string,
+      unknown
+    >;
+    const wrongProjectResponse = await app.fetch(
+      new Request(wrongProjectRequest.url, {
+        method: "POST",
+        headers: wrongProjectRequest.headers,
+        body: JSON.stringify({ ...wrongProjectBody, project: "other-project" }),
+      }),
+      env,
+      executionContext(),
+    );
+    expect(wrongProjectResponse.status).toBe(403);
+    expect(ledger.names).toHaveLength(allocatedNamesAfterValidRequests);
+
+    const unsupportedOperationRequest = request("bot:123", 2);
+    const unsupportedOperationBody =
+      (await unsupportedOperationRequest.json()) as Record<string, unknown>;
+    const unsupportedOperationResponse = await app.fetch(
+      new Request(unsupportedOperationRequest.url, {
+        method: "POST",
+        headers: unsupportedOperationRequest.headers,
+        body: JSON.stringify({
+          ...unsupportedOperationBody,
+          operation: "prepare_plan",
+          chunkDigests: ["a".repeat(64)],
+        }),
+      }),
+      env,
+      executionContext(),
+    );
+    expect(unsupportedOperationResponse.status).toBe(400);
+    expect(ledger.names).toHaveLength(allocatedNamesAfterValidRequests);
+  });
+
+  test("requires Worker-side Telegram scope configuration before delivery reconciliation", async () => {
+    const ledger = namespace();
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    const response = await app.fetch(
+      new Request(
+        "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/delivery",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Eliza-Webhook-Forwarder-Secret": "gateway-secret",
+          },
+          body: JSON.stringify({
+            deliveryEpoch: 2,
+            project: "eliza-app",
+            connectorAccountId: "bot:123",
+            senderId: "123456",
+            messageId: "81614",
+            operation: "mark_delivered",
+          }),
+        },
+      ),
+      {
+        ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+        ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
+        PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+      } as AppEnv["Bindings"],
+      executionContext(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(ledger.names).toHaveLength(0);
   });
 
   test("accepts the gateway edge handoff while public cutover is false and rechecks provider auth", async () => {
@@ -830,6 +985,7 @@ describe("Personal Shared Telegram edge", () => {
       inbound,
     );
     request.headers.set("X-Eliza-Webhook-Forwarder-Secret", "gateway-secret");
+    request.headers.set("X-Eliza-Connector-Account-Id", "bot:123");
     request.headers.set("X-Telegram-Bot-Api-Secret-Token", "wrong-provider");
 
     const response = await app.fetch(
@@ -844,5 +1000,69 @@ describe("Personal Shared Telegram edge", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  test("allows a headerless old gateway only while the exact legacy rollout gate is enabled", async () => {
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    const request = new Request(
+      "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/edge",
+      telegramRequest(81616),
+    );
+    request.headers.set("X-Eliza-Webhook-Forwarder-Secret", "gateway-secret");
+    request.headers.set("X-Telegram-Bot-Api-Secret-Token", "wrong-provider");
+
+    const response = await app.fetch(
+      request,
+      {
+        PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true",
+        ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      } as AppEnv["Bindings"],
+      executionContext(),
+    );
+
+    // The compatibility gate bypasses only the absent account header. Provider
+    // authentication remains mandatory and is rechecked by the Worker.
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects a gateway edge handoff whose bot account is absent or mismatched before delivery state", async () => {
+    const app = new Hono<AppEnv>();
+    app.route("/api/eliza-app/webhook/telegram", telegramRoute);
+    for (const { accountId, legacyCompat } of [
+      { accountId: undefined, legacyCompat: undefined },
+      { accountId: "bot:not-valid", legacyCompat: undefined },
+      { accountId: "bot:456", legacyCompat: undefined },
+      { accountId: "bot:456", legacyCompat: "true" },
+    ]) {
+      const ledger = namespace();
+      const request = new Request(
+        "https://api-staging.eliza.app/api/eliza-app/webhook/telegram/edge",
+        telegramRequest(81615),
+      );
+      request.headers.set("X-Eliza-Webhook-Forwarder-Secret", "gateway-secret");
+      if (accountId) {
+        request.headers.set("X-Eliza-Connector-Account-Id", accountId);
+      }
+      const response = await app.fetch(
+        request,
+        {
+          PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: legacyCompat,
+          ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:rotated-secret",
+          PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+        } as AppEnv["Bindings"],
+        executionContext(),
+      );
+
+      expect(response.status).toBe(409);
+      expect(response.headers.get("X-Eliza-Failure-Stage")).toBe(
+        "connector_account",
+      );
+      expect(ledger.names).toHaveLength(0);
+    }
   });
 });

--- a/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
+++ b/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
@@ -187,6 +187,7 @@ describe("Dedicated cutover group reminder relay", () => {
     await expect(requests[0]?.json()).resolves.toEqual({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
       chatId: "-100123456789",
       providerThreadId: "909",
       text: "Reminder for this group from Nubs: pay the rent",

--- a/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.test.ts
+++ b/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.test.ts
@@ -15,7 +15,12 @@ const committedTask = {
   ownerVisible: true,
   contextRequest: undefined,
   metadata: {
-    delivery: { platform: "telegram", project: "main", chatId: "42" },
+    delivery: {
+      platform: "telegram",
+      project: "main",
+      connectorAccountId: "bot:123456789",
+      chatId: "42",
+    },
   },
 };
 const readCommittedSharedReminderForTarget = mock(
@@ -89,7 +94,12 @@ describe("Dedicated Shared-reminder delivery", () => {
         taskId: "shared-reminder-1",
         promptInstructions: "trusted stored reminder",
         metadata: {
-          delivery: { platform: "telegram", project: "main", chatId: "42" },
+          delivery: {
+            platform: "telegram",
+            project: "main",
+            connectorAccountId: "bot:123456789",
+            chatId: "42",
+          },
         },
       }),
     );

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -93,6 +93,15 @@ function readEnvString(env: AppEnv["Bindings"], key: string): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+async function resolveTelegramConnectorAccountId(
+  botToken: string,
+): Promise<string> {
+  // Match the gateway identity contract: the documented decimal prefix is the
+  // immutable bot id, while opaque proxy/test credentials remain non-secret.
+  const botId = botToken.match(/^(\d{1,20}):/)?.[1];
+  return botId ? `bot:${botId}` : `bot:${await sha256Hex(botToken)}`;
+}
+
 async function runInternalRoute(
   app: Hono<AppEnv>,
   body: Record<string, unknown>,
@@ -477,12 +486,14 @@ function startTyping(
 
 function deliveryBody(
   project: string,
+  connectorAccountId: string,
   event: TelegramConnectorEvent,
   voiceNote?: Awaited<ReturnType<typeof resolveTelegramVoiceNote>>,
 ): Record<string, unknown> {
   return {
     platform: "telegram",
     project,
+    connectorAccountId,
     chatId: event.chatId,
     telegramUserId: event.senderId,
     displayName: event.senderName,
@@ -580,6 +591,7 @@ export async function handlePersonalTelegramEdge(
   const project =
     readEnvString(c.env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
   const config = { botToken, webhookSecret };
+  const connectorAccountId = await resolveTelegramConnectorAccountId(botToken);
   const ledger = await edgeLedger(c.env, project, event);
 
   try {
@@ -645,7 +657,7 @@ export async function handlePersonalTelegramEdge(
           const turn = await runTurnWithRetry(
             c,
             deps,
-            deliveryBody(project, event, voiceNote),
+            deliveryBody(project, connectorAccountId, event, voiceNote),
             event,
             traceId,
           );

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -27,7 +27,10 @@ import {
   TelegramEgressAlreadyClaimedError,
 } from "@elizaos/cloud-services-common/telegram-delivery";
 import type { Hono, ExecutionContext as HonoExecutionContext } from "hono";
-import { PERSONAL_TELEGRAM_DELIVERY_PATH } from "@/api-app/personal-telegram-delivery";
+import {
+  PERSONAL_TELEGRAM_DELIVERY_EPOCH,
+  PERSONAL_TELEGRAM_DELIVERY_PATH,
+} from "@/api-app/personal-telegram-delivery";
 import { runWithDbCacheAsync } from "@/db/client";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { appendServerTiming } from "@/lib/observability/http-telemetry";
@@ -44,6 +47,8 @@ const RETRY_DELAY_CAP_MS = 5_000;
 const TYPING_REFRESH_MS = 4_000;
 const DELIVERY_PROJECT_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const DELIVERY_SENDER_RE = /^\d{1,32}$/;
+const DELIVERY_MESSAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,159}$/;
+const TELEGRAM_CONNECTOR_ACCOUNT_RE = /^bot:(?:\d{1,20}|[0-9a-f]{64})$/;
 
 export interface TelegramEdgeDeps {
   runTurn(
@@ -100,6 +105,28 @@ async function resolveTelegramConnectorAccountId(
   // immutable bot id, while opaque proxy/test credentials remain non-secret.
   const botId = botToken.match(/^(\d{1,20}):/)?.[1];
   return botId ? `bot:${botId}` : `bot:${await sha256Hex(botToken)}`;
+}
+
+async function telegramCanonicalMessageId(
+  project: string,
+  connectorAccountId: string,
+  providerMessageId: string,
+): Promise<string> {
+  const readable = `telegram:${project}:${connectorAccountId}:${providerMessageId}`;
+  if (DELIVERY_MESSAGE_ID_RE.test(readable)) return readable;
+  return `telegram:v2:${connectorAccountId}:${await sha256Hex(
+    `${project}\0${providerMessageId}`,
+  )}`;
+}
+
+function telegramDeliveryObjectName(
+  project: string,
+  senderId: string,
+  connectorAccountId?: string,
+): string {
+  return connectorAccountId
+    ? `telegram:${project}:personal-shared:${connectorAccountId}:${senderId}`
+    : `telegram:${project}:personal-shared:${senderId}`;
 }
 
 async function runInternalRoute(
@@ -247,11 +274,23 @@ export async function handlePersonalTelegramDeliveryLedger(
   const input = body as Record<string, unknown>;
   const project = input.project;
   const senderId = input.senderId;
+  const messageId = input.messageId;
+  const deliveryEpoch = input.deliveryEpoch;
+  const connectorAccountId = input.connectorAccountId;
+  const legacyEpoch =
+    deliveryEpoch === undefined && connectorAccountId === undefined;
+  const accountScopedEpoch =
+    deliveryEpoch === PERSONAL_TELEGRAM_DELIVERY_EPOCH &&
+    typeof connectorAccountId === "string" &&
+    TELEGRAM_CONNECTOR_ACCOUNT_RE.test(connectorAccountId);
   if (
     typeof project !== "string" ||
     !DELIVERY_PROJECT_RE.test(project) ||
     typeof senderId !== "string" ||
-    !DELIVERY_SENDER_RE.test(senderId)
+    !DELIVERY_SENDER_RE.test(senderId) ||
+    typeof messageId !== "string" ||
+    !DELIVERY_MESSAGE_ID_RE.test(messageId) ||
+    (!legacyEpoch && !accountScopedEpoch)
   ) {
     return c.json({ success: false, error: "Invalid delivery scope" }, 400);
   }
@@ -259,8 +298,23 @@ export async function handlePersonalTelegramDeliveryLedger(
   if (!namespace) {
     return c.json({ success: false, error: "Delivery binding missing" }, 503);
   }
+  // Epoch 1 requests come only from an older gateway binary during a rolling
+  // deployment. Its account-independent tombstones are ambiguous, so epoch 2
+  // never reads them; the Durable Object expires them after 30 days. A current
+  // gateway must identify its stable account explicitly and writes only v2.
+  const scopedConnectorAccountId =
+    accountScopedEpoch && typeof connectorAccountId === "string"
+      ? connectorAccountId
+      : undefined;
+  const scopedMessageId = scopedConnectorAccountId
+    ? await telegramCanonicalMessageId(
+        project,
+        scopedConnectorAccountId,
+        messageId,
+      )
+    : messageId;
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${senderId}`,
+    telegramDeliveryObjectName(project, senderId, scopedConnectorAccountId),
   );
   const response = await stub.fetch(
     `https://personal-telegram-delivery${PERSONAL_TELEGRAM_DELIVERY_PATH}`,
@@ -271,6 +325,9 @@ export async function handlePersonalTelegramDeliveryLedger(
         ...input,
         project: undefined,
         senderId: undefined,
+        connectorAccountId: undefined,
+        deliveryEpoch: undefined,
+        messageId: scopedMessageId,
       }),
     },
   );
@@ -284,38 +341,40 @@ export async function handlePersonalTelegramDeliveryLedger(
 async function edgeLedger(
   env: AppEnv["Bindings"],
   project: string,
+  connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
 ): Promise<TelegramDeliveryLedger> {
   const namespace = env.PERSONAL_TELEGRAM_DELIVERIES;
   if (!namespace)
     throw new Error("Personal Telegram delivery binding is missing");
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${event.senderId}`,
+    telegramDeliveryObjectName(project, event.senderId, connectorAccountId),
   );
   return {
     async read() {
-      const body = await callLedger(stub, event.messageId, "read");
+      const body = await callLedger(stub, canonicalMessageId, "read");
       return body.state === "uncertain" || body.state === "delivered"
         ? body.state
         : null;
     },
     async claimProcessing() {
       return (
-        (await callLedger(stub, event.messageId, "claim_processing"))
+        (await callLedger(stub, canonicalMessageId, "claim_processing"))
           .claimed === true
       );
     },
     async releaseProcessing() {
-      await callLedger(stub, event.messageId, "release_processing");
+      await callLedger(stub, canonicalMessageId, "release_processing");
     },
     async preparePlan(chunkDigests) {
-      const body = await callLedger(stub, event.messageId, "prepare_plan", {
+      const body = await callLedger(stub, canonicalMessageId, "prepare_plan", {
         chunkDigests,
       });
       return body.plan === "prepared" ? "prepared" : "conflict";
     },
     async readChunk(chunkIndex, chunkDigest) {
-      const body = await callLedger(stub, event.messageId, "read_chunk", {
+      const body = await callLedger(stub, canonicalMessageId, "read_chunk", {
         chunkIndex,
         chunkDigest,
       });
@@ -332,7 +391,7 @@ async function edgeLedger(
     async claimChunk(chunkIndex, chunkDigest) {
       return (
         (
-          await callLedger(stub, event.messageId, "claim_chunk", {
+          await callLedger(stub, canonicalMessageId, "claim_chunk", {
             chunkIndex,
             chunkDigest,
           })
@@ -340,20 +399,20 @@ async function edgeLedger(
       );
     },
     async releaseChunk(chunkIndex, chunkDigest) {
-      await callLedger(stub, event.messageId, "release_chunk", {
+      await callLedger(stub, canonicalMessageId, "release_chunk", {
         chunkIndex,
         chunkDigest,
       });
     },
     async markChunkDelivered(chunkIndex, chunkDigest, providerMessageId) {
-      await callLedger(stub, event.messageId, "mark_chunk_delivered", {
+      await callLedger(stub, canonicalMessageId, "mark_chunk_delivered", {
         chunkIndex,
         chunkDigest,
         providerMessageId,
       });
     },
     async markDelivered() {
-      await callLedger(stub, event.messageId, "mark_delivered");
+      await callLedger(stub, canonicalMessageId, "mark_delivered");
     },
   };
 }
@@ -361,14 +420,16 @@ async function edgeLedger(
 async function readEdgeReceipt(
   env: AppEnv["Bindings"],
   project: string,
+  connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
 ): Promise<{ acceptedAt: string; providerMessageIds: string[] } | null> {
   const namespace = env.PERSONAL_TELEGRAM_DELIVERIES;
   if (!namespace) return null;
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${event.senderId}`,
+    telegramDeliveryObjectName(project, event.senderId, connectorAccountId),
   );
-  const body = await callLedger(stub, event.messageId, "read_receipt");
+  const body = await callLedger(stub, canonicalMessageId, "read_receipt");
   const acceptedAt =
     typeof body.acceptedAt === "string" &&
     Number.isFinite(Date.parse(body.acceptedAt))
@@ -413,7 +474,20 @@ export async function dispatchPersonalTelegramReminder(
     rawPayload: { source: "shared-reminder" },
   };
   try {
-    const ledger = await edgeLedger(env, input.project, event);
+    const connectorAccountId =
+      await resolveTelegramConnectorAccountId(botToken);
+    const canonicalMessageId = await telegramCanonicalMessageId(
+      input.project,
+      connectorAccountId,
+      event.messageId,
+    );
+    const ledger = await edgeLedger(
+      env,
+      input.project,
+      connectorAccountId,
+      canonicalMessageId,
+      event,
+    );
     const outcome = await executeTelegramDelivery(ledger, async (hooks) => {
       await sendTelegramReply({ botToken }, event, input.text, logger, hooks);
     });
@@ -424,7 +498,13 @@ export async function dispatchPersonalTelegramReminder(
         message: `Telegram reminder delivery is ${outcome}`,
       };
     }
-    const receipt = await readEdgeReceipt(env, input.project, event);
+    const receipt = await readEdgeReceipt(
+      env,
+      input.project,
+      connectorAccountId,
+      canonicalMessageId,
+      event,
+    );
     return receipt
       ? { ok: true, ...receipt }
       : {
@@ -487,6 +567,7 @@ function startTyping(
 function deliveryBody(
   project: string,
   connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
   voiceNote?: Awaited<ReturnType<typeof resolveTelegramVoiceNote>>,
 ): Record<string, unknown> {
@@ -497,7 +578,7 @@ function deliveryBody(
     chatId: event.chatId,
     telegramUserId: event.senderId,
     displayName: event.senderName,
-    messageId: `telegram:${project}:${event.messageId}`,
+    messageId: canonicalMessageId,
     ...(event.text ? { message: event.text } : {}),
     ...(voiceNote ? { voiceNote } : {}),
   };
@@ -592,7 +673,18 @@ export async function handlePersonalTelegramEdge(
     readEnvString(c.env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
   const config = { botToken, webhookSecret };
   const connectorAccountId = await resolveTelegramConnectorAccountId(botToken);
-  const ledger = await edgeLedger(c.env, project, event);
+  const canonicalMessageId = await telegramCanonicalMessageId(
+    project,
+    connectorAccountId,
+    event.messageId,
+  );
+  const ledger = await edgeLedger(
+    c.env,
+    project,
+    connectorAccountId,
+    canonicalMessageId,
+    event,
+  );
 
   try {
     let turnMs = 0;
@@ -657,7 +749,13 @@ export async function handlePersonalTelegramEdge(
           const turn = await runTurnWithRetry(
             c,
             deps,
-            deliveryBody(project, connectorAccountId, event, voiceNote),
+            deliveryBody(
+              project,
+              connectorAccountId,
+              canonicalMessageId,
+              event,
+              voiceNote,
+            ),
             event,
             traceId,
           );

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -15,6 +15,7 @@ import {
   resolveTelegramVoiceNote,
   sendTelegramReply,
   sendTelegramTyping,
+  TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER,
   TelegramApiResponseError,
   type TelegramConnectorConfig,
   type TelegramConnectorEvent,
@@ -28,6 +29,7 @@ import {
 } from "@elizaos/cloud-services-common/telegram-delivery";
 import type { Hono, ExecutionContext as HonoExecutionContext } from "hono";
 import {
+  isPersonalTelegramDeliveryEpoch1CompatEnabled,
   PERSONAL_TELEGRAM_DELIVERY_EPOCH,
   PERSONAL_TELEGRAM_DELIVERY_PATH,
 } from "@/api-app/personal-telegram-delivery";
@@ -76,6 +78,7 @@ interface LedgerResponse {
 
 export interface PersonalTelegramReminderDispatchInput {
   project: string;
+  connectorAccountId: string;
   chatId: string;
   providerThreadId?: string;
   text: string;
@@ -107,6 +110,19 @@ async function resolveTelegramConnectorAccountId(
   // immutable bot id, while opaque proxy/test credentials remain non-secret.
   const botId = botToken.match(/^(\d{1,20}):/)?.[1];
   return botId ? `bot:${botId}` : `bot:${await sha256Hex(botToken)}`;
+}
+
+async function configuredPersonalTelegramScope(
+  env: AppEnv["Bindings"],
+): Promise<{ project: string; connectorAccountId: string } | null> {
+  const project =
+    readEnvString(env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
+  const botToken = readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_TOKEN");
+  if (!DELIVERY_PROJECT_RE.test(project) || !botToken) return null;
+  return {
+    project,
+    connectorAccountId: await resolveTelegramConnectorAccountId(botToken),
+  };
 }
 
 async function telegramCanonicalMessageId(
@@ -257,6 +273,45 @@ export function verifyPersonalTelegramGatewayRequest(c: AppContext): boolean {
   );
 }
 
+/**
+ * Binds an authenticated Gateway handoff to the exact Worker-side bot account
+ * before the Worker allocates delivery state or performs a provider action.
+ */
+export async function personalTelegramGatewayConnectorAccountFailure(
+  c: AppContext,
+): Promise<Response | null> {
+  const configuredScope = await configuredPersonalTelegramScope(c.env);
+  if (!configuredScope) {
+    return c.json(
+      { success: false, error: "Telegram connector is not configured" },
+      503,
+    );
+  }
+  const presentedHeader = c.req.header(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER);
+  if (
+    presentedHeader === undefined &&
+    isPersonalTelegramDeliveryEpoch1CompatEnabled(c.env)
+  ) {
+    logger.warn(
+      "[PersonalTelegramEdge] legacy headerless gateway handoff accepted",
+      { deliveryEpoch: 1 },
+    );
+    return null;
+  }
+  const presentedAccountId = presentedHeader?.trim() ?? "";
+  if (
+    !TELEGRAM_CONNECTOR_ACCOUNT_RE.test(presentedAccountId) ||
+    presentedAccountId !== configuredScope.connectorAccountId
+  ) {
+    c.header("X-Eliza-Failure-Stage", "connector_account");
+    return c.json(
+      { success: false, error: "Telegram connector account mismatch" },
+      409,
+    );
+  }
+  return null;
+}
+
 export async function handlePersonalTelegramDeliveryLedger(
   c: AppContext,
 ): Promise<Response> {
@@ -277,6 +332,7 @@ export async function handlePersonalTelegramDeliveryLedger(
   const project = input.project;
   const senderId = input.senderId;
   const messageId = input.messageId;
+  const operation = input.operation;
   const deliveryEpoch = input.deliveryEpoch;
   const connectorAccountId = input.connectorAccountId;
   const legacyEpoch =
@@ -292,31 +348,67 @@ export async function handlePersonalTelegramDeliveryLedger(
     !DELIVERY_SENDER_RE.test(senderId) ||
     typeof messageId !== "string" ||
     !DELIVERY_MESSAGE_ID_RE.test(messageId) ||
+    (operation !== "mark_uncertain" && operation !== "mark_delivered") ||
     (!legacyEpoch && !accountScopedEpoch)
   ) {
     return c.json({ success: false, error: "Invalid delivery scope" }, 400);
+  }
+  const configuredScope = await configuredPersonalTelegramScope(c.env);
+  if (!configuredScope) {
+    return c.json(
+      { success: false, error: "Telegram connector is not configured" },
+      503,
+    );
+  }
+  if (
+    project !== configuredScope.project ||
+    (accountScopedEpoch &&
+      connectorAccountId !== configuredScope.connectorAccountId)
+  ) {
+    return c.json({ success: false, error: "Forbidden delivery scope" }, 403);
+  }
+  if (legacyEpoch && !isPersonalTelegramDeliveryEpoch1CompatEnabled(c.env)) {
+    logger.warn(
+      "[PersonalTelegramDelivery] legacy epoch reconciliation rejected",
+      { deliveryEpoch: 1, operation },
+    );
+    return c.json(
+      {
+        success: false,
+        error: "Legacy Telegram delivery epoch is disabled",
+        code: "LEGACY_DELIVERY_EPOCH_DISABLED",
+      },
+      409,
+    );
   }
   const namespace = c.env.PERSONAL_TELEGRAM_DELIVERIES;
   if (!namespace) {
     return c.json({ success: false, error: "Delivery binding missing" }, 503);
   }
-  // Epoch 1 requests come only from an older gateway binary during a rolling
-  // deployment. Its account-independent tombstones are ambiguous, so epoch 2
-  // never reads them; the Durable Object expires them after 30 days. A current
-  // gateway must identify its stable account explicitly and writes only v2.
-  const scopedConnectorAccountId =
-    accountScopedEpoch && typeof connectorAccountId === "string"
-      ? connectorAccountId
-      : undefined;
+  // Epoch 1 is a temporary, observable rolling-upgrade bridge. Its ambiguous
+  // tombstones stay quarantined from epoch 2 and expire after 30 days.
+  if (legacyEpoch) {
+    logger.warn(
+      "[PersonalTelegramDelivery] legacy epoch reconciliation accepted",
+      { deliveryEpoch: 1, operation },
+    );
+  }
+  const scopedConnectorAccountId = accountScopedEpoch
+    ? configuredScope.connectorAccountId
+    : undefined;
   const scopedMessageId = scopedConnectorAccountId
     ? await telegramCanonicalMessageId(
-        project,
+        configuredScope.project,
         scopedConnectorAccountId,
         messageId,
       )
     : messageId;
   const stub = namespace.getByName(
-    telegramDeliveryObjectName(project, senderId, scopedConnectorAccountId),
+    telegramDeliveryObjectName(
+      configuredScope.project,
+      senderId,
+      scopedConnectorAccountId,
+    ),
   );
   const response = await stub.fetch(
     `https://personal-telegram-delivery${PERSONAL_TELEGRAM_DELIVERY_PATH}`,
@@ -324,12 +416,8 @@ export async function handlePersonalTelegramDeliveryLedger(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        ...input,
-        project: undefined,
-        senderId: undefined,
-        connectorAccountId: undefined,
-        deliveryEpoch: undefined,
         messageId: scopedMessageId,
+        operation,
       }),
     },
   );
@@ -475,6 +563,20 @@ export async function dispatchPersonalTelegramReminder(
       message: "Telegram connector is not configured",
     };
   }
+  const configuredScope = await configuredPersonalTelegramScope(env);
+  if (
+    !configuredScope ||
+    configuredScope.project !== input.project ||
+    !TELEGRAM_CONNECTOR_ACCOUNT_RE.test(input.connectorAccountId) ||
+    configuredScope.connectorAccountId !== input.connectorAccountId
+  ) {
+    return {
+      ok: false,
+      acceptance: "not_accepted",
+      message:
+        "Telegram connector account no longer matches the reminder destination",
+    };
+  }
   const event: TelegramConnectorEvent = {
     platform: "telegram",
     messageId: input.idempotencyKey,
@@ -490,8 +592,7 @@ export async function dispatchPersonalTelegramReminder(
     rawPayload: { source: "shared-reminder" },
   };
   try {
-    const connectorAccountId =
-      await resolveTelegramConnectorAccountId(botToken);
+    const connectorAccountId = input.connectorAccountId;
     const canonicalMessageId = await telegramCanonicalMessageId(
       input.project,
       connectorAccountId,

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -27,7 +27,10 @@ import {
   TelegramEgressAlreadyClaimedError,
 } from "@elizaos/cloud-services-common/telegram-delivery";
 import type { Hono, ExecutionContext as HonoExecutionContext } from "hono";
-import { PERSONAL_TELEGRAM_DELIVERY_PATH } from "@/api-app/personal-telegram-delivery";
+import {
+  PERSONAL_TELEGRAM_DELIVERY_EPOCH,
+  PERSONAL_TELEGRAM_DELIVERY_PATH,
+} from "@/api-app/personal-telegram-delivery";
 import { runWithDbCacheAsync } from "@/db/client";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { appendServerTiming } from "@/lib/observability/http-telemetry";
@@ -45,6 +48,8 @@ const TYPING_REFRESH_MS = 4_000;
 const DELIVERY_PROJECT_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const DELIVERY_SENDER_RE = /^\d{1,32}$/;
 const DELIVERY_THREAD_RE = /^[1-9]\d{0,15}$/;
+const DELIVERY_MESSAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,159}$/;
+const TELEGRAM_CONNECTOR_ACCOUNT_RE = /^bot:(?:\d{1,20}|[0-9a-f]{64})$/;
 
 export interface TelegramEdgeDeps {
   runTurn(
@@ -102,6 +107,28 @@ async function resolveTelegramConnectorAccountId(
   // immutable bot id, while opaque proxy/test credentials remain non-secret.
   const botId = botToken.match(/^(\d{1,20}):/)?.[1];
   return botId ? `bot:${botId}` : `bot:${await sha256Hex(botToken)}`;
+}
+
+async function telegramCanonicalMessageId(
+  project: string,
+  connectorAccountId: string,
+  providerMessageId: string,
+): Promise<string> {
+  const readable = `telegram:${project}:${connectorAccountId}:${providerMessageId}`;
+  if (DELIVERY_MESSAGE_ID_RE.test(readable)) return readable;
+  return `telegram:v2:${connectorAccountId}:${await sha256Hex(
+    `${project}\0${providerMessageId}`,
+  )}`;
+}
+
+function telegramDeliveryObjectName(
+  project: string,
+  senderId: string,
+  connectorAccountId?: string,
+): string {
+  return connectorAccountId
+    ? `telegram:${project}:personal-shared:${connectorAccountId}:${senderId}`
+    : `telegram:${project}:personal-shared:${senderId}`;
 }
 
 async function runInternalRoute(
@@ -249,11 +276,23 @@ export async function handlePersonalTelegramDeliveryLedger(
   const input = body as Record<string, unknown>;
   const project = input.project;
   const senderId = input.senderId;
+  const messageId = input.messageId;
+  const deliveryEpoch = input.deliveryEpoch;
+  const connectorAccountId = input.connectorAccountId;
+  const legacyEpoch =
+    deliveryEpoch === undefined && connectorAccountId === undefined;
+  const accountScopedEpoch =
+    deliveryEpoch === PERSONAL_TELEGRAM_DELIVERY_EPOCH &&
+    typeof connectorAccountId === "string" &&
+    TELEGRAM_CONNECTOR_ACCOUNT_RE.test(connectorAccountId);
   if (
     typeof project !== "string" ||
     !DELIVERY_PROJECT_RE.test(project) ||
     typeof senderId !== "string" ||
-    !DELIVERY_SENDER_RE.test(senderId)
+    !DELIVERY_SENDER_RE.test(senderId) ||
+    typeof messageId !== "string" ||
+    !DELIVERY_MESSAGE_ID_RE.test(messageId) ||
+    (!legacyEpoch && !accountScopedEpoch)
   ) {
     return c.json({ success: false, error: "Invalid delivery scope" }, 400);
   }
@@ -261,8 +300,23 @@ export async function handlePersonalTelegramDeliveryLedger(
   if (!namespace) {
     return c.json({ success: false, error: "Delivery binding missing" }, 503);
   }
+  // Epoch 1 requests come only from an older gateway binary during a rolling
+  // deployment. Its account-independent tombstones are ambiguous, so epoch 2
+  // never reads them; the Durable Object expires them after 30 days. A current
+  // gateway must identify its stable account explicitly and writes only v2.
+  const scopedConnectorAccountId =
+    accountScopedEpoch && typeof connectorAccountId === "string"
+      ? connectorAccountId
+      : undefined;
+  const scopedMessageId = scopedConnectorAccountId
+    ? await telegramCanonicalMessageId(
+        project,
+        scopedConnectorAccountId,
+        messageId,
+      )
+    : messageId;
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${senderId}`,
+    telegramDeliveryObjectName(project, senderId, scopedConnectorAccountId),
   );
   const response = await stub.fetch(
     `https://personal-telegram-delivery${PERSONAL_TELEGRAM_DELIVERY_PATH}`,
@@ -273,6 +327,9 @@ export async function handlePersonalTelegramDeliveryLedger(
         ...input,
         project: undefined,
         senderId: undefined,
+        connectorAccountId: undefined,
+        deliveryEpoch: undefined,
+        messageId: scopedMessageId,
       }),
     },
   );
@@ -286,38 +343,40 @@ export async function handlePersonalTelegramDeliveryLedger(
 async function edgeLedger(
   env: AppEnv["Bindings"],
   project: string,
+  connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
 ): Promise<TelegramDeliveryLedger> {
   const namespace = env.PERSONAL_TELEGRAM_DELIVERIES;
   if (!namespace)
     throw new Error("Personal Telegram delivery binding is missing");
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${event.senderId}`,
+    telegramDeliveryObjectName(project, event.senderId, connectorAccountId),
   );
   return {
     async read() {
-      const body = await callLedger(stub, event.messageId, "read");
+      const body = await callLedger(stub, canonicalMessageId, "read");
       return body.state === "uncertain" || body.state === "delivered"
         ? body.state
         : null;
     },
     async claimProcessing() {
       return (
-        (await callLedger(stub, event.messageId, "claim_processing"))
+        (await callLedger(stub, canonicalMessageId, "claim_processing"))
           .claimed === true
       );
     },
     async releaseProcessing() {
-      await callLedger(stub, event.messageId, "release_processing");
+      await callLedger(stub, canonicalMessageId, "release_processing");
     },
     async preparePlan(chunkDigests) {
-      const body = await callLedger(stub, event.messageId, "prepare_plan", {
+      const body = await callLedger(stub, canonicalMessageId, "prepare_plan", {
         chunkDigests,
       });
       return body.plan === "prepared" ? "prepared" : "conflict";
     },
     async readChunk(chunkIndex, chunkDigest) {
-      const body = await callLedger(stub, event.messageId, "read_chunk", {
+      const body = await callLedger(stub, canonicalMessageId, "read_chunk", {
         chunkIndex,
         chunkDigest,
       });
@@ -334,7 +393,7 @@ async function edgeLedger(
     async claimChunk(chunkIndex, chunkDigest) {
       return (
         (
-          await callLedger(stub, event.messageId, "claim_chunk", {
+          await callLedger(stub, canonicalMessageId, "claim_chunk", {
             chunkIndex,
             chunkDigest,
           })
@@ -342,20 +401,20 @@ async function edgeLedger(
       );
     },
     async releaseChunk(chunkIndex, chunkDigest) {
-      await callLedger(stub, event.messageId, "release_chunk", {
+      await callLedger(stub, canonicalMessageId, "release_chunk", {
         chunkIndex,
         chunkDigest,
       });
     },
     async markChunkDelivered(chunkIndex, chunkDigest, providerMessageId) {
-      await callLedger(stub, event.messageId, "mark_chunk_delivered", {
+      await callLedger(stub, canonicalMessageId, "mark_chunk_delivered", {
         chunkIndex,
         chunkDigest,
         providerMessageId,
       });
     },
     async markDelivered() {
-      await callLedger(stub, event.messageId, "mark_delivered");
+      await callLedger(stub, canonicalMessageId, "mark_delivered");
     },
   };
 }
@@ -363,14 +422,16 @@ async function edgeLedger(
 async function readEdgeReceipt(
   env: AppEnv["Bindings"],
   project: string,
+  connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
 ): Promise<{ acceptedAt: string; providerMessageIds: string[] } | null> {
   const namespace = env.PERSONAL_TELEGRAM_DELIVERIES;
   if (!namespace) return null;
   const stub = namespace.getByName(
-    `telegram:${project}:personal-shared:${event.senderId}`,
+    telegramDeliveryObjectName(project, event.senderId, connectorAccountId),
   );
-  const body = await callLedger(stub, event.messageId, "read_receipt");
+  const body = await callLedger(stub, canonicalMessageId, "read_receipt");
   const acceptedAt =
     typeof body.acceptedAt === "string" &&
     Number.isFinite(Date.parse(body.acceptedAt))
@@ -429,7 +490,20 @@ export async function dispatchPersonalTelegramReminder(
     rawPayload: { source: "shared-reminder" },
   };
   try {
-    const ledger = await edgeLedger(env, input.project, event);
+    const connectorAccountId =
+      await resolveTelegramConnectorAccountId(botToken);
+    const canonicalMessageId = await telegramCanonicalMessageId(
+      input.project,
+      connectorAccountId,
+      event.messageId,
+    );
+    const ledger = await edgeLedger(
+      env,
+      input.project,
+      connectorAccountId,
+      canonicalMessageId,
+      event,
+    );
     const outcome = await executeTelegramDelivery(ledger, async (hooks) => {
       await sendTelegramReply({ botToken }, event, input.text, logger, hooks);
     });
@@ -440,7 +514,13 @@ export async function dispatchPersonalTelegramReminder(
         message: `Telegram reminder delivery is ${outcome}`,
       };
     }
-    const receipt = await readEdgeReceipt(env, input.project, event);
+    const receipt = await readEdgeReceipt(
+      env,
+      input.project,
+      connectorAccountId,
+      canonicalMessageId,
+      event,
+    );
     return receipt
       ? { ok: true, ...receipt }
       : {
@@ -503,6 +583,7 @@ function startTyping(
 function deliveryBody(
   project: string,
   connectorAccountId: string,
+  canonicalMessageId: string,
   event: TelegramConnectorEvent,
   voiceNote?: Awaited<ReturnType<typeof resolveTelegramVoiceNote>>,
 ): Record<string, unknown> {
@@ -513,7 +594,7 @@ function deliveryBody(
     chatId: event.chatId,
     telegramUserId: event.senderId,
     displayName: event.senderName,
-    messageId: `telegram:${project}:${event.messageId}`,
+    messageId: canonicalMessageId,
     ...(event.text ? { message: event.text } : {}),
     ...(voiceNote ? { voiceNote } : {}),
   };
@@ -608,7 +689,18 @@ export async function handlePersonalTelegramEdge(
     readEnvString(c.env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
   const config = { botToken, webhookSecret };
   const connectorAccountId = await resolveTelegramConnectorAccountId(botToken);
-  const ledger = await edgeLedger(c.env, project, event);
+  const canonicalMessageId = await telegramCanonicalMessageId(
+    project,
+    connectorAccountId,
+    event.messageId,
+  );
+  const ledger = await edgeLedger(
+    c.env,
+    project,
+    connectorAccountId,
+    canonicalMessageId,
+    event,
+  );
 
   try {
     let turnMs = 0;
@@ -673,7 +765,13 @@ export async function handlePersonalTelegramEdge(
           const turn = await runTurnWithRetry(
             c,
             deps,
-            deliveryBody(project, connectorAccountId, event, voiceNote),
+            deliveryBody(
+              project,
+              connectorAccountId,
+              canonicalMessageId,
+              event,
+              voiceNote,
+            ),
             event,
             traceId,
           );

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -95,6 +95,15 @@ function readEnvString(env: AppEnv["Bindings"], key: string): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+async function resolveTelegramConnectorAccountId(
+  botToken: string,
+): Promise<string> {
+  // Match the gateway identity contract: the documented decimal prefix is the
+  // immutable bot id, while opaque proxy/test credentials remain non-secret.
+  const botId = botToken.match(/^(\d{1,20}):/)?.[1];
+  return botId ? `bot:${botId}` : `bot:${await sha256Hex(botToken)}`;
+}
+
 async function runInternalRoute(
   app: Hono<AppEnv>,
   body: Record<string, unknown>,
@@ -493,12 +502,14 @@ function startTyping(
 
 function deliveryBody(
   project: string,
+  connectorAccountId: string,
   event: TelegramConnectorEvent,
   voiceNote?: Awaited<ReturnType<typeof resolveTelegramVoiceNote>>,
 ): Record<string, unknown> {
   return {
     platform: "telegram",
     project,
+    connectorAccountId,
     chatId: event.chatId,
     telegramUserId: event.senderId,
     displayName: event.senderName,
@@ -596,6 +607,7 @@ export async function handlePersonalTelegramEdge(
   const project =
     readEnvString(c.env, "ELIZA_APP_WEBHOOK_PROJECT") ?? "eliza-app";
   const config = { botToken, webhookSecret };
+  const connectorAccountId = await resolveTelegramConnectorAccountId(botToken);
   const ledger = await edgeLedger(c.env, project, event);
 
   try {
@@ -661,7 +673,7 @@ export async function handlePersonalTelegramEdge(
           const turn = await runTurnWithRetry(
             c,
             deps,
-            deliveryBody(project, event, voiceNote),
+            deliveryBody(project, connectorAccountId, event, voiceNote),
             event,
             traceId,
           );

--- a/packages/cloud/api/eliza-app/webhook/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/webhook/telegram/route.ts
@@ -6,6 +6,7 @@ import { forwardToWebhookGateway, safeWebhookSuffix } from "../_forward";
 import {
   handlePersonalTelegramDeliveryLedger,
   handlePersonalTelegramEdge,
+  personalTelegramGatewayConnectorAccountFailure,
   verifyPersonalTelegramGatewayRequest,
 } from "../_telegram-edge";
 
@@ -16,9 +17,12 @@ const handle = async (c: Parameters<typeof handlePersonalTelegramEdge>[0]) => {
     return handlePersonalTelegramDeliveryLedger(c);
   }
   if (c.req.method === "POST" && suffix === "/edge") {
-    return verifyPersonalTelegramGatewayRequest(c)
-      ? handlePersonalTelegramEdge(c)
-      : c.json({ success: false, error: "Unauthorized" }, 401);
+    if (!verifyPersonalTelegramGatewayRequest(c)) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const connectorAccountFailure =
+      await personalTelegramGatewayConnectorAccountFailure(c);
+    return connectorAccountFailure ?? handlePersonalTelegramEdge(c);
   }
   return c.req.method === "POST" &&
     isPersonalSharedTelegramEdgeEnabled(c.env) &&

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -521,6 +521,7 @@ describe("personal Shared messaging deliveries", () => {
       {
         platform: "telegram",
         project: "eliza-app",
+        connectorAccountId: "telegram:test-bot",
         chatId: "123456789",
       },
       "hello",
@@ -784,6 +785,7 @@ describe("personal Shared messaging deliveries", () => {
         {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "telegram:test-bot",
           chatId: "123456789",
         },
         "please verify it\nremember the red bicycle",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1877,6 +1877,7 @@ app.post("/", async (c) => {
         ? {
             platform: "telegram" as const,
             project: parsed.data.project,
+            connectorAccountId: parsed.data.connectorAccountId,
             chatId: parsed.data.chatId,
           }
         : parsed.data.platform === "blooio"

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1107,6 +1107,10 @@ describe("cloud-api worker entrypoint", () => {
       region: "local-test",
       commit: "feedfacefeedfacefeedfacefeedfacefeedface",
       personalSharedTelegramEdge: { enabled: false },
+      personalTelegramDelivery: {
+        epoch: 2,
+        legacyEpoch1CompatEnabled: false,
+      },
       schemaCompatibility: { usageQuotasTombstone: true },
     });
   });
@@ -1150,6 +1154,7 @@ describe("cloud-api worker entrypoint", () => {
         ENVIRONMENT: "staging",
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
         PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
+        PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "never-return-this-bot-token",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "never-return-this-webhook-secret",
       } as never,
@@ -1160,6 +1165,10 @@ describe("cloud-api worker entrypoint", () => {
     expect(JSON.parse(text)).toMatchObject({
       environment: "staging",
       personalSharedTelegramEdge: { enabled: true },
+      personalTelegramDelivery: {
+        epoch: 2,
+        legacyEpoch1CompatEnabled: true,
+      },
     });
     expect(text).not.toContain("never-return-this-bot-token");
     expect(text).not.toContain("never-return-this-webhook-secret");
@@ -1316,6 +1325,7 @@ describe("cloud-api worker entrypoint", () => {
     ) as {
       vars?: {
         PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+        PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
@@ -1325,6 +1335,7 @@ describe("cloud-api worker entrypoint", () => {
         staging?: {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+            PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
@@ -1334,6 +1345,7 @@ describe("cloud-api worker entrypoint", () => {
         production?: {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+            PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
@@ -1353,6 +1365,17 @@ describe("cloud-api worker entrypoint", () => {
       config.env?.production?.vars?.PERSONAL_DELIVERY_PROJECTION_READ_ENABLED,
     ).toBe("false");
     expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
+    expect(
+      config.vars?.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars
+        ?.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED,
+    ).toBeUndefined();
     expect(
       config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBeUndefined();

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1319,7 +1319,7 @@ describe("cloud-api worker entrypoint", () => {
     ).toBeUndefined();
   });
 
-  test("keeps the legacy edge guard false and reserves the replacement names for the cutover secrets", async () => {
+  test("keeps production closed while staging atomically bridges delivery epoch 1", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -1371,7 +1371,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(
       config.env?.staging?.vars
         ?.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED,
-    ).toBeUndefined();
+    ).toBe("true");
     expect(
       config.env?.production?.vars
         ?.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED,

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -36,6 +36,10 @@ import { KNOWN_ROUTE_SHARD_KEYS } from "./_router-shard-keys.generated";
 import { isStorageReadCapabilityPath, serveBlobHostRequest } from "./blob-host";
 import { isThinCliSessionPath } from "./cli-session-paths";
 import { isPersonalSharedTelegramEdgeEnabled } from "./personal-shared-telegram-edge";
+import {
+  isPersonalTelegramDeliveryEpoch1CompatEnabled,
+  PERSONAL_TELEGRAM_DELIVERY_EPOCH,
+} from "./personal-telegram-delivery";
 import { serveRegistryHostRequest } from "./registry-host";
 import { knownRouteShardKey } from "./router-shards";
 import { isThinStewardPath } from "./steward/public-paths";
@@ -648,6 +652,11 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
       // a provider-side mutation has an ambiguous result.
       personalSharedTelegramEdge: {
         enabled: personalSharedTelegramEdgeEnabled,
+      },
+      personalTelegramDelivery: {
+        epoch: PERSONAL_TELEGRAM_DELIVERY_EPOCH,
+        legacyEpoch1CompatEnabled:
+          isPersonalTelegramDeliveryEpoch1CompatEnabled(env),
       },
       // Value-free schema compatibility beacon. The release workflow checks
       // the currently served Worker for this marker before the later quota

--- a/packages/cloud/api/src/personal-telegram-delivery.test.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.test.ts
@@ -3,7 +3,9 @@
 import { describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
+  PERSONAL_TELEGRAM_DELIVERY_EPOCH,
   PERSONAL_TELEGRAM_DELIVERY_PATH,
+  PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS,
   PersonalTelegramDelivery,
 } from "./personal-telegram-delivery";
 
@@ -76,6 +78,32 @@ async function json(response: Promise<Response>): Promise<unknown> {
 }
 
 describe("PersonalTelegramDelivery", () => {
+  test("bounds quarantined epoch 1 tombstones to the 30-day delivery TTL", async () => {
+    expect(PERSONAL_TELEGRAM_DELIVERY_EPOCH).toBe(2);
+    expect(PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS).toBe(
+      30 * 24 * 60 * 60_000,
+    );
+    const storage = new MemoryStorage();
+    const object = new PersonalTelegramDelivery(
+      durableState(storage),
+      {} as AppEnv["Bindings"],
+    );
+    const before = Date.now();
+
+    await object.fetch(operation("legacy-epoch-1", "mark_delivered"));
+
+    const entry = storage.values.get("delivery:legacy-epoch-1") as
+      | { expiresAt?: unknown }
+      | undefined;
+    expect(typeof entry?.expiresAt).toBe("number");
+    expect(Number(entry?.expiresAt)).toBeGreaterThanOrEqual(
+      before + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS,
+    );
+    expect(Number(entry?.expiresAt)).toBeLessThanOrEqual(
+      Date.now() + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS,
+    );
+  });
+
   test("persists an uncertain chunk across object eviction", async () => {
     const storage = new MemoryStorage();
     const first = new PersonalTelegramDelivery(

--- a/packages/cloud/api/src/personal-telegram-delivery.test.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
+  isPersonalTelegramDeliveryEpoch1CompatEnabled,
   PERSONAL_TELEGRAM_DELIVERY_EPOCH,
   PERSONAL_TELEGRAM_DELIVERY_PATH,
   PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS,
@@ -78,6 +79,16 @@ async function json(response: Promise<Response>): Promise<unknown> {
 }
 
 describe("PersonalTelegramDelivery", () => {
+  test.each([
+    [{}, false],
+    [{ PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "false" }, false],
+    [{ PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "1" }, false],
+    [{ PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: " true " }, false],
+    [{ PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED: "true" }, true],
+  ])("resolves epoch-1 compatibility %o as %s", (env, expected) => {
+    expect(isPersonalTelegramDeliveryEpoch1CompatEnabled(env)).toBe(expected);
+  });
+
   test("bounds quarantined epoch 1 tombstones to the 30-day delivery TTL", async () => {
     expect(PERSONAL_TELEGRAM_DELIVERY_EPOCH).toBe(2);
     expect(PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS).toBe(

--- a/packages/cloud/api/src/personal-telegram-delivery.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.ts
@@ -9,8 +9,13 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 export const PERSONAL_TELEGRAM_DELIVERY_PATH = "/v1/delivery";
+// Epoch 1 omitted the connector account from both routing boundaries. Epoch 2
+// is intentionally disjoint because those historical owners cannot be inferred.
+export const PERSONAL_TELEGRAM_DELIVERY_EPOCH = 2;
+// This also bounds the quarantine window for account-independent epoch 1 state.
+export const PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS =
+  30 * 24 * 60 * 60_000;
 const PROCESSING_TTL_MS = 120_000;
-const DELIVERY_TTL_MS = 30 * 24 * 60 * 60_000;
 const MESSAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,199}$/;
 const PROVIDER_MESSAGE_ID_RE = /^\d{1,32}$/;
 
@@ -205,7 +210,8 @@ export class PersonalTelegramDelivery {
           plan: plansEqual(existing, chunkDigests) ? "prepared" : "conflict",
         });
       }
-      const expiresAt = Date.now() + DELIVERY_TTL_MS;
+      const expiresAt =
+        Date.now() + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS;
       await this.state.storage.put(storageKey, {
         value: chunkDigests,
         expiresAt,
@@ -240,7 +246,8 @@ export class PersonalTelegramDelivery {
       if (input.operation === "claim_chunk") {
         const existing = await this.readExpiring<DeliveryState>(storageKey);
         if (existing) return Response.json({ claimed: false });
-        const expiresAt = Date.now() + DELIVERY_TTL_MS;
+        const expiresAt =
+          Date.now() + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS;
         await this.state.storage.put(storageKey, {
           value: "uncertain",
           expiresAt,
@@ -248,7 +255,8 @@ export class PersonalTelegramDelivery {
         await this.scheduleCleanup(expiresAt);
         return Response.json({ claimed: true });
       }
-      const expiresAt = Date.now() + DELIVERY_TTL_MS;
+      const expiresAt =
+        Date.now() + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS;
       const delivered = {
         value: "delivered",
         expiresAt,
@@ -283,7 +291,7 @@ export class PersonalTelegramDelivery {
     const requested =
       input.operation === "mark_uncertain" ? "uncertain" : "delivered";
     const value = existing === "delivered" ? "delivered" : requested;
-    const expiresAt = Date.now() + DELIVERY_TTL_MS;
+    const expiresAt = Date.now() + PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS;
     await this.state.storage.put(deliveryStorageKey, {
       value,
       expiresAt,

--- a/packages/cloud/api/src/personal-telegram-delivery.ts
+++ b/packages/cloud/api/src/personal-telegram-delivery.ts
@@ -12,6 +12,19 @@ export const PERSONAL_TELEGRAM_DELIVERY_PATH = "/v1/delivery";
 // Epoch 1 omitted the connector account from both routing boundaries. Epoch 2
 // is intentionally disjoint because those historical owners cannot be inferred.
 export const PERSONAL_TELEGRAM_DELIVERY_EPOCH = 2;
+/**
+ * Temporary rolling-upgrade bridge for an older Gateway that neither sends
+ * the connector-account edge header nor account-scoped epoch-2 reconciliation.
+ * It is deliberately exact-true and off when absent.
+ */
+export function isPersonalTelegramDeliveryEpoch1CompatEnabled(
+  env: Pick<
+    AppEnv["Bindings"],
+    "PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED"
+  >,
+): boolean {
+  return env.PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED === "true";
+}
 // This also bounds the quarantine window for account-independent epoch 1 state.
 export const PERSONAL_TELEGRAM_DELIVERY_TOMBSTONE_TTL_MS =
   30 * 24 * 60 * 60_000;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -239,6 +239,10 @@ SHARED_TURN_TRACES_ENABLED = "true"
 SHARED_TURN_TRACES_SAMPLE = "0.1"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED is deliberately absent from
+# every vars block. It is a temporary exact-true bridge for a legacy Gateway's
+# headerless edge handoff and epoch-1 reconciliation; bind it only through a
+# protected environment for a bounded Worker-first rollout. Default is closed.
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED and
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED are deliberately
 # absent from every [vars] block. The protected activation workflows own them

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -240,9 +240,9 @@ SHARED_TURN_TRACES_SAMPLE = "0.1"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 # PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED is deliberately absent from
-# every vars block. It is a temporary exact-true bridge for a legacy Gateway's
-# headerless edge handoff and epoch-1 reconciliation; bind it only through a
-# protected environment for a bounded Worker-first rollout. Default is closed.
+# the root and production vars blocks. Staging commits the temporary exact-true
+# bridge below so its Worker deploy cannot race the legacy Gateway's headerless
+# handoff or epoch-1 reconciliation. Production remains protected and closed.
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED and
 # PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED are deliberately
 # absent from every [vars] block. The protected activation workflows own them
@@ -545,6 +545,11 @@ SHARED_TURN_TRACES_SAMPLE = "1"
 # identity/lifecycle writer participates in the durable mutation-fence protocol.
 # The bound Durable Object remains available for exact-head isolated proof.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
+# Temporary Worker-first compatibility fence: this must deploy atomically with
+# delivery epoch 2 before the legacy staging Gateway is replaced. Remove it only
+# after the epoch-2 Gateway is live, legacy warnings are zero, and the drain and
+# reconciliation checks in the PR rollout evidence have passed.
+PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED = "true"
 # The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED
 # as a secret binding. It uses a fresh name because keep_vars preserved the old
 # staging plaintext binding; either binding must be exactly true to opt in.

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -6,6 +6,8 @@
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_MESSAGE_LENGTH = 4096;
+export const TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER =
+  "X-Eliza-Connector-Account-Id";
 export const TELEGRAM_HOSTED_FILE_MAX_BYTES = 20 * 1024 * 1024;
 export const TELEGRAM_VOICE_MAX_BYTES = 8 * 1024 * 1024;
 const TELEGRAM_API_TIMEOUT_MS = 10_000;

--- a/packages/cloud/services/_common/tests/telegram-connector-delivery.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-delivery.test.ts
@@ -46,7 +46,7 @@ afterEach(() => {
 });
 
 describe("sendTelegramReply delivery state", () => {
-  test("retries only a rate-limited second chunk", async () => {
+  test("retries only a rate-limited second chunk without dropping its leading newline", async () => {
     const sentTexts: string[] = [];
     let call = 0;
     globalThis.fetch = mock(async (_input, init) => {
@@ -73,7 +73,7 @@ describe("sendTelegramReply delivery state", () => {
       hooks(events),
     );
 
-    expect(sentTexts).toEqual(["a".repeat(4096), "b", "b"]);
+    expect(sentTexts).toEqual(["a".repeat(4096), "\nb", "\nb"]);
     expect(receipt.providerMessageIds).toEqual(["1", "3"]);
     expect(events).toEqual([
       "prepare:2",

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { credentialFingerprint } from "../src/connector-account";
 import { deliverInternalMessage } from "../src/internal-delivery";
 import type { GatewayRedis } from "../src/redis";
 
@@ -50,6 +51,8 @@ const originalFetch = globalThis.fetch;
 const originalToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
 const originalBlooioKey = process.env.ELIZA_APP_BLOOIO_API_KEY;
 const originalBlooioNumber = process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
+const TELEGRAM_TEST_TOKEN = "telegram-test-token";
+const TELEGRAM_CONNECTOR_ACCOUNT_ID = `bot:${credentialFingerprint(TELEGRAM_TEST_TOKEN)}`;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -72,6 +75,7 @@ function request(overrides: Record<string, unknown> = {}) {
     body: JSON.stringify({
       platform: "blooio",
       project: "eliza-app",
+      connectorAccountId: "+15550001111",
       chatId: "chat_group_123",
       text: "Reminder for this group from Nubs: pay the rent",
       idempotencyKey: "group-task-1:2026-08-20T19:30:00.000Z",
@@ -121,7 +125,7 @@ describe("internal proactive group delivery", () => {
   });
 
   test("sends a Telegram group reminder to its negative chat id unchanged", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(
@@ -136,7 +140,11 @@ describe("internal proactive group delivery", () => {
     ) as typeof fetch;
 
     const response = await deliverInternalMessage(
-      request({ platform: "telegram", chatId: "-100123456789" }),
+      request({
+        platform: "telegram",
+        connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
+        chatId: "-100123456789",
+      }),
       { redis },
     );
 
@@ -172,6 +180,7 @@ describe("internal proactive group delivery", () => {
     const response = await deliverInternalMessage(
       request({
         platform: "telegram",
+        connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
         chatId: "-100123456789",
         providerThreadId: "909",
       }),
@@ -203,6 +212,7 @@ describe("internal proactive group delivery", () => {
       const response = await deliverInternalMessage(
         request({
           platform: "telegram",
+          connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
           chatId: "-100123456789",
           providerThreadId,
         }),
@@ -213,6 +223,28 @@ describe("internal proactive group delivery", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("rejects a group connector-account mismatch before claim or provider egress", async () => {
+    process.env.ELIZA_APP_BLOOIO_API_KEY = "blooio-test-key";
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () => {
+      throw new Error("provider must not run");
+    }) as typeof fetch;
+
+    const response = await deliverInternalMessage(
+      request({ connectorAccountId: "+15550009999" }),
+      { redis },
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      retryable: false,
+      acceptance: "not_accepted",
+    });
+    expect(redis.store).toEqual(new Map());
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
   test("rejects malformed group recipients before egress", async () => {
     const redis = new MemoryRedis();
     globalThis.fetch = mock(async () => {
@@ -247,7 +279,11 @@ describe("internal proactive group delivery", () => {
     ) as typeof fetch;
 
     const response = await deliverInternalMessage(
-      request({ chatId: undefined, phoneNumber: "+15551234567" }),
+      request({
+        connectorAccountId: undefined,
+        chatId: undefined,
+        phoneNumber: "+15551234567",
+      }),
       { redis },
     );
 

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
@@ -1,6 +1,7 @@
 /** Verifies proactive Telegram delivery ownership and replay against the gateway boundary. */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { credentialFingerprint } from "../src/connector-account";
 import { deliverInternalMessage } from "../src/internal-delivery";
 import type { GatewayRedis } from "../src/redis";
 
@@ -54,6 +55,8 @@ const originalFetch = globalThis.fetch;
 const originalToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
 const originalBlooioKey = process.env.ELIZA_APP_BLOOIO_API_KEY;
 const originalBlooioNumber = process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
+const TELEGRAM_TEST_TOKEN = "telegram-test-token";
+const TELEGRAM_CONNECTOR_ACCOUNT_ID = `bot:${credentialFingerprint(TELEGRAM_TEST_TOKEN)}`;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -76,6 +79,7 @@ function request(overrides: Record<string, unknown> = {}) {
     body: JSON.stringify({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId: TELEGRAM_CONNECTOR_ACCOUNT_ID,
       chatId: "123456789",
       text: "take a break",
       idempotencyKey: "task-1:2026-08-14T20:00:00.000Z",
@@ -90,6 +94,7 @@ function dependencies(redis: GatewayRedis) {
 
 describe("internal proactive delivery", () => {
   test("reports Redis read and claim failures as retryable before egress", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const send = mock(async () => {
       throw new Error("provider must not run");
     });
@@ -112,7 +117,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("does not mask an explicit provider rejection when claim release fails", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     redis.failDelete = true;
     globalThis.fetch = mock(async () =>
@@ -132,7 +137,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("delivers without Cloud API auth and replays the completed idempotency key", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     const telegramBodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(async (input, init) => {
@@ -166,6 +171,65 @@ describe("internal proactive delivery", () => {
         parse_mode: "Markdown",
       },
     ]);
+  });
+
+  test("keeps the bot identity stable across Telegram secret rotation", async () => {
+    const redis = new MemoryRedis();
+    const connectorAccountId = "bot:123456789";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123456789:first-secret";
+    globalThis.fetch = mock(async () =>
+      Response.json({ ok: true, result: { message_id: 73 } }),
+    ) as typeof fetch;
+
+    const first = await deliverInternalMessage(
+      request({ connectorAccountId }),
+      dependencies(redis),
+    );
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123456789:rotated-secret";
+    const replay = await deliverInternalMessage(
+      request({ connectorAccountId }),
+      dependencies(redis),
+    );
+
+    expect(first.status).toBe(200);
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      success: true,
+      replayed: true,
+      providerMessageIds: ["73"],
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect([...redis.store.keys()]).toEqual([
+      "internal-delivery:telegram:eliza-app:task-1:2026-08-14T20:00:00.000Z",
+    ]);
+  });
+
+  test("rejects a missing or different Telegram bot before receipt lookup or egress", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "987654321:configured-secret";
+    const redis = new MemoryRedis();
+    redis.failGet = true;
+    globalThis.fetch = mock(async () => {
+      throw new Error("provider must not run");
+    }) as typeof fetch;
+
+    const missing = await deliverInternalMessage(
+      request({ connectorAccountId: undefined }),
+      dependencies(redis),
+    );
+    const differentBot = await deliverInternalMessage(
+      request({ connectorAccountId: "bot:123456789" }),
+      dependencies(redis),
+    );
+
+    expect(missing.status).toBe(400);
+    expect(differentBot.status).toBe(422);
+    await expect(differentBot.json()).resolves.toMatchObject({
+      success: false,
+      retryable: false,
+      acceptance: "not_accepted",
+    });
+    expect(redis.store).toEqual(new Map());
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("delivers Blooio iMessage once with the provider idempotency key and receipt", async () => {
@@ -215,7 +279,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("rejects a concurrent duplicate while the first send owns delivery", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     let finishSend: (() => void) | undefined;
     let markSendStarted: (() => void) | undefined;
@@ -251,7 +315,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("does not resend after Telegram accepts but the completion receipt write fails", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     redis.failCompletionWrite = true;
     globalThis.fetch = mock(async () =>
@@ -277,7 +341,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("retains an indeterminate tombstone when the provider response times out", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     globalThis.fetch = mock(async () => {
       throw new Error("response timeout");
@@ -328,6 +392,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("never reports a pre-existing indeterminate tombstone as accepted", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     redis.store.set(
       "internal-delivery:telegram:eliza-app:task-1:2026-08-14T20:00:00.000Z",
@@ -353,7 +418,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("retries without Markdown only after Telegram explicitly rejects formatting", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(async (input, init) => {
@@ -386,7 +451,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("releases the delivery claim when Telegram explicitly rate-limits the first send", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     globalThis.fetch = mock(async () =>
       Response.json({
@@ -412,7 +477,7 @@ describe("internal proactive delivery", () => {
   });
 
   test("releases the claim when the plain-text retry is explicitly forbidden", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = TELEGRAM_TEST_TOKEN;
     const redis = new MemoryRedis();
     const bodies: Array<Record<string, unknown>> = [];
     globalThis.fetch = mock(async (input, init) => {

--- a/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 
 describe("Personal Telegram gateway-to-edge handoff", () => {
   test("preserves the signed payload and lets the Worker own egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
     const redis = new MemoryRedis();
     let forwarded: Request | null = null;
     globalThis.fetch = mock(async (input, init) => {
@@ -135,20 +135,21 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
   });
 
   test("reconciles an old ambiguous Railway send without invoking edge egress", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",
       "egress_started",
     );
-    let operation = "";
+    let reconciliationBody: Record<string, unknown> = {};
     globalThis.fetch = mock(async (input, init) => {
       expect(String(input)).toEndWith(
         "/api/eliza-app/webhook/telegram/delivery",
       );
-      operation = String(
-        (JSON.parse(String(init?.body)) as { operation?: unknown }).operation,
-      );
+      reconciliationBody = JSON.parse(String(init?.body)) as Record<
+        string,
+        unknown
+      >;
       return Response.json({ state: "uncertain" });
     }) as unknown as typeof fetch;
 
@@ -165,19 +166,28 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
     );
 
     expect(response.status).toBe(503);
-    expect(operation).toBe("mark_uncertain");
+    expect(reconciliationBody).toMatchObject({
+      deliveryEpoch: 2,
+      connectorAccountId: "bot:123",
+      operation: "mark_uncertain",
+    });
   });
 
   test("heals a lost gateway receipt without downgrading Worker delivery", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",
       "egress_started",
     );
-    globalThis.fetch = mock(async () =>
-      Response.json({ state: "delivered" }),
-    ) as unknown as typeof fetch;
+    let reconciliationBody: Record<string, unknown> = {};
+    globalThis.fetch = mock(async (_input, init) => {
+      reconciliationBody = JSON.parse(String(init?.body)) as Record<
+        string,
+        unknown
+      >;
+      return Response.json({ state: "delivered" });
+    }) as unknown as typeof fetch;
 
     const response = await handleWebhook(
       request(),
@@ -195,10 +205,15 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
     expect(
       redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
     ).toBe("delivered");
+    expect(reconciliationBody).toMatchObject({
+      deliveryEpoch: 2,
+      connectorAccountId: "bot:123",
+      operation: "mark_uncertain",
+    });
   });
 
   test("keeps a Redis-only old gateway fenced after Worker authority begins", async () => {
-    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "test-token";
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
     const redis = new MemoryRedis();
     redis.values.set(
       "webhook:telegram:scope:message:edge-forward-1",

--- a/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/personal-telegram-edge-forward.test.ts
@@ -1,6 +1,7 @@
 /** Proves the flag-off gateway hands Personal Telegram to the Worker authority once. */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER } from "@elizaos/cloud-services-common/telegram-connector";
 import type { ChatEvent, PlatformAdapter } from "../src/adapters/types";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
@@ -41,6 +42,7 @@ class MemoryRedis implements GatewayRedis {
 
 const originalFetch = globalThis.fetch;
 const originalBotToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+const rawPayload = ` { "update_id": 1, "message": { "text": "hey how are you? 👋" } }\n`;
 const event: ChatEvent = {
   platform: "telegram",
   messageId: "edge-forward-1",
@@ -71,10 +73,11 @@ function request(): Request {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      [TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER]: "bot:spoofed",
       "X-Eliza-Trace-Id": "11111111-1111-4111-8111-111111111111",
       "X-Telegram-Bot-Api-Secret-Token": "provider-secret",
     },
-    body: JSON.stringify({ update_id: 1, message: { text: event.text } }),
+    body: rawPayload,
   });
 }
 
@@ -120,10 +123,16 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
     expect(forwarded?.headers.get("x-eliza-webhook-forwarder-secret")).toBe(
       "gateway-secret",
     );
+    expect(forwarded?.headers.get(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER)).toBe(
+      "bot:123",
+    );
+    expect(
+      forwarded?.headers.get(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER),
+    ).not.toContain("test-token");
     expect(forwarded?.headers.get("x-telegram-bot-api-secret-token")).toBe(
       "provider-secret",
     );
-    expect(await forwarded?.text()).toContain("hey how are you?");
+    expect(await forwarded?.text()).toBe(rawPayload);
     expect(
       redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
     ).toBe("delivered");
@@ -132,6 +141,87 @@ describe("Personal Telegram gateway-to-edge handoff", () => {
         "webhook:telegram:scope:message:edge-forward-1:processing",
       ),
     ).toBe(false);
+  });
+
+  test("reopens a connector-account rejection for a corrected retry", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    const redis = new MemoryRedis();
+    let edgeAttempts = 0;
+    globalThis.fetch = mock(async (input, init) => {
+      edgeAttempts += 1;
+      const forwarded = new Request(input, init);
+      expect(forwarded.headers.get(TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER)).toBe(
+        "bot:123",
+      );
+      expect(await forwarded.text()).toBe(rawPayload);
+      if (edgeAttempts === 1) {
+        return Response.json(
+          { error: "connector account mismatch" },
+          {
+            status: 409,
+            headers: { "X-Eliza-Failure-Stage": "connector_account" },
+          },
+        );
+      }
+      return Response.json({ ok: true });
+    }) as unknown as typeof fetch;
+
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api-staging.eliza.app",
+      deliveryAuthoritySecret: "gateway-secret",
+      getAuthHeader: () => ({ Authorization: "Bearer internal" }),
+    };
+
+    const rejected = await handleWebhook(
+      request(),
+      adapter(),
+      deps,
+      "eliza-app",
+    );
+
+    expect(rejected.status).toBe(409);
+    expect(
+      redis.values.has("webhook:telegram:scope:message:edge-forward-1"),
+    ).toBe(false);
+
+    const retried = await handleWebhook(
+      request(),
+      adapter(),
+      deps,
+      "eliza-app",
+    );
+
+    expect(retried.status).toBe(200);
+    expect(edgeAttempts).toBe(2);
+    expect(
+      redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
+    ).toBe("delivered");
+  });
+
+  test("keeps an ambiguous unclassified rejection fenced", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "123:test-token";
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () =>
+      Response.json({ error: "conflict" }, { status: 409 }),
+    ) as unknown as typeof fetch;
+
+    const response = await handleWebhook(
+      request(),
+      adapter(),
+      {
+        redis,
+        cloudBaseUrl: "https://api-staging.eliza.app",
+        deliveryAuthoritySecret: "gateway-secret",
+        getAuthHeader: () => ({ Authorization: "Bearer internal" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(409);
+    expect(
+      redis.values.get("webhook:telegram:scope:message:edge-forward-1"),
+    ).toBe("egress_started");
   });
 
   test("reconciles an old ambiguous Railway send without invoking edge egress", async () => {

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -3,6 +3,7 @@
 import { BlooioApiResponseError, blooioAdapter } from "./adapters/blooio";
 import { TelegramApiResponseError, telegramAdapter } from "./adapters/telegram";
 import type { ChatEvent } from "./adapters/types";
+import { resolveConnectorAccountId } from "./connector-account";
 import { logger } from "./logger";
 import type { GatewayRedis } from "./redis";
 import { resolveSharedWebhookConfig } from "./webhook-config";
@@ -15,6 +16,7 @@ type InternalWebhookDelivery =
   | {
       platform: "telegram";
       project: string;
+      connectorAccountId: string;
       chatId: string;
       providerThreadId?: string;
       text: string;
@@ -30,6 +32,7 @@ type InternalWebhookDelivery =
   | {
       platform: "blooio";
       project: string;
+      connectorAccountId: string;
       chatId: string;
       text: string;
       idempotencyKey: string;
@@ -94,6 +97,9 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
   }
   if (
     input.platform === "telegram" &&
+    typeof input.connectorAccountId === "string" &&
+    input.connectorAccountId.trim().length >= 3 &&
+    input.connectorAccountId.length <= 160 &&
     typeof input.chatId === "string" &&
     /^-?\d{1,20}$/.test(input.chatId) &&
     (input.providerThreadId === undefined ||
@@ -104,6 +110,7 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
     return {
       platform: "telegram",
       project: input.project,
+      connectorAccountId: input.connectorAccountId,
       chatId: input.chatId,
       ...(typeof input.providerThreadId === "string"
         ? { providerThreadId: input.providerThreadId }
@@ -131,12 +138,16 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
   if (
     input.platform === "blooio" &&
     input.providerThreadId === undefined &&
+    typeof input.connectorAccountId === "string" &&
+    input.connectorAccountId.trim().length >= 3 &&
+    input.connectorAccountId.length <= 160 &&
     typeof input.chatId === "string" &&
     /^chat_[A-Za-z0-9_-]{1,120}$/i.test(input.chatId)
   ) {
     return {
       platform: "blooio",
       project: input.project,
+      connectorAccountId: input.connectorAccountId,
       chatId: input.chatId,
       text: input.text.trim(),
       idempotencyKey: input.idempotencyKey,
@@ -167,6 +178,33 @@ export async function deliverInternalMessage(
     );
   }
 
+  const config = resolveSharedWebhookConfig(
+    delivery.platform,
+    delivery.project,
+  );
+  const configuredConnectorAccountId = resolveConnectorAccountId(
+    delivery.platform,
+    config,
+  );
+  if (
+    !configuredConnectorAccountId ||
+    ("connectorAccountId" in delivery &&
+      delivery.connectorAccountId !== configuredConnectorAccountId)
+  ) {
+    return Response.json(
+      {
+        success: false,
+        error: "connector account mismatch",
+        retryable: false,
+        acceptance: "not_accepted",
+      },
+      { status: 422 },
+    );
+  }
+
+  // Keep the pre-account key as the monotonic replay fence. Changing this key
+  // during rollout would strand complete/indeterminate receipts and could
+  // resend a reminder that the provider already accepted.
   const dedupeKey = `internal-delivery:${delivery.platform}:${delivery.project}:${delivery.idempotencyKey}`;
   let existingValue: string | null;
   try {
@@ -241,10 +279,6 @@ export async function deliverInternalMessage(
 
   let connectorAttempted = false;
   try {
-    const config = resolveSharedWebhookConfig(
-      delivery.platform,
-      delivery.project,
-    );
     const recipientId =
       "chatId" in delivery ? delivery.chatId : delivery.phoneNumber;
     const event: ChatEvent = {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -43,6 +43,7 @@ const PERSONAL_SHARED_ATTEMPTS = 3;
 const PERSONAL_SHARED_RETRY_DELAY_CAP_MS = 5_000;
 const PROCESSING_TTL_SECONDS = 120;
 const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
+const PERSONAL_TELEGRAM_DELIVERY_EPOCH = 2;
 const CONNECTOR_PROCESSING = "processing";
 const CONNECTOR_DELIVERED = "delivered";
 const CONNECTOR_UNCERTAIN = "uncertain";
@@ -197,6 +198,7 @@ async function sendReplyWithRequiredReceipt(
 async function reconcileLegacyTelegramDelivery(
   deps: HandlerDeps,
   project: string,
+  connectorAccountId: string,
   event: ChatEvent,
   traceId: string,
   operation: "mark_uncertain" | "mark_delivered",
@@ -215,7 +217,9 @@ async function reconcileLegacyTelegramDelivery(
         "X-Eliza-Webhook-Forwarder-Secret": secret,
       },
       body: JSON.stringify({
+        deliveryEpoch: PERSONAL_TELEGRAM_DELIVERY_EPOCH,
         project,
+        connectorAccountId,
         senderId: event.senderId,
         messageId: event.messageId,
         operation,
@@ -246,6 +250,7 @@ async function forwardPersonalTelegramToEdge(
   rawBody: string,
   deps: HandlerDeps,
   project: string,
+  connectorAccountId: string,
   event: ChatEvent,
   dedupKey: string,
   traceId: string,
@@ -259,6 +264,7 @@ async function forwardPersonalTelegramToEdge(
     const reconciled = await reconcileLegacyTelegramDelivery(
       deps,
       project,
+      connectorAccountId,
       event,
       traceId,
       legacy === TELEGRAM_DELIVERED ? "mark_delivered" : "mark_uncertain",
@@ -520,11 +526,19 @@ export async function handleWebhook(
         event.chatType !== "supergroup" &&
         deps.deliveryAuthoritySecret !== undefined
       ) {
+        const connectorAccountId = resolveConnectorAccountId(
+          "telegram",
+          config,
+        );
+        if (!connectorAccountId) {
+          throw new Error("Telegram connector account identity is missing");
+        }
         return forwardPersonalTelegramToEdge(
           request,
           rawBody,
           deps,
           project,
+          connectorAccountId,
           event,
           dedupKey,
           trace.traceId,

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -8,6 +8,7 @@ import {
   executeResponseAttempts,
   type ResponseAttemptsResult,
 } from "@elizaos/cloud-services-common/response-attempts";
+import { TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER } from "@elizaos/cloud-services-common/telegram-connector";
 import {
   executeTelegramDelivery,
   type TelegramDeliveryHooks,
@@ -327,6 +328,7 @@ async function forwardPersonalTelegramToEdge(
         headers: {
           "Content-Type": "application/json",
           [ELIZA_TRACE_ID_HEADER]: traceId,
+          [TELEGRAM_CONNECTOR_ACCOUNT_ID_HEADER]: connectorAccountId,
           "X-Eliza-Webhook-Forwarder-Secret": secret,
           "X-Telegram-Bot-Api-Secret-Token": telegramSignature,
         },
@@ -338,6 +340,14 @@ async function forwardPersonalTelegramToEdge(
       await deps.redis.set(dedupKey, TELEGRAM_DELIVERED, {
         ex: TELEGRAM_DELIVERY_TTL_SECONDS,
       });
+    } else if (
+      response.status === 409 &&
+      response.headers.get("X-Eliza-Failure-Stage") === "connector_account"
+    ) {
+      // The Worker rejected the handoff before provider egress because this
+      // gateway resolved a different bot account. Reopen only this explicit,
+      // pre-egress failure so a corrected gateway/config can retry the update.
+      await deps.redis.del(dedupKey);
     }
     return response;
   } finally {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -43,6 +43,7 @@ const PERSONAL_SHARED_ATTEMPTS = 3;
 const PERSONAL_SHARED_RETRY_DELAY_CAP_MS = 5_000;
 const PROCESSING_TTL_SECONDS = 120;
 const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
+const PERSONAL_TELEGRAM_DELIVERY_EPOCH = 2;
 const CONNECTOR_PROCESSING = "processing";
 const CONNECTOR_DELIVERED = "delivered";
 const CONNECTOR_UNCERTAIN = "uncertain";
@@ -210,6 +211,7 @@ async function sendReplyWithRequiredReceipt(
 async function reconcileLegacyTelegramDelivery(
   deps: HandlerDeps,
   project: string,
+  connectorAccountId: string,
   event: ChatEvent,
   traceId: string,
   operation: "mark_uncertain" | "mark_delivered",
@@ -228,7 +230,9 @@ async function reconcileLegacyTelegramDelivery(
         "X-Eliza-Webhook-Forwarder-Secret": secret,
       },
       body: JSON.stringify({
+        deliveryEpoch: PERSONAL_TELEGRAM_DELIVERY_EPOCH,
         project,
+        connectorAccountId,
         senderId: event.senderId,
         messageId: event.messageId,
         operation,
@@ -259,6 +263,7 @@ async function forwardPersonalTelegramToEdge(
   rawBody: string,
   deps: HandlerDeps,
   project: string,
+  connectorAccountId: string,
   event: ChatEvent,
   dedupKey: string,
   traceId: string,
@@ -272,6 +277,7 @@ async function forwardPersonalTelegramToEdge(
     const reconciled = await reconcileLegacyTelegramDelivery(
       deps,
       project,
+      connectorAccountId,
       event,
       traceId,
       legacy === TELEGRAM_DELIVERED ? "mark_delivered" : "mark_uncertain",
@@ -533,11 +539,19 @@ export async function handleWebhook(
         event.chatType !== "supergroup" &&
         deps.deliveryAuthoritySecret !== undefined
       ) {
+        const connectorAccountId = resolveConnectorAccountId(
+          "telegram",
+          config,
+        );
+        if (!connectorAccountId) {
+          throw new Error("Telegram connector account identity is missing");
+        }
         return forwardPersonalTelegramToEdge(
           request,
           rawBody,
           deps,
           project,
+          connectorAccountId,
           event,
           dedupKey,
           trace.traceId,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
@@ -91,7 +91,8 @@ mock.module("@elizaos/plugin-scheduling/edge", () => ({
   parseSharedReminderDelivery(value: unknown) {
     if (!value || typeof value !== "object") return undefined;
     const delivery = value as Record<string, unknown>;
-    if (delivery.platform === "telegram") return delivery;
+    if (delivery.platform === "telegram" && typeof delivery.connectorAccountId === "string")
+      return delivery;
     if (delivery.platform === "blooio") return delivery;
     if (delivery.platform === "discord") return delivery;
     return undefined;
@@ -219,6 +220,7 @@ describe("Shared group reminder dispatch", () => {
     await expect(requests[0]?.json()).resolves.toEqual({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
       chatId: "-100123456789",
       text: "Reminder for this group from Nubs: pay the rent",
       idempotencyKey: IDEMPOTENCY_KEY,
@@ -377,6 +379,7 @@ describe("Shared group reminder dispatch", () => {
     );
     expect(telegramDispatch).toHaveBeenCalledWith({
       project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
       chatId: "-100123456789",
       providerThreadId: "909",
       text: "Reminder for this group from Nubs: pay the rent",
@@ -422,6 +425,7 @@ describe("Shared group reminder dispatch", () => {
     await expect(requests[0]?.json()).resolves.toEqual({
       platform: "blooio",
       project: "eliza-app",
+      connectorAccountId: "blooio:test-number",
       chatId: "chat_group_123",
       text: "Reminder for this group from Nubs: pay the rent",
       idempotencyKey: IDEMPOTENCY_KEY,
@@ -571,6 +575,7 @@ describe("Shared group reminder dispatch", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
@@ -34,6 +34,7 @@ const createSharedScheduledTaskRunner = mock(
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456789",
           },
         },
@@ -57,7 +58,8 @@ mock.module("@elizaos/plugin-scheduling/edge", () => ({
   parseSharedReminderDelivery(value: unknown) {
     if (!value || typeof value !== "object") return undefined;
     const delivery = value as Record<string, unknown>;
-    if (delivery.platform === "telegram") return delivery;
+    if (delivery.platform === "telegram" && typeof delivery.connectorAccountId === "string")
+      return delivery;
     if (delivery.platform === "blooio") return delivery;
     if (delivery.platform === "discord") return delivery;
     return undefined;
@@ -130,6 +132,7 @@ describe("Shared reminder cron", () => {
     await expect(requests[0]?.json()).resolves.toEqual({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId: "bot:123456789",
       chatId: "123456789",
       text: "time to stand up and stretch",
       idempotencyKey: "reminder-1:2026-08-14T20:00:00.000Z",
@@ -178,6 +181,7 @@ describe("Shared reminder cron", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },
@@ -185,6 +189,7 @@ describe("Shared reminder cron", () => {
 
     expect(telegramDispatch).toHaveBeenCalledWith({
       project: "eliza-app",
+      connectorAccountId: "bot:123456789",
       chatId: "123456789",
       text: "time to stretch",
       idempotencyKey: "edge-reminder:2026-08-20T19:30:00.000Z",
@@ -215,6 +220,30 @@ describe("Shared reminder cron", () => {
     await expect(processDueSharedReminders(env)).rejects.toThrow(
       "Shared reminder delivery metadata is invalid",
     );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("fails closed before egress for a legacy Telegram row without a connector account", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("egress must not run");
+    }) as typeof fetch;
+    const dispatcher = sharedReminderDispatcher(env);
+
+    await expect(
+      dispatcher.dispatch({
+        taskId: "legacy-reminder",
+        promptInstructions: "stand up",
+        firedAtIso: "2026-08-14T20:00:00.000Z",
+        metadata: {
+          dispatchIdempotencyKey: "legacy-reminder:2026-08-14T20:00:00.000Z",
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            chatId: "123456789",
+          },
+        },
+      }),
+    ).rejects.toThrow("Shared reminder delivery metadata is invalid");
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -309,6 +338,7 @@ describe("Shared reminder cron", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },
@@ -340,6 +370,7 @@ describe("Shared reminder cron", () => {
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456789",
           },
         },
@@ -455,6 +486,7 @@ describe("Shared reminder cron", () => {
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456789",
           },
         },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -63,6 +63,7 @@ type GatewayDeliveryResponse = {
 
 export interface SharedTelegramReminderDispatchInput {
   project: string;
+  connectorAccountId: string;
   chatId: string;
   providerThreadId?: string;
   text: string;
@@ -156,6 +157,7 @@ function gatewayWireDelivery(delivery: SharedReminderDelivery) {
     ? {
         platform: delivery.platform,
         project: delivery.project,
+        connectorAccountId: delivery.connectorAccountId,
         chatId: delivery.chatId,
         ...(delivery.platform === "telegram" && delivery.providerThreadId
           ? { providerThreadId: delivery.providerThreadId }
@@ -237,6 +239,7 @@ export function sharedReminderDispatcher(
       if (delivery.platform === "telegram" && options.telegramDispatch) {
         const result = await options.telegramDispatch({
           project: delivery.project,
+          connectorAccountId: delivery.connectorAccountId,
           chatId: delivery.chatId,
           ...(groupDelivery?.platform === "telegram" && groupDelivery.providerThreadId
             ? { providerThreadId: groupDelivery.providerThreadId }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1042,6 +1042,7 @@ describe("SharedRuntimeChatService", () => {
         trustedDelivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },
@@ -1062,6 +1063,7 @@ describe("SharedRuntimeChatService", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456789",
         },
       },

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -518,6 +518,11 @@ export interface Bindings {
   ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+  /**
+   * Temporary exact-`"true"` bridge for a legacy Telegram Gateway without the
+   * account header or epoch-2 reconciliation. Keep absent outside a cutover.
+   */
+  PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED?: string;
   /** Collision-free secret used by the protected staging edge cutover. */
   PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
   /** Collision-free secret used by the protected production edge cutover; inert outside production. */

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -198,6 +198,7 @@ describe("explicit Shared reminder relative delay", () => {
           delivery: {
             platform: "telegram",
             project: "eliza-app",
+            connectorAccountId: "bot:123456789",
             chatId: "123456",
           },
           now: () => new Date(NOW),

--- a/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
@@ -107,6 +107,7 @@ describe("Shared group reminder delivery parsing", () => {
       isSharedGroupReminderDelivery({
         platform: "telegram",
         project: "eliza-app",
+        connectorAccountId: "bot:123456789",
         chatId: "123456",
       }),
     ).toBe(false);
@@ -231,14 +232,27 @@ describe("Shared group reminder delivery parsing", () => {
     ).toMatchObject({ ownerLabel: "the group owner" });
   });
 
-  it("still parses the existing private-chat destinations unchanged", () => {
+  it("requires the private Telegram connector account and preserves other private destinations", () => {
+    expect(
+      parseSharedReminderDelivery({
+        platform: "telegram",
+        project: "eliza-app",
+        connectorAccountId: "bot:123456789",
+        chatId: "123456",
+      }),
+    ).toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "bot:123456789",
+      chatId: "123456",
+    });
     expect(
       parseSharedReminderDelivery({
         platform: "telegram",
         project: "eliza-app",
         chatId: "123456",
       }),
-    ).toEqual({ platform: "telegram", project: "eliza-app", chatId: "123456" });
+    ).toBeUndefined();
     expect(
       parseSharedReminderDelivery({
         platform: "blooio",
@@ -303,6 +317,7 @@ describe("Shared group reminder action", () => {
       sharedReminderMaxBodyLength({
         platform: "telegram",
         project: "eliza-app",
+        connectorAccountId: "bot:123456789",
         chatId: "123456",
       }),
     ).toBe(SHARED_REMINDER_MAX_TEXT_LENGTH);

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -130,6 +130,7 @@ function harness(): {
       delivery: {
         platform: "telegram",
         project: "eliza-app",
+        connectorAccountId: "bot:123456789",
         chatId: "123456",
       },
       now: () => new Date(NOW),
@@ -139,6 +140,26 @@ function harness(): {
 
 describe("Shared reminders edge plugin", () => {
   it("accepts only trusted private Telegram, Blooio, and Discord destinations", () => {
+    expect(
+      parseSharedReminderDelivery({
+        platform: "telegram",
+        project: "eliza-app",
+        connectorAccountId: "bot:123456789",
+        chatId: "123456",
+      }),
+    ).toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "bot:123456789",
+      chatId: "123456",
+    });
+    expect(
+      parseSharedReminderDelivery({
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456",
+      }),
+    ).toBeUndefined();
     expect(
       parseSharedReminderDelivery({
         platform: "blooio",
@@ -210,6 +231,7 @@ describe("Shared reminders edge plugin", () => {
         delivery: {
           platform: "telegram",
           project: "eliza-app",
+          connectorAccountId: "bot:123456789",
           chatId: "123456",
         },
       },

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -61,6 +61,7 @@ export type SharedReminderDelivery =
   | {
       platform: "telegram";
       project: string;
+      connectorAccountId: string;
       chatId: string;
     }
   | {
@@ -228,12 +229,16 @@ export function parseSharedReminderDelivery(
     delivery.platform === "telegram" &&
     typeof delivery.project === "string" &&
     PROJECT_PATTERN.test(delivery.project) &&
+    typeof delivery.connectorAccountId === "string" &&
+    delivery.connectorAccountId.trim().length >= 3 &&
+    delivery.connectorAccountId.length <= CONNECTOR_ACCOUNT_ID_MAX_LENGTH &&
     typeof delivery.chatId === "string" &&
     TELEGRAM_CHAT_ID_PATTERN.test(delivery.chatId)
   ) {
     return {
       platform: "telegram",
       project: delivery.project,
+      connectorAccountId: delivery.connectorAccountId,
       chatId: delivery.chatId,
     };
   }


### PR DESCRIPTION
# Relates to

Related to #17888, #18235, #25025, and #25076. This PR repairs the Telegram ingress and delivery-account boundary; it does not claim the full onboarding or Shared-to-Dedicated acceptance journeys.

# Summary

Telegram update IDs are bot-scoped. This revision keeps the Durable Object, canonical message identity, receipts, reminders, gateway reconciliation, and authenticated Gateway-to-Worker handoff attached to the stable connector account. Numeric Telegram bot IDs survive secret rotation; raw credentials are never forwarded or logged.

The Worker rejects absent, malformed, or mismatched accounts before state allocation, agent execution, or provider egress. Reminder delivery also fails closed when its originating account no longer matches current configuration. Epoch-1 reconciliation remains quarantined and explicitly gated.

# Exact candidate

- Rebased onto `origin/develop@518cde18d1f`; rebase conflicts were resolved by preserving both the current forum-topic contract and this PR's account validation.
- Exact head: `91ebfe9d588aeebdf65676f90f50b795c2093797`.
- Hosted checks are pending for this rewritten head; no CI exception is requested.

# Rollout blocker resolved

The staging Worker-first compatibility bridge is now committed in `[env.staging.vars]` as `PERSONAL_TELEGRAM_DELIVERY_EPOCH1_COMPAT_ENABLED = "true"`. It therefore deploys atomically with delivery epoch 2 and cannot race an old staging gateway.

Production remains closed: the root and production vars blocks omit the compatibility flag, so production still requires its separately protected, explicitly authorized pre-bind before any Worker rollout.

Mandatory order:

1. Merge only after exact-head checks and approval.
2. Deploy the staging Worker; the committed staging bridge accepts the old gateway's headerless handoff and epoch-1 reconciliation.
3. Verify the health beacon reports epoch 2 with compatibility enabled.
4. Deploy the new gateway from the reviewed release, then drain old instances.
5. Require zero legacy-acceptance warnings through the agreed drain/retry window.
6. Remove the temporary staging var in a reviewed follow-up and verify headerless/epoch-1 negative probes fail closed.
7. For production, perform the protected pre-bind first and repeat the same Worker-first sequence; this PR does not activate production.

# Verification

Exact-head focused results so far:

- staging-vs-production Wrangler configuration assertion: pass;
- gateway handoff, internal delivery, account mismatch, replay, group and forum-topic suites: 28 pass, 0 fail in the focused gateway run;
- Personal Telegram delivery, Dedicated relay, and edge suites: 36 pass, 0 fail, 155 assertions across the Personal Telegram delivery, Dedicated relay, and edge suites after the rebase repair;
- Biome on all conflict resolutions and rollout changes: pass;
- `git diff --check`: pass.

The previous source-equivalent head passed the broader 365-test matrix, package typechecks, Worker bundle dry-run, and repository verify. Hosted CI is the authority for the rebased exact head.

# Risk

Moderate and cutover-sensitive. The default and final states fail closed. The temporary staging bridge exists only to make the Worker-first deployment safe while legacy gateway instances drain.

# Evidence Gate

<!-- evidence-head:91ebfe9d588aeebdf65676f90f50b795c2093797 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only delivery-state change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only delivery-state change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused delivery, replay, account, epoch, and rollout tests recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no user-facing domain artifact is produced by this transport boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface.

# Known gaps

- No live Telegram send, staging deployment, production deployment, bot setting, or webhook mutation was performed.
- Historical reminders without an originating connector account fail closed; their prior bot owner cannot be inferred safely.
- Exact-head hosted checks and a fresh independent approval remain required before merge.