### PR TITLE
test(ui): cover cloud-ui share ShareButtons

### DIFF
--- a/packages/ui/src/cloud-ui/components/share/index.test.tsx
+++ b/packages/ui/src/cloud-ui/components/share/index.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Verifies the cloud-ui share barrel's ShareButtons — clipboard copy state,
+ * native-share delegation and fallback, and the social intent URLs — through
+ * the package's configured jsdom harness.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ShareButtons } from "./index";
+
+function stubClipboard(behavior: "resolves" | "rejects") {
+  const writeText = vi.fn(
+    behavior === "resolves"
+      ? () => Promise.resolve()
+      : () => Promise.reject(new Error("denied")),
+  );
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+function stubNativeShare() {
+  const share = vi.fn(() => Promise.resolve());
+  Object.defineProperty(navigator, "share", {
+    value: share,
+    configurable: true,
+  });
+  return share;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(navigator, "clipboard");
+  Reflect.deleteProperty(navigator, "share");
+});
+
+describe("ShareButtons (cloud-ui/components/share)", () => {
+  it("renders the five sharing affordances from the barrel export", () => {
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    for (const name of [
+      "Share",
+      "Copy Link",
+      "Twitter",
+      "LinkedIn",
+      "Telegram",
+    ]) {
+      expect(screen.getByRole("button", { name })).not.toBeNull();
+    }
+  });
+
+  it("writes the URL to the clipboard and flips the copy button to Copied!", async () => {
+    const writeText = stubClipboard("resolves");
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Link" }));
+    await act(async () => {});
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("https://example.com/a");
+    expect(screen.getByRole("button", { name: "Copied!" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy Link" })).toBeNull();
+  });
+
+  it("reverts the copy button to its idle label after two seconds", async () => {
+    stubClipboard("resolves");
+    vi.useFakeTimers();
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Link" }));
+    await act(async () => {});
+    expect(screen.getByRole("button", { name: "Copied!" })).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole("button", { name: "Copy Link" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull();
+  });
+
+  it("keeps the idle label when the clipboard write rejects", async () => {
+    const writeText = stubClipboard("rejects");
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Link" }));
+    await act(async () => {});
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy Link" })).not.toBeNull();
+  });
+
+  it("delegates the Share button to the native share API with title, description and URL", async () => {
+    const share = stubNativeShare();
+    render(
+      <ShareButtons
+        url="https://example.com/a"
+        title="A post"
+        description="about a"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    await act(async () => {});
+
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledWith({
+      title: "A post",
+      text: "about a",
+      url: "https://example.com/a",
+    });
+    // Native share consumed the interaction; the clipboard must stay untouched.
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull();
+  });
+
+  it("falls back to copying the link when the native share API is unavailable", async () => {
+    const writeText = stubClipboard("resolves");
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    await act(async () => {});
+
+    expect(writeText).toHaveBeenCalledWith("https://example.com/a");
+    expect(screen.getByRole("button", { name: "Copied!" })).not.toBeNull();
+  });
+
+  it("opens the Twitter intent with the encoded title, description and URL", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    render(
+      <ShareButtons
+        url="https://example.com/a b"
+        title="A post & more"
+        description="about it"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Twitter" }));
+    await act(async () => {});
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      "https://twitter.com/intent/tweet?text=A%20post%20%26%20more%20-%20about%20it&url=https%3A%2F%2Fexample.com%2Fa%20b",
+      "_blank",
+      "width=550,height=420",
+    );
+  });
+
+  it("composes the Twitter text from the title alone when no description is given", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    render(<ShareButtons url="https://example.com/a" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Twitter" }));
+    await act(async () => {});
+
+    expect(open).toHaveBeenCalledWith(
+      "https://twitter.com/intent/tweet?text=A%20post&url=https%3A%2F%2Fexample.com%2Fa",
+      "_blank",
+      "width=550,height=420",
+    );
+  });
+
+  it("opens the LinkedIn share-offsite URL with the encoded URL", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    render(<ShareButtons url="https://example.com/a?x=1" title="A post" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "LinkedIn" }));
+    await act(async () => {});
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      "https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fexample.com%2Fa%3Fx%3D1",
+      "_blank",
+      "width=550,height=420",
+    );
+  });
+
+  it("opens the Telegram share URL with the encoded URL and composed text", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    render(
+      <ShareButtons
+        url="https://example.com/tg"
+        title="A post"
+        description="see this"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Telegram" }));
+    await act(async () => {});
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      "https://t.me/share/url?url=https%3A%2F%2Fexample.com%2Ftg&text=A%20post%20-%20see%20this",
+      "_blank",
+      "width=550,height=420",
+    );
+  });
+});


### PR DESCRIPTION

## What

Adds a co-located unit suite for the cloud-ui share surface: `packages/ui/src/cloud-ui/components/share/index.test.tsx`, importing `ShareButtons` through the barrel (`./index`) that this target exports.

`packages/ui/src/cloud-ui/components/share/index.ts` had no same-named test file anywhere on `develop`.

## Coverage

The suite drives the real component in jsdom (`@testing-library/react` + real DOM events) and asserts observable behavior only:

- renders all five affordances (Share, Copy Link, Twitter, LinkedIn, Telegram)
- clipboard copy: writes the URL via `navigator.clipboard.writeText`, flips the button to "Copied!", and reverts to the idle label after 2000 ms
- clipboard failure path: rejected `writeText` keeps the idle label and never enters the copied state
- native share delegation: `navigator.share` receives `{title, text, url}`; with no share API present the Share button falls back to copying the link
- social intents: exact `window.open` URLs for Twitter (`intent/tweet?text=…&url=…`), LinkedIn (`share-offsite/?url=…`), Telegram (`t.me/share/url?url=…&text=…`), including the description-omitted composition and URL encoding

External boundaries are stubbed at their seam only (`navigator.clipboard`, `navigator.share`, `window.open`); assertions target what the component does, not what the stubs return.

## Evidence

Test-only change — no production behavior modified; diff is a single new test file (+209/−0).

- `bunx vitest run src/cloud-ui/components/share/index.test.tsx` (in `packages/ui`, against current `develop` @ `1f236fd1f5`): **1 file passed, 10 tests passed / 0 failed**
- `bunx biome check packages/ui/src/cloud-ui/components/share/index.test.tsx`: clean (no fixes needed)
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics reference the new file
- No type-level assertions (`expectTypeOf`) are used; no existing suite was modified

Note: I contribute from a fork, so hosted CI does not run on this PR — the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4696a8ca28735531cd3a2182aca9541acf0b5764 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
