### PR TITLE
test(agent): cover handoff index

### DIFF
--- a/packages/agent/src/services/handoff/index.test.ts
+++ b/packages/agent/src/services/handoff/index.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for the services/handoff public barrel (`./index.ts`).
+ *
+ * Every runtime export is exercised through the public entry point rather than
+ * the private modules: service resolution keyed by HANDOFF_SERVICE, store
+ * input validation and corrupt-cache handling, and the pure resume-evaluation
+ * branches consumed by the room-policy provider. The harness is deterministic
+ * — the runtime cache is an in-memory Map behind spies, no SQL, no timers.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { HandoffStatus, ResumeEvaluationInput } from "./index.ts";
+import {
+  createHandoffStore,
+  describeResumeCondition,
+  evaluateResume,
+  HANDOFF_SERVICE,
+  HandoffService,
+  resolveHandoffService,
+} from "./index.ts";
+
+function makeRuntime() {
+  const cache = new Map<string, unknown>();
+  const getCache = vi.fn(async (key: string): Promise<unknown> => {
+    return cache.get(key) ?? null;
+  });
+  const setCache = vi.fn(
+    async (key: string, value: unknown): Promise<boolean> => {
+      cache.set(key, value);
+      return true;
+    },
+  );
+  const deleteCache = vi.fn(async (key: string): Promise<boolean> => {
+    return cache.delete(key);
+  });
+  const getService = vi.fn((_serviceType: string): unknown => null);
+  const runtime = {
+    agentId: "test-agent",
+    getCache,
+    setCache,
+    deleteCache,
+    getService,
+  } as unknown as IAgentRuntime;
+  return { cache, runtime, getCache, setCache, deleteCache, getService };
+}
+
+describe("services/handoff public barrel", () => {
+  it("resolves a registered HandoffService by the HANDOFF_SERVICE key", async () => {
+    const { runtime, getService } = makeRuntime();
+    const service = await HandoffService.start(runtime);
+    getService.mockImplementation(() => service);
+
+    const resolved = resolveHandoffService(runtime);
+    expect(resolved).toBe(service);
+    expect(getService).toHaveBeenCalledWith(HANDOFF_SERVICE);
+
+    // The resolved service hands out a working store.
+    const store = resolved?.getStore();
+    expect(store).toBeDefined();
+    await store?.enter("room-resolve", {
+      reason: "resolved through the barrel",
+      resumeOn: { kind: "mention" },
+    });
+    expect((await store?.status("room-resolve"))?.active).toBe(true);
+    await store?.exit("room-resolve");
+    expect((await store?.status("room-resolve"))?.active).toBe(false);
+  });
+
+  it("rejects invalid enter input before touching the cache", async () => {
+    const { runtime, setCache } = makeRuntime();
+    const store = createHandoffStore(runtime);
+
+    await expect(
+      store.enter("", { reason: "r", resumeOn: { kind: "mention" } }),
+    ).rejects.toThrow(/roomId is required/);
+
+    await expect(
+      store.enter("room-bad", {
+        reason: "r",
+        resumeOn: { kind: "nope" } as never,
+      }),
+    ).rejects.toThrow(/invalid resumeOn/);
+
+    await expect(
+      store.enter("room-bad", {
+        reason: "r",
+        resumeOn: { kind: "silence_minutes", minutes: 0 },
+      }),
+    ).rejects.toThrow(/invalid resumeOn/);
+
+    await expect(
+      store.enter("room-bad", {
+        reason: "r",
+        resumeOn: { kind: "user_request_help", userId: "" },
+      }),
+    ).rejects.toThrow(/invalid resumeOn/);
+
+    await expect(
+      store.enter("room-bad", {
+        reason: "   ",
+        resumeOn: { kind: "mention" },
+      }),
+    ).rejects.toThrow(/reason is required/);
+
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("trims the reason and replaces lone surrogates before storing it", async () => {
+    const { runtime } = makeRuntime();
+    const store = createHandoffStore(runtime);
+
+    await store.enter("room-normalize", {
+      reason: "  handing off \ud800  ",
+      resumeOn: { kind: "mention" },
+    });
+    const status = await store.status("room-normalize");
+    expect(status.active).toBe(true);
+    // Outer whitespace trimmed; the unpaired surrogate became U+FFFD.
+    expect(status.reason).toBe("handing off \uFFFD");
+  });
+
+  it("treats empty room ids as inactive without reading or writing the cache", async () => {
+    const { runtime, getCache, deleteCache } = makeRuntime();
+    const store = createHandoffStore(runtime);
+
+    expect(await store.exit("")).toBeUndefined();
+    expect(deleteCache).not.toHaveBeenCalled();
+
+    expect(await store.status("")).toEqual({ active: false });
+    expect(getCache).not.toHaveBeenCalled();
+
+    expect(await store.status("never-entered")).toEqual({ active: false });
+    expect(getCache).toHaveBeenCalledWith(
+      `${"eliza:lifeops:handoff:v1:"}never-entered`,
+    );
+  });
+
+  it("reports inactive when the cached record fails validation, active again when it is valid", async () => {
+    const { cache, runtime, setCache } = makeRuntime();
+    const store = createHandoffStore(runtime);
+
+    await store.enter("room-corrupt", {
+      reason: "valid entry",
+      resumeOn: { kind: "mention" },
+    });
+    const key = setCache.mock.calls[0]?.[0] ?? "";
+    const validRecord = setCache.mock.calls[0]?.[1];
+    expect(await store.status("room-corrupt")).toMatchObject({
+      active: true,
+      reason: "valid entry",
+    });
+
+    const corruptRecords: unknown[] = [
+      {
+        roomId: "",
+        enteredAt: new Date().toISOString(),
+        reason: "r",
+        resumeOn: { kind: "mention" },
+      },
+      {
+        roomId: "room-corrupt",
+        enteredAt: "not-a-date",
+        reason: "r",
+        resumeOn: { kind: "mention" },
+      },
+      {
+        roomId: "room-corrupt",
+        enteredAt: new Date().toISOString(),
+        reason: null,
+        resumeOn: { kind: "mention" },
+      },
+      {
+        roomId: "room-corrupt",
+        enteredAt: new Date().toISOString(),
+        reason: "r",
+        resumeOn: { kind: "silence_minutes", minutes: -1 },
+      },
+      {
+        roomId: "room-corrupt",
+        enteredAt: new Date().toISOString(),
+        reason: "r",
+        resumeOn: { kind: "bogus" },
+      },
+    ];
+    for (const record of corruptRecords) {
+      cache.set(key, record);
+      expect(await store.status("room-corrupt")).toEqual({ active: false });
+    }
+
+    cache.set(key, validRecord);
+    expect((await store.status("room-corrupt")).active).toBe(true);
+  });
+
+  it("never auto-resumes an explicit_resume condition on any inbound signal", () => {
+    const evaluation = evaluateResume({
+      status: { active: true, resumeOn: { kind: "explicit_resume" } },
+      mentionsAgent: true,
+      userRequestedHelp: true,
+      requestingUserId: "user-1",
+    });
+    expect(evaluation.shouldResume).toBe(false);
+    expect(evaluation.reason).toBeUndefined();
+  });
+
+  it("fires silence_minutes only at or past the threshold with a parsable last message", () => {
+    const lastMessageIso = "2026-01-01T00:00:00.000Z";
+    const base: ResumeEvaluationInput = {
+      status: {
+        active: true,
+        resumeOn: { kind: "silence_minutes", minutes: 5 },
+      },
+      lastMessageIso,
+    };
+
+    const atThreshold = evaluateResume({
+      ...base,
+      nowIso: "2026-01-01T00:05:00.000Z",
+    });
+    expect(atThreshold.shouldResume).toBe(true);
+    expect(atThreshold.reason).toBe("silence ≥ 5m");
+
+    const justUnder = evaluateResume({
+      ...base,
+      nowIso: "2026-01-01T00:04:59.999Z",
+    });
+    expect(justUnder.shouldResume).toBe(false);
+
+    const beforeLast = evaluateResume({
+      ...base,
+      nowIso: "2025-12-31T23:00:00.000Z",
+    });
+    expect(beforeLast.shouldResume).toBe(false);
+
+    const missingLast = evaluateResume({
+      status: base.status,
+      nowIso: "2026-01-01T01:00:00.000Z",
+    });
+    expect(missingLast.shouldResume).toBe(false);
+
+    const unparsableLast = evaluateResume({
+      ...base,
+      lastMessageIso: "not-a-date",
+      nowIso: "2026-01-01T01:00:00.000Z",
+    });
+    expect(unparsableLast.shouldResume).toBe(false);
+  });
+
+  it("resumes user_request_help only for the flagged matching requester", () => {
+    const status: HandoffStatus = {
+      active: true,
+      resumeOn: { kind: "user_request_help", userId: "user-42" },
+    };
+
+    const matched = evaluateResume({
+      status,
+      requestingUserId: "user-42",
+      userRequestedHelp: true,
+    });
+    expect(matched.shouldResume).toBe(true);
+    expect(matched.reason).toBe("user requested help");
+
+    const wrongUser = evaluateResume({
+      status,
+      requestingUserId: "user-other",
+      userRequestedHelp: true,
+    });
+    expect(wrongUser.shouldResume).toBe(false);
+
+    const unflagged = evaluateResume({
+      status,
+      requestingUserId: "user-42",
+      userRequestedHelp: false,
+    });
+    expect(unflagged.shouldResume).toBe(false);
+  });
+
+  it("resumes a mention condition only while the handoff is active", () => {
+    const activeMention = evaluateResume({
+      status: { active: true, resumeOn: { kind: "mention" } },
+      mentionsAgent: true,
+    });
+    expect(activeMention).toEqual({ shouldResume: true, reason: "mentioned" });
+
+    const noMention = evaluateResume({
+      status: { active: true, resumeOn: { kind: "mention" } },
+    });
+    expect(noMention.shouldResume).toBe(false);
+
+    const inactiveRoom = evaluateResume({
+      status: { active: false },
+      mentionsAgent: true,
+    });
+    expect(inactiveRoom.shouldResume).toBe(false);
+  });
+
+  it("renders each condition to a phrase carrying its parameters", () => {
+    expect(typeof describeResumeCondition({ kind: "mention" })).toBe("string");
+    expect(describeResumeCondition({ kind: "mention" }).length).toBeGreaterThan(
+      0,
+    );
+
+    const singular = describeResumeCondition({
+      kind: "silence_minutes",
+      minutes: 1,
+    });
+    const plural = describeResumeCondition({
+      kind: "silence_minutes",
+      minutes: 2,
+    });
+    expect(singular).toContain("1");
+    expect(plural).toContain("2");
+    expect(singular).not.toBe(plural);
+
+    const helpPhrase = describeResumeCondition({
+      kind: "user_request_help",
+      userId: "alice",
+    });
+    expect(helpPhrase).toContain("alice");
+  });
+});


### PR DESCRIPTION

Adds `packages/agent/src/services/handoff/index.test.ts` — unit coverage for the `services/handoff` public barrel (`index.ts`), which previously had no same-named suite anywhere in the repo. The diff is a single new test file: additive only, +0 deletions, no production behaviour change.

The suite drives the real module through the barrel entry point (`./index.ts`) rather than asserting re-export shapes:

- **Service resolution:** `resolveHandoffService(runtime)` returns the registered `HandoffService` instance and resolves it via `runtime.getService(HANDOFF_SERVICE)`; the resolved service's `getStore()` performs a full enter → status → exit round-trip.
- **Store input validation:** `enter()` rejects an empty room id, unknown resume kinds, non-positive `silence_minutes`, empty help-requester ids, and whitespace-only reasons — all before any cache write (spy-verified).
- **Reason normalization:** stored reason is trimmed and a lone surrogate becomes U+FFFD (`toWellFormedUnicode` path), observed through `status()`.
- **Empty-room handling:** `status("")` / `exit("")` are inactive no-ops that never touch the cache; `status()` of an unentered room reads the expected cache key and reports `{ active: false }`.
- **Corrupt-cache records:** records failing validation (empty roomId, unparsable `enteredAt`, non-string reason, invalid `resumeOn`) report inactive; restoring the valid record restores active — proving record validity drives the status.
- **Resume-evaluation branches:** `explicit_resume` never auto-resumes on any inbound signal; `silence_minutes` fires exactly at the threshold (≥ semantics) but not below, not before the last message, not without a parsable timestamp; `user_request_help` requires both the help flag and the matching requester; `mention` resumes only when active and actually mentioned.

## Verification (run on this branch)

- `bunx vitest run packages/agent/src/services/handoff/index.test.ts` — **Test Files 1 passed (1), Tests 10 passed (10)**.
- `bunx biome check --write packages/agent/src/services/handoff/index.test.ts` — clean ("Checked 1 file", no fixes applied).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/agent` — zero mentions of `services/handoff/index.test.ts`.
- Diff touches only `packages/agent/src/services/handoff/index.test.ts`.

Note: we are a fork contributor — hosted CI does not run on this pull request; the counts above were executed locally against the branch head.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:585209476070759dc58d8539e8dcfcbc590539c7 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
