### PR TITLE
test(app-core): cover electrobun-stub

### DIFF
--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
@@ -83,4 +83,45 @@ describe("ensureElectrobunGlobal", () => {
       bun.receiveInternalMessageFromBun({ kind: "internal" }),
     ).toBeUndefined();
   });
+
+  it("leaves falsy non-undefined placeholders untouched", () => {
+    for (const placeholder of [false, 0, ""] as const) {
+      const w = makeWindow();
+      (w as { __electrobun?: unknown }).__electrobun = placeholder;
+      ensureElectrobunGlobal();
+      expect(w.__electrobun).toBe(placeholder);
+    }
+  });
+
+  it("leaves a partial stub untouched instead of completing its handlers", () => {
+    const w = makeWindow();
+    const partial = { receiveMessageFromBun: () => "partial" };
+    (w as { __electrobun?: unknown }).__electrobun = partial;
+    ensureElectrobunGlobal();
+    expect(w.__electrobun).toBe(partial);
+    const installed = w.__electrobun;
+    if (installed === null || installed === undefined) {
+      throw new Error("ensureElectrobunGlobal replaced an existing stub");
+    }
+    expect(installed.receiveInternalMessageFromBun).toBeUndefined();
+  });
+
+  it("reinstalls a fresh stub after the global was deleted", () => {
+    const w = makeWindow();
+    ensureElectrobunGlobal();
+    const first = w.__electrobun;
+    delete (w as { __electrobun?: unknown }).__electrobun;
+    ensureElectrobunGlobal();
+    expect(typeof w.__electrobun?.receiveMessageFromBun).toBe("function");
+    expect(typeof w.__electrobun?.receiveInternalMessageFromBun).toBe(
+      "function",
+    );
+    expect(w.__electrobun).not.toBe(first);
+  });
+
+  it("propagates the install failure when window rejects new properties", () => {
+    makeWindow();
+    Object.freeze(globalThis.window);
+    expect(() => ensureElectrobunGlobal()).toThrow(TypeError);
+  });
 });


### PR DESCRIPTION

## Summary

Additive unit-test coverage for `ensureElectrobunGlobal()` in
`packages/app-core/platforms/electrobun/src/bridge/electrobun-stub.ts`.

A suite for this module already exists on `develop` (landed via #25770), so this
diff only **adds** four cases to it (+41/-0, no existing line is touched or
removed). The new cases cover real branches the merged suite does not reach:

- **Falsy non-undefined placeholders are preserved** (`false`, `0`, `""`): the
  guard is `typeof window.__electrobun === "undefined"`, so any defined value
  must survive re-entry untouched - not just objects and `null`.
- **A partial stub is preserved instead of completed**: when an existing global
  has `receiveMessageFromBun` but lacks `receiveInternalMessageFromBun`, the
  helper keeps the original object by reference rather than silently patching a
  half-initialised native layer.
- **Reinstall after deletion**: deleting `window.__electrobun` and calling the
  helper again installs a fresh working stub (new object identity, callable
  handlers) - the late-preload recovery path.
- **Unwritable-window failure propagates**: with a frozen `window` and no
  global installed, the strict-mode assignment throws `TypeError`; the helper
  does not swallow installation failures.

All expectations record observed behaviour of the current module; no
production code is changed.

## Test evidence

Test-only diff: 1 file changed, +41 insertions / 0 deletions.

- `bunx vitest run packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts`
  against current `origin/develop`: **1 test file passed (1), 10 tests passed
  (10)** (6 pre-existing + 4 new).
- `bunx biome check --write <file>` then re-check: clean ("Checked 1 file... No
  fixes applied"), run against the repo's real `biome.json` (worktree is not
  sparse-checked).
- `bunx tsc --noEmit -p tsconfig.json` in
  `packages/app-core/platforms/electrobun`: the new test file appears nowhere
  in the output; remaining diagnostics are pre-existing errors in referenced
  `@elizaos/agent` sources, unchanged by this diff.
- No hosted CI runs on fork PRs; the counts above are from local runs quoted
  verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:df0cfad678cd99fad69f3571f32dbc9ee3f66d8e -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
