### PR TITLE
fix(cloud): make MCP creator and affiliate earnings idempotent per call

### DIFF
--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -765,12 +765,16 @@ class UserMcpsService {
 
     // Credit Affiliate (per-call unique sourceId so each MCP call is credited; idempotency is per-call)
     if (affiliateFeeCredits > 0 && affiliateOwnerId && affiliateCodeId) {
-      const callId = crypto.randomUUID();
+      const sourceSuffix =
+        typeof params.metadata?.preChargeTransactionId === "string"
+          ? params.metadata.preChargeTransactionId
+          : crypto.randomUUID();
       await redeemableEarningsService.addEarnings({
         userId: affiliateOwnerId,
         amount: legacyMcpPointsToOrganizationCredits(affiliateFeeCredits),
         source: "affiliate",
-        sourceId: `affiliate_mcp:${affiliateCodeId}:${callId}`,
+        sourceId: `affiliate_mcp:${affiliateCodeId}:${sourceSuffix}`,
+        dedupeBySourceId: true,
         description: `API Usage Affiliate Fee: ${mcp.name} - ${params.toolName}`,
         metadata: {
           buyer_user_id: params.userId,
@@ -796,11 +800,16 @@ class UserMcpsService {
 
       // CRITICAL: Also credit the creator's redeemable_earnings for token redemption
       if (mcp.created_by_user_id) {
+        const sourceSuffix =
+          typeof params.metadata?.preChargeTransactionId === "string"
+            ? params.metadata.preChargeTransactionId
+            : crypto.randomUUID();
         const result = await redeemableEarningsService.addEarnings({
           userId: mcp.created_by_user_id,
           amount: legacyMcpPointsToOrganizationCredits(creatorEarnings),
           source: "mcp",
-          sourceId: mcp.id,
+          sourceId: `mcp:${mcp.id}:${sourceSuffix}`,
+          dedupeBySourceId: true,
           description: `MCP earnings: ${mcp.name} - ${params.toolName}`,
           metadata: {
             mcpId: mcp.id,
@@ -952,11 +961,16 @@ class UserMcpsService {
 
       // Credit the creator's redeemable_earnings for token redemption
       if (mcp.created_by_user_id) {
+        const sourceSuffix =
+          typeof params.metadata?.preChargeTransactionId === "string"
+            ? params.metadata.preChargeTransactionId
+            : crypto.randomUUID();
         const result = await redeemableEarningsService.addEarnings({
           userId: mcp.created_by_user_id,
           amount: legacyMcpPointsToOrganizationCredits(creatorEarnings),
           source: "mcp",
-          sourceId: mcp.id,
+          sourceId: `mcp:${mcp.id}:${sourceSuffix}`,
+          dedupeBySourceId: true,
           description: `MCP earnings: ${mcp.name} - ${params.toolName}`,
           metadata: {
             mcpId: mcp.id,


### PR DESCRIPTION
## Problem

MCP creator/affiliate earnings crediting is not idempotent per call:

- `recordUsage` affiliate crediting uses `crypto.randomUUID()` as the sourceId suffix with no `dedupeBySourceId`, so a retried charge (client timeout+retry, webhook re-delivery) double-pays the affiliate — violating the repo invariant "Retrying must not double-charge, double-credit, or double-pay".
- Both `recordUsage` and `recordUsageWithoutDeduction` credit creator redeemable earnings with a constant `sourceId: mcp.id`, so with dedupe enabled the key would be wrong, and without it retries double-credit.

## Change

Unify on the pattern already used by `recordUsageWithoutDeduction`'s affiliate path:
- sourceId suffix = `metadata.preChargeTransactionId` when present (stable per transaction), else a fresh UUID.
- `dedupeBySourceId: true` on affiliate and both creator-earnings calls; creator sourceId becomes `mcp:${mcp.id}:${suffix}`.

Live transactions dedupe on retry; distinct transactions each credit once.

## Evidence

- No dedicated unit test exists for `user-mcps.ts`; the change mirrors the already-landed affiliate pattern in the same file and matches `RedeemableEarningsService.addEarnings`'s documented `dedupeBySourceId` contract (ledger lookup on `(source, source_id, user_id)`).

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
