### PR TITLE
fix(cloud-sdk): cap Twilio SMS per-segment cost at a sane maximum

### DIFF
--- a/packages/cloud/sdk/src/browser-contracts/markup.ts
+++ b/packages/cloud/sdk/src/browser-contracts/markup.ts
@@ -200,6 +200,12 @@ export function resolveTwilioSmsCostPerSegment(
     return fallbackCostPerSegment;
   }
 
+  // Sanity cap: no real Twilio segment cost approaches $100; reject typos like
+  // "1e100" that the exponent grammar accepts but that would bill absurdly.
+  if (parsed > 100) {
+    return fallbackCostPerSegment;
+  }
+
   return parsed;
 }
 


### PR DESCRIPTION
## Problem

`TWILIO_SMS_COST_PATTERN` accepts exponent forms (`"1e100"`), and `Number.isFinite(1e100)` is true, so a typo'd or attacker-set env value bills `1e100` USD per SMS segment — directly contradicting the docstring's "malformed config falls back to the safe default instead of billing an absurd per-segment cost".

## Change

Add a sanity cap: parsed values above $100/segment fall back to the default. No real Twilio segment cost approaches $100, so this only rejects absurd magnitudes.

## Evidence

- `bun test packages/cloud/sdk/src/browser-contracts/markup.test.ts` — passes (existing cases unchanged; `"1e100"` now falls back).

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
