### PR TITLE
fix(cloud): report projected spending in dollars not legacy points

### DIFF
--- a/packages/cloud/shared/src/lib/analytics/projections.ts
+++ b/packages/cloud/shared/src/lib/analytics/projections.ts
@@ -267,7 +267,7 @@ export function generateProjectionAlerts(
     alerts.push({
       type: "warning",
       title: "High Projected Spending",
-      message: `Projected spending for the period: ${(totalProjectedCost / 100).toFixed(2)} credits`,
+      message: `Projected spending for the period: ${totalProjectedCost.toFixed(2)} credits`,
       projectedValue: totalProjectedCost,
     });
   }


### PR DESCRIPTION
## Problem

The "High Projected Spending" alert divides the projected dollar cost by 100 and labels it "credits". `totalCost` is USD (sum of input/output cost in the usage-records pipeline), and 1 org credit = exactly $1, so a $100k projection renders as "1000.00 credits" — a 100× underestimate of the projected spend shown to the user.

## Change

Remove the stray `/100` (a legacy MCP-points ratio) and report the dollar figure directly.

## Evidence

- `projectedValue` already carried the un-divided dollar value; message now matches it. No unit test exists for this alert builder.

AI provider/model: deepseek / deepseek-v4-flash
Client / agent tooling: hermes-agent
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 -->
