### PR TITLE
test(scenario-runner): cover effect-assertions

### DIFF
--- a/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
+++ b/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
@@ -128,3 +128,193 @@ describe("expectNoActionCalled", () => {
     expect(message).toContain("bad");
   });
 });
+
+describe("toRecord additional coercions", () => {
+  it("rejects undefined, numbers, and booleans", () => {
+    expect(toRecord(undefined)).toBeNull();
+    expect(toRecord(42)).toBeNull();
+    expect(toRecord(true)).toBeNull();
+  });
+
+  it("returns the identical object reference for objects", () => {
+    const value = { nested: { deep: 1 } };
+    expect(toRecord(value)).toBe(value);
+  });
+
+  it("passes class instances through as records", () => {
+    const date = new Date(0);
+    expect(toRecord(date)).toBe(date);
+  });
+});
+
+describe("successfulActionData payload coercion", () => {
+  it("skips successful calls whose data is not an object", () => {
+    const c = ctx([
+      action({
+        actionName: "t",
+        result: { success: true, data: "plain-text" },
+      }),
+      action({ actionName: "t", result: { success: true, data: [1, 2] } }),
+      action({ actionName: "t", result: { success: true, data: null } }),
+      action({ actionName: "t", result: { success: true, data: { good: 1 } } }),
+    ]);
+    expect(successfulActionData(c, "t")).toEqual({ good: 1 });
+  });
+
+  it("returns null when no qualifying call carries an object payload", () => {
+    const c = ctx([
+      action({ actionName: "t", result: { success: true, data: "s" } }),
+      action({ actionName: "t", result: { success: true, data: null } }),
+    ]);
+    expect(successfulActionData(c, "t")).toBeNull();
+  });
+
+  it("only skips exact synthesized-reply markers", () => {
+    const c = ctx([
+      action({
+        actionName: "t",
+        result: {
+          success: true,
+          data: { source: "synthesized-reply-v2" },
+        },
+      }),
+    ]);
+    expect(successfulActionData(c, "t")).toEqual({
+      source: "synthesized-reply-v2",
+    });
+  });
+});
+
+describe("successfulCalls ordering and filtering", () => {
+  it("returns matching calls in capture order with identity intact", () => {
+    const first = action({
+      actionName: "t",
+      result: { success: true, data: { n: 1 } },
+    });
+    const second = action({
+      actionName: "t",
+      result: { success: true, data: { n: 2 } },
+    });
+    const noise = action({
+      actionName: "other",
+      result: { success: true, data: { n: 3 } },
+    });
+    const failed = action({
+      actionName: "t",
+      result: { success: false, data: { n: 4 } },
+    });
+    const synthesized = action({
+      actionName: "t",
+      result: { success: true, data: { source: "synthesized-reply" } },
+    });
+    const result = successfulCalls(
+      ctx([first, noise, failed, synthesized, second]),
+      ["t", "u"],
+    );
+    expect(result).toEqual([first, second]);
+    expect(result[0]).toBe(first);
+    expect(result[1]).toBe(second);
+  });
+
+  it("returns an empty list for an empty context", () => {
+    expect(successfulCalls(ctx([]), "t")).toEqual([]);
+  });
+});
+
+describe("callPayloadBlob serialization details", () => {
+  it("renders missing parameters and results as nulls", () => {
+    const c = ctx([{ actionName: "t" } as CapturedAction]);
+    expect(callPayloadBlob(c, "t")).toBe(
+      '[{"parameters":null,"data":null,"text":null}]',
+    );
+  });
+
+  it("excludes calls to other actions entirely", () => {
+    const c = ctx([
+      action({ actionName: "DeleteAll", result: { success: true } }),
+      action({ actionName: "SendEmail", result: { success: true } }),
+    ]);
+    const blob = callPayloadBlob(c, "SendEmail");
+    expect(blob).not.toContain("DeleteAll");
+    expect(JSON.parse(blob)).toHaveLength(1);
+  });
+
+  it("keeps capture order across multiple matching calls", () => {
+    const c = ctx([
+      action({
+        actionName: "t",
+        result: { success: true, data: { n: 1 } },
+      }),
+      action({
+        actionName: "t",
+        result: { success: true, data: { n: 2 } },
+      }),
+    ]);
+    const parsed = JSON.parse(callPayloadBlob(c, "t")) as Array<{
+      data: { n: number };
+    }>;
+    expect(parsed.map((entry) => entry.data.n)).toEqual([1, 2]);
+  });
+
+  it("matches action names case-sensitively while lowercasing content", () => {
+    const c = ctx([
+      action({ actionName: "SendEmail", result: { success: true } }),
+    ]);
+    expect(callPayloadBlob(c, "sendemail")).toBe("[]");
+  });
+});
+
+describe("describeCalls rendering details", () => {
+  it("joins multiple call summaries with ' | '", () => {
+    const c = ctx([
+      action({ actionName: "one", result: { success: true } }),
+      action({ actionName: "two", result: { success: true } }),
+    ]);
+    const detail = describeCalls(c);
+    expect(detail).toContain("one(success=true");
+    expect(detail).toContain(" | two(success=true");
+  });
+
+  it("truncates oversized data payloads at 200 characters", () => {
+    const c = ctx([
+      action({
+        actionName: "go",
+        result: { success: true, data: { k: "a".repeat(210) } },
+      }),
+    ]);
+    const detail = describeCalls(c);
+    expect(detail).toContain(`"k":"${"a".repeat(150)}`);
+    expect(detail).not.toContain("a".repeat(195));
+  });
+
+  it("renders failures and missing results explicitly", () => {
+    const failedOnly = ctx([
+      action({ actionName: "go", result: { success: false } }),
+    ]);
+    expect(describeCalls(failedOnly)).toContain("go(success=false");
+    const bare = ctx([{ actionName: "go" } as CapturedAction]);
+    expect(describeCalls(bare)).toBe("go(success=undefined, data=null)");
+  });
+});
+
+describe("expectNoActionCalled failure details", () => {
+  it("lists every offending call and omits clean ones", () => {
+    const message = expectNoActionCalled(
+      ctx([
+        action({ actionName: "bad", result: { success: true, data: null } }),
+        action({ actionName: "fine" }),
+        action({ actionName: "worse" }),
+      ]),
+      ["bad", "worse"],
+    );
+    expect(message).toContain("expected none of [bad, worse]");
+    expect(message).toContain("bad(success=true");
+    expect(message).toContain("worse(success=true");
+    expect(message).not.toContain("fine");
+  });
+
+  it("passes when the forbidden list is empty", () => {
+    const result = expectNoActionCalled(ctx([action({ actionName: "x" })]), []);
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## Summary

Additive-only unit-test coverage for `packages/scenario-runner/src/scenario-assertions/effect-assertions.ts`, the shared helpers that scenario `custom` finalChecks use to prove action effects. The suite already covered each helper's happy path; this change appends 17 new cases for real branches those tests did not reach. No existing case was modified or removed (+190/-0 on one test file).

## What the new cases pin down

- `toRecord`: rejects `undefined` / numbers / booleans; returns the identical object reference; passes class instances through as records.
- `successfulActionData`: skips successful calls whose `data` is not an object (string / array / null) and falls through to the first object payload; returns null when no qualifying call carries an object payload; only skips exact `synthesized-reply` markers (a near-miss like `synthesized-reply-v2` still qualifies).
- `successfulCalls`: preserves capture order and element identity across accepted-name filtering (`["t","u"]`), excluding other names, failed calls, and synthesized replies; empty context yields an empty list.
- `callPayloadBlob`: missing `parameters` and missing `result` render as explicit nulls; calls to other actions are excluded entirely; multiple matching calls serialize in capture order; name matching is case-sensitive even though serialized content is lowercased.
- `describeCalls`: joins multiple call summaries with `" | "`; truncates oversized `data` payloads at 200 characters; renders failures and result-less captures explicitly (`success=false`, `success=undefined, data=null`).
- `expectNoActionCalled`: failure message lists every offending call and omits clean ones; an empty forbidden list never fails.

All expectations were written against observed behavior of the current implementation; no aspirational behavior is asserted.

## Evidence

Test-only change; vitest, biome and tsc counts are quoted in the PR body:

1. **vitest** — `bunx vitest run src/scenario-assertions/__tests__/effect-assertions.test.ts` in `packages/scenario-runner` (v4.1.10): **Test Files 1 passed (1), Tests 27 passed (27)** — 10 pre-existing cases plus 17 new ones. Re-fetched `origin/develop` immediately before filing (tip `1f236fd1f5`) and re-ran: same 27/27.
2. **biome** — `bunx biome check --write` on the touched file with the repo's root `biome.json`: clean ("Checked 1 file", no fixes applied).
3. **tsc** — `bunx tsc --noEmit` in `packages/scenario-runner`: zero diagnostics referencing `effect-assertions.test.ts`.
4. The diff touches only `packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts`, purely additive (190 insertions, 0 deletions).

This PR comes from a fork, so hosted CI does not run on it; the counts above are from local runs against the pushed head's exact tree.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a29304592c369f60161ce9117092c3d65cc43c7d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
