### PR TITLE
test(agent): cover runtime

### DIFF
--- a/packages/agent/src/runtime/operations/manager.test.ts
+++ b/packages/agent/src/runtime/operations/manager.test.ts
@@ -1,0 +1,601 @@
+/**
+ * Unit coverage for DefaultRuntimeOperationManager. Drives the real manager
+ * against a real in-memory RuntimeOperationRepository: start outcome kinds
+ * and their precedence, prepare/classify-context ordering, the asynchronous
+ * phase lifecycle, every failure-code branch, and single-flight rejection.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { ClassifyContext } from "./classifier.ts";
+import type { HealthChecker } from "./health.ts";
+import { DefaultRuntimeOperationManager } from "./manager.ts";
+import type {
+  OperationIntent,
+  OperationPhase,
+  ReloadStrategy,
+  RuntimeOperation,
+  RuntimeOperationListOptions,
+  RuntimeOperationRepository,
+} from "./types.ts";
+
+function makeRuntime(id: string): AgentRuntime {
+  return { agentId: id } as AgentRuntime;
+}
+
+function makeRepository(
+  seed: RuntimeOperation[] = [],
+): RuntimeOperationRepository & { ops: RuntimeOperation[] } {
+  const ops = [...seed];
+  const find = (id: string) => ops.find((op) => op.id === id);
+  return {
+    ops,
+    async create(op) {
+      ops.push(structuredClone(op));
+    },
+    async update(id, patch) {
+      const op = find(id);
+      if (!op) throw new Error(`missing op ${id}`);
+      Object.assign(op, structuredClone(patch));
+    },
+    async appendPhase(id, phase) {
+      const op = find(id);
+      if (!op) throw new Error(`missing op ${id}`);
+      op.phases.push(structuredClone(phase));
+    },
+    async updateLastPhase(id, patch) {
+      const op = find(id);
+      if (!op) throw new Error(`missing op ${id}`);
+      const last = op.phases.at(-1);
+      if (!last) throw new Error(`op ${id} has no phases`);
+      Object.assign(last, structuredClone(patch));
+    },
+    async get(id) {
+      const op = find(id);
+      return op ? structuredClone(op) : null;
+    },
+    async list(opts?: RuntimeOperationListOptions) {
+      const filtered = opts?.status
+        ? ops.filter((op) => op.status === opts.status)
+        : ops;
+      return filtered.map((op) => structuredClone(op));
+    },
+    async findByIdempotencyKey(key) {
+      const op = [...ops].reverse().find((o) => o.idempotencyKey === key);
+      return op ? structuredClone(op) : null;
+    },
+    async findActive() {
+      const op = ops.find(
+        (o) => o.status === "pending" || o.status === "running",
+      );
+      return op ? structuredClone(op) : null;
+    },
+  };
+}
+
+type RepoFixture = ReturnType<typeof makeRepository>;
+
+interface Harness {
+  repo: RepoFixture;
+  manager: DefaultRuntimeOperationManager;
+}
+
+function makeHarness(options?: {
+  seed?: RuntimeOperation[];
+  runtime?: AgentRuntime | null;
+  strategies?: Partial<Record<string, ReloadStrategy>>;
+  healthReport?: Awaited<ReturnType<HealthChecker["runForRuntime"]>>;
+  classifier?: (intent: OperationIntent, ctx: ClassifyContext) => string;
+  classifyContext?: () => ClassifyContext;
+}): Harness & {
+  strategies: Partial<Record<string, ReloadStrategy>>;
+} {
+  const repo = makeRepository(options?.seed ?? []);
+  const strategies = options?.strategies ?? {};
+  const healthChecker = makeHealthChecker(async () =>
+    options?.healthReport
+      ? options.healthReport
+      : {
+          ok: true,
+          passed: [{ name: "database-liveness", durationMs: 1 }],
+          failed: [],
+        },
+  );
+  const manager = new DefaultRuntimeOperationManager({
+    repository: repo,
+    runtime: () => options?.runtime ?? null,
+    classifyContext:
+      options?.classifyContext ??
+      ((): ClassifyContext => ({ currentProvider: "openai" })),
+    ...(options?.classifier ? { classifier: options.classifier as never } : {}),
+    healthChecker,
+    strategies: strategies as never,
+  });
+  return { repo, manager, strategies };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+type HealthCheckReport = Awaited<ReturnType<HealthChecker["runForRuntime"]>>;
+
+function makeHealthChecker(
+  run: (runtime: AgentRuntime) => Promise<HealthCheckReport>,
+): HealthChecker {
+  const stub = {
+    async runForRuntime(runtime: AgentRuntime): Promise<HealthCheckReport> {
+      return run(runtime);
+    },
+  };
+  return stub as unknown as HealthChecker;
+}
+
+const restartIntent: OperationIntent = { kind: "restart", reason: "manual" };
+
+function hotStrategy(apply: ReloadStrategy["apply"]): ReloadStrategy {
+  return { tier: "hot", apply };
+}
+
+describe("DefaultRuntimeOperationManager.start", () => {
+  describe("accepted", () => {
+    it("persists the accepted operation synchronously as pending", async () => {
+      const { repo, manager } = makeHarness();
+      const outcome = await manager.start({ intent: restartIntent });
+
+      expect(outcome.kind).toBe("accepted");
+      if (outcome.kind !== "accepted") return;
+      const { operation } = outcome;
+      expect(operation.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+      expect(operation.kind).toBe("restart");
+      expect(operation.intent).toEqual(restartIntent);
+      expect(operation.tier).toBe("cold");
+      expect(operation.status).toBe("pending");
+      expect(operation.phases).toEqual([]);
+      expect(typeof operation.startedAt).toBe("number");
+
+      const stored = await repo.get(operation.id);
+      expect(stored?.id).toBe(operation.id);
+    });
+
+    it("uses the conservative cold tier when no classifier is wired", async () => {
+      const { manager } = makeHarness();
+      const outcome = await manager.start({
+        intent: { kind: "provider-switch", provider: "openai" },
+      });
+      expect(outcome.kind).toBe("accepted");
+      if (outcome.kind !== "accepted") return;
+      expect(outcome.operation.tier).toBe("cold");
+    });
+
+    it("records the custom classifier's tier on the persisted operation", async () => {
+      const { repo, manager } = makeHarness({
+        classifier: () => "warm",
+        strategies: {},
+      });
+      const outcome = await manager.start({ intent: restartIntent });
+      expect(outcome.kind).toBe("accepted");
+      if (outcome.kind !== "accepted") return;
+      expect(outcome.operation.tier).toBe("warm");
+      expect((await repo.get(outcome.operation.id))?.tier).toBe("warm");
+    });
+  });
+
+  describe("deduped", () => {
+    it("returns the existing operation for a known idempotency key", async () => {
+      const existing: RuntimeOperation = {
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "restart",
+        intent: restartIntent,
+        tier: "cold",
+        idempotencyKey: "retry-1",
+        status: "succeeded",
+        phases: [],
+        startedAt: 1,
+      };
+      const { manager } = makeHarness({ seed: [existing] });
+
+      const outcome = await manager.start({
+        intent: restartIntent,
+        idempotencyKey: "retry-1",
+      });
+
+      expect(outcome.kind).toBe("deduped");
+      if (outcome.kind !== "deduped") return;
+      expect(outcome.operation.id).toBe(existing.id);
+    });
+
+    it("checks idempotency before the busy gate", async () => {
+      const active: RuntimeOperation = {
+        id: "22222222-2222-4222-8222-222222222222",
+        kind: "restart",
+        intent: restartIntent,
+        tier: "cold",
+        status: "running",
+        phases: [],
+        startedAt: 1,
+      };
+      const done: RuntimeOperation = {
+        ...active,
+        id: "33333333-3333-4333-8333-333333333333",
+        idempotencyKey: "retry-2",
+        status: "succeeded",
+      };
+      const { manager } = makeHarness({ seed: [active, done] });
+
+      const outcome = await manager.start({
+        intent: restartIntent,
+        idempotencyKey: "retry-2",
+      });
+
+      expect(outcome.kind).toBe("deduped");
+    });
+  });
+
+  describe("rejected-busy", () => {
+    it("rejects with the active operation id", async () => {
+      const active: RuntimeOperation = {
+        id: "44444444-4444-4444-8444-444444444444",
+        kind: "config-reload",
+        intent: { kind: "config-reload" },
+        tier: "hot",
+        status: "running",
+        phases: [],
+        startedAt: 1,
+      };
+      const { manager } = makeHarness({ seed: [active] });
+
+      const outcome = await manager.start({
+        intent: restartIntent,
+        idempotencyKey: "unused-key",
+      });
+
+      expect(outcome).toEqual({
+        kind: "rejected-busy",
+        activeOperationId: active.id,
+      });
+    });
+
+    it("serializes concurrent submissions through the single-flight gate", async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const { manager } = makeHarness({
+        runtime: makeRuntime("rt-live"),
+        strategies: {
+          cold: hotStrategy(async () => {
+            await gate;
+            return makeRuntime("rt-next");
+          }),
+        },
+      });
+
+      const first = await manager.start({ intent: restartIntent });
+      expect(first.kind).toBe("accepted");
+      await settle();
+
+      const second = await manager.start({ intent: restartIntent });
+      expect(second.kind).toBe("rejected-busy");
+      if (first.kind !== "accepted" || second.kind !== "rejected-busy") return;
+      expect(second.activeOperationId).toBe(first.operation.id);
+
+      release();
+      await settle();
+      const settled = await manager.get(first.operation.id);
+      expect(settled?.status).toBe("succeeded");
+    });
+  });
+
+  describe("prepare and classification ordering", () => {
+    it("classifies against the context snapshot taken before prepare mutates state", async () => {
+      const providerState = { value: "openai" };
+      const seenAtClassification: string[] = [];
+      const { manager } = makeHarness({
+        classifyContext: () => ({ currentProvider: providerState.value }),
+        classifier: (_intent, ctx) => {
+          seenAtClassification.push(ctx.currentProvider ?? "");
+          return "hot";
+        },
+        strategies: {
+          hot: hotStrategy(async () => makeRuntime("rt")),
+        },
+      });
+
+      await manager.start({
+        intent: restartIntent,
+        prepare: async () => {
+          providerState.value = "cerebras";
+          return undefined;
+        },
+      });
+      await settle();
+      expect(seenAtClassification).toEqual(["openai"]);
+
+      await manager.start({ intent: restartIntent });
+      expect(seenAtClassification).toEqual(["openai", "cerebras"]);
+    });
+
+    it("replaces the intent with prepare's returned payload", async () => {
+      const seenIntents: OperationIntent[] = [];
+      const { repo, manager } = makeHarness({
+        runtime: makeRuntime("rt-live"),
+        classifier: (intent) => {
+          seenIntents.push(intent);
+          return "hot";
+        },
+        strategies: {
+          hot: hotStrategy(async ({ intent }) => {
+            seenIntents.push(intent);
+            return makeRuntime("rt");
+          }),
+        },
+      });
+      const replacement: OperationIntent = {
+        kind: "plugin-enable",
+        pluginId: "plugin-sql",
+      };
+
+      const outcome = await manager.start({
+        intent: restartIntent,
+        prepare: async () => replacement,
+      });
+
+      expect(outcome.kind).toBe("accepted");
+      await settle();
+      expect(seenIntents[0]).toEqual(replacement);
+      expect(seenIntents[1]).toEqual(replacement);
+      expect(repo.ops[0]?.kind).toBe("plugin-enable");
+    });
+
+    it("keeps the request intent when prepare resolves undefined", async () => {
+      const { repo, manager } = makeHarness();
+      const outcome = await manager.start({
+        intent: restartIntent,
+        prepare: async () => undefined,
+      });
+      expect(outcome.kind).toBe("accepted");
+      expect(repo.ops[0]?.intent).toEqual(restartIntent);
+    });
+  });
+});
+
+describe("DefaultRuntimeOperationManager execution lifecycle", () => {
+  it("runs validate, strategy and health-check to success", async () => {
+    const liveRuntime = makeRuntime("rt-live");
+    const nextRuntime = makeRuntime("rt-next");
+    const appliedContexts: Array<{
+      runtime: AgentRuntime;
+      intent: OperationIntent;
+    }> = [];
+    const healthTargets: AgentRuntime[] = [];
+    const repo = makeRepository();
+    const manager = new DefaultRuntimeOperationManager({
+      repository: repo,
+      runtime: () => liveRuntime,
+      classifyContext: () => ({}),
+      healthChecker: makeHealthChecker(async (runtime) => {
+        healthTargets.push(runtime);
+        return {
+          ok: true,
+          passed: [
+            { name: "database-liveness", durationMs: 2 },
+            { name: "provider-ready", durationMs: 3 },
+          ],
+          failed: [],
+        };
+      }),
+      strategies: {
+        cold: hotStrategy(async (ctx) => {
+          appliedContexts.push({
+            runtime: ctx.runtime,
+            intent: ctx.intent,
+          });
+          await ctx.reportPhase({
+            name: "apply-env",
+            status: "succeeded",
+            startedAt: 1,
+            finishedAt: 2,
+          });
+          return nextRuntime;
+        }),
+      },
+    });
+
+    const outcome = await manager.start({
+      intent: { kind: "config-reload", changedPaths: ["env.KEY"] },
+    });
+    expect(outcome.kind).toBe("accepted");
+    await settle();
+
+    expect(appliedContexts).toHaveLength(1);
+    expect(appliedContexts[0].runtime).toBe(liveRuntime);
+    expect(appliedContexts[0].intent).toEqual({
+      kind: "config-reload",
+      changedPaths: ["env.KEY"],
+    });
+    expect(healthTargets).toEqual([nextRuntime]);
+
+    const stored = repo.ops[0];
+    expect(stored.status).toBe("succeeded");
+    expect(stored.error).toBeUndefined();
+    expect(stored.finishedAt).toBeGreaterThanOrEqual(stored.startedAt);
+    expect(stored.phases.map((phase) => [phase.name, phase.status])).toEqual([
+      ["validate", "succeeded"],
+      ["apply-env", "succeeded"],
+      ["health-check", "succeeded"],
+    ]);
+    const healthPhase = stored.phases.at(-1) as OperationPhase;
+    expect(healthPhase.detail).toEqual({
+      passed: [
+        { name: "database-liveness", durationMs: 2 },
+        { name: "provider-ready", durationMs: 3 },
+      ],
+      failed: [],
+    });
+    expect(healthPhase.finishedAt).toBeGreaterThanOrEqual(
+      healthPhase.startedAt ?? 0,
+    );
+  });
+
+  it("fails with no-strategy-for-tier when the tier has no strategy", async () => {
+    const { repo, manager } = makeHarness({ runtime: makeRuntime("rt") });
+
+    const outcome = await manager.start({ intent: restartIntent });
+    expect(outcome.kind).toBe("accepted");
+    await settle();
+
+    const stored = repo.ops[0];
+    expect(stored.status).toBe("failed");
+    expect(stored.error).toEqual({
+      message: "No strategy registered for tier=cold",
+      code: "no-strategy-for-tier",
+    });
+    expect(stored.finishedAt).toBeDefined();
+    expect(stored.phases.map((p) => [p.name, p.status])).toEqual([
+      ["validate", "succeeded"],
+    ]);
+  });
+
+  it("fails with no-runtime when no live runtime is available", async () => {
+    const { repo, manager } = makeHarness({
+      runtime: null,
+      strategies: { cold: hotStrategy(async () => makeRuntime("rt")) },
+    });
+
+    await manager.start({ intent: restartIntent });
+    await settle();
+
+    expect(repo.ops[0].status).toBe("failed");
+    expect(repo.ops[0].error).toMatchObject({
+      code: "no-runtime",
+      message: "No live runtime available to apply operation",
+    });
+  });
+
+  it("checks the strategy registry before the runtime lookup", async () => {
+    const { repo, manager } = makeHarness({
+      runtime: null,
+      strategies: {},
+    });
+
+    await manager.start({ intent: restartIntent });
+    await settle();
+
+    expect(repo.ops[0].error?.code).toBe("no-strategy-for-tier");
+  });
+
+  it("maps a plain strategy throw to strategy-failed", async () => {
+    const { repo, manager } = makeHarness({
+      runtime: makeRuntime("rt"),
+      strategies: {
+        cold: hotStrategy(async () => {
+          throw new Error("boot exploded");
+        }),
+      },
+    });
+
+    await manager.start({ intent: restartIntent });
+    await settle();
+
+    expect(repo.ops[0].status).toBe("failed");
+    expect(repo.ops[0].error).toEqual({
+      message: "boot exploded",
+      code: "strategy-failed",
+    });
+  });
+
+  it("preserves vault-resolve-failed thrown codes", async () => {
+    const { repo, manager } = makeHarness({
+      runtime: makeRuntime("rt"),
+      strategies: {
+        cold: hotStrategy(async () => {
+          throw Object.assign(new Error("vault miss"), {
+            code: "vault-resolve-failed",
+          });
+        }),
+      },
+    });
+
+    await manager.start({ intent: restartIntent });
+    await settle();
+
+    expect(repo.ops[0].error).toEqual({
+      message: "vault miss",
+      code: "vault-resolve-failed",
+    });
+  });
+
+  it("fails with health-check-failed and marks only the last phase failed", async () => {
+    const repo = makeRepository();
+    const manager = new DefaultRuntimeOperationManager({
+      repository: repo,
+      runtime: () => makeRuntime("rt-live"),
+      classifyContext: () => ({}),
+      healthChecker: makeHealthChecker(async () => ({
+        ok: false,
+        passed: [],
+        failed: [
+          {
+            name: "database-liveness",
+            required: true,
+            reason: "connection refused",
+            durationMs: 5,
+          },
+        ],
+      })),
+      strategies: { cold: hotStrategy(async () => makeRuntime("rt-next")) },
+    });
+
+    await manager.start({ intent: restartIntent });
+    await settle();
+
+    const stored = repo.ops[0];
+    expect(stored.status).toBe("failed");
+    expect(stored.error).toEqual({
+      message: "Required health checks failed",
+      code: "health-check-failed",
+    });
+    expect(stored.phases.map((p) => [p.name, p.status])).toEqual([
+      ["validate", "succeeded"],
+      ["health-check", "failed"],
+    ]);
+    expect(stored.phases[1].detail).toEqual({
+      passed: [],
+      failed: [
+        {
+          name: "database-liveness",
+          required: true,
+          reason: "connection refused",
+          durationMs: 5,
+        },
+      ],
+    });
+    expect(stored.finishedAt).toBeDefined();
+  });
+});
+
+describe("DefaultRuntimeOperationManager queries", () => {
+  it("delegates get, list and findActive to the repository", async () => {
+    const active: RuntimeOperation = {
+      id: "55555555-5555-4555-8555-555555555555",
+      kind: "restart",
+      intent: restartIntent,
+      tier: "cold",
+      status: "running",
+      phases: [],
+      startedAt: 1,
+    };
+    const { manager } = makeHarness({ seed: [active] });
+
+    expect(await manager.get(active.id)).toEqual(active);
+    expect(await manager.get("missing")).toBeNull();
+    expect(await manager.list()).toEqual([active]);
+    expect(await manager.list({ status: "failed" })).toEqual([]);
+    expect(await manager.findActive()).toEqual(active);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `DefaultRuntimeOperationManager` (`packages/agent/src/runtime/operations/manager.ts`), which had no test coverage on `develop`: the operations directory covered classifier, cold-strategy, health, health-checks, reload-hot and vault-bridge, but not the manager that sequences them.

## Why this file (target substitution)

This lane was assigned `packages/agent/src/actions/runtime.ts`, but open PR #27046 already adds `actions/runtime.test.ts` and modifies `runtime.ts` itself. Under one-PR-per-file this lane pivoted to the next uncovered module in the same package (`src/runtime/operations/manager.ts`), re-verified immediately before filing: no same-named suite on current `origin/develop`, zero open PRs referencing it, and `manager.ts`/`types.ts` byte-identical between the working tree base and `origin/develop`.

## Coverage (behaviour asserted, real class + real in-memory repository fixture — the subject is never mocked)

- Start outcomes: `accepted` (uuid id, pending status, empty phase log, tier persisted), `deduped` on a known idempotency key, `rejected-busy` carrying the active op id; idempotency gate checked before the busy gate.
- Classification: custom classifier tiers recorded; conservative `cold` default when none is wired; classify context snapshotted BEFORE `prepare()` runs — proven by mutating provider state inside prepare and asserting the classifier still sees pre-prepare values while a subsequent start sees the mutation.
- `prepare()` contract: returned intent replaces the request intent for both classification and execution; `undefined` keeps the original.
- Async lifecycle to success: validate → strategy-applied phases → health-check, with the strategy receiving the live runtime + prepared intent, its returned runtime passed to `runForRuntime`, phase details carrying passed/failed counts and monotone timestamps.
- Failure branches: `no-strategy-for-tier` (and its precedence over the runtime lookup), `no-runtime`, plain throw → `strategy-failed`, thrown `code: "vault-resolve-failed"` preserved, failed health check flipping only the last phase to `failed` while earlier phases stay immutable.
- Single-flight: concurrent submissions serialize; the second is rejected busy against the in-flight op id, then the first completes to succeeded.
- Query delegation: `get`/`list`/`findActive` passthrough.

## Evidence (test-only change; counts quoted from this exact tree)

- `bunx vitest run src/runtime/operations/manager.test.ts` (in `packages/agent`, vitest-owned lane): **Test Files 1 passed (1); Tests 18 passed (18)** — re-fetched and re-verified against current `origin/develop` immediately before filing.
- `bunx biome check src/runtime/operations/manager.test.ts`: clean, 0 problems.
- `bunx tsc --noEmit` (packages/agent): grep for `manager.test.ts` returns nothing — the new file contributes zero type errors.
- Diff is strictly additive: 1 new test file, +601/−0. No production behaviour changed; hosted CI does not run on fork PRs, so the counts above are the verification record.

Note: the first draft of this suite asserted two behaviours the code does not have (pending visibility after an await, strict finishedAt > startedAt within the same millisecond). Both were corrected to observed behaviour before filing; every assertion now records what the manager actually does.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:322ddabdf32553c7be55ef1ead82ff6dcd76c54a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
