### PR TITLE
test(core): cover trustProfile

### DIFF
--- a/packages/core/src/features/trust/providers/trustProfile.test.ts
+++ b/packages/core/src/features/trust/providers/trustProfile.test.ts
@@ -218,3 +218,46 @@ describe("trustProfileProvider", () => {
 		},
 	);
 });
+
+describe("trustProfileProvider classification boundaries and tallies", () => {
+	test.each([
+		[79, "good trust"],
+		[59, "moderate trust"],
+		[39, "low trust"],
+	] as const)(
+		"classifies a score of %i just below each tier boundary as %s",
+		async (score, trustLevel) => {
+			const { runtime } = runtimeWithService({ profile: profile(score) });
+
+			const result = await trustProfileProvider.get(runtime, message, state);
+
+			expect(result.text).toBe(
+				`The user has ${trustLevel} (${score}/100) with stable trust trend based on 12 interactions.`,
+			);
+			expect(result.values.trustLevel).toBe(trustLevel);
+			expect(result.values.trustScore).toBe(score);
+		},
+	);
+
+	test("tallies several negative interactions without counting any as positive", async () => {
+		const { runtime } = runtimeWithService({
+			interactions: [interaction(-2), interaction(-5)],
+		});
+
+		const result = await trustProfileProvider.get(runtime, message, state);
+
+		expect(result.values.recentPositiveActions).toBe(0);
+		expect(result.values.recentNegativeActions).toBe(2);
+	});
+
+	test("tallies several positive interactions without counting any as negative", async () => {
+		const { runtime } = runtimeWithService({
+			interactions: [interaction(3), interaction(7)],
+		});
+
+		const result = await trustProfileProvider.get(runtime, message, state);
+
+		expect(result.values.recentPositiveActions).toBe(2);
+		expect(result.values.recentNegativeActions).toBe(0);
+	});
+});


### PR DESCRIPTION

## What

Additive unit coverage for `packages/core/src/features/trust/providers/trustProfile.ts`, extending the suite introduced by #26450 (merged earlier today) with five new cases. The diff is a single test file, **+43/-0** — no existing line is touched, no production behaviour changes.

## Why these cases

- **Off-by-one tier boundaries (79, 59, 39):** the provider classifies trust with chained `>=` comparisons. The base suite pins the threshold values themselves (80/60/40/20 and 19), but never proves that a score *just below* a boundary drops to the next tier. 79 → "good trust", 59 → "moderate trust", 39 → "low trust" are now asserted through the real provider result (text plus `values.trustLevel` / `values.trustScore`). A score of 21 was observed to classify as "low trust" (`>= 20` tier) during development, consistent with the source; the case below 20 already exists in the base suite as 19.
- **Interaction tallies:** an all-negative recent-interaction list yields `recentPositiveActions: 0, recentNegativeActions: 2` and an all-positive list yields `2` / `0`, proving both filters aggregate counts over multiple items rather than acting as booleans, and that positive items never leak into the negative count (and vice versa).

All cases drive the real provider through the same typed trust-service fakes the existing suite uses; no mocks assert their own return values.

## Verification (run locally at head 487ec0371865 against current origin/develop)

- `bunx vitest run src/features/trust/providers/trustProfile.test.ts` (in `packages/core`) → **Test Files 1 passed (1), Tests 18 passed (18)** — 13 pre-existing + 5 new.
- `bunx biome check --write packages/core/src/features/trust/providers/trustProfile.test.ts` → clean, "No fixes applied".
- `bunx tsc --noEmit` in `packages/core` → zero mentions of `trustProfile.test.ts` in output.
- Diff vs `origin/develop` touches only `packages/core/src/features/trust/providers/trustProfile.test.ts`.

## Notes

- Test-only pull request: no production code path is modified. Hosted CI does not run on fork-submitted PRs, so the checks above were executed locally and their exact counts are quoted here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:487ec0371865b08135c1d63a8ef0da763996324b -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
