### PR TITLE
test(wallet): cover inventory chain filters

### DIFF
--- a/plugins/plugin-wallet/src/ui/inventory/inventory-chain-filters.test.ts
+++ b/plugins/plugin-wallet/src/ui/inventory/inventory-chain-filters.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Covers the inventory chain-filter helpers against the real module and the
+ * real chain registry: normalization of missing/partial filter state onto the
+ * all-enabled defaults, alias-aware chain matching restricted to the primary
+ * chains, single-chain focus detection, and toggle semantics on normalized
+ * copies. No module under test is mocked.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeSingleChainFocus,
+  DEFAULT_INVENTORY_CHAIN_FILTERS,
+  matchesInventoryChainFilter,
+  normalizeInventoryChainFilters,
+  toggleInventoryChainFilter,
+} from "./inventory-chain-filters.ts";
+
+describe("normalizeInventoryChainFilters", () => {
+  it("treats null and undefined as every primary chain enabled", () => {
+    expect(normalizeInventoryChainFilters(null)).toEqual(
+      DEFAULT_INVENTORY_CHAIN_FILTERS,
+    );
+    expect(normalizeInventoryChainFilters(undefined)).toEqual(
+      DEFAULT_INVENTORY_CHAIN_FILTERS,
+    );
+    expect(normalizeInventoryChainFilters({})).toEqual(
+      DEFAULT_INVENTORY_CHAIN_FILTERS,
+    );
+  });
+
+  it("fills only the missing keys of a partial filter object", () => {
+    expect(normalizeInventoryChainFilters({ ethereum: false })).toEqual({
+      ethereum: false,
+      base: true,
+      bsc: true,
+      avax: true,
+      solana: true,
+    });
+  });
+
+  it("returns a new object and never mutates its input", () => {
+    const partial = { bsc: false };
+    const normalized = normalizeInventoryChainFilters(partial);
+    expect(partial).toEqual({ bsc: false });
+    expect(normalized).not.toBe(partial);
+    expect(normalized.bsc).toBe(false);
+  });
+});
+
+describe("matchesInventoryChainFilter", () => {
+  it("resolves case-insensitive aliases onto primary chains", () => {
+    expect(matchesInventoryChainFilter("ETH", null)).toBe(true);
+    expect(matchesInventoryChainFilter("  mainnet ", null)).toBe(true);
+    expect(matchesInventoryChainFilter("SOL", undefined)).toBe(true);
+    expect(matchesInventoryChainFilter("BNB SMART CHAIN", {})).toBe(true);
+    expect(matchesInventoryChainFilter("avalanche c-chain", null)).toBe(true);
+  });
+
+  it("rejects resolvable non-primary chains even with all filters enabled", () => {
+    expect(matchesInventoryChainFilter("arbitrum", null)).toBe(false);
+    expect(matchesInventoryChainFilter("optimism", null)).toBe(false);
+    expect(matchesInventoryChainFilter("polygon", null)).toBe(false);
+  });
+
+  it("rejects unknown chains instead of defaulting to a primary key", () => {
+    expect(matchesInventoryChainFilter("sui", null)).toBe(false);
+    expect(matchesInventoryChainFilter("", null)).toBe(false);
+  });
+
+  it("honours an explicit false on the resolved primary chain only", () => {
+    expect(matchesInventoryChainFilter("eth", { ethereum: false })).toBe(false);
+    expect(matchesInventoryChainFilter("eth", { base: false })).toBe(true);
+    expect(
+      matchesInventoryChainFilter("sol", { solana: false, base: true }),
+    ).toBe(false);
+  });
+});
+
+describe("computeSingleChainFocus", () => {
+  it("returns null when nothing or everything is enabled after normalization", () => {
+    expect(computeSingleChainFocus(null)).toBeNull();
+    expect(computeSingleChainFocus(undefined)).toBeNull();
+    expect(computeSingleChainFocus(DEFAULT_INVENTORY_CHAIN_FILTERS)).toBeNull();
+  });
+
+  it("a partial object normalizes to all-enabled and therefore has no focus", () => {
+    expect(computeSingleChainFocus({})).toBeNull();
+    expect(computeSingleChainFocus({ solana: true })).toBeNull();
+  });
+
+  it("returns the only enabled primary chain", () => {
+    expect(
+      computeSingleChainFocus({
+        ethereum: false,
+        base: false,
+        bsc: false,
+        avax: false,
+        solana: true,
+      }),
+    ).toBe("solana");
+  });
+
+  it("returns null when two or more chains stay enabled", () => {
+    expect(
+      computeSingleChainFocus({
+        ethereum: false,
+        base: true,
+        bsc: true,
+        avax: false,
+        solana: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("toggleInventoryChainFilter", () => {
+  it("flips one key off an all-enabled baseline without mutating the input", () => {
+    const input = DEFAULT_INVENTORY_CHAIN_FILTERS;
+    const toggled = toggleInventoryChainFilter(input, "solana");
+    expect(toggled.solana).toBe(false);
+    expect(toggled.ethereum).toBe(true);
+    expect(toggled).not.toBe(input);
+    expect(input.solana).toBe(true);
+  });
+
+  it("round-trips back to the original posture when toggled twice", () => {
+    const once = toggleInventoryChainFilter(null, "bsc");
+    const twice = toggleInventoryChainFilter(once, "bsc");
+    expect(twice).toEqual(DEFAULT_INVENTORY_CHAIN_FILTERS);
+  });
+
+  it("normalizes first, preserving explicit partial values while flipping the target", () => {
+    const toggled = toggleInventoryChainFilter({ bsc: false }, "avax");
+    expect(toggled).toEqual({
+      ethereum: true,
+      base: true,
+      bsc: false,
+      avax: false,
+      solana: true,
+    });
+  });
+});


### PR DESCRIPTION

Adds the first unit suite for `plugins/plugin-wallet/src/ui/inventory/inventory-chain-filters.ts` — the per-user chain toggles that gate every token row in the wallet inventory view. The module had no test coverage anywhere in the repository.

What is covered (14 cases, real module + real chain registry, nothing mocked):

- `normalizeInventoryChainFilters`: `null`, `undefined`, and `{}` all normalize to every primary chain enabled; partial objects keep explicit values while missing keys default on; normalization never mutates its input.
- `matchesInventoryChainFilter`: alias resolution through the live chain registry (`ETH`, `mainnet`, `SOL`, `BNB SMART CHAIN`, `avalanche c-chain` are case/whitespace-insensitive); resolvable non-primary chains (`arbitrum`, `optimism`, `polygon`) are rejected even when their filters are enabled; unknown chains reject rather than fall through; an explicit `false` blocks only the resolved primary chain.
- `computeSingleChainFocus`: returns the single enabled primary chain, `null` for zero-or-many, and — importantly — `null` for partial objects because they normalize to all-enabled.
- `toggleInventoryChainFilter`: flips against the normalized baseline, round-trips to the original posture when applied twice, preserves other explicit partial values, and returns new objects without mutating inputs.

Diff scope: one new test file, `+141/-0`. No production code paths change.

Local verification at head `10e022a7c5985d228616e8e78663155c0d2ccee6`:

- `bunx vitest run src/ui/inventory/inventory-chain-filters.test.ts` (in `plugins/plugin-wallet`) — Test Files 1 passed, Tests 14 passed / 0 failed.
- `bunx biome check --write` on the touched file — clean.
- `tsc --noEmit -p tsconfig.json` — exit 0; `tsc --noEmit -p tsconfig.ui.json` — exit 0. Both package trees exclude `src/**/*.test.ts` by configuration, so the new file was additionally proven with a standalone strict pass: `tsc --ignoreConfig --noEmit --strict ... inventory-chain-filters.test.ts` — exit 0, zero errors.

This pull request is filed from a fork, so hosted CI does not run on it; the counts above are from local runs against the pushed head commit.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:10e022a7c5985d228616e8e78663155c0d2ccee6 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
