### PR TITLE
test(core): cover security

### DIFF
--- a/packages/core/src/features/trust/types/security.test.ts
+++ b/packages/core/src/features/trust/types/security.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Covers the runtime surface of the trust capability's security type
+ * definitions: the `SecurityEventType` enum whose snake_case members are the
+ * persisted wire vocabulary for `SecurityEvent.type`. SecurityModule resolves
+ * every member through an exhaustive `Record<SecurityEventType,
+ * TrustEvidenceType>` mapping, while CredentialProtector and the service
+ * wrappers emit specific members, so the load-bearing contracts are wire-value
+ * stability, value uniqueness, string-enum enumeration semantics (no
+ * reverse-mapping entries), and serialization round-trips. Pure deterministic
+ * harness against the real module; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { SecurityEventType } from "./security.ts";
+
+const ALL_VALUES = Object.values(SecurityEventType);
+const MEMBER_NAMES = [
+	"PROMPT_INJECTION_ATTEMPT",
+	"SOCIAL_ENGINEERING_ATTEMPT",
+	"PRIVILEGE_ESCALATION_ATTEMPT",
+	"ANOMALOUS_REQUEST",
+	"TRUST_MANIPULATION",
+	"IDENTITY_SPOOFING",
+	"MULTI_ACCOUNT_ABUSE",
+	"CREDENTIAL_THEFT_ATTEMPT",
+	"PHISHING_ATTEMPT",
+	"IMPERSONATION_ATTEMPT",
+	"COORDINATED_ATTACK",
+	"MALICIOUS_LINK_CAMPAIGN",
+] as const;
+
+describe("SecurityEventType wire vocabulary", () => {
+	it("maps every member to its canonical persisted snake_case string", () => {
+		expect(SecurityEventType.PROMPT_INJECTION_ATTEMPT).toBe(
+			"prompt_injection_attempt",
+		);
+		expect(SecurityEventType.SOCIAL_ENGINEERING_ATTEMPT).toBe(
+			"social_engineering_attempt",
+		);
+		expect(SecurityEventType.PRIVILEGE_ESCALATION_ATTEMPT).toBe(
+			"privilege_escalation_attempt",
+		);
+		expect(SecurityEventType.ANOMALOUS_REQUEST).toBe("anomalous_request");
+		expect(SecurityEventType.TRUST_MANIPULATION).toBe("trust_manipulation");
+		expect(SecurityEventType.IDENTITY_SPOOFING).toBe("identity_spoofing");
+		expect(SecurityEventType.MULTI_ACCOUNT_ABUSE).toBe("multi_account_abuse");
+		expect(SecurityEventType.CREDENTIAL_THEFT_ATTEMPT).toBe(
+			"credential_theft_attempt",
+		);
+		expect(SecurityEventType.PHISHING_ATTEMPT).toBe("phishing_attempt");
+		expect(SecurityEventType.IMPERSONATION_ATTEMPT).toBe(
+			"impersonation_attempt",
+		);
+		expect(SecurityEventType.COORDINATED_ATTACK).toBe("coordinated_attack");
+		expect(SecurityEventType.MALICIOUS_LINK_CAMPAIGN).toBe(
+			"malicious_link_campaign",
+		);
+	});
+
+	it("exposes exactly the twelve declared members", () => {
+		expect(ALL_VALUES).toHaveLength(MEMBER_NAMES.length);
+	});
+
+	it("keeps every event type value unique so exhaustive lookups cannot collapse", () => {
+		expect(new Set(ALL_VALUES).size).toBe(ALL_VALUES.length);
+	});
+});
+
+describe("SecurityEventType enumeration semantics", () => {
+	const enumAsRecord = SecurityEventType as unknown as Record<string, string>;
+
+	it("enumerates each member name exactly once with no reverse-mapping keys", () => {
+		expect(Object.keys(enumAsRecord).sort()).toEqual([...MEMBER_NAMES].sort());
+	});
+
+	it("does not resolve a value string back to its key through bracket access", () => {
+		expect(enumAsRecord["prompt_injection_attempt"]).toBeUndefined();
+		expect(enumAsRecord["coordinated_attack"]).toBeUndefined();
+	});
+
+	it("resolves every member by name through bracket access", () => {
+		for (const name of MEMBER_NAMES) {
+			expect(typeof enumAsRecord[name]).toBe("string");
+			expect(ALL_VALUES).toContain(enumAsRecord[name]);
+		}
+	});
+});
+
+describe("SecurityEventType serialization boundary", () => {
+	const membership = new Map<string, SecurityEventType>(
+		ALL_VALUES.map((value) => [value, value]),
+	);
+
+	it("round-trips an emitted SecurityEvent through JSON without losing its type", () => {
+		const emitted = {
+			type: SecurityEventType.CREDENTIAL_THEFT_ATTEMPT,
+			entityId: "11111111-2222-4333-8444-555555555555",
+			severity: "critical",
+			details: { source: "clipboard" },
+		};
+		const stored = JSON.parse(JSON.stringify(emitted)) as typeof emitted;
+		expect(membership.get(stored.type)).toBe(
+			SecurityEventType.CREDENTIAL_THEFT_ATTEMPT,
+		);
+	});
+
+	it("fails membership resolution for a string that is not a declared event type", () => {
+		expect(membership.has("totally_unknown_event")).toBe(false);
+		expect(membership.has("prompt_injection")).toBe(false);
+	});
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/core/src/features/trust/types/security.ts`, which previously had no test coverage anywhere in the repository (`security.test.ts` did not exist on `develop`). This is a **test-only** change: +110/−0 in a single new file, no production code touched.

## Why this module matters at runtime

The file is mostly type declarations, but it exports one runtime value: the `SecurityEventType` enum. Its snake_case members are the persisted wire vocabulary for `SecurityEvent.type`. Real consumers depend on it:

- `packages/core/src/features/trust/services/SecurityModule.ts` resolves every member through an exhaustive `Record<SecurityEventType, TrustEvidenceType>` mapping (~line 695) — a renamed or duplicated value silently changes evidence classification.
- `CredentialProtector.ts` and `services/wrappers.ts` emit specific members onto `SecurityEvent`s that are stored and later re-resolved by string value.

## What the suite asserts (real behavior, no mocks)

- every member maps to its canonical persisted snake_case wire string (12/12 pinned);
- all twelve values are unique, so exhaustive lookups cannot collapse two event types;
- string-enum enumeration semantics: `Object.keys` yields exactly the twelve member names once each (no numeric-style reverse-mapping doubling), and value strings do not resolve back through bracket access while member names do;
- serialization boundary: an emitted `SecurityEvent` survives `JSON.stringify`/`parse` with its `type` still resolvable through membership built from `Object.values(SecurityEventType)`, and unknown strings fail membership resolution.

## Verification (run against current `origin/develop` @ `1f236fd1f58f` immediately before filing)

- `bunx vitest run packages/core/src/features/trust/types/security.test.ts` → **Test Files 1 passed (1), Tests 8 passed (8)**, 0 failed.
- `bunx biome check packages/core/src/features/trust/types/security.test.ts` → exit 0, clean (2 informational `useLiteralKeys` notes only; the bracket accesses are intentional computed lookups proving value-string key semantics).
- `bunx tsc --noEmit` in `packages/core` → the new file appears nowhere in the output (zero errors attributable to this change).
- `git diff --stat origin/develop..HEAD` → exactly one new file, `packages/core/src/features/trust/types/security.test.ts`, 110 insertions, 0 deletions.

## CI note

This PR comes from a fork, so hosted CI does not run on it. All checks above were executed locally against current `develop` and are quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c16d1ba82cdd48f0db13daabe54690cabc1d9c7e -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
