### PR TITLE
test(shared): cover index

### DIFF
--- a/packages/shared/src/apps/index.test.ts
+++ b/packages/shared/src/apps/index.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests the apps extension barrel (`src/apps/index.ts`) as the single public
+ * entry point React and Node consumers import: overlay-app registration,
+ * lookup and listing, AOSP platform-availability gating, detail-panel
+ * extension wiring, and the catalog `RegistryAppInfo` mapping — all driven
+ * through the barrel's re-exported bindings against the real globalThis-backed
+ * registry host, reset around each case. Deterministic: no mocks, explicit
+ * availability contexts everywhere.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RegistryAppInfo } from "../contracts/apps.js";
+import { resetUiRegistryHostForTests } from "../registry-host.js";
+import {
+  getAppDetailExtension as directGetAppDetailExtension,
+  registerDetailExtension as directRegisterDetailExtension,
+} from "./detail-extension-registry.js";
+import {
+  getAllOverlayApps,
+  getAppDetailExtension,
+  getAvailableOverlayApps,
+  getOverlayApp,
+  isAospAndroid,
+  isOverlayApp,
+  overlayAppToRegistryInfo,
+  registerDetailExtension,
+  registerOverlayApp,
+} from "./index";
+import type { OverlayApp } from "./overlay-app-api.js";
+import { registerOverlayApp as directRegisterOverlayApp } from "./overlay-app-registry.js";
+
+const AOSP_ELIZAOS_UA =
+  "Mozilla/5.0 (Linux; Android 15; sdk_gphone64_x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 ElizaOS/dev-2026-01";
+const STOCK_ANDROID_UA =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36";
+
+function makeOverlayApp(name: string, androidOnly = false): OverlayApp {
+  return {
+    name,
+    displayName: `${name} display`,
+    description: `${name} description`,
+    category: "system",
+    icon: null,
+    androidOnly: androidOnly || undefined,
+    Component: () => null as never,
+  };
+}
+
+function infoWithPanelId(detailPanelId: string | undefined): RegistryAppInfo {
+  return {
+    uiExtension: detailPanelId ? { detailPanelId } : undefined,
+  } as RegistryAppInfo;
+}
+
+const noopComponent = () => null as never;
+
+describe("apps entry-point barrel", () => {
+  beforeEach(() => {
+    resetUiRegistryHostForTests();
+  });
+
+  afterEach(() => {
+    resetUiRegistryHostForTests();
+  });
+
+  it("re-exports the live registry implementations, not copies", () => {
+    expect(registerOverlayApp).toBe(directRegisterOverlayApp);
+    expect(registerDetailExtension).toBe(directRegisterDetailExtension);
+    expect(getAppDetailExtension).toBe(directGetAppDetailExtension);
+  });
+
+  it("shares one process-global store between barrel and direct-module bindings", () => {
+    const app = makeOverlayApp("@elizaos/plugin-feed");
+    directRegisterOverlayApp(app);
+    expect(getOverlayApp("@elizaos/plugin-feed")).toBe(app);
+  });
+
+  it("registers, looks up, lists and recognises overlay apps through one entry point", () => {
+    const feed = makeOverlayApp("@elizaos/plugin-feed");
+    const phone = makeOverlayApp("@elizaos/plugin-phone");
+    registerOverlayApp(feed);
+    registerOverlayApp(phone);
+
+    expect(getOverlayApp("@elizaos/plugin-feed")).toBe(feed);
+    expect(isOverlayApp("@elizaos/plugin-phone")).toBe(true);
+    expect(isOverlayApp("@elizaos/plugin-missing")).toBe(false);
+
+    const names = getAllOverlayApps().map((app) => app.name);
+    expect(names).toEqual(["@elizaos/plugin-feed", "@elizaos/plugin-phone"]);
+  });
+
+  it("re-registering an existing name replaces the earlier definition", () => {
+    const first = makeOverlayApp("@elizaos/plugin-feed");
+    const second = { ...first, displayName: "Feed v2" };
+
+    registerOverlayApp(first);
+    registerOverlayApp(second);
+
+    expect(getOverlayApp("@elizaos/plugin-feed")).toBe(second);
+    expect(getAllOverlayApps()).toHaveLength(1);
+  });
+
+  it("gates androidOnly apps to AOSP Eliza-derived Android builds only", () => {
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-phone", true));
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-feed"));
+
+    expect(
+      getAvailableOverlayApps({
+        platform: "android",
+        userAgent: STOCK_ANDROID_UA,
+      }).map((app) => app.name),
+    ).toEqual(["@elizaos/plugin-feed"]);
+
+    expect(
+      getAvailableOverlayApps({
+        platform: "web",
+        userAgent: AOSP_ELIZAOS_UA,
+      }).map((app) => app.name),
+    ).toEqual(["@elizaos/plugin-feed"]);
+
+    expect(
+      getAvailableOverlayApps({
+        platform: "android",
+        userAgent: AOSP_ELIZAOS_UA,
+      })
+        .map((app) => app.name)
+        .sort(),
+    ).toEqual(["@elizaos/plugin-feed", "@elizaos/plugin-phone"]);
+  });
+
+  it("treats the legacy string context as a non-AOSP platform", () => {
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-phone", true));
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-feed"));
+
+    expect(getAvailableOverlayApps("android").map((app) => app.name)).toEqual([
+      "@elizaos/plugin-feed",
+    ]);
+    expect(getAvailableOverlayApps("web").map((app) => app.name)).toEqual([
+      "@elizaos/plugin-feed",
+    ]);
+  });
+
+  it("reports AOSP-Android only for the android platform carrying the framework marker", () => {
+    expect(
+      isAospAndroid({ platform: "android", userAgent: AOSP_ELIZAOS_UA }),
+    ).toBe(true);
+    expect(
+      isAospAndroid({ platform: "android", userAgent: STOCK_ANDROID_UA }),
+    ).toBe(false);
+    expect(isAospAndroid({ platform: "web", userAgent: AOSP_ELIZAOS_UA })).toBe(
+      false,
+    );
+  });
+
+  it("derives availability from the ambient user agent when no context is passed", () => {
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-phone", true));
+    registerOverlayApp(makeOverlayApp("@elizaos/plugin-feed"));
+
+    const names = getAvailableOverlayApps().map((app) => app.name);
+    expect(names).toContain("@elizaos/plugin-feed");
+    expect(names).not.toContain("@elizaos/plugin-phone");
+  });
+
+  it("returns null from the detail-panel lookup when the app declares no panel id", () => {
+    expect(getAppDetailExtension(infoWithPanelId(undefined))).toBeNull();
+  });
+
+  it("returns null from the detail-panel lookup for an unregistered panel id", () => {
+    expect(
+      getAppDetailExtension(infoWithPanelId("never-registered")),
+    ).toBeNull();
+  });
+
+  it("roundtrips a detail-panel registration to the exact component registered", () => {
+    registerDetailExtension("example-detail-panel", noopComponent);
+
+    expect(getAppDetailExtension(infoWithPanelId("example-detail-panel"))).toBe(
+      noopComponent,
+    );
+  });
+
+  it("serves the latest registration when a panel id is claimed twice", () => {
+    const first = () => null as never;
+    const second = () => null as never;
+
+    registerDetailExtension("panel-2", first);
+    registerDetailExtension("panel-2", second);
+
+    expect(getAppDetailExtension(infoWithPanelId("panel-2"))).toBe(second);
+  });
+
+  it("maps an overlay app to catalog RegistryAppInfo through the barrel", () => {
+    const app: OverlayApp = {
+      ...makeOverlayApp("@elizaos/plugin-feed"),
+      icon: "https://example.test/icon.png",
+      heroImage: "https://example.test/hero.png",
+    };
+
+    expect(overlayAppToRegistryInfo(app)).toEqual({
+      name: "@elizaos/plugin-feed",
+      displayName: "@elizaos/plugin-feed display",
+      description: "@elizaos/plugin-feed description",
+      category: "system",
+      launchType: "overlay",
+      launchUrl: null,
+      icon: "https://example.test/icon.png",
+      heroImage: "https://example.test/hero.png",
+      capabilities: [],
+      stars: 0,
+      repository: "",
+      latestVersion: null,
+      supports: { v0: false, v1: false, v2: true },
+      npm: {
+        package: "@elizaos/plugin-feed",
+        v0Version: null,
+        v1Version: null,
+        v2Version: null,
+      },
+    });
+  });
+
+  it("normalises a missing hero image to null in the catalog mapping", () => {
+    const info = overlayAppToRegistryInfo(
+      makeOverlayApp("@elizaos/plugin-wifi"),
+    );
+
+    expect(info.heroImage).toBeNull();
+    expect(info.npm.package).toBe("@elizaos/plugin-wifi");
+  });
+});


### PR DESCRIPTION

Adds a new vitest suite for `packages/shared/src/apps/index.ts` — the public entry-point barrel for the app UI extension surface (detail-panel registry + overlay-app registry/types). The barrel previously had no same-named test anywhere on develop; the underlying modules have their own suites, but none exercises the entry point consumers actually import.

## What the suite covers (behaviour, not shapes)

All cases drive the real registries through `./index` imports against the real globalThis-backed registry host (`resetUiRegistryHostForTests()` around every case) with deterministic, explicit availability contexts. No mocks of the system under test; no `vi.hoisted`; no type-level assertions.

- Re-export wiring: barrel bindings are the live implementations (`toBe` identity vs direct-module imports), and a registration made via a direct module binding is visible through the barrel — one process-global store.
- Overlay registry: register / lookup by name / list order / `isOverlayApp` hit-and-miss; re-registering an existing name replaces the earlier definition in place.
- Availability gating: `androidOnly` apps hidden on stock Android and on web even with an AOSP user agent, shown on android only when the UA carries the framework `ElizaOS/` marker; legacy string-context overload treated as non-AOSP; `isAospAndroid` platform+marker matrix; ambient-UA default context path.
- Detail-panel extensions: null when the app declares no panel id; null for an unregistered id; roundtrip returns the exact registered component; latest registration wins when a panel id is claimed twice.
- Catalog mapping: `overlayAppToRegistryInfo` full-shape equality (`launchType: "overlay"`, npm package = app name, `supports: { v0: false, v1: false, v2: true }`, stars/repository/latestVersion defaults) and missing-hero-image normalised to null.

## Evidence (test-only diff, single new file, +229/-0)

Fork contributor: hosted CI does not run on this PR; the checks below were run locally at head `ae24f11c54...` on current `develop` (`1f236fd1f5`).

1. Vitest (from `packages/shared`, config `./vitest.config.ts`): `bunx vitest run src/apps/index.test.ts --config ./vitest.config.ts` → **Test Files 1 passed (1), Tests 14 passed (14)**. Re-fetched origin/develop immediately before filing — tip unchanged (`1f236fd1f5`) — counts reproduce as quoted.
2. Biome (repo root): `bunx biome check --write packages/shared/src/apps/index.test.ts` → fixed once, then `bunx biome check packages/shared/src/apps/index.test.ts` → **clean, no fixes applied**.
3. TypeScript: `bunx tsc --noEmit -p tsconfig.json` from `packages/shared` → the new test file appears **nowhere** in the output. Control run with the file removed produces an identical error set (3 pre-existing unresolved-module errors in `core/src/cloud-routing.ts` and `src/todo-cutover.ts`, unrelated to this change) — zero new errors introduced.
4. Diff scope: exactly one new file, `packages/shared/src/apps/index.test.ts`; no production code touched.

Note on head branch name: filed from `test/shared-apps-index-coverage` rather than the nominally assigned `test/shared-index-coverage`, because that exact branch name was already occupied on the fork by a different in-flight single-file suite; keeping one file per PR took precedence.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ae24f11c545a4f92bafa49e903b8b74fac640779 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
