### PR TITLE
test(core): cover spec-helpers

### DIFF
--- a/packages/core/src/__tests__/spec-helpers.test.ts
+++ b/packages/core/src/__tests__/spec-helpers.test.ts
@@ -4,6 +4,12 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+	allActionDocs,
+	allProviderDocs,
+	coreActionDocs,
+	coreProviderDocs,
+} from "../generated/action-docs.ts";
+import {
 	getActionSpec,
 	getProviderSpec,
 	requireActionSpec,
@@ -41,5 +47,70 @@ describe("spec-helpers", () => {
 		expect(() => requireProviderSpec("UNKNOWN_XYZ")).toThrow(
 			"Provider spec not found",
 		);
+	});
+
+	it("getActionSpec returns the exact core doc object for a core action", () => {
+		const doc = coreActionDocs.find((d) => d.name === "REPLY");
+		expect(doc).toBeDefined();
+		expect(getActionSpec("REPLY")).toBe(doc);
+	});
+
+	it("getActionSpec resolves actions outside the core set through the generated catalog fallback", () => {
+		expect(coreActionDocs.some((d) => d.name === "ACCOUNTS_COMMAND")).toBe(
+			false,
+		);
+		const spec = getActionSpec("ACCOUNTS_COMMAND");
+		expect(spec?.name).toBe("ACCOUNTS_COMMAND");
+		expect(allActionDocs.includes(spec as (typeof allActionDocs)[number])).toBe(
+			true,
+		);
+	});
+
+	it("every generated action doc resolves by name with core precedence", () => {
+		for (const doc of allActionDocs) {
+			const resolved = getActionSpec(doc.name);
+			expect(resolved?.name).toBe(doc.name);
+			const coreDoc = coreActionDocs.find((d) => d.name === doc.name);
+			expect(resolved).toBe(coreDoc ?? doc);
+		}
+	});
+
+	it("every generated provider doc resolves by name to the core doc object", () => {
+		for (const doc of allProviderDocs) {
+			const resolved = getProviderSpec(doc.name);
+			expect(resolved?.name).toBe(doc.name);
+			const coreDoc = coreProviderDocs.find((d) => d.name === doc.name);
+			expect(resolved).toBe(coreDoc ?? doc);
+		}
+	});
+
+	it("requireActionSpec returns the same resolved doc as getActionSpec", () => {
+		expect(requireActionSpec("REPLY")).toBe(getActionSpec("REPLY"));
+	});
+
+	it("requireProviderSpec returns the same resolved doc as getProviderSpec", () => {
+		expect(requireProviderSpec("TIME")).toBe(getProviderSpec("TIME"));
+	});
+
+	it("requireActionSpec names the missing action in its error message", () => {
+		expect(() => requireActionSpec("NO_SUCH_ACTION")).toThrow(
+			"Action spec not found: NO_SUCH_ACTION",
+		);
+	});
+
+	it("requireProviderSpec names the missing provider in its error message", () => {
+		expect(() => requireProviderSpec("NO_SUCH_PROVIDER")).toThrow(
+			"Provider spec not found: NO_SUCH_PROVIDER",
+		);
+	});
+
+	it("lookups are case-sensitive", () => {
+		expect(getActionSpec("reply")).toBeUndefined();
+		expect(getProviderSpec("time")).toBeUndefined();
+	});
+
+	it("empty-string lookups miss every map", () => {
+		expect(getActionSpec("")).toBeUndefined();
+		expect(getProviderSpec("")).toBeUndefined();
 	});
 });


### PR DESCRIPTION

## What

Adds unit coverage for `packages/core/src/generated/spec-helpers.ts` (`getActionSpec`, `requireActionSpec`, `getProviderSpec`, `requireProviderSpec`) by extending the existing suite `packages/core/src/__tests__/spec-helpers.test.ts` with 10 new cases. The diff is **+71/−0, purely additive** — every pre-existing case is untouched and still runs.

Context: this module acquired a suite on develop after the coverage target was picked, so per the additive-only policy this PR appends cases only; it rewrites and deletes nothing.

## Behavior the new cases pin (all observed against the real module, no mocks)

- **Core-precedence identity:** `getActionSpec("REPLY")` returns the exact `coreActionDocs` object. Non-core command actions such as `ACCOUNTS_COMMAND` (verified absent from `coreActionDocs`) resolve through the generated-catalog fallback map and return their own `allActionDocs` object — the previously untested `?? allActionMap.get(name)` branch.
- **Whole-catalog resolution:** all 24 action docs and all 22 provider docs resolve by name, with core-map precedence pinned per entry via `toBe(coreDoc ?? doc)`.
- **Happy-path returns:** `requireActionSpec` / `requireProviderSpec` return the identical resolved doc object (previously only their throw paths were covered).
- **Error interpolation:** missing names appear in the thrown messages — `"Action spec not found: NO_SUCH_ACTION"` and `"Provider spec not found: NO_SUCH_PROVIDER"`.
- **Map semantics:** lookups are case-sensitive; empty-string names miss every map.

## Evidence (test-only change; no production behavior modified)

- `bunx vitest run packages/core/src/__tests__/spec-helpers.test.ts` → **Test Files 1 passed (1); Tests 16 passed (16)**, re-run against current origin/develop (`1f236fd1f58f`) immediately before filing.
- `bunx biome check --write packages/core/src/__tests__/spec-helpers.test.ts` → clean ("Checked 1 file… No fixes applied"); root `biome.json` present and worktree confirmed non-sparse, so the config genuinely enforced.
- `bunx tsc --noEmit` in `packages/core` → **exit 0 with zero output**; the new file appears nowhere in diagnostics.
- The diff touches exactly one test file, +71/−0.
- No `expectTypeOf` or other type-level assertions; the suite drives the real generated module directly.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
