### PR TITLE
test(core): cover action-docs

### DIFF
--- a/packages/core/src/generated/action-docs.test.ts
+++ b/packages/core/src/generated/action-docs.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Behavioral coverage for the generated canonical action/provider doc
+ * aggregate. Drives the real enrichment consumers (`withCanonicalActionDocs`,
+ * `withCanonicalProviderDocs`) across every generated row so lookup-key
+ * integrity, complete-description injection, parameter round-tripping, and
+ * aggregate version coherence fail loudly instead of silently degrading
+ * prompt-facing docs. Deterministic: pure generated data plus the overlay
+ * functions, no model, network, or database.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	withCanonicalActionDocs,
+	withCanonicalActionDocsAll,
+	withCanonicalProviderDocs,
+} from "../action-docs.ts";
+import type { Action, Provider } from "../types/index.ts";
+import {
+	allActionDocs,
+	allActionsSpec,
+	allActionsSpecVersion,
+	allProviderDocs,
+	allProvidersSpec,
+	allProvidersSpecVersion,
+	coreActionDocs,
+	coreActionsSpec,
+	coreActionsSpecVersion,
+	coreProviderDocs,
+	coreProvidersSpec,
+	coreProvidersSpecVersion,
+} from "./action-docs.ts";
+
+function bareAction(name: string): Action {
+	return {
+		name,
+		description: "",
+		handler: async () => true,
+		validate: async () => true,
+		examples: [],
+	};
+}
+
+function bareProvider(name: string): Provider {
+	return {
+		name,
+		description: "",
+		get: async () => "",
+	};
+}
+
+describe("generated action-docs aggregate", () => {
+	it("keeps spec version constants coherent with their aggregates", () => {
+		expect(coreActionsSpec.version).toBe(coreActionsSpecVersion);
+		expect(allActionsSpec.version).toBe(allActionsSpecVersion);
+		expect(coreProvidersSpec.version).toBe(coreProvidersSpecVersion);
+		expect(allProvidersSpec.version).toBe(allProvidersSpecVersion);
+	});
+
+	it("keeps generated action names unique so name-keyed lookups cannot shadow rows", () => {
+		// Consumers index these docs into name-keyed records via reduce; a
+		// duplicate name would silently overwrite the earlier row.
+		expect(new Set(coreActionDocs.map((doc) => doc.name)).size).toBe(
+			coreActionDocs.length,
+		);
+		expect(new Set(allActionDocs.map((doc) => doc.name)).size).toBe(
+			allActionDocs.length,
+		);
+	});
+
+	it("keeps generated provider names unique so name-keyed lookups cannot shadow rows", () => {
+		expect(new Set(coreProviderDocs.map((doc) => doc.name)).size).toBe(
+			coreProviderDocs.length,
+		);
+		expect(new Set(allProviderDocs.map((doc) => doc.name)).size).toBe(
+			allProviderDocs.length,
+		);
+	});
+
+	it("carries a complete non-empty description for every generated doc", () => {
+		for (const doc of [...allActionDocs, ...allProviderDocs]) {
+			expect(
+				doc.description.trim().length,
+				`${doc.name} must declare a non-empty description`,
+			).toBeGreaterThan(0);
+		}
+	});
+
+	it("mirrors descriptionCompressed onto the complete description whenever present", () => {
+		// Legacy compressed aliases must never carry semantically shortened
+		// substitutes for compatibility consumers.
+		for (const doc of allActionDocs) {
+			if (doc.descriptionCompressed !== undefined) {
+				expect(doc.descriptionCompressed, doc.name).toBe(doc.description);
+			}
+		}
+		for (const doc of allProviderDocs) {
+			if (doc.descriptionCompressed !== undefined) {
+				expect(doc.descriptionCompressed, doc.name).toBe(doc.description);
+			}
+		}
+	});
+
+	it("keeps the core aggregates contained within the all aggregates", () => {
+		const allActionNames = new Set(allActionDocs.map((doc) => doc.name));
+		for (const doc of coreActionDocs) {
+			expect(allActionNames.has(doc.name), doc.name).toBe(true);
+		}
+		const allProviderNames = new Set(allProviderDocs.map((doc) => doc.name));
+		for (const doc of coreProviderDocs) {
+			expect(allProviderNames.has(doc.name), doc.name).toBe(true);
+		}
+	});
+
+	it("resolves every generated action row through the canonical enrichment lookup", () => {
+		const bareActions = allActionDocs.map((doc) => bareAction(doc.name));
+		const enriched = withCanonicalActionDocsAll(bareActions);
+
+		expect(enriched).toHaveLength(allActionDocs.length);
+		for (const [index, doc] of allActionDocs.entries()) {
+			expect(enriched[index].description, doc.name).toBe(doc.description);
+			expect(enriched[index].similes, doc.name).toEqual(doc.similes);
+		}
+
+		// The single-item entry point resolves identically for a probe row.
+		const single = withCanonicalActionDocs(bareAction(allActionDocs[0].name));
+		expect(single.description).toBe(allActionDocs[0].description);
+	});
+
+	it("round-trips generated parameters through enrichment preserving order, required flags, enums, and defaults", () => {
+		for (const doc of allActionDocs) {
+			if (!doc.parameters || doc.parameters.length === 0) continue;
+			const enriched = withCanonicalActionDocs(bareAction(doc.name));
+			const parameters = enriched.parameters ?? [];
+
+			expect(
+				parameters.map((p) => p.name),
+				doc.name,
+			).toEqual(doc.parameters.map((p) => p.name));
+			expect(
+				parameters.map((p) => p.required),
+				doc.name,
+			).toEqual(doc.parameters.map((p) => p.required));
+
+			for (const [index, param] of doc.parameters.entries()) {
+				const converted = parameters[index].schema;
+				if (param.schema.enum) {
+					expect(converted.enum, `${doc.name}.${param.name}`).toEqual(
+						param.schema.enum,
+					);
+					expect(converted.enumValues, `${doc.name}.${param.name}`).toEqual(
+						param.schema.enum,
+					);
+				}
+				if (param.schema.default !== undefined) {
+					expect(converted.default, `${doc.name}.${param.name}`).toEqual(
+						param.schema.default,
+					);
+				}
+			}
+		}
+	});
+
+	it("resolves every generated provider row through the provider enrichment lookup", () => {
+		for (const doc of allProviderDocs) {
+			const enriched = withCanonicalProviderDocs(bareProvider(doc.name));
+			expect(enriched.description, doc.name).toBe(doc.description);
+		}
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/generated/action-docs.test.ts` — a new colocated vitest suite (168 lines, +N/-0, test-only) covering the generated canonical action/provider doc aggregate. No production file is touched.

The generated module's runtime surface is four spec aggregates (`coreActionsSpec`, `allActionsSpec`, `coreProvidersSpec`, `allProvidersSpec`), four derived doc arrays, and four version constants. Its real consumer is `packages/core/src/action-docs.ts`, which reduces `allActionDocs` / `allProviderDocs` into name-keyed lookup records and exposes the `withCanonicalActionDocs` / `withCanonicalProviderDocs` enrichment used at action/provider registration.

## How it is tested (behaviour, not mocks)

Every case drives the real module and its real consumer — no mocks, no type-level assertions:

- **Lookup-key integrity:** generated action and provider names must be unique within each aggregate; consumers build name-keyed records via reduce, so a duplicate would silently shadow an earlier row.
- **Complete descriptions:** every doc declares a non-empty description, and `descriptionCompressed`, when present, mirrors the complete description exactly (legacy compressed aliases must never carry shortened substitutes).
- **Version coherence:** each `*SpecVersion` constant equals its aggregate's own `version`.
- **Core ⊆ all:** every row of `coreActionDocs`/`coreProviderDocs` is present in the corresponding `all*` aggregate.
- **Enrichment reachability:** every generated action row resolves through `withCanonicalActionDocsAll` (description injected verbatim, similes carried over), and every provider row through `withCanonicalProviderDocs` — a mistyped or shadowed key would surface as a missing enrichment.
- **Parameter round-trip:** for every parameterized doc, enrichment preserves parameter order, names, and required flags, mirrors top-level schema enums into `enumValues`, and carries defaults through the JSON clone.
- **Single-item path:** `withCanonicalActionDocs` agrees with the batch mapper on a probe row.

## Verification

Fork contributor: hosted CI does not run on this PR; all checks below were run locally.

- `bunx vitest run src/generated/action-docs.test.ts` (in `packages/core`): **1 file passed, 9 tests passed**. Re-verified against current `origin/develop` module content immediately before filing: **9/9 passed** again.
- `bunx biome check --write packages/core/src/generated/action-docs.test.ts`: clean (`biome.json` present, checkout not sparse).
- `bunx tsc --noEmit` in `packages/core`: exit 0 with no output; the new test file appears nowhere in the log.
- Diff touches only the new test file (+168/-0).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:04b5b23fe5324d4903430fad9eff95cbf8a1cad0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
