### PR TITLE
test(shared): cover index

### DIFF
--- a/packages/shared/src/checkout/__tests__/checkout-standalone.test.ts
+++ b/packages/shared/src/checkout/__tests__/checkout-standalone.test.ts
@@ -99,3 +99,179 @@ describe("checkout", () => {
     });
   });
 });
+
+describe("checkout error contract and navigation wrapper", () => {
+  const originalFetch = globalThis.fetch;
+  const windowSlot = globalThis as { window?: unknown };
+  const originalWindow = windowSlot.window;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    windowSlot.window = originalWindow;
+    vi.restoreAllMocks();
+  });
+
+  const request = {
+    hardwareSku: "SKU-PRO-1",
+    hardwareColor: "black",
+    returnUrl: "https://elizaos.ai/order/success",
+  };
+
+  async function rejectionOf(promise: Promise<string>): Promise<unknown> {
+    return promise.catch((reason: unknown) => reason);
+  }
+
+  describe("createStripeCheckoutSession", () => {
+    it("omits the Authorization header when bearerToken is null", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          url: "https://checkout.stripe.com/c/pay/cs_test_anon",
+        }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const url = await createStripeCheckoutSession(request, {
+        apiBaseUrl: "https://api.eliza.app",
+        bearerToken: null,
+      });
+
+      expect(url).toBe("https://checkout.stripe.com/c/pay/cs_test_anon");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    });
+
+    it("sends the caller-supplied credentials mode instead of the default include", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          url: "https://checkout.stripe.com/c/pay/cs_test_sameorigin",
+        }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      await createStripeCheckoutSession(request, {
+        apiBaseUrl: "https://api.eliza.app",
+        credentials: "same-origin",
+      });
+
+      const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      expect(init.credentials).toBe("same-origin");
+    });
+
+    it("carries the server error message and HTTP status on StripeCheckoutError", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        json: async () => ({ error: "Card declined" }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const error = await rejectionOf(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.eliza.app",
+        }),
+      );
+
+      expect(error).toBeInstanceOf(StripeCheckoutError);
+      expect(error).toBeInstanceOf(Error);
+      if (!(error instanceof StripeCheckoutError)) {
+        throw new Error("expected a StripeCheckoutError rejection");
+      }
+      expect(error.name).toBe("StripeCheckoutError");
+      expect(error.message).toBe("Card declined");
+      expect(error.status).toBe(402);
+    });
+
+    it("falls back to the default message and keeps the status when the body is not JSON", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new Error("Unexpected token < in JSON");
+        },
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const error = await rejectionOf(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.eliza.app",
+        }),
+      );
+
+      expect(error).toBeInstanceOf(StripeCheckoutError);
+      if (!(error instanceof StripeCheckoutError)) {
+        throw new Error("expected a StripeCheckoutError rejection");
+      }
+      expect(error.message).toBe("Could not start checkout.");
+      expect(error.status).toBe(503);
+    });
+
+    it("surfaces the server error when a 200 response carries no url", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ error: "Session expired" }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const error = await rejectionOf(
+        createStripeCheckoutSession(request, {
+          apiBaseUrl: "https://api.eliza.app",
+        }),
+      );
+
+      expect(error).toBeInstanceOf(StripeCheckoutError);
+      if (!(error instanceof StripeCheckoutError)) {
+        throw new Error("expected a StripeCheckoutError rejection");
+      }
+      expect(error.message).toBe("Session expired");
+      expect(error.status).toBe(200);
+    });
+  });
+
+  describe("startStripeCheckout", () => {
+    it("navigates the browser to the returned Stripe URL", async () => {
+      const { startStripeCheckout } = await import("../index.ts");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          url: "https://checkout.stripe.com/c/pay/cs_test_nav",
+        }),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+      const location = { href: "" };
+      windowSlot.window = { location };
+
+      await startStripeCheckout(request, {
+        apiBaseUrl: "https://api.eliza.app",
+        bearerToken: "steward-session-token",
+      });
+
+      expect(location.href).toBe(
+        "https://checkout.stripe.com/c/pay/cs_test_nav",
+      );
+    });
+
+    it("propagates session failures without navigating", async () => {
+      const { startStripeCheckout } = await import("../index.ts");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+      const location = { href: "" };
+      windowSlot.window = { location };
+
+      await expect(
+        startStripeCheckout(request, { apiBaseUrl: "https://api.eliza.app" }),
+      ).rejects.toThrow(StripeCheckoutError);
+      expect(location.href).toBe("");
+    });
+  });
+});


### PR DESCRIPTION

## What

Additive coverage for `packages/shared/src/checkout/index.ts`, extending the existing suite at `packages/shared/src/checkout/__tests__/checkout-standalone.test.ts`. The diff is **+176/-0 in a single test file** — no production code, no existing case rewritten or removed.

## Why

The suite covered the happy path of `createStripeCheckoutSession` and two rejection shapes, but left several real branches unexercised:

- no `Authorization` header when `bearerToken` is absent/null (guest flow)
- caller-supplied `credentials` override instead of the default `"include"`
- `StripeCheckoutError` contract: `name`, `status`, and server message carried together
- non-JSON response body falling back to the default message while keeping the HTTP status
- a 200 response with an `error` field but no `url`
- `startStripeCheckout`: navigates `window.location.href` on success, and propagates failures **without** navigating

All cases drive the real module; `fetch` is stubbed at the network boundary exactly as the pre-existing cases in this file already do. No mocks assert their own return values.

## Verification

Fork contributor: hosted CI does not run on this PR. Verified locally at head `ee1f2518d0`:

- `bunx vitest run src/checkout/__tests__/checkout-standalone.test.ts` → **1 file passed, 10 passed** (3 pre-existing + 7 new)
- `bunx @biomejs/biome check src/checkout/__tests__/checkout-standalone.test.ts` → clean, "Checked 1 file … No fixes applied"
- `bunx tsc --noEmit -p tsconfig.json` in `packages/shared` → zero diagnostics mention the touched file

Test-only change; no behavioural production diff to prove beyond the counts above.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ee1f2518d07bbfbd6d59bc9f1d628e39315c2f2c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
