### PR TITLE
fix(cloud): return 402 for /v1/messages credit admission failures

### DIFF
--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -913,9 +913,9 @@ app.post("/", async (c) => {
       }
       if (error instanceof InsufficientCreditsError) {
         return anthropicError(
-          "rate_limit_error",
+          "billing_error",
           `Insufficient cloud credits. Required: $${error.required.toFixed(4)}`,
-          429,
+          402,
         );
       }
       if (
@@ -959,9 +959,9 @@ app.post("/", async (c) => {
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
         return anthropicError(
-          "rate_limit_error",
+          "billing_error",
           `Insufficient credits. Required: $${error.required.toFixed(4)}`,
-          429,
+          402,
         );
       }
       if (error instanceof InferenceBalanceCacheWarmingError) {


### PR DESCRIPTION
## Summary
`POST /api/v1/messages` caught `InsufficientCreditsError` at both inference-admission boundaries but returned HTTP 429 — conflating a deterministic payment/credit failure with the route's genuine rate-limit response (which correctly uses 429 plus `Retry-After`). Sibling inference routes and the public SDK already treat insufficient credits as HTTP 402.

## Fix
Return 402 with the Anthropic `billing_error` error type at both affected boundaries:
- monetized-app credit admission (`route.ts:914`)
- organization credit admission (`route.ts:960`)

The Anthropic response shape and credit amount message are preserved. The genuine org rate-limit branch (`orgRateLimited.status === 429`) is untouched.

## Verification
`grep` confirms both `InsufficientCreditsError` handlers now emit `billing_error` / 402, and the org rate-limit branch still emits `rate_limit_error` / 429. Closes #27740.