### PR TITLE
test(core): cover native-features.edge

### DIFF
--- a/packages/core/src/plugins/native-features.edge.test.ts
+++ b/packages/core/src/plugins/native-features.edge.test.ts
@@ -73,3 +73,69 @@ describe("native-features.edge", () => {
 		expect(resolveNativeRuntimeFeatureFromServiceType("anything")).toBeNull();
 	});
 });
+
+describe("native-features.edge fail-closed policy details", () => {
+	it("getNativeRuntimeFeaturePlugin throws an Error naming the requested feature", () => {
+		for (const feature of Object.keys(nativeRuntimeFeatureDefaults) as Array<
+			keyof typeof nativeRuntimeFeatureDefaults
+		>) {
+			let caught: unknown;
+			try {
+				getNativeRuntimeFeaturePlugin(feature);
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(Error);
+			expect((caught as Error).message).toBe(
+				`Core native feature ${feature} requires a dedicated runtime host`,
+			);
+		}
+	});
+
+	it("resolves every exported plugin name back to its own feature", () => {
+		for (const feature of Object.keys(nativeRuntimeFeaturePluginNames) as Array<
+			keyof typeof nativeRuntimeFeaturePluginNames
+		>) {
+			expect(
+				resolveNativeRuntimeFeatureFromPluginName(
+					nativeRuntimeFeaturePluginNames[feature],
+				),
+			).toBe(feature);
+		}
+	});
+
+	it("keeps defaults and plugin names in sync with unique plugin names", () => {
+		expect(Object.keys(nativeRuntimeFeaturePluginNames).sort()).toEqual(
+			Object.keys(nativeRuntimeFeatureDefaults).sort(),
+		);
+		const names = Object.values(nativeRuntimeFeaturePluginNames);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	it("does not resolve near-miss plugin names", () => {
+		expect(resolveNativeRuntimeFeatureFromPluginName(" documents")).toBeNull();
+		expect(resolveNativeRuntimeFeatureFromPluginName("documents ")).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName("ADVANCED-PLANNING"),
+		).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName("advanced_planning"),
+		).toBeNull();
+		expect(
+			resolveNativeRuntimeFeatureFromPluginName("advancedPlanning"),
+		).toBeNull();
+	});
+
+	it("resolveNativeRuntimeFeatureFromServiceType rejects feature-shaped service types", () => {
+		for (const feature of Object.keys(nativeRuntimeFeaturePluginNames) as Array<
+			keyof typeof nativeRuntimeFeaturePluginNames
+		>) {
+			expect(resolveNativeRuntimeFeatureFromServiceType(feature)).toBeNull();
+		}
+		expect(
+			resolveNativeRuntimeFeatureFromServiceType(
+				nativeRuntimeFeaturePluginNames.advancedPlanning,
+			),
+		).toBeNull();
+	});
+});


### PR DESCRIPTION

## Summary

Additive unit-test coverage for `packages/core/src/plugins/native-features.edge.ts` â€” the workerd/edge policy bundle where Shared agents start with every core native feature disabled and any direct request fails explicitly.

A base suite for this module already exists on `develop` (landed via #27025). This pull request **only appends cases** to that suite: the diff is +66/âˆ’0 in a single test file and removes no lines from any file on the base.

## What the new cases pin

All five additions drive the real module (no mocks) and record behaviour observed on current `develop`:

1. **Exact throw message names the requested feature.** The existing suite matches only the substring "requires a dedicated runtime host"; these cases capture the thrown error and assert the full interpolated message `Core native feature <feature> requires a dedicated runtime host` for every feature â€” hosts surface this message when diagnosing why a capability is unavailable.
2. **Plugin-name round-trip through the real resolver loop.** For every entry of `nativeRuntimeFeaturePluginNames`, `resolveNativeRuntimeFeatureFromPluginName` returns its own feature key.
3. **Record-sync invariant.** Both exported records expose identical sorted key sets and all plugin-name values are unique â drift between them or a duplicated plugin name would make reverse resolution ambiguous or leave a feature unresolvable.
4. **Near-miss plugin names stay disabled.** `" documents"`, `"documents "`, `"ADVANCED-PLANNING"`, `"advanced_planning"`, and `"advancedPlanning"` all resolve to `null`, pinning exact-equality matching so stray config whitespace or casing cannot silently enable a native feature on edge hosts.
5. **Service-type resolution rejects feature-shaped service types too.** `resolveNativeRuntimeFeatureFromServiceType` returns `null` for every feature id and for a configured plugin name â the fail-closed edge contract: no service type can enable a native feature.

## Evidence (local, quoted from real runs)

Fork contributor note: hosted CI does not run on this pull request. All counts below are from local runs against current `develop` (`1f236fd1f58f`):

- `bunx vitest run src/plugins/native-features.edge.test.ts` (in `packages/core`): **Test Files 1 passed (1), Tests 11 passed (11)** â 6 pre-existing cases plus the 5 added here, re-run after formatting.
- `bunx biome check --write packages/core/src/plugins/native-features.edge.test.ts`: fixed formatting once, then `bunx biome check`: **Checked 1 file, no fixes applied** (clean).
- `bunx tsc --noEmit` in `packages/core`, grepped for `native-features.edge.test`: **no output** â zero type errors introduced by this file.
- `git diff --numstat origin/develop..HEAD`: `66 0 packages/core/src/plugins/native-features.edge.test.ts` â the diff touches only this one test file, purely additive.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:caed96b847adc99b8548c344df6d9a6807a46fd4 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
