### PR TITLE
test(core): cover action-model-routing

### DIFF
--- a/packages/core/src/runtime/__tests__/action-model-routing.test.ts
+++ b/packages/core/src/runtime/__tests__/action-model-routing.test.ts
@@ -524,3 +524,119 @@ describe("action routing context", () => {
 		expect(observed.after).toEqual(ctx);
 	});
 });
+
+// ─── forward-compat: unregistered model classes ──────────────────────────
+
+describe("unregistered modelClass forward-compat", () => {
+	it("getActionModelStrategy returns undefined for a string that is not a registered key", () => {
+		// A plugin built against a newer ActionModelClass union (e.g. "MEDIUM")
+		// running on an older runtime degrades to default resolution instead
+		// of crashing — the unknown key is treated as "no preference".
+		const newerRuntimeClass = "MEDIUM" as string;
+		expect(
+			getActionModelStrategy(newerRuntimeClass as ActionModelClass),
+		).toBeUndefined();
+	});
+
+	it("maybeReroute returns undefined for an unregistered class on a routable type", () => {
+		const newerRuntimeClass = "MEDIUM" as string;
+		expect(
+			maybeReroute(newerRuntimeClass as ActionModelClass, ModelType.TEXT_LARGE),
+		).toBeUndefined();
+	});
+});
+
+// ─── resolveStep: present-but-empty registration lists ───────────────────
+
+describe("resolveStep empty-registration boundary", () => {
+	it("returns undefined when the model type maps to an empty handler array", () => {
+		// Distinct from an absent key: the lookup succeeds but has no entries.
+		const lookup = makeRegistry({ [ModelType.TEXT_SMALL]: [] });
+		expect(
+			resolveStep({ modelType: ModelType.TEXT_SMALL }, lookup),
+		).toBeUndefined();
+	});
+});
+
+// ─── isLowConfidence: non-object and malformed results ───────────────────
+
+describe("isLowConfidence non-object and malformed results", () => {
+	it("treats null, undefined, and primitive results as acceptable even with a threshold", () => {
+		expect(isLowConfidence(null, 0.5)).toBe(false);
+		expect(isLowConfidence(undefined, 0.5)).toBe(false);
+		expect(isLowConfidence(42, 0.5)).toBe(false);
+	});
+
+	it("ignores non-numeric confidence fields rather than escalating", () => {
+		expect(isLowConfidence({ confidence: "high" }, 0.5)).toBe(false);
+		expect(isLowConfidence({ confidence: null }, 0.5)).toBe(false);
+	});
+});
+
+// ─── executeChainWithFallback: mixed failure modes ───────────────────────
+
+describe("executeChainWithFallback mixed failure modes", () => {
+	function mk(modelType: string, provider: string): ResolvedActionModel {
+		return {
+			modelType,
+			provider,
+			handler: vi.fn(
+				async () => "unused",
+			) as unknown as ModelHandler["handler"],
+		};
+	}
+
+	it("escalates past a thrown error and accepts the next high-confidence result", async () => {
+		let calls = 0;
+		const invoke = vi.fn(async (r: ResolvedActionModel) => {
+			calls++;
+			if (calls === 1) {
+				throw new Error("local backend offline");
+			}
+			return { provider: r.provider, confidence: 0.9 };
+		});
+		const chain = [
+			mk(ModelType.TEXT_SMALL, "ollama"),
+			mk(ModelType.TEXT_LARGE, "anthropic"),
+		];
+		const result = (await executeChainWithFallback(chain, 0.5, invoke)) as {
+			provider: string;
+			confidence: number;
+		};
+		expect(result.provider).toBe("anthropic");
+		expect(result.confidence).toBeGreaterThanOrEqual(0.5);
+		expect(invoke).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps escalating while every non-terminal step is low-confidence", async () => {
+		// Every step reports 0.1 confidence against a 0.5 threshold; only the
+		// terminal step's result is returned as-is.
+		const invoke = vi.fn(async (r: ResolvedActionModel) => ({
+			provider: r.provider,
+			confidence: 0.1,
+		}));
+		const chain = [
+			mk(ModelType.TEXT_SMALL, "alpha"),
+			mk(ModelType.TEXT_SMALL, "beta"),
+			mk(ModelType.TEXT_LARGE, "gamma"),
+		];
+		const result = (await executeChainWithFallback(chain, 0.5, invoke)) as {
+			provider: string;
+		};
+		expect(result.provider).toBe("gamma");
+		expect(invoke).toHaveBeenCalledTimes(3);
+	});
+
+	it("converts non-Error throwables into the generic aggregate failure", async () => {
+		const invoke = vi.fn(async (): Promise<string> => {
+			throw "hard crash";
+		});
+		const chain = [
+			mk(ModelType.TEXT_SMALL, "ollama"),
+			mk(ModelType.TEXT_LARGE, "anthropic"),
+		];
+		await expect(
+			executeChainWithFallback(chain, undefined, invoke),
+		).rejects.toThrow(/all 2 step\(s\) failed without a thrown error/);
+	});
+});


### PR DESCRIPTION

## What

Additive-only unit-test coverage for `packages/core/src/runtime/action-model-routing.ts`. A suite already exists on develop (landed today in #26295); this PR **only appends** cases — `+116/-0`, no existing test is modified or removed.

## Why these cases

Each new case pins a documented behavioral branch that the current suite does not exercise:

- **Forward-compat unregistered `modelClass`** — `getActionModelStrategy("MEDIUM"→unknown)` and `maybeReroute(unknown, TEXT_LARGE)` return `undefined` so plugins built against a newer `ActionModelClass` union degrade to default resolution instead of crashing (documented contract in the module header).
- **Present-but-empty registration list** — `resolveStep` returns `undefined` when the lookup succeeds but maps to an empty handler array (`handlers.length === 0` arm, distinct from an absent key).
- **`isLowConfidence` malformed results** — `null` / `undefined` / primitive results never escalate even with a threshold set, and non-numeric `confidence` fields (`"high"`, `null`) are ignored rather than compared.
- **`executeChainWithFallback` mixed failure modes**:
  - escalates past a thrown error and accepts the next step's high-confidence result;
  - keeps escalating while every *non-terminal* step returns low confidence, returning only the terminal step's result;
  - converts non-`Error` throwables into the generic aggregate failure (`all N step(s) failed without a thrown error`) instead of leaking the raw value.

## Evidence (local runs at head `087fc86f`, base develop `1f236fd1f58f`)

- `bunx vitest run src/runtime/__tests__/action-model-routing.test.ts` (in `packages/core`): **Test Files 1 passed (1), Tests 52 passed (52)** — 44 pre-existing + 8 new, re-run immediately before filing against current origin/develop.
- `bunx biome check --write` on the touched file: clean (config verified present; checkout not sparse).
- `bunx tsc --noEmit` in `packages/core`: **0 errors package-wide; the touched file appears nowhere in output.**

This is a test-only diff: no production behavior changes. As a fork contribution, hosted CI does not run on this PR — the counts above are from local runs quoted verbatim. No `expectTypeOf`, no `vi.hoisted`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:087fc86f4c796d3b8a5bd187420a9dcd95c8222c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
