### PR TITLE
test(core): cover candidate-action-backstop

### DIFF
--- a/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
+++ b/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
@@ -112,4 +112,119 @@ describe("candidate-action backstop registry", () => {
 		expect(coding.plan.contexts).toContain("code");
 		expect(coding.plan.candidateActions).toEqual(["TASKS"]);
 	});
+
+	it("protects candidates registered under a loosely-cased action name", () => {
+		const runtime = makeRuntime();
+		registerCandidateActionBackstopRule(runtime, {
+			actionNames: ["Scheduled_Tasks_Create"],
+			matches: (text) => /\bremind\s+me\b/iu.test(text),
+		});
+
+		const runtimeContext = {
+			actions: [
+				{
+					name: "TASKS",
+					tags: ["domain:coding", "resource:agent-task", "capability:delegate"],
+				},
+				{ name: "SCHEDULED_TASKS_CREATE" },
+			],
+			candidateBackstopRules: getCandidateActionBackstopRules(runtime),
+		};
+
+		// The turn reads as coding work, but the rule owns the candidate through
+		// canonical identifier normalization and recognizes the request, so the
+		// candidate survives instead of being rewritten to TASKS.
+		const protectedTurn = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["tasks"],
+				intents: ["set reminder"],
+				replyText: "Done.",
+				candidateActionNames: ["SCHEDULED_TASKS_CREATE"],
+				facts: [],
+				relationships: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				...runtimeContext,
+				messageText: "fix the login bug and remind me tomorrow",
+			},
+		);
+		expect(protectedTurn.plan.candidateActions).toEqual([
+			"SCHEDULED_TASKS_CREATE",
+		]);
+		expect(protectedTurn.plan.contexts).not.toContain("code");
+	});
+
+	it("resets only the given runtime's rules", () => {
+		const a = makeRuntime();
+		const b = makeRuntime();
+		registerCandidateActionBackstopRule(a, schedulingRule);
+		registerCandidateActionBackstopRule(b, schedulingRule);
+
+		__resetCandidateActionBackstopRulesForTests(a);
+
+		expect(getCandidateActionBackstopRules(a)).toEqual([]);
+		expect(getCandidateActionBackstopRules(b)).toEqual([schedulingRule]);
+	});
+
+	it("appends duplicate registrations without deduplicating them", () => {
+		const runtime = makeRuntime();
+		const other: CandidateActionBackstopRule = {
+			actionNames: ["OTHER"],
+			matches: () => false,
+		};
+
+		registerCandidateActionBackstopRule(runtime, schedulingRule);
+		registerCandidateActionBackstopRule(runtime, other);
+		registerCandidateActionBackstopRule(runtime, schedulingRule);
+
+		expect(getCandidateActionBackstopRules(runtime)).toEqual([
+			schedulingRule,
+			other,
+			schedulingRule,
+		]);
+	});
+
+	it("consults each rule with the exact current message text", () => {
+		const runtime = makeRuntime();
+		const consultedWith: string[] = [];
+		registerCandidateActionBackstopRule(runtime, {
+			actionNames: ["SCHEDULED_TASKS_CREATE"],
+			matches: (text) => {
+				consultedWith.push(text);
+				return false;
+			},
+		});
+
+		const runtimeContext = {
+			actions: [
+				{
+					name: "TASKS",
+					tags: ["domain:coding", "resource:agent-task", "capability:delegate"],
+				},
+				{ name: "SCHEDULED_TASKS_CREATE" },
+			],
+			candidateBackstopRules: getCandidateActionBackstopRules(runtime),
+		};
+
+		const messageText = "update the website code, add some fixes";
+		messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["tasks"],
+				intents: ["update website"],
+				replyText: "On it.",
+				candidateActionNames: ["SCHEDULED_TASKS_CREATE"],
+				facts: [],
+				relationships: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ ...runtimeContext, messageText },
+		);
+
+		expect(consultedWith).toEqual([messageText]);
+	});
 });


### PR DESCRIPTION

## Summary

Additive unit-test coverage for the per-runtime candidate-action backstop registry in `packages/core/src/runtime/candidate-action-backstop.ts`. This is a test-only change: no production file is touched, and the diff is a pure addition (+115/−0) against current `develop`.

A suite already existed for this module on `develop`; per this repository's additive-only rule for existing suites, this PR appends four new cases and rewrites nothing. No existing line is modified or removed.

## What the new cases cover

Each case drives the real module and its real consumer (`messageHandlerFromFieldResult` in `packages/core/src/services/message.ts`); no mock returns are asserted against themselves:

1. **Loosely-cased registration protects through canonical normalization** — a rule registered with action name `Scheduled_Tasks_Create` still protects the canonical `SCHEDULED_TASKS_CREATE` candidate from the coding-delegation backstop on a coding-looking turn, exercising the identifier normalization contract documented on `CandidateActionBackstopRule.actionNames`.
2. **Reset is scoped to one runtime** — `__resetCandidateActionBackstopRulesForTests(a)` empties runtime A while runtime B's registration survives intact (the module-scoped WeakMap deletes only the given key).
3. **Duplicate registrations append without deduplication** — registering the same rule object twice yields `[rule, other, rule]`, pinning the append-only semantics of `registerCandidateActionBackstopRule`.
4. **Rules are consulted with the exact message text** — a recording rule observes that the pipeline hands every consulted rule the verbatim `runtimeContext.messageText`, guarding the text-flow contract between the message pipeline and registered rules.

## Evidence (local runs by a fork contributor; hosted CI does not run on fork PRs)

- `bunx vitest run src/runtime/__tests__/candidate-action-backstop.test.ts` (in `packages/core`): **Test Files 1 passed (1), Tests 7 passed (7)** — 3 pre-existing cases still green, 4 new cases pass.
- `bunx biome check --write packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts`: clean — "Checked 1 file in 69ms. No fixes applied."
- `bunx tsc --noEmit` (in `packages/core`): zero errors; the new test file appears nowhere in the output.
- `git diff --stat` vs base: 1 file changed, **+115 insertions(+)**, 0 deletions — the only changed file is the test file above.

No type-level assertions (`expectTypeOf`) are used; all assertions run at runtime under vitest, which owns the `packages/core` lane.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
