### PR TITLE
test(core): cover action-tiering

### DIFF
--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -144,6 +144,142 @@ describe("complete action surface", () => {
 	});
 });
 
+describe("action tiering boundary behaviour", () => {
+	it("breaks score ties deterministically by normalized name", () => {
+		const catalog = buildActionCatalog([
+			{ name: "ZULU", description: "Zulu action." },
+			{ name: "ALPHA", description: "Alpha action." },
+			{ name: "MIKE", description: "Mike action." },
+		]);
+		const scored = ["ZULU", "ALPHA", "MIKE"].map((name) => {
+			const parent = catalog.parentByName.get(name);
+			if (!parent) throw new Error(`missing ${name} parent`);
+			return resultFor(parent, 0.5);
+		});
+
+		const surface = tierActionResults({ catalog, results: scored });
+
+		expect(surface.tierAParents.map((parent) => parent.name)).toEqual([
+			"ALPHA",
+			"MIKE",
+			"ZULU",
+		]);
+	});
+
+	it("lets callers override the protocol control set", () => {
+		const catalog = buildActionCatalog([
+			{ name: "DELTA", description: "Delta action." },
+			{ name: "ECHO", description: "Echo action." },
+		]);
+
+		const surface = tierActionResults({
+			catalog,
+			results: [],
+			protocolActions: ["STOP"],
+		});
+
+		expect(surface.protocolActions).toEqual(["STOP"]);
+		expect(surface.exposedActionNames).toEqual(["STOP", "DELTA", "ECHO"]);
+	});
+
+	it("ignores retrieval results whose normalized name matches no catalog parent", () => {
+		const wideCatalog = buildActionCatalog([
+			{ name: "SOLO", description: "Only entry in the narrow catalog." },
+			{ name: "GHOST", description: "Absent from the narrow catalog." },
+		]);
+		const catalog = buildActionCatalog([
+			{ name: "SOLO", description: "Only entry in the narrow catalog." },
+		]);
+		const ghost = wideCatalog.parentByName.get("GHOST");
+		if (!ghost) throw new Error("missing GHOST parent");
+
+		const surface = tierActionResults({
+			catalog,
+			results: [resultFor(ghost, 0.9)],
+		});
+		const solo = surface.tierAParents[0];
+		if (!solo) throw new Error("missing SOLO parent");
+
+		expect(surface.exposedParentNames).toEqual(["SOLO"]);
+		expect(surface.exposedActionNames).toEqual([
+			...TIER0_PROTOCOL_ACTIONS,
+			"SOLO",
+		]);
+		expect(solo.score).toBe(0);
+		expect(solo.result.rank).toBe(0);
+		expect(solo.result.rrfScore).toBe(0);
+		expect(solo.result.matchedBy).toEqual([]);
+		expect(solo.result.name).toBe("SOLO");
+	});
+
+	it("passes retrieval results through and isolates child arrays from the catalog", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "MUSIC",
+				description: "Control music playback.",
+				subActions: ["PLAY_TRACK", "PAUSE_MUSIC"],
+			},
+			{ name: "PLAY_TRACK", description: "Play a song." },
+			{ name: "PAUSE_MUSIC", description: "Pause music." },
+		]);
+		const music = catalog.parentByName.get("MUSIC");
+		if (!music) throw new Error("missing MUSIC parent");
+		const musicResult = resultFor(music, 0.7);
+
+		const surface = tierActionResults({ catalog, results: [musicResult] });
+		const tieredMusic = surface.tierAParents.find(
+			(parent) => parent.name === "MUSIC",
+		);
+		if (!tieredMusic) throw new Error("missing tiered MUSIC parent");
+
+		expect(tieredMusic.result).toBe(musicResult);
+		tieredMusic.childNames.push("MUTATED_CHILD");
+		tieredMusic.childNormalizedNames.push("MUTATED_CHILD");
+		expect(music.childNames).toEqual(["PAUSE_MUSIC", "PLAY_TRACK"]);
+		expect(tieredMusic.childNames.at(-1)).toBe("MUTATED_CHILD");
+	});
+
+	it("keeps the surface hash independent of relevance but sensitive to the callable set", () => {
+		const catalog = buildActionCatalog(actions);
+		const music = catalog.parentByName.get("MUSIC");
+		const email = catalog.parentByName.get("EMAIL");
+		if (!music || !email) throw new Error("missing catalog parent");
+		const smallerCatalog = buildActionCatalog([
+			{ name: "EMAIL", description: "Send email.", subActions: ["SEND_EMAIL"] },
+			{ name: "SEND_EMAIL", description: "Send an email message." },
+		]);
+
+		const musicLeads = tierActionResults({
+			catalog,
+			results: [resultFor(music, 0.99), resultFor(email, 0.1)],
+		});
+		const emailLeads = tierActionResults({
+			catalog,
+			results: [resultFor(email, 0.99), resultFor(music, 0.1)],
+		});
+
+		expect(musicLeads.actionSurfaceHash).toBe(emailLeads.actionSurfaceHash);
+		expect(musicLeads.actionSurfaceHash).not.toBe(
+			tierActionResults({ catalog: smallerCatalog, results: [] })
+				.actionSurfaceHash,
+		);
+	});
+
+	it("hashes omitted segments identically to explicitly empty ones", () => {
+		expect(stableActionSurfaceHash({})).toBe(
+			stableActionSurfaceHash({
+				protocolActions: [],
+				tierAParentNames: [],
+				tierBParentNames: [],
+				tierAChildNames: [],
+			}),
+		);
+		expect(stableActionSurfaceHash({ tierAParentNames: ["X"] })).not.toBe(
+			stableActionSurfaceHash({ tierBParentNames: ["X"] }),
+		);
+	});
+});
+
 function resultFor(
 	parent: ReturnType<typeof buildActionCatalog>["parents"][number],
 	score: number,


### PR DESCRIPTION

## Summary

Adds unit coverage for `packages/core/src/runtime/action-tiering.ts` (`tierActionResults` and `stableActionSurfaceHash`). This is a **test-only** change: +136/-0 in one file, no production behaviour is modified.

A suite already existed for this module on `develop`; this PR only **adds six new cases** to it. No existing line or assertion was removed or rewritten.

## New coverage

- **Score ties break deterministically by normalized name** — three parents at an identical score sort by `localeCompare` of their normalized names, independent of insertion order (`compareTieredParents` tie branch).
- **Custom `protocolActions` override** — a caller-provided protocol set replaces the `TIER0_PROTOCOL_ACTIONS` default and leads `exposedActionNames`.
- **Retrieval results for unknown parents are ignored** — a result whose `normalizedName` matches no catalog parent never fabricates a surface entry, and the unmatched parent receives the full fallback shape (`score 0`, plus `rank 0`, `rrfScore 0`, empty `matchedBy` on `.result`).
- **Result passthrough and defensive child-array copies** — the tiered entry carries the original retrieval result by reference, while `childNames`/`childNormalizedNames` are copies: mutating them does not corrupt the shared catalog.
- **Hash is relevance-invariant but callable-set-sensitive** — reordering retrieval scores leaves `actionSurfaceHash` unchanged; shrinking the catalog changes it.
- **Hash defaults equivalence and segment distinctness** — `{}` hashes identically to explicitly empty segments; the same value in different payload segments (`a:` vs `b:`) yields different hashes.

The two initial draft assertions that did not match observed behaviour (child ordering, where `rank` lives) were corrected to what the code actually does before filing.

## Verification (all commands run against current `origin/develop` @ `1f236fd1f58f`)

- `bunx vitest run packages/core/src/runtime/__tests__/action-tiering.test.ts` → **Test Files 1 passed (1), Tests 11 passed (11)** — 5 pre-existing cases untouched, 6 new.
- `bunx biome check --write packages/core/src/runtime/__tests__/action-tiering.test.ts` → **clean**, "Checked 1 file… No fixes applied" (config verified present; checkout is not sparse).
- `bunx tsc --noEmit` in `packages/core` → **zero occurrences** of `action-tiering` in the output (grep exit 1).
- `git diff --stat` vs `origin/develop`: exactly **1 file changed, 136 insertions(+), 0 deletions**.

Note: we are a fork contributor, so hosted CI does not run on this PR; the counts above are quoted from local runs of the exact commands listed.

No production code paths change, so no origin reproduction or revert corpus applies.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:eac5cd4f3ff848cd13f85b035223f8dafb478847 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
