### PR TITLE
test(plugin-agent-orchestrator): cover ssrf guard ip classification

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/__tests__/ssrf-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertHostAllowed,
+  classifyIpLiteral,
+  SsrfBlockedError,
+} from "./ssrf-guard.ts";
+
+describe("classifyIpLiteral", () => {
+  it("classifies public addresses as allowed", () => {
+    expect(classifyIpLiteral("8.8.8.8")).toBe("allowed");
+    expect(classifyIpLiteral("1.1.1.1")).toBe("allowed");
+    expect(classifyIpLiteral("2606:4700:4700::1111")).toBe("allowed");
+  });
+
+  it("classifies loopback as loopback", () => {
+    expect(classifyIpLiteral("127.0.0.1")).toBe("loopback");
+    expect(classifyIpLiteral("127.255.255.254")).toBe("loopback");
+    expect(classifyIpLiteral("::1")).toBe("loopback");
+    expect(classifyIpLiteral("::ffff:127.0.0.1")).toBe("loopback");
+  });
+
+  it("blocks private and internal ranges", () => {
+    expect(classifyIpLiteral("10.0.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("172.16.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("192.168.1.1")).toBe("blocked");
+  });
+
+  it("blocks cloud metadata and link-local", () => {
+    expect(classifyIpLiteral("169.254.169.254")).toBe("blocked");
+    expect(classifyIpLiteral("169.254.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("fe80::1")).toBe("blocked");
+  });
+
+  it("blocks ipv6-mapped internal addresses", () => {
+    expect(classifyIpLiteral("::ffff:10.0.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("::ffff:192.168.1.1")).toBe("blocked");
+  });
+
+  it("blocks multicast and unspecified", () => {
+    expect(classifyIpLiteral("224.0.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("ff02::1")).toBe("blocked");
+    expect(classifyIpLiteral("::")).toBe("blocked");
+  });
+
+  it("blocks malformed literals", () => {
+    expect(classifyIpLiteral("999.1.1.1")).toBe("blocked");
+    expect(classifyIpLiteral("not-an-ip")).toBe("blocked");
+  });
+});
+
+describe("assertHostAllowed", () => {
+  it("allows public hostnames via the resolver", async () => {
+    const { setHostResolver } = await import("./ssrf-guard.ts");
+    setHostResolver(async () => [{ address: "93.184.216.34" }]);
+    const pinned = await assertHostAllowed("example.com");
+    expect(pinned).toEqual(["93.184.216.34"]);
+    setHostResolver();
+  });
+
+  it("rejects hostnames resolving to internal addresses", async () => {
+    const { setHostResolver } = await import("./ssrf-guard.ts");
+    setHostResolver(async () => [{ address: "10.0.0.1" }]);
+    await expect(assertHostAllowed("internal.example.com")).rejects.toThrow(
+      SsrfBlockedError,
+    );
+    setHostResolver();
+  });
+
+  it("fails closed when DNS resolution fails", async () => {
+    const { setHostResolver } = await import("./ssrf-guard.ts");
+    setHostResolver(async () => {
+      throw new Error("ENOTFOUND");
+    });
+    await expect(assertHostAllowed("unresolvable.test")).rejects.toThrow(
+      SsrfBlockedError,
+    );
+    setHostResolver();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 10 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
