### PR TITLE
test(scenario-runner): evaluate product character presets

### DIFF
--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -28,9 +28,15 @@ boundary used by production group messages:
 bun run --cwd packages/scenario-runner eval:when2speak -- \
   --input=/path/to/finetune_test_dialogue.jsonl \
   --provider=anthropic \
+  --character-preset=eliza \
   --shard-index=0 \
   --shard-count=8
 ```
+
+`--character-preset=minimal` keeps the evaluator's small `ScenarioAgent`
+identity and remains the default for compatibility. Use
+`--character-preset=eliza` to evaluate with the same built-in English Eliza
+style preset selected by the product runtime.
 
 The command writes `reports/group-chat-timing/when2speak.json`. It reports two
 separate objectives: agreement with the corpus SPEAK/SILENT labels and ambient

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -243,6 +243,7 @@ function cancelScenarioOnlyLazyServiceStarts(runtime: AgentRuntime): void {
 }
 
 export interface CreateScenarioRuntimeOptions {
+  character?: Parameters<typeof createCharacter>[0];
   characterName?: string;
   preferredProvider?: LiveProviderName;
   extraPlugins?: Plugin[];
@@ -912,9 +913,9 @@ export async function createScenarioRuntime(
     process.env.SELFCONTROL_HOSTS_FILE_PATH = scenarioHostsFilePath;
   }
 
-  const character = createCharacter({
-    name: options?.characterName ?? "ScenarioAgent",
-  });
+  const character = createCharacter(
+    options?.character ?? { name: options?.characterName ?? "ScenarioAgent" },
+  );
   const scenarioRuntimeSettings =
     executionProfile === "simulated"
       ? {

--- a/packages/scenario-runner/src/timing-matrix-runner-cli.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner-cli.ts
@@ -51,7 +51,7 @@ const input = option("input");
 const outputDir = option("output-dir");
 if (!input || !outputDir) {
   throw argumentError(
-    "usage: timing-matrix-runner --input=<jsonl> --output-dir=<dir> [--input-format=when2speak|discord-replay] [--provider=<name>] [--shard-count=<n>] [--workers=<n>] [--max-attempts=<n>] [--retry-delay-ms=<n>]",
+    "usage: timing-matrix-runner --input=<jsonl> --output-dir=<dir> [--input-format=when2speak|discord-replay] [--character-preset=minimal|eliza] [--provider=<name>] [--shard-count=<n>] [--workers=<n>] [--max-attempts=<n>] [--retry-delay-ms=<n>]",
   );
 }
 const resolvedInput = path.resolve(input);
@@ -61,6 +61,10 @@ if (inputFormatText !== "when2speak" && inputFormatText !== "discord-replay") {
   throw argumentError("--input-format must be when2speak or discord-replay");
 }
 const inputFormat: TimingInputFormat = inputFormatText;
+const characterPreset = option("character-preset") ?? "minimal";
+if (characterPreset !== "minimal" && characterPreset !== "eliza") {
+  throw argumentError("--character-preset must be minimal or eliza");
+}
 const provider = option("provider") ?? "cli";
 const shardCount = positiveInteger("shard-count", 8);
 const workers = positiveInteger("workers", Math.min(4, shardCount));
@@ -122,6 +126,7 @@ function runShard(
       `--output=${invocation.report}`,
       `--run-dir=${invocation.trajectoryDir}`,
       `--provider=${provider}`,
+      `--character-preset=${characterPreset}`,
       `--shard-index=${invocation.shardIndex}`,
       `--shard-count=${invocation.shardCount}`,
       "--checkpoint-every=1",

--- a/packages/scenario-runner/src/timing-matrix-runner.test.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner.test.ts
@@ -39,6 +39,7 @@ function writeReport(options: {
     provider: "cli",
     requestedModel: "test-model",
     backend: "test-backend",
+    characterPreset: "minimal",
     trajectoryDir: options.invocation.trajectoryDir,
     selection: {
       shardIndex: options.invocation.shardIndex,

--- a/packages/scenario-runner/src/timing-report-merge.test.ts
+++ b/packages/scenario-runner/src/timing-report-merge.test.ts
@@ -30,6 +30,7 @@ function writeShard(options: {
     provider: "cli",
     requestedModel: "test-model",
     backend: "test-backend",
+    characterPreset: "minimal",
     trajectoryDir: path.join(options.directory, "trajectories"),
     selection: {
       shardIndex: options.shardIndex,

--- a/packages/scenario-runner/src/timing-report-merge.ts
+++ b/packages/scenario-runner/src/timing-report-merge.ts
@@ -25,6 +25,7 @@ type TimingReportFragment = Pick<
   | "provider"
   | "requestedModel"
   | "backend"
+  | "characterPreset"
   | "selection"
   | "predictions"
   | "exclusions"
@@ -38,6 +39,7 @@ export interface TimingMatrixCell {
   provider: string;
   requestedModel: string;
   backend: string;
+  characterPreset: TimingReport["characterPreset"];
   shardCount: number;
   sourceReports: string[];
   physicalRows: number;
@@ -183,6 +185,9 @@ function parseReport(file: string): TimingReportFragment {
     typeof value.requestedModel !== "string" ||
     !("backend" in value) ||
     typeof value.backend !== "string" ||
+    !("characterPreset" in value) ||
+    (value.characterPreset !== "minimal" &&
+      value.characterPreset !== "eliza") ||
     !("selection" in value) ||
     !isSelection(value.selection) ||
     !("predictions" in value) ||
@@ -210,6 +215,7 @@ function parseReport(file: string): TimingReportFragment {
     provider: value.provider,
     requestedModel: value.requestedModel,
     backend: value.backend,
+    characterPreset: value.characterPreset,
     selection: value.selection,
     predictions: value.predictions,
     exclusions: value.exclusions,
@@ -225,6 +231,7 @@ function cellKey(report: TimingReportFragment): string {
     report.provider,
     report.requestedModel,
     report.backend,
+    report.characterPreset,
     report.selection.shardCount,
   ]);
 }
@@ -369,6 +376,7 @@ export function mergeTimingReports(
       provider: first.provider,
       requestedModel: first.requestedModel,
       backend: first.backend,
+      characterPreset: first.characterPreset,
       shardCount: first.selection.shardCount,
       sourceReports: entries.map(({ file }) => file).sort(),
       physicalRows,

--- a/packages/scenario-runner/src/when2speak-eval-cli.ts
+++ b/packages/scenario-runner/src/when2speak-eval-cli.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { ElizaError } from "@elizaos/core";
 import type { LiveProviderName } from "@elizaos/core/testing";
-import type { TimingInputFormat, TimingReport } from "./when2speak-eval.ts";
+import type {
+  TimingCharacterPreset,
+  TimingInputFormat,
+  TimingReport,
+} from "./when2speak-eval.ts";
 import { runWhen2SpeakEval } from "./when2speak-eval.ts";
 
 function usageError(message: string): ElizaError {
@@ -21,7 +25,7 @@ function option(name: string): string | undefined {
 const input = option("input");
 if (!input)
   throw usageError(
-    "usage: when2speak-eval --input=<jsonl> [--input-format=when2speak|discord-replay] [--output=<json>] [--run-dir=<dir>] [--provider=<name>] [--limit=<n>] [--shard-index=<n> --shard-count=<n>] [--start-row=<n>] [--checkpoint-every=<n>] [--resume=<in-progress-report>]",
+    "usage: when2speak-eval --input=<jsonl> [--input-format=when2speak|discord-replay] [--character-preset=minimal|eliza] [--output=<json>] [--run-dir=<dir>] [--provider=<name>] [--limit=<n>] [--shard-index=<n> --shard-count=<n>] [--start-row=<n>] [--checkpoint-every=<n>] [--resume=<in-progress-report>]",
   );
 function positiveInteger(name: string): number | undefined {
   const text = option(name);
@@ -39,6 +43,10 @@ const inputFormatText = option("input-format") ?? "when2speak";
 if (inputFormatText !== "when2speak" && inputFormatText !== "discord-replay")
   throw usageError("--input-format must be when2speak or discord-replay");
 const inputFormat: TimingInputFormat = inputFormatText;
+const characterPresetText = option("character-preset") ?? "minimal";
+if (characterPresetText !== "minimal" && characterPresetText !== "eliza")
+  throw usageError("--character-preset must be minimal or eliza");
+const characterPreset: TimingCharacterPreset = characterPresetText;
 const shardCount = positiveInteger("shard-count") ?? 1;
 const shardIndexText = option("shard-index");
 const shardIndex = shardIndexText === undefined ? 0 : Number(shardIndexText);
@@ -105,6 +113,7 @@ const report = await runWhen2SpeakEval({
   startRow,
   checkpointEvery,
   resumeReport,
+  characterPreset,
   onCheckpoint: writeReport,
 });
 writeReport(report);

--- a/packages/scenario-runner/src/when2speak-eval.test.ts
+++ b/packages/scenario-runner/src/when2speak-eval.test.ts
@@ -7,11 +7,28 @@ import {
   isTimingRowSelected,
   parseDiscordReplayLine,
   parseWhen2SpeakLine,
+  resolveTimingCharacter,
   summarizeTimingPredictions,
   validateTimingResumeRows,
 } from "./when2speak-eval.ts";
 
 describe("When2Speak evaluator", () => {
+  it("loads the product Eliza preset only when requested", () => {
+    expect(resolveTimingCharacter("minimal")).toBeUndefined();
+
+    const character = resolveTimingCharacter("eliza");
+    expect(character).toMatchObject({
+      name: "Eliza",
+      adjectives: expect.arrayContaining(["brief", "warm", "dry"]),
+    });
+    expect(character?.system).toContain(
+      "In group chats, not every message deserves a reply.",
+    );
+    expect(character?.style?.chat).toContain(
+      "if another assistant already answered, don't answer again",
+    );
+  });
+
   it("parses a complete labeled dialogue", () => {
     const row = parseWhen2SpeakLine(
       JSON.stringify({

--- a/packages/scenario-runner/src/when2speak-eval.ts
+++ b/packages/scenario-runner/src/when2speak-eval.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import readline from "node:readline";
 import {
   ChannelType,
+  type CharacterInput,
   ElizaError,
   type IAgentRuntime,
   type Memory,
@@ -17,6 +18,7 @@ import {
   stringToUuid,
 } from "@elizaos/core";
 import type { LiveProviderName } from "@elizaos/core/testing";
+import { getDefaultStylePreset } from "@elizaos/shared";
 import { createScenarioRuntime } from "./runtime-factory.ts";
 
 export type TimingLabel = "SPEAK" | "SILENT";
@@ -24,6 +26,30 @@ export type TimingDataset =
   | "duke-trust-lab/When2Speak"
   | "mookiezi/Discord-Dialogues";
 export type TimingInputFormat = "when2speak" | "discord-replay";
+export type TimingCharacterPreset = "minimal" | "eliza";
+
+export function resolveTimingCharacter(
+  preset: TimingCharacterPreset,
+): (CharacterInput & { name: string }) | undefined {
+  if (preset === "minimal") return undefined;
+  const eliza = getDefaultStylePreset("en");
+  return {
+    name: eliza.name,
+    system: eliza.system,
+    bio: eliza.bio,
+    adjectives: eliza.adjectives,
+    style: eliza.style,
+    topics: eliza.topics,
+    postExamples: eliza.postExamples,
+    messageExamples: eliza.messageExamples.map((example) =>
+      example.map((message) => ({
+        name: message.user,
+        content: message.content,
+      })),
+    ),
+    ...(eliza.templates ? { templates: { ...eliza.templates } } : {}),
+  };
+}
 export interface When2SpeakExample {
   row: number;
   turns: Array<{ speaker: string; text: string; isAgent: boolean }>;
@@ -69,6 +95,7 @@ export interface TimingReport {
   provider: string;
   requestedModel: string;
   backend: string;
+  characterPreset: TimingCharacterPreset;
   trajectoryDir: string;
   selection: {
     shardIndex: number;
@@ -555,6 +582,7 @@ function validateResumeReport(options: {
   provider: string;
   requestedModel: string;
   backend: string;
+  characterPreset: TimingCharacterPreset;
   shardIndex: number;
   shardCount: number;
   startRow: number;
@@ -581,6 +609,8 @@ function validateResumeReport(options: {
     value.requestedModel !== options.requestedModel ||
     !("backend" in value) ||
     value.backend !== options.backend ||
+    !("characterPreset" in value) ||
+    value.characterPreset !== options.characterPreset ||
     !("selection" in value) ||
     value.selection === null ||
     typeof value.selection !== "object" ||
@@ -633,6 +663,7 @@ export async function runWhen2SpeakEval(options: {
   checkpointEvery?: number;
   onCheckpoint?: (report: TimingReport) => void | Promise<void>;
   resumeReport?: unknown;
+  characterPreset?: TimingCharacterPreset;
 }): Promise<TimingReport> {
   const shardIndex = options.shardIndex ?? 0;
   const shardCount = options.shardCount ?? 1;
@@ -672,8 +703,11 @@ export async function runWhen2SpeakEval(options: {
   process.env.ELIZA_TRAJECTORY_DIR = trajectoryDir;
   let runtimeResult: Awaited<ReturnType<typeof createScenarioRuntime>>;
   try {
+    const characterPreset = options.characterPreset ?? "minimal";
+    const timingCharacter = resolveTimingCharacter(characterPreset);
     runtimeResult = await createScenarioRuntime({
       ...(options.provider ? { preferredProvider: options.provider } : {}),
+      ...(timingCharacter ? { character: timingCharacter } : {}),
     });
   } catch (error) {
     // error-policy:J2 Restore process state, then add evaluator context while
@@ -686,7 +720,10 @@ export async function runWhen2SpeakEval(options: {
     throw new ElizaError("Failed to create the When2Speak scenario runtime", {
       code: "WHEN2SPEAK_RUNTIME_CREATE_FAILED",
       cause: error,
-      context: { provider: options.provider ?? "auto" },
+      context: {
+        provider: options.provider ?? "auto",
+        characterPreset: options.characterPreset ?? "minimal",
+      },
     });
   }
   const predictions: TimingReport["predictions"] = [];
@@ -712,6 +749,7 @@ export async function runWhen2SpeakEval(options: {
     provider: runtimeResult.providerName,
     requestedModel,
     backend,
+    characterPreset: options.characterPreset ?? "minimal",
     shardIndex,
     shardCount,
     startRow,
@@ -740,6 +778,7 @@ export async function runWhen2SpeakEval(options: {
       provider: runtimeResult.providerName,
       requestedModel,
       backend,
+      characterPreset: options.characterPreset ?? "minimal",
       trajectoryDir,
       selection: {
         shardIndex,


### PR DESCRIPTION
## Summary

- add `--character-preset=minimal|eliza` to the When2Speak evaluator and timing matrix runner
- load the product default English Eliza style preset when requested
- bind the selected preset into reports, resume validation, and matrix merge identity so incompatible runs cannot mix
- keep the minimal ScenarioAgent identity as the compatibility default

Follow-up to #27508, which merged before this evaluator capability was added.

## Verification

- `bun run --cwd packages/scenario-runner typecheck`
- `bun run --cwd packages/scenario-runner build`
- `bunx vitest run --config vitest.config.ts src/when2speak-eval.test.ts src/timing-report-merge.test.ts src/timing-matrix-runner.test.ts` (19 passed)
- Biome check on all changed TypeScript files
- live 100-row runs with `--character-preset=eliza`: Haiku 58%, GPT-5.6 Luna 87%, GPT-5.6 Terra 82%; each accepted 100/100 rows with zero exclusions or malformed rows

## Evidence

- UI screenshots/video: N/A - evaluator and report plumbing only
- Live model trajectories: generated locally for the three 100-row runs; not committed
- Domain artifacts: completed schema-3 matrix reports for Haiku, Luna, and Terra, each bound to the same input SHA
