### PR TITLE
test(shared): cover http-helpers

### DIFF
--- a/packages/shared/src/api/http-helpers.test.ts
+++ b/packages/shared/src/api/http-helpers.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Behavioral coverage for the shared HTTP helper surface re-exported from
+ * `src/api/http-helpers.ts`. Every case drives the real exported helpers
+ * against a live `node:http` exchange on the loopback interface: bounded body
+ * reads, size guards, cross-call body memoization, JSON-object enforcement,
+ * error-status translation, and the safe JSON responders. Assertions cover
+ * what an HTTP caller observes plus values captured inside the handler, never
+ * the internal wiring behind the re-export.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_BODY_BYTES,
+  readJsonBody,
+  readRequestBody,
+  readRequestBodyBuffer,
+  sendJson,
+  sendJsonError,
+} from "./http-helpers.js";
+
+interface ExchangeResult {
+  status: number;
+  contentType: string | null;
+  text: string;
+}
+
+type Handler = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+) => Promise<void>;
+
+async function exchange(
+  handler: Handler,
+  init?: { body?: Uint8Array<ArrayBuffer> | string },
+): Promise<ExchangeResult> {
+  return new Promise<ExchangeResult>((resolveExchange) => {
+    const server = http.createServer((req, res) => {
+      handler(req, res).catch(() => {
+        // Handler-owned outcomes are captured by the individual test;
+        // an escaped rejection here only means the response never fired.
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo;
+      const url = `http://127.0.0.1:${address.port}/`;
+      void (async () => {
+        try {
+          const response = await fetch(url, {
+            method: "POST",
+            body: init?.body ?? "",
+          });
+          const text = await response.text();
+          resolveExchange({
+            status: response.status,
+            contentType: response.headers.get("content-type"),
+            text,
+          });
+        } catch (error) {
+          resolveExchange({
+            status: 0,
+            contentType: null,
+            text: error instanceof Error ? error.message : String(error),
+          });
+        } finally {
+          server.close();
+        }
+      })();
+    });
+  });
+}
+
+describe("shared http helpers: bounded body reads", () => {
+  it("concatenates streamed chunks into one buffer and hands the SAME buffer to repeat readers", async () => {
+    const payload = Buffer.from("hello streamed world");
+    let firstLength = -1;
+    let sameReference = false;
+    await exchange(
+      async (req, res) => {
+        const first = await readRequestBodyBuffer(req);
+        const second = await readRequestBodyBuffer(req);
+        firstLength = first?.length ?? -1;
+        sameReference = second === first;
+        res.end("ok");
+      },
+      { body: payload },
+    );
+
+    expect(firstLength).toBe(payload.length);
+    expect(sameReference).toBe(true);
+  });
+
+  it("returns an empty buffer for an empty body", async () => {
+    let length = -1;
+    let text: string | null = null;
+    await exchange(async (req, res) => {
+      const body = await readRequestBodyBuffer(req);
+      length = body?.length ?? -1;
+      text = await readRequestBody(req);
+      res.end("ok");
+    });
+
+    expect(length).toBe(0);
+    expect(text).toBe("");
+  });
+
+  it("decodes the body with the requested encoding", async () => {
+    const payload = Buffer.from([0x00, 0x01, 0xfe, 0xff]);
+    let encoded: string | null = null;
+    let plain: string | null = null;
+    await exchange(
+      async (req, res) => {
+        plain = await readRequestBody(req);
+        encoded = await readRequestBody(req, { encoding: "base64" });
+        res.end("ok");
+      },
+      { body: payload },
+    );
+
+    expect(plain).toBe(payload.toString("utf-8"));
+    expect(encoded).toBe(payload.toString("base64"));
+  });
+});
+
+describe("shared http helpers: size guards", () => {
+  it("rejects bodies over the default cap with a typed too-large error carrying context", async () => {
+    const oversized = Buffer.alloc(DEFAULT_MAX_BODY_BYTES + 1, 0x61);
+    let code: string | null = null;
+    let message: string | null = null;
+    let context: unknown = null;
+    let isError = false;
+    await exchange(
+      async (req, res) => {
+        try {
+          await readRequestBodyBuffer(req);
+        } catch (error) {
+          isError = error instanceof ElizaError;
+          if (error instanceof ElizaError) {
+            code = error.code;
+            message = error.message;
+            context = error.context;
+          }
+        }
+        res.end("ok");
+      },
+      { body: oversized },
+    );
+
+    expect(isError).toBe(true);
+    expect(code).toBe("HTTP_REQUEST_BODY_TOO_LARGE");
+    expect(message).toBe(
+      `Request body exceeds maximum size (${DEFAULT_MAX_BODY_BYTES} bytes)`,
+    );
+    expect(context).toMatchObject({
+      maxBytes: DEFAULT_MAX_BODY_BYTES,
+      observedBytes: oversized.length,
+    });
+  });
+
+  it("honors a custom too-large message", async () => {
+    let message: string | null = null;
+    await exchange(
+      async (req, res) => {
+        try {
+          await readRequestBodyBuffer(req, {
+            maxBytes: 4,
+            tooLargeMessage: "way too big for this lane",
+          });
+        } catch (error) {
+          if (error instanceof ElizaError) {
+            message = error.message;
+          }
+        }
+        res.end("ok");
+      },
+      { body: "abcdefgh" },
+    );
+
+    expect(message).toBe("way too big for this lane");
+  });
+
+  it("resolves null instead of rejecting when returnNullOnTooLarge is set, destroying the stream on request", async () => {
+    let resolvedNull = false;
+    let destroyed = false;
+    await exchange(
+      async (req, _res) => {
+        const body = await readRequestBodyBuffer(req, {
+          maxBytes: 4,
+          returnNullOnTooLarge: true,
+          destroyOnTooLarge: true,
+        });
+        resolvedNull = body === null;
+        destroyed = req.destroyed;
+      },
+      { body: "abcdefgh" },
+    );
+
+    expect(resolvedNull).toBe(true);
+    expect(destroyed).toBe(true);
+  });
+
+  it("rejects AND destroys the stream when destroyOnTooLarge is set alone", async () => {
+    let sawError = false;
+    let destroyed = false;
+    await exchange(
+      async (req) => {
+        try {
+          await readRequestBodyBuffer(req, {
+            maxBytes: 4,
+            destroyOnTooLarge: true,
+          });
+        } catch (error) {
+          sawError = error instanceof ElizaError;
+          destroyed = req.destroyed;
+        }
+      },
+      { body: "abcdefgh" },
+    );
+
+    expect(sawError).toBe(true);
+    expect(destroyed).toBe(true);
+  });
+
+  it("applies the size guard to an already-memoized buffer on repeat reads", async () => {
+    let cachedLength = -1;
+    let repeatCode: string | null = null;
+    let repeatContext: unknown = null;
+    await exchange(
+      async (req, res) => {
+        const first = await readRequestBodyBuffer(req);
+        cachedLength = first?.length ?? -1;
+        try {
+          await readRequestBodyBuffer(req, { maxBytes: 4 });
+        } catch (error) {
+          if (error instanceof ElizaError) {
+            repeatCode = error.code;
+            repeatContext = error.context;
+          }
+        }
+        res.end("ok");
+      },
+      { body: "0123456789" },
+    );
+
+    expect(cachedLength).toBe(10);
+    expect(repeatCode).toBe("HTTP_REQUEST_BODY_TOO_LARGE");
+    expect(repeatContext).toMatchObject({ maxBytes: 4, observedBytes: 10 });
+  });
+
+  it("resolves null on a repeat read of a cached buffer that now exceeds a smaller cap", async () => {
+    let repeatIsNull = false;
+    await exchange(
+      async (req, res) => {
+        await readRequestBodyBuffer(req);
+        const repeat = await readRequestBodyBuffer(req, {
+          maxBytes: 4,
+          returnNullOnTooLarge: true,
+        });
+        repeatIsNull = repeat === null;
+        res.end("ok");
+      },
+      { body: "0123456789" },
+    );
+
+    expect(repeatIsNull).toBe(true);
+  });
+});
+
+describe("shared http helpers: readJsonBody", () => {
+  it("parses a JSON object, memoizes it on the request, and serves repeat callers from the cache", async () => {
+    let firstParsed: unknown = null;
+    let secondSameReference = false;
+    let exposedOnRequest: unknown = "unset";
+    await exchange(
+      async (req, res) => {
+        firstParsed = await readJsonBody(req, res);
+        const second = await readJsonBody(req, res);
+        secondSameReference = second === firstParsed;
+        exposedOnRequest = (req as unknown as { body?: unknown }).body;
+        res.end("ok");
+      },
+      { body: '{"a":1,"nested":{"b":[2,3]}}' },
+    );
+
+    expect(firstParsed).toEqual({ a: 1, nested: { b: [2, 3] } });
+    expect(secondSameReference).toBe(true);
+    expect(exposedOnRequest).toEqual(firstParsed);
+  });
+
+  it("rejects non-object bodies by default with a 400 JSON error", async () => {
+    for (const body of ["[1,2,3]", '"just a string"', "5", "null"]) {
+      const result = await exchange(
+        async (req, res) => {
+          const parsed = await readJsonBody(req, res);
+          if (parsed === null) return;
+          res.end("unexpected");
+        },
+        { body },
+      );
+
+      expect(result.status).toBe(400);
+      expect(result.contentType).toBe("application/json");
+      expect(JSON.parse(result.text)).toEqual({
+        error: "Request body must be a JSON object",
+      });
+    }
+  });
+
+  it("accepts arrays and scalars when requireObject is false", async () => {
+    const seen: unknown[] = [];
+    await exchange(
+      async (req, res) => {
+        const parsed = await readJsonBody<unknown>(req, res, {
+          requireObject: false,
+        });
+        seen.push(parsed);
+        res.end("ok");
+      },
+      { body: "[1,2,3]" },
+    );
+    await exchange(
+      async (req, res) => {
+        const parsed = await readJsonBody<unknown>(req, res, {
+          requireObject: false,
+        });
+        seen.push(parsed);
+        res.end("ok");
+      },
+      { body: "7" },
+    );
+
+    expect(seen[0]).toEqual([1, 2, 3]);
+    expect(seen[1]).toBe(7);
+  });
+
+  it("reports malformed JSON syntax with the dedicated message and status", async () => {
+    const result = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res);
+      },
+      { body: '{"a": oops}' },
+    );
+
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.text)).toEqual({
+      error: "Invalid JSON in request body",
+    });
+  });
+
+  it("honors custom statuses and messages for non-object and parse failures", async () => {
+    const nonObject = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res, {
+          nonObjectStatus: 422,
+          nonObjectMessage: "objects only please",
+        });
+      },
+      { body: "[1]" },
+    );
+
+    const parseError = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res, {
+          parseErrorStatus: 418,
+          parseErrorMessage: "that is not JSON",
+        });
+      },
+      { body: "{nope" },
+    );
+
+    expect(nonObject.status).toBe(422);
+    expect(JSON.parse(nonObject.text)).toEqual({
+      error: "objects only please",
+    });
+    expect(parseError.status).toBe(418);
+    expect(JSON.parse(parseError.text)).toEqual({
+      error: "that is not JSON",
+    });
+  });
+
+  it("translates body-read failures (including size overflow) into the configured read-error response", async () => {
+    const thrown = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res, { maxBytes: 4 });
+      },
+      { body: "abcdefgh" },
+    );
+
+    const nulled = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res, { maxBytes: 4, returnNullOnError: true });
+      },
+      { body: "abcdefgh" },
+    );
+
+    expect(thrown.status).toBe(413);
+    expect(JSON.parse(thrown.text)).toEqual({
+      error: "Failed to read request body",
+    });
+    expect(nulled.status).toBe(413);
+    expect(JSON.parse(nulled.text)).toEqual({
+      error: "Failed to read request body",
+    });
+  });
+
+  it("honors custom read-error status and message", async () => {
+    const result = await exchange(
+      async (req, res) => {
+        await readJsonBody(req, res, {
+          maxBytes: 2,
+          readErrorStatus: 422,
+          readErrorMessage: "body refused",
+        });
+      },
+      { body: "abcdef" },
+    );
+
+    expect(result.status).toBe(422);
+    expect(JSON.parse(result.text)).toEqual({ error: "body refused" });
+  });
+});
+
+describe("shared http helpers: safe JSON responders", () => {
+  it("sendJson writes the payload with the given status and JSON content type", async () => {
+    const created = await exchange(
+      async (_req, res) => {
+        sendJson(res, { ok: true, items: [1, 2] }, 201);
+        return;
+      },
+      { body: "" },
+    );
+
+    const defaulted = await exchange(
+      async (_req, res) => {
+        sendJson(res, { hello: "world" });
+        return;
+      },
+      { body: "" },
+    );
+
+    expect(created.status).toBe(201);
+    expect(created.contentType).toBe("application/json");
+    expect(JSON.parse(created.text)).toEqual({ ok: true, items: [1, 2] });
+    expect(defaulted.status).toBe(200);
+    expect(JSON.parse(defaulted.text)).toEqual({ hello: "world" });
+  });
+
+  it("sendJsonError writes an error envelope with 400 default or an explicit status", async () => {
+    const defaulted = await exchange(
+      async (_req, res) => {
+        sendJsonError(res, "nothing to see here");
+        return;
+      },
+      { body: "" },
+    );
+
+    const custom = await exchange(
+      async (_req, res) => {
+        sendJsonError(res, "denied", 403);
+        return;
+      },
+      { body: "" },
+    );
+
+    expect(defaulted.status).toBe(400);
+    expect(defaulted.contentType).toBe("application/json");
+    expect(JSON.parse(defaulted.text)).toEqual({
+      error: "nothing to see here",
+    });
+    expect(custom.status).toBe(403);
+    expect(JSON.parse(custom.text)).toEqual({ error: "denied" });
+  });
+
+  it("responders do not throw synchronously when the client vanished before the write", async () => {
+    let threw = false;
+    await exchange(
+      async (req, res) => {
+        req.destroy();
+        try {
+          sendJson(res, { late: true });
+          sendJsonError(res, "also late");
+        } catch {
+          threw = true;
+        }
+      },
+      { body: "" },
+    );
+
+    expect(threw).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/shared/src/api/http-helpers.test.ts` — a new, additive-only suite (+492/−0, no other files touched) covering the runtime surface re-exported by `packages/shared/src/api/http-helpers.ts`: `DEFAULT_MAX_BODY_BYTES`, `readRequestBodyBuffer`, `readRequestBody`, `readJsonBody`, `sendJson`, and `sendJsonError`.

Every case drives the real exported helpers against a live `node:http` exchange on loopback — no mocks of the module under test. The covered behavior:

- **Bounded body reads** — chunk concatenation; repeat readers receive the SAME memoized buffer (`Symbol.for` cache) without re-consuming the stream; empty bodies; explicit `encoding` handling (utf-8/base64).
- **Size guards** — default cap rejects oversized bodies with typed `HTTP_REQUEST_BODY_TOO_LARGE` carrying `{maxBytes, observedBytes}` context; custom `tooLargeMessage`; `returnNullOnTooLarge` / `destroyOnTooLarge` combinations including stream destruction; the guard re-applied to an already-memoized buffer on repeat reads.
- **`readJsonBody`** — object parsing memoized on the request (`req.body` exposed, second call served from cache); non-object rejection by default (arrays/scalars/null) with 400 JSON error envelope; `requireObject: false` accepts arrays and scalars; dedicated parse-error vs non-object statuses/messages, all overridable; read failures (including size overflow) translated to the configured read-error response (default 413).
- **Safe responders** — `sendJson` / `sendJsonError` status defaults and overrides, `application/json` content type, `{error}` envelope, and no synchronous throw when the client vanished before the write.

Note: an existing suite covers core's own `packages/core/src/api/http-helpers.ts` implementation directly; this PR covers the shared re-export surface that shared-package consumers actually import.

## Evidence

Test-only change; no production behavior modified.

- `bunx vitest run packages/shared/src/api/http-helpers.test.ts` → **Test Files 1 passed (1); Tests 19 passed (19)** (also green via the package lane `node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/api/http-helpers.test.ts`).
- `bunx @biomejs/biome check src/api/http-helpers.test.ts` → clean, no fixes needed.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/shared` → the new test file appears nowhere in the output.

As a fork contributor, hosted CI does not run on this pull request; the counts above are quoted from local runs at head `371340adc847f61a5b3004a63e2ad6eb79732b3a`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:371340adc847f61a5b3004a63e2ad6eb79732b3a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
