### PR TITLE
test(ui): cover use-explorer-api-key

### DIFF
--- a/packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts
+++ b/packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for useExplorerApiKey — the API Explorer credential hook backed
+ * by `GET /api/v1/api-keys/explorer`. Drives the real hook through the
+ * package's configured test harness; only the HTTP transport (`api`) and the
+ * explorer toast adapter are mocked at their module boundaries.
+ */
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/api-client", () => {
+  class MockApiError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly code: string,
+      message: string,
+      public readonly body?: unknown,
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+  return { ApiError: MockApiError, api: vi.fn() };
+});
+
+vi.mock("./toast", () => ({ toast: vi.fn() }));
+
+import { ApiError, api } from "../lib/api-client";
+import { toast } from "./toast";
+import { type ExplorerApiKey, useExplorerApiKey } from "./use-explorer-api-key";
+
+const apiMock = vi.mocked(api);
+const toastMock = vi.mocked(toast);
+
+const EXPLORER_PATH = "/api/v1/api-keys/explorer";
+const EXPLORER_INIT = { cache: "no-store" };
+
+function makeKey(overrides: Partial<ExplorerApiKey> = {}): ExplorerApiKey {
+  return {
+    id: "key-1",
+    name: "API Explorer",
+    description: null,
+    key_prefix: "eliza_explorer_",
+    key: "eliza_explorer_secret",
+    created_at: "2026-08-24T00:00:00.000Z",
+    is_active: true,
+    usage_count: 0,
+    last_used_at: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  apiMock.mockReset();
+  toastMock.mockReset();
+});
+
+describe("useExplorerApiKey", () => {
+  it("starts loading and auto-fetches the explorer endpoint on mount", async () => {
+    apiMock.mockResolvedValueOnce({ apiKey: makeKey() });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.authToken).toBe("");
+    expect(result.current.explorerKey).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(apiMock).toHaveBeenCalledWith(EXPLORER_PATH, EXPLORER_INIT);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("adopts an existing explorer key without announcing it as created", async () => {
+    const existing = makeKey({ usage_count: 7 });
+    apiMock.mockResolvedValueOnce({ apiKey: existing });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.explorerKey).toEqual(existing);
+    expect(result.current.authToken).toBe(existing.key);
+    expect(result.current.error).toBeNull();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("announces a freshly minted key with a success toast", async () => {
+    const minted = makeKey({ key: "eliza_explorer_fresh" });
+    apiMock.mockResolvedValueOnce({ apiKey: minted, isNew: true });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.explorerKey).toEqual(minted);
+    expect(result.current.authToken).toBe(minted.key);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(toastMock).toHaveBeenCalledWith({
+      message: "API Explorer key created!",
+      mode: "success",
+    });
+  });
+
+  it("surfaces the backend error message when the response carries no key", async () => {
+    apiMock.mockResolvedValueOnce({ error: "Explorer keys are disabled" });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.explorerKey).toBeNull();
+    expect(result.current.authToken).toBe("");
+    expect(result.current.error).toBe("Explorer keys are disabled");
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic failure message when the response has neither key nor error", async () => {
+    apiMock.mockResolvedValueOnce({});
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.explorerKey).toBeNull();
+    expect(result.current.authToken).toBe("");
+    expect(result.current.error).toBe("Failed to fetch API key");
+  });
+
+  it("maps an ApiError rejection onto the error state using its own message", async () => {
+    apiMock.mockRejectedValueOnce(
+      new ApiError(401, "HTTP_401", "Session expired"),
+    );
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("Session expired");
+    expect(result.current.explorerKey).toBeNull();
+    expect(result.current.authToken).toBe("");
+  });
+
+  it("reports a connection failure for non-ApiError rejections", async () => {
+    apiMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to connect to server");
+    expect(result.current.explorerKey).toBeNull();
+    expect(result.current.authToken).toBe("");
+  });
+
+  it("clears a previous error and adopts the fresh key when refreshExplorerKey is called", async () => {
+    apiMock.mockResolvedValueOnce({ error: "transient outage" });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.error).toBe("transient outage"));
+
+    const refreshed = makeKey({ key: "eliza_explorer_second" });
+    apiMock.mockResolvedValueOnce({ apiKey: refreshed });
+    await act(async () => {
+      await result.current.refreshExplorerKey();
+    });
+
+    expect(apiMock).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+    expect(result.current.explorerKey).toEqual(refreshed);
+    expect(result.current.authToken).toBe(refreshed.key);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("lets setAuthToken override the local token without refetching", async () => {
+    const existing = makeKey();
+    apiMock.mockResolvedValueOnce({ apiKey: existing });
+
+    const { result } = renderHook(() => useExplorerApiKey());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.setAuthToken("manually-entered-token");
+    });
+
+    expect(result.current.authToken).toBe("manually-entered-token");
+    expect(result.current.explorerKey).toEqual(existing);
+    expect(apiMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts` — a unit suite for `useExplorerApiKey`, the hook that auto-mints/fetches the per-user API Explorer key (`GET /api/v1/api-keys/explorer`). The module had no same-named test file anywhere on `develop`.

## Scope

Test-only change: one new test file (+188/-0), no production code touched.

## Coverage

The suite drives the real hook via `renderHook` (`@testing-library/react`, jsdom) and mocks only the module boundaries the hook cannot touch in a unit run: the HTTP transport (`api`) and the explorer toast adapter:

- starts loading and auto-fetches `/api/v1/api-keys/explorer` with `{ cache: "no-store" }` on mount
- adopts an existing key into `explorerKey`/`authToken` without a toast
- announces a freshly minted key (`isNew`) with the success toast payload `{ message: "API Explorer key created!", mode: "success" }`
- surfaces the backend `error` string when the response carries no key
- falls back to `"Failed to fetch API key"` when neither key nor error text is present
- maps an `ApiError` rejection onto `error` using its own message (exercises the real `instanceof ApiError` branch)
- maps non-`ApiError` failures to `"Failed to connect to server"`
- `refreshExplorerKey()` re-fetches and clears a previous error state
- `setAuthToken()` overrides the local token without refetching

## Evidence

Fork contributor: hosted CI does not run on this PR. Verification performed locally against `origin/develop` @ `1f236fd1f5` in the owning package (`packages/ui`, vitest runner per its `package.json`):

1. `bunx vitest run --config ./vitest.config.ts src/cloud/api-explorer/use-explorer-api-key.test.ts` → **Test Files 1 passed (1), Tests 9 passed (9)** (~1.2s)
2. `bunx @biomejs/biome check packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts` → clean ("Checked 1 file ... No fixes applied")
3. `bunx tsc --noEmit -p tsconfig.json` in `packages/ui` → grep for `use-explorer-api-key` returns **zero** matches (no new type errors introduced by this diff)
4. Diff touches only `packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts`

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - standalone test-coverage addition; no linked issue or ticket. The module had no unit suite on `develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`). Branch cut from `origin/develop` @ `1f236fd1f5`; single-commit diff, no conflicts possible.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Not run: test-only diff (one new file). Per-package gates were run instead — see Evidence and Known gaps below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. Branch created from `origin/develop` @ `1f236fd1f5` immediately before filing.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.
      Not run — test-only diff; scoped gates (vitest/biome/tsc) quoted below.

# Risks

Low. Test-only change: one new `*.test.ts` file, +188/-0, no production code, no exports, no config touched. Worst case is a flaky assertion in CI, mitigated by deterministic mocked transport (no network, no timers beyond microtasks).

# Background

## What does this PR do?

Adds unit coverage for `useExplorerApiKey` (`packages/ui/src/cloud/api-explorer/use-explorer-api-key.ts`), the hook that auto-mints/fetches the per-user API Explorer key used for billed test calls from the explorer.

## What kind of change is this?

Improvements (misc. changes to existing features) — test-coverage addition only; no runtime behavior change.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/api-explorer/use-explorer-api-key.test.ts` — read it next to `use-explorer-api-key.ts`.

## Detailed testing steps

```bash
cd packages/ui
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" \
  bunx vitest run --config ./vitest.config.ts src/cloud/api-explorer/use-explorer-api-key.test.ts
```

Expected: `Test Files  1 passed (1)` / `Tests  9 passed (9)`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d816976306962c3d0a88ce8f8ca1858082d73ffe -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - test-only change; no UI surface is rendered or altered by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - test-only change; no UI surface is rendered or altered by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      `N/A - no user-facing flow changed; automated suite output quoted in Evidence above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      `N/A - no runtime/server code path changed; the hook's HTTP boundary is exercised through the mocked transport in vitest.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      `N/A - no shipped frontend code changed; state transitions are asserted directly by the suite.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      `N/A - no model/provider/prompt path touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      `N/A - no domain artifacts produced by a unit test suite.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      `N/A - the diff contains no rendered component (.tsx/.css); it is a plain .ts unit suite.`

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

`N/A - test-only change; no rendered UI before or after.`

### After

`N/A - test-only change; no rendered UI before or after.`

### Walkthrough video

`N/A - no user-facing flow changed; see the vitest command under Testing.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT path touched.`

## Known gaps / failures

- `bun run verify` (full-repo gate) was not run: this diff is one new test file with no production change; the owning-package gates were run instead and are quoted above (vitest 9/9, biome clean, tsc zero matches for the new file).
- Hosted CI does not run on fork PRs, so no upstream check runs for this PR; all verification is local and reproducible via the command under Testing.
- Evidence waiver recorded at render time: unattended session cannot finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
