### PR TITLE
test(core): cover canonical-model-capabilities

### DIFF
--- a/packages/core/src/runtime/__tests__/canonical-model-capabilities.test.ts
+++ b/packages/core/src/runtime/__tests__/canonical-model-capabilities.test.ts
@@ -54,4 +54,101 @@ describe("isCanonicalModelCapabilityDisabled", () => {
 		);
 		expect(getSetting).not.toHaveBeenCalled();
 	});
+
+	it("parses case and whitespace variants of the string false", () => {
+		for (const setting of [" FALSE ", "False", "fAlSe", "\tfalse\n"]) {
+			const { runtime } = runtimeWith(setting);
+			expect(
+				isCanonicalModelCapabilityDisabled(runtime, ModelType.TEXT_LARGE),
+			).toBe(true);
+			const embedding = runtimeWith(setting);
+			expect(
+				isCanonicalModelCapabilityDisabled(
+					embedding.runtime,
+					ModelType.TEXT_EMBEDDING,
+				),
+			).toBe(true);
+		}
+	});
+
+	it("treats non-false string settings as enabled", () => {
+		for (const setting of ["", "0", "falsey", "TRUE"]) {
+			const { runtime } = runtimeWith(setting);
+			expect(
+				isCanonicalModelCapabilityDisabled(runtime, ModelType.TEXT_LARGE),
+			).toBe(false);
+		}
+	});
+
+	it("treats boolean true and numeric settings as enabled", () => {
+		for (const setting of [true, 1, 0]) {
+			const { runtime } = runtimeWith(setting);
+			expect(
+				isCanonicalModelCapabilityDisabled(runtime, ModelType.TEXT_SMALL),
+			).toBe(false);
+		}
+	});
+
+	it("checks every text generation type against the text setting", () => {
+		const generationTypes = [
+			ModelType.TEXT_NANO,
+			ModelType.TEXT_SMALL,
+			ModelType.TEXT_MEDIUM,
+			ModelType.TEXT_LARGE,
+			ModelType.TEXT_MEGA,
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.TEXT_REASONING_SMALL,
+			ModelType.TEXT_REASONING_LARGE,
+			ModelType.TEXT_COMPLETION,
+		];
+		for (const modelType of generationTypes) {
+			const disabled = runtimeWith(false);
+			expect(
+				isCanonicalModelCapabilityDisabled(disabled.runtime, modelType),
+			).toBe(true);
+			const enabled = runtimeWith(undefined);
+			expect(
+				isCanonicalModelCapabilityDisabled(enabled.runtime, modelType),
+			).toBe(false);
+		}
+	});
+
+	it("treats embedding enabled and unset settings as not disabled", () => {
+		const enabled = runtimeWith("true");
+		expect(
+			isCanonicalModelCapabilityDisabled(
+				enabled.runtime,
+				ModelType.TEXT_EMBEDDING,
+			),
+		).toBe(false);
+		const unset = runtimeWith(undefined);
+		expect(
+			isCanonicalModelCapabilityDisabled(
+				unset.runtime,
+				ModelType.TEXT_EMBEDDING,
+			),
+		).toBe(false);
+		expect(unset.getSetting).toHaveBeenCalledWith(
+			CANONICAL_EMBEDDING_CAPABILITY_SETTING,
+		);
+	});
+
+	it("routes batch embeddings through neither capability gate", () => {
+		const { runtime, getSetting } = runtimeWith("false");
+		expect(
+			isCanonicalModelCapabilityDisabled(
+				runtime,
+				ModelType.TEXT_EMBEDDING_BATCH,
+			),
+		).toBe(false);
+		expect(getSetting).not.toHaveBeenCalled();
+	});
+
+	it("consults exactly one setting per generation lookup", () => {
+		const { runtime, getSetting } = runtimeWith(undefined);
+		isCanonicalModelCapabilityDisabled(runtime, ModelType.TEXT_MEDIUM);
+		expect(getSetting).toHaveBeenCalledTimes(1);
+		expect(getSetting).toHaveBeenCalledWith(CANONICAL_TEXT_CAPABILITY_SETTING);
+	});
 });


### PR DESCRIPTION

Additive-only unit coverage for `isCanonicalModelCapabilityDisabled` in
`packages/core/src/runtime/canonical-model-capabilities.ts`.

`origin/develop` already carries a four-case suite for this module, so this PR
strictly extends it (+97/-0 on that single test file) and rewrites nothing.
Seven cases are added for branches the suite did not reach:

- string-coercion parsing of the `"false"` comparison: `" FALSE "`, `"False"`,
  `"fAlSe"`, and tab/newline-padded variants are disabled, while `""`, `"0"`,
  `"falsey"`, and `"TRUE"` are not;
- boolean `true`, `1`, and `0` settings are treated as enabled;
- a parametric sweep over every member of `TEXT_GENERATION_MODEL_TYPES`
  (all ten, enumerated via `ModelType`) asserting each consults the text gate:
  boolean `false` disables, unset does not;
- embedding-side enabled (`"true"`) and unset settings are not disabled, and
  the embedding setting key is the one consulted;
- `TEXT_EMBEDDING_BATCH` routes through neither capability gate and consults
  no setting (observed routing: it is neither a text-generation type nor
  `ModelType.TEXT_EMBEDDING`);
- exactly one setting lookup happens per generation-type call, against
  `ELIZA_CANONICAL_LLM_TEXT_ENABLED`.

Only the runtime's `getSetting` accessor is stubbed; all module logic, the
real `ModelType` table, and the real generation-type set are exercised.

Evidence (fork PR - hosted CI does not run on it):

- `bunx vitest run packages/core/src/runtime/__tests__/canonical-model-capabilities.test.ts`
  on current develop base `1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c`:
  Test Files 1 passed (1), Tests 11 passed (11) - re-run immediately before filing.
- `bunx biome check --write` on the touched file exits clean; the diff vs
  origin/develop remains 97 insertions, 0 deletions.
- `bunx tsc --noEmit` in `packages/core`: the new test file appears nowhere
  in the output.
- The diff touches only the one test file; no production behavior changes.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9263821a7183561a5edc2c327a926c8459a65043 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
