### PR TITLE
test(core): cover addressed-to

### DIFF
--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -437,3 +437,410 @@ describe("messageVocativelyAddressesOtherParticipant (structural vocative)", () 
 		).toBe(false);
 	});
 });
+
+/**
+ * Additive edge coverage for the two exports the suites above do not exercise
+ * directly: applyAddressedTo (the relationship-edge persistence write path)
+ * and resolveAddressedTargets (deterministic name/id resolution), plus a few
+ * gate/vocative boundaries the earlier cases miss. Same vi-mocked-runtime
+ * harness; no model or database.
+ */
+import { applyAddressedTo, resolveAddressedTargets } from "../addressed-to.ts";
+
+const ROOM_ROSTER: Entity[] = [
+	{ id: AGENT_ID, agentId: AGENT_ID, names: ["MyAgent", "myagent_bot"] },
+	{ id: OTHER_BOT, agentId: AGENT_ID, names: ["SomeOtherBot"] },
+	{ id: HUMAN_X, agentId: AGENT_ID, names: ["Alice"] },
+	{ id: SENDER_ID, agentId: AGENT_ID, names: ["nubs"] },
+];
+
+// Runtime whose room roster and relationship-edge fakes are all held as
+// handles so each test can inspect the exact calls the module makes.
+function relationalRuntime(
+	participants: Entity[] = ROOM_ROSTER,
+	existingEdges: Relationship[] = [],
+): {
+	runtime: IAgentRuntime;
+	getEntitiesForRoom: IAgentRuntime["getEntitiesForRoom"];
+	getRelationships: IAgentRuntime["getRelationships"];
+	createRelationship: IAgentRuntime["createRelationship"];
+	updateRelationship: IAgentRuntime["updateRelationship"];
+} {
+	const getEntitiesForRoom: IAgentRuntime["getEntitiesForRoom"] = vi.fn(
+		async () => participants,
+	);
+	const getRelationships: IAgentRuntime["getRelationships"] = vi.fn(
+		async () => existingEdges,
+	);
+	const createRelationship: IAgentRuntime["createRelationship"] = vi.fn(
+		async () => true,
+	);
+	const updateRelationship: IAgentRuntime["updateRelationship"] = vi.fn(
+		async () => {},
+	);
+	return {
+		runtime: makeRuntime({
+			getEntitiesForRoom,
+			getRelationships,
+			createRelationship,
+			updateRelationship,
+		}),
+		getEntitiesForRoom,
+		getRelationships,
+		createRelationship,
+		updateRelationship,
+	};
+}
+
+describe("applyAddressedTo (addressed-edge persistence)", () => {
+	it("short-circuits to an empty result without any runtime interaction when there are no addressees", async () => {
+		for (const addressedTo of [
+			[],
+			undefined,
+		] as unknown as readonly string[][]) {
+			const h = relationalRuntime();
+			expect(
+				await applyAddressedTo({
+					runtime: h.runtime,
+					message: makeMessage(),
+					addressedTo,
+				}),
+			).toEqual({ created: 0, updated: 0, resolved: [] });
+			expect(h.getEntitiesForRoom).not.toHaveBeenCalled();
+			expect(h.getRelationships).not.toHaveBeenCalled();
+			expect(h.createRelationship).not.toHaveBeenCalled();
+			expect(h.updateRelationship).not.toHaveBeenCalled();
+		}
+	});
+
+	it("returns an empty result without resolving anything when the message has no speaker", async () => {
+		const h = relationalRuntime();
+		const message = { ...makeMessage(), entityId: undefined } as Memory;
+		expect(
+			await applyAddressedTo({
+				runtime: h.runtime,
+				message,
+				addressedTo: ["Alice"],
+			}),
+		).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(h.getEntitiesForRoom).not.toHaveBeenCalled();
+		expect(h.createRelationship).not.toHaveBeenCalled();
+	});
+
+	it("creates one addressed edge per resolved other participant with canonical tags and source metadata", async () => {
+		const h = relationalRuntime();
+		const result = await applyAddressedTo({
+			runtime: h.runtime,
+			message: makeMessage(),
+			addressedTo: ["@alice"],
+		});
+		expect(result).toEqual({ created: 1, updated: 0, resolved: [HUMAN_X] });
+		expect(h.createRelationship).toHaveBeenCalledTimes(1);
+		const edge = vi.mocked(h.createRelationship).mock.calls[0][0];
+		expect(edge.sourceEntityId).toBe(SENDER_ID);
+		expect(edge.targetEntityId).toBe(HUMAN_X);
+		expect(edge.tags).toEqual(["addressed", "addressed:auto"]);
+		expect(edge.metadata?.source).toBe("message_handler_addressedTo");
+		expect(
+			Number.isNaN(
+				new Date(edge.metadata?.lastInteractionAt as string).getTime(),
+			),
+		).toBe(false);
+		expect(h.updateRelationship).not.toHaveBeenCalled();
+	});
+
+	it("updates the existing edge instead of duplicating it: dedupes tags, keeps foreign metadata, stamps source", async () => {
+		const existing: Relationship = {
+			id: "00000000-0000-0000-0000-00000000ff01" as UUID,
+			sourceEntityId: SENDER_ID,
+			targetEntityId: OTHER_BOT,
+			agentId: AGENT_ID,
+			tags: ["addressed", "custom-tag"],
+			metadata: { custom: "keep" },
+		};
+		const h = relationalRuntime(ROOM_ROSTER, [existing]);
+		const result = await applyAddressedTo({
+			runtime: h.runtime,
+			message: makeMessage(),
+			addressedTo: ["SomeOtherBot"],
+		});
+		expect(result).toEqual({ created: 0, updated: 1, resolved: [OTHER_BOT] });
+		expect(h.getRelationships).toHaveBeenCalledWith({
+			entityIds: [SENDER_ID],
+			tags: ["addressed"],
+		});
+		expect(h.createRelationship).not.toHaveBeenCalled();
+		expect(h.updateRelationship).toHaveBeenCalledTimes(1);
+		const updatedEdge = vi.mocked(h.updateRelationship).mock.calls[0][0];
+		expect(updatedEdge.id).toBe(existing.id);
+		expect(updatedEdge.tags).toEqual([
+			"addressed",
+			"custom-tag",
+			"addressed:auto",
+		]);
+		expect(updatedEdge.metadata?.custom).toBe("keep");
+		expect(updatedEdge.metadata?.source).toBe("message_handler_addressedTo");
+	});
+
+	it("never writes an edge for a tag resolving to the SPEAKER themself", async () => {
+		const h = relationalRuntime();
+		const result = await applyAddressedTo({
+			runtime: h.runtime,
+			message: makeMessage(),
+			addressedTo: ["nubs"],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(h.getRelationships).not.toHaveBeenCalled();
+		expect(h.createRelationship).not.toHaveBeenCalled();
+		expect(h.updateRelationship).not.toHaveBeenCalled();
+	});
+
+	it("persists UUID addressees without consulting the room entity list", async () => {
+		const h = relationalRuntime([]);
+		vi.mocked(h.getEntitiesForRoom).mockImplementation(async () => {
+			throw new Error("room must not be read for pure-UUID tags");
+		});
+		const result = await applyAddressedTo({
+			runtime: h.runtime,
+			message: makeMessage(),
+			addressedTo: [HUMAN_X],
+		});
+		expect(result).toEqual({ created: 1, updated: 0, resolved: [HUMAN_X] });
+		expect(
+			vi.mocked(h.createRelationship).mock.calls[0][0].targetEntityId,
+		).toBe(HUMAN_X);
+	});
+
+	it("collapses repeated spellings of the same participant into a single edge", async () => {
+		const h = relationalRuntime();
+		const result = await applyAddressedTo({
+			runtime: h.runtime,
+			message: makeMessage(),
+			addressedTo: ["Alice", "@alice", "ALICE"],
+		});
+		expect(result.created).toBe(1);
+		expect(result.resolved).toEqual([HUMAN_X]);
+		expect(h.createRelationship).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("resolveAddressedTargets (name/id resolution)", () => {
+	it("drops blank entries and non-string junk without any room lookup", async () => {
+		const h = relationalRuntime();
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: ["", "   ", 42 as unknown as string],
+			}),
+		).toEqual([]);
+		expect(h.getEntitiesForRoom).not.toHaveBeenCalled();
+	});
+
+	it("keeps uppercase UUIDs verbatim and drops uuid-shaped invalid strings as unresolvable names", async () => {
+		const h = relationalRuntime();
+		const upper = HUMAN_X.toUpperCase();
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: [upper, "00000000-0000-0000-0000-not-valid-uuid"],
+			}),
+		).toEqual([upper]);
+	});
+
+	it("strips @ and matches participant names case-insensitively against the room roster", async () => {
+		const h = relationalRuntime();
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: ["@ALICE"],
+			}),
+		).toEqual([HUMAN_X]);
+	});
+
+	it("maps the agent's own character.name to agentId even when absent from the room roster", async () => {
+		const h = relationalRuntime([
+			{ id: HUMAN_X, agentId: AGENT_ID, names: ["Alice"] },
+		]);
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: ["MyAgent"],
+			}),
+		).toEqual([AGENT_ID]);
+	});
+
+	it("skips participants without ids and non-string/empty alias entries", async () => {
+		const h = relationalRuntime([
+			{ agentId: AGENT_ID, names: ["Ghost"] },
+			{ id: HUMAN_X, agentId: AGENT_ID, names: [123, "", "Alice"] },
+		] as unknown as Entity[]);
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: ["ghost", "Alice"],
+			}),
+		).toEqual([HUMAN_X]);
+	});
+
+	it("deduplicates an id tag and its name spelling into one resolution", async () => {
+		const h = relationalRuntime();
+		expect(
+			await resolveAddressedTargets({
+				runtime: h.runtime,
+				message: makeMessage(),
+				addressedTo: [OTHER_BOT, "@someotherbot"],
+			}),
+		).toEqual([OTHER_BOT]);
+	});
+});
+
+describe("messageAddressedToOtherParticipant — added edge coverage", () => {
+	it("treats the agent's character.username as self", async () => {
+		const runtime = makeRuntime({
+			character: { name: "Totally Unrelated", username: "selfhandle" },
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, agentId: AGENT_ID, names: ["selfhandle"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "selfhandle you around?"),
+				addressedTo: ["@selfhandle"],
+			}),
+		).toBe(false);
+	});
+
+	it("never corroborates through a one-character name but does through a two-character one", async () => {
+		const runtime = makeRuntime({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: HUMAN_X, agentId: AGENT_ID, names: ["Q"] },
+				{ id: OTHER_BOT, agentId: AGENT_ID, names: ["QQ"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "Q status report"),
+				addressedTo: ["Q"],
+			}),
+		).toBe(false);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "QQ status report"),
+				addressedTo: ["QQ"],
+			}),
+		).toBe(true);
+	});
+
+	it("escapes regex metacharacters in participant names", async () => {
+		const runtime = makeRuntime({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: HUMAN_X, agentId: AGENT_ID, names: ["Eliza.Bot"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(
+					undefined,
+					undefined,
+					"hey ElizaXBot are you there",
+				),
+				addressedTo: ["Eliza.Bot"],
+			}),
+		).toBe(false);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "Eliza.Bot status?"),
+				addressedTo: ["Eliza.Bot"],
+			}),
+		).toBe(true);
+	});
+
+	it("filters non-string entries out of the tag list instead of crashing", async () => {
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(undefined, undefined, "Alice do the thing"),
+				addressedTo: [null, "Alice"] as unknown as readonly string[],
+			}),
+		).toBe(true);
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(),
+				addressedTo: [42] as unknown as readonly string[],
+			}),
+		).toBe(false);
+	});
+});
+
+describe("messageVocativelyAddressesOtherParticipant — added edge coverage", () => {
+	const nubilio = (): IAgentRuntime =>
+		makeRuntime({
+			character: { name: "remilio nubilio" },
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, agentId: AGENT_ID, names: ["remilio nubilio"] },
+				{ id: OTHER_BOT, agentId: AGENT_ID, names: ["Eliza"] },
+				{ id: SENDER_ID, agentId: AGENT_ID, names: ["nubs"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+
+	it('gates further greeting forms ("yo eliza …", "gm @eliza!")', async () => {
+		expect(
+			await messageVocativelyAddressesOtherParticipant({
+				runtime: nubilio(),
+				message: makeMessage(
+					undefined,
+					undefined,
+					"yo eliza can you take this",
+				),
+			}),
+		).toBe(true);
+		expect(
+			await messageVocativelyAddressesOtherParticipant({
+				runtime: nubilio(),
+				message: makeMessage(undefined, undefined, "gm @eliza!"),
+			}),
+		).toBe(true);
+	});
+
+	it("skips a participant whose only name equals one token of OUR multi-word name", async () => {
+		const runtime = makeRuntime({
+			character: { name: "remilio nubilio" },
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: OTHER_BOT, agentId: AGENT_ID, names: ["remilio"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await messageVocativelyAddressesOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "remilio you around?"),
+			}),
+		).toBe(false);
+	});
+
+	it("returns false for whitespace-only text without reading the room", async () => {
+		const getEntitiesForRoom = vi.fn(async () => {
+			throw new Error("whitespace-only text must exit before room reads");
+		});
+		const runtime = makeRuntime({
+			getEntitiesForRoom,
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await messageVocativelyAddressesOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "  \n\t "),
+			}),
+		).toBe(false);
+		expect(getEntitiesForRoom).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION

## What

Additive test-only coverage for `packages/core/src/runtime/addressed-to.ts`. The existing suite covered the two gate helpers; this PR adds 20 cases for the exports it did not exercise directly:

- **`applyAddressedTo`** (relationship-edge persistence, previously untested): empty/missing addressee short-circuit with zero runtime interaction; missing-speaker short-circuit; create path asserting canonical tags (`addressed`, `addressed:auto`), `source: "message_handler_addressedTo"` metadata and a parseable `lastInteractionAt`; update path asserting tag dedupe order (`["addressed", "custom-tag", "addressed:auto"]`), preservation of foreign metadata, and the `getRelationships({ entityIds: [speakerId], tags: ["addressed"] })` query shape; speaker self-tags never produce an edge; pure-UUID addressees resolve without a room-entity read; repeated spellings of one participant collapse into a single edge.
- **`resolveAddressedTargets`** (previously only exercised indirectly): blank and non-string entries dropped without a room lookup; uppercase UUIDs accepted verbatim while uuid-shaped invalid strings fall through to name resolution and are dropped; `@`-stripped case-insensitive roster matching; the agent's own `character.name` mapping to `agentId` even when absent from the roster; participants without ids and non-string aliases skipped; id+name spellings of one participant deduped.
- **Gate/vocative boundaries**: `character.username` treated as self; one-character names never corroborate while two-character names do (pins the `length < 2` boundary); regex metacharacters in participant names are escaped rather than interpreted; non-string entries are filtered instead of crashing; additional vocative greeting forms ("yo eliza", "gm @eliza!"); participants named after one token of the agent's own multi-word name are skipped as self; whitespace-only text exits before any room read.

## Evidence

- `bunx vitest run packages/core/src/runtime/__tests__/addressed-to.test.ts` → **Test Files 1 passed (1), Tests 47 passed (47)** — 27 pre-existing cases unchanged plus 20 new. Re-fetched origin/develop immediately before filing; source blob `8141390` and test blob `ecf0df0` were current, so the run reproduces on today's develop head `1f236fd`.
- `bunx biome check packages/core/src/runtime/__tests__/addressed-to.test.ts` → clean, no fixes applied (repo `biome.json` + `packages/core/biome.json` present; checkout is not sparse).
- `bunx tsc --noEmit` in `packages/core` → zero diagnostics mentioning `addressed-to`.
- Diff touches exactly one file, purely additive (+407/−0). No production code changed.

## Notes

- Fork contributor: hosted CI does not run on this PR; the counts above are from local runs quoted verbatim.
- All expectations record observed behavior of the module as it exists on develop; no behavioral change is proposed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
