### PR TITLE
test(core): cover pairing

### DIFF
--- a/packages/core/src/types/pairing.test.ts
+++ b/packages/core/src/types/pairing.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Coverage for pairing.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_PAIRING_CONFIG,
+	DEFAULT_PAIRING_PAGE_LIMIT,
+	getPairingIdLabel,
+	MAX_PAIRING_PAGE_LIMIT,
+	normalizePairingPageOptions,
+	PAIRING_CODE_ALPHABET,
+} from "./pairing.js";
+
+describe("pairing", () => {
+	describe("normalizePairingPageOptions", () => {
+		it("defaults to the page limit at offset 0 when called without options", () => {
+			expect(normalizePairingPageOptions()).toEqual({
+				limit: DEFAULT_PAIRING_PAGE_LIMIT,
+				offset: 0,
+			});
+			expect(normalizePairingPageOptions({})).toEqual({
+				limit: DEFAULT_PAIRING_PAGE_LIMIT,
+				offset: 0,
+			});
+		});
+
+		it("passes explicit options through unchanged", () => {
+			expect(normalizePairingPageOptions({ limit: 25, offset: 75 })).toEqual({
+				limit: 25,
+				offset: 75,
+			});
+		});
+
+		it("defaults each field independently", () => {
+			expect(normalizePairingPageOptions({ offset: 40 })).toEqual({
+				limit: DEFAULT_PAIRING_PAGE_LIMIT,
+				offset: 40,
+			});
+			expect(normalizePairingPageOptions({ limit: 10 })).toEqual({
+				limit: 10,
+				offset: 0,
+			});
+		});
+
+		it("accepts the inclusive limit boundaries 1 and MAX_PAIRING_PAGE_LIMIT", () => {
+			expect(normalizePairingPageOptions({ limit: 1 })).toEqual({
+				limit: 1,
+				offset: 0,
+			});
+			expect(
+				normalizePairingPageOptions({ limit: MAX_PAIRING_PAGE_LIMIT }),
+			).toEqual({ limit: MAX_PAIRING_PAGE_LIMIT, offset: 0 });
+		});
+
+		it("rejects limits outside 1..MAX_PAIRING_PAGE_LIMIT", () => {
+			expect(() =>
+				normalizePairingPageOptions({ limit: MAX_PAIRING_PAGE_LIMIT + 1 }),
+			).toThrow(RangeError);
+			expect(() => normalizePairingPageOptions({ limit: 0 })).toThrow(
+				RangeError,
+			);
+			expect(() => normalizePairingPageOptions({ limit: -5 })).toThrow(
+				RangeError,
+			);
+		});
+
+		it("rejects non-integer and non-safe limits", () => {
+			expect(() => normalizePairingPageOptions({ limit: 2.5 })).toThrow(
+				RangeError,
+			);
+			expect(() => normalizePairingPageOptions({ limit: Number.NaN })).toThrow(
+				RangeError,
+			);
+			expect(() =>
+				normalizePairingPageOptions({ limit: Number.POSITIVE_INFINITY }),
+			).toThrow(RangeError);
+		});
+
+		it("accepts zero and maximum safe offsets", () => {
+			expect(normalizePairingPageOptions({ offset: 0 })).toEqual({
+				limit: DEFAULT_PAIRING_PAGE_LIMIT,
+				offset: 0,
+			});
+			expect(
+				normalizePairingPageOptions({ offset: Number.MAX_SAFE_INTEGER }),
+			).toEqual({
+				limit: DEFAULT_PAIRING_PAGE_LIMIT,
+				offset: Number.MAX_SAFE_INTEGER,
+			});
+		});
+
+		it("rejects negative, non-integer, and non-safe offsets", () => {
+			expect(() => normalizePairingPageOptions({ offset: -1 })).toThrow(
+				RangeError,
+			);
+			expect(() => normalizePairingPageOptions({ offset: 0.5 })).toThrow(
+				RangeError,
+			);
+			expect(() =>
+				normalizePairingPageOptions({ offset: Number.MAX_SAFE_INTEGER + 1 }),
+			).toThrow(RangeError);
+		});
+
+		it("validates the limit before the offset", () => {
+			expect(() =>
+				normalizePairingPageOptions({ limit: 0, offset: -1 }),
+			).toThrowError(/limit/);
+		});
+	});
+
+	describe("getPairingIdLabel", () => {
+		it("returns the configured label for known channels", () => {
+			expect(getPairingIdLabel("telegram")).toBe("userId");
+			expect(getPairingIdLabel("whatsapp")).toBe("phoneNumber");
+			expect(getPairingIdLabel("googlechat")).toBe("email");
+		});
+
+		it("falls back to userId for unknown and extension channels", () => {
+			expect(getPairingIdLabel("farcaster")).toBe("userId");
+			expect(getPairingIdLabel("")).toBe("userId");
+		});
+	});
+
+	describe("pairing code contract", () => {
+		it("draws codes from an unambiguous duplicate-free alphabet", () => {
+			const characters = [...PAIRING_CODE_ALPHABET];
+			expect(new Set(characters).size).toBe(characters.length);
+			for (const ambiguous of ["0", "O", "1", "I", "l"]) {
+				expect(characters).not.toContain(ambiguous);
+			}
+		});
+
+		it("defaults support generation within the alphabet", () => {
+			expect(DEFAULT_PAIRING_CONFIG.codeLength).toBeLessThanOrEqual(
+				PAIRING_CODE_ALPHABET.length,
+			);
+			expect(DEFAULT_PAIRING_CONFIG.maxPendingRequests).toBeGreaterThanOrEqual(
+				1,
+			);
+			expect(DEFAULT_PAIRING_CONFIG.requestTtlMs).toBe(60 * 60 * 1000);
+		});
+	});
+});


### PR DESCRIPTION

## What

Adds `packages/core/src/types/pairing.test.ts` — a unit suite for the DM-pairing type module's runtime surface (`normalizePairingPageOptions`, `getPairingIdLabel`, and the pairing constants). Test-only change: no production code, no behavior change.

## Coverage

`normalizePairingPageOptions` (consumed by `services/pairing.ts` and `database/inMemoryAdapter.ts` for every bounded pairing read):

- defaults to `{ limit: 50, offset: 0 }` — both fields together and independently
- explicit valid options pass through unchanged
- inclusive boundaries: `limit: 1` and `limit: MAX_PAIRING_PAGE_LIMIT` accepted; `0`, negative, and over-max rejected with `RangeError`
- non-integer and non-safe limits rejected (`2.5`, `NaN`, `Infinity`)
- offsets: `0` and `Number.MAX_SAFE_INTEGER` accepted; negative, fractional, and unsafe rejected
- the limit is validated before the offset

`getPairingIdLabel` (consumed by `services/pairing-integration.ts`):

- returns the configured label for known channels
- falls back to `"userId"` for unknown and extension channels (the `?? "userId"` branch)

Constant contracts are asserted through behavior rather than pinned literals: the exported page-limit constants drive the enforcement boundary actually observed through `normalizePairingPageOptions`, and the code alphabet is verified duplicate-free with ambiguous characters (`0`, `O`, `1`, `I`, `l`) excluded as documented.

## Evidence

- `bunx vitest run packages/core/src/types/pairing.test.ts` — **1 test file passed, 13/13 tests passed** (re-run against freshly fetched `origin/develop` immediately before filing; identical counts)
- `bunx biome check --write packages/core/src/types/pairing.test.ts` — clean
- `bunx tsc --noEmit` in `packages/core` — `pairing.test.ts` appears nowhere in the output
- the diff is a single new test file, +143/-0

We are a fork contributor: hosted CI does not run on this PR; the local runs above are the verification.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:32ea8f503c30ce36b5b67070727a40002a2ae4fc -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
