### PR TITLE
test(core): cover primitives

### DIFF
--- a/packages/core/src/types/primitives.test.ts
+++ b/packages/core/src/types/primitives.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Coverage for the runtime surface of the foundational primitives module:
+ * `asUUID` validation and passthrough, the nil `DEFAULT_UUID`, and the
+ * `ChannelType` / `ContentType` token maps as they flow through serialized
+ * `Media`. Deterministic real-module harness; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	asUUID,
+	ChannelType,
+	ContentType,
+	DEFAULT_UUID,
+} from "./primitives.js";
+
+describe("asUUID", () => {
+	it("returns the identical string for a valid UUID", () => {
+		const id = "123e4567-e89b-12d3-a456-426614174000";
+		expect(asUUID(id)).toBe(id);
+	});
+
+	it("accepts uppercase hex and preserves the original casing", () => {
+		const id = "123E4567-E89B-12D3-A456-426614174000";
+		expect(asUUID(id)).toBe(id);
+	});
+
+	it("accepts the nil UUID", () => {
+		expect(asUUID(DEFAULT_UUID)).toBe(DEFAULT_UUID);
+	});
+
+	it("throws for an empty string", () => {
+		expect(() => asUUID("")).toThrow();
+	});
+
+	it("throws when a group has the wrong length", () => {
+		expect(() => asUUID("123e4567-e89b-12d3-a456-42661417400")).toThrow();
+		expect(() => asUUID("123e4567-e89-b12d3-a456-426614174000")).toThrow();
+	});
+
+	it("throws when separators are missing entirely", () => {
+		expect(() => asUUID("123e4567e89b12d3a456426614174000")).toThrow();
+	});
+
+	it("throws when separators are in the wrong positions", () => {
+		expect(() => asUUID("123e456-7e89b-12d3-a456-426614174000")).toThrow();
+		expect(() => asUUID("123e4567-e89b12d3-a456-426614174000")).toThrow();
+	});
+
+	it("throws for non-hex characters", () => {
+		expect(() => asUUID("123e4567-e89b-12d3-a456-42661417400g")).toThrow();
+	});
+
+	it("includes the offending value in the error message", () => {
+		expect(() => asUUID("not-a-uuid")).toThrow(
+			"Invalid UUID format: not-a-uuid",
+		);
+	});
+
+	it("throws for null or undefined input", () => {
+		expect(() => asUUID(undefined as unknown as string)).toThrow();
+		expect(() => asUUID(null as unknown as string)).toThrow();
+	});
+});
+
+describe("DEFAULT_UUID", () => {
+	it("is the canonical zero UUID", () => {
+		expect(DEFAULT_UUID).toBe("00000000-0000-0000-0000-000000000000");
+	});
+});
+
+describe("ChannelType", () => {
+	it("assigns a distinct non-empty string to every channel kind", () => {
+		const values = Object.values(ChannelType);
+		expect(values.length).toBeGreaterThan(0);
+		for (const value of values) {
+			expect(typeof value).toBe("string");
+			expect(value.length).toBeGreaterThan(0);
+		}
+		expect(new Set(values).size).toBe(values.length);
+	});
+});
+
+describe("ContentType", () => {
+	it("assigns a distinct non-empty string to every content kind", () => {
+		const values = Object.values(ContentType);
+		expect(values.length).toBeGreaterThan(0);
+		for (const value of values) {
+			expect(typeof value).toBe("string");
+			expect(value.length).toBeGreaterThan(0);
+		}
+		expect(new Set(values).size).toBe(values.length);
+	});
+
+	it("survives a JSON round trip on a Media attachment", () => {
+		const media = {
+			id: "11111111-2222-3333-4444-555555555555",
+			url: "/api/media/deadbeef.png",
+			contentType: ContentType.IMAGE,
+		};
+		const parsed = JSON.parse(JSON.stringify(media));
+		expect(parsed).toEqual(media);
+		expect(parsed.contentType).toBe(ContentType.IMAGE);
+	});
+});


### PR DESCRIPTION

Adds `packages/core/src/types/primitives.test.ts` — the first unit suite for the foundational `types/primitives` module (`asUUID`, `DEFAULT_UUID`, `ChannelType`, `ContentType`). This is a test-only diff: it changes no production behaviour.

The suite drives the real module directly (no mocks):

- `asUUID`: returns the identical string for a valid UUID (uppercase hex accepted, original casing preserved), accepts the nil UUID, and throws for empty input, wrong-length groups, entirely missing separators, separators in wrong positions, non-hex characters, and `null`/`undefined` input — including asserting the offending value surfaces verbatim in the error message.
- `DEFAULT_UUID`: pinned to the canonical zero UUID that callers compare room/world ids against.
- `ChannelType` / `ContentType`: every kind maps to a distinct, non-empty string (the invariant discriminated branching and stored channel/content columns rely on).
- `ContentType` exercised through a `Media` JSON round trip, mirroring how attachments are actually serialized inside `memories.content`.

Evidence (fork contributor — hosted CI does not run on this pull request):

- `bunx vitest run packages/core/src/types/primitives.test.ts` from the repo root: **Test Files 1 passed (1); Tests 14 passed (14)** (~140 ms).
- `bunx biome check --write packages/core/src/types/primitives.test.ts`: applied one formatting pass; immediate re-check reported "No fixes applied" (clean).
- From `packages/core`: `bunx tsc --noEmit 2>&1 | grep 'primitives.test'` produces no output — the new file introduces zero type errors.
- Re-verified immediately before filing against current `origin/develop`; `types/primitives.ts` is byte-identical between this branch's base and current develop, so the quoted counts reproduce exactly.
- The diff touches only the single new test file (+103/-0).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
